### PR TITLE
Allow markdown in beta text provided by applications.

### DIFF
--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -21,6 +21,7 @@ import { OdhApplication } from '../../types';
 import { useWatchDashboardConfig } from '../../utilities/useWatchDashboardConfig';
 import { useGettingStarted } from '../../utilities/useGettingStarted';
 import MarkdownView from '../../components/MarkdownView';
+import { markdownConverter } from '../../utilities/markdown';
 
 import './GetStartedPanel.scss';
 
@@ -143,7 +144,13 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
               aria-live="polite"
               isInline
             >
-              {selectedApp.spec.betaText || DEFAULT_BETA_TEXT}
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: markdownConverter.makeHtml(
+                    selectedApp.spec.betaText || DEFAULT_BETA_TEXT,
+                  ),
+                }}
+              />
             </Alert>
           ) : null}
           {renderMarkdownContents()}


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-2164

**Analysis / Root cause**: 
Applications may want to include links or other controls in the beta text shown in the info side panel in the explore page.

**Solution Description**: 
Place the text for the beta notification in a markdown viewer
