### PR TITLE
Fix to remove faux category which still was focusable/selectable

### DIFF
--- a/frontend/src/pages/learningCenter/CategoryFilters.tsx
+++ b/frontend/src/pages/learningCenter/CategoryFilters.tsx
@@ -13,7 +13,6 @@ type CategoryFiltersProps = {
 };
 
 const ALL_ITEMS = 'All Items';
-const SPACER = 'SPACER';
 
 const CategoryFilters: React.FC<CategoryFiltersProps> = ({ docApps, favorites }) => {
   const [categories, setCategories] = React.useState<string[]>([]);
@@ -39,7 +38,7 @@ const CategoryFilters: React.FC<CategoryFiltersProps> = ({ docApps, favorites })
         return acc;
       }, initCategories)
       .sort((a, b) => a.localeCompare(b));
-    setCategories([ALL_ITEMS, SPACER, ...updatedCategories]);
+    setCategories([ALL_ITEMS, ...updatedCategories]);
   }, [docApps, favorites]);
 
   const onSelectCategory = (selectedCategory: string): void => {
@@ -55,10 +54,11 @@ const CategoryFilters: React.FC<CategoryFiltersProps> = ({ docApps, favorites })
       {categories.map((category) => (
         <VerticalTabsTab
           key={category}
-          title={category === SPACER ? '' : category}
-          shown={category !== SPACER}
+          title={category}
+          shown
           active={category === categoryQuery || (!categoryQuery && category == ALL_ITEMS)}
           onActivate={() => onSelectCategory(category)}
+          tabIndex={-1}
         />
       ))}
     </VerticalTabs>

--- a/frontend/src/pages/learningCenter/LearningCenter.scss
+++ b/frontend/src/pages/learningCenter/LearningCenter.scss
@@ -25,6 +25,9 @@
     .vertical-tabs-pf-tab > a {
       font-size: var(--pf-global--FontSize--sm);
     }
+    .vertical-tabs-pf-tab:first-of-type {
+      margin-bottom: var(--pf-global--spacer--lg);
+    }
     .filter-panel-pf-category {
       padding-left: var(--pf-global--spacer--md);
       .filter-panel-pf-category-title {


### PR DESCRIPTION
**Fixes**: 
A faux category was added to space out the `All Items` category from the filtered categories. This category was still accessible via click or tab:
![image](https://user-images.githubusercontent.com/11633780/122271926-f92be680-cead-11eb-9875-84ee2e0b1a77.png)

**Analysis / Root cause**: 
The faux category was added based on an example. It was not noticed that this item was still clickable and focusable and could then be filtered on.

**Solution Description**: 
Remove the faux item and use a margin on the first item instead.
