### PR TITLE
Add detailed logs for starting server modal

### DIFF
--- a/backend/src/routes/api/nb-events/eventUtils.ts
+++ b/backend/src/routes/api/nb-events/eventUtils.ts
@@ -1,14 +1,14 @@
-import { V1EventList } from '@kubernetes/client-node';
-import { EventStatus, KubeFastifyInstance, NotebookStatus } from '../../../types';
-import createError from 'http-errors';
+import { V1Event, V1EventList } from '@kubernetes/client-node';
+import { KubeFastifyInstance } from '../../../types';
 
 export const getNotebookEvents = async (
   fastify: KubeFastifyInstance,
+  namespace: string,
   nbName: string,
-): Promise<NotebookStatus> => {
+): Promise<V1Event[]> => {
   const response = await fastify.kube.coreV1Api
     .listNamespacedEvent(
-      fastify.kube.namespace,
+      namespace,
       undefined,
       undefined,
       undefined,
@@ -17,77 +17,6 @@ export const getNotebookEvents = async (
     .then((res) => {
       return res.body as V1EventList;
     });
-  let percentile = 0;
-  let status: EventStatus = EventStatus.IN_PROGRESS;
-  let lastItem;
-  try {
-    lastItem = response.items[response.items.length - 1];
-    if (lastItem.message.includes('oauth-proxy')) {
-      switch (lastItem.reason) {
-        case 'Pulling': {
-          percentile = 72;
-          break;
-        }
-        case 'Pulled': {
-          percentile = 81;
-          break;
-        }
-        case 'Created': {
-          percentile = 90;
-          break;
-        }
-        case 'Started': {
-          percentile = 100;
-          status = EventStatus.SUCCESS;
-          break;
-        }
-      }
-    } else {
-      switch (lastItem.reason) {
-        case 'SuccessfulCreate': {
-          percentile = 9;
-          break;
-        }
-        case 'Scheduled': {
-          percentile = 18;
-          break;
-        }
-        case 'AddedInterface': {
-          percentile = 27;
-          break;
-        }
-        case 'Pulling': {
-          percentile = 36;
-          break;
-        }
-        case 'Pulled': {
-          percentile = 45;
-          break;
-        }
-        case 'Created': {
-          percentile = 54;
-          break;
-        }
-        case 'Started': {
-          percentile = 63;
-          break;
-        }
-        default: {
-          status = EventStatus.ERROR;
-        }
-      }
-    }
-  } catch (e) {
-    const error = createError(404, 'failed to get event items');
-    throw error;
-  }
 
-  const statusObject: NotebookStatus = {
-    percentile: percentile,
-    currentStatus: status,
-    currentEvent: lastItem.reason,
-    currentEventDescription: lastItem.message,
-    events: response.items,
-  };
-  return statusObject;
+  return response.items;
 };

--- a/backend/src/routes/api/nb-events/index.ts
+++ b/backend/src/routes/api/nb-events/index.ts
@@ -3,16 +3,17 @@ import { getNotebookEvents } from './eventUtils';
 
 export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
-    '/:notebookName',
+    '/:namespace/:notebookName',
     async (
       request: FastifyRequest<{
         Params: {
+          namespace: string;
           notebookName: string;
         };
       }>,
     ) => {
       const params = request.params;
-      return getNotebookEvents(fastify, params.notebookName);
+      return getNotebookEvents(fastify, params.namespace, params.notebookName);
     },
   );
 };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -40,21 +40,6 @@ export type DashboardConfig = K8sResourceCommon & {
   };
 };
 
-export type NotebookStatus = {
-  percentile: number;
-  currentStatus: EventStatus;
-  currentEvent: string;
-  currentEventDescription: string;
-  events: V1Event[];
-};
-
-export enum EventStatus {
-  IN_PROGRESS = 'In Progress',
-  WARNING = 'Warning',
-  ERROR = 'Error',
-  SUCCESS = 'Success',
-}
-
 export type NotebookResources = {
   requests?: {
     cpu?: string;

--- a/frontend/src/pages/notebookController/NotebookController.scss
+++ b/frontend/src/pages/notebookController/NotebookController.scss
@@ -99,18 +99,20 @@
     .pf-c-list {
       font-size: var(--pf-global--FontSize--sm);
     }
-    .pf-c-spinner {
-      display: block;
-      margin-bottom: var(--pf-global--spacer--md);
-    }
     .pf-c-expandable-section {
       width: 100%;
       padding-right: var(--pf-global--spacer--lg);
+      margin-top: var(--pf-global--spacer--sm);
       &__content {
         margin-top: 0;
+        max-height: 250px;
+        overflow: auto;
       }
     }
-    &-text {
+    .pf-c-progress {
+      margin-bottom: var(--pf-global--spacer--md);
+    }
+    .pf-c-alert {
       margin-bottom: var(--pf-global--spacer--md);
     }
   }

--- a/frontend/src/pages/notebookController/NotebookControllerContext.tsx
+++ b/frontend/src/pages/notebookController/NotebookControllerContext.tsx
@@ -11,6 +11,8 @@ type NotebookControllerContextProps = {
   impersonatingUser: boolean;
   setCurrentAdminTab: (newTab: NotebookControllerTabTypes) => void;
   currentTab: NotebookControllerTabTypes;
+  lastNotebookCreationTime: Date;
+  setLastNotebookCreationTime: (date: Date) => void;
 };
 
 const defaultNotebookControllerContext: NotebookControllerContextProps = {
@@ -20,6 +22,8 @@ const defaultNotebookControllerContext: NotebookControllerContextProps = {
   impersonatingUser: false,
   setCurrentAdminTab: () => undefined,
   currentTab: NotebookControllerTabTypes.SERVER,
+  lastNotebookCreationTime: new Date(),
+  setLastNotebookCreationTime: () => undefined,
 };
 
 export const NotebookControllerContext = React.createContext(defaultNotebookControllerContext);
@@ -31,6 +35,7 @@ export const NotebookControllerContextProvider: React.FC = ({ children }) => {
     React.useState<NotebookControllerUserState>(EMPTY_USER_STATE);
   const [impersonatingUser, setImpersonatingUser] = React.useState<boolean>(false);
   const [currentTab, setCurrentTab] = React.useState(NotebookControllerTabTypes.SERVER);
+  const [lastNotebookCreationTime, setLastNotebookCreationTime] = React.useState(new Date());
   const { isAdmin } = useUser();
 
   const getNewStateFromUser = useGetUserStateFromDashboardConfig();
@@ -91,6 +96,8 @@ export const NotebookControllerContextProvider: React.FC = ({ children }) => {
         setImpersonatingUsername,
         currentTab,
         setCurrentAdminTab,
+        lastNotebookCreationTime,
+        setLastNotebookCreationTime,
       }}
     >
       {children}

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -1,7 +1,24 @@
 import * as React from 'react';
-import { Alert, AlertVariant, Button, Modal, ModalVariant, Spinner } from '@patternfly/react-core';
-import { Notebook } from '../../../../types';
-import { checkNotebookRunning } from '../../../../utilities/notebookControllerUtils';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ExpandableSection,
+  List,
+  ListItem,
+  Modal,
+  ModalVariant,
+  Progress,
+  ProgressVariant,
+} from '@patternfly/react-core';
+import {
+  checkNotebookRunning,
+  getNotebookStatus,
+} from '../../../../utilities/notebookControllerUtils';
+import { useWatchNotebookEvents } from '../../../../utilities/useWatchNotebookEvents';
+import { NotebookControllerContext } from '../../NotebookControllerContext';
+import { EventStatus, Notebook } from '../../../../types';
+import useNamespaces from '../../../../pages/notebookController/useNamespaces';
 
 import '../../NotebookController.scss';
 
@@ -15,7 +32,7 @@ type StartServerModalProps = {
 type SpawnStatus = {
   status: AlertVariant;
   title: string;
-  reason: React.ReactNode;
+  description: React.ReactNode;
 };
 
 const StartServerModal: React.FC<StartServerModalProps> = ({
@@ -24,18 +41,41 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
   setStartModalShown,
   onClose,
 }) => {
+  const { lastNotebookCreationTime } = React.useContext(NotebookControllerContext);
+  const { notebookNamespace } = useNamespaces();
+  const [spawnInProgress, setSpawnInProgress] = React.useState<boolean>(false);
+  const [logsExpaned, setLogsExpaned] = React.useState<boolean>(false);
+  const [spawnPercentile, setSpawnPercentile] = React.useState<number>(0);
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
 
   const isNotebookRunning = checkNotebookRunning(notebook);
   const notebookLink = notebook?.metadata.annotations?.['opendatahub.io/link'];
 
+  const notebookEvents = useWatchNotebookEvents(
+    notebookNamespace,
+    notebook?.metadata.name || '',
+    spawnInProgress,
+  );
+  const spawnFailed =
+    spawnStatus?.status === AlertVariant.danger || spawnStatus?.status === AlertVariant.warning;
+
+  const notebookStatus = getNotebookStatus(notebookEvents, lastNotebookCreationTime);
+
+  const onUnload = React.useCallback((e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    return (e.returnValue = '');
+  }, []);
+
   React.useEffect(() => {
     let timer;
     if (isNotebookRunning) {
+      window.removeEventListener('beforeunload', onUnload);
+      setSpawnInProgress(false);
+      setSpawnPercentile(100);
       setSpawnStatus({
         status: AlertVariant.success,
         title: 'Success',
-        reason: 'The notebook server is up and running. This page will update momentarily.',
+        description: 'The notebook server is up and running. This page will update momentarily.',
       });
       timer = setTimeout(() => {
         if (notebookLink) {
@@ -44,7 +84,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
           setSpawnStatus({
             status: AlertVariant.danger,
             title: 'Failed to redirect',
-            reason:
+            description:
               'For unknown reasons the notebook server was unable to be redirected to. Please check your notebook status.',
           });
         }
@@ -55,22 +95,66 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
         clearTimeout(timer);
       }
     };
-  }, [isNotebookRunning, notebookLink]);
+  }, [isNotebookRunning, notebookLink, onUnload]);
 
-  const loading = () => (
-    <>
-      <Spinner isSVG aria-label="Starting server modal spinner" />
-      <Button key="cancel" variant="secondary" onClick={onClose}>
-        Cancel
-      </Button>
-    </>
-  );
+  React.useEffect(() => {
+    setSpawnInProgress(startShown);
+    setSpawnStatus(null);
+    setSpawnPercentile(0);
+    setLogsExpaned(false);
+    // Notify user if they are trying to refresh the page when spawning is in progress
+    if (startShown) {
+      window.addEventListener('beforeunload', onUnload);
+    }
+    return () => window.removeEventListener('beforeunload', onUnload);
+  }, [startShown, onUnload]);
 
-  const running = () => (
-    <p className="odh-notebook-controller__start-server-modal-text">
-      Server ready at {notebookLink}
-    </p>
-  );
+  React.useEffect(() => {
+    if (spawnInProgress && !isNotebookRunning) {
+      if (!notebookStatus) {
+        return;
+      }
+      if (notebookStatus.currentStatus === EventStatus.IN_PROGRESS) {
+        setSpawnPercentile(notebookStatus.percentile);
+      } else if (notebookStatus.currentStatus === EventStatus.ERROR) {
+        setSpawnInProgress(false);
+        setSpawnStatus({
+          status: AlertVariant.danger,
+          title: notebookStatus.currentEventReason,
+          description: notebookStatus.currentEventDescription,
+        });
+      }
+    }
+  }, [notebookStatus, spawnInProgress, isNotebookRunning]);
+
+  const renderProgress = () => {
+    let variant;
+    switch (spawnStatus?.status) {
+      case AlertVariant.danger:
+        variant = ProgressVariant.danger;
+        break;
+      case AlertVariant.success:
+        variant = ProgressVariant.success;
+        break;
+      case AlertVariant.warning:
+        variant = ProgressVariant.warning;
+        break;
+      default:
+        variant = undefined;
+    }
+    return (
+      <Progress
+        id="progress-bar"
+        value={spawnPercentile}
+        title={
+          notebookStatus?.events.length
+            ? notebookStatus.currentEvent
+            : 'Waiting for server request to start...'
+        }
+        variant={variant}
+      />
+    );
+  };
 
   const renderStatus = () => {
     if (!spawnStatus) {
@@ -78,27 +162,52 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
     }
     return (
       <Alert isInline variant={spawnStatus.status} title={spawnStatus.title}>
-        <p>{spawnStatus.reason}</p>
+        <p>{spawnStatus.description}</p>
       </Alert>
     );
   };
+
+  const renderButtons = () =>
+    !isNotebookRunning ? (
+      <Button key="cancel" variant="secondary" onClick={onClose}>
+        {spawnFailed ? 'Close' : 'Cancel'}
+      </Button>
+    ) : null;
+
+  const renderLogs = () => (
+    <ExpandableSection
+      toggleText={`${logsExpaned ? 'Collapse' : 'Expand'} event log`}
+      onToggle={(isExpanded) => setLogsExpaned(isExpanded)}
+      isExpanded={logsExpaned}
+      isIndented
+    >
+      <List isPlain isBordered>
+        {notebookStatus?.events.reverse().map((event, index) => (
+          <ListItem key={`notebook-event-${index}`}>
+            {`${event.lastTimestamp} [${event.type}] ${event.message}`}
+          </ListItem>
+        ))}
+        <ListItem>Server requested</ListItem>
+      </List>
+    </ExpandableSection>
+  );
 
   return (
     <Modal
       aria-label="Starting server modal"
       className="odh-notebook-controller__start-server-modal"
-      description="Depending on the size and resources requested, this can take several minutes."
+      description="Depending on the size and resources requested, this can take several minutes. To track progress, expand the event log."
       appendTo={document.body}
       variant={ModalVariant.small}
       title="Starting server"
       isOpen={startShown}
-      showClose={
-        spawnStatus?.status === AlertVariant.danger || spawnStatus?.status === AlertVariant.warning
-      }
+      showClose={spawnFailed}
       onClose={() => (isNotebookRunning ? setStartModalShown(false) : onClose())}
     >
-      {isNotebookRunning ? running() : loading()}
+      {renderProgress()}
       {renderStatus()}
+      {renderButtons()}
+      {renderLogs()}
     </Modal>
   );
 };

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -44,7 +44,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
   const { lastNotebookCreationTime } = React.useContext(NotebookControllerContext);
   const { notebookNamespace } = useNamespaces();
   const [spawnInProgress, setSpawnInProgress] = React.useState<boolean>(false);
-  const [logsExpaned, setLogsExpaned] = React.useState<boolean>(false);
+  const [logsExpanded, setLogsExpanded] = React.useState<boolean>(false);
   const [spawnPercentile, setSpawnPercentile] = React.useState<number>(0);
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
 
@@ -91,9 +91,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
       }, 6000);
     }
     return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
+      clearTimeout(timer);
     };
   }, [isNotebookRunning, notebookLink, onUnload]);
 
@@ -101,7 +99,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
     setSpawnInProgress(startShown);
     setSpawnStatus(null);
     setSpawnPercentile(0);
-    setLogsExpaned(false);
+    setLogsExpanded(false);
     // Notify user if they are trying to refresh the page when spawning is in progress
     if (startShown) {
       window.addEventListener('beforeunload', onUnload);
@@ -176,14 +174,14 @@ const StartServerModal: React.FC<StartServerModalProps> = ({
 
   const renderLogs = () => (
     <ExpandableSection
-      toggleText={`${logsExpaned ? 'Collapse' : 'Expand'} event log`}
-      onToggle={(isExpanded) => setLogsExpaned(isExpanded)}
-      isExpanded={logsExpaned}
+      toggleText={`${logsExpanded ? 'Collapse' : 'Expand'} event log`}
+      onToggle={(isExpanded) => setLogsExpanded(isExpanded)}
+      isExpanded={logsExpanded}
       isIndented
     >
       <List isPlain isBordered>
         {notebookStatus?.events.reverse().map((event, index) => (
-          <ListItem key={`notebook-event-${index}`}>
+          <ListItem key={`notebook-event-${event.metadata.uid ?? index}`}>
             {`${event.lastTimestamp} [${event.type}] ${event.message}`}
           </ListItem>
         ))}

--- a/frontend/src/services/notebookEventsService.ts
+++ b/frontend/src/services/notebookEventsService.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { K8sEvent } from '../types';
+
+export const getNotebookEvents = (
+  projectName: string,
+  notebookName: string,
+): Promise<K8sEvent[]> => {
+  const url = `/api/nb-events/${projectName}/${notebookName}`;
+  return axios.get(url).then((response) => {
+    return response.data;
+  });
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -575,3 +575,24 @@ export type ResourceCreator<T extends K8sResourceCommon> = (resource: T) => Prom
 export type ResourceReplacer<T extends K8sResourceCommon> = (resource: T) => Promise<T>;
 
 export type ResourceDeleter = (projectName: string, resourceName: string) => Promise<DeleteStatus>;
+
+export type K8sEvent = {
+  lastTimestamp: string;
+  message: string;
+  reason: string;
+  type: string;
+} & K8sResourceCommon;
+
+export type NotebookStatus = {
+  percentile: number;
+  currentStatus: EventStatus;
+  currentEvent: string;
+  currentEventReason: string;
+  currentEventDescription: string;
+  events: K8sEvent[];
+};
+
+export enum EventStatus {
+  IN_PROGRESS = 'In Progress',
+  ERROR = 'Error',
+}

--- a/frontend/src/utilities/useNotification.ts
+++ b/frontend/src/utilities/useNotification.ts
@@ -5,12 +5,13 @@ import { addNotification } from '../redux/actions/actions';
 type SuccessProps = (title: string) => void;
 type ErrorProps = (title: string, message?: React.ReactNode) => void;
 
-const useNotification = (): {
+type NotificationFunc = {
   success: SuccessProps;
   error: ErrorProps;
-} => {
-  const dispatch = useDispatch();
+};
 
+const useNotification = (): NotificationFunc => {
+  const dispatch = useDispatch();
   const success: SuccessProps = React.useCallback(
     (title) => {
       dispatch(
@@ -38,7 +39,9 @@ const useNotification = (): {
     [dispatch],
   );
 
-  return { success, error };
+  const notification = React.useMemo(() => ({ success, error }), [success, error]);
+
+  return notification;
 };
 
 export default useNotification;

--- a/frontend/src/utilities/useWatchNotebookEvents.tsx
+++ b/frontend/src/utilities/useWatchNotebookEvents.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { getNotebookEvents } from '../services/notebookEventsService';
+import { useDeepCompareMemoize } from './useDeepCompareMemoize';
+import useNotification from './useNotification';
+import { K8sEvent } from '../types';
+
+export const useWatchNotebookEvents = (
+  projectName: string,
+  notebookName: string,
+  watch: boolean,
+): K8sEvent[] => {
+  const [notebookEvents, setNoteBookEvents] = React.useState<K8sEvent[]>([]);
+  const notification = useNotification();
+
+  React.useEffect(() => {
+    let watchHandle;
+    let cancelled = false;
+
+    const clear = () => {
+      cancelled = true;
+      if (watchHandle) {
+        clearTimeout(watchHandle);
+      }
+    };
+
+    const watchNotebookEvents = () => {
+      if (projectName && notebookName && watch) {
+        getNotebookEvents(projectName, notebookName)
+          .then((data: K8sEvent[]) => {
+            if (cancelled) {
+              return;
+            }
+            setNoteBookEvents(data);
+          })
+          .catch((e) => {
+            notification.error('Error fetching notebook events', e.response.data.message);
+            clear();
+          });
+        watchHandle = setTimeout(watchNotebookEvents, 1000);
+      }
+    };
+
+    watchNotebookEvents();
+    return clear;
+  }, [projectName, notebookName, notification, watch]);
+
+  const retNotebookEvents = useDeepCompareMemoize<K8sEvent[]>(notebookEvents);
+
+  return retNotebookEvents;
+};

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -108,6 +108,15 @@ rules:
       - rolebindings
       - roles
   - apiGroups:
+      - ''
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - kubeflow.org
     verbs:
       - get


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #351 
I use the context to track the last time user clicks on `Start Server`, so I can filter the latest events for a new notebook server.
I moved the process of the events to the frontend, in that case, I can better filter the events.

## Description
<!--- Describe your changes in detail -->
When spawning the notebook, add the expandable detailed logs to help users track the events.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Start notebook -> Expand the logs -> See the events.
(You could also try to run into some bad situation to see the error status, it will show an alert and stop the spawning process)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
