### PR TITLE
Add documentation link on the Resources page

### DIFF
--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -17,7 +17,7 @@ import './ApplicationsPage.scss';
 
 type ApplicationsPageProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   loaded: boolean;
   empty: boolean;
   loadError?: Error;

--- a/frontend/src/pages/learningCenter/LearningCenter.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenter.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as _ from 'lodash';
 import useDimensions from 'react-cool-dimensions';
 import { QuickStartContext, QuickStartContextValues } from '@cloudmosaic/quickstarts';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { OdhDocument, OdhDocumentType } from '../../types';
 import { useWatchComponents } from '../../utilities/useWatchComponents';
 import { useWatchDocs } from '../../utilities/useWatchDocs';
@@ -25,12 +26,14 @@ import {
 import LearningCenterToolbar from './LearningCenterToolbar';
 import LearningCenterFilters from './LearningCenterFilters';
 import { useDocFilterer } from './useDocFilterer';
+import { DOC_LINK } from '../../utilities/const';
 import { combineCategoryAnnotations } from '../../utilities/utils';
 import LearningCenterDataView from './LearningCenterDataView';
 
 import './LearningCenter.scss';
 
 const description = `Access all learning resources for Open Data Hub and supported applications.`;
+const docText = ` To learn more about Open Data Hub, `;
 
 export const LearningCenter: React.FC = () => {
   const { docs: odhDocs, loaded: docsLoaded, loadError: docsLoadError } = useWatchDocs();
@@ -174,10 +177,30 @@ export const LearningCenter: React.FC = () => {
     [favoriteResources, setFavorites],
   );
 
+  const docLink = DOC_LINK ? (
+    <>
+      {docText}
+      <a
+        className="odh-dashboard__external-link"
+        href={DOC_LINK}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        view the documentation.
+        <ExternalLinkAltIcon />
+      </a>
+    </>
+  ) : null;
+
   return (
     <ApplicationsPage
       title="Resources"
-      description={description}
+      description={
+        <>
+          {description}
+          {docLink}
+        </>
+      }
       loaded={loaded && docsLoaded}
       loadError={loadError || docsLoadError}
       empty={false}


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1685

**Analysis / Root cause**: 
Users expect to documentation under Resources, multiple links entitled Documentation

**Solution Description**: 
Add a sentence and a link in the header of the Resources page to get the user to the dashboard documentation.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/130804180-6b9838e5-b258-4c64-aa80-cac2ec7bbdaa.png)

