### PR TITLE
Don't show filter close button unless collapsible

### DIFF
--- a/frontend/src/pages/learningCenter/LearningCenterFilters.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterFilters.tsx
@@ -35,14 +35,16 @@ const LearningCenterFilters: React.FC<LearningCenterFilterProps> = ({
   });
   return (
     <div className={classes}>
-      <Button
-        className="odh-learning-paths__filter-panel__collapse-button"
-        variant={ButtonVariant.plain}
-        aria-label="Close filters"
-        onClick={onCollapse}
-      >
-        <TimesIcon />
-      </Button>
+      {collapsible ? (
+        <Button
+          className="odh-learning-paths__filter-panel__collapse-button"
+          variant={ButtonVariant.plain}
+          aria-label="Close filters"
+          onClick={onCollapse}
+        >
+          <TimesIcon />
+        </Button>
+      ) : null}
       <CategoryFilters docApps={docApps} favorites={favorites} />
       <EnabledFilters categoryApps={categoryApps} />
       <DocTypeFilters categoryApps={categoryApps} />


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-995

**Analysis / Root cause**: 
The close button for the filter panel is being shown when the filter panel is not collapsible. Its positioning causes it to show to the far right of the header panel.

**Solution Description**: 
Hide the button when the filter panel is not collapsible.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge