### PR TITLE
Fix to quick start scrolling

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 APP_ENV=production
+FASTIFY_LOG_LEVEL=warn

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -66,7 +66,12 @@ html, body, #root {
       }
     }
   }
-
+  .pf-c-page__main {
+    height: 100%;
+  }
+  .pf-c-drawer__content {
+    overflow-y: auto;
+  }
   .pf-c-page__main-section {
     .pf-l-gallery {
       --pf-l-gallery--GridTemplateColumns--max-on-xl: 330px;

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -25,7 +25,6 @@ export const useWatchDashboardConfig = (): {
     const watchDashboardConfig = () => {
       fetchDashboardConfig()
         .then((config) => {
-          console.dir(config);
           if (cancelled) {
             return;
           }


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1669

**Analysis / Root cause**: 
The quick start drawer is sized to the height of the application page. If the page gets really long due to lots of tiles or a narrow width, the quick start also gets very long and the action buttons are shown at the very bottom of the drawer requiring the user to scroll to find them.

**Solution Description**: 
Size the quick start drawer to the window height so that the action buttons always remain visible w/o scrolling.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/129193650-b097198b-4b53-417f-a155-36b71ee25af2.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge