### PR TITLE
Add logic for dealing with new DashboardConfig CR and add sizes

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,4 @@ DOC_LINK ='https://opendatahub.io/docs.html'
 COMMUNITY_LINK ='https://opendatahub.io/community.html'
 ENABLED_APPS_CM = 'odh-enabled-applications-config'
 KUSTOMIZE_MANIFEST_DIR=manifests
+DASHBOARD_CONFIG = 'odh-dashboard-config'

--- a/backend/src/routes/api/config/configUtils.ts
+++ b/backend/src/routes/api/config/configUtils.ts
@@ -1,0 +1,24 @@
+import { PatchUtils } from '@kubernetes/client-node';
+import { KubeFastifyInstance, DashboardConfig } from '../../../types';
+
+export const setDashboardConfig = async (
+  fastify: KubeFastifyInstance,
+  request: any,
+): Promise<DashboardConfig> => {
+  const options = {
+    headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+  };
+  const response = await fastify.kube.customObjectsApi.patchNamespacedCustomObject(
+    'opendatahub.io',
+    'v1alpha',
+    fastify.kube.namespace,
+    'odhdashboardconfigs',
+    'odh-dashboard-config',
+    request,
+    undefined,
+    undefined,
+    undefined,
+    options,
+  );
+  return response.body as DashboardConfig;
+};

--- a/backend/src/routes/api/config/index.ts
+++ b/backend/src/routes/api/config/index.ts
@@ -1,9 +1,14 @@
 import { KubeFastifyInstance } from '../../../types';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { getDashboardConfig } from '../../../utils/resourceUtils';
+import { setDashboardConfig } from './configUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
     reply.send(getDashboardConfig());
+  });
+
+  fastify.patch('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    reply.send(setDashboardConfig(fastify, request.body));
   });
 };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -2,15 +2,59 @@ import k8s from '@kubernetes/client-node';
 import { User } from '@kubernetes/client-node/dist/config_types';
 import { FastifyInstance } from 'fastify';
 
