### PR TITLE
Update manifests for deploying latest dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Run the tests.
 
 For in-depth testing guidance review the [contribution guidelines](./docs/CONTRIBUTING.md#Testing)
 
+## Deploying the ODH Dashbard using a kfdef
+The [manifests](./manifests) folder contains a [kustomize](https://kustomize.io) manifest that can be used with `kustomize build` or included as a `kustomizeConfig` in a `kfdef` format that is supported by the ODH operator. An example kfdef to deploy ODH Dashboard with the Notebook Controller backend is located in [odh-dashboard-kfnbc-test.yaml](manifests/kfdef/odh-dashboard-kfnbc-test.yaml)
+
 ## Contributing
 Contributing encompasses [repository specific requirements](./docs/CONTRIBUTING.md)
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -13,7 +13,6 @@ export type DashboardConfig = K8sResourceCommon & {
       disableBYONImageStream: boolean;
       disableISVBadges: boolean;
       disableAppLauncher: boolean;
-      disableUserManagement: boolean;
     };
     notebookSizes?: NotebookSize[];
     notebookController?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -36,7 +36,6 @@ export const blankDashboardCR: DashboardConfig = {
       disableBYONImageStream: false,
       disableISVBadges: false,
       disableAppLauncher: false,
-      disableUserManagement: false,
     },
   },
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -28,7 +28,6 @@ export type DashboardCommonConfig = {
   disableBYONImageStream: boolean;
   disableISVBadges: boolean;
   disableAppLauncher: boolean;
-  disableUserManagement: boolean;
 };
 
 export type NotebookControllerUserState = {

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -20,7 +20,6 @@ const blankDashboardCR: DashboardConfig = {
       disableBYONImageStream: false,
       disableISVBadges: false,
       disableAppLauncher: false,
-      disableUserManagement: false,
     },
   },
 };

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -27,17 +27,17 @@ spec:
       serviceAccount: odh-dashboard
       containers:
       - name: odh-dashboard
-        image: odh-dashboard    # Replaced by the kustomize images parameter
+        image: odh-dashboard
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
         resources:
           requests:
-            cpu: 300m
-            memory: 500Mi
-          limits:
             cpu: 500m
             memory: 1Gi
+          limits:
+            cpu: 1000m
+            memory: 2Gi
         livenessProbe:
           httpGet:
             path: /api/status

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
-namespace: odh-dashboard
 resources:
+- odh-dashboard-crd.yaml
 - role.yaml
 - cluster-role.yaml
 - service-account.yaml
@@ -13,9 +13,7 @@ resources:
 - deployment.yaml
 - routes.yaml
 - service.yaml
-- odh-dashboard-crd.yaml
-- odh-dashboard-config.yaml
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard
-  newTag: v1.0
+  newTag: latest

--- a/manifests/base/odh-dashboard-config.yaml
+++ b/manifests/base/odh-dashboard-config.yaml
@@ -11,7 +11,6 @@ spec:
     disableSupport: false
     disableTracking: false
     disableAppLauncher: false
-    disableUserManagement: false
     enablement: true
   notebookController:
     enabled: false

--- a/manifests/base/odh-dashboard-crd.yaml
+++ b/manifests/base/odh-dashboard-crd.yaml
@@ -37,8 +37,6 @@ spec:
                       type: boolean
                     disableISVBadges:
                       type: boolean
-                    disableUserManagement:
-                      type: boolean
                 notebookSizes:
                   type: array
                   items:

--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -31,6 +31,7 @@ rules:
       - watch
     resources:
       - configmaps
+      - persistentvolumeclaims
       - secrets
   - apiGroups:
       - batch
@@ -89,3 +90,27 @@ rules:
     resources:
       - deploymentconfigs
       - deploymentconfigs/instantiate
+  - apiGroups:
+      - opendatahub.io
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    resources:
+      - odhdashboardconfigs
+  - apiGroups:
+      - kubeflow.org
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    resources:
+      - notebooks

--- a/manifests/base/service-account.yaml
+++ b/manifests/base/service-account.yaml
@@ -2,6 +2,3 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: odh-dashboard
-  # Manually specifying the namespace will force kustomize to transform the
-  #  namespace for all Cluster)RoleBindings referencing this ServiceAccount
-  namespace: odh-dashboard

--- a/manifests/kfdef/odh-dashboard-kfnbc-test.yaml
+++ b/manifests/kfdef/odh-dashboard-kfnbc-test.yaml
@@ -1,0 +1,35 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: odh-dashboard-kfnbc-test
+  namespace: opendatahub
+spec:
+  applications:
+  - kustomizeConfig:
+    # We just need this for creating the ODH default notebook images that are provided by ODH JupyterHub
+    #TODO: Replace with the new ODH default notebook images as part of ODH Core
+      overlays:
+      - additional
+      repoRef:
+        name: manifests
+        path: jupyterhub/notebook-images
+    name: notebook-images
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-notebook-controller
+    name: odh-notebook-controller
+  - kustomizeConfig:
+      overlays:
+      - authentication
+      repoRef:
+        name: manifests-dashboard  # Use the odh-dashboard repo as the source for this kustomize manifest
+        path: manifests
+    name: odh-dashboard
+  repos:
+  - name: manifests
+    uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
+  - name: manifests-dashboard  # Use the manifests from the odh-dashboard repo
+    uri: https://github.com/opendatahub-io/odh-dashboard/tarball/main

--- a/manifests/overlays/authentication/deployment.yaml
+++ b/manifests/overlays/authentication/deployment.yaml
@@ -12,7 +12,7 @@
       - --cookie-secret=SECRET
       - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "odh-dashboard"}}'
       - --skip-auth-regex=^/metrics
-    image: oauth-proxy    # Replaced by the kustomize images parameter
+    image: oauth-proxy
     ports:
       - containerPort: 8443
         name: https

--- a/manifests/overlays/authentication/kustomization.yaml
+++ b/manifests/overlays/authentication/kustomization.yaml
@@ -1,31 +1,32 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+  - ../../base
 resources:
-- ../../base
-- clusterrolebinding.yaml
+  - clusterrolebinding.yaml
 patchesJson6902:
-- path: deployment.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: odh-dashboard
-    version: v1
-- path: service-account.yaml
-  target:
-    kind: ServiceAccount
-    name: odh-dashboard
-    version: v1
-- path: service.yaml
-  target:
-    kind: Service
-    name: odh-dashboard
-    version: v1
-- path: route.yaml
-  target:
-    group: route.openshift.io
-    kind: Route
-    name: odh-dashboard
-    version: v1
+  - path: deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: odh-dashboard
+  - path: service-account.yaml
+    target:
+      kind: ServiceAccount
+      version: v1
+      name: odh-dashboard
+  - path: service.yaml
+    target:
+      kind: Service
+      version: v1
+      name: odh-dashboard
+  - target:
+      group: route.openshift.io
+      version: v1
+      kind: Route
+      name: odh-dashboard
+    path: route.yaml
 images:
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy


### PR DESCRIPTION
* Update dashboard manifest to pull :latest imageTag
* Add ODHDashboardConfig CRD to base manifests
* Add updates for odh-manifests for ODH 1.3 release

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

This should bring the `manifests` repo current with the latest configs for the dashboard and support deployment via the ODH `kfdef` using the example kfdef in the `manifests/kfdef`

Since this does not include any JH configMaps, you will need to add a groups-config manually

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: groups-config
data:
  groups-config: odh-dashboard-groups-config
---
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app: jupyterhub
  name: odh-dashboard-groups-config
data:
  admin_groups: "odh-jupyterhub-admins"
  allowed_groups: "system:authenticated"
```
