### PR TITLE
Add a SpawnerPage error alert when the server fails

### DIFF
--- a/backend/src/utils/requestUtils.ts
+++ b/backend/src/utils/requestUtils.ts
@@ -1,8 +1,12 @@
 import createError from 'http-errors';
 
-export const createCustomError = (title: string, message: string): createError.HttpError<500> => {
-  const error = createError(500, title);
-  error.explicitInternalServerError = true;
+export const createCustomError = (
+  title: string,
+  message: string,
+  code = 500,
+): createError.HttpError => {
+  const error = createError(code, title);
+  error.explicitInternalServerError = code >= 500;
   error.error = title;
   error.message = message;
   return error;

--- a/frontend/src/utilities/useWatchNotebooksForUsers.tsx
+++ b/frontend/src/utilities/useWatchNotebooksForUsers.tsx
@@ -32,13 +32,17 @@ const useWatchNotebooksForUsers = (
       )
         .then(([successes, fails]) => {
           if (fails.length > 0) {
-            setLoadError(
-              new Error(
-                `Failed to fetch ${fails.length} notebooks. ${fails.map(
-                  ({ reason }) => `\n  - ${reason.message}`,
-                )}`,
-              ),
-            );
+            if (fails.length === 1) {
+              setLoadError(new Error(`Failed to fetch notebook. ${fails[0].reason.toString()}`));
+            } else {
+              setLoadError(
+                new Error(
+                  `Failed to fetch ${fails.length} notebooks. ${fails.map(
+                    ({ reason }) => `\n  - ${reason.message}`,
+                  )}`,
+                ),
+              );
+            }
           } else {
             setLoadError(undefined);
           }


### PR DESCRIPTION
Resolves #368

## Description
We don't show errors to the user when something goes wrong on the server. This will add an alert above the submit button.

When an error happens, it will look something like this (the body of the alert is the kube generated error): 
![image](https://user-images.githubusercontent.com/8126518/182939062-9815b83a-4aad-4e96-92b1-5976a67c3df9.png)


## How Has This Been Tested?
No easy way to test it, I forced an error on the backend by changing code. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
