### PR TITLE
Use replace instead of patch

### DIFF
--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -7,7 +7,6 @@ import {
   getNotebookStatus,
   replaceNotebook,
 } from './notebookUtils';
-import { RecursivePartial } from '../../../typeHelpers';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get('/:projectName', async (request: FastifyRequest) => {

--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -70,7 +70,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     ),
   );
 
-  fastify.patch(
+  fastify.put(
     '/:namespace/:name',
     secureRoute(fastify)(
       async (
@@ -83,9 +83,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         }>,
       ) => {
         const { namespace, name } = request.params;
-        const data = await sanitizeNotebookForSecurity(fastify, request, request.body);
+        const data = (await sanitizeNotebookForSecurity(
+          fastify,
+          request,
+          request.body,
+        )) as Notebook;
 
-      return await replaceNotebook(fastify, data, namespace, name);
-    },
+        return await replaceNotebook(fastify, data, namespace, name);
+      },
+    ),
   );
 };

--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -3,9 +3,9 @@ import { FastifyRequest } from 'fastify';
 import {
   getNotebook,
   getNotebooks,
-  patchNotebook,
   createNotebook,
   getNotebookStatus,
+  replaceNotebook,
 } from './notebookUtils';
 import { RecursivePartial } from '../../../typeHelpers';
 
@@ -70,7 +70,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     '/:projectName/:notebookName',
     async (
       request: FastifyRequest<{
-        Body: RecursivePartial<Notebook>;
+        Body: Notebook;
         Params: {
           projectName: string;
           notebookName: string;
@@ -80,7 +80,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       const params = request.params;
       const data = request.body;
 
-      return await patchNotebook(fastify, data, params.projectName, params.notebookName);
+      return await replaceNotebook(fastify, data, params.projectName, params.notebookName);
     },
   );
 };

--- a/backend/src/routes/api/notebooks/notebookUtils.ts
+++ b/backend/src/routes/api/notebooks/notebookUtils.ts
@@ -189,6 +189,26 @@ export const patchNotebook = async (
     .then((response) => response.body as Notebook);
 };
 
+export const replaceNotebook = async (
+  fastify: KubeFastifyInstance,
+  body: Notebook,
+  namespace: string,
+  notebookName: string,
+): Promise<Notebook> => {
+  return fastify.kube.customObjectsApi
+    .replaceNamespacedCustomObject(
+      'kubeflow.org',
+      'v1',
+      namespace,
+      'notebooks',
+      notebookName,
+      body,
+      undefined,
+      undefined,
+      undefined,
+    )
+    .then((response) => response.body as Notebook);
+};
 export const createRBAC = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest<{

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -12,7 +12,6 @@ import {
   NotebookResources,
   NotebookAffinity,
 } from '../types';
-import { RecursivePartial } from '../typeHelpers';
 import { LIMIT_NOTEBOOK_IMAGE_GPU } from '../utilities/const';
 import { MOUNT_PATH } from '../pages/notebookController/const';
 import { usernameTranslate } from '../utilities/notebookControllerUtils';

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -86,15 +86,15 @@ const assembleNotebook = (data: StartNotebookData): Notebook => {
   const resources: NotebookResources = { ...notebookSize.resources };
   const tolerations: NotebookToleration[] = [];
   let affinity: NotebookAffinity = {};
+  if (!resources.limits) {
+    resources.limits = {};
+  }
+  if (!resources.requests) {
+    resources.requests = {};
+  }
+  resources.limits[LIMIT_NOTEBOOK_IMAGE_GPU] = gpus;
+  resources.requests[LIMIT_NOTEBOOK_IMAGE_GPU] = gpus;
   if (gpus > 0) {
-    if (!resources.limits) {
-      resources.limits = {};
-    }
-    if (!resources.requests) {
-      resources.requests = {};
-    }
-    resources.limits[LIMIT_NOTEBOOK_IMAGE_GPU] = gpus;
-    resources.requests[LIMIT_NOTEBOOK_IMAGE_GPU] = gpus;
     tolerations.push({
       effect: 'NoSchedule',
       key: LIMIT_NOTEBOOK_IMAGE_GPU,

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -315,8 +315,8 @@ export const replaceNotebook = async (
   const notebook = _.cloneDeep(await getNotebook(projectName, notebookName));
 
   notebook.spec = data.spec;
-  notebook.metadata.annotations = data.metadata.annotations;
-  notebook.metadata.labels = data.metadata.labels;
+  notebook.metadata.annotations['kubeflow-resource-stopped'] =
+    data.metadata.annotations['kubeflow-resource-stopped'];
 
   return axios
     .put(url, _.merge(notebook, data))


### PR DESCRIPTION
Resolves #470 

## Description
This PR Changes the notebookService logic so that it uses replace instead of patch. Additionally to make sure no changes from the previous notebook are left in the spec, the spec is directly replaced without a merge, while the rest of the fields are merged.

## How Has This Been Tested?
1. Deploy dev overlay of odh-dashboard
2. Start regular notebook
3. Stop regular notebook
4. Start notebook with gpu
5. Verify notebook object does not contain non-gpu affinity

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
