### PR TITLE
Fix to show accurate validation results on app enablement

### DIFF
--- a/backend/src/utils/resourceWatcher.ts
+++ b/backend/src/utils/resourceWatcher.ts
@@ -1,6 +1,6 @@
 import { KubeFastifyInstance } from '../types';
 
-export const DEFAULT_ACTIVE_TIMEOUT: number = 2 * 20 * 1000;
+export const DEFAULT_ACTIVE_TIMEOUT: number = 2 * 60 * 1000;
 export const DEFAULT_INACTIVE_TIMEOUT: number = 30 * 60 * 1000;
 
 export const ACTIVITY_TIMEOUT: number = 2 * 60 * 1000;


### PR DESCRIPTION
**Fixes**: 
Fixes https://issues.redhat.com/browse/RHODS-1019

**Analysis / Root cause**: 
The check for validity was checking the status of the job that runs the validation. That job is returning true regardless of the validation state, the results are put into the validation CM.

**Solution Description**: 
When the job complete successfully, check the validation CM for the result status

