### PR TITLE
Removes default bug and feature assignees from new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,10 +2,6 @@ name: Bug Report
 description: File a bug report
 title: "[Bug]: "
 labels: ["kind/bug", "untriaged"]
-assignees:
-  - lucferbux
-  - DaoDaoNoCode
-  - dlabaj
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,10 +2,6 @@ name: Feature request
 description: Suggest an idea for this project
 title: "[Feature Request]: "
 labels: ["kind/enhancement", "untriaged"]
-assignees:
-  - lucferbux
-  - DaoDaoNoCode
-  - dlabaj
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
It is unnecessary to assign people to issues when they are created, we'll filter through them as we look periodically at the labels associated. 