### PR TITLE
fix: Grafana component names

### DIFF
--- a/routes/api/components/available-components.js
+++ b/routes/api/components/available-components.js
@@ -41,7 +41,7 @@ module.exports = [
     key: "grafana",
     label: "Grafana",
     description: "Visualization and analytics software",
-    kfdefApplications: ["grafana-cluster", "grafana-instance"],
+    kfdefApplications: ["grafana-cluster", "grafana-operator"],
     route: "grafana-route",
     img: "images/grafana.svg",
     docsLink: "https://grafana.com/docs/grafana/latest/",


### PR DESCRIPTION
Similar to https://github.com/opendatahub-io/odh-dashboard/pull/31

There's no `grafana-instance` component upstream.

https://github.com/opendatahub-io/odh-manifests/tree/master/grafana
https://github.com/opendatahub-io/odh-manifests/blob/master/tests/setup/kfctl_openshift.yaml