### PR TITLE
Cleanup BYON references in the UI

### DIFF
--- a/frontend/src/pages/BYONImages/BYONImages.tsx
+++ b/frontend/src/pages/BYONImages/BYONImages.tsx
@@ -55,12 +55,12 @@ const BYONImages: React.FC = () => {
 
   return (
     <ApplicationsPage
-      title="BYON image settings"
+      title="Notebook image settings"
       description={description}
       loaded={loaded}
       empty={isEmpty}
       loadError={loadError}
-      errorMessage="Unable to load BYON images."
+      errorMessage="Unable to load notebook images."
       emptyStatePage={noImagesPageSection}
     >
       {!isEmpty ? (

--- a/frontend/src/pages/BYONImages/BYONImagesTable.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTable.tsx
@@ -295,7 +295,7 @@ export const BYONImagesTable: React.FC<BYONImagesTableProps> = ({ images, forceU
       </Toolbar>
       <TableComposable
         className={tableFilter.count === 0 ? 'empty-table' : ''}
-        aria-label="BYON Images table"
+        aria-label="Notebook images table"
         variant="compact"
       >
         <Thead>

--- a/frontend/src/pages/BYONImages/DeleteBYONImageModal.tsx
+++ b/frontend/src/pages/BYONImages/DeleteBYONImageModal.tsx
@@ -17,7 +17,7 @@ export const DeleteImageModal: React.FC<ImportImageModalProps> = ({
   return (
     <Modal
       variant={ModalVariant.medium}
-      title="Delete Notebook image"
+      title="Delete notebook image"
       titleIconVariant="warning"
       isOpen={isOpen}
       onClose={onCloseHandler}

--- a/frontend/src/pages/BYONImages/ImportImageModal.tsx
+++ b/frontend/src/pages/BYONImages/ImportImageModal.tsx
@@ -62,7 +62,7 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
   return (
     <Modal
       variant={ModalVariant.medium}
-      title="Import BYON images"
+      title="Import notebook images"
       isOpen={isOpen}
       onClose={onCloseHandler}
       actions={[
@@ -84,7 +84,7 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
                     addNotification({
                       status: 'danger',
                       title: 'Error',
-                      message: `Unable to add BYON image ${name}`,
+                      message: `Unable to add notebook image ${name}`,
                       timestamp: new Date(),
                     }),
                   );
@@ -114,7 +114,7 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
           label="Repository"
           isRequired
           fieldId="byon-image-repository-label"
-          helperText="Repo where byon images are stored."
+          helperText="Repo where notebook images are stored."
           helperTextInvalid="This field is required."
           helperTextInvalidIcon={<ExclamationCircleIcon />}
           validated={validRepo ? undefined : 'error'}
@@ -226,8 +226,8 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
                     No software added
                   </Title>
                   <EmptyStateBody>
-                    Add software to be advertised with your BYON image. Making changes here won’t
-                    affect the contents of the image.{' '}
+                    Add software to be advertised with your notebook image. Making changes here
+                    won’t affect the contents of the image.{' '}
                   </EmptyStateBody>
                   <Button
                     className="empty-button"
@@ -253,8 +253,8 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
                 <>
                   <TableComposable aria-label="Simple table" variant="compact" isStickyHeader>
                     <Caption>
-                      Add the advertised packages shown with this BYON image. Modifying the packages
-                      here does not effect the contents of the BYON image.
+                      Add the advertised packages shown with this notebook image. Modifying the
+                      packages here does not effect the contents of the notebook image.
                     </Caption>
                     <Thead>
                       <Tr>
@@ -304,8 +304,8 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
                     No packages added
                   </Title>
                   <EmptyStateBody>
-                    Add packages to be advertised with your BYON image. Making changes here won’t
-                    affect the contents of the image.{' '}
+                    Add packages to be advertised with your notebook image. Making changes here
+                    won’t affect the contents of the image.{' '}
                   </EmptyStateBody>
                   <Button
                     className="empty-button"

--- a/frontend/src/pages/BYONImages/UpdateImageModal.tsx
+++ b/frontend/src/pages/BYONImages/UpdateImageModal.tsx
@@ -155,8 +155,8 @@ export const UpdateImageModal: React.FC<UpdateImageModalProps> = ({
                 <>
                   <TableComposable aria-label="Simple table" variant="compact">
                     <Caption>
-                      Change the advertised software shown with this BYON image. Modifying the
-                      software here does not effect the contents of the BYON image.
+                      Change the advertised software shown with this notebook image. Modifying the
+                      software here does not effect the contents of the notebook image.
                     </Caption>
                     <Thead>
                       <Tr>
@@ -207,8 +207,8 @@ export const UpdateImageModal: React.FC<UpdateImageModalProps> = ({
                     No software added
                   </Title>
                   <EmptyStateBody>
-                    Add software to be advertised with your BYON image. Making changes here won’t
-                    affect the contents of the image.{' '}
+                    Add software to be advertised with your notebook image. Making changes here
+                    won’t affect the contents of the image.{' '}
                   </EmptyStateBody>
                   <Button
                     id="add-software-button"
@@ -235,8 +235,8 @@ export const UpdateImageModal: React.FC<UpdateImageModalProps> = ({
                 <>
                   <TableComposable aria-label="Simple table" variant="compact" isStickyHeader>
                     <Caption>
-                      Change the advertised packages shown with this BYON image. Modifying the
-                      packages here does not effect the contents of the BYON image.
+                      Change the advertised packages shown with this notebook image. Modifying the
+                      packages here does not effect the contents of the notebook image.
                     </Caption>
                     <Thead>
                       <Tr>
@@ -287,8 +287,8 @@ export const UpdateImageModal: React.FC<UpdateImageModalProps> = ({
                     No packages added
                   </Title>
                   <EmptyStateBody>
-                    Add packages to be advertised with your BYON image. Making changes here won’t
-                    affect the contents of the image.{' '}
+                    Add packages to be advertised with your notebook image. Making changes here
+                    won’t affect the contents of the image.{' '}
                   </EmptyStateBody>
                   <Button
                     id="add-package-button"

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -324,8 +324,8 @@ const SpawnerPage: React.FC = React.memo(() => {
     <>
       {impersonatingUser && <ImpersonateAlert />}
       <ApplicationsPage
-        title="Start a Notebook server"
-        description="Select options for your Notebook server."
+        title="Start a notebook server"
+        description="Select options for your notebook server."
         loaded={loaded}
         loadError={loadError}
         empty={!images || images.length === 0}
@@ -368,7 +368,7 @@ const SpawnerPage: React.FC = React.memo(() => {
               <Alert
                 variant="danger"
                 isInline
-                title="Failed to create the Notebook, please try again later"
+                title="Failed to create the notebook, please try again later"
               >
                 {submitError.message}
               </Alert>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #352 

## Description
<!--- Describe your changes in detail -->
Just cleaning up some UI references to BYON. Should be just `Notebook`

## How Has This Been Tested?

Searched for all references and clicked around in the UI to check contextual usages.

## Screenshots

![Screen Shot 2022-08-19 at 3 53 36 PM](https://user-images.githubusercontent.com/8126518/185697170-aa63b694-ec27-4558-bb1a-68d184c70744.png)
![Screen Shot 2022-08-19 at 3 53 41 PM](https://user-images.githubusercontent.com/8126518/185697174-491f8702-6b7d-4be9-8c68-f3f46f7fc37b.png)
![Screen Shot 2022-08-19 at 3 53 58 PM](https://user-images.githubusercontent.com/8126518/185697176-2ea2410c-861c-4b87-adf6-651dd14fd029.png)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
