### PR TITLE
Improve initial Application loading, wait on user info

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import '@patternfly/patternfly/patternfly.min.css';
 import '@patternfly/patternfly/patternfly-addons.css';
-import { Page } from '@patternfly/react-core';
+import { Alert, Bullseye, Page, PageSection, Spinner } from '@patternfly/react-core';
 import { detectUser } from '../redux/actions/actions';
 import { useDesktopWidth } from '../utilities/useDesktopWidth';
 import { useTrackHistory } from '../utilities/useTrackHistory';
@@ -17,11 +17,13 @@ import AppContext from './AppContext';
 
 import './App.scss';
 import { useWatchDashboardConfig } from 'utilities/useWatchDashboardConfig';
+import { useUser } from '../redux/selectors';
 
 const App: React.FC = () => {
   const isDeskTop = useDesktopWidth();
   const [isNavOpen, setIsNavOpen] = React.useState(isDeskTop);
   const [notificationsOpen, setNotificationsOpen] = React.useState(false);
+  const { username, userError } = useUser();
   const dispatch = useDispatch();
   useSegmentTracking();
   useTrackHistory();
@@ -40,6 +42,30 @@ const App: React.FC = () => {
   const onNavToggle = () => {
     setIsNavOpen(!isNavOpen);
   };
+
+  if (!username) {
+    // We do not have the data yet for who they are, we can't show the app. If we allow anything
+    // to render right now, the username is going to be blank and we won't know permissions
+    if (userError) {
+      // We likely don't have a username still so just show the error
+      return (
+        <Page>
+          <PageSection>
+            <Alert variant="danger" isInline title="General loading error">
+              {userError.message}
+            </Alert>
+          </PageSection>
+        </Page>
+      );
+    }
+
+    // Assume we are still waiting on the API to finish
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #444 

## Description
<!--- Describe your changes in detail -->
We don't wait until the user information is fully fetched -- so we get unknown permission problems and can show 404 if they are on a nested route. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Refreshing the app on the root page and on nested "conditional rendered" pages (based on permissions.

## Screenshots


https://user-images.githubusercontent.com/8126518/186885574-039f597f-fe23-4080-97be-465bb15d0460.mov

And a fake error state:
![Screen Shot 2022-08-26 at 6 29 13 AM](https://user-images.githubusercontent.com/8126518/186885609-99d51f1b-d8a5-498b-8bb7-166e3e4997c5.png)

The body of the Alert is the `error.message` -- there is nothing to show if we failed to load the user information.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
