### PR TITLE
Removing the now unused OdhDashboardConfig status property

### DIFF
--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -86,15 +86,17 @@ notebookController:
 
 ### Notebook Controller State
 
-This field (`notebookControllerState`) controls the state of each user of the Notebook controller. This field is managed by the backend of the Dashboard and should not be manually modified. This field is present on the `status` stanza of the OdhDashboardConfig
+We make use of the Notebook resource as a source of truth for what the user has last selected. To that extent, we added new annotations to track the values of the user's last selection. We also rely on two existing kubeflow annotations, `kubeflow-resource-stopped` & `notebooks.kubeflow.org/last-activity`.
 
-```yaml
-notebookControllerState:
-- user: username
-  lastSelectedImage: foo:bar
-  lastSelectedSize: XSmall
-  lastActivity: 733122000000
-```
+New annotations we created are:
+
+| Annotation name | What it represents |
+| --------------- | ------------------ |
+| `opendatahub.io/username` | The untranslated username behind the notebook`*` |
+| `notebooks.opendatahub.io/last-image-selection` | The last image the user selected (on create notebook) |
+| `notebooks.opendatahub.io/last-size-selection` | The last notebook size the user selected (on create notebook) |
+
+`*` - We need the original user's name (we translate their name to kube safe characters for notebook name and for the label) for some functionality. If this is omitted from the Notebook (or they don't have one yet) we try to make a validation against the current logged in user. This will work most of the time (and we assume logged in user when they don't have a Notebook), if this fails because you're an Admin and we don't have this state, we consider this an invalid state -- should be rare though as it requires the subset of users that are Admins to have a bad-state Notebook they are trying to impersonate (to start or view that users Notebook information).
 
 ## Example OdhDashboard Config
 
@@ -144,10 +146,4 @@ spec:
       limits:
         memory: 8Gi
         cpu: '8'
-status:
-  notebookControllerState:
-  - user: username
-    lastSelectedImage: foo:bar
-    lastSelectedSize: XSmall
-    lastActivity: 733122000000
 ```

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -287,8 +287,6 @@ export type Notebook = K8sResourceCommon & {
       'notebooks.kubeflow.org/last-activity': string; // datestamp of last use
       'opendatahub.io/link': string; // redirect notebook url
       'opendatahub.io/username': string; // the untranslated username behind the notebook
-
-      // TODO: Can we get this from the data in the Notebook??
       'notebooks.opendatahub.io/last-image-selection': string; // the last image they selected
       'notebooks.opendatahub.io/last-size-selection': string; // the last notebook size they selected
     }>;

--- a/manifests/base/odh-dashboard-crd.yaml
+++ b/manifests/base/odh-dashboard-crd.yaml
@@ -92,23 +92,7 @@ spec:
                     notebookTolerationSettings:
                       type: object
                       properties:
-                          enabled: 
+                          enabled:
                             type: boolean
-                          key: 
+                          key:
                             type: string
-            status:
-              type: object
-              properties:
-                notebookControllerState:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      user:
-                        type: string
-                      lastSelectedImage:
-                        type: string
-                      lastSelectedSize:
-                        type: string
-                      lastActivity:
-                        type: number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #445

## Description
<!--- Describe your changes in detail -->
Cleanup we didn't do late in ODH Dashboard 2.1 release -- it was requested of RHODS not to impact any migration scripts by modifying the CRD. These values are obsolete now and need to be cleaned up. See the doc update in the PR for more detailed information, but the data was moved to the Notebook.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] The developer has manually tested the changes and verified that the changes work
