### PR TITLE
fix(byon): Fix error message propagation

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -239,7 +239,7 @@ export type Notebook = {
   phase?: NotebookStatus;
   user?: string;
   uploaded?: Date;
-  error?: NotebookError;
+  error?: NotebookError[];
   software?: NotebookPackage[];
 } & NotebookCreateRequest & NotebookUpdateRequest;
 

--- a/frontend/src/pages/notebookImages/NotebookImagesTable.tsx
+++ b/frontend/src/pages/notebookImages/NotebookImagesTable.tsx
@@ -91,7 +91,15 @@ export const NotebookImagesTable: React.FC<NotebookImagesTableProps> = ({
           headerComponent="h1"
           bodyContent={
             <div>
-              {nb.error && nb.error.message ? nb.error?.message : 'An unknown error has occurred.'}
+              {nb.error?.length ? (
+                <ul>
+                  {nb.error.map((e) => (
+                    <li>{e.message}</li>
+                  ))}
+                </ul>
+              ) : (
+                'An unknown error has occurred.'
+              )}
             </div>
           }
         >

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -120,7 +120,7 @@ export type Notebook = {
   phase?: NotebookStatus;
   user?: string;
   uploaded?: Date;
-  error?: NotebookError;
+  error?: NotebookError[];
   software?: NotebookPackage[];
 } & NotebookCreateRequest &
   NotebookUpdateRequest;


### PR DESCRIPTION
I've noticed error messages are not propagating properly due to invalid schema - there can be more than one error, it's a list.

### Before
![image](https://user-images.githubusercontent.com/7453394/166683261-31d971bd-1241-4223-84b8-4a88f7b7bba2.png)

### After
![image](https://user-images.githubusercontent.com/7453394/166682993-a80b098f-4886-4c87-8229-be1a9966e9ed.png)
