### PR TITLE
Allow the Cluster settings page to save with no tolerations settings

### DIFF
--- a/backend/src/routes/api/cluster-settings/clusterSettingsUtils.ts
+++ b/backend/src/routes/api/cluster-settings/clusterSettingsUtils.ts
@@ -137,8 +137,10 @@ export const getClusterSettings = async (
         dashConfig.spec.notebookController.pvcSize.replace('Gi', ''),
       );
     }
-    clusterSettings.notebookTolerationSettings =
-      dashConfig.spec.notebookController.notebookTolerationSettings;
+    if (dashConfig.spec.notebookController.notebookTolerationSettings) {
+      clusterSettings.notebookTolerationSettings =
+        dashConfig.spec.notebookController.notebookTolerationSettings;
+    }
     clusterSettings.cullerTimeout = DEFAULT_CULLER_TIMEOUT; // For backwards compatibility with jupyterhub and less changes to UI
     await fastify.kube.coreV1Api
       .readNamespacedConfigMap(nbcCfg, fastify.kube.namespace)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #443 

## Description
<!--- Describe your changes in detail -->
During the fetching of the data for the cluster settings page, it starts with defaults and builds up a set of settings. Each step of the way drawing from existing data in the OdhDashboardConfig. However, if your `notebookTolerationSettings` is not in your config, the setting is overriding the default and removing the default from the request.

When the client calls the server to update the data based on a change the user did, the data has an omission and thus runs into an NPE issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To reproduce:

1. Remove the `.spec.notebookController.notebookTolerationSettings` key from your OdhDashboardConfig. That causes this issue.
2. Save the page with or without changes once you start up the UI. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
