### PR TITLE
Add stop server modal

### DIFF
--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdmin.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdmin.tsx
@@ -2,11 +2,18 @@ import * as React from 'react';
 import NotebookAdminControl from './NotebookAdminControl';
 import NotebookServerRoutes from '../server/NotebookServerRoutes';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
+import { NotebookAdminContextProvider } from './NotebookAdminContext';
 
 const NotebookAdmin: React.FC = () => {
   const { impersonatingUser } = React.useContext(NotebookControllerContext);
 
-  return impersonatingUser ? <NotebookServerRoutes /> : <NotebookAdminControl />;
+  return impersonatingUser ? (
+    <NotebookServerRoutes />
+  ) : (
+    <NotebookAdminContextProvider>
+      <NotebookAdminControl />
+    </NotebookAdminContextProvider>
+  );
 };
 
 export default NotebookAdmin;

--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminContext.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminContext.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { User } from './types';
+
+type NotebookAdminContextProps = {
+  setServerStatuses: (serverStatuses: User['serverStatus'][]) => void;
+  serverStatuses: User['serverStatus'][];
+};
+
+const defaultNotebookAdminContext: NotebookAdminContextProps = {
+  setServerStatuses: () => undefined,
+  serverStatuses: [],
+};
+
+export const NotebookAdminContext = React.createContext(defaultNotebookAdminContext);
+
+export const NotebookAdminContextProvider: React.FC = ({ children }) => {
+  const [serverStatuses, setServerStatuses] = React.useState<User['serverStatus'][]>([]);
+
+  return (
+    <NotebookAdminContext.Provider
+      value={{
+        serverStatuses,
+        setServerStatuses,
+      }}
+    >
+      {children}
+    </NotebookAdminContext.Provider>
+  );
+};

--- a/frontend/src/pages/notebookController/screens/admin/ServerStatus.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/ServerStatus.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { useUser } from '../../../../redux/selectors';
-import { deleteNotebook } from '../../../../services/notebookService';
 import { User } from './types';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 import { usernameTranslate } from '../../../../utilities/notebookControllerUtils';
-import useNotification from '../../../../utilities/useNotification';
 import { NotebookControllerTabTypes } from '../../const';
