### PR TITLE
Fix validation response messaging, increase timeout

### DIFF
--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -24,10 +24,10 @@ type EnableModalProps = {
 };
 
 const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, onClose }) => {
-  const [postError, setPostError] = React.useState<boolean>(false);
+  const [postError, setPostError] = React.useState<string>('');
   const [validationInProgress, setValidationInProgress] = React.useState<boolean>(false);
   const [enableValues, setEnableValues] = React.useState<{ [key: string]: string }>({});
-  const validationStatus = useEnableApplication(
+  const [validationStatus, validationErrorMessage] = useEnableApplication(
     validationInProgress,
     selectedApp.metadata.name,
     selectedApp.spec.displayName,
@@ -48,7 +48,7 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, onClose }) => {
   };
 
   const onDoEnableApp = () => {
-    setPostError(false);
+    setPostError('');
     setValidationInProgress(true);
   };
 
@@ -59,9 +59,9 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, onClose }) => {
     }
     if (validationInProgress && validationStatus === EnableApplicationStatus.FAILED) {
       setValidationInProgress(false);
-      setPostError(true);
+      setPostError(validationErrorMessage);
     }
-  }, [onClose, validationInProgress, validationStatus]);
+  }, [onClose, validationErrorMessage, validationInProgress, validationStatus]);
 
   return (
     <Modal
@@ -93,7 +93,7 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, onClose }) => {
               <Alert
                 variantLabel="error"
                 variant="danger"
-                title="Error attempting to validate. Please check your entries."
+                title={postError}
                 aria-live="polite"
                 isInline
               />

--- a/frontend/src/services/validateIsvService.ts
+++ b/frontend/src/services/validateIsvService.ts
@@ -4,7 +4,7 @@ import { getBackendURL } from '../utilities/utils';
 export const postValidateIsv = (
   appName: string,
   values: { [key: string]: string },
-): Promise<boolean> => {
+): Promise<{ valid: boolean; error: string }> => {
   const url = getBackendURL('/api/validate-isv');
   const searchParams = new URLSearchParams();
   if (appName) {


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1414

**Analysis / Root cause**: 
Anaconda CE key validation failed in the Dashboard but the tile is Enabled and image available in the spawner. Different failures are not communicated to the user.

**Solution Description**: 
Increase the timeout used for watching for the validation job results. Add messaging around each point of failure to communicate what caused the failure.
