### PR TITLE
Add GET Images

### DIFF
--- a/backend/src/routes/api/images/index.ts
+++ b/backend/src/routes/api/images/index.ts
@@ -1,0 +1,15 @@
+import { KubeFastifyInstance } from '../../../types';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { listImageStreams } from './list';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return listImageStreams()
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
+};

--- a/backend/src/routes/api/images/list.ts
+++ b/backend/src/routes/api/images/list.ts
@@ -1,0 +1,6 @@
+import { ImageInfo } from '../../../types';
+import { getImageInfo } from '../../../utils/resourceUtils';
+
+export const listImageStreams = async (): Promise<ImageInfo[]> => {
+  return Promise.resolve(getImageInfo());
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -230,3 +230,83 @@ export type BuildStatus = {
   status: BUILD_PHASE;
   timestamp?: string;
 };
+
+export type ImageStreamTag = {
+  name: string;
+  labels?: { [key: string]: string };
+  annotations?: { [key: string]: string };
+  from: {
+    kind: string;
+    name: string;
+  };
+};
+
+export type ImageStreamStatusTagItem = {
+  created: string;
+  dockerImageReference: string;
+  image: string;
+  generation: number;
+};
+
+export type ImageStreamStatusTag = {
+  tag: string;
+  items: ImageStreamStatusTagItem[];
+};
+
+export type ImageStreamStatus = {
+  dockerImageRepository?: string;
+  publicDockerImageRepository?: string;
+  tags?: ImageStreamStatusTag[];
+};
+
+export type ImageStream = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    labels?: { [key: string]: string };
+    annotations?: { [key: string]: string };
+  };
+  spec: {
+    lookupPolicy?: {
+      local: boolean;
+    };
+    tags?: ImageStreamTag[];
+  };
+  status: ImageStreamStatus;
+};
+
+export type ImageStreamList = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: Record<string, unknown>;
+  items: ImageStream[];
+} & K8sResourceCommon;
+
+export type NameVersionPair = {
+  name: string;
+  version: string;
+};
+
+export type TagContent = {
+  software: NameVersionPair[];
+  dependencies: NameVersionPair[];
+};
+
+export type ImageTagInfo = {
+  name: string;
+  content: TagContent;
+  recommended: boolean;
+  default: boolean;
+};
+
+export type ImageInfo = {
+  name: string;
+  tags: ImageTagInfo[];
+  description?: string;
+  url?: string;
+  display_name?: string;
+  default?: boolean;
+  order?: number;
+};

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -8,3 +8,14 @@ export const APP_ENV = process.env.APP_ENV;
 
 export const yamlRegExp = /\.ya?ml$/;
 export const mdRegExp = /\.md$/;
+
+export const IMAGE_ANNOTATIONS = {
+  DESC: 'opendatahub.io/notebook-image-desc',
+  DISP_NAME: 'opendatahub.io/notebook-image-name',
+  URL: 'opendatahub.io/notebook-image-url',
+  DEFAULT: 'opendatahub.io/default-image',
+  SOFTWARE: 'opendatahub.io/notebook-software',
+  DEPENDENCIES: 'opendatahub.io/notebook-python-dependencies',
+  IMAGE_ORDER: 'opendatahub.io/notebook-image-order',
+  RECOMMENDED: 'opendatahub.io/notebook-image-recommended',
+};


### PR DESCRIPTION
Based on JSP Image API calls. Gets all the annotation information, and image information and sets it as a single JSON for the UI (which can then expect the same response as the JH Spawner UI expects from JSP API)

Work in progress:
Optional parameters not all set
Build status not checked

Part of: #148 and opendatahub-io/odh-dashboard#214
