### PR TITLE
Enable viewing users notebook details from the admin panel

### DIFF
--- a/frontend/src/pages/notebookController/screens/admin/NotebookActions.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookActions.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { ActionsColumn, IAction } from '@patternfly/react-table';
+import { AdminViewUserData } from './types';
+import { NotebookAdminContext } from './NotebookAdminContext';
+
+type ServerStatusProps = {
+  data: AdminViewUserData['actions'];
+};
+
+const NotebookActions: React.FC<ServerStatusProps> = ({ data }) => {
+  const { setServerStatuses } = React.useContext(NotebookAdminContext);
+
+  if (!data.isNotebookRunning) {
+    return null;
+  }
+
+  const rowActions: IAction[] = [
+    {
+      title: 'Stop server',
+      onClick: () => {
+        setServerStatuses([data]);
+      },
+    },
+  ];
+
+  return <ActionsColumn items={rowActions} />;
+};
+
+export default NotebookActions;

--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -18,6 +18,7 @@ import useTableColumnSort from '../../../../utilities/useTableColumnSort';
 import { AdminViewUserData } from './types';
 import StopServerModal from '../server/StopServerModal';
 import { NotebookAdminContext } from './NotebookAdminContext';
+import NotebookActions from './NotebookActions';
 import { Notebook } from '../../../../types';
 
 const INITIAL_PAGE_LIMIT = 10;
