### PR TITLE
Allow system:authenicated to work for users

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -56,8 +56,10 @@ const fetchDashboardCR = (fastify: KubeFastifyInstance): Promise<DashboardConfig
       const dashboardCR = res?.body as DashboardConfig;
       return [dashboardCR];
     })
-    .catch(() => {
-      fastify.log.warn('Received error fetching OdhDashboardConfig, creating new.');
+    .catch((e) => {
+      fastify.log.warn(
+        `Received error (${e.body.message}) fetching OdhDashboardConfig, creating new.`,
+      );
       return createDashboardCR(fastify);
     });
   return crResponse;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #422 

## Description
<!--- Describe your changes in detail -->
We didn't allow `system:authenticated` users to get access when we set our groups to it. This was because we tried to fetch a group by that name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See ticket

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
