### PR TITLE
Rbac rule

### DIFF
--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -1,6 +1,12 @@
 import { KubeFastifyInstance, Notebook } from '../../../types';
 import { FastifyRequest } from 'fastify';
-import { getNotebook, getNotebooks, patchNotebook, postNotebook } from './notebookUtils';
+import {
+  deleteNotebook,
+  getNotebook,
+  getNotebooks,
+  patchNotebook,
+  postNotebook,
+} from './notebookUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get('/:projectName', async (request: FastifyRequest) => {
@@ -23,29 +29,33 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     return await getNotebook(fastify, params.projectName, params.notebookName);
   });
 
-  fastify.post('/:projectName', async (request: FastifyRequest) => {
-    const params = request.params as {
-      projectName: string;
-    };
-    const notebookData = request.body as Notebook;
+  fastify.post(
+    '/:projectName',
+    async (
+      request: FastifyRequest<{
+        Params: {
+          projectName: string;
+        };
+        Body: Notebook;
+      }>,
+    ) => {
+      return postNotebook(fastify, request);
+    },
+  );
 
-    return await postNotebook(fastify, params.projectName, notebookData);
-  });
-
-  fastify.delete('/:projectName/:notebookName', async (request: FastifyRequest) => {
-    const params = request.params as {
-      projectName: string;
-      notebookName: string;
-    };
-
-    return fastify.kube.customObjectsApi.deleteNamespacedCustomObject(
-      'kubeflow.org',
-      'v1',
-      params.projectName,
-      'notebooks',
-      params.notebookName,
-    );
-  });
+  fastify.delete(
+    '/:projectName/:notebookName',
+    async (
+      request: FastifyRequest<{
+        Params: {
+          projectName: string;
+          notebookName: string;
+        };
+      }>,
+    ) => {
+      return deleteNotebook(fastify, request);
+    },
+  );
 
   fastify.patch('/:projectName/:notebookName', async (request: FastifyRequest) => {
     const params = request.params as {

--- a/backend/src/utils/requestUtils.ts
+++ b/backend/src/utils/requestUtils.ts
@@ -1,0 +1,9 @@
+import createError from 'http-errors';
+
+export const createCustomError = (title: string, message: string): createError.HttpError<500> => {
+  const error = createError(500, title);
+  error.explicitInternalServerError = true;
+  error.error = title;
+  error.message = message;
+  return error;
+};

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -83,3 +83,12 @@ rules:
       - secrets
       - services
       - namespaces
+  - verbs:
+      - create
+      - delete
+      - list
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #290

* Backend will create a `role` and a `rolebinding` for the notebook.
* Refactor `post` and `delete` endpoints to catch and raise errors.
* Add the ability to retrieve user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Deploy the KfDef bellow.
2. Run `make build`, `make push` & `make deploy`.
3. Create a new notebook.
4. Check that the `role` and `rolebinding` for that notebook are created.

## KfDef

```yaml
kind: KfDef
metadata:
  name: odh-dashboard-kfnbc-test
spec:
  applications:
    - kustomizeConfig:
        overlays:
          - additional
        repoRef:
          name: manifests
          path: jupyterhub/notebook-images
      name: notebook-images
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-notebook-controller
      name: odh-notebook-controller
  repos:
    - name: manifests
      uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/master'
    - name: manifests-dashboard
      uri: 'https://github.com/opendatahub-io/odh-dashboard/tarball/main'
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
