### PR TITLE
Fix list view access label for tutorials, column widths.

### DIFF
--- a/frontend/src/components/OdhDocListItem.tsx
+++ b/frontend/src/components/OdhDocListItem.tsx
@@ -50,7 +50,7 @@ const OdhDocListItem: React.FC<OdhDocCardProps> = ({ odhDoc, favorite, updateFav
         title = 'View documentation';
         break;
       case OdhDocumentType.Tutorial:
-        title = 'View documentation';
+        title = 'Access tutorial';
         break;
       case OdhDocumentType.QuickStart:
         title = getQuickStartLabel(odhDoc.metadata.name, qsContext);

--- a/frontend/src/pages/learningCenter/LearningCenter.scss
+++ b/frontend/src/pages/learningCenter/LearningCenter.scss
@@ -59,7 +59,7 @@
     display: grid;
     column-gap: var(--pf-global--spacer--md);
     row-gap: var(--pf-global--spacer--md);
-    grid-template-columns: auto fit-content(50%) fit-content(20%) auto auto auto;
+    grid-template-columns: 20px fit-content(50%) fit-content(20%) 110px auto auto;
     &.m-odh-size-md {
       grid-template-columns: auto fit-content(50%) fit-content(20%) auto 0 auto;
       .odh-list-item__link {


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1078

**Analysis / Root cause**: 
The list item for tutorials had incorrect text for the access label. Column widths for the favorite and doc type were taking up too much space.

**Solution Description**: 
Fix the text for the tutorials access label to be consistent with the card view. Change the column widths from auto to a reasonable fixed width.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/126629198-3db9dc20-2079-4741-ac1e-e41ab535d0d5.png)
