### PR TITLE
Added handling of the case when no GPUs are configured/present

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -25,9 +25,9 @@ export type DashboardConfig = K8sResourceCommon & {
       pvcSize?: string;
       notebookNamespace?: string;
       notebookTolerationSettings?: {
-        enabled: boolean,
-        key: string
-      }
+        enabled: boolean;
+        key: string;
+      };
     };
   };
 };
@@ -56,7 +56,7 @@ export type NotebookSize = {
 export type NotebookTolerationSettings = {
   enabled: boolean;
   key: string;
-}
+};
 
 export type ClusterSettings = {
   pvcSize: number;

--- a/frontend/src/services/gpuService.ts
+++ b/frontend/src/services/gpuService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const getGPU = (): Promise<number> => {
+export const getGPU = (): Promise<[boolean, number]> => {
   const url = '/api/gpu';
   return axios
     .get(url)


### PR DESCRIPTION
Resolves:#428

## Description
Implements handling of the case where no GPUs are configured/present

## How Has This Been Tested?
1. Deploy this PR on a cluster
2. Disable the GPU mock exporter
3. Launch Spawner in ODH
4. No GPU dropdown is rendered nor there is the on-click GPU fetch functionality for this case (refresh is required)
Additionally, the case of available GPUs and existing-but-taken GPUs were tested through modifying the mock GPU exporter, as well as the changes between these three cases. 

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
