### PR TITLE
Add telemetry event for starting server

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -51,6 +51,7 @@ import useCurrentUser from '../../useCurrentUser';
 import useNamespaces from '../../useNamespaces';
 import GPUSelectField from './GPUSelectField';
 import SizeSelectField from './SizeSelectField';
+import { fireTrackingEvent } from '../../../../utilities/segmentIOUtils';
 
 import '../../NotebookController.scss';
 
@@ -252,6 +253,14 @@ const SpawnerPage: React.FC = React.memo(() => {
     setVariableRows([...variableRows, newRow]);
   };
 
+  const fireStartServerEvent = () => {
+    fireTrackingEvent('Notebook Server Started', {
+      GPU: parseInt(selectedGpu),
+      lastSelectedSize: selectedSize,
+      lastSelectedImage: `${selectedImageTag.image?.name}:${selectedImageTag.tag?.name}`,
+    });
+  };
+
   const handleNotebookAction = async () => {
     setSubmitError(null);
     const notebookSize = dashboardConfig?.spec?.notebookSizes?.find(
@@ -281,7 +290,10 @@ const SpawnerPage: React.FC = React.memo(() => {
       volumes,
       volumeMounts,
     )
-      .then(() => true)
+      .then(() => {
+        fireStartServerEvent();
+        return true;
+      })
       .catch((e) => {
         setSubmitError(e);
         return false;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -242,6 +242,9 @@ export type TrackingEventProperties = {
   anonymousID?: string;
   type?: string;
   term?: string;
+  GPU?: number;
+  lastSelectedSize?: string;
+  lastSelectedImage?: string;
 };
 
 export type NotebookPort = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #430 

## Description
<!--- Describe your changes in detail -->
Based on what we did in JupyterHub https://github.com/red-hat-data-services/jupyterhub-singleuser-profiles/blob/master/jupyterhub_singleuser_profiles/ui/src/App/Spawner.tsx#L86-L98, fire the telemetry event when the user creates a notebook.

## How Has This Been Tested?
You may need a segment.io account to test it. Maybe @jgarciao could help to test whether the event is really fired.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
