### PR TITLE
Update doc on Explore page and Resources page

### DIFF
--- a/backend/src/routes/api/components/list.ts
+++ b/backend/src/routes/api/components/list.ts
@@ -1,13 +1,20 @@
 import { FastifyRequest } from 'fastify';
 import { KubeFastifyInstance, OdhApplication } from '../../../types';
 import { getRouteForApplication } from '../../../utils/componentUtils';
-import { getApplicationDefs, updateApplicationDefs } from '../../../utils/resourceUtils';
+import {
+  getApplicationDefs,
+  getDashboardConfig,
+  updateApplicationDefs,
+} from '../../../utils/resourceUtils';
 
 export const listComponents = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest,
 ): Promise<OdhApplication[]> => {
-  const applicationDefs = getApplicationDefs();
+  const isJupyterEnabled = getDashboardConfig().spec.notebookController.enabled;
+  const applicationDefs = getApplicationDefs().filter(
+    (component) => component.metadata.name !== (isJupyterEnabled ? 'jupyterhub' : 'jupyter'),
+  );
   const installedComponents = [];
   const query = request.query as { [key: string]: string };
 

--- a/backend/src/routes/api/quickstarts/quickStartUtils.ts
+++ b/backend/src/routes/api/quickstarts/quickStartUtils.ts
@@ -4,6 +4,7 @@ import * as jsYaml from 'js-yaml';
 import { yamlRegExp } from '../../../utils/constants';
 import { KubeFastifyInstance, QuickStart } from '../../../types';
 import { getComponentFeatureFlags } from '../../../utils/features';
+import { getDashboardConfig } from '../../../utils/resourceUtils';
 
 const quickStartsGroup = 'console.openshift.io';
 const quickStartsVersion = 'apiextensions.k8s.io/v1';
@@ -33,6 +34,10 @@ export const getInstalledQuickStarts = async (
         const doc: QuickStart = jsYaml.load(
           fs.readFileSync(path.join(normalizedPath, file), 'utf8'),
         );
+        const isJupyterEnabled = getDashboardConfig().spec.notebookController.enabled;
+        if (doc.spec.appName === 'jupyterhub' && isJupyterEnabled) {
+          doc.spec.appName = 'jupyter';
+        }
         if (!doc.spec.featureFlag || featureFlags[doc.spec.featureFlag]) {
           installedQuickStarts.push(doc);
         }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -74,6 +74,7 @@ export declare type QuickStart = {
     annotations?: { [key: string]: string };
   };
   spec: {
+    appName?: string;
     version?: number;
     displayName: string;
     durationMinutes: number;

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -223,6 +223,10 @@ const fetchDocs = async (fastify: KubeFastifyInstance): Promise<OdhDocument[]> =
         const doc: OdhDocument = jsYaml.load(
           fs.readFileSync(path.join(normalizedPath, file), 'utf8'),
         );
+        const isJupyterEnabled = getDashboardConfig().spec.notebookController.enabled;
+        if (doc.spec.appName === 'jupyterhub' && isJupyterEnabled) {
+          doc.spec.appName = 'jupyter';
+        }
         if (doc.spec.featureFlag) {
           if (featureFlags[doc.spec.featureFlag]) {
             docs.push(doc);

--- a/data/applications/jupyter.yaml
+++ b/data/applications/jupyter.yaml
@@ -14,4 +14,4 @@ spec:
   docsLink: https://jupyter.org
   internalRoute: notebookController
   quickStart: create-jupyter-notebook
-  hiddenOnExplorePage: true
+  getStartedLink: https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html

--- a/data/getting-started/jupyter.md
+++ b/data/getting-started/jupyter.md
@@ -1,0 +1,49 @@
+# Jupyter
+
+Launch Jupyter and start a notebook server to start working with your notebooks.
+
+## Prerequisites
+
+- You have logged in to Red Hat OpenShift Data Science.
+
+- You know the names and values you want to use for any environment variables in your notebook server environment, for example, `AWS_SECRET_ACCESS_KEY`.
+
+- If you want to work with a very large data set, work with your administrator to proactively increase the storage capacity of your notebook server.
+
+## Procedure
+
+1. Locate the **Jupyter** card on the **Enabled applications** page.
+
+2. Click **Launch application**.
+
+  i. If prompted, select your identity provider.
+
+  ii. Enter your credentials and click **Log in** (or equivalent for your identity provider).
+
+  If you see **Error 403: Forbidden**, you are not in the default user group or the default administrator group for OpenShift Data Science. Contact your administrator so that they can add you to the correct group using [Adding users for OpenShift Data Science](https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/adding-users-for-openshift-data-science_useradd).
+
+3. Start a notebook server.
+
+  This is not required if you have previously launched Jupyter.
+
+  i. Select the **Notebook image** to use for your server.
+
+  ii. If the notebook image contains multiple versions, select the version of the notebook image from the **Versions** section.
+
+  iii. Select the **Container size** for your server.
+
+  iv. Optional: Select the **Number of GPUs** (graphics processing units) for your server.
+
+  v. Optional: Select and specify values for any new **Environment variables**.
+
+  For example, if you plan to integrate with Red Hat OpenShift Streams for Apache Kafka, create environment variables to store your Kafka bootstrap server and the service account username and password here.
+
+  he interface stores these variables so that you only need to enter them once. Example variable names for common environment variables are automatically provided for frequently integrated environments and frameworks, such as Amazon Web Services (AWS).
+
+  vi. Click **Start server**.
+  
+  The **Starting server** progress indicator appears. If you encounter a problem during this process, an error message appears with more information. Click **Expand event log** to view additional information on the server creation process. Depending on the deployment size and resources you requested, starting the server can take up to several minutes. After the server starts, the JupyterLab interface opens.
+
+## Verification
+
+The JupyterLab interface opens in the same tab.

--- a/frontend/src/components/OdhExploreCard.tsx
+++ b/frontend/src/components/OdhExploreCard.tsx
@@ -34,9 +34,6 @@ const OdhExploreCard: React.FC<OdhExploreCardProps> = ({
       makeCardVisible(odhApp.metadata.name);
     }
   }, [odhApp.metadata.name, isSelected]);
-  if (odhApp.spec.hiddenOnExplorePage) {
-    return null;
-  }
   const disabled = odhApp.spec.comingSoon || disableInfo;
   const cardClasses = classNames('odh-card', { 'm-disabled': disabled });
   const badgeClasses = classNames('odh-card__partner-badge', {

--- a/frontend/src/pages/enabledApplications/EnabledApplications.tsx
+++ b/frontend/src/pages/enabledApplications/EnabledApplications.tsx
@@ -9,7 +9,6 @@ import QuickStarts from '../../app/QuickStarts';
 import { fireTrackingEvent } from '../../utilities/segmentIOUtils';
 
 import './EnabledApplications.scss';
-import { useWatchDashboardConfig } from 'utilities/useWatchDashboardConfig';
 
 const description = `Launch your enabled applications, view documentation, or get started with quick start instructions and tasks.`;
 
@@ -53,16 +52,12 @@ EnabledApplicationsInner.displayName = 'EnabledApplicationsInner';
 
 const EnabledApplications: React.FC = () => {
   const { components, loaded, loadError } = useWatchComponents(true);
-  const { dashboardConfig } = useWatchDashboardConfig();
 
   const sortedComponents = React.useMemo(() => {
-    const filteredComponents = dashboardConfig.spec.notebookController?.enabled
-      ? components.filter((component) => component.metadata.name !== 'jupyterhub')
-      : components.filter((component) => component.metadata.name !== 'jupyter');
-    return _.cloneDeep(filteredComponents).sort((a, b) =>
+    return _.cloneDeep(components).sort((a, b) =>
       a.spec.displayName.localeCompare(b.spec.displayName),
     );
-  }, [components, dashboardConfig.spec.notebookController?.enabled]);
+  }, [components]);
 
   React.useEffect(() => {
     /*

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -141,7 +141,6 @@ export type OdhApplication = {
     };
     featureFlag?: string;
     internalRoute?: string;
-    hiddenOnExplorePage?: boolean | null;
   };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #400 
Closes #336 

## Description
<!--- Describe your changes in detail -->
1. Update backend functions to filter or change the resources that returned to the frontend to make sure it matches the current dashboard config (whether the notebook controller is enabled or not)
2. Add getting-started doc for Jupyter based on https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/getting_started_with_red_hat_openshift_data_science/launching-jupyterhub-and-starting-a-notebook-server_get-started

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to different pages to see the tiles.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
