### PR TITLE
Remove secret from notebookControllerState, fix modal close bug

### DIFF
--- a/backend/src/routes/api/config/configUtils.ts
+++ b/backend/src/routes/api/config/configUtils.ts
@@ -1,7 +1,6 @@
 import { PatchUtils } from '@kubernetes/client-node';
-import { updateDashboardConfig } from '../../../utils/resourceUtils';
+import { getDashboardConfig, updateDashboardConfig } from '../../../utils/resourceUtils';
 import { KubeFastifyInstance, DashboardConfig } from '../../../types';
-import { FastifyRequest } from 'fastify';
 
 export const setDashboardConfig = async (
   fastify: KubeFastifyInstance,
@@ -10,7 +9,7 @@ export const setDashboardConfig = async (
   const options = {
     headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
   };
-  const response = await fastify.kube.customObjectsApi.patchNamespacedCustomObject(
+  await fastify.kube.customObjectsApi.patchNamespacedCustomObject(
     'opendatahub.io',
     'v1alpha',
     fastify.kube.namespace,
@@ -23,5 +22,5 @@ export const setDashboardConfig = async (
     options,
   );
   await updateDashboardConfig();
-  return response.body as DashboardConfig;
+  return getDashboardConfig();
 };

--- a/backend/src/routes/api/notebooks/notebookUtils.ts
+++ b/backend/src/routes/api/notebooks/notebookUtils.ts
@@ -74,10 +74,7 @@ export const postNotebook = async (
   if (!notebookContainers[0]) {
     console.error('No containers found in posted notebook');
   }
-  notebookContainers[0].env.push(
-    { name: 'JUPYTER_NOTEBOOK_PORT', value: '8888' },
-    { name: 'NOTEBOOK_ARGS', value: "--NotebookApp.token='' --NotebookApp.password=''" },
-  );
+  notebookContainers[0].env.push({ name: 'JUPYTER_NOTEBOOK_PORT', value: '8888' });
   notebookContainers[0].imagePullPolicy = 'Always';
   notebookContainers[0].workingDir = '/opt/app-root/src';
 

--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash-es';
 import { Button, ActionList, ActionListItem } from '@patternfly/react-core';
 import ApplicationsPage from '../ApplicationsPage';
 import SpawnerPage from './SpawnerPage';
@@ -17,7 +16,6 @@ import NotebookControllerContext from './NotebookControllerContext';
 import StartServerModal from './StartServerModal';
 import { patchDashboardConfig } from '../../services/dashboardConfigService';
 import { NotebookControllerUserState } from '../../types';
-import { EMPTY_USER_STATE } from './const';
 
 export const NotebookController: React.FC = React.memo(() => {
   const { setIsNavOpen } = React.useContext(AppContext);
@@ -40,7 +38,6 @@ export const NotebookController: React.FC = React.memo(() => {
   );
 
   const [startShown, setStartShown] = React.useState<boolean>(false);
-  const [userState, setUserState] = React.useState<NotebookControllerUserState>(EMPTY_USER_STATE);
 
   React.useEffect(() => {
     const checkUserState = async () => {
@@ -62,16 +59,11 @@ export const NotebookController: React.FC = React.memo(() => {
             },
           };
           await patchDashboardConfig(patch);
-          setUserState(newUserState);
-        } else {
-          if (!_.isEqual(userState, fetchedUserState)) {
-            setUserState(fetchedUserState);
-          }
         }
       }
     };
     checkUserState().catch((e) => console.error(e));
-  }, [username, dashboardConfig, namespace, userState]);
+  }, [username, dashboardConfig, namespace]);
 
   React.useEffect(() => {
     setNotebookPollInterval(startShown ? FAST_POLL_INTERVAL : POLL_INTERVAL);
@@ -96,7 +88,6 @@ export const NotebookController: React.FC = React.memo(() => {
         notebook,
         isNotebookRunning,
         projectName,
-        userState,
       }}
     >
       <ApplicationsPage

--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -11,16 +11,12 @@ import { useWatchNotebook } from 'utilities/useWatchNotebook';
 import { deleteNotebook } from '../../services/notebookService';
 import { useSelector } from 'react-redux';
 import { State } from 'redux/types';
-import {
-  generateNotebookNameFromUsername,
-  generateSecretNameFromUsername,
-} from '../../utilities/utils';
+import { generateNotebookNameFromUsername } from '../../utilities/utils';
 import { FAST_POLL_INTERVAL, ODH_NOTEBOOK_REPO, POLL_INTERVAL } from '../../utilities/const';
 import NotebookControllerContext from './NotebookControllerContext';
 import StartServerModal from './StartServerModal';
 import { patchDashboardConfig } from '../../services/dashboardConfigService';
-import { NotebookControllerUserState, Secret } from '../../types';
-import { createSecret, getSecret } from '../../services/secretsService';
+import { NotebookControllerUserState } from '../../types';
 import { EMPTY_USER_STATE } from './const';
 
 export const NotebookController: React.FC = React.memo(() => {
@@ -51,27 +47,12 @@ export const NotebookController: React.FC = React.memo(() => {
       if (username && dashboardConfig.spec.notebookController) {
         const notebookControllerState = dashboardConfig.spec.notebookControllerState;
         const fetchedUserState = notebookControllerState?.find((state) => state.user === username);
-        const secretName = generateSecretNameFromUsername(username);
-        const secret = await getSecret(secretName);
-        if (!secret) {
-          const newSecret: Secret = {
-            apiVersion: 'v1',
-            metadata: {
-              name: secretName,
-              namespace: namespace,
-            },
-            stringData: {},
-            type: 'Opaque',
-          };
-          await createSecret(newSecret);
-        }
         if (!fetchedUserState) {
           const newUserState: NotebookControllerUserState = {
             user: username,
             lastSelectedImage: '',
             lastSelectedSize: '',
             environmentVariables: [],
-            secrets: secretName,
           };
           const patch = {
             spec: {

--- a/frontend/src/pages/notebookController/NotebookControllerContext.tsx
+++ b/frontend/src/pages/notebookController/NotebookControllerContext.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { DashboardConfig, ImageInfo, Notebook, NotebookControllerUserState } from 'types';
-import { EMPTY_USER_STATE } from './const';
+import { DashboardConfig, ImageInfo, Notebook } from 'types';
 
 type NotebookControllerContextProps = {
   notebook: Notebook | null | undefined;
@@ -8,7 +7,6 @@ type NotebookControllerContextProps = {
   images: ImageInfo[];
   isNotebookRunning: boolean;
   projectName: string;
-  userState: NotebookControllerUserState;
 };
 
 const defaultNotebookControllerContext: NotebookControllerContextProps = {
@@ -17,7 +15,6 @@ const defaultNotebookControllerContext: NotebookControllerContextProps = {
   images: [],
   isNotebookRunning: false,
   projectName: '',
-  userState: EMPTY_USER_STATE,
 };
 
 const NotebookControllerContext = React.createContext(defaultNotebookControllerContext);

--- a/frontend/src/pages/notebookController/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/SpawnerPage.tsx
@@ -16,7 +16,7 @@ import { ImageInfo, ImageTag, VariableRow, ImageTagInfo, EnvironmentVariable } f
 import { useSelector } from 'react-redux';
 import ImageSelector from './ImageSelector';
 import EnvironmentVariablesRow from './EnvironmentVariablesRow';
-import { CUSTOM_VARIABLE, EMPTY_KEY } from './const';
+import { CUSTOM_VARIABLE, EMPTY_KEY, EMPTY_USER_STATE } from './const';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router';
 import { createNotebook } from '../../services/notebookService';
@@ -44,12 +44,15 @@ type SpawnerPageProps = {
 
 const SpawnerPage: React.FC<SpawnerPageProps> = React.memo(({ setStartModalShown }) => {
   const history = useHistory();
-  const { images, dashboardConfig, userState } = React.useContext(NotebookControllerContext);
+  const { images, dashboardConfig } = React.useContext(NotebookControllerContext);
   const [username, namespace] = useSelector<State, [string, string]>((state) => [
     state.appState.user || '',
     state.appState.namespace || '',
   ]);
   const projectName = ODH_NOTEBOOK_REPO || namespace;
+  const userState =
+    dashboardConfig?.spec.notebookControllerState?.find((state) => state.user === username) ||
+    EMPTY_USER_STATE;
   const { buildStatuses } = React.useContext(AppContext);
   const [selectedImageTag, setSelectedImageTag] = React.useState<ImageTag>({
     image: undefined,
@@ -182,7 +185,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = React.memo(({ setStartModalShown
     return () => {
       cancelled = true;
     };
-  }, [userState]);
+  }, [userState, username]);
 
   const handleImageTagSelection = (image: ImageInfo, tag: ImageTagInfo, checked: boolean) => {
     if (checked) {
@@ -334,7 +337,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = React.memo(({ setStartModalShown
         stringData: envVars.secrets,
         type: 'Opaque',
       };
-      if (!secret) {
+      if (!secret && envVars.secrets) {
         createSecret(newSecret);
       } else if (!_.isEqual(secret.data, envVars.secrets)) {
         replaceSecret(secretName, newSecret);

--- a/frontend/src/pages/notebookController/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/StartServerModal.tsx
@@ -65,7 +65,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
       title="Starting server"
       isOpen={startShown}
       showClose
-      onClose={onClose}
+      onClose={() => (isNotebookRunning ? setStartModalShown(false) : onClose())}
     >
       {isNotebookRunning ? running() : loading()}
     </Modal>

--- a/frontend/src/pages/notebookController/const.ts
+++ b/frontend/src/pages/notebookController/const.ts
@@ -5,5 +5,4 @@ export const EMPTY_USER_STATE = {
   lastSelectedImage: '',
   lastSelectedSize: '',
   environmentVariables: [],
-  secrets: '',
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,7 +36,6 @@ export type NotebookControllerUserState = {
   lastSelectedImage: string;
   lastSelectedSize: string;
   environmentVariables: EnvironmentVariable[];
-  secrets: string;
 };
 
 export type NotebookResources = {

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -133,7 +133,12 @@ export const getTimeoutByHourAndMinute = (hour: number, minute: number): number 
   (hour * 60 + minute) * 60;
 
 export const jupyterhubUsernameTranslate = (username: string): string =>
-  username.replace(/-/g, '-2d').replace(/@/g, '-40').replace(/\./g, '-2e').replace(/:/g, '-3a');
+  username
+    .replace(/-/g, '-2d')
+    .replace(/@/g, '-40')
+    .replace(/\./g, '-2e')
+    .replace(/:/g, '-3a')
+    .toLowerCase();
 
 export const generateNotebookNameFromUsername = (username: string): string =>
   `jupyter-nb-${jupyterhubUsernameTranslate(username)}`;


### PR DESCRIPTION
While testing the notebook, I found 2 bugs.
1. There are some logical problems in fetching the secret environment variables, which might cause an infinite loop of fetching or type error. To get rid of this, I removed the `secrets` field from `notebookControllerState`, we don't need that state to indicate the secret name. Also, the `secrets` field will be removed in https://github.com/opendatahub-io/odh-dashboard/issues/282 anyway.
2. After we create the notebook, if we use that 'x' close button to close the modal, it will delete the notebook. I fixed that issue in this PR, too.