-import useNamespaces from '../../useNamespaces';
+import { NotebookAdminContext } from './NotebookAdminContext';
 
 type ServerStatusProps = {
   data: User['serverStatus'];
@@ -15,13 +13,11 @@ type ServerStatusProps = {
 };
 
 const ServerStatus: React.FC<ServerStatusProps> = ({ data, username }) => {
-  const { notebookNamespace } = useNamespaces();
-  const notification = useNotification();
   const { setImpersonatingUsername, setCurrentAdminTab } =
     React.useContext(NotebookControllerContext);
   const { username: stateUser } = useUser();
-  const [deleting, setDeleting] = React.useState(false);
   const forStateUser = stateUser === username;
+  const { setServerStatuses } = React.useContext(NotebookAdminContext);
 
   if (!data.notebook) {
     return (
@@ -45,23 +41,13 @@ const ServerStatus: React.FC<ServerStatusProps> = ({ data, username }) => {
   return (
     <Button
       variant="link"
-      isDisabled={deleting}
       isDanger
       isInline
       onClick={() => {
-        const notebookName = data.notebook?.metadata.name;
-        if (notebookName) {
-          setDeleting(true);
-          deleteNotebook(notebookNamespace, notebookName)
-            .then(() => data.forceRefresh())
-            .catch((e) => {
-              notification.error(`Error delete notebook ${notebookName}`, e.message);
-              setDeleting(false);
-            });
-        }
+        setServerStatuses([data]);
       }}
     >
-      {deleting ? 'Stopping server...' : 'Stop server'}
+      Stop server
     </Button>
   );
 };

--- a/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
@@ -3,28 +3,37 @@ import { Button, ActionList, ActionListItem } from '@patternfly/react-core';
 import ApplicationsPage from '../../../ApplicationsPage';
 import NotebookServerDetails from './NotebookServerDetails';
 import { useWatchImages } from '../../../../utilities/useWatchImages';
-import { useWatchNotebook } from 'utilities/useWatchNotebook';
-import { deleteNotebook } from '../../../../services/notebookService';
-import {
-  checkNotebookRunning,
-  generateNotebookNameFromUsername,
-} from '../../../../utilities/notebookControllerUtils';
+import { useWatchNotebook } from '../../../../utilities/useWatchNotebook';
+import { checkNotebookRunning } from '../../../../utilities/notebookControllerUtils';
 import { Redirect, useHistory } from 'react-router-dom';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 import ImpersonateAlert from '../admin/ImpersonateAlert';
-import { useUser } from '../../../../redux/selectors';
 import useNamespaces from '../../useNamespaces';
+import StopServerModal from './StopServerModal';
+import useCurrentUser from '../../useCurrentUser';
+import { Notebook } from '../../../../types';
 
 import '../../NotebookController.scss';
 
-export const NotebookServer: React.FC = React.memo(() => {
+export const NotebookServer: React.FC = () => {
   const history = useHistory();
   const { images } = useWatchImages();
-  const { currentUserState, impersonatingUser } = React.useContext(NotebookControllerContext);
-  const { username: stateUsername } = useUser();
-  const username = currentUserState.user || stateUsername;
+  const { impersonatingUser } = React.useContext(NotebookControllerContext);
+  const username = useCurrentUser();
   const { notebookNamespace: projectName } = useNamespaces();
   const { notebook, loaded, loadError } = useWatchNotebook(projectName, username);
+
+  const [notebooksToStop, setNotebooksToStop] = React.useState<Notebook[]>([]);
+
+  const onNotebooksStop = React.useCallback(
+    (didStop: boolean) => {
+      setNotebooksToStop([]);
+      if (didStop) {
+        history.push(`/notebookController/spawner`);
+      }
+    },
+    [setNotebooksToStop, history],
+  );
 
   return (
     <>
@@ -40,20 +49,12 @@ export const NotebookServer: React.FC = React.memo(() => {
         {notebook && (
           <div className="odh-notebook-controller__page">
             <ActionList>
-              <ActionListItem
-                onClick={() => {
-                  deleteNotebook(projectName, generateNotebookNameFromUsername(username))
-                    .then(() => {
-                      history.push(`/notebookController/spawner`);
-                    })
-                    .catch((e) => console.error(e));
-                }}
-              >
+              <ActionListItem onClick={() => setNotebooksToStop([notebook])}>
                 <Button variant="primary">Stop notebook server</Button>
               </ActionListItem>
               <ActionListItem
                 onClick={() => {
-                  if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
+                  if (notebook.metadata.annotations?.['opendatahub.io/link']) {
                     window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
                   }
                 }}
@@ -62,12 +63,13 @@ export const NotebookServer: React.FC = React.memo(() => {
               </ActionListItem>
             </ActionList>
             <NotebookServerDetails notebook={notebook} images={images} />
+            <StopServerModal notebooksToStop={notebooksToStop} onNotebooksStop={onNotebooksStop} />
           </div>
         )}
       </ApplicationsPage>
     </>
   );
-});
+};
 
 NotebookServer.displayName = 'NotebookController';
 

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -48,7 +48,7 @@ import { useWatchNotebookForSpawnerPage } from './useWatchNotebookForSpawnerPage
 import useNotification from '../../../../utilities/useNotification';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 import ImpersonateAlert from '../admin/ImpersonateAlert';
-import { useUser } from '../../../../redux/selectors';
+import useCurrentUser from '../../useCurrentUser';
 import useNamespaces from '../../useNamespaces';
 
 import '../../NotebookController.scss';
@@ -65,8 +65,7 @@ const SpawnerPage: React.FC = React.memo(() => {
     setImpersonatingUsername,
     setLastNotebookCreationTime,
   } = React.useContext(NotebookControllerContext);
-  const { username: stateUsername } = useUser();
-  const username = currentUserState.user || stateUsername;
+  const username = useCurrentUser();
   const { notebookNamespace: projectName } = useNamespaces();
   const [startShown, setStartShown] = React.useState<boolean>(false);
   const { notebook, notebookLoaded } = useWatchNotebookForSpawnerPage(

--- a/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Notebook } from '../../../../types';
+import { deleteNotebook } from '../../../../services/notebookService';
+import useNamespaces from '../../useNamespaces';
+import useNotification from '../../../../utilities/useNotification';
+import { allSettledPromises } from '../../../../utilities/allSettledPromises';
+
+type StopServerModalProps = {
+  notebooksToStop: Notebook[];
+  onNotebooksStop: (didStop: boolean) => void;
+};
+
+const StopServerModal: React.FC<StopServerModalProps> = ({ notebooksToStop, onNotebooksStop }) => {
+  const { notebookNamespace } = useNamespaces();
+  const notification = useNotification();
+  const [isDeleting, setDeleting] = React.useState(false);
+
+  const hasMultipleServers = notebooksToStop.length > 1;
+  const textToShow = hasMultipleServers ? 'all servers' : 'server';
+
+  const isModalShown = notebooksToStop.length !== 0;
+
+  const onClose = () => {
+    onNotebooksStop(false);
+  };
+
+  const handleStopServer = () => {
+    setDeleting(true);
+    allSettledPromises<Notebook | void>(
+      notebooksToStop.map((notebook) => {
+        const notebookName = notebook.metadata.name || '';
+        if (!notebookName) return Promise.resolve();
+        return deleteNotebook(notebookNamespace, notebookName);
+      }),
+    )
+      .then(() => {
+        onNotebooksStop(true);
+      })
+      .catch((e) => {
+        notification.error(`Error stopping ${textToShow}`, e.message);
+      })
+      .finally(() => {
+        setDeleting(false);
+      });
+  };
+
+  const modalActions = [
+    <Button isDisabled={isDeleting} key="confirm" variant="primary" onClick={handleStopServer}>
+      Stop {textToShow}
+    </Button>,
+    <Button key="cancel" variant="secondary" onClick={onClose}>
+      Cancel
+    </Button>,
+  ];
+
+  return (
+    <Modal
+      aria-label="Stop server modal"
+      appendTo={document.body}
+      variant={ModalVariant.small}
+      title={`Stop ${textToShow}`}
+      isOpen={isModalShown}
+      showClose
+      onClose={onClose}
+      actions={modalActions}
+    >
+      Are you sure you want to stop {hasMultipleServers ? 'all servers' : 'the server'}? Any changes
+      made without saving will be lost.
+    </Modal>
+  );
+};
+
+StopServerModal.displayName = 'StopServerModal';
+
+export default StopServerModal;

--- a/frontend/src/pages/notebookController/useCurrentUser.ts
+++ b/frontend/src/pages/notebookController/useCurrentUser.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { useUser } from '../../redux/selectors';
+import { NotebookControllerContext } from './NotebookControllerContext';
+
+const useCurrentUser = (): string => {
+  const { username: stateUsername } = useUser();
+  const { currentUserState } = React.useContext(NotebookControllerContext);
+  return currentUserState.user || stateUsername;
+};
+
+export default useCurrentUser;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #293 
1. Create a StopServerModal that works for both the Notebook server page and the Admin page
2. For the Notebook server page, it uses props to set the notebook and handle it (delete)
3. For the Admin page, it uses context to handle it, because it needs to support both Stop server and Stop all servers
4. Add a hook to compare `currentUserState` and username from redux (although I don't need to do this in this PR, I did it)
5. Fix a small issue that is not related to this PR for events. When the node is insufficient, it cannot show the error in the detailed logs, I will now first check whether the event is a warning or not

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Try to click `stop server` or `stop all servers` on both Server Control Panel and Admin Panel.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
