### PR TITLE
Collapse filter panel when view gets too narrow

### DIFF
--- a/frontend/src/pages/ApplicationsPage.scss
+++ b/frontend/src/pages/ApplicationsPage.scss
@@ -19,3 +19,10 @@
     }
   }
 }
+
+.odh-dashboard__page-content {
+  border: 1px solid var(--pf-global--BorderColor--100);
+  display: flex;
+  flex: 1;
+  margin: var(--pf-global--spacer--md);
+}

--- a/frontend/src/pages/enabledApplications/EnabledApplications.tsx
+++ b/frontend/src/pages/enabledApplications/EnabledApplications.tsx
@@ -29,13 +29,15 @@ const EnabledApplicationsInner: React.FC<EnabledApplicationsInnerProps> = React.
         loadError={loadError}
       >
         {!isEmpty ? (
-          <PageSection>
-            <Gallery className="odh-installed-apps__gallery" hasGutter>
-              {components.map((c) => (
-                <OdhAppCard key={c.metadata.name} odhApp={c} />
-              ))}
-            </Gallery>
-          </PageSection>
+          <div className="odh-dashboard__page-content">
+            <PageSection>
+              <Gallery className="odh-installed-apps__gallery" hasGutter>
+                {components.map((c) => (
+                  <OdhAppCard key={c.metadata.name} odhApp={c} />
+                ))}
+              </Gallery>
+            </PageSection>
+          </div>
         ) : null}
       </ApplicationsPage>
     );

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -50,18 +50,20 @@ const ExploreApplicationsInner: React.FC<ExploreApplicationsInnerProps> = React.
               }
             >
               <DrawerContentBody className="odh-explore-apps__body">
-                <PageSection>
-                  <Gallery className="odh-explore-apps__gallery" hasGutter>
-                    {exploreComponents.map((c) => (
-                      <OdhExploreCard
-                        key={c.metadata.name}
-                        odhApp={c}
-                        isSelected={selectedComponent === c}
-                        onSelect={() => updateSelection(c.metadata.name)}
-                      />
-                    ))}
-                  </Gallery>
-                </PageSection>
+                <div className="odh-dashboard__page-content">
+                  <PageSection>
+                    <Gallery className="odh-explore-apps__gallery" hasGutter>
+                      {exploreComponents.map((c) => (
+                        <OdhExploreCard
+                          key={c.metadata.name}
+                          odhApp={c}
+                          isSelected={selectedComponent === c}
+                          onSelect={() => updateSelection(c.metadata.name)}
+                        />
+                      ))}
+                    </Gallery>
+                  </PageSection>
+                </div>
               </DrawerContentBody>
             </DrawerContent>
           </Drawer>

--- a/frontend/src/pages/learningCenter/CategoryFilters.tsx
+++ b/frontend/src/pages/learningCenter/CategoryFilters.tsx
@@ -9,18 +9,20 @@ import { CATEGORY_FILTER_KEY } from './const';
 
 type CategoryFiltersProps = {
   docApps: OdhDocument[];
+  favorites: string[];
 };
 
 const ALL_ITEMS = 'All Items';
 const SPACER = 'SPACER';
 
-const CategoryFilters: React.FC<CategoryFiltersProps> = ({ docApps }) => {
+const CategoryFilters: React.FC<CategoryFiltersProps> = ({ docApps, favorites }) => {
   const [categories, setCategories] = React.useState<string[]>([]);
   const history = useHistory();
   const queryParams = useQueryParams();
   const categoryQuery = queryParams.get(CATEGORY_FILTER_KEY) || '';
 
   React.useEffect(() => {
+    const initCategories = favorites.length ? ['Favorites'] : [];
     const updatedCategories = docApps
       .reduce((acc, docApp) => {
         const categoryAnnotation = docApp.metadata.annotations?.[CATEGORY_ANNOTATION];
@@ -35,10 +37,10 @@ const CategoryFilters: React.FC<CategoryFiltersProps> = ({ docApps }) => {
             });
         }
         return acc;
-      }, [] as string[])
+      }, initCategories)
       .sort((a, b) => a.localeCompare(b));
     setCategories([ALL_ITEMS, SPACER, ...updatedCategories]);
