### PR TITLE
RBAC: Allow dashboard SA to get IS layers

### DIFF
--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -23,6 +23,13 @@ rules:
       - subscriptions
   - apiGroups:
       - ''
+      - image.openshift.io
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
+  - apiGroups:
+      - ''
     verbs:
       - create
       - delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dashboard SA cannot create `rhods-notebooks-image-pullers` RoleBinding because it grants access itself to get `imagestreams/layers` object.

Needed by https://github.com/opendatahub-io/odh-dashboard/issues/297

