### PR TITLE
Fix for ISV enablement failure due to unsuspend cronjob failure

### DIFF
--- a/backend/src/routes/api/validate-isv/validateISV.ts
+++ b/backend/src/routes/api/validate-isv/validateISV.ts
@@ -133,14 +133,20 @@ export const runValidation = async (
     });
   }
 
-  const updateCronJobSuspension = (suspend: boolean) => {
-    // Flag the cronjob as no longer suspended
-    cronJob.spec.suspend = suspend;
-    batchV1beta1Api.replaceNamespacedCronJob(cronjobName, namespace, cronJob).catch((e) => {
+  const updateCronJobSuspension = async (suspend: boolean) => {
+    try {
+      const updateCronJob = await batchV1beta1Api
+        .readNamespacedCronJob(cronjobName, namespace)
+        .then((res) => res.body);
+
+      // Flag the cronjob as no longer suspended
+      updateCronJob.spec.suspend = suspend;
+      await batchV1beta1Api.replaceNamespacedCronJob(cronjobName, namespace, updateCronJob);
+    } catch (e) {
       fastify.log.error(
         `failed to ${suspend ? 'suspend' : 'unsuspend'} cronjob: ${e.response.body.message}`,
       );
-    });
+    }
   };
 
   // Suspend the cron job


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1790

**Analysis / Root cause**: 
While the validation of the entries succeeded, the attempt to unsuspend the cronjob failed due to it having been updated (the previous suspension) throwing an exception which was then deemed as a validation failure.

**Solution Description**: 
Refetch the cronjob in order to unsuspend it properly.

