### PR TITLE
Invert Access/Stop notebook server buttons on notebook server control panel

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -25,9 +25,9 @@ export type DashboardConfig = K8sResourceCommon & {
       pvcSize?: string;
       notebookNamespace?: string;
       notebookTolerationSettings?: {
-        enabled: boolean,
-        key: string
-      }
+        enabled: boolean;
+        key: string;
+      };
     };
   };
 };
@@ -56,7 +56,7 @@ export type NotebookSize = {
 export type NotebookTolerationSettings = {
   enabled: boolean;
   key: string;
-}
+};
 
 export type ClusterSettings = {
   pvcSize: number;

--- a/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
@@ -50,9 +50,6 @@ export const NotebookServer: React.FC = () => {
                 onNotebooksStop={onNotebooksStop}
               />
               <ActionList>
-                <ActionListItem onClick={() => setNotebooksToStop([notebook])}>
-                  <Button variant="primary">Stop notebook server</Button>
-                </ActionListItem>
                 <ActionListItem
                   onClick={() => {
                     if (notebook.metadata.annotations?.['opendatahub.io/link']) {
@@ -60,7 +57,10 @@ export const NotebookServer: React.FC = () => {
                     }
                   }}
                 >
-                  <Button variant="secondary">Return to server</Button>
+                  <Button variant="primary">Access notebook server</Button>
+                </ActionListItem>
+                <ActionListItem onClick={() => setNotebooksToStop([notebook])}>
+                  <Button variant="secondary">Stop notebook server</Button>
                 </ActionListItem>
               </ActionList>
             </StackItem>


### PR DESCRIPTION
Resolves:#466 

## Description
Inverts the buttons for notebook server termination and access.

## How Has This Been Tested?
1. Deploy this PR on a cluster
2. Have a running notebook instance
3. Access Notebook server control panel and test the buttons

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
