### PR TITLE
Update the logic of getting and patching the route for notebook

### DIFF
--- a/backend/src/routes/api/notebooks/notebookUtils.ts
+++ b/backend/src/routes/api/notebooks/notebookUtils.ts
@@ -34,7 +34,7 @@ export const getNotebook = async (
   fastify: KubeFastifyInstance,
   namespace: string,
   notebookName: string,
-): Promise<Notebook> => {
+): Promise<Notebook | null> => {
   try {
     const kubeResponse = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
       'kubeflow.org',
@@ -82,6 +82,28 @@ export const verifyResources = (resources: NotebookResources): NotebookResources
   return resources;
 };
 
+export const patchNotebookRoute = async (
+  fastify: KubeFastifyInstance,
+  route: Route,
+  namespace: string,
+  notebookName: string,
+): Promise<Notebook> => {
+  const patch: RecursivePartial<Notebook> = {
+    metadata: {
+      annotations: {
+        'opendatahub.io/link': `https://${route.spec.host}/notebook/${namespace}/${notebookName}`,
+      },
+    },
+  };
+
+  return await patchNotebook(fastify, patch, namespace, notebookName).catch((res) => {
+    const e = res.response.body;
+    const error = createCustomError('Error adding route data to Notebook', e.message, e.code);
+    fastify.log.error(error);
+    throw error;
+  });
+};
+
 export const createNotebook = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest<{
@@ -116,8 +138,9 @@ export const createNotebook = async (
   notebookContainers[0].env.push({ name: 'JUPYTER_NOTEBOOK_PORT', value: '8888' });
   notebookContainers[0].resources = verifyResources(notebookContainers[0].resources);
 
-  await fastify.kube.customObjectsApi
+  const notebook = await fastify.kube.customObjectsApi
     .createNamespacedCustomObject('kubeflow.org', 'v1', namespace, 'notebooks', notebookData)
+    .then((res) => res.body as Notebook)
     .catch((res) => {
       const e = res.response.body;
       const error = createCustomError('Error creating Notebook Custom Resource', e.message, e.code);
@@ -139,30 +162,30 @@ export const createNotebook = async (
     throw error;
   });
 
-  await new Promise((r) => setTimeout(r, 500));
-  const route = await fastify.kube.customObjectsApi
-    .getNamespacedCustomObject('route.openshift.io', 'v1', namespace, 'routes', notebookName)
-    .then((response) => response.body as Route)
-    .catch((res) => {
-      const e = res.response.body;
-      const error = createCustomError('Error fetching Notebook Route', e.message, e.code);
-      fastify.log.error(error);
-      throw error;
+  let route: Route | undefined;
+  let fetchTime = 10;
+  while (fetchTime > 0) {
+    route = await getRoute(fastify, namespace, notebookName).catch(async (e) => {
+      // if the route is not created yet
+      // wait for 1 sec and fetch time minus 1
+      if (e.code === 404) {
+        await new Promise((r) => setTimeout(r, 1000));
+        fetchTime -= 1;
+        if (fetchTime <= 0) {
+          fastify.log.warn(
+            'Wait for 10 seconds and route is still missing, skipping patching for now.',
+          );
+        }
+        return undefined;
+      }
+      throw e;
     });
-
-  const patch: RecursivePartial<Notebook> = {
-    metadata: {
-      annotations: {
-        'opendatahub.io/link': `https://${route.spec.host}/notebook/${namespace}/${notebookName}`,
-      },
-    },
-  };
-
-  return await patchNotebook(fastify, patch, namespace, notebookName).catch((res) => {
-    const e = res.response.body;
-    const error = createCustomError('Error adding route data to Notebook', e.message, e.code);
-    fastify.log.error(error);
-    throw error;
+  }
+  return await patchNotebookRoute(fastify, route, namespace, notebookName).catch((e) => {
+    fastify.log.error(
+      `Failed to patch Notebook Route at the end of notebook creation: ${e.message}`,
+    );
+    return notebook;
   });
 };
 
@@ -241,4 +264,20 @@ export const createRBAC = async (
 
   await fastify.kube.rbac.createNamespacedRole(namespace, notebookRole);
   await fastify.kube.rbac.createNamespacedRoleBinding(namespace, notebookRoleBinding);
+};
+
+export const getRoute = async (
+  fastify: KubeFastifyInstance,
+  namespace: string,
+  routeName: string,
+): Promise<Route> => {
+  const kubeResponse = await fastify.kube.customObjectsApi
+    .getNamespacedCustomObject('route.openshift.io', 'v1', namespace, 'routes', routeName)
+    .catch((res) => {
+      const e = res.response.body;
+      const error = createCustomError('Error getting Route', e.message, e.code);
+      fastify.log.error(error);
+      throw error;
+    });
+  return kubeResponse.body as Route;
 };

--- a/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
@@ -7,11 +7,13 @@ import { NotebookControllerContext } from '../../NotebookControllerContext';
 import ImpersonateAlert from '../admin/ImpersonateAlert';
 import NotebookServerDetails from './NotebookServerDetails';
 import StopServerModal from './StopServerModal';
+import useNotification from '../../../../utilities/useNotification';
 
 import '../../NotebookController.scss';
 
 export const NotebookServer: React.FC = () => {
   const history = useHistory();
+  const notification = useNotification();
   const {
     currentUserNotebook: notebook,
     currentUserNotebookIsRunning,
@@ -54,6 +56,11 @@ export const NotebookServer: React.FC = () => {
                   onClick={() => {
                     if (notebook.metadata.annotations?.['opendatahub.io/link']) {
                       window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+                    } else {
+                      notification.error(
+                        'Error accessing notebook server',
+                        'Failed to redirect page due to missing notebook URL, please try to refresh the page and try it again.',
+                      );
                     }
                   }}
                 >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #506 
Instead of waiting for 500ms, now the backend will do a loop fetching every second for 10 sec until it gets the route. Also, if there is no route, it will also fetch it when it detects the notebook is running and no link annotation in it, which makes it more robust.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