-  }, [docApps]);
+  }, [docApps, favorites]);
 
   const onSelectCategory = (selectedCategory: string): void => {
     if (selectedCategory === ALL_ITEMS) {

--- a/frontend/src/pages/learningCenter/LearningCenter.scss
+++ b/frontend/src/pages/learningCenter/LearningCenter.scss
@@ -1,11 +1,6 @@
 .odh-learning-paths {
-  &__content {
-    border-top: 1px solid var(--pf-global--BorderColor--100);
-    display: flex;
-    flex: 1;
-  }
   &__filter-panel {
-    padding: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) var(--pf-global--spacer--md);
+    padding-top: var(--pf-global--spacer--md);
     width: 240px;
     &.m-is-collapsible {
       background: var(--pf-global--BackgroundColor--light-100);
@@ -26,6 +21,21 @@
       right: 0;
       top: var(--pf-global--spacer--sm);
       z-index: var(--pf-global--ZIndex--md);
+    }
+    .vertical-tabs-pf-tab > a {
+      font-size: var(--pf-global--FontSize--sm);
+    }
+    .filter-panel-pf-category {
+      padding-left: var(--pf-global--spacer--md);
+      .filter-panel-pf-category-title {
+        font-size: var(--pf-global--FontSize--sm);
+      }
+      .pf-c-check__label {
+        font-size: var(--pf-global--FontSize--sm);
+      }
+      .pf-c-button.pf-m-link {
+        font-size: var(--pf-global--FontSize--sm);
+      }
     }
   }
   &__view-panel {

--- a/frontend/src/pages/learningCenter/LearningCenter.scss
+++ b/frontend/src/pages/learningCenter/LearningCenter.scss
@@ -7,6 +7,26 @@
   &__filter-panel {
     padding: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) var(--pf-global--spacer--md);
     width: 240px;
+    &.m-is-collapsible {
+      background: var(--pf-global--BackgroundColor--light-100);
+      border-right: 1px solid var(--pf-global--BorderColor--100);
+      border-bottom: 1px solid var(--pf-global--BorderColor--100);
+      position: absolute;
+      transition: left 0.5s;
+      z-index: var(--pf-global--ZIndex--md);
+      left: 0;
+    }
+    &.m-is-collapsed {
+      padding: 0;
+      overflow: hidden;
+      left: -240px;
+    }
+    &__collapse-button {
+      position: absolute;
+      right: 0;
+      top: var(--pf-global--spacer--sm);
+      z-index: var(--pf-global--ZIndex--md);
+    }
   }
   &__view-panel {
     display: flex;

--- a/frontend/src/pages/learningCenter/LearningCenter.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenter.tsx
@@ -1,32 +1,14 @@
 import React from 'react';
-import { useHistory } from 'react-router';
-import classNames from 'classnames';
 import * as _ from 'lodash';
 import useDimensions from 'react-cool-dimensions';
-import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateSecondaryActions,
-  EmptyStateVariant,
-  Gallery,
-  PageSection,
-  PageSectionVariants,
-  Title,
-} from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
 import { QuickStartContext, QuickStartContextValues } from '@cloudmosaic/quickstarts';
 import { OdhDocument, OdhDocumentType } from '../../types';
 import { useWatchComponents } from '../../utilities/useWatchComponents';
 import { useWatchDocs } from '../../utilities/useWatchDocs';
 import { useLocalStorage } from '../../utilities/useLocalStorage';
 import { useQueryParams } from '../../utilities/useQueryParams';
-import { removeQueryArgument } from '../../utilities/router';
 import ApplicationsPage from '../ApplicationsPage';
 import QuickStarts from '../../app/QuickStarts';
-import OdhDocCard from '../../components/OdhDocCard';
-import OdhDocListItem from '../../components/OdhDocListItem';
 import {
   DOC_SORT_KEY,
   DOC_SORT_ORDER_KEY,
@@ -37,122 +19,18 @@ import {
   SORT_TYPE_NAME,
   SORT_TYPE_TYPE,
   CARD_VIEW,
-  LIST_VIEW,
   VIEW_TYPE,
-  ENABLED_FILTER_KEY,
-  SEARCH_FILTER_KEY,
-  DOC_TYPE_FILTER_KEY,
-  PROVIDER_FILTER_KEY,
-  CATEGORY_FILTER_KEY,
+  FAVORITE_RESOURCES,
 } from './const';
-import LearningCenterListHeader from './LearningCenterListHeader';
 import LearningCenterToolbar from './LearningCenterToolbar';
 import LearningCenterFilters from './LearningCenterFilters';
 import { useDocFilterer } from './useDocFilterer';
+import { combineCategoryAnnotations } from '../../utilities/utils';
+import LearningCenterDataView from './LearningCenterDataView';
 
 import './LearningCenter.scss';
-import { combineCategoryAnnotations } from '../../utilities/utils';
-
-export const FAVORITE_RESOURCES = 'ods.dashboard.resources.favorites';
 
 const description = `Access all learning resources for Open Data Hub and supported applications.`;
-
-type LearningCenterDataViewProps = {
-  filteredDocApps: OdhDocument[];
-  favorites: string[];
-  updateFavorite: (isFavorite: boolean, name: string) => void;
-  viewType: string;
-};
-
-const LearningCenterDataView: React.FC<LearningCenterDataViewProps> = React.memo(
-  ({ filteredDocApps, favorites, updateFavorite, viewType }) => {
-    const history = useHistory();
-    const [sizeClass, setSizeClass] = React.useState<string>('m-ods-size-lg');
-    const { observe } = useDimensions({
-      breakpoints: { sm: 0, md: 600, lg: 750 },
-      onResize: ({ currentBreakpoint }) => {
-        setSizeClass(`m-odh-size-${currentBreakpoint}`);
-      },
-    });
-
-    const onClearFilters = () => {
-      removeQueryArgument(history, SEARCH_FILTER_KEY);
-      removeQueryArgument(history, CATEGORY_FILTER_KEY);
-      removeQueryArgument(history, ENABLED_FILTER_KEY);
-      removeQueryArgument(history, DOC_TYPE_FILTER_KEY);
-      removeQueryArgument(history, PROVIDER_FILTER_KEY);
-    };
-
-    const renderContent = () => {
-      if (filteredDocApps.length === 0) {
-        return (
-          <EmptyState variant={EmptyStateVariant.full}>
-            <EmptyStateIcon icon={SearchIcon} />
-            <Title headingLevel="h2" size="lg">
-              No results match the filter criteria
-            </Title>
-            <EmptyStateBody>
-              No resources are being shown due to the filters being applied.
-            </EmptyStateBody>
-            <EmptyStateSecondaryActions>
-              <Button variant="link" onClick={onClearFilters}>
-                Clear all filters
-              </Button>
-            </EmptyStateSecondaryActions>
-          </EmptyState>
-        );
-      }
-
-      if (viewType !== LIST_VIEW) {
-        return (
-          <Gallery className="odh-learning-paths__gallery" hasGutter>
-            {filteredDocApps.map((doc) => (
-              <OdhDocCard
-                key={`${doc.metadata.name}`}
-                odhDoc={doc}
-                favorite={favorites.includes(doc.metadata.name)}
-                updateFavorite={(isFavorite) => updateFavorite(isFavorite, doc.metadata.name)}
-              />
-            ))}
-          </Gallery>
-        );
-      }
-
-      const listViewClasses = classNames('odh-learning-paths__list-view', sizeClass);
-      return (
-        <div className={listViewClasses} aria-label="Simple data list example">
-          <LearningCenterListHeader />
-          {filteredDocApps.map((doc) => (
-            <OdhDocListItem
-              key={`${doc.metadata.name}`}
-              odhDoc={doc}
-              favorite={favorites.includes(doc.metadata.name)}
-              updateFavorite={(isFavorite) => updateFavorite(isFavorite, doc.metadata.name)}
-            />
-          ))}
-        </div>
-      );
-    };
-
-    return (
-      <>
-        <PageSection
-          isFilled={true}
-          variant={viewType === LIST_VIEW ? PageSectionVariants.light : PageSectionVariants.default}
-          className={
-            viewType === LIST_VIEW
-              ? 'odh-learning-paths__view-panel__list-view'
-              : 'odh-learning-paths__view-panel__card-view'
-          }
-        >
-          {renderContent()}
-        </PageSection>
-        <div ref={observe} />
-      </>
-    );
-  },
-);
-LearningCenterDataView.displayName = 'LearningCenterInner';
 
 const LearningCenter: React.FC = () => {
   const { docs: odhDocs, loaded: docsLoaded, loadError: docsLoadError } = useWatchDocs();
@@ -161,12 +39,21 @@ const LearningCenter: React.FC = () => {
   const [docApps, setDocApps] = React.useState<OdhDocument[]>([]);
   const [filteredDocApps, setFilteredDocApps] = React.useState<OdhDocument[]>([]);
   const queryParams = useQueryParams();
-  const docFilterer = useDocFilterer();
   const sortType = queryParams.get(DOC_SORT_KEY) || SORT_TYPE_NAME;
   const sortOrder = queryParams.get(DOC_SORT_ORDER_KEY) || SORT_ASC;
   const [favorites, setFavorites] = useLocalStorage(FAVORITE_RESOURCES);
   const favoriteResources = React.useMemo(() => JSON.parse(favorites || '[]'), [favorites]);
+  const docFilterer = useDocFilterer(favoriteResources);
   const [viewType, setViewType] = useLocalStorage(VIEW_TYPE);
+  const [filtersCollapsed, setFiltersCollapsed] = React.useState<boolean>(false);
+  const [filtersCollapsible, setFiltersCollapsible] = React.useState<boolean>(false);
+  const { observe } = useDimensions({
+    breakpoints: { sm: 0, md: 600 },
+    onResize: ({ currentBreakpoint }) => {
+      setFiltersCollapsed(currentBreakpoint === 'sm');
+      setFiltersCollapsible(currentBreakpoint === 'sm');
+    },
+  });
 
   React.useEffect(() => {
     if (loaded && !loadError && docsLoaded && !docsLoadError) {
@@ -215,7 +102,6 @@ const LearningCenter: React.FC = () => {
           } else {
             updatedDoc.spec.appEnabled = false;
           }
-          console.log(`===== ${updatedDoc.metadata.name}: =>  ${updatedDoc.metadata.annotations}`);
           return updatedDoc;
         });
       setDocApps(updatedDocApps);
@@ -296,14 +182,22 @@ const LearningCenter: React.FC = () => {
       loadError={loadError || docsLoadError}
       empty={false}
     >
-      <div className="odh-learning-paths__content">
-        <LearningCenterFilters docApps={docApps} />
+      <div className="odh-learning-paths__content" ref={observe}>
+        <LearningCenterFilters
+          docApps={docApps}
+          collapsible={filtersCollapsible}
+          collapsed={filtersCollapsed}
+          onCollapse={() => setFiltersCollapsed(true)}
+          favorites={favoriteResources}
+        />
         <div className="odh-learning-paths__view-panel">
           <LearningCenterToolbar
             count={filteredDocApps.length}
             totalCount={docApps.length}
             viewType={viewType || CARD_VIEW}
             updateViewType={setViewType}
+            filtersCollapsible={filtersCollapsible}
+            onToggleFiltersCollapsed={() => setFiltersCollapsed(!filtersCollapsed)}
           />
           <LearningCenterDataView
             filteredDocApps={filteredDocApps}

--- a/frontend/src/pages/learningCenter/LearningCenter.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenter.tsx
@@ -182,7 +182,7 @@ const LearningCenter: React.FC = () => {
       loadError={loadError || docsLoadError}
       empty={false}
     >
-      <div className="odh-learning-paths__content" ref={observe}>
+      <div className="odh-dashboard__page-content" ref={observe}>
         <LearningCenterFilters
           docApps={docApps}
           collapsible={filtersCollapsible}

--- a/frontend/src/pages/learningCenter/LearningCenterDataView.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterDataView.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { useHistory } from 'react-router';
+import classNames from 'classnames';
+import useDimensions from 'react-cool-dimensions';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  EmptyStateVariant,
+  Gallery,
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { OdhDocument } from '../../types';
+import { removeQueryArgument } from '../../utilities/router';
+import OdhDocCard from '../../components/OdhDocCard';
+import OdhDocListItem from '../../components/OdhDocListItem';
+import {
+  LIST_VIEW,
+  ENABLED_FILTER_KEY,
+  SEARCH_FILTER_KEY,
+  DOC_TYPE_FILTER_KEY,
+  PROVIDER_FILTER_KEY,
+  CATEGORY_FILTER_KEY,
+} from './const';
+import LearningCenterListHeader from './LearningCenterListHeader';
+
+type LearningCenterDataViewProps = {
+  filteredDocApps: OdhDocument[];
+  favorites: string[];
+  updateFavorite: (isFavorite: boolean, name: string) => void;
+  viewType: string;
+};
+
+const LearningCenterDataView: React.FC<LearningCenterDataViewProps> = React.memo(
+  ({ filteredDocApps, favorites, updateFavorite, viewType }) => {
+    const history = useHistory();
+    const [sizeClass, setSizeClass] = React.useState<string>('m-ods-size-lg');
+    const { observe } = useDimensions({
+      breakpoints: { sm: 0, md: 600, lg: 750 },
+      onResize: ({ currentBreakpoint }) => {
+        setSizeClass(`m-odh-size-${currentBreakpoint}`);
+      },
+    });
+
+    const onClearFilters = () => {
+      removeQueryArgument(history, SEARCH_FILTER_KEY);
+      removeQueryArgument(history, CATEGORY_FILTER_KEY);
+      removeQueryArgument(history, ENABLED_FILTER_KEY);
+      removeQueryArgument(history, DOC_TYPE_FILTER_KEY);
+      removeQueryArgument(history, PROVIDER_FILTER_KEY);
+    };
+
+    const renderContent = () => {
+      if (filteredDocApps.length === 0) {
+        return (
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h2" size="lg">
+              No results match the filter criteria
+            </Title>
+            <EmptyStateBody>
+              No resources are being shown due to the filters being applied.
+            </EmptyStateBody>
+            <EmptyStateSecondaryActions>
+              <Button variant="link" onClick={onClearFilters}>
+                Clear all filters
+              </Button>
+            </EmptyStateSecondaryActions>
+          </EmptyState>
+        );
+      }
+
+      if (viewType !== LIST_VIEW) {
+        return (
+          <Gallery className="odh-learning-paths__gallery" hasGutter>
+            {filteredDocApps.map((doc) => (
+              <OdhDocCard
+                key={`${doc.metadata.name}`}
+                odhDoc={doc}
+                favorite={favorites.includes(doc.metadata.name)}
+                updateFavorite={(isFavorite) => updateFavorite(isFavorite, doc.metadata.name)}
+              />
+            ))}
+          </Gallery>
+        );
+      }
+
+      const listViewClasses = classNames('odh-learning-paths__list-view', sizeClass);
+      return (
+        <div className={listViewClasses} aria-label="Simple data list example">
+          <LearningCenterListHeader />
+          {filteredDocApps.map((doc) => (
+            <OdhDocListItem
+              key={`${doc.metadata.name}`}
+              odhDoc={doc}
+              favorite={favorites.includes(doc.metadata.name)}
+              updateFavorite={(isFavorite) => updateFavorite(isFavorite, doc.metadata.name)}
+            />
+          ))}
+        </div>
+      );
+    };
+
+    return (
+      <>
+        <PageSection
+          isFilled={true}
+          variant={viewType === LIST_VIEW ? PageSectionVariants.light : PageSectionVariants.default}
+          className={
+            viewType === LIST_VIEW
+              ? 'odh-learning-paths__view-panel__list-view'
+              : 'odh-learning-paths__view-panel__card-view'
+          }
+        >
+          {renderContent()}
+        </PageSection>
+        <div ref={observe} />
+      </>
+    );
+  },
+);
+
+LearningCenterDataView.displayName = 'LearningCenterInner';
+
+export default LearningCenterDataView;

--- a/frontend/src/pages/learningCenter/LearningCenterFilters.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterFilters.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import { OdhDocument } from '../../types';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import { useQueryParams } from '../../utilities/useQueryParams';
 import { matchesCategories } from '../../utilities/utils';
 import CategoryFilters from './CategoryFilters';
@@ -10,16 +13,37 @@ import ApplicationFilters from './ApplicationFilters';
 
 type LearningCenterFilterProps = {
   docApps: OdhDocument[];
+  favorites: string[];
+  collapsible: boolean;
+  collapsed: boolean;
+  onCollapse: () => void;
 };
 
-const LearningCenterFilters: React.FC<LearningCenterFilterProps> = ({ docApps }) => {
+const LearningCenterFilters: React.FC<LearningCenterFilterProps> = ({
+  docApps,
+  favorites,
+  collapsible,
+  collapsed,
+  onCollapse,
+}) => {
   const queryParams = useQueryParams();
   const category = queryParams.get(CATEGORY_FILTER_KEY) || '';
-  const categoryApps = docApps.filter((odhDoc) => matchesCategories(odhDoc, category));
-
+  const categoryApps = docApps.filter((odhDoc) => matchesCategories(odhDoc, category, favorites));
+  const classes = classNames('odh-learning-paths__filter-panel', {
+    'm-is-collapsible': collapsible,
+    'm-is-collapsed': collapsed,
+  });
   return (
-    <div className="odh-learning-paths__filter-panel">
-      <CategoryFilters docApps={docApps} />
+    <div className={classes}>
+      <Button
+        className="odh-learning-paths__filter-panel__collapse-button"
+        variant={ButtonVariant.plain}
+        aria-label="Close filters"
+        onClick={onCollapse}
+      >
+        <TimesIcon />
+      </Button>
+      <CategoryFilters docApps={docApps} favorites={favorites} />
       <EnabledFilters categoryApps={categoryApps} />
       <DocTypeFilters categoryApps={categoryApps} />
       <ApplicationFilters docApps={docApps} categoryApps={categoryApps} />

--- a/frontend/src/pages/learningCenter/LearningCenterToolbar.scss
+++ b/frontend/src/pages/learningCenter/LearningCenterToolbar.scss
@@ -10,6 +10,9 @@
   &__view-filter {
     display: flex;
     justify-content: space-between;
+    .pf-c-button.pf-m-link {
+      margin-left: var(--pf-global--spacer--xs);
+    }
   }
   &__count {
     font-weight: var(--pf-global--FontWeight--bold);

--- a/frontend/src/pages/learningCenter/LearningCenterToolbar.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterToolbar.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { useHistory } from 'react-router';
 import {
+  Button,
+  ButtonVariant,
   SearchInput,
   Select,
   SelectOption,
@@ -10,10 +12,12 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   ThIcon,
   CheckIcon,
+  FilterIcon,
   ListIcon,
   PficonSortCommonAscIcon,
   PficonSortCommonDescIcon,
@@ -31,6 +35,10 @@ import {
   SORT_TYPE_DURATION,
   CARD_VIEW,
   LIST_VIEW,
+  CATEGORY_FILTER_KEY,
+  ENABLED_FILTER_KEY,
+  DOC_TYPE_FILTER_KEY,
+  APPLICATION_FILTER_KEY,
 } from './const';
 
 import './LearningCenterToolbar.scss';
@@ -41,6 +49,8 @@ type LearningCenterToolbarProps = {
   onSearchInputChange?: (value: string) => void;
   viewType: string;
   updateViewType: (updatedType: string) => void;
+  filtersCollapsible: boolean;
+  onToggleFiltersCollapsed: () => void;
 };
 
 const LearningCenterToolbar: React.FC<LearningCenterToolbarProps> = ({
@@ -48,11 +58,17 @@ const LearningCenterToolbar: React.FC<LearningCenterToolbarProps> = ({
   totalCount,
   viewType,
   updateViewType,
+  filtersCollapsible,
+  onToggleFiltersCollapsed,
 }) => {
   const history = useHistory();
   const [isSortTypeDropdownOpen, setIsSortTypeDropdownOpen] = React.useState(false);
   const [isSortOrderDropdownOpen, setIsSortOrderDropdownOpen] = React.useState(false);
   const queryParams = useQueryParams();
+  const categoryQuery = queryParams.get(CATEGORY_FILTER_KEY) || '';
+  const enabled = queryParams.get(ENABLED_FILTER_KEY);
+  const docTypes = queryParams.get(DOC_TYPE_FILTER_KEY);
+  const applications = queryParams.get(APPLICATION_FILTER_KEY);
   const searchQuery = queryParams.get(SEARCH_FILTER_KEY) || '';
   const [searchInputText, setSearchInputText] = React.useState(searchQuery);
   const sortType = queryParams.get(DOC_SORT_KEY) || SORT_TYPE_NAME;
@@ -127,10 +143,24 @@ const LearningCenterToolbar: React.FC<LearningCenterToolbarProps> = ({
     setSearchInputText(val);
   };
 
+  const isFiltered = categoryQuery || enabled || docTypes || applications;
+
   return (
     <Toolbar className="odh-learning-paths__toolbar">
       <div className="odh-learning-paths__toolbar__view-filter">
-        <span>All Items</span>
+        <span>
+          {categoryQuery || 'All Items'}
+          {filtersCollapsible ? (
+            <Tooltip content={isFiltered ? 'Filters set' : 'No filters set'}>
+              <Button
+                aria-label="Toggle filters shown"
+                variant={ButtonVariant.link}
+                icon={<FilterIcon />}
+                onClick={onToggleFiltersCollapsed}
+              />
+            </Tooltip>
+          ) : null}
+        </span>
         <ToggleGroup aria-label="View type">
           <ToggleGroupItem
             icon={<ThIcon />}

--- a/frontend/src/pages/learningCenter/const.ts
+++ b/frontend/src/pages/learningCenter/const.ts
@@ -1,5 +1,7 @@
 import { OdhDocumentType } from '../../types';
 
+export const FAVORITE_RESOURCES = 'ods.dashboard.resources.favorites';
+
 export const SEARCH_FILTER_KEY = 'keyword';
 export const DOC_TYPE_FILTER_KEY = 'type';
 export const CATEGORY_FILTER_KEY = 'category';

--- a/frontend/src/pages/learningCenter/useDocFilterer.ts
+++ b/frontend/src/pages/learningCenter/useDocFilterer.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useQueryParams } from '../../utilities/useQueryParams';
 import { OdhDocument } from '../../types';
+import { matchesCategories, matchesSearch } from '../../utilities/utils';
 import {
   APPLICATION_FILTER_KEY,
   CATEGORY_FILTER_KEY,
@@ -8,9 +9,10 @@ import {
   ENABLED_FILTER_KEY,
   SEARCH_FILTER_KEY,
 } from './const';
-import { matchesCategories, matchesSearch } from '../../utilities/utils';
 
-export const useDocFilterer = (): ((odhDocs: OdhDocument[]) => OdhDocument[]) => {
+export const useDocFilterer = (
+  favorites: string[],
+): ((odhDocs: OdhDocument[]) => OdhDocument[]) => {
   const queryParams = useQueryParams();
   const enabled = queryParams.get(ENABLED_FILTER_KEY);
   const docTypes = queryParams.get(DOC_TYPE_FILTER_KEY);
@@ -24,8 +26,8 @@ export const useDocFilterer = (): ((odhDocs: OdhDocument[]) => OdhDocument[]) =>
         .filter((odhDoc) => !enabled || enabled.includes(`${odhDoc.spec.appEnabled}`))
         .filter((odhDoc) => !docTypes || docTypes.includes(`${odhDoc.metadata.type}`))
         .filter((odhDoc) => !applications || applications.includes(`${odhDoc.spec.appDisplayName}`))
-        .filter((odhDoc) => matchesCategories(odhDoc, category))
+        .filter((odhDoc) => matchesCategories(odhDoc, category, favorites))
         .filter((odhDoc) => matchesSearch(odhDoc, searchQuery)),
-    [category, docTypes, enabled, applications, searchQuery],
+    [enabled, docTypes, applications, category, favorites, searchQuery],
   );
 };

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -103,7 +103,7 @@ export const matchesCategories = (
     return true;
   }
   if (category === 'Favorites') {
-    return favorites.includes(odhDoc.metadata.name) ?? false;
+    return favorites.includes(odhDoc.metadata.name);
   }
   return odhDoc.metadata.annotations?.[CATEGORY_ANNOTATION]?.includes(category) ?? false;
 };

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -94,9 +94,16 @@ export const combineCategoryAnnotations = (doc: OdhDocument, app: OdhApplication
   };
 };
 
-export const matchesCategories = (odhDoc: OdhDocument, category: string): boolean => {
+export const matchesCategories = (
+  odhDoc: OdhDocument,
+  category: string,
+  favorites: string[],
+): boolean => {
   if (!category) {
     return true;
+  }
+  if (category === 'Favorites') {
+    return favorites.includes(odhDoc.metadata.name) ?? false;
   }
   return odhDoc.metadata.annotations?.[CATEGORY_ANNOTATION]?.includes(category) ?? false;
 };


### PR DESCRIPTION
**Fixes**: 
At low resolution or when the nav is open and a quick start is open, the resources view gets too narrow to show much of the information for each resource.

**Analysis / Root cause**: 
The addition of the filter panel decreases the width used by the view to show the resources.

**Solution Description**: 
When the view width becomes narrow (under 600px) turn the filter panel into a slide out drawer controlled by a filter button in the header panel.

This PR also adds "Favorites" category.

**Screen shots / Gifs for design review**: 
![FilterDrawer](https://user-images.githubusercontent.com/11633780/122097895-2f019a00-cdde-11eb-8144-d6fa8e9a46f1.gif)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

/cc @kywalker-rh
