### PR TITLE
Revert "fix: Grafana component names (#33)"

### DIFF
--- a/routes/api/components/available-components.js
+++ b/routes/api/components/available-components.js
@@ -41,7 +41,7 @@ module.exports = [
     key: "grafana",
     label: "Grafana",
     description: "Visualization and analytics software",
-    kfdefApplications: ["grafana-cluster", "grafana-operator"],
+    kfdefApplications: ["grafana-cluster", "grafana-instance"],
     route: "grafana-route",
     img: "images/grafana.svg",
     docsLink: "https://grafana.com/docs/grafana/latest/",


### PR DESCRIPTION
This reverts commit 4ebc0b90664c2b182478a352ecd219fe5f87c392.