### PR TITLE
Fix issue with requesting kube resources

### DIFF
--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -8,79 +8,85 @@ import {
   getNotebookStatus,
 } from './notebookUtils';
 import { RecursivePartial } from '../../../typeHelpers';
+import { secureRoute } from '../../../utils/route-security';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  fastify.get('/:projectName', async (request: FastifyRequest) => {
-    const params = request.params as {
-      projectName: string;
-    };
-    const query = request.query as {
-      labels: string;
-    };
-
-    return await getNotebooks(fastify, params.projectName, query.labels);
-  });
-
-  fastify.get('/:projectName/:notebookName', async (request: FastifyRequest) => {
-    const params = request.params as {
-      projectName: string;
-      notebookName: string;
-    };
-
-    return await getNotebook(fastify, params.projectName, params.notebookName);
-  });
+  fastify.get(
+    '/:namespace',
+    secureRoute(fastify)(
+      async (
+        request: FastifyRequest<{ Params: { namespace: string }; Querystring: { labels: string } }>,
+      ) => {
+        const { namespace } = request.params;
+        return await getNotebooks(fastify, namespace, request.query.labels);
+      },
+    ),
+  );
 
   fastify.get(
-    '/:projectName/:notebookName/status',
-    async (
-      request: FastifyRequest<{
-        Params: {
-          projectName: string;
-          notebookName: string;
-        };
-      }>,
-    ) => {
-      const { projectName, notebookName } = request.params;
+    '/:namespace/:name',
+    secureRoute(fastify)(
+      async (request: FastifyRequest<{ Params: { namespace: string; name: string } }>) => {
+        const { namespace, name } = request.params;
+        return await getNotebook(fastify, namespace, name);
+      },
+    ),
+  );
 
-      const notebook = await getNotebook(fastify, projectName, notebookName);
-      const hasStopAnnotation = !!notebook?.metadata.annotations?.['kubeflow-resource-stopped'];
-      const isRunning = hasStopAnnotation
-        ? false
-        : await getNotebookStatus(fastify, projectName, notebookName);
+  fastify.get(
+    '/:namespace/:name/status',
+    secureRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Params: { namespace: string; name: string };
+        }>,
+      ) => {
+        const { namespace, name } = request.params;
 
-      return { notebook, isRunning };
-    },
+        const notebook = await getNotebook(fastify, namespace, name);
+        const hasStopAnnotation = !!notebook?.metadata.annotations?.['kubeflow-resource-stopped'];
+        const isRunning = hasStopAnnotation
+          ? false
+          : await getNotebookStatus(fastify, namespace, name);
+
+        return { notebook, isRunning };
+      },
+    ),
   );
 
   fastify.post(
-    '/:projectName',
-    async (
-      request: FastifyRequest<{
-        Params: {
-          projectName: string;
-        };
-        Body: Notebook;
-      }>,
-    ) => {
-      return createNotebook(fastify, request);
-    },
+    '/:namespace',
+    secureRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Params: {
+            namespace: string;
+          };
+          Body: Notebook;
+        }>,
+      ) => {
+        return createNotebook(fastify, request);
+      },
+    ),
   );
 
   fastify.patch(
-    '/:projectName/:notebookName',
-    async (
-      request: FastifyRequest<{
-        Body: RecursivePartial<Notebook>;
-        Params: {
-          projectName: string;
-          notebookName: string;
-        };
-      }>,
-    ) => {
-      const params = request.params;
-      const data = request.body;
+    '/:namespace/:name',
+    secureRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Body: RecursivePartial<Notebook>;
+          Params: {
+            namespace: string;
+            name: string;
+          };
+        }>,
+      ) => {
+        const { namespace, name } = request.params;
+        const data = request.body;
 
-      return await patchNotebook(fastify, data, params.projectName, params.notebookName);
-    },
+        return await patchNotebook(fastify, data, namespace, name);
+      },
+    ),
   );
 };

--- a/backend/src/routes/api/notebooks/notebookUtils.ts
+++ b/backend/src/routes/api/notebooks/notebookUtils.ts
@@ -85,12 +85,12 @@ export const createNotebook = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest<{
     Params: {
-      projectName: string;
+      namespace: string;
     };
     Body: Notebook;
   }>,
 ): Promise<Notebook> => {
-  const namespace = request.params.projectName;
+  const namespace = request.params.namespace;
   const notebookData = request.body;
   const notebookName = notebookData.metadata.name;
   notebookData.metadata.namespace = namespace;
@@ -193,7 +193,7 @@ export const createRBAC = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest<{
     Params: {
-      projectName: string;
+      namespace: string;
     };
     Body: Notebook;
   }>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Follow up #488 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Overview
I'm gonna detail all the tests performed in different sections:

* Ensure notebook creation ✅
* Ensure notebook can read env variables and these variables are created ✅
* Ensure dashboard can read PVC ✅

### Accessing a namespaced configmap

```bash
❯ oc get configmap kube-root-ca.crt -n odh-notebook
NAME                    DATA   AGE
kube-root-ca.crt   1      17d
```

https://odh-dashboard-opendatahub.apps.lferrnan-odh.dev.datahub.redhat.com/api/configmaps/odh-notebook/kube-root-ca.crt 

**Main branch**

🐞 You can access 

**Bugfix branch**

✅ **You can’t access** —> `{"statusCode":403,"error":"Forbidden","message":"Cannot request a resource that does not belong to you"}`

### Accessing user's configmap

```bash
❯ oc get configmap jupyterhub-singleuser-profile-lferrnan-envs -n odh-notebook
NAME                                          DATA   AGE
jupyterhub-singleuser-profile-lferrnan-envs   1      33h
```

https://odh-dashboard-opendatahub.apps.lferrnan-odh.dev.datahub.redhat.com/api/configmaps/odh-notebook/jupyterhub-singleuser-profile-lferrnan-envs 

**Main branch**

✅ You can access

**Bugfix branch**

✅ You can access

### Accessing a namespaced secret

```bash
❯ oc get secret builder-dockercfg-kcgfc -n odh-notebook
NAME                      TYPE                      DATA   AGE
builder-dockercfg-kcgfc   kubernetes.io/dockercfg   1      33h
```

https://odh-dashboard-opendatahub.apps.lferrnan-odh.dev.datahub.redhat.com/api/secrets/odh-notebook/builder-dockercfg-kcgfc

**Main branch**

🐞 You can access 

**Bugfix branch**

✅ **You can’t access** —> `{"statusCode":403,"error":"Forbidden","message":"Cannot request a resource that does not belong to you"}`

### Accessing user's secret

```bash
❯ oc get secret jupyterhub-singleuser-profile-lferrnan-envs -n odh-notebook
NAME                                          DATA   AGE
jupyterhub-singleuser-profile-lferrnan-envs   1      33h
```

https://odh-dashboard-opendatahub.apps.lferrnan-odh.dev.datahub.redhat.com/api/secrets/odh-notebook/jupyterhub-singleuser-profile-lferrnan-envs 

**Main branch**

✅ You can access

**Bugfix branch**

✅ You can access

### Accessing other notebook

```bash
❯ oc get notebook jupyter-nb-user1 -n odh-notebook                      
NAME                  AGE
jupyter-nb-user1   33h
```

https://odh-dashboard-opendatahub.apps.lferrnan-odh.dev.datahub.redhat.com/api/notebooks/odh-notebook/jupyter-nb-user1 

**Main branch**

🐞 You can access 

**Bugfix branch**

✅ **You can’t access** —> `{"statusCode":403,"error":"Forbidden","message":"Cannot request a resource that does not belong to you"}`


### Accessing user's notebook

```bash
❯ oc get notebook jupyter-nb-lferrnan -n odh-notebook                      
NAME                  AGE
jupyter-nb-lferrnan   33h
```

https://odh-dashboard-opendatahub.apps.lferrnan-odh.dev.datahub.redhat.com/api/notebooks/odh-notebook/jupyter-nb-lferrnan 

**Main branch**

✅ You can access

**Bugfix branch**

✅ You can access



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
