### PR TITLE
fix: Spark kfDef component name

### DIFF
--- a/routes/api/components/available-components.js
+++ b/routes/api/components/available-components.js
@@ -50,7 +50,7 @@ module.exports = [
     key: "spark",
     label: "Spark",
     description: "Unified analytics engine for large-scale data processing",
-    kfdefApplications: ["radanalyticsio-cluster"],
+    kfdefApplications: ["radanalyticsio-spark-cluster"],
     route: null,
     img: "images/spark.svg",
     docsLink: "https://spark.apache.org/docs/latest/",


### PR DESCRIPTION
ODH Dashboard is unable to detect spark component, since upstream uses a different name for it, see:

- https://github.com/opendatahub-io/odh-manifests/tree/master/radanalyticsio
- https://github.com/opendatahub-io/odh-manifests/blob/master/tests/setup/kfctl_openshift.yaml

/kind bug