### PR TITLE
Refactor routes and redirect hub control panel and log out to correct url

### DIFF
--- a/backend/src/routes/api/pvc/index.ts
+++ b/backend/src/routes/api/pvc/index.ts
@@ -14,7 +14,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         );
         return pvcResponse.body;
       } catch (e) {
-        fastify.log.error(`Secret ${pvcName} could not be read, ${e}`);
+        fastify.log.error(`PVC ${pvcName} could not be read, ${e}`);
         reply.send(e);
       }
     },
@@ -31,7 +31,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         );
         return pvcResponse.body;
       } catch (e) {
-        fastify.log.error(`Secret could not be created: ${e}`);
+        fastify.log.error(`PVC could not be created: ${e}`);
         reply.send(e);
       }
     },

--- a/frontend/.env
+++ b/frontend/.env
@@ -2,7 +2,7 @@ ODH_IS_PROJECT_ROOT_DIR=false
 ODH_PORT=${FRONTEND_PORT}
 
 ########## Change the following three variables for ODH/RHODS ##########
-ODH_LOGO=../images/odh-logo.svg
+ODH_LOGO=odh-logo.svg
 ODH_PRODUCT_NAME=Open Data Hub
 ODH_FAVICON=odh-favicon.svg
 ODH_NOTEBOOK_REPO=opendatahub

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -16,6 +16,7 @@ import { useWatchBuildStatus } from '../utilities/useWatchBuildStatus';
 import AppContext from './AppContext';
 
 import './App.scss';
