### PR TITLE
Fix blank dashboard when a sub without status or installedCSV exists.

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -86,9 +86,9 @@ export type RouteKind = {
 
 // Minimal type for Subscriptions
 export type SubscriptionKind = {
-  status: {
-    installedCSV: string;
-    installPlanRef: {
+  status?: {
+    installedCSV?: string;
+    installPlanRef?: {
       namespace: string;
     };
   };

--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -169,9 +169,19 @@ const getCSVForApp = (
 
   const subscriptions = getSubscriptions();
   const appSubscription = subscriptions.find((sub) =>
-    sub.status.installedCSV.startsWith(app.spec.csvName),
+    sub.status?.installedCSV?.startsWith(app.spec.csvName),
   );
   if (!appSubscription) {
+    return Promise.resolve(undefined);
+  }
+
+  const appInstalledCSV = appSubscription.status?.installedCSV;
+  if (!appInstalledCSV) {
+    return Promise.resolve(undefined);
+  }
+
+  const namespace = appSubscription.status?.installPlanRef?.namespace;
+  if (!namespace) {
     return Promise.resolve(undefined);
   }
 
@@ -179,9 +189,9 @@ const getCSVForApp = (
     .getNamespacedCustomObject(
       'operators.coreos.com',
       'v1alpha1',
-      appSubscription.status.installPlanRef.namespace,
+      namespace,
       'clusterserviceversions',
-      appSubscription.status.installedCSV,
+      appInstalledCSV,
     )
     .then((response) => {
       const csv = response.body as CSVKind;


### PR DESCRIPTION
If there's any subscription on a cluster without status, status.installedCSV, or status.installPlanRef, all tiles on the enabled/explore tabs disappear.  To test you can create a bad subscription and restart the dashboard pods.

```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: bad-sub
  namespace: bad-sub
spec:
  channel: alpha
  installPlanApproval: Manual
  name: bad-sub
  source: redhat-operators
  sourceNamespace: openshift-marketplace
```