### PR TITLE
Allow use of ConsoleLinks for route determination.

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -58,6 +58,13 @@ export type CSVKind = {
   };
 } & K8sResourceCommon;
 
+// Minimal type for ConsoleLinks
+export type ConsoleLinkKind = {
+  spec: {
+    href?: string;
+  };
+} & K8sResourceCommon;
+
 export type KfDefApplication = {
   kustomizeConfig: {
     repoRef: {
@@ -111,6 +118,7 @@ export type OdhApplication = {
     routeNamespace: string | null;
     routeSuffix: string | null;
     serviceName: string | null;
+    consoleLink: string | null;
     endpoint: string | null;
     link: string | null;
     img: string;

--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -1,12 +1,23 @@
 import { IncomingMessage } from 'http';
 import { V1ConfigMap } from '@kubernetes/client-node/dist/gen/model/v1ConfigMap';
 import { OdhApplication, K8sResourceCommon, KubeFastifyInstance, RouteKind } from '../types';
+import { getConsoleLinks, getServices } from './resourceUtils';
 
 type RoutesResponse = {
   body: {
     items: RouteKind[];
   };
   response: IncomingMessage;
+};
+
+export const getRouteForClusterId = (fastify: KubeFastifyInstance, route: string): string =>
+  route ? route.replace('<CLUSTER_ID/>', fastify.kube.clusterID) : route;
+
+const getEndPointForApp = (fastify: KubeFastifyInstance, app: OdhApplication): string => {
+  if (!app.spec.endpoint) {
+    return null;
+  }
+  return getRouteForClusterId(fastify, app.spec.endpoint);
 };
 
 const getURLForRoute = (route: RouteKind, routeSuffix: string): string => {
@@ -28,6 +39,9 @@ export const getLink = async (
 ): Promise<string> => {
   const customObjectsApi = fastify.kube.customObjectsApi;
   const routeNamespace = namespace || fastify.kube.namespace;
+  if (!routeName) {
+    return null;
+  }
   try {
     const route = await customObjectsApi
       .getNamespacedCustomObject('route.openshift.io', 'v1', routeNamespace, 'routes', routeName)
@@ -39,15 +53,24 @@ export const getLink = async (
   }
 };
 
+export const getConsoleLinkRoute = (appDef: OdhApplication): string => {
+  if (!appDef.spec.consoleLink) {
+    return null;
+  }
+  const consoleLinks = getConsoleLinks();
+  const consoleLink = consoleLinks.find((cl) => cl.metadata.name === appDef.spec.consoleLink);
+  return consoleLink ? consoleLink.spec.href : null;
+};
+
 export const getServiceLink = async (
   fastify: KubeFastifyInstance,
-  services: K8sResourceCommon[],
   serviceName: string,
   routeSuffix: string,
 ): Promise<string> => {
-  if (!services?.length || !serviceName) {
+  if (!serviceName) {
     return null;
   }
+  const services = getServices();
   const service = services.find((service) => service.metadata.name === serviceName);
   if (!service) {
     return null;
@@ -64,6 +87,46 @@ export const getServiceLink = async (
     fastify.log.error(`failed to get route in namespace ${namespace}`);
     return null;
   }
+};
+
+export const getRouteForApplication = async (
+  fastify: KubeFastifyInstance,
+  app: OdhApplication,
+  operatorCSV?: K8sResourceCommon,
+): Promise<string> => {
+  // Check for an Endpoint
+  let route = getEndPointForApp(fastify, app);
+  if (route) {
+    return route;
+  }
+
+  // Check for CSV route
+  route = await getLink(
+    fastify,
+    app.spec.route,
+    app.spec.routeNamespace || operatorCSV?.metadata.namespace,
+    app.spec.routeSuffix,
+  );
+  if (route) {
+    return route;
+  }
+
+  // Check for specified route
+  route = await getLink(fastify, app.spec.route);
+  if (route) {
+    return route;
+  }
+
+  // Check for console link
+  route = await getConsoleLinkRoute(app);
+  if (route) {
+    return route;
+  }
+
+  // Check for service based route
+  route = await getServiceLink(fastify, app.spec.serviceName, app.spec.routeSuffix);
+
+  return route;
 };
 
 export const getApplicationEnabledConfigMap = (


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-750
Jira: https://issues.redhat.com/browse/RHODS-245

**Analysis / Root cause**: 
To determine the route for some applications, we need to find the ConsoleLink associated with the application.
Other applications may need to specify an endpoint (full URL) for the route.

**Solution Description**: 
Allow the application to specify a ConsoleLink to use to find the URL from (the spec.href field).
Allow the application to specify an endpoint for the route.
Also, allow <CLUSTER_ID/> as a replaceable variable in endpoint routes and for getting started links.

