### PR TITLE
Auto add 'untriaged' label to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["bug", "untriaged"]
 assignees:
   - lucferbux
   - DaoDaoNoCode

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report
 title: "[Bug]: "
-labels: ["bug", "untriaged"]
+labels: ["kind/bug", "untriaged"]
 assignees:
   - lucferbux
   - DaoDaoNoCode

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "[Feature Request]: "
-labels: ["enhancement"]
+labels: ["enhancement", "untriaged"]
 assignees:
   - lucferbux
   - DaoDaoNoCode
@@ -12,7 +12,7 @@ body:
       value: |
         Thanks for taking the time to fill out this feature request! Please, fill this form to help us improve the project.
   - type: textarea
-    id: description 
+    id: description
     attributes:
       label: Feature description
       description: A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for this project
 title: "[Feature Request]: "
-labels: ["enhancement", "untriaged"]
+labels: ["kind/enhancement", "untriaged"]
 assignees:
   - lucferbux
   - DaoDaoNoCode


### PR DESCRIPTION
Help us track what is new and what is triaged into the set of labels it has.

Added the label to the [repo](https://github.com/opendatahub-io/odh-dashboard/labels) already:
![image](https://user-images.githubusercontent.com/8126518/179274062-56e1ef4c-c99e-4eb5-a0d7-4ca36e0af050.png)
