### PR TITLE
Update contrast for the un-favorited favorite icon.

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -47,11 +47,8 @@ html, body, #root {
   &__favorite {
     cursor: pointer;
     position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
     &__outer {
-      fill: var(--pf-global--disabled-color--200);
+      fill: var(--pf-global--disabled-color--100);
       .m-is-favorite & {
         fill: var(--pf-global--palette--gold-200);
       }
@@ -59,8 +56,10 @@ html, body, #root {
     &__inner {
       fill: var(--pf-global--BackgroundColor--100);
       position: absolute;
-      width: calc(1em - 2px);
-      height: calc(1em - 2px);
+      top: 5px;
+      left: 2px;
+      width: calc(1em - 4px);
+      height: calc(1em - 4px);
       .m-is-favorite & {
         fill: var(--pf-global--palette--gold-200);
       }


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1549

**Analysis / Root cause**: 
color of the non-selected favorite button does not provide enough contrast making it hard to see

**Solution Description**: 
Increase the darkness and double the border width of the button.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/130097091-89b348d9-7140-41be-86cc-992233273143.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