@@ -89,11 +90,17 @@ const NotebookAdminControl: React.FC = () => {
                 <Tbody>
                   {users.slice(perPage * pageIndex, perPage * pageIndex + perPage).map((user) => (
                     <Tr key={user.name}>
-                      {columns.map((column) => (
-                        <Td key={column.field} dataLabel={column.field}>
-                          <UserTableCellTransform user={user} userProperty={column.field} />
-                        </Td>
-                      ))}
+                      {columns.map((column) =>
+                        column.field === 'actions' ? (
+                          <Td key={column.field} isActionCell>
+                            <NotebookActions data={user[column.field]} />
+                          </Td>
+                        ) : (
+                          <Td key={column.field} dataLabel={column.field}>
+                            <UserTableCellTransform user={user} userProperty={column.field} />
+                          </Td>
+                        ),
+                      )}
                     </Tr>
                   ))}
                 </Tbody>

--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -18,7 +18,6 @@ import useTableColumnSort from '../../../../utilities/useTableColumnSort';
 import { AdminViewUserData } from './types';
 import StopServerModal from '../server/StopServerModal';
 import { NotebookAdminContext } from './NotebookAdminContext';
-import NotebookActions from './NotebookActions';
 import { Notebook } from '../../../../types';
 
 const INITIAL_PAGE_LIMIT = 10;
@@ -90,17 +89,15 @@ const NotebookAdminControl: React.FC = () => {
                 <Tbody>
                   {users.slice(perPage * pageIndex, perPage * pageIndex + perPage).map((user) => (
                     <Tr key={user.name}>
-                      {columns.map((column) =>
-                        column.field === 'actions' ? (
-                          <Td key={column.field} isActionCell>
-                            <NotebookActions data={user[column.field]} />
-                          </Td>
-                        ) : (
-                          <Td key={column.field} dataLabel={column.field}>
-                            <UserTableCellTransform user={user} userProperty={column.field} />
-                          </Td>
-                        ),
-                      )}
+                      {columns.map((column) => (
+                        <Td
+                          key={column.field}
+                          dataLabel={column.field}
+                          isActionCell={column.field === 'actions'}
+                        >
+                          <UserTableCellTransform user={user} userProperty={column.field} />
+                        </Td>
+                      ))}
                     </Tr>
                   ))}
                 </Tbody>

--- a/frontend/src/pages/notebookController/screens/admin/ServerStatus.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/ServerStatus.tsx
@@ -4,7 +4,6 @@ import { useUser } from '../../../../redux/selectors';
 import { AdminViewUserData } from './types';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 import { NotebookControllerTabTypes } from '../../const';
-import { NotebookAdminContext } from './NotebookAdminContext';
 
 type ServerStatusProps = {
   data: AdminViewUserData['serverStatus'];
@@ -15,40 +14,26 @@ const ServerStatus: React.FC<ServerStatusProps> = ({ data, username }) => {
   const { setImpersonating, setCurrentAdminTab } = React.useContext(NotebookControllerContext);
   const { username: stateUser } = useUser();
   const forStateUser = stateUser === username;
-  const { setServerStatuses } = React.useContext(NotebookAdminContext);
 
+  const onClickServerAction = () => {
+    if (forStateUser) {
+      // Starting your own server, no need to impersonate
+      setCurrentAdminTab(NotebookControllerTabTypes.SERVER);
+      return;
+    }
+    setImpersonating({ notebook: data.notebook, isRunning: data.isNotebookRunning }, username);
+  };
+
+  let buttonText = '';
   if (!data.isNotebookRunning) {
-    return (
-      <Button
-        variant="link"
-        isInline
-        onClick={() => {
-          if (forStateUser) {
-            // Starting your own server, no need to impersonate
-            setCurrentAdminTab(NotebookControllerTabTypes.SERVER);
-            return;
-          }
-          setImpersonating(
-            { notebook: data.notebook, isRunning: data.isNotebookRunning },
-            username,
-          );
-        }}
-      >
-        {forStateUser ? 'Start your server' : 'Start server'}
-      </Button>
-    );
+    buttonText = forStateUser ? 'Start your server' : 'Start server';
+  } else {
+    buttonText = forStateUser ? 'View your server' : 'View server';
   }
 
   return (
-    <Button
-      variant="link"
-      isDanger
-      isInline
-      onClick={() => {
-        setServerStatuses([data]);
-      }}
-    >
-      Stop server
+    <Button variant="link" isInline onClick={onClickServerAction}>
+      {buttonText}
     </Button>
   );
 };

--- a/frontend/src/pages/notebookController/screens/admin/UserTableCellTransform.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/UserTableCellTransform.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { relativeTime } from '../../../../utilities/time';
 import { isField, AdminViewUserData } from './types';
 import ServerStatus from './ServerStatus';
+import NotebookActions from './NotebookActions';
 
 type TableDataRendererProps = {
   user: AdminViewUserData;
@@ -13,6 +14,10 @@ const UserTableCellTransform: React.FC<TableDataRendererProps> = ({ user, userPr
 
   if (isField<AdminViewUserData['serverStatus']>(content, userProperty === 'serverStatus')) {
     return <ServerStatus username={user.name} data={content} />;
+  }
+
+  if (isField<AdminViewUserData['actions']>(content, userProperty === 'actions')) {
+    return <NotebookActions data={content} />;
   }
 
   if (isField<AdminViewUserData['lastActivity']>(content, userProperty === 'lastActivity')) {

--- a/frontend/src/pages/notebookController/screens/admin/const.ts
+++ b/frontend/src/pages/notebookController/screens/admin/const.ts
@@ -9,9 +9,14 @@ export const columns: SortableData<AdminViewUserData>[] = [
     label: 'Server status',
     field: 'serverStatus',
     sortable: (a: AdminViewUserData, b: AdminViewUserData): number => {
-      const first = a.serverStatus.notebook ? 1 : -1;
-      const second = b.serverStatus.notebook ? 1 : -1;
+      const first = a.serverStatus.isNotebookRunning ? 1 : -1;
+      const second = b.serverStatus.isNotebookRunning ? 1 : -1;
       return first - second;
     },
+  },
+  {
+    label: '',
+    field: 'actions',
+    sortable: false,
   },
 ];

--- a/frontend/src/pages/notebookController/screens/admin/types.ts
+++ b/frontend/src/pages/notebookController/screens/admin/types.ts
@@ -17,11 +17,14 @@ export type AdminViewUserData = {
   name: string;
   privilege: PrivilegeState;
   lastActivity?: string;
-  serverStatus: {
-    notebook: Notebook | null;
-    isNotebookRunning: boolean;
-    forceRefresh: () => void;
-  };
+  serverStatus: ServerStatus;
+  actions: ServerStatus;
+};
+
+export type ServerStatus = {
+  notebook: Notebook | null;
+  isNotebookRunning: boolean;
+  forceRefresh: () => void;
 };
 
 /**

--- a/frontend/src/pages/notebookController/screens/admin/useAdminUsers.ts
+++ b/frontend/src/pages/notebookController/screens/admin/useAdminUsers.ts
@@ -4,7 +4,7 @@ import useWatchNotebooksForUsers from '../../../../utilities/useWatchNotebooksFo
 import { NotebookRunningState } from '../../../../types';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 import useNamespaces from '../../useNamespaces';
-import { AdminViewUserData } from './types';
+import { AdminViewUserData, ServerStatus } from './types';
 import useCheckForAllowedUsers from './useCheckForAllowedUsers';
 
 const useAdminUsers = (): [AdminViewUserData[], boolean, Error | undefined] => {
@@ -29,7 +29,7 @@ const useAdminUsers = (): [AdminViewUserData[], boolean, Error | undefined] => {
     const notebook = notebookRunningState?.notebook ?? null;
     const isNotebookRunning = notebookRunningState?.isRunning ?? false;
 
-    const serverStatusObject = {
+    const serverStatusObject: ServerStatus = {
       notebook,
       isNotebookRunning,
       forceRefresh: () => {

--- a/frontend/src/pages/notebookController/screens/admin/useAdminUsers.ts
+++ b/frontend/src/pages/notebookController/screens/admin/useAdminUsers.ts
@@ -29,21 +29,24 @@ const useAdminUsers = (): [AdminViewUserData[], boolean, Error | undefined] => {
     const notebook = notebookRunningState?.notebook ?? null;
     const isNotebookRunning = notebookRunningState?.isRunning ?? false;
 
+    const serverStatusObject = {
+      notebook,
+      isNotebookRunning,
+      forceRefresh: () => {
+        forceRefresh([allowedUser.username]);
+        if (allowedUser.username === loggedInUser) {
+          // Refresh your own state too -- so you can live updates if you navigate or restart your server
+          requestNotebookRefresh();
+        }
+      },
+    };
+
     return {
       name: allowedUser.username,
       privilege: allowedUser.privilege,
       lastActivity: allowedUser.lastActivity,
-      serverStatus: {
-        notebook,
-        isNotebookRunning,
-        forceRefresh: () => {
-          forceRefresh([allowedUser.username]);
-          if (allowedUser.username === loggedInUser) {
-            // Refresh your own state too -- so you can live updates if you navigate or restart your server
-            requestNotebookRefresh();
-          }
-        },
-      },
+      serverStatus: serverStatusObject,
+      actions: serverStatusObject,
     };
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #441 
Based on the design in the issue, I added a new action column that holds a kebab dropdown button, which only shows when the notebook is running. Currently, there is only one option `Stop server` in the dropdown menu but it has a good scalability and could add more actions in the future.

<img width="1792" alt="Screen Shot 2022-09-01 at 4 29 39 PM" src="https://user-images.githubusercontent.com/37624318/188007592-c558ee0c-5d76-4b19-8916-2c9ff94091ce.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Try to create a notebook, and go back to the admin panel, you can either view the notebook details or stop the notebook by selecting in the dropdown menu.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
