### PR TITLE
feat(byon): Allow python dependency visibility field changes

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -240,6 +240,7 @@ export type Notebook = {
   user?: string;
   uploaded?: Date;
   error?: NotebookError;
+  software?: NotebookPackage[];
 } & NotebookCreateRequest & NotebookUpdateRequest;
 
 export type NotebookCreateRequest = {
@@ -256,12 +257,12 @@ export type NotebookUpdateRequest = {
   description?: string;
   visible?: boolean;
   packages?: NotebookPackage[];
-  software?: NotebookPackage[];
 }
 
 export type NotebookPackage = {
   name: string;
   version: string;
+  visible: boolean;
 }
 
 


### PR DESCRIPTION
Part of: https://github.com/open-services-group/byon/issues/41

This allows for both full and partial upgrades of the `packages` list. This PR also disables patching of the `software` field.


Example:

```
PUT http://0.0.0.0:4000/api/notebook/{{id}}
Content-Type: application/json

{
    "id": "{{id}}",
    "packages": [{
          "name": "backports.functools-lru-cache",
          "version": "1.6.4",
          "visible": true
        }]
}
```

Changes visibility on the single package with matching name. If the package in the patch payload is not found, the change is simply ignored and request returns 200. Other packages, not mentioned in the patch payload are not affected.


