### PR TITLE
Set unique ID for every env var field and input

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesField.tsx
@@ -15,12 +15,14 @@ import { EnvVarType, VariableRow } from '../../../../types';
 import '../../NotebookController.scss';
 
 type EnvironmentVariablesFieldProps = {
+  fieldIndex: string;
   variable: EnvVarType;
   variableRow: VariableRow;
   onUpdateVariable: (updatedVariable: EnvVarType) => void;
 };
 
 const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
+  fieldIndex,
   variable,
   onUpdateVariable,
   variableRow,
@@ -41,14 +43,14 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
   return (
     <div className="odh-notebook-controller__env-var-field">
       <FormGroup
-        fieldId={variable.name}
+        fieldId={`${fieldIndex}-${variable.name}`}
         label="Variable name"
         helperTextInvalid={variableRow.errors[variable.name]}
         helperTextInvalidIcon={<ExclamationCircleIcon />}
         validated={validated}
       >
         <TextInput
-          id={variable.name}
+          id={`${fieldIndex}-${variable.name}`}
           type={TextInputTypes.text}
           onChange={(newKey) =>
             onUpdateVariable({ name: newKey, type: variable.type, value: variable.value })
@@ -57,11 +59,11 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
           validated={validated}
         />
       </FormGroup>
-      <FormGroup fieldId={`${variable.name}-value`} label="Variable value">
+      <FormGroup fieldId={`${fieldIndex}-${variable.name}-value`} label="Variable value">
         <Flex>
           <InputGroup>
             <TextInput
-              id={`${variable.name}-value`}
+              id={`${fieldIndex}-${variable.name}-value`}
               type={
                 showPassword && variableType === 'password'
                   ? TextInputTypes.text
@@ -85,7 +87,7 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
               isChecked={variableType === 'password'}
               onChange={handleSecretChange}
               aria-label="secret"
-              id={`${variable.name}-secret`}
+              id={`${fieldIndex}-${variable.name}-secret`}
               name="secret"
             />
           ) : null}

--- a/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesRow.tsx
+++ b/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesRow.tsx
@@ -6,12 +6,14 @@ import { EnvVarCategoryType, EnvVarType, VariableRow } from '../../../../types';
 import EnvironmentVariablesField from './EnvironmentVariablesField';
 
 type EnvironmentVariablesRowProps = {
+  rowIndex: string;
   variableRow: VariableRow;
   categories: EnvVarCategoryType[];
   onUpdate: (updatedRow?: VariableRow) => void;
 };
 
 const EnvironmentVariablesRow: React.FC<EnvironmentVariablesRowProps> = ({
+  rowIndex,
   variableRow,
   categories,
   onUpdate,
@@ -91,7 +93,8 @@ const EnvironmentVariablesRow: React.FC<EnvironmentVariablesRowProps> = ({
       </Flex>
       {variableRow.variables.map((variable, index) => (
         <EnvironmentVariablesField
-          key={index}
+          key={`${rowIndex}-${index}`}
+          fieldIndex={`${rowIndex}-${index}`}
           variable={variable}
           variableRow={variableRow}
           onUpdateVariable={(updatedVariable) => updateVariable(updatedVariable, variable.name)}

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -206,6 +206,7 @@ const SpawnerPage: React.FC = React.memo(() => {
     return variableRows.map((row, index) => (
       <EnvironmentVariablesRow
         key={`environment-variable-row-${index}`}
+        rowIndex={`environment-variable-row-${index}`}
         categories={[]}
         variableRow={row}
         onUpdate={(updatedRow) => onUpdateRow(index, updatedRow)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #411 

## Description
<!--- Describe your changes in detail -->
The cause for this issue is the current id is not unique, so when you create 2 env vars fields, they have the same id, and it always finds the first one when you select the checkbox. Now we set every input to a unique id based on their index.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Play around with creating env vars and deleting them, checking the secret checkbox, and so on, make sure there is no warning message in the devTool console.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