-export type DashboardConfig = {
-  enablement: boolean;
-  disableInfo: boolean;
-  disableSupport: boolean;
-  disableClusterManager: boolean;
-  disableTracking: boolean;
-  disableBYONImageStream: boolean;
-  disableISVBadges: boolean;
-  disableAppLauncher: boolean;
+export type DashboardConfig = K8sResourceCommon & {
+  spec: {
+    dashboardConfig: {
+      enablement: boolean;
+      disableInfo: boolean;
+      disableSupport: boolean;
+      disableClusterManager: boolean;
+      disableTracking: boolean;
+      disableBYONImageStream: boolean;
+      disableISVBadges: boolean;
+      disableAppLauncher: boolean;
+    };
+    notebookSizes?: [
+      {
+        name: string;
+        resources: NotebookResources;
+      },
+    ];
+    notebookController?: {
+      enabled: boolean;
+      gpuConfig?: {
+        enabled: boolean;
+      };
+      envVarConfig?: {
+        enabled: boolean;
+      };
+    };
+    notebookControllerState?: [
+      {
+        user: string;
+        lastSelectedImage: string;
+        lastSelectedSize: string;
+        environmentVariables: EnvironmentVariable[];
+        secrets: string;
+      },
+    ];
+  };
+};
+
+export type NotebookResources = {
+  requests?: {
+    cpu?: string;
+    memory?: string;
+  };
+  limits: {
+    cpu?: string;
+    memory?: string;
+  };
+};
+
+export type EnvironmentVariable = {
+  name: string;
+  value: string;
 };
 
 export type ClusterSettings = {
@@ -242,22 +286,6 @@ export type BuildStatus = {
   name: string;
   status: BUILD_PHASE;
   timestamp?: string;
-};
-
-export type EnvironmentVariable = {
-  name: string;
-  value: string;
-};
-
-export type NotebookResources = {
-  requests: {
-    cpu?: string;
-    memory?: string;
-  };
-  limits?: {
-    cpu?: string;
-    memory?: string;
-  };
 };
 
 export type NotebookPort = {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import './dotenv';
+import { DashboardConfig } from '../types';
 
 export const PORT = process.env.PORT || process.env.BACKEND_PORT || 8080;
 export const IP = process.env.IP || '0.0.0.0';
@@ -18,4 +19,23 @@ export const IMAGE_ANNOTATIONS = {
   DEPENDENCIES: 'opendatahub.io/notebook-python-dependencies',
   IMAGE_ORDER: 'opendatahub.io/notebook-image-order',
   RECOMMENDED: 'opendatahub.io/notebook-image-recommended',
+};
+export const blankDashboardCR: DashboardConfig = {
+  apiVersion: 'opendatahub.io/v1alpha',
+  kind: 'OdhDashboardConfig',
+  metadata: {
+    name: 'odh-dashboard-config',
+  },
+  spec: {
+    dashboardConfig: {
+      enablement: true,
+      disableInfo: false,
+      disableSupport: false,
+      disableClusterManager: false,
+      disableTracking: false,
+      disableBYONImageStream: false,
+      disableISVBadges: false,
+      disableAppLauncher: false,
+    },
+  },
 };

--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -1,0 +1,115 @@
+# Dashboard Config
+
+The dashboard can be configured from its OdhDashboard CR, `odh-dashboard-config`.
+
+## Defaults
+
+In its default state the Dashboard config is in this form:
+
+```
+spec:
+  dashboardConfig:
+    disableBYONImageStream: false
+    disableClusterManager: false
+    disableISVBadges: false
+    disableInfo: false
+    disableSupport: false
+    disableTracking: false
+    disableAppLauncher: false
+    enablement: true
+```
+
+## Additional fields
+
+The Dashboard config enables adding additional configuration
+
+### Sizes
+
+The `notebookSizes` field of the config lists kubernetes style size descriptions. These are added to the dropdown shown when spawning notebooks with the notebook controller.
+
+Note: These sizes must follow conventions such as requests smaller than limits
+```
+notebookSizes:
+- name: XSmall
+    resources:
+    requests:
+        memory: 0.5Gi
+        cpu: '0.1'
+    limits:
+        memory: 2Gi
+        cpu: '0.1'
+```
+### Notebook controller
+
+The `notebookController` field controls the Notebook Controller options such as whether it is enabled in the dashboard and which parts should be visible.
+
+```
+notebookController:
+    enabled: true
+    envVarConfig:
+        enabled: true
+    gpuConfig:
+        enabled: true
+```
+
+### Notebook Controller State
+
+This field (`notebookControllerState`) controls the state of each user of the Notebook controller. This field is managed by the backend of the Dashboard and should not be manually modified.
+
+```
+notebookControllerState:
+- user: username
+    environmentVariables:
+    - key: foo
+        value: bar
+    lastSelectedImage: foo:bar
+    lastSelectedSize: XSmall
+    secrets: odh-secrets-username
+```
+
+## Example OdhDashboard Config
+```
+apiVersion: opendatahub.io/v1alpha
+kind: OdhDashboardConfig
+metadata:
+  name: odh-dashboard-config
+spec:
+  dashboardConfig:
+    disableBYONImageStream: false
+    disableClusterManager: false
+    disableISVBadges: false
+    disableInfo: false
+    disableSupport: false
+    disableTracking: false
+    disableAppLauncher: false
+    enablement: true
+  notebookController:
+    enabled: false
+  notebookSizes:
+  - name: Small
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: '1'
+      limits:
+        memory: 2Gi
+        cpu: '2'
+  - name: Medium
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: '2'
+      limits:
+        memory: 4Gi
+        cpu: '4'
+  - name: Large
+    resources:
+      requests:
+        memory: 4Gi
+        cpu: '4'
+      limits:
+        memory: 8Gi
+        cpu: '8'
+```
+
+

--- a/frontend/src/__tests__/ExploreApplications.spec.tsx
+++ b/frontend/src/__tests__/ExploreApplications.spec.tsx
@@ -10,8 +10,12 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 const dashboardConfig = {
-  disableInfo: false,
-  enablement: true,
+  spec: {
+    dashboardConfig: {
+      enablement: true,
+      disableInfo: true,
+    },
+  },
 };
 
 jest.mock('react-router-dom', () => {
@@ -64,8 +68,8 @@ window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
 describe('ExploreApplications', () => {
   beforeEach(() => {
-    dashboardConfig.disableInfo = false;
-    dashboardConfig.enablement = true;
+    dashboardConfig.spec.dashboardConfig.disableInfo = false;
+    dashboardConfig.spec.dashboardConfig.enablement = true;
   });
 
   it('should display available applications', () => {
@@ -149,7 +153,7 @@ describe('ExploreApplications', () => {
   });
 
   it('should disable the cards when disableInfo is set', async () => {
-    dashboardConfig.disableInfo = true;
+    dashboardConfig.spec.dashboardConfig.disableInfo = true;
     const user = userEvent.setup();
     render(
       <Provider store={store}>
@@ -169,7 +173,7 @@ describe('ExploreApplications', () => {
   });
 
   it('should hide the enable button when dashboard config enablement is false', async () => {
-    dashboardConfig.enablement = false;
+    dashboardConfig.spec.dashboardConfig.enablement = false;
     const user = userEvent.setup();
     const { container } = render(
       <Provider store={store}>

--- a/frontend/src/app/AppLauncher.tsx
+++ b/frontend/src/app/AppLauncher.tsx
@@ -69,7 +69,7 @@ const sectionSortValue = (section: Section): number => {
 };
 
 type AppLauncherProps = {
-  dashboardConfig: DashboardConfig;
+  dashboardConfig: any; // Changed to avoid creating new types.
 };
 
 const AppLauncher: React.FC<AppLauncherProps> = ({ dashboardConfig }) => {

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -27,7 +27,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
     (state) => state.appState.notifications,
   );
   const userName: string = useSelector<State, string>((state) => state.appState.user || '');
-  const { dashboardConfig } = useWatchDashboardConfig();
+  const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
 
   const newNotifications = React.useMemo(() => {
     return notifications.filter((notification) => !notification.read).length;

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -38,7 +38,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
     odhApp.metadata.name,
   );
   const disabled = !odhApp.spec.isEnabled;
-  const { dashboardConfig } = useWatchDashboardConfig();
+  const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
   const dispatch = useDispatch();
 
   const onToggle = (value) => {

--- a/frontend/src/components/OdhExploreCard.tsx
+++ b/frontend/src/components/OdhExploreCard.tsx
@@ -34,7 +34,7 @@ const OdhExploreCard: React.FC<OdhExploreCardProps> = ({
     'm-warning': odhApp.spec.category === 'Third party support',
     'm-hidden': odhApp.spec.category === ODH_PRODUCT_NAME,
   });
-  const { dashboardConfig } = useWatchDashboardConfig();
+  const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
 
   React.useEffect(() => {
     if (isSelected) {

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -60,7 +60,7 @@ const ClusterSettings: React.FC = () => {
   const [minute, setMinute] = React.useState<number>(0);
   const [isSettingsChanged, setSettingsChanged] = React.useState<boolean>(false);
   const pvcDefaultBtnRef = React.useRef<HTMLButtonElement>();
-  const { dashboardConfig } = useWatchDashboardConfig();
+  const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
   const dispatch = useDispatch();
 
   React.useEffect(() => {

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -36,7 +36,7 @@ type ExploreApplicationsInnerProps = {
 
 const ExploreApplicationsInner: React.FC<ExploreApplicationsInnerProps> = React.memo(
   ({ loaded, isEmpty, loadError, exploreComponents, selectedComponent, updateSelection }) => {
-    const { dashboardConfig } = useWatchDashboardConfig();
+    const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
     const bodyClasses = classNames('odh-explore-apps__body', {
       'm-side-panel-open': !!selectedComponent,
     });

--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -40,7 +40,7 @@ type GetStartedPanelProps = {
 const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose, onEnable }) => {
   const appName = selectedApp?.metadata.name;
   const { odhGettingStarted, loaded, loadError } = useGettingStarted(appName);
-  const { dashboardConfig } = useWatchDashboardConfig();
+  const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
   if (!selectedApp) {
     return null;
   }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,15 +2,59 @@
  * Common types, should be kept up to date with backend types
  */
 
-export type DashboardConfig = {
-  enablement: boolean;
-  disableInfo: boolean;
-  disableSupport: boolean;
-  disableClusterManager: boolean;
-  disableTracking: boolean;
-  disableBYONImageStream: boolean;
-  disableISVBadges: boolean;
-  disableAppLauncher: boolean;
+export type DashboardConfig = K8sResourceCommon & {
+  spec: {
+    dashboardConfig: {
+      enablement: boolean;
+      disableInfo: boolean;
+      disableSupport: boolean;
+      disableClusterManager: boolean;
+      disableTracking: boolean;
+      disableBYONImageStream: boolean;
+      disableISVBadges: boolean;
+      disableAppLauncher: boolean;
+    };
+    notebookSizes?: [
+      {
+        name: string;
+        resources: NotebookResources;
+      },
+    ];
+    notebookController?: {
+      enabled: boolean;
+      gpuConfig?: {
+        enabled: boolean;
+      };
+      envVarConfig?: {
+        enabled: boolean;
+      };
+    };
+    notebookControllerState?: [
+      {
+        user: string;
+        lastSelectedImage: string;
+        lastSelectedSize: string;
+        environmentVariables: EnvironmentVariable[];
+        secrets: string;
+      },
+    ];
+  };
+};
+
+export type NotebookResources = {
+  requests?: {
+    cpu?: string;
+    memory?: string;
+  };
+  limits: {
+    cpu?: string;
+    memory?: string;
+  };
+};
+
+export type EnvironmentVariable = {
+  key: string;
+  value: string;
 };
 
 export type ClusterSettings = {
@@ -121,7 +165,7 @@ export type K8sResourceCommon = {
   metadata: {
     name: string;
     namespace?: string;
-    uid: string;
+    uid?: string;
     labels?: { [key: string]: string };
     annotations?: { [key: string]: string };
   };
@@ -162,9 +206,73 @@ export type TrackingEventProperties = {
   term?: string;
 };
 
-export type ResponseStatus = {
-  success: boolean;
-  error: string;
+export type NotebookPort = {
+  name: string;
+  containerPort: number;
+  protocol: string;
+};
+
+export type NotebookContainer = {
+  name: string;
+  image: string;
+  imagePullPolicy?: string;
+  workingDir?: string;
+  env: EnvironmentVariable[];
+  ports?: NotebookPort[];
+  resources?: NotebookResources;
+  livenessProbe?: Record<string, unknown>;
+};
+
+export type Notebook = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    labels?: { [key: string]: string };
+    annotations?: { [key: string]: string };
+  };
+  spec: {
+    template: {
+      spec: {
+        containers: NotebookContainer[];
+      };
+    };
+  };
+  status?: Record<string, unknown>;
+} & K8sResourceCommon;
+
+export type NotebookList = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: Record<string, unknown>;
+  items: Notebook[];
+} & K8sResourceCommon;
+
+export type Route = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    annotations?: { [key: string]: string };
+  };
+  spec: {
+    host: string;
+    port: {
+      targetPort: string;
+    };
+    tls: {
+      insecureEdgeTerminationPolicy: string;
+      termination: string;
+    };
+    to: {
+      kind: string;
+      name: string;
+      weight: number;
+    };
+    wildcardPolicy: string;
+  };
 };
 
 export type BYONImageError = {
@@ -243,6 +351,11 @@ export type ImageStreamTag = {
     kind: string;
     name: string;
   };
+};
+
+export type ResponseStatus = {
+  success: boolean;
+  error: string;
 };
 
 export type ImageStreamStatusTagItem = {

--- a/frontend/src/utilities/NavData.ts
+++ b/frontend/src/utilities/NavData.ts
@@ -30,14 +30,14 @@ export const getNavBarData = (
 
   const enabledFeatures: NavDataItem[] = [];
 
-  if (!dashboardConfig.disableBYONImageStream)
+  if (!dashboardConfig.spec.dashboardConfig.disableBYONImageStream)
     enabledFeatures.push({
       id: 'settings-notebook-images',
       label: 'Notebook Images',
       href: '/notebookImages',
     });
 
-  if (!dashboardConfig.disableClusterManager)
+  if (!dashboardConfig.spec.dashboardConfig.disableClusterManager)
     enabledFeatures.push({
       id: 'settings-cluster-settings',
       label: 'Cluster settings',

--- a/frontend/src/utilities/useSegmentTracking.ts
+++ b/frontend/src/utilities/useSegmentTracking.ts
@@ -7,7 +7,7 @@ import { useWatchDashboardConfig } from './useWatchDashboardConfig';
 
 export const useSegmentTracking = (): void => {
   const { segmentKey, loaded, loadError } = useWatchSegmentKey();
-  const { dashboardConfig } = useWatchDashboardConfig();
+  const { dashboardConfig } = useWatchDashboardConfig().dashboardConfig.spec;
   const username = useSelector((state: RootState) => state.appState.user);
   const clusterID = useSelector((state: RootState) => state.appState.clusterID);
 

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -4,15 +4,24 @@ import { POLL_INTERVAL } from './const';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { fetchDashboardConfig } from '../services/dashboardConfigService';
 
-const DEFAULT_CONFIG: DashboardConfig = {
-  enablement: true,
-  disableInfo: false,
-  disableSupport: false,
-  disableClusterManager: true,
-  disableTracking: true,
-  disableISVBadges: true,
-  disableBYONImageStream: true,
-  disableAppLauncher: true,
+const blankDashboardCR: DashboardConfig = {
+  apiVersion: 'opendatahub.io/v1alpha',
+  kind: 'OdhDashboardConfig',
+  metadata: {
+    name: 'odh-dashboard-config',
+  },
+  spec: {
+    dashboardConfig: {
+      enablement: true,
+      disableInfo: false,
+      disableSupport: false,
+      disableClusterManager: false,
+      disableTracking: false,
+      disableBYONImageStream: false,
+      disableISVBadges: false,
+      disableAppLauncher: false,
+    },
+  },
 };
 
 export const useWatchDashboardConfig = (): {
@@ -22,7 +31,7 @@ export const useWatchDashboardConfig = (): {
 } => {
   const [loaded, setLoaded] = React.useState<boolean>(false);
   const [loadError, setLoadError] = React.useState<Error>();
-  const [dashboardConfig, setDashboardConfig] = React.useState<DashboardConfig>(DEFAULT_CONFIG);
+  const [dashboardConfig, setDashboardConfig] = React.useState<DashboardConfig>(blankDashboardCR);
 
   React.useEffect(() => {
     let watchHandle;
@@ -54,5 +63,5 @@ export const useWatchDashboardConfig = (): {
 
   const retConfig = useDeepCompareMemoize<DashboardConfig>(dashboardConfig);
 
-  return { dashboardConfig: retConfig || DEFAULT_CONFIG, loaded, loadError };
+  return { dashboardConfig: retConfig || blankDashboardCR, loaded, loadError };
 };

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
 - deployment.yaml
 - routes.yaml
 - service.yaml
+- odh-dashboard-crd.yaml
+- odh-dashboard-config.yaml
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard

--- a/manifests/base/odh-dashboard-config.yaml
+++ b/manifests/base/odh-dashboard-config.yaml
@@ -1,0 +1,41 @@
+apiVersion: opendatahub.io/v1alpha
+kind: OdhDashboardConfig
+metadata:
+  name: odh-dashboard-config
+spec:
+  dashboardConfig:
+    disableBYONImageStream: false
+    disableClusterManager: false
+    disableISVBadges: false
+    disableInfo: false
+    disableSupport: false
+    disableTracking: false
+    disableAppLauncher: false
+    enablement: true
+  notebookController:
+    enabled: false
+  notebookSizes:
+  - name: Small
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: '1'
+      limits:
+        memory: 2Gi
+        cpu: '2'
+  - name: Medium
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: '2'
+      limits:
+        memory: 4Gi
+        cpu: '4'
+  - name: Large
+    resources:
+      requests:
+        memory: 4Gi
+        cpu: '4'
+      limits:
+        memory: 8Gi
+        cpu: '8'

--- a/manifests/base/odh-dashboard-crd.yaml
+++ b/manifests/base/odh-dashboard-crd.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: odhdashboardconfigs.opendatahub.io
+spec:
+  group: opendatahub.io
+  scope: Namespaced
+  names:
+    plural: odhdashboardconfigs
+    singular: odhdashboardconfig
+    kind: OdhDashboardConfig
+  versions:
+    - name: v1alpha
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                dashboardConfig:
+                  type: object
+                  properties:
+                    enablement:
+                      type: boolean
+                    disableInfo:
+                      type: boolean
+                    disableSupport:
+                      type: boolean
+                    disableClusterManager:
+                      type: boolean
+                    disableTracking:
+                      type: boolean
+                    disableBYONImageStream:
+                      type: boolean
+                    disableISVBadges:
+                      type: boolean
+                notebookSizes:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - resources
+                    properties:
+                      name:
+                        type: string
+                      resources:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                notebookController:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    gpuConfig:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                    envVarConfig:
+                      type: object
+                      properties:
+                        enabled: 
+                          type: boolean
+                notebookControllerState:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      user: 
+                        type: string
+                      lastSelectedImage:
+                        type: string
+                      lastSelectedSize:
+                        type: string
+                      environmentVariables:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            value: 
+                              type: string
+                      secrets:
+                        type: string

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev": "run-p -l dev:*",
     "dev:backend": "cd ./backend && npm run start:dev",
     "dev:frontend": "cd ./frontend && npm run start:dev",
-    "format": "prettier --write \"backend/**/*.js\" \"frontend/**/*.ts\" \"frontend/**/*.tsx\"",
+    "format": "prettier --write \"backend/**/*.ts\" \"frontend/**/*.ts\" \"frontend/**/*.tsx\"",
     "make": "make",
     "make:build": "make build",
     "make:deploy": "make deploy",


### PR DESCRIPTION
The PR adds logic to use the OdhDashboard CR from here: https://github.com/opendatahub-io/odh-manifests/pull/561
The included calls are a GET call which read the CR, if it does not exist a default gets created. The read CR is also merged with the default CR to avoid problems with incomplete configs.

There is also a PATCH call which can later be user by the admin UI to change cluster settings and add notebook sizes to the notebook controller dropdown.

Usage of the CR is documented in the docs folder.

Resolves https://github.com/opendatahub-io/odh-dashboard/issues/159