### PR TITLE
Update delegate urls argument for dashboard oauth

### DIFF
--- a/manifests/overlays/authentication/deployment.yaml
+++ b/manifests/overlays/authentication/deployment.yaml
@@ -11,7 +11,7 @@
       - --tls-key=/etc/tls/private/tls.key
       - --cookie-secret-file=/etc/oauth/config/cookie_secret
       - --pass-access-token
-      - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "odh-dashboard"}}'
+      - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard"}}'
       - --skip-auth-regex=^/metrics
     image: oauth-proxy
     ports:


### PR DESCRIPTION
## Description
There was a misconfiguration in the --openshift-delegate-urls parameter
for the `authentication` overlay of the dashboard. This caused
authentication/authorization to fail for some use cases, particularly
when attempting to authenticate to the dashboard programmatically using
a bearer token. This change updates the argument to a valid value to fix
this use case.

## How Has This Been Tested?
This has been tested on an openshift 4.11 cluster by performing the following:

* Deploy the ODH operator to your cluster from the operator catalog
* Create a namespace for testing this change:
```
oc new-project auth-fix
```
* Create a kfdef to deploy the current version:
```
cat <<EOF | oc apply -f -
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: opendatahub
  namespace: auth-fix
spec:
  applications:
    - kustomizeConfig:
        overlays:
          - authentication
        repoRef:
          name: manifests
          path: manifests
      name: odh-dashboard
  repos:
    - name: manifests
      uri: 'https://github.com/opendatahub-io/odh-dashboard/tarball/main'
EOF
```
* Run the following command to attempt to log into the dashboard using the `odh-dashboard` service account. The command should output `403`, indicating that the service account has been restricted from accessing the dashboard:
```
curl --header "Authorization: Bearer $(oc get secret -n auth-fix -o jsonpath='{.data.token}' `oc get secret -n auth-fix | grep odh-dashboard-token | awk '{print $1}'` | base64 -d)" -s -o /dev/null -w "%{http_code}\n" -k https://$(oc get route -n auth-fix odh-dashboard -o jsonpath='{.spec.host}')
```
* Update the kfdef to deploy this change by running the following:
```
cat <<EOF | oc apply -f -
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: opendatahub
  namespace: auth-fix
spec:
  applications:
    - kustomizeConfig:
        overlays:
          - authentication
        repoRef:
          name: manifests
          path: manifests
      name: odh-dashboard
  repos:
    - name: manifests
      uri: 'https://github.com/accorvin/odh-dashboard/tarball/fix-oauth'
EOF
```
* Run the curl command again. This time it should print a status code of `200`, indicating that the service account has successfully reached the dashboard:
```
curl --header "Authorization: Bearer $(oc get secret -n auth-fix -o jsonpath='{.data.token}' `oc get secret -n auth-fix | grep odh-dashboard-token | awk '{print $1}'` | base64 -d)" -s -o /dev/null -w "%{http_code}\n" -k https://$(oc get route -n auth-fix odh-dashboard -o jsonpath='{.spec.host}')
```
* Navigate to the dashboard in a browser. Confirm that you can log in and use the dashboard as normal.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
