### PR TITLE
Refactor user group settings

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -639,7 +639,7 @@ export type GroupsConfigBody = {
   allowedGroups: string;
 };
 
-export type groupObjResponse = {
+export type GroupObjResponse = {
   users: string[] | null;
 };
 

--- a/backend/src/utils/groupsUtils.ts
+++ b/backend/src/utils/groupsUtils.ts
@@ -2,7 +2,7 @@ import { CustomObjectsApi } from '@kubernetes/client-node';
 import { setDashboardConfig } from '../routes/api/config/configUtils';
 import {
   GroupCustomObject,
-  groupObjResponse,
+  GroupObjResponse,
   GroupsConfigBody,
   KubeFastifyInstance,
 } from '../types';
@@ -16,11 +16,10 @@ export class MissingGroupError extends Error {
 }
 
 export const getGroupsCR = (): GroupsConfigBody => {
-  try {
-    return getDashboardConfig().spec.groupsConfig || { adminGroups: '', allowedGroups: '' };
-  } catch (e) {
-    throw new Error(`Failed to retrieve Dashboard CR groups configuration`);
+  if (typeof getDashboardConfig().spec.groupsConfig !== 'undefined') {
+    return getDashboardConfig().spec.groupsConfig;
   }
+  throw new Error(`Failed to retrieve Dashboard CR groups configuration`);
 };
 
 export const updateGroupsCR = async (
@@ -66,7 +65,7 @@ export const getGroup = async (
       'groups',
       adminGroup,
     );
-    return (adminGroupResponse.body as groupObjResponse).users;
+    return (adminGroupResponse.body as GroupObjResponse).users;
   } catch (e) {
     throw new MissingGroupError(`Failed to retrieve Group ${adminGroup}, might not exist.`);
   }

--- a/frontend/src/components/FormGroupSettings.tsx
+++ b/frontend/src/components/FormGroupSettings.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  Text,
+  HelperText,
+  HelperTextItem,
+  Alert,
+  AlertActionCloseButton,
+  Hint,
+  HintBody,
+} from '@patternfly/react-core';
+import { MultiSelection } from './MultiSelection';
+import { GroupsConfigField, MenuItemStatus } from 'pages/groupSettings/groupTypes';
+
+type FormGroupSettingsProps = {
+  title: string;
+  body: string;
+  groupsField: GroupsConfigField;
+  items: MenuItemStatus[];
+  handleMenuItemSelection: (newState: MenuItemStatus[], field: GroupsConfigField) => void;
+  handleClose: () => void;
+  error?: string;
+};
+
+export const FormGroupSettings: React.FC<FormGroupSettingsProps> = ({
+  title,
+  body,
+  groupsField,
+  items,
+  handleMenuItemSelection,
+  handleClose,
+  error,
+}) => {
+  return (
+    <FormGroup fieldId={groupsField} label={title}>
+      <Text>{body}</Text>
+      <MultiSelection
+        value={items}
+        setValue={(newState) => handleMenuItemSelection(newState, groupsField)}
+      />
+      {!error && (
+        <>
+          <HelperText>
+            <HelperTextItem variant="indeterminate">
+              {'View, edit, or create groups in OpenShift under User Management'}
+            </HelperTextItem>
+          </HelperText>
+          {groupsField === GroupsConfigField.ADMIN && (
+            <Hint>
+              <HintBody>
+                {'All cluster admins are automatically assigned as Data Science administrators.'}
+              </HintBody>
+            </Hint>
+          )}
+        </>
+      )}
+      {error && (
+        <Alert
+          isInline
+          variant="warning"
+          title={`Group error`}
+          actionClose={<AlertActionCloseButton onClose={handleClose} />}
+        >
+          <p>{error}</p>
+        </Alert>
+      )}
+    </FormGroup>
+  );
+};

--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -1,84 +1,61 @@
-import React, { useEffect, useState } from 'react';
+import * as React from 'react';
 import {
   HelperText,
   HelperTextItem,
   Select,
   SelectOption,
-  SelectOptionObject,
   SelectVariant,
 } from '@patternfly/react-core';
-import { MenuItemStatus } from 'pages/groupSettings/GroupTypes';
+import { MenuItemStatus } from 'pages/groupSettings/groupTypes';
 
-type MenuOptionMultiSelectProps = {
-  initialState: MenuItemStatus[];
-  onChange: (itemSelection: MenuItemStatus[]) => void;
+type MultiSelectionProps = {
+  value: MenuItemStatus[];
+  setValue: (itemSelection: MenuItemStatus[]) => void;
 };
 
-const ARIAL_LABEL = 'Select a group';
-const ERROR_LABEL = 'One or more group must be selected';
-
-export const MenuOptionMultiSelect: React.FC<MenuOptionMultiSelectProps> = ({
-  initialState,
-  onChange,
-}) => {
-  const [menuItemsState, setMenuItemsState] = useState<MenuItemStatus[] | undefined>();
-  const [showMenu, setShowMenu] = useState<boolean>(false);
-
-  useEffect(() => {
-    setMenuItemsState(initialState);
-  }, [initialState]);
+export const MultiSelection: React.FC<MultiSelectionProps> = ({ value, setValue }) => {
+  const [showMenu, setShowMenu] = React.useState<boolean>(false);
 
   const toggleMenu = (isOpen: React.SetStateAction<boolean>) => {
     setShowMenu(isOpen);
   };
 
-  const onSelect = (
-    _: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
-    value: string | SelectOptionObject,
-  ) => {
-    try {
-      if (menuItemsState?.filter((option) => option.name === value).length) {
-        const newState = menuItemsState.map((element) =>
-          element.name === value ? { ...element, enabled: !element.enabled } : element,
-        );
-        setMenuItemsState(newState);
-        onChange(newState);
-      }
-    } catch (e) {
-      // Error.
-    }
+  const clearSelection = () => {
+    const newState = value?.map((element) => ({ ...element, enabled: false }));
+    setValue(newState);
   };
 
-  const clearSelection = () => {
-    const newState = menuItemsState?.map((element) => ({ ...element, enabled: false }));
-    setMenuItemsState(newState);
-    if (newState) onChange(newState);
-  };
+  const noSelectedItems = value?.filter((option) => option.enabled).length === 0;
 
   return (
     <>
       <Select
         variant={SelectVariant.typeaheadMulti}
         onToggle={toggleMenu}
-        onSelect={onSelect}
+        onSelect={(e, newValue) => {
+          if (value?.filter((option) => option.name === newValue).length) {
+            const newState = value.map((element) =>
+              element.name === newValue ? { ...element, enabled: !element.enabled } : element,
+            );
+            setValue(newState);
+          }
+        }}
         onClear={clearSelection}
-        selections={menuItemsState?.flatMap((element) => (element.enabled ? element.name : []))}
+        selections={value?.filter((element) => element.enabled).map((element) => element.name)}
         isOpen={showMenu}
-        aria-labelledby={ARIAL_LABEL}
+        aria-labelledby="Select a group"
         isCreatable={false}
         onCreateOption={undefined}
-        validated={
-          menuItemsState?.filter((option) => option.enabled).length === 0 ? 'error' : 'default'
-        }
+        validated={noSelectedItems ? 'error' : 'default'}
       >
-        {menuItemsState?.map((option, index) => (
+        {value?.map((option, index) => (
           <SelectOption isDisabled={false} key={index} value={option.name} />
         ))}
       </Select>
-      {menuItemsState?.filter((option) => option.enabled).length === 0 && (
+      {noSelectedItems && (
         <HelperText>
           <HelperTextItem variant="error" hasIcon>
-            {ERROR_LABEL}
+            One or more group must be selected
           </HelperTextItem>
         </HelperText>
       )}

--- a/frontend/src/pages/groupSettings/GroupSettings.scss
+++ b/frontend/src/pages/groupSettings/GroupSettings.scss
@@ -10,52 +10,12 @@
     }
   }
 
-  .odh-number-input {
-    max-width: 100px;
-  }
-
-  .pf-c-input-group {
-    padding-top: var(--pf-global--spacer--md);
-    padding-bottom: var(--pf-global--spacer--md);
-
-    &__text {
-      font-size: var(--pf-global--FontSize--sm);
-      color: var(--pf-global--Color--100);
-    }
-  }
-
   .pf-c-helper-text {
     margin-top: var(--pf-global--spacer--sm);
-  }
-
-  .pf-c-radio {
-    margin: var(--pf-global--spacer--sm) 0;
-    padding-left: var(--pf-global--spacer--sm);
-
-    &__label {
-      font-size: var(--pf-global--FontSize--sm);
-    }
-  }
-
-  .pf-c-hint {
-    margin: 6 px;
   }
 
   &__form {
     margin: 0 var(--pf-global--spacer--lg);
   }
 
-  &__culler-input-group {
-    &.pf-c-input-group {
-      padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--lg) 0;
-    }
-
-    .odh-number-input {
-      max-width: 40px;
-
-      &__hour {
-        max-width: 60px;
-      }
-    }
-  }
 }

--- a/frontend/src/pages/groupSettings/GroupSettings.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettings.tsx
@@ -3,24 +3,15 @@ import {
   ActionGroup,
   Button,
   Form,
-  FormGroup,
   PageSection,
   PageSectionVariants,
-  Text,
-  HelperText,
-  HelperTextItem,
-  Alert,
-  AlertActionCloseButton,
-  Hint,
-  HintBody,
 } from '@patternfly/react-core';
 import ApplicationsPage from '../ApplicationsPage';
-import './GroupSettings.scss';
-import { GroupsConfigField, MenuItemStatus } from './GroupTypes';
-import { MenuOptionMultiSelect } from 'components/MultiSelection';
+import { GroupsConfigField, MenuItemStatus } from './groupTypes';
 import { useWatchGroups } from 'utilities/useWatchGroups';
-
-const CARD_FOOTER = `View, edit, or create groups in OpenShift under User Management`;
+import { FormGroupSettings } from 'components/FormGroupSettings';
+import './GroupSettings.scss';
+import { isGroupEmpty } from 'utilities/utils';
 
 const GroupSettings: React.FC = () => {
   const {
@@ -51,10 +42,6 @@ const GroupSettings: React.FC = () => {
     setIsGroupSettingsChanged(true);
   };
 
-  const isGroupEmpty = (groupList: MenuItemStatus[]): boolean => {
-    return groupList.filter((element) => element.enabled).length === 0;
-  };
-
   return (
     <ApplicationsPage
       title={`User and group settings`}
@@ -62,7 +49,7 @@ const GroupSettings: React.FC = () => {
       loaded={loaded}
       empty={false}
       loadError={loadError}
-      errorMessage={`Unable to load User and group settings`}
+      errorMessage={`Unable to load user and group settings`}
       emptyMessage={`No user and group settings found`}
     >
       {loaded && (
@@ -77,70 +64,29 @@ const GroupSettings: React.FC = () => {
               e.preventDefault();
             }}
           >
-            <FormGroup fieldId="admin-groups" label={`Data Science administrator groups`}>
-              <Text>{`Select the OpenShift groups that contain all Data Science administrators.`}</Text>
-              <MenuOptionMultiSelect
-                initialState={groupSettings.adminGroups}
-                onChange={(newState) => handleMenuItemSelection(newState, GroupsConfigField.ADMIN)}
-              />
-              {!groupSettings.errorAdmin && (
-                <>
-                  <HelperText>
-                    <HelperTextItem variant="indeterminate">{CARD_FOOTER}</HelperTextItem>
-                  </HelperText>
-                  <Hint>
-                    <HintBody>
-                      All cluster admins are automatically assigned as Data Science administrators.
-                    </HintBody>
-                  </Hint>
-                </>
-              )}
-              {groupSettings.errorAdmin && (
-                <Alert
-                  isInline
-                  variant="warning"
-                  title={`Group no longer exists`}
-                  actionClose={
-                    <AlertActionCloseButton
-                      onClose={() => {
-                        setGroupSettings({ ...groupSettings, errorAdmin: undefined });
-                      }}
-                    />
-                  }
-                >
-                  <p>{groupSettings.errorAdmin}</p>
-                </Alert>
-              )}
-            </FormGroup>
+            <FormGroupSettings
+              title="Data Science administrator groups"
+              body="Select the OpenShift groups that contain all Data Science administrators."
+              groupsField={GroupsConfigField.ADMIN}
+              items={groupSettings.adminGroups}
+              error={groupSettings.errorAdmin}
+              handleMenuItemSelection={handleMenuItemSelection}
+              handleClose={() => {
+                setGroupSettings({ ...groupSettings, errorAdmin: undefined });
+              }}
+            />
 
-            <FormGroup fieldId="user-groups" label={`Data Science user groups`}>
-              <Text>{`Select the OpenShift groups that contain all Data Science users.`}</Text>
-              <MenuOptionMultiSelect
-                initialState={groupSettings.allowedGroups}
-                onChange={(newState) => handleMenuItemSelection(newState, GroupsConfigField.USER)}
-              />
-              {!groupSettings.errorUser && (
-                <HelperText>
-                  <HelperTextItem variant="indeterminate">{CARD_FOOTER}</HelperTextItem>
-                </HelperText>
-              )}
-              {groupSettings.errorUser && (
-                <Alert
-                  isInline
-                  variant="warning"
-                  title={`Group no longer exists`}
-                  actionClose={
-                    <AlertActionCloseButton
-                      onClose={() => {
-                        setGroupSettings({ ...groupSettings, errorUser: undefined });
-                      }}
-                    />
-                  }
-                >
-                  <p>{groupSettings.errorUser}</p>
-                </Alert>
-              )}
-            </FormGroup>
+            <FormGroupSettings
+              title="Data Science user groups"
+              body="Select the OpenShift groups that contain all Data Science users."
+              groupsField={GroupsConfigField.USER}
+              items={groupSettings.allowedGroups}
+              error={groupSettings.errorUser}
+              handleMenuItemSelection={handleMenuItemSelection}
+              handleClose={() => {
+                setGroupSettings({ ...groupSettings, errorUser: undefined });
+              }}
+            />
 
             <ActionGroup>
               <Button

--- a/frontend/src/pages/groupSettings/groupTypes.ts
+++ b/frontend/src/pages/groupSettings/groupTypes.ts
@@ -6,8 +6,8 @@ export type GroupsConfig = {
 };
 
 export enum GroupsConfigField {
-  ADMIN,
-  USER,
+  ADMIN = 'admin',
+  USER = 'user',
 }
 
 export type GroupStatus = {

--- a/frontend/src/services/groupSettingsService.ts
+++ b/frontend/src/services/groupSettingsService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { GroupsConfig } from '../pages/groupSettings/GroupTypes';
+import { GroupsConfig } from '../pages/groupSettings/groupTypes';
 
 export const fetchGroupsSettings = (): Promise<GroupsConfig> => {
   const url = '/api/groups-config';

--- a/frontend/src/utilities/useWatchGroups.tsx
+++ b/frontend/src/utilities/useWatchGroups.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GroupsConfig } from 'pages/groupSettings/GroupTypes';
+import { GroupsConfig } from 'pages/groupSettings/groupTypes';
 import { fetchGroupsSettings, updateGroupsSettings } from 'services/groupSettingsService';
 import useNotification from './useNotification';
 
@@ -22,6 +22,7 @@ export const useWatchGroups = (): {
     adminGroups: [],
     allowedGroups: [],
   });
+  const { errorAdmin, errorUser } = groupSettings;
 
   React.useEffect(() => {
     const fetchGroups = () => {
@@ -29,7 +30,6 @@ export const useWatchGroups = (): {
       fetchGroupsSettings()
         .then((groupsResponse) => {
           setGroupSettings(groupsResponse);
-          createMissingGroupAlert(groupsResponse);
           setLoadError(undefined);
           setLoaded(true);
         })
@@ -44,8 +44,16 @@ export const useWatchGroups = (): {
         });
     };
     fetchGroups();
-    //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [notification]);
+
+  React.useEffect(() => {
+    if (errorAdmin) {
+      notification.error(`Group no longer exists`, errorAdmin);
+    }
+    if (errorUser) {
+      notification.error(`Group no longer exists`, errorUser);
+    }
+  }, [errorAdmin, errorUser, notification]);
 
   const updateGroups = (group: GroupsConfig) => {
     setIsLoading(true);
@@ -53,7 +61,6 @@ export const useWatchGroups = (): {
       .then((response) => {
         if (response.success) {
           setGroupSettings(response.success);
-          createMissingGroupAlert(response.success);
           notification.success('Group settings changes saved');
         }
       })
@@ -65,15 +72,6 @@ export const useWatchGroups = (): {
         setIsLoading(false);
         setIsGroupSettingsChanged(false);
       });
-  };
-
-  const createMissingGroupAlert = (groupsConfig: GroupsConfig) => {
-    if (groupsConfig.errorAdmin) {
-      notification.error(`Group no longer exists`, groupsConfig.errorAdmin);
-    }
-    if (groupsConfig.errorUser) {
-      notification.error(`Group no longer exists`, groupsConfig.errorUser);
-    }
   };
 
   return {

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -131,3 +131,7 @@ export const getHourAndMinuteByTimeout = (timeout: number): { hour: number; minu
 
 export const getTimeoutByHourAndMinute = (hour: number, minute: number): number =>
   (hour * 60 + minute) * 60;
+
+export const isGroupEmpty = <T extends { enabled: boolean }>(groupList: Array<T>): boolean => {
+  return groupList.filter((element) => element.enabled).length === 0;
+};

--- a/manifests/overlays/odhdashboardconfig/kustomization.yaml
+++ b/manifests/overlays/odhdashboardconfig/kustomization.yaml
@@ -4,6 +4,5 @@ kind: Kustomization
 bases:
 - ../authentication
 resources:
-- groups-config.configmap.yaml
 - odh-dashboard-config.yaml
 - odh-enabled-applications-config.configmap.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


- [X] Reuse Render Blocks -> Done, now there's a new component based in the Groups form.
- [X] Form & Fields ---> Done, changed the state to be controlled by the parent.
- [X] Remove eslint-ignore for hook dependencies —> Done, changed how to display the error messages
- [X] Avoid `try/catch` usage on the frontend, lean into Promises --> Done
- [X] Files should be named the same as their components -- eg `MenuOptionMultiSelect` is in `MultiSelection.tsx` -- omit `Option` in the name
- [x] Handle optional case behind type of OdhDashboardConfig --> Done, although I'm not sure if this is the solution you were looking after.
- [X] What did we do with the `detectUser` call you made? That probably is needed to refresh the user state to see if they did something to their permissions, no? —>  I don’t recall that part, and it’s not present in the code, can’t remember why i added that.
-  [X] Avoid constant text --> Done, you're right, changed
- [X] Convert flatmap --> Done
- [X] Generic utility for reading your state at empty --> Created a constant and a generic function in utils
- [X] `GroupTypes.ts` should be `groupTypes.ts` or `group-types.ts` -- Components are PascalCase, utilities are camelCase or snake-case -- not sure what we do here or if we have a standard... avoid PascalCase for anything that is not directly a component (of the same name)
- [ ]  Throwing error if admin is `system:authenticated`; we should look to present this as an issue in the UI --> I would further discuss this one, cause right now if it’s added by force, the system will clean up the group since it doesn’t exist.
- [ ] Avoid PF CSS Overrides -> **No completed**, I've **reduced CSS to the minimum**, but Cards have a different style than the one provided by UX, and is adding more complexity (layout-wise) to the form, and the padding is not formatted.
- [ ]  We may want to look at your new hook too, is there more we can do here? It takes A LOT and returns A LOT, maybe needed to be this complex, but we can see about that —> Yes, not done right now, I would love to have a discussion about that, maybe in a different PR.
-  [ ] Apply to the `GroupSettings` form the `isWidthLimited` property ([docs](https://www.patternfly.org/v4/components/form#form)) ---> **Not applied**, maybe cause we are using an old version of patternfly, but `maxWidth` is missing from `Form`, and when applying `isWidthLimited` is limited to 500px width.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Follow the steps in the `CONTRIBUTING` file to `build`, `push` and `deploy` an image of this PR.
2. Navigate to `Settings > User management`
3. Try to add and remove groups

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
