### PR TITLE
Added types for notebook image and REST end point stubs.

### DIFF
--- a/backend/src/routes/api/notebook/index.ts
+++ b/backend/src/routes/api/notebook/index.ts
@@ -1,0 +1,60 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import {
+  addNotebook,
+  deleteNotebook,
+  getNotebook,
+  getNotebooks,
+  updateNotebook,
+} from './notebooksUtils';
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return getNotebooks(fastify)
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
+
+  fastify.get('/:notebook', async (request: FastifyRequest, reply: FastifyReply) => {
+    return getNotebook(fastify, request)
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
+
+  fastify.delete('/:notebook', async (request: FastifyRequest, reply: FastifyReply) => {
+    return deleteNotebook(fastify, request)
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
+
+  fastify.put('/:notebook', async (request: FastifyRequest, reply: FastifyReply) => {
+    return updateNotebook(fastify, request)
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
+
+  fastify.post('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return addNotebook(fastify, request)
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
+};

--- a/backend/src/routes/api/notebook/notebooksUtils.ts
+++ b/backend/src/routes/api/notebook/notebooksUtils.ts
@@ -1,0 +1,86 @@
+import { FastifyRequest } from 'fastify';
+import { KubeFastifyInstance, Notebook } from '../../../types';
+
+export const getNotebooks = async (
+  fastify: KubeFastifyInstance,
+): Promise<{ notebooks: Notebook[]; error: string }> => {
+  const notebooks: Notebook[] = [];
+  // const coreV1Api = fastify.kube.coreV1Api;
+  // const namespace = fastify.kube.namespace;
+  try {
+    return { notebooks: notebooks, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error('Unable to retrieve notebook image(s): ' + e.toString());
+      return { notebooks: null, error: 'Unable to retrieve notebook image(s): ' + e.message };
+    }
+  }
+};
+
+export const getNotebook = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ notebooks: Notebook; error: string }> => {
+  const notebook: Notebook = {
+    name: '',
+    repo: '',
+  };
+  // const coreV1Api = fastify.kube.coreV1Api;
+  // const namespace = fastify.kube.namespace;
+  try {
+    return { notebooks: notebook, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error('Unable to retrieve notebook image(s): ' + e.toString());
+      return { notebooks: null, error: 'Unable to retrieve notebook image(s): ' + e.message };
+    }
+  }
+};
+
+export const addNotebook = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ success: boolean; error: string }> => {
+  // const coreV1Api = fastify.kube.coreV1Api;
+  // const namespace = fastify.kube.namespace;
+  try {
+    return { success: true, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error('Unable to add notebook image: ' + e.toString());
+      return { success: false, error: 'Unable to add notebook image: ' + e.message };
+    }
+  }
+};
+
+export const deleteNotebook = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ success: boolean; error: string }> => {
+  // const coreV1Api = fastify.kube.coreV1Api;
+  // const namespace = fastify.kube.namespace;
+  try {
+    return { success: true, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error('Unable to update notebook image: ' + e.toString());
+      return { success: false, error: 'Unable to update notebook image: ' + e.message };
+    }
+  }
+};
+
+export const updateNotebook = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ success: boolean; error: string }> => {
+  // const coreV1Api = fastify.kube.coreV1Api;
+  // const namespace = fastify.kube.namespace;
+  try {
+    return { success: true, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error('Unable to update notebook image: ' + e.toString());
+      return { success: false, error: 'Unable to update notebook image: ' + e.message };
+    }
+  }
+};

--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -6,10 +6,6 @@ type groupObjResponse = {
   users: string[];
 };
 
-type groupObjResponse = {
-  users: string[];
-};
-
 const status = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -219,3 +219,25 @@ export type BuildStatus = {
   status: BUILD_PHASE;
   timestamp?: string;
 };
+
+export enum NotebookStatus {
+  VALIDITING,
+  SUCCESS,
+  FAILED
+}
+
+export type Notebook = {
+  name: string;
+  repo: string;
+  description?: string;
+  status?: NotebookStatus;
+  user?: string;
+  uploaded?: Date;
+  visible?: boolean;
+  packages?: NotebookPackage[];
+}
+
+export type NotebookPackage = {
+  name: string;
+  version :string;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -106,3 +106,25 @@ export type BuildStatus = {
   status: BUILD_PHASE;
   timestamp: string;
 };
+
+export enum NotebookStatus {
+  VALIDITING,
+  SUCCESS,
+  FAILED,
+}
+
+export type Notebook = {
+  name: string;
+  repo: string;
+  description?: string;
+  status?: NotebookStatus;
+  user?: string;
+  uploaded?: Date;
+  visible?: boolean;
+  packages?: NotebookPackage[];
+};
+
+export type NotebookPackage = {
+  name: string;
+  version: string;
+};


### PR DESCRIPTION
Updated with REST api BYON notebook image endpoints and new notebook image types.

Here is a link to the BYON REST api:

https://studio-ws.apicur.io/sharing/f34aaaa8-58e0-48fb-b36f-1d91ac5ebf48

Relates to issue #140  and https://github.com/open-services-group/byon/issues/18