### PR TITLE
Fix quotes

### DIFF
--- a/backend/src/routes/api/status/statusUtils.ts
+++ b/backend/src/routes/api/status/statusUtils.ts
@@ -33,7 +33,7 @@ export const status = async (
 
     if (adminGroup === SYSTEM_AUTHENTICATED || adminGroup === '') {
       throw new Error(
-        'It is not allowed to set "system:authenticated" or an empty string as admin group.',
+        'It is not allowed to set system:authenticated or an empty string as admin group.',
       );
     } else {
       const adminUsers = await getGroup(customObjectsApi, adminGroup);


### PR DESCRIPTION
## Changes proposed in this pull request

Add the ability to have system:authenticated as a group option
Refactor log error to add more info:

``` bash
Error: It is not allowed to set system:authenticated or an empty string as admin group.
Error: Failed to retrieve Group fakegroup, might not exist.
Error: Failed to retrieve ConfigMap fake-groups-config-jupyterhub, might be malformed or doesn't exist.
Error: Failed to retrieve ConfigMap groups-config, might be malformed or doesn't exist.
```

## Kfdef

```yaml
kind: KfDef
apiVersion: kfdef.apps.kubeflow.org/v1
metadata:
  name: opendatahub
  namespace: opendatahub
spec:
  applications:
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-common
      name: odh-common
    - kustomizeConfig:
        parameters:
          - name: s3_endpoint_url
            value: s3.odh.com
        repoRef:
          name: manifests
          path: jupyterhub/jupyterhub
      name: jupyterhub
    - kustomizeConfig:
        overlays:
          - additional
        repoRef:
          name: manifests
          path: jupyterhub/notebook-images
      name: notebook-images
    - kustomizeConfig:
        overlays:
          - authentication
        repoRef:
          name: dashboard
          path: manifests
      name: odh-dashboard
  repos:
    - name: kf-manifests
      uri: >-
        https://github.com/opendatahub-io/manifests/tarball/v1.4.0-rc.2-openshift
    - name: manifests
      uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v1.2'
    - name: dashboard
      uri: 'https://github.com/lucferbux/odh-dashboard/tarball/fix_admin_groups'

```

## Test instructions (required)

Run a new instance of ODH
Stop the operator to be able to edit de configmap
Change the value of jupyterhub-default-groups-config Configmap to admin_groups: 'system:authenticated'
Check the logs to see a new error: `Error, it is not allowed to set "system:authenticated" as admin group : failed to get admin user`

