### PR TITLE
show correct getting-started title for jupyterhub

### DIFF
--- a/data/getting-started/jupyterhub.md
+++ b/data/getting-started/jupyterhub.md
@@ -1,4 +1,4 @@
-# Quickstart
+# JupyterHub
 
 ## Prerequisites
 


### PR DESCRIPTION
JIRA issue: https://issues.redhat.com/browse/RHODS-2739
Just change the title of this getting-started YAML file.