### PR TITLE
Convert to Dockerfile build for dashboard image

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,7 @@
 
 ############### Default settings ###############
 BACKEND_PORT=8080
-CONTAINER_BUILDER=docker
-IMAGE_REPOSITORY=quay.io/opendatahub/odh-dashboard:latest
+IMAGE_REPOSITORY=quay.io/opendatahub/odh-dashboard:dev
 SOURCE_REPOSITORY_URL=git@github.com:opendatahub-io/odh-dashboard.git
 SOURCE_REPOSITORY_REF=master
 DOC_LINK ='https://opendatahub.io/docs.html'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Build arguments
+ARG SOURCE_CODE=.
+
+# Use ubi8/nodejs-14 as default base image
+ARG BASE_IMAGE="registry.access.redhat.com/ubi8/nodejs-14:latest"
+
+
+FROM ${BASE_IMAGE}
+
+## Build args to be used at this step
+ARG SOURCE_CODE
+
+LABEL io.opendatahub.component="odh-dashboard" \
+      io.k8s.display-name="odh-dashboard" \
+      name="open-data-hub/odh-dashboard-ubi8" \
+      summary="odh-dashboard" \
+      description="Open Data Hub Dashboard"
+
+
+## Switch to root as required for some operations
+USER root
+
+## Install additional packages. Headers needed by node-gyp and node-sass,
+## the version of node-gyp (3.8.0) requires python 2 and update nodejs-nodemon
+## for vulnerability
+RUN dnf module install -y nodejs:14/development && \
+    dnf install -y python2 && \
+    dnf clean all && rm -rf /var/cache/yum
+
+## Copying in source code
+RUN mkdir /tmp/src && chown -R 1001:0 /tmp/src
+COPY --chown=default:root ${SOURCE_CODE} /tmp/src
+
+## For npm context. The assemble script will "mv /tmp/src/* /opt/app-root/src"
+#@ but that won't pick up .* files at the root
+COPY ${SOURCE_CODE}/.npmrc /opt/app-root/src/
+
+# Change file ownership to the assemble user
+USER default
+
+## Build dashboard using NPM
+ENV NPM_CONFIG_NODEDIR=/usr
+RUN /usr/libexec/s2i/assemble
+
+CMD /usr/libexec/s2i/run
+
+

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ include ${ENV_FILE}
 export $(shell sed 's/=.*//' ${ENV_FILE})
 endif
 
+CONTAINER_BUILDER=podman
+CONTAINER_DOCKERFILE=Dockerfile
+
 ##################################
 
 # DEV Convenience
@@ -22,7 +25,8 @@ reinstall: build push undeploy deploy
 
 .PHONY: build
 build:
-	./install/build.sh
+	echo "Building ${IMAGE_REPOSITORY} from ${CONTAINER_DOCKERFILE}"
+	${CONTAINER_BUILDER} build -f ${CONTAINER_DOCKERFILE} -t ${IMAGE_REPOSITORY} .
 
 ##################################
 
@@ -30,7 +34,8 @@ build:
 
 .PHONY: push
 push:
-	./install/push.sh
+	echo "Pushing ${IMAGE_REPOSITORY}"
+	${CONTAINER_BUILDER} push ${IMAGE_REPOSITORY}
 
 ##################################
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A dashboard for Open Data Hub components.
 
 ## Requirements
 Before developing for ODH, the basic requirements:
-* Your system needs to be running [NodeJS version 12+ and NPM](https://nodejs.org/)
+* Your system needs to be running [NodeJS version 14 and NPM](https://nodejs.org/)
   
 ### Additional tooling requirements
 * [OpenShift CLI, the "oc" command](https://docs.openshift.com/enterprise/3.2/cli_reference/get_started_cli.html#installing-the-cli)
-* [s2i](https://github.com/openshift/source-to-image)
+* [podman](https://github.com/containers/podman)
 * [Quay.io](https://quay.io/)
 
 ## Development

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Before developing you'll need to install:
 * [NodeJS and NPM](https://nodejs.org/)
 * [OpenShift CLI](https://docs.openshift.com/enterprise/3.2/cli_reference/get_started_cli.html#installing-the-cli)
 * [kustomize](https://github.com/kubernetes-sigs/kustomize)
-* [s2i](https://github.com/openshift/source-to-image)
+* [podman](https://github.com/containers/podman)
 * and have access to [Quay.io](https://quay.io/)
 
 ## Writing code
@@ -110,7 +110,6 @@ $ npm run make:undeploy
 Customize `.env.local` file to image and source information as desired. `npm` and the `s2i` command line tool is required.
 
 ```.env.local
-CONTAINER_BUILDER=docker
 IMAGE_REPOSITORY=quay.io/my-org/odh-dashboard:latest
 SOURCE_REPOSITORY_URL=git@github.com:my-org/odh-dashboard.git
 SOURCE_REPOSITORY_REF=my-branch

--- a/install/build.sh
+++ b/install/build.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-printf "\n\n######## build ########\n"
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-echo "Building ${IMAGE_REPOSITORY} from ${SOURCE_REPOSITORY_URL} on ${SOURCE_REPOSITORY_REF}"
-
-s2i build ${SOURCE_REPOSITORY_URL} --ref ${SOURCE_REPOSITORY_REF} --context-dir / registry.access.redhat.com/ubi8/nodejs-14 ${IMAGE_REPOSITORY}

--- a/install/push.sh
+++ b/install/push.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-printf "\n\n######## push ########\n"
-
-echo "Pushing ${IMAGE_REPOSITORY}"
-${CONTAINER_BUILDER} push ${IMAGE_REPOSITORY}


### PR DESCRIPTION
The replaces the container s2i build with a Dockerfile.  Going forward we can use this to support CI builds of the Dashboard image

TEST Steps:
1. Run `make build` to build the image using `podman`
1. Run `make push` to push the image to the `IMAGE_REPOSITORY` specified in `.env.local` file
1. Run `make deploy` to deploy the odh-dashboard deployment to your OpenShift cluster

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>