### PR TITLE
Use notebook name for build status messages

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -28,8 +28,17 @@ export type K8sResourceCommon = {
     name?: string;
     namespace?: string;
     uid?: string;
+    labels?: { [key: string]: string };
   };
 };
+
+export type BuildKind = {
+  status: {
+    phase: string;
+    completionTimestamp: string;
+    startTimestamp: string;
+  };
+} & K8sResourceCommon;
 
 // Minimal type for routes
 export type RouteKind = {


### PR DESCRIPTION
**Fixes**: 
Build failure messages show the name of the build config when builds fail, this name is not what a user would expect to see.

**Analysis / Root cause**: 
There was no way to determine which notebook a build config was for.

**Solution Description**: 
Now that labels for the notebook name have been added to the notebook build configs (https://github.com/red-hat-data-services/odh-deployer/pull/114) use this notebook name for build status messages shown to the users when builds fail.