+import { useWatchDashboardConfig } from 'utilities/useWatchDashboardConfig';
 
 const App: React.FC = () => {
   const isDeskTop = useDesktopWidth();
@@ -26,6 +27,7 @@ const App: React.FC = () => {
   useTrackHistory();
 
   const buildStatuses = useWatchBuildStatus();
+  const { dashboardConfig } = useWatchDashboardConfig();
 
   React.useEffect(() => {
     dispatch(detectUser());
@@ -46,6 +48,7 @@ const App: React.FC = () => {
         setIsNavOpen,
         onNavToggle,
         buildStatuses,
+        dashboardConfig,
       }}
     >
       <Page

--- a/frontend/src/app/AppContext.ts
+++ b/frontend/src/app/AppContext.ts
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { BuildStatus } from '../types';
+import { blankDashboardCR } from '../utilities/useWatchDashboardConfig';
+import { BuildStatus, DashboardConfig } from '../types';
 
 type AppContextProps = {
   isNavOpen: boolean;
   setIsNavOpen: (isNavOpen: boolean) => void;
   onNavToggle: () => void;
   buildStatuses: BuildStatus[];
+  dashboardConfig: DashboardConfig;
 };
 
 const defaultAppContext: AppContextProps = {
@@ -13,6 +15,7 @@ const defaultAppContext: AppContextProps = {
   setIsNavOpen: () => undefined,
   onNavToggle: () => undefined,
   buildStatuses: [],
+  dashboardConfig: blankDashboardCR,
 };
 
 const AppContext = React.createContext(defaultAppContext);

--- a/frontend/src/app/Header.tsx
+++ b/frontend/src/app/Header.tsx
@@ -14,10 +14,13 @@ const Header: React.FC<HeaderProps> = ({ onNotificationsClick }) => {
   return (
     <PageHeader
       logo={
-        <Link to="/">
-          <Brand src={ODH_LOGO} alt={`${ODH_PRODUCT_NAME} Logo`} />
-        </Link>
+        <Brand
+          src={`${window.location.origin}/images/${ODH_LOGO}`}
+          alt={`${ODH_PRODUCT_NAME} Logo`}
+        />
       }
+      logoComponent={Link}
+      logoProps={{ to: '/' }}
       headerTools={<HeaderTools onNotificationsClick={onNotificationsClick} />}
       showNavToggle
       isNavOpen={isNavOpen}

--- a/frontend/src/app/Routes.tsx
+++ b/frontend/src/app/Routes.tsx
@@ -3,6 +3,7 @@ import { Route, Switch } from 'react-router-dom';
 import ApplicationsPage from '../pages/ApplicationsPage';
 import { State } from '../redux/types';
 import { useSelector } from 'react-redux';
+import NotebookControllerRoutes from '../pages/notebookController/NotebookControllerRoutes';
 
 const InstalledApplications = React.lazy(
   () => import('../pages/enabledApplications/EnabledApplications'),
@@ -10,8 +11,8 @@ const InstalledApplications = React.lazy(
 const ExploreApplications = React.lazy(
   () => import('../pages/exploreApplication/ExploreApplications'),
 );
-const NotebookController = React.lazy(
-  () => import('../pages/notebookController/NotebookController'),
+const NotebookLogoutRedirectPage = React.lazy(
+  () => import('../pages/notebookController/NotebookLogoutRedirect'),
 );
 
 const ClusterSettingsPage = React.lazy(() => import('../pages/clusterSettings/ClusterSettings'));
@@ -30,7 +31,14 @@ const Routes: React.FC = () => {
         <Route path="/" exact component={InstalledApplications} />
         <Route path="/explore" exact component={ExploreApplications} />
         <Route path="/resources" exact component={LearningCenterPage} />
-        <Route path="/notebookController" exact component={NotebookController} />
+        <Route path="/notebookController">
+          <NotebookControllerRoutes />
+        </Route>
+        <Route
+          path="/notebook/:namespace/:notebookName/logout"
+          exact
+          component={NotebookLogoutRedirectPage}
+        />
         {isAdmin && <Route path="/notebookImages" exact component={BYONImagesPage} />}
         {isAdmin && <Route path="/clusterSettings" exact component={ClusterSettingsPage} />}
         <Route component={NotFound} />

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -23,7 +23,7 @@ import { removeComponent } from '../services/componentsServices';
 import { addNotification, forceComponentsUpdate } from '../redux/actions/actions';
 import { useWatchDashboardConfig } from '../utilities/useWatchDashboardConfig';
 import { ODH_PRODUCT_NAME } from '../utilities/const';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 
 import './OdhCard.scss';
 
@@ -122,7 +122,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
 
   const cardFooter = (
     <CardFooter className="odh-card__footer">
-      {odhApp.spec.internalRoute ? (
+      {odhApp.metadata.name === 'jupyter' ? (
         <a
           className="odh-card__footer__link"
           onClick={() => history.push(odhApp.spec.internalRoute)}

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import classNames from 'classnames';
 import * as _ from 'lodash';
 import {

--- a/frontend/src/pages/learningCenter/ApplicationFilters.tsx
+++ b/frontend/src/pages/learningCenter/ApplicationFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { OdhDocument } from '../../types';
 import { FilterSidePanelCategory } from '@patternfly/react-catalog-view-extension';
 import FilterSidePanelCategoryItem from '../../components/FilterSidePanelCategoryItem';

--- a/frontend/src/pages/learningCenter/CategoryFilters.tsx
+++ b/frontend/src/pages/learningCenter/CategoryFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { VerticalTabs, VerticalTabsTab } from '@patternfly/react-catalog-view-extension';
 import { OdhDocument } from '../../types';
 import { CATEGORY_ANNOTATION } from '../../utilities/const';

--- a/frontend/src/pages/learningCenter/DocTypeFilters.tsx
+++ b/frontend/src/pages/learningCenter/DocTypeFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { FilterSidePanelCategory } from '@patternfly/react-catalog-view-extension';
 import FilterSidePanelCategoryItem from '../../components/FilterSidePanelCategoryItem';
 import { OdhDocument, OdhDocumentType } from '../../types';

--- a/frontend/src/pages/learningCenter/EnabledFilters.tsx
+++ b/frontend/src/pages/learningCenter/EnabledFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { FilterSidePanelCategory } from '@patternfly/react-catalog-view-extension';
 import FilterSidePanelCategoryItem from '../../components/FilterSidePanelCategoryItem';
 import { OdhDocument } from '../../types';

--- a/frontend/src/pages/learningCenter/LearningCenterDataView.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterDataView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import classNames from 'classnames';
 import useDimensions from 'react-cool-dimensions';
 import {

--- a/frontend/src/pages/learningCenter/LearningCenterListHeader.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterListHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { ArrowsAltVIcon, LongArrowAltDownIcon, LongArrowAltUpIcon } from '@patternfly/react-icons';
 import { setQueryArgument } from '../../utilities/router';
 import { useQueryParams } from '../../utilities/useQueryParams';

--- a/frontend/src/pages/learningCenter/LearningCenterToolbar.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterToolbar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import {
   Button,
   ButtonVariant,

--- a/frontend/src/pages/learningCenter/ProviderTypeFilters.tsx
+++ b/frontend/src/pages/learningCenter/ProviderTypeFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { OdhDocument } from '../../types';
 import { FilterSidePanelCategory } from '@patternfly/react-catalog-view-extension';
 import FilterSidePanelCategoryItem from '../../components/FilterSidePanelCategoryItem';

--- a/frontend/src/pages/notebookController/NotebookControlPanelRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookControlPanelRedirect.tsx
@@ -14,13 +14,13 @@ const NotebookControlPanelRedirect: React.FC = () => {
     if (translatedUsername && dashboardConfig.spec.notebookController?.enabled) {
       const userState = getUserStateFromDashboardConfig(
         translatedUsername,
-        dashboardConfig.status?.notebookControllerState,
+        dashboardConfig.status?.notebookControllerState || [],
       );
       if (!userState) {
         history.push('/not-found');
       } else {
         setCurrentUserState(userState);
-        history.push('/notebookController');
+        history.replace('/notebookController');
       }
     }
   }, [translatedUsername, dashboardConfig, history, setCurrentUserState]);

--- a/frontend/src/pages/notebookController/NotebookControlPanelRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookControlPanelRedirect.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { useParams, useHistory } from 'react-router-dom';
+import ApplicationsPage from 'pages/ApplicationsPage';
+import { getUserStateFromDashboardConfig } from 'utilities/notebookControllerUtils';
+import AppContext from '../../app/AppContext';
+import NotebookControllerContext from './NotebookControllerContext';
+
+const NotebookControlPanelRedirect: React.FC = () => {
+  const history = useHistory();
+  const { username: translatedUsername } = useParams<{ username: string }>();
+  const { dashboardConfig } = React.useContext(AppContext);
+  const { setCurrentUserState } = React.useContext(NotebookControllerContext);
+  React.useEffect(() => {
+    if (translatedUsername && dashboardConfig.spec.notebookController?.enabled) {
+      const userState = getUserStateFromDashboardConfig(
+        translatedUsername,
+        dashboardConfig.status?.notebookControllerState,
+      );
+      if (!userState) {
+        history.push('/not-found');
+      } else {
+        setCurrentUserState(userState);
+        history.push('/notebookController');
+      }
+    }
+  }, [translatedUsername, dashboardConfig, history, setCurrentUserState]);
+  return (
+    <ApplicationsPage title="Redirecting..." description={null} loaded={false} empty={false} />
+  );
+};
+
+export default NotebookControlPanelRedirect;

--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -14,7 +14,6 @@ import {
   getUserStateFromDashboardConfig,
   usernameTranslate,
 } from '../../utilities/notebookControllerUtils';
-import QuickStarts from '../../app/QuickStarts';
 import { ODH_NOTEBOOK_REPO } from '../../utilities/const';
 import { patchDashboardConfig } from '../../services/dashboardConfigService';
 import { Redirect, useHistory } from 'react-router-dom';
@@ -37,7 +36,7 @@ export const NotebookController: React.FC = React.memo(() => {
   React.useEffect(() => {
     const checkUserState = async () => {
       if (translatedUsername && dashboardConfig.spec.notebookController) {
-        const notebookControllerState = dashboardConfig.status?.notebookControllerState;
+        const notebookControllerState = dashboardConfig.status?.notebookControllerState || [];
         const fetchedUserState = getUserStateFromDashboardConfig(
           translatedUsername,
           notebookControllerState,
@@ -65,7 +64,6 @@ export const NotebookController: React.FC = React.memo(() => {
   }, [setIsNavOpen]);
 
   return (
-    <QuickStarts>
       <ApplicationsPage
         title="Notebook server control panel"
         description={null}
@@ -102,7 +100,6 @@ export const NotebookController: React.FC = React.memo(() => {
           </div>
         )}
       </ApplicationsPage>
-    </QuickStarts>
   );
 });
 

--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -1,153 +1,107 @@
 import * as React from 'react';
 import { Button, ActionList, ActionListItem } from '@patternfly/react-core';
 import ApplicationsPage from '../ApplicationsPage';
-import SpawnerPage from './SpawnerPage';
 import NotebookServerDetails from './NotebookServerDetails';
 import AppContext from '../../app/AppContext';
 import { useWatchImages } from '../../utilities/useWatchImages';
-import { useWatchDashboardConfig } from 'utilities/useWatchDashboardConfig';
 import { useWatchNotebook } from 'utilities/useWatchNotebook';
 import { deleteNotebook } from '../../services/notebookService';
 import { useSelector } from 'react-redux';
-import { State } from 'redux/types';
+import { State } from '../../redux/types';
 import {
+  checkNotebookRunning,
   generateNotebookNameFromUsername,
+  getUserStateFromDashboardConfig,
   usernameTranslate,
 } from '../../utilities/notebookControllerUtils';
-import { FAST_POLL_INTERVAL, ODH_NOTEBOOK_REPO, POLL_INTERVAL } from '../../utilities/const';
-import NotebookControllerContext from './NotebookControllerContext';
-import StartServerModal from './StartServerModal';
-import { patchDashboardConfig } from '../../services/dashboardConfigService';
-import { NotebookControllerUserState } from '../../types';
 import QuickStarts from '../../app/QuickStarts';
+import { ODH_NOTEBOOK_REPO } from '../../utilities/const';
+import { patchDashboardConfig } from '../../services/dashboardConfigService';
+import { Redirect, useHistory } from 'react-router-dom';
+import NotebookControllerContext from './NotebookControllerContext';
+
+import './NotebookController.scss';
 
 export const NotebookController: React.FC = React.memo(() => {
-  const { setIsNavOpen } = React.useContext(AppContext);
+  const history = useHistory();
+  const { setIsNavOpen, dashboardConfig } = React.useContext(AppContext);
   const { images } = useWatchImages();
-  const { dashboardConfig } = useWatchDashboardConfig();
-  const [username, namespace] = useSelector<State, [string, string]>((state) => [
-    state.appState.user || '',
-    state.appState.namespace || '',
-  ]);
+  const { currentUserState, setCurrentUserState } = React.useContext(NotebookControllerContext);
+  const stateUsername = useSelector<State, string>((state) => state.appState.user || '');
+  const username = currentUserState.user || stateUsername;
+  const translatedUsername = usernameTranslate(username);
+  const namespace = useSelector<State, string>((state) => state.appState.namespace || '');
   const projectName = ODH_NOTEBOOK_REPO || namespace;
-  const {
-    notebook,
-    loaded,
-    loadError,
-    forceUpdate: updateNotebook,
-    setPollInterval: setNotebookPollInterval,
-  } = useWatchNotebook(projectName);
-  const isNotebookRunning = !!(
-    notebook?.status?.readyReplicas && notebook?.status?.readyReplicas >= 1
-  );
-
-  const [startShown, setStartShown] = React.useState<boolean>(false);
+  const { notebook, loaded, loadError } = useWatchNotebook(projectName, username);
 
   React.useEffect(() => {
     const checkUserState = async () => {
-      if (username && dashboardConfig.spec.notebookController) {
-        const translatedUsername = usernameTranslate(username);
+      if (translatedUsername && dashboardConfig.spec.notebookController) {
         const notebookControllerState = dashboardConfig.status?.notebookControllerState;
-        const fetchedUserState = notebookControllerState?.find(
-          (state) => state.user === translatedUsername,
+        const fetchedUserState = getUserStateFromDashboardConfig(
+          translatedUsername,
+          notebookControllerState,
         );
         if (!fetchedUserState) {
-          const newUserState: NotebookControllerUserState = {
-            user: translatedUsername,
-            lastSelectedImage: '',
-            lastSelectedSize: '',
-          };
+          currentUserState.user = username;
           const patch = {
             status: {
               notebookControllerState: notebookControllerState
-                ? [...notebookControllerState, newUserState]
-                : [newUserState],
+                ? [...notebookControllerState, currentUserState]
+                : [currentUserState],
             },
           };
           await patchDashboardConfig(patch);
+        } else {
+          setCurrentUserState(fetchedUserState);
         }
       }
     };
     checkUserState().catch((e) => console.error(e));
-  }, [username, dashboardConfig, namespace]);
-
-  React.useEffect(() => {
-    setNotebookPollInterval(startShown ? FAST_POLL_INTERVAL : POLL_INTERVAL);
-  }, [startShown, setNotebookPollInterval]);
+  }, [translatedUsername, dashboardConfig, currentUserState, setCurrentUserState, username]);
 
   React.useEffect(() => {
     setIsNavOpen(false);
   }, [setIsNavOpen]);
 
-  const onModalClose = () => {
-    setStartShown(false);
-    if (notebook) {
-      deleteNotebook(projectName, notebook?.metadata.name).catch((e) => console.error(e));
-    }
-  };
-
   return (
     <QuickStarts>
-      <NotebookControllerContext.Provider
-        value={{
-          images,
-          dashboardConfig,
-          notebook,
-          isNotebookRunning,
-          projectName,
-        }}
+      <ApplicationsPage
+        title="Notebook server control panel"
+        description={null}
+        loaded={loaded}
+        loadError={loadError}
+        empty={loaded && !checkNotebookRunning(notebook)}
+        emptyStatePage={<Redirect to={`/notebookController/spawner`} />}
       >
-        <ApplicationsPage
-          title={!isNotebookRunning ? 'Start a Notebook server' : 'Notebook server control panel'}
-          description={!isNotebookRunning ? 'Select options for your Notebook server.' : null}
-          loaded={loaded}
-          loadError={loadError}
-          empty={!isNotebookRunning}
-          emptyStatePage={
-            <SpawnerPage
-              setStartModalShown={setStartShown}
-              updateNotebook={updateNotebook}
-              setNotebookPollInterval={setNotebookPollInterval}
-            />
-          }
-        >
-          {notebook && (
-            <div className="odh-notebook-controller__page">
-              <ActionList>
-                <ActionListItem
-                  onClick={() => {
-                    deleteNotebook(projectName, generateNotebookNameFromUsername(username))
-                      .then(() => {
-                        updateNotebook();
-                      })
-                      .catch((e) => console.error(e));
-                  }}
-                >
-                  <Button variant="primary">Stop notebook server</Button>
-                </ActionListItem>
-                <ActionListItem>
-                  <Button
-                    variant="secondary"
-                    onClick={() => {
-                      window.open(notebook?.metadata.annotations?.['opendatahub.io/link']);
-                    }}
-                  >
-                    Return to server
-                  </Button>
-                </ActionListItem>
-              </ActionList>
-              <NotebookServerDetails />
-            </div>
-          )}
-        </ApplicationsPage>
-        {startShown && (
-          <StartServerModal
-            startShown={startShown}
-            setStartModalShown={setStartShown}
-            onClose={onModalClose}
-          />
+        {notebook && (
+          <div className="odh-notebook-controller__page">
+            <ActionList>
+              <ActionListItem
+                onClick={() => {
+                  deleteNotebook(projectName, generateNotebookNameFromUsername(username))
+                    .then(() => {
+                      history.push(`/notebookController/spawner`);
+                    })
+                    .catch((e) => console.error(e));
+                }}
+              >
+                <Button variant="primary">Stop notebook server</Button>
+              </ActionListItem>
+              <ActionListItem
+                onClick={() => {
+                  if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
+                    window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+                  }
+                }}
+              >
+                <Button variant="secondary">Return to server</Button>
+              </ActionListItem>
+            </ActionList>
+            <NotebookServerDetails notebook={notebook} images={images} />
+          </div>
         )}
-      </NotebookControllerContext.Provider>
+      </ApplicationsPage>
     </QuickStarts>
   );
 });

--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -64,42 +64,42 @@ export const NotebookController: React.FC = React.memo(() => {
   }, [setIsNavOpen]);
 
   return (
-      <ApplicationsPage
-        title="Notebook server control panel"
-        description={null}
-        loaded={loaded}
-        loadError={loadError}
-        empty={loaded && !checkNotebookRunning(notebook)}
-        emptyStatePage={<Redirect to={`/notebookController/spawner`} />}
-      >
-        {notebook && (
-          <div className="odh-notebook-controller__page">
-            <ActionList>
-              <ActionListItem
-                onClick={() => {
-                  deleteNotebook(projectName, generateNotebookNameFromUsername(username))
-                    .then(() => {
-                      history.push(`/notebookController/spawner`);
-                    })
-                    .catch((e) => console.error(e));
-                }}
-              >
-                <Button variant="primary">Stop notebook server</Button>
-              </ActionListItem>
-              <ActionListItem
-                onClick={() => {
-                  if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
-                    window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
-                  }
-                }}
-              >
-                <Button variant="secondary">Return to server</Button>
-              </ActionListItem>
-            </ActionList>
-            <NotebookServerDetails notebook={notebook} images={images} />
-          </div>
-        )}
-      </ApplicationsPage>
+    <ApplicationsPage
+      title="Notebook server control panel"
+      description={null}
+      loaded={loaded}
+      loadError={loadError}
+      empty={loaded && !checkNotebookRunning(notebook)}
+      emptyStatePage={<Redirect to={`/notebookController/spawner`} />}
+    >
+      {notebook && (
+        <div className="odh-notebook-controller__page">
+          <ActionList>
+            <ActionListItem
+              onClick={() => {
+                deleteNotebook(projectName, generateNotebookNameFromUsername(username))
+                  .then(() => {
+                    history.push(`/notebookController/spawner`);
+                  })
+                  .catch((e) => console.error(e));
+              }}
+            >
+              <Button variant="primary">Stop notebook server</Button>
+            </ActionListItem>
+            <ActionListItem
+              onClick={() => {
+                if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
+                  window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+                }
+              }}
+            >
+              <Button variant="secondary">Return to server</Button>
+            </ActionListItem>
+          </ActionList>
+          <NotebookServerDetails notebook={notebook} images={images} />
+        </div>
+      )}
+    </ApplicationsPage>
   );
 });
 

--- a/frontend/src/pages/notebookController/NotebookControllerContext.tsx
+++ b/frontend/src/pages/notebookController/NotebookControllerContext.tsx
@@ -1,20 +1,15 @@
 import * as React from 'react';
-import { DashboardConfig, ImageInfo, Notebook } from 'types';
+import { NotebookControllerUserState } from '../../types';
+import { EMPTY_USER_STATE } from './const';
 
 type NotebookControllerContextProps = {
-  notebook: Notebook | null | undefined;
-  dashboardConfig: DashboardConfig | undefined;
-  images: ImageInfo[];
-  isNotebookRunning: boolean;
-  projectName: string;
+  setCurrentUserState: (userState: NotebookControllerUserState) => void;
+  currentUserState: NotebookControllerUserState;
 };
 
 const defaultNotebookControllerContext: NotebookControllerContextProps = {
-  notebook: undefined,
-  dashboardConfig: undefined,
-  images: [],
-  isNotebookRunning: false,
-  projectName: '',
+  setCurrentUserState: () => undefined,
+  currentUserState: EMPTY_USER_STATE,
 };
 
 const NotebookControllerContext = React.createContext(defaultNotebookControllerContext);

--- a/frontend/src/pages/notebookController/NotebookControllerRoutes.tsx
+++ b/frontend/src/pages/notebookController/NotebookControllerRoutes.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { NotebookControllerUserState } from 'types';
+import { EMPTY_USER_STATE } from './const';
+import NotebookController from './NotebookController';
+import NotebookControllerContext from './NotebookControllerContext';
+import NotebookControlPanelRedirect from './NotebookControlPanelRedirect';
+import SpawnerPage from './SpawnerPage';
+
+const NotebookControllerRoutes: React.FC = () => {
+  const { path } = useRouteMatch();
+  const [currentUserState, setCurrentUserState] =
+    React.useState<NotebookControllerUserState>(EMPTY_USER_STATE);
+
+  return (
+    <NotebookControllerContext.Provider
+      value={{
+        setCurrentUserState,
+        currentUserState,
+      }}
+    >
+      <Switch>
+        <Route exact path={path}>
+          <NotebookController />
+        </Route>
+        <Route exact path={`${path}/spawner`}>
+          <SpawnerPage />
+        </Route>
+        <Route exact path={`${path}/:username/home`}>
+          <NotebookControlPanelRedirect />
+        </Route>
+      </Switch>
+    </NotebookControllerContext.Provider>
+  );
+};
+
+export default NotebookControllerRoutes;

--- a/frontend/src/pages/notebookController/NotebookControllerRoutes.tsx
+++ b/frontend/src/pages/notebookController/NotebookControllerRoutes.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
-import { NotebookControllerUserState } from 'types';
+import { NotebookControllerUserState } from '../../types';
 import { EMPTY_USER_STATE } from './const';
+import QuickStarts from '../../app/QuickStarts';
 import NotebookController from './NotebookController';
 import NotebookControllerContext from './NotebookControllerContext';
 import NotebookControlPanelRedirect from './NotebookControlPanelRedirect';
@@ -13,24 +14,26 @@ const NotebookControllerRoutes: React.FC = () => {
     React.useState<NotebookControllerUserState>(EMPTY_USER_STATE);
 
   return (
-    <NotebookControllerContext.Provider
-      value={{
-        setCurrentUserState,
-        currentUserState,
-      }}
-    >
-      <Switch>
-        <Route exact path={path}>
-          <NotebookController />
-        </Route>
-        <Route exact path={`${path}/spawner`}>
-          <SpawnerPage />
-        </Route>
-        <Route exact path={`${path}/:username/home`}>
-          <NotebookControlPanelRedirect />
-        </Route>
-      </Switch>
-    </NotebookControllerContext.Provider>
+    <QuickStarts>
+      <NotebookControllerContext.Provider
+        value={{
+          setCurrentUserState,
+          currentUserState,
+        }}
+      >
+        <Switch>
+          <Route exact path={path}>
+            <NotebookController />
+          </Route>
+          <Route exact path={`${path}/spawner`}>
+            <SpawnerPage />
+          </Route>
+          <Route exact path={`${path}/:username/home`}>
+            <NotebookControlPanelRedirect />
+          </Route>
+        </Switch>
+      </NotebookControllerContext.Provider>
+    </QuickStarts>
   );
 };
 

--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import { getNotebook } from '../../services/notebookService';
+import ApplicationsPage from 'pages/ApplicationsPage';
+
+const NotebookLogoutRedirect: React.FC = () => {
+  const { namespace, notebookName } = useParams<{ namespace: string; notebookName: string }>();
+  React.useEffect(() => {
+    if (namespace && notebookName) {
+      getNotebook(namespace, notebookName)
+        .then((notebook) => {
+          if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
+            const location = new URL(notebook.metadata.annotations['opendatahub.io/link']);
+            window.location.href = `${location.origin}/oauth/sign_out`;
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+    }
+  }, [namespace, notebookName]);
+  return (
+    <ApplicationsPage title="Logging out..." description={null} loaded={false} empty={false} />
+  );
+};
+
+export default NotebookLogoutRedirect;

--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 import { getNotebook } from '../../services/notebookService';
-import ApplicationsPage from 'pages/ApplicationsPage';
+import ApplicationsPage from '../../pages/ApplicationsPage';
+import useNotification from '../../utilities/useNotification';
 
 const NotebookLogoutRedirect: React.FC = () => {
   const { namespace, notebookName } = useParams<{ namespace: string; notebookName: string }>();
+  const notification = useNotification();
+  const history = useHistory();
   React.useEffect(() => {
     if (namespace && notebookName) {
       getNotebook(namespace, notebookName)
@@ -12,6 +15,9 @@ const NotebookLogoutRedirect: React.FC = () => {
           if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
             const location = new URL(notebook.metadata.annotations['opendatahub.io/link']);
             window.location.href = `${location.origin}/oauth/sign_out`;
+          } else {
+            notification.error("Error fetching notebook URL.", "Please check the status of your notebook.");
+            history.push('not-found');
           }
         })
         .catch((e) => {

--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -16,7 +16,10 @@ const NotebookLogoutRedirect: React.FC = () => {
             const location = new URL(notebook.metadata.annotations['opendatahub.io/link']);
             window.location.href = `${location.origin}/oauth/sign_out`;
           } else {
-            notification.error("Error fetching notebook URL.", "Please check the status of your notebook.");
+            notification.error(
+              'Error fetching notebook URL.',
+              'Please check the status of your notebook.',
+            );
             history.push('not-found');
           }
         })
@@ -24,7 +27,7 @@ const NotebookLogoutRedirect: React.FC = () => {
           console.error(e);
         });
     }
-  }, [namespace, notebookName]);
+  }, [namespace, notebookName, history, notification]);
   return (
     <ApplicationsPage title="Logging out..." description={null} loaded={false} empty={false} />
   );

--- a/frontend/src/pages/notebookController/NotebookServerDetails.tsx
+++ b/frontend/src/pages/notebookController/NotebookServerDetails.tsx
@@ -9,19 +9,23 @@ import {
   Text,
   TextVariants,
 } from '@patternfly/react-core';
-import { NotebookContainer } from '../../types';
+import { ImageInfo, Notebook, NotebookContainer } from '../../types';
 import {
   getDescriptionForTag,
   getImageTagByContainer,
   getNameVersionString,
   getNumGpus,
 } from '../../utilities/imageUtils';
+import AppContext from '../../app/AppContext';
 
-import NotebookControllerContext from './NotebookControllerContext';
+type NotebookServerDetailsProps = {
+  notebook?: Notebook;
+  images: ImageInfo[];
+};
 
-const NotebookServerDetails: React.FC = () => {
+const NotebookServerDetails: React.FC<NotebookServerDetailsProps> = ({ notebook, images }) => {
   const [isExpanded, setExpanded] = React.useState(false);
-  const { notebook, images, dashboardConfig } = React.useContext(NotebookControllerContext);
+  const { dashboardConfig } = React.useContext(AppContext);
 
   const empty = React.useCallback(() => <div>Error load notebook details</div>, []);
 

--- a/frontend/src/pages/notebookController/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/SpawnerPage.tsx
@@ -47,7 +47,6 @@ import { getConfigMap } from '../../services/configMapService';
 import { useWatchImages } from '../../utilities/useWatchImages';
 import ApplicationsPage from '../../pages/ApplicationsPage';
 import StartServerModal from './StartServerModal';
-import QuickStarts from '../../app/QuickStarts';
 import { useWatchNotebookForSpawnerPage } from './useWatchNotebookForSpawnerPage';
 import useNotification from '../../utilities/useNotification';
 import NotebookControllerContext from './NotebookControllerContext';
@@ -103,7 +102,7 @@ const SpawnerPage: React.FC = React.memo(() => {
         if (!isNotebookRunning) {
           setStartShown(true);
         } else {
-          history.push('/notebookController');
+          history.replace('/notebookController');
         }
       }
     }
@@ -367,7 +366,6 @@ const SpawnerPage: React.FC = React.memo(() => {
   };
 
   return (
-    <QuickStarts>
       <ApplicationsPage
         title="Start a Notebook server"
         description="Select options for your Notebook server."
@@ -460,7 +458,6 @@ const SpawnerPage: React.FC = React.memo(() => {
           onClose={onModalClose}
         />
       </ApplicationsPage>
-    </QuickStarts>
   );
 });
 

--- a/frontend/src/pages/notebookController/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/SpawnerPage.tsx
@@ -366,98 +366,98 @@ const SpawnerPage: React.FC = React.memo(() => {
   };
 
   return (
-      <ApplicationsPage
-        title="Start a Notebook server"
-        description="Select options for your Notebook server."
-        loaded={loaded}
-        loadError={loadError}
-        empty={!images || images.length === 0}
-      >
-        <Form className="odh-notebook-controller__page odh-notebook-controller__page-form">
-          <FormSection title="Notebook image">
-            <FormGroup fieldId="modal-notebook-image">
-              <Grid sm={12} md={12} lg={12} xl={6} xl2={6} hasGutter>
-                {images.sort(checkOrder).map((image) => (
-                  <GridItem key={image.name}>
-                    <ImageSelector
-                      image={image}
-                      selectedImage={selectedImageTag.image}
-                      selectedTag={selectedImageTag.tag}
-                      handleSelection={handleImageTagSelection}
-                    />
-                  </GridItem>
-                ))}
-              </Grid>
+    <ApplicationsPage
+      title="Start a Notebook server"
+      description="Select options for your Notebook server."
+      loaded={loaded}
+      loadError={loadError}
+      empty={!images || images.length === 0}
+    >
+      <Form className="odh-notebook-controller__page odh-notebook-controller__page-form">
+        <FormSection title="Notebook image">
+          <FormGroup fieldId="modal-notebook-image">
+            <Grid sm={12} md={12} lg={12} xl={6} xl2={6} hasGutter>
+              {images.sort(checkOrder).map((image) => (
+                <GridItem key={image.name}>
+                  <ImageSelector
+                    image={image}
+                    selectedImage={selectedImageTag.image}
+                    selectedTag={selectedImageTag.tag}
+                    handleSelection={handleImageTagSelection}
+                  />
+                </GridItem>
+              ))}
+            </Grid>
+          </FormGroup>
+        </FormSection>
+        <FormSection title="Deployment size">
+          {sizeOptions && (
+            <FormGroup label="Container size" fieldId="modal-notebook-container-size">
+              <Select
+                isOpen={sizeDropdownOpen}
+                onToggle={() => setSizeDropdownOpen(!sizeDropdownOpen)}
+                aria-labelledby="container-size"
+                selections={selectedSize}
+                onSelect={handleSizeSelection}
+                menuAppendTo="parent"
+              >
+                {sizeOptions}
+              </Select>
             </FormGroup>
-          </FormSection>
-          <FormSection title="Deployment size">
-            {sizeOptions && (
-              <FormGroup label="Container size" fieldId="modal-notebook-container-size">
-                <Select
-                  isOpen={sizeDropdownOpen}
-                  onToggle={() => setSizeDropdownOpen(!sizeDropdownOpen)}
-                  aria-labelledby="container-size"
-                  selections={selectedSize}
-                  onSelect={handleSizeSelection}
-                  menuAppendTo="parent"
-                >
-                  {sizeOptions}
-                </Select>
-              </FormGroup>
-            )}
-            {gpuOptions && (
-              <FormGroup label="Number of GPUs" fieldId="modal-notebook-gpu-number">
-                <Select
-                  isOpen={gpuDropdownOpen}
-                  onToggle={() => setGpuDropdownOpen(!gpuDropdownOpen)}
-                  aria-labelledby="gpu-numbers"
-                  selections={selectedGpu}
-                  onSelect={handleGpuSelection}
-                  menuAppendTo="parent"
-                >
-                  {gpuOptions}
-                </Select>
-              </FormGroup>
-            )}
-          </FormSection>
-          <FormSection title="Environment variables" className="odh-notebook-controller__env-var">
-            {renderEnvironmentVariableRows()}
-            <Button
-              className="odh-notebook-controller__env-var-add-button"
-              isInline
-              variant="link"
-              onClick={addEnvironmentVariableRow}
-            >
-              <PlusCircleIcon />
-              {` Add more variables`}
-            </Button>
-          </FormSection>
-          <ActionGroup>
-            <Button
-              variant="primary"
-              onClick={() => {
-                handleNotebookAction().catch((e) => {
-                  setCreateInProgress(false);
-                  setStartShown(false);
-                  console.error(e);
-                });
-              }}
-              isDisabled={createInProgress}
-            >
-              Start server
-            </Button>
-            <Button variant="secondary" onClick={() => history.push('/')}>
-              Cancel
-            </Button>
-          </ActionGroup>
-        </Form>
-        <StartServerModal
-          notebook={notebook}
-          startShown={startShown}
-          setStartModalShown={setStartShown}
-          onClose={onModalClose}
-        />
-      </ApplicationsPage>
+          )}
+          {gpuOptions && (
+            <FormGroup label="Number of GPUs" fieldId="modal-notebook-gpu-number">
+              <Select
+                isOpen={gpuDropdownOpen}
+                onToggle={() => setGpuDropdownOpen(!gpuDropdownOpen)}
+                aria-labelledby="gpu-numbers"
+                selections={selectedGpu}
+                onSelect={handleGpuSelection}
+                menuAppendTo="parent"
+              >
+                {gpuOptions}
+              </Select>
+            </FormGroup>
+          )}
+        </FormSection>
+        <FormSection title="Environment variables" className="odh-notebook-controller__env-var">
+          {renderEnvironmentVariableRows()}
+          <Button
+            className="odh-notebook-controller__env-var-add-button"
+            isInline
+            variant="link"
+            onClick={addEnvironmentVariableRow}
+          >
+            <PlusCircleIcon />
+            {` Add more variables`}
+          </Button>
+        </FormSection>
+        <ActionGroup>
+          <Button
+            variant="primary"
+            onClick={() => {
+              handleNotebookAction().catch((e) => {
+                setCreateInProgress(false);
+                setStartShown(false);
+                console.error(e);
+              });
+            }}
+            isDisabled={createInProgress}
+          >
+            Start server
+          </Button>
+          <Button variant="secondary" onClick={() => history.push('/')}>
+            Cancel
+          </Button>
+        </ActionGroup>
+      </Form>
+      <StartServerModal
+        notebook={notebook}
+        startShown={startShown}
+        setStartModalShown={setStartShown}
+        onClose={onModalClose}
+      />
+    </ApplicationsPage>
   );
 });
 

--- a/frontend/src/pages/notebookController/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/StartServerModal.tsx
@@ -27,6 +27,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
 
   const isNotebookRunning = checkNotebookRunning(notebook);
+  const notebookLink = notebook?.metadata.annotations?.['opendatahub.io/link'];
 
   React.useEffect(() => {
     let timer;
@@ -37,13 +38,14 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
         reason: 'The notebook server is up and running. This page will update momentarily.',
       });
       timer = setTimeout(() => {
-        if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
-          window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+        if (notebookLink) {
+          window.location.href = notebookLink;
         } else {
           setSpawnStatus({
             status: AlertVariant.danger,
             title: 'Failed to redirect',
-            reason: 'For unknown reasons the notebook server was unable to be redirected to. Please check your notebook status.',
+            reason:
+              'For unknown reasons the notebook server was unable to be redirected to. Please check your notebook status.',
           });
         }
       }, 6000);
@@ -53,7 +55,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
         clearTimeout(timer);
       }
     };
-  }, [isNotebookRunning]);
+  }, [isNotebookRunning, notebookLink]);
 
   const loading = () => (
     <>
@@ -66,7 +68,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
 
   const running = () => (
     <p className="odh-notebook-controller__start-server-modal-text">
-      Server ready at {notebook?.metadata.annotations?.['opendatahub.io/link']}
+      Server ready at {notebookLink}
     </p>
   );
 

--- a/frontend/src/pages/notebookController/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/StartServerModal.tsx
@@ -1,28 +1,54 @@
 import * as React from 'react';
-import {
-  ActionList,
-  ActionListItem,
-  Button,
-  Modal,
-  ModalVariant,
-  Spinner,
-} from '@patternfly/react-core';
-import NotebookControllerContext from './NotebookControllerContext';
+import { Alert, AlertVariant, Button, Modal, ModalVariant, Spinner } from '@patternfly/react-core';
+import { Notebook } from '../../types';
+import { checkNotebookRunning } from '../../utilities/notebookControllerUtils';
 
 import './NotebookController.scss';
 
 type StartServerModalProps = {
+  notebook: Notebook | undefined;
   startShown: boolean;
   setStartModalShown: (shown: boolean) => void;
   onClose: () => void;
 };
 
+type SpawnStatus = {
+  status: AlertVariant;
+  title: string;
+  reason: React.ReactNode;
+};
+
 const StartServerModal: React.FC<StartServerModalProps> = ({
+  notebook,
   startShown,
   setStartModalShown,
   onClose,
 }) => {
-  const { notebook, isNotebookRunning } = React.useContext(NotebookControllerContext);
+  const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
+
+  const isNotebookRunning = checkNotebookRunning(notebook);
+
+  React.useEffect(() => {
+    let timer;
+    if (isNotebookRunning) {
+      setSpawnStatus({
+        status: AlertVariant.success,
+        title: 'Success',
+        reason: 'The notebook server is up and running. This page will update momentarily.',
+      });
+      timer = setTimeout(() => {
+        if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
+          window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+        }
+      }, 6000);
+    }
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isNotebookRunning]);
 
   const loading = () => (
     <>
@@ -34,26 +60,21 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
   );
 
   const running = () => (
-    <>
-      <p className="odh-notebook-controller__start-server-modal-text">
-        Server ready at {notebook?.metadata.annotations?.['opendatahub.io/link']}
-      </p>
-      <ActionList>
-        <ActionListItem>
-          <Button
-            onClick={() => window.open(notebook?.metadata.annotations?.['opendatahub.io/link'])}
-          >
-            Access server
-          </Button>
-        </ActionListItem>
-        <ActionListItem>
-          <Button variant="link" onClick={() => setStartModalShown(false)}>
-            Notebook server control panel
-          </Button>
-        </ActionListItem>
-      </ActionList>
-    </>
+    <p className="odh-notebook-controller__start-server-modal-text">
+      Server ready at {notebook?.metadata.annotations?.['opendatahub.io/link']}
+    </p>
   );
+
+  const renderStatus = () => {
+    if (!spawnStatus) {
+      return null;
+    }
+    return (
+      <Alert isInline variant={spawnStatus.status} title={spawnStatus.title}>
+        <p>{spawnStatus.reason}</p>
+      </Alert>
+    );
+  };
 
   return (
     <Modal
@@ -64,10 +85,13 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
       variant={ModalVariant.small}
       title="Starting server"
       isOpen={startShown}
-      showClose
+      showClose={
+        spawnStatus?.status === AlertVariant.danger || spawnStatus?.status === AlertVariant.warning
+      }
       onClose={() => (isNotebookRunning ? setStartModalShown(false) : onClose())}
     >
       {isNotebookRunning ? running() : loading()}
+      {renderStatus()}
     </Modal>
   );
 };

--- a/frontend/src/pages/notebookController/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/StartServerModal.tsx
@@ -6,7 +6,7 @@ import { checkNotebookRunning } from '../../utilities/notebookControllerUtils';
 import './NotebookController.scss';
 
 type StartServerModalProps = {
-  notebook: Notebook | undefined;
+  notebook?: Notebook;
   startShown: boolean;
   setStartModalShown: (shown: boolean) => void;
   onClose: () => void;
@@ -39,6 +39,12 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
       timer = setTimeout(() => {
         if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
           window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+        } else {
+          setSpawnStatus({
+            status: AlertVariant.danger,
+            title: 'Failed to redirect',
+            reason: 'For unknown reasons the notebook server was unable to be redirected to. Please check your notebook status.',
+          });
         }
       }, 6000);
     }
@@ -47,7 +53,6 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
         clearTimeout(timer);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNotebookRunning]);
 
   const loading = () => (

--- a/frontend/src/pages/notebookController/useWatchNotebookForSpawnerPage.ts
+++ b/frontend/src/pages/notebookController/useWatchNotebookForSpawnerPage.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { useWatchNotebook } from '../../utilities/useWatchNotebook';
+import { FAST_POLL_INTERVAL, POLL_INTERVAL } from '../../utilities/const';
+import { Notebook } from '../../types';
+
+export const useWatchNotebookForSpawnerPage = (
+  startShown: boolean,
+  projectName: string,
+  username: string,
+): {
+  notebook?: Notebook;
+  notebookLoaded: boolean;
+} => {
+  const {
+    notebook,
+    loaded: notebookLoaded,
+    setPollInterval: setNotebookPollInterval,
+  } = useWatchNotebook(projectName, username);
+  React.useEffect(() => {
+    setNotebookPollInterval(startShown ? FAST_POLL_INTERVAL : POLL_INTERVAL);
+  }, [startShown, setNotebookPollInterval]);
+  return { notebook, notebookLoaded };
+};

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { EnvVarReducedType, Notebook, NotebookSize, Volume, VolumeMount } from '../types';
 import { LIMIT_NOTEBOOK_IMAGE_GPU } from '../utilities/const';
 import { MOUNT_PATH } from '../pages/notebookController/const';
+import { usernameTranslate } from 'utilities/notebookControllerUtils';
 
 export const getNotebook = (projectName: string, notebookName: string): Promise<Notebook> => {
   const url = `/api/notebooks/${projectName}/${notebookName}`;
@@ -34,6 +35,7 @@ export const createNotebook = (
     }
     resources.limits[LIMIT_NOTEBOOK_IMAGE_GPU] = gpus;
   }
+  const translatedUsername = usernameTranslate(username);
 
   const configMapEnvs = Object.keys(envVars.configMap).map((key) => ({
     name: key,
@@ -54,8 +56,9 @@ export const createNotebook = (
       },
     },
   }));
+  const location = new URL(window.location.href);
+  const origin = location.origin;
 
-  //TODO: instead of store.getState().appState.user, we need to use session and proper auth permissions
   const data = {
     apiVersion: 'kubeflow.org/v1',
     kind: 'Notebook',
@@ -63,7 +66,10 @@ export const createNotebook = (
       labels: {
         app: notebookName,
         'opendatahub.io/odh-managed': 'true',
-        'opendatahub.io/user': username,
+        'opendatahub.io/user': translatedUsername,
+      },
+      annotations: {
+        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/notebookController/${translatedUsername}/home`,
       },
       name: notebookName,
     },
@@ -83,7 +89,9 @@ export const createNotebook = (
                   value: `--ServerApp.port=8888
                   --ServerApp.token=''
                   --ServerApp.password=''
-                  --ServerApp.base_url=/notebook/${projectName}/${notebookName}`,
+                  --ServerApp.base_url=/notebook/${projectName}/${notebookName}
+                  --ServerApp.quit_button=False
+                  --ServerApp.tornado_settings={"user":"${username}","hub_host":"${origin}","hub_prefix":"/notebookController/${translatedUsername}"}`,
                 },
                 {
                   name: 'JUPYTER_IMAGE',
@@ -132,6 +140,8 @@ export const createNotebook = (
       },
     },
   };
+
+  console.log(data);
 
   return axios
     .post(url, data)

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -91,7 +91,7 @@ export const createNotebook = (
                   --ServerApp.password=''
                   --ServerApp.base_url=/notebook/${projectName}/${notebookName}
                   --ServerApp.quit_button=False
-                  --ServerApp.tornado_settings={"user":"${username}","hub_host":"${origin}","hub_prefix":"/notebookController/${translatedUsername}"}`,
+                  --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${origin}","hub_prefix":"/notebookController/${translatedUsername}"}`,
                 },
                 {
                   name: 'JUPYTER_IMAGE',
@@ -140,8 +140,6 @@ export const createNotebook = (
       },
     },
   };
-
-  console.log(data);
 
   return axios
     .post(url, data)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -55,7 +55,7 @@ export type NotebookResources = {
 };
 
 export type EnvironmentVariable = {
-  key: string;
+  name: string;
   value: string | number;
 };
 

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -9,7 +9,7 @@ const FAST_POLL_INTERVAL = process.env.FAST_POLL_INTERVAL
 const DOC_LINK = process.env.DOC_LINK;
 const COMMUNITY_LINK = process.env.COMMUNITY_LINK;
 const SUPPORT_LINK = process.env.SUPPORT_LINK;
-const ODH_LOGO = process.env.ODH_LOGO;
+const ODH_LOGO = process.env.ODH_LOGO || 'odh-logo.svg';
 const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const ODH_NOTEBOOK_REPO = process.env.ODH_NOTEBOOK_REPO;
 

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash-es';
+import * as _ from 'lodash';
 import { AxiosError } from 'axios';
 import {
   createConfigMap,
@@ -14,6 +14,8 @@ import {
   EnvVarReducedTypeKeyValues,
   EnvVarResource,
   EnvVarResourceType,
+  Notebook,
+  NotebookControllerUserState,
   PersistentVolumeClaim,
   Secret,
   VariableRow,
@@ -172,3 +174,16 @@ export const generatePvc = (pvcName: string, pvcSize: string): PersistentVolumeC
     phase: 'Pending',
   },
 });
+
+export const checkNotebookRunning = (notebook?: Notebook): boolean =>
+  !!(
+    notebook?.status?.readyReplicas &&
+    notebook?.status?.readyReplicas >= 1 &&
+    notebook?.metadata.annotations?.['opendatahub.io/link']
+  );
+
+export const getUserStateFromDashboardConfig = (
+  translatedUsername: string,
+  notebookControllerState?: NotebookControllerUserState[],
+): NotebookControllerUserState | undefined =>
+  notebookControllerState?.find((state) => usernameTranslate(state.user) === translatedUsername);

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -184,6 +184,6 @@ export const checkNotebookRunning = (notebook?: Notebook): boolean =>
 
 export const getUserStateFromDashboardConfig = (
   translatedUsername: string,
-  notebookControllerState?: NotebookControllerUserState[],
+  notebookControllerState: NotebookControllerUserState[],
 ): NotebookControllerUserState | undefined =>
-  notebookControllerState?.find((state) => usernameTranslate(state.user) === translatedUsername);
+  notebookControllerState.find((state) => usernameTranslate(state.user) === translatedUsername);

--- a/frontend/src/utilities/useNotification.ts
+++ b/frontend/src/utilities/useNotification.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { addNotification } from '../redux/actions/actions';
+
+type SuccessProps = (title: string) => void;
+type ErrorProps = (title: string, message?: React.ReactNode) => void;
+
+const useNotification = (): {
+  success: SuccessProps;
+  error: ErrorProps;
+} => {
+  const dispatch = useDispatch();
+
+  const success: SuccessProps = (title) => {
+    dispatch(
+      addNotification({
+        status: 'success',
+        title,
+        timestamp: new Date(),
+      }),
+    );
+  };
+
+  const error: ErrorProps = (title, message?) => {
+    dispatch(
+      addNotification({
+        status: 'danger',
+        title,
+        message,
+        timestamp: new Date(),
+      }),
+    );
+  };
+  return { success, error };
+};
+
+export default useNotification;

--- a/frontend/src/utilities/useNotification.ts
+++ b/frontend/src/utilities/useNotification.ts
@@ -11,26 +11,33 @@ const useNotification = (): {
 } => {
   const dispatch = useDispatch();
 
-  const success: SuccessProps = (title) => {
-    dispatch(
-      addNotification({
-        status: 'success',
-        title,
-        timestamp: new Date(),
-      }),
-    );
-  };
+  const success: SuccessProps = React.useCallback(
+    (title) => {
+      dispatch(
+        addNotification({
+          status: 'success',
+          title,
+          timestamp: new Date(),
+        }),
+      );
+    },
+    [dispatch],
+  );
 
-  const error: ErrorProps = (title, message?) => {
-    dispatch(
-      addNotification({
-        status: 'danger',
-        title,
-        message,
-        timestamp: new Date(),
-      }),
-    );
-  };
+  const error: ErrorProps = React.useCallback(
+    (title, message?) => {
+      dispatch(
+        addNotification({
+          status: 'danger',
+          title,
+          message,
+          timestamp: new Date(),
+        }),
+      );
+    },
+    [dispatch],
+  );
+
   return { success, error };
 };
 

--- a/frontend/src/utilities/useTrackHistory.ts
+++ b/frontend/src/utilities/useTrackHistory.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { fireTrackingEvent } from './segmentIOUtils';
 
 export const useTrackHistory = (): void => {

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -4,7 +4,7 @@ import { POLL_INTERVAL } from './const';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { fetchDashboardConfig } from '../services/dashboardConfigService';
 
-const blankDashboardCR: DashboardConfig = {
+export const blankDashboardCR: DashboardConfig = {
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',
   metadata: {

--- a/frontend/src/utilities/useWatchImages.tsx
+++ b/frontend/src/utilities/useWatchImages.tsx
@@ -15,14 +15,21 @@ export const useWatchImages = (): {
 
   React.useEffect(() => {
     let watchHandle;
+    let cancelled = false;
     const watchImages = () => {
       fetchImages()
         .then((data: ImageInfo[]) => {
+          if (cancelled) {
+            return;
+          }
           setLoaded(true);
           setLoadError(undefined);
           setImages(data);
         })
         .catch((e) => {
+          if (cancelled) {
+            return;
+          }
           setLoadError(e);
         });
       watchHandle = setTimeout(watchImages, POLL_INTERVAL);
@@ -30,6 +37,7 @@ export const useWatchImages = (): {
     watchImages();
 
     return () => {
+      cancelled = true;
       if (watchHandle) {
         clearTimeout(watchHandle);
       }


### PR DESCRIPTION
Closes #294, #302, #305

This PR is doing the following things:
1. Refactor the route of the notebook controller, the spawner page will now be running at `${dashboard_domain}/notebookController/spawner` and the control panel will be running at `${dashboard_domain}/notebookController`
2. When the user successfully starts the server, it will automatically redirect to the JupyterLab notebook server
3. The Hub Control Panel in the JupyterLab notebook is activated, and it will redirect the user back to `${dashboard_domain}/notebookController`
4. Log out in the JupyterLab notebook will work now
5. Set dashboard config as the context of the App, so all the pages could use them through context
6. Stop using `react-router`, instead, use `react-router-dom` since this is a web app