### PR TITLE
Support listing all available namespaces

### DIFF
--- a/install/odh/base/role.yaml
+++ b/install/odh/base/role.yaml
@@ -19,3 +19,19 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Resolves #26 

Back-end implementation. If it's intended to visualize this in any way on front-end, there should come another PR for that.

This PR makes the node back-end to lookup for all namespaces to which it has access to (via Openshift `project` resource). This happens at the server startup. If this lookup fails, it falls back to using the original implementation for looking up the current namespace.

During runtime, when serving requests to `/api/components`, the component lookup code tries for fetch all kfdef resources in all available namespaces (even when multiple `kfdefs` are present in the same namespace) and then builds the application list out of it.

Later on, it may be needed to change the lookup logic to allow for duplicate apps listing.

The available namespaces are determined by Openshift RBAC - only the namespaces to which the ODH dashboard's service account  has access to, are queried.

Backend now lists the namespace property for each enabled component in the `/api/components` response.
