### PR TITLE
Support not having an issue if the Notebook was deleted

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7834,7 +7834,7 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "optional": true
     },
     "gzip-size": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #474 

## Description
<!--- Describe your changes in detail -->
We (me 😞) failed to properly read the error object. `e.body` is the object behind the call... `e.response.body` is the object behind the error. I effectively hid the errors on createNotebook because of this. Logs didn't even get anything useful.

I have corrected that logging issue and handled the `409` conflict issue if you delete a Notebook -- we also created a Role that needs to be deleted (in the previous implementation) -- now it just ignores when there is a conflict and allows the flow to continue. Which will apply the route to the Notebook & not have an error in the form on the UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See ticket for full steps -- just delete your Notebook, keep the Role.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
