### PR TITLE
Allow creating notebook in different namespace

### DIFF
--- a/backend/src/routes/api/pvc/index.ts
+++ b/backend/src/routes/api/pvc/index.ts
@@ -4,13 +4,17 @@ import { V1PersistentVolumeClaim } from '@kubernetes/client-node';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get(
-    '/:name',
-    async (request: FastifyRequest<{ Params: { name: string } }>, reply: FastifyReply) => {
+    '/:namespace/:name',
+    async (
+      request: FastifyRequest<{ Params: { namespace: string; name: string } }>,
+      reply: FastifyReply,
+    ) => {
       const pvcName = request.params.name;
+      const pvcNamespace = request.params.namespace;
       try {
         const pvcResponse = await fastify.kube.coreV1Api.readNamespacedPersistentVolumeClaim(
           pvcName,
-          fastify.kube.namespace,
+          pvcNamespace,
         );
         return pvcResponse.body;
       } catch (e) {
@@ -26,7 +30,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       const pvcRequest = request.body;
       try {
         const pvcResponse = await fastify.kube.coreV1Api.createNamespacedPersistentVolumeClaim(
-          fastify.kube.namespace,
+          pvcRequest.metadata.namespace,
           pvcRequest,
         );
         return pvcResponse.body;

--- a/backend/src/routes/api/rolebindings/index.ts
+++ b/backend/src/routes/api/rolebindings/index.ts
@@ -1,0 +1,49 @@
+import { KubeFastifyInstance } from '../../../types';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { V1RoleBinding } from '@kubernetes/client-node';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.get(
+    '/:namespace/:name',
+    async (
+      request: FastifyRequest<{ Params: { namespace: string; name: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const rbName = request.params.name;
+      const rbNamespace = request.params.namespace;
+      try {
+        const rbResponse = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
+          'rbac.authorization.k8s.io',
+          'v1',
+          rbNamespace,
+          'rolebindings',
+          rbName,
+        );
+        return rbResponse.body;
+      } catch (e) {
+        fastify.log.error(`rolebinding ${rbName} could not be read, ${e}`);
+        reply.send(e);
+      }
+    },
+  );
+
+  fastify.post(
+    '/',
+    async (request: FastifyRequest<{ Body: V1RoleBinding }>, reply: FastifyReply) => {
+      const rbRequest = request.body;
+      try {
+        const rbResponse = await fastify.kube.customObjectsApi.createNamespacedCustomObject(
+          'rbac.authorization.k8s.io',
+          'v1',
+          rbRequest.metadata.namespace,
+          'rolebindings',
+          rbRequest,
+        );
+        return rbResponse.body;
+      } catch (e) {
+        fastify.log.error(`rolebinding could not be created: ${e}`);
+        reply.send(e);
+      }
+    },
+  );
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -24,6 +24,7 @@ export type DashboardConfig = K8sResourceCommon & {
       envVarConfig?: {
         enabled: boolean;
       };
+      notebookNamespace?: string;
     };
   };
   status?: {

--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -67,6 +67,7 @@ notebookController:
         enabled: true
     gpuConfig:
         enabled: true
+    notebookNamespace: odh-notebooks
 ```
 
 ### Notebook Controller State

--- a/frontend/src/pages/notebookController/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/SpawnerPage.tsx
@@ -60,8 +60,11 @@ const SpawnerPage: React.FC = React.memo(() => {
   const { buildStatuses, dashboardConfig, setIsNavOpen } = React.useContext(AppContext);
   const stateUsername = useSelector<State, string>((state) => state.appState.user || '');
   const username = currentUserState.user || stateUsername;
-  const namespace = useSelector<State, string>((state) => state.appState.namespace || '');
-  const projectName = dashboardConfig.spec.notebookController?.notebookNamespace || namespace;
+  const dashboardNamespace = useSelector<State, string>(
+    (state) => state.appState.dashboardNamespace || '',
+  );
+  const projectName =
+    dashboardConfig.spec.notebookController?.notebookNamespace || dashboardNamespace;
   const [startShown, setStartShown] = React.useState<boolean>(false);
   const { notebook, notebookLoaded } = useWatchNotebookForSpawnerPage(
     startShown,
@@ -69,7 +72,7 @@ const SpawnerPage: React.FC = React.memo(() => {
     username,
   );
   const isNotebookRunning = checkNotebookRunning(notebook);
-  
+
   const [selectedImageTag, setSelectedImageTag] = React.useState<ImageTag>({
     image: undefined,
     tag: undefined,

--- a/frontend/src/pages/notebookController/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/SpawnerPage.tsx
@@ -39,7 +39,6 @@ import {
   checkNotebookRunning,
 } from '../../utilities/notebookControllerUtils';
 import AppContext from '../../app/AppContext';
-import { ODH_NOTEBOOK_REPO } from '../../utilities/const';
 import { getGPU } from '../../services/gpuService';
 import { patchDashboardConfig } from '../../services/dashboardConfigService';
 import { getSecret } from '../../services/secretsService';
@@ -58,10 +57,11 @@ const SpawnerPage: React.FC = React.memo(() => {
   const notification = useNotification();
   const { images, loaded, loadError } = useWatchImages();
   const { currentUserState, setCurrentUserState } = React.useContext(NotebookControllerContext);
+  const { buildStatuses, dashboardConfig, setIsNavOpen } = React.useContext(AppContext);
   const stateUsername = useSelector<State, string>((state) => state.appState.user || '');
   const username = currentUserState.user || stateUsername;
   const namespace = useSelector<State, string>((state) => state.appState.namespace || '');
-  const projectName = ODH_NOTEBOOK_REPO || namespace;
+  const projectName = dashboardConfig.spec.notebookController?.notebookNamespace || namespace;
   const [startShown, setStartShown] = React.useState<boolean>(false);
   const { notebook, notebookLoaded } = useWatchNotebookForSpawnerPage(
     startShown,
@@ -69,7 +69,7 @@ const SpawnerPage: React.FC = React.memo(() => {
     username,
   );
   const isNotebookRunning = checkNotebookRunning(notebook);
-  const { buildStatuses, dashboardConfig, setIsNavOpen } = React.useContext(AppContext);
+  
   const [selectedImageTag, setSelectedImageTag] = React.useState<ImageTag>({
     image: undefined,
     tag: undefined,
@@ -174,13 +174,13 @@ const SpawnerPage: React.FC = React.memo(() => {
   }, [dashboardConfig, currentUserState]);
 
   const mapRows = React.useCallback(
-    async (fetchFunc: (name: string) => Promise<ConfigMap | Secret>) => {
+    async (fetchFunc: (namespace: string, name: string) => Promise<ConfigMap | Secret>) => {
       if (!username) {
         return [];
       }
       let fetchedVariableRows: VariableRow[] = [];
       const envVarFileName = generateEnvVarFileNameFromUsername(username);
-      const response = await verifyResource(envVarFileName, fetchFunc);
+      const response = await verifyResource(envVarFileName, projectName, fetchFunc);
       if (response && response.data) {
         const isSecret = response.kind === EnvVarResourceType.Secret;
         fetchedVariableRows = Object.entries(response.data).map(([key, value]) => {
@@ -204,7 +204,7 @@ const SpawnerPage: React.FC = React.memo(() => {
       }
       return fetchedVariableRows;
     },
-    [username],
+    [username, projectName],
   );
 
   React.useEffect(() => {
@@ -322,8 +322,8 @@ const SpawnerPage: React.FC = React.memo(() => {
       (ns) => ns.name === selectedSize,
     );
     const pvcName = generatePvcNameFromUsername(username);
-    const pvcBody = generatePvc(pvcName, '20Gi');
-    await verifyResource(pvcName, getPvc, createPvc, pvcBody).catch((e) =>
+    const pvcBody = generatePvc(pvcName, projectName, '20Gi');
+    await verifyResource(pvcName, projectName, getPvc, createPvc, pvcBody).catch((e) =>
       console.error(`Something wrong with PVC ${pvcName}: ${e}`),
     );
     const volumes = [{ name: pvcName, persistentVolumeClaim: { claimName: pvcName } }];
@@ -331,7 +331,7 @@ const SpawnerPage: React.FC = React.memo(() => {
     const notebookName = generateNotebookNameFromUsername(username);
     const imageUrl = `${selectedImageTag.image?.dockerImageRepo}:${selectedImageTag.tag?.name}`;
     setCreateInProgress(true);
-    const envVars = await checkEnvVarFile(username, namespace, variableRows);
+    const envVars = await checkEnvVarFile(username, projectName, variableRows);
     await createNotebook(
       projectName,
       notebookName,

--- a/frontend/src/redux/actions/actions.ts
+++ b/frontend/src/redux/actions/actions.ts
@@ -23,7 +23,7 @@ export const getUserFulfilled = (response: {
     clusterID: response.kube.clusterID,
     clusterBranding: response.kube.clusterBranding,
     isAdmin: response.kube.isAdmin,
-    namespace: response.kube.namespace,
+    dashboardNamespace: response.kube.namespace,
   },
 });
 

--- a/frontend/src/redux/reducers/appReducer.ts
+++ b/frontend/src/redux/reducers/appReducer.ts
@@ -17,7 +17,7 @@ const appReducer = (state: AppState = initialState, action: GetUserAction): AppS
         userError: null,
         clusterID: '',
         clusterBranding: '',
-        namespace: '',
+        dashboardNamespace: '',
       };
     case Actions.GET_USER_FULFILLED:
       return {
@@ -28,7 +28,7 @@ const appReducer = (state: AppState = initialState, action: GetUserAction): AppS
         clusterID: action.payload.clusterID,
         clusterBranding: action.payload.clusterBranding,
         isAdmin: action.payload.isAdmin,
-        namespace: action.payload.namespace,
+        dashboardNamespace: action.payload.dashboardNamespace,
       };
     case Actions.GET_USER_REJECTED:
       return {
@@ -38,7 +38,7 @@ const appReducer = (state: AppState = initialState, action: GetUserAction): AppS
         userError: action.payload.error,
         clusterID: '',
         clusterBranding: '',
-        namespace: '',
+        dashboardNamespace: '',
       };
     case Actions.ADD_NOTIFICATION:
       if (!action.payload.notification) {

--- a/frontend/src/redux/types.ts
+++ b/frontend/src/redux/types.ts
@@ -31,7 +31,7 @@ export interface GetUserAction {
     user?: string;
     clusterID?: string;
     clusterBranding?: string;
-    namespace?: string;
+    dashboardNamespace?: string;
     isAdmin?: boolean;
     error?: Error | null;
     notification?: AppNotification;
@@ -45,7 +45,7 @@ export interface AppState {
   clusterID?: string;
   clusterBranding?: string;
   isAdmin?: boolean;
-  namespace?: string;
+  dashboardNamespace?: string;
   notifications: AppNotification[];
   forceComponentsUpdate: number;
 }

--- a/frontend/src/services/configMapService.ts
+++ b/frontend/src/services/configMapService.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { ConfigMap, DeleteStatus } from '../types';
 
-export const getConfigMap = (configMapName: string): Promise<ConfigMap> => {
-  const url = `/api/configmaps/${configMapName}`;
+export const getConfigMap = (projectName: string, configMapName: string): Promise<ConfigMap> => {
+  const url = `/api/configmaps/${projectName}/${configMapName}`;
   return axios.get(url).then((response) => {
     return response.data;
   });
@@ -15,15 +15,18 @@ export const createConfigMap = (data: ConfigMap): Promise<ConfigMap> => {
   });
 };
 
-export const replaceConfigMap = (configMapName: string, data: ConfigMap): Promise<ConfigMap> => {
-  const url = `/api/configmaps/${configMapName}`;
+export const replaceConfigMap = (data: ConfigMap): Promise<ConfigMap> => {
+  const url = `/api/configmaps`;
   return axios.put(url, data).then((response) => {
     return response.data;
   });
 };
 
-export const deleteConfigMap = (configMapName: string): Promise<DeleteStatus> => {
-  const url = `/api/configmaps/${configMapName}`;
+export const deleteConfigMap = (
+  projectName: string,
+  configMapName: string,
+): Promise<DeleteStatus> => {
+  const url = `/api/configmaps/${projectName}/${configMapName}`;
   return axios.delete(url).then((response) => {
     return response.data;
   });

--- a/frontend/src/services/pvcService.ts
+++ b/frontend/src/services/pvcService.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { PersistentVolumeClaim } from '../types';
 
-export const getPvc = (pvcName: string): Promise<PersistentVolumeClaim> => {
-  const url = `/api/pvc/${pvcName}`;
+export const getPvc = (projectName: string, pvcName: string): Promise<PersistentVolumeClaim> => {
+  const url = `/api/pvc/${projectName}/${pvcName}`;
   return axios.get(url).then((response) => {
     return response.data;
   });

--- a/frontend/src/services/roleBindingService.ts
+++ b/frontend/src/services/roleBindingService.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { RoleBinding } from '../types';
+
+export const getRoleBinding = (projectName: string, rbName: string): Promise<RoleBinding> => {
+  const url = `/api/rolebindings/${projectName}/${rbName}`;
+  return axios.get(url).then((response) => {
+    return response.data;
+  });
+};
+
+export const createRoleBinding = (data: RoleBinding): Promise<RoleBinding> => {
+  const url = `/api/rolebindings`;
+  return axios.post(url, data).then((response) => {
+    return response.data;
+  });
+};

--- a/frontend/src/services/secretsService.ts
+++ b/frontend/src/services/secretsService.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { DeleteStatus, Secret } from '../types';
 
-export const getSecret = (secretName: string): Promise<Secret> => {
-  const url = `/api/secrets/${secretName}`;
+export const getSecret = (projectName: string, secretName: string): Promise<Secret> => {
+  const url = `/api/secrets/${projectName}/${secretName}`;
   return axios.get(url).then((response) => {
     return response.data;
   });
@@ -15,15 +15,15 @@ export const createSecret = (data: Secret): Promise<Secret> => {
   });
 };
 
-export const replaceSecret = (secretName: string, data: Secret): Promise<Secret> => {
-  const url = `/api/secrets/${secretName}`;
+export const replaceSecret = (data: Secret): Promise<Secret> => {
+  const url = `/api/secrets`;
   return axios.put(url, data).then((response) => {
     return response.data;
   });
 };
 
-export const deleteSecret = (secretName: string): Promise<DeleteStatus> => {
-  const url = `/api/secrets/${secretName}`;
+export const deleteSecret = (projectName: string, secretName: string): Promise<DeleteStatus> => {
+  const url = `/api/secrets/${projectName}/${secretName}`;
   return axios.delete(url).then((response) => {
     return response.data;
   });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -562,3 +562,14 @@ export type RoleBinding = {
   subjects: RoleBindingSubject[];
   roleRef: RoleBindingSubject;
 } & K8sResourceCommon;
+
+export type ResourceGetter<T extends K8sResourceCommon> = (
+  projectName: string,
+  resourceName: string,
+) => Promise<T>;
+
+export type ResourceCreator<T extends K8sResourceCommon> = (resource: T) => Promise<T>;
+
+export type ResourceReplacer<T extends K8sResourceCommon> = (resource: T) => Promise<T>;
+
+export type ResourceDeleter = (projectName: string, resourceName: string) => Promise<DeleteStatus>;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -18,6 +18,7 @@ export type DashboardConfig = K8sResourceCommon & {
       envVarConfig?: {
         enabled: boolean;
       };
+      notebookNamespace?: string;
     };
   };
   status?: {
@@ -550,3 +551,14 @@ export type DeleteStatus = {
   reason?: string;
   status?: string;
 };
+
+export type RoleBindingSubject = {
+  kind: string;
+  apiGroup: string;
+  name: string;
+};
+
+export type RoleBinding = {
+  subjects: RoleBindingSubject[];
+  roleRef: RoleBindingSubject;
+} & K8sResourceCommon;

--- a/frontend/src/utilities/useWatchNotebook.tsx
+++ b/frontend/src/utilities/useWatchNotebook.tsx
@@ -55,7 +55,7 @@ export const useWatchNotebook = (
     };
     // Don't update when components are updated
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [username, pollInterval]);
+  }, [username, pollInterval, projectName]);
 
   return { notebook, loaded, loadError, setPollInterval };
 };

--- a/frontend/src/utilities/useWatchNotebook.tsx
+++ b/frontend/src/utilities/useWatchNotebook.tsx
@@ -53,8 +53,6 @@ export const useWatchNotebook = (
         clearTimeout(watchHandle);
       }
     };
-    // Don't update when components are updated
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [username, pollInterval, projectName]);
 
   return { notebook, loaded, loadError, setPollInterval };

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -21,15 +21,20 @@ rules:
     resources:
       - clusterserviceversions
       - subscriptions
-  - verbs:
+  - apiGroups:
+      - ''
+    verbs:
+      - create
+      - delete
       - get
       - list
+      - patch
+      - update
       - watch
-    apiGroups:
-      - ''
     resources:
-      - services
       - configmaps
+      - persistentvolumeclaims
+      - secrets
   - verbs:
       - get
       - list
@@ -80,15 +85,30 @@ rules:
     resources:
       - pods
       - serviceaccounts
-      - secrets
       - services
       - namespaces
-  - verbs:
-      - create
-      - delete
-      - list
-    apiGroups:
+  - apiGroups:
       - rbac.authorization.k8s.io
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
     resources:
-      - roles
       - rolebindings
+      - roles
+  - apiGroups:
+      - kubeflow.org
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    resources:
+      - notebooks

--- a/manifests/base/odh-dashboard-crd.yaml
+++ b/manifests/base/odh-dashboard-crd.yaml
@@ -71,6 +71,8 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    notebookNamespace:
+                      type: string
                     gpuConfig:
                       type: object
                       properties:

--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -20,20 +20,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ''
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    resources:
-      - configmaps
-      - persistentvolumeclaims
-      - secrets
-  - apiGroups:
       - batch
     verbs:
       - create
@@ -71,12 +57,6 @@ rules:
       - builds
       - buildconfigs
       - buildconfigs/instantiate
-  - verbs:
-      - list
-    apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
   - apiGroups:
       - apps.openshift.io
     verbs:
@@ -102,15 +82,3 @@ rules:
       - delete
     resources:
       - odhdashboardconfigs
-  - apiGroups:
-      - kubeflow.org
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-    resources:
-      - notebooks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
~~Look only at the last commit. The other commits are based on #331~~
Closes #297 
By setting `notebookNamespace` in the dashboard config, you can create all the notebooks in a different namespace. As well as PVC, config maps and secrets.

## Description
<!--- Describe your changes in detail -->
Pass `projectName` everywhere so all the functions and API calls has the ability to create K8s resources on the assigned project(namespace).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a new project on cluster -> Add/Change the `notebookNamespace` under `notebookController` in the dashboard config -> Try to create a notebook -> You will see the notebook running in your assigned project (namespace).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
