### PR TITLE
Add TENSORBOARD_PROXY_URL env variable to Notebook

### DIFF
--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -64,6 +64,10 @@ export const createNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                {
+                  name: 'TENSORBOARD_PROXY_URL',
+                  value: `/notebook/${projectName}/${notebookName}/proxy/6006/`,
+                },
               ],
               resources,
               volumeMounts,


### PR DESCRIPTION
Closes #314 

This commit adds env variable that points to proxy url for Tensorboard. This allows
users to view Tensorboards on JupyterLab given the image has `jupyter-server-proxy` 
package installed