### PR TITLE
Fix for path to feature flags file

### DIFF
--- a/backend/src/utils/features.ts
+++ b/backend/src/utils/features.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export const getComponentFeatureFlags = (): { [key: string]: string } => {
-  const normalizedPath = path.join(__dirname, '../../data/features.json');
+  const normalizedPath = path.join(__dirname, '../../../data/features.json');
   try {
     return JSON.parse(fs.readFileSync(normalizedPath, 'utf8'));
   } catch {


### PR DESCRIPTION
**Fixes**: 
Feature flags are not effective

**Analysis / Root cause**: 
The location of the `data` directory changes and the path to the `features.json` file was not updated

**Solution Description**: 
Fix the path to the `features.json` file.
