### PR TITLE
Add a dashboard config option to hide the support link

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -5,6 +5,7 @@ import { FastifyInstance } from 'fastify';
 export type DashboardConfig = {
   enablement: boolean;
   disableInfo: boolean;
+  disableSupport: boolean;
 };
 
 // Add a minimal QuickStart type here as there is no way to get types without pulling in frontend (React) modules

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -46,6 +46,7 @@ const DEFAULT_DASHBOARD_CONFIG: V1ConfigMap = {
   data: {
     enablement: 'true',
     disableInfo: 'false',
+    disableSupport: 'false',
   },
 };
 
@@ -297,6 +298,7 @@ export const getDashboardConfig = (): DashboardConfig => {
   return {
     enablement: (config.data?.enablement ?? '').toLowerCase() !== 'false',
     disableInfo: (config.data?.disableInfo ?? '').toLowerCase() === 'true',
+    disableSupport: (config.data?.disableSupport ?? '').toLowerCase() === 'true',
   };
 };
 

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -13,6 +13,7 @@ import {
 import { CaretDownIcon, ExternalLinkAltIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK } from '../utilities/const';
 import { AppNotification, State } from '../redux/types';
+import { useWatchDashboardConfig } from '../utilities/useWatchDashboardConfig';
 
 interface HeaderToolsProps {
   onNotificationsClick: () => void;
@@ -25,6 +26,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
     (state) => state.appState.notifications,
   );
   const userName: string = useSelector<State, string>((state) => state.appState.user || '');
+  const { dashboardConfig } = useWatchDashboardConfig();
 
   const newNotifications = React.useMemo(() => {
     return notifications.filter((notification) => !notification.read).length;
@@ -64,7 +66,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
       </DropdownItem>,
     );
   }
-  if (SUPPORT_LINK) {
+  if (SUPPORT_LINK && !dashboardConfig.disableSupport) {
     helpMenuItems.push(
       <DropdownItem
         key="support"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@
 export type DashboardConfig = {
   enablement: boolean;
   disableInfo: boolean;
+  disableSupport: boolean;
 };
 
 export type OdhApplication = {

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -4,6 +4,12 @@ import { POLL_INTERVAL } from './const';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { fetchDashboardConfig } from '../services/dashboardConfigService';
 
+const DEFAULT_CONFIG: DashboardConfig = {
+  enablement: true,
+  disableInfo: false,
+  disableSupport: false,
+};
+
 export const useWatchDashboardConfig = (): {
   dashboardConfig: DashboardConfig;
   loaded: boolean;
@@ -11,9 +17,7 @@ export const useWatchDashboardConfig = (): {
 } => {
   const [loaded, setLoaded] = React.useState<boolean>(false);
   const [loadError, setLoadError] = React.useState<Error>();
-  const [dashboardConfig, setDashboardConfig] = React.useState<DashboardConfig>({
-    enablement: true,
-  });
+  const [dashboardConfig, setDashboardConfig] = React.useState<DashboardConfig>(DEFAULT_CONFIG);
 
   React.useEffect(() => {
     let watchHandle;
@@ -21,6 +25,7 @@ export const useWatchDashboardConfig = (): {
     const watchDashboardConfig = () => {
       fetchDashboardConfig()
         .then((config) => {
+          console.dir(config);
           if (cancelled) {
             return;
           }
@@ -45,5 +50,5 @@ export const useWatchDashboardConfig = (): {
 
   const retConfig = useDeepCompareMemoize<DashboardConfig>(dashboardConfig);
 
-  return { dashboardConfig: retConfig || { enablement: true }, loaded, loadError };
+  return { dashboardConfig: retConfig || DEFAULT_CONFIG, loaded, loadError };
 };


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-987

**Analysis / Root cause**: 
There should be no support link for sandbox cluster

**Solution Description**: 
Check for a `odh-dashboard-config` config map in the current namespace. If it exists, check the `data.disableSupport` field for `true` to determine if we should prevent including the support link.
