### PR TITLE
Fix to return correct getting started data on fetch

### DIFF
--- a/frontend/src/services/gettingStartedService.ts
+++ b/frontend/src/services/gettingStartedService.ts
@@ -12,7 +12,7 @@ export const fetchGettingStartedDoc = (appName: string): Promise<OdhGettingStart
   return axios
     .get(url, options)
     .then((response) => {
-      return response.data;
+      return response.data[0];
     })
     .catch((e) => {
       throw new Error(e.response.data.message);


### PR DESCRIPTION
Fixes an issue where the UI is not translating the data returned when fetching the getting started markdown for an application.