### PR TITLE
Don't blanket allow reading of dashboard namespace

### DIFF
--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -1,28 +1,10 @@
 import { KubeFastifyInstance, Notebook } from '../../../types';
 import { FastifyRequest } from 'fastify';
-import {
-  getNotebook,
-  getNotebooks,
-  patchNotebook,
-  createNotebook,
-  getNotebookStatus,
-} from './notebookUtils';
+import { getNotebook, patchNotebook, createNotebook, getNotebookStatus } from './notebookUtils';
 import { RecursivePartial } from '../../../typeHelpers';
 import { sanitizeNotebookForSecurity, secureRoute } from '../../../utils/route-security';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  fastify.get(
-    '/:namespace',
-    secureRoute(fastify)(
-      async (
-        request: FastifyRequest<{ Params: { namespace: string }; Querystring: { labels: string } }>,
-      ) => {
-        const { namespace } = request.params;
-        return await getNotebooks(fastify, namespace, request.query.labels);
-      },
-    ),
-  );
-
   fastify.get(
     '/:namespace/:name',
     secureRoute(fastify)(

--- a/backend/src/routes/api/rolebindings/index.ts
+++ b/backend/src/routes/api/rolebindings/index.ts
@@ -23,7 +23,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return rbResponse.body;
         } catch (e) {
-          fastify.log.error(`rolebinding ${rbName} could not be read, ${e}`);
+          fastify.log.error(
+            `rolebinding ${rbName} could not be read, ${e.response?.body?.message || e.message}`,
+          );
           reply.send(e);
         }
       },
@@ -45,7 +47,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return rbResponse.body;
         } catch (e) {
-          fastify.log.error(`rolebinding could not be created: ${e}`);
+          fastify.log.error(
+            `rolebinding could not be created: ${e.response?.body?.message || e.message}`,
+          );
           reply.send(e);
         }
       },

--- a/backend/src/routes/api/secrets/index.ts
+++ b/backend/src/routes/api/secrets/index.ts
@@ -21,7 +21,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           return secretResponse.body;
         } catch (e) {
           fastify.log.error(
-            `Secret ${secretName} could not be read, ${e.response?.body || e.message || e}`,
+            `Secret ${secretName} could not be read, ${
+              e.response?.body?.message || e.message || e
+            }`,
           );
           reply.send(e);
         }
@@ -41,7 +43,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return secretResponse.body;
         } catch (e) {
-          fastify.log.error(`Secret could not be created: ${e.response?.body || e.message || e}`);
+          fastify.log.error(
+            `Secret could not be created: ${e.response?.body?.message || e.message || e}`,
+          );
           reply.send(e);
         }
       },
@@ -63,7 +67,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         } catch (e) {
           fastify.log.error(
             `Secret ${secretRequest.metadata.name} could not be replaced: ${
-              e.response?.body || e.message || e
+              e.response?.body?.message || e.message || e
             }`,
           );
           reply.send(e);
@@ -89,7 +93,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           return secretResponse.body;
         } catch (e) {
           fastify.log.error(
-            `Secret ${secretName} could not be deleted, ${e.response?.body || e.message || e}`,
+            `Secret ${secretName} could not be deleted, ${
+              e.response?.body?.message || e.message || e
+            }`,
           );
           reply.send(e);
         }

--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -114,7 +114,9 @@ export const isUserClusterRole = async (
     const isAdminRoleBinding = checkRoleBindings(rolebinding.body, username);
     return isAdminClusterRoleBinding || isAdminRoleBinding;
   } catch (e) {
-    fastify.log.error(`Failed to list rolebindings for user, ${e}`);
+    fastify.log.error(
+      `Failed to list rolebindings for user, ${e.response?.body?.message || e.message}`,
+    );
     return false;
   }
 };

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -48,12 +48,6 @@ const requestSecurityGuard = async (
 
   const isReadRequest = request.method.toLowerCase() === 'get';
 
-  // Getting a dashboard resource
-  if (isReadRequest && namespace === dashboardNamespace) {
-    // The application resources are fine to read in all cases
-    return;
-  }
-
   // Api with no name object
   if (!name && namespace === notebookNamespace && isReadRequest) {
     return;
@@ -111,8 +105,8 @@ const handleSecurityOnRouteData = async (
   const username = await getUserName(fastify, request);
   const { dashboardNamespace } = getNamespaces(fastify);
   const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
-  if (isAdmin) {
-    // User is an admin, trust
+  if (isAdmin && !request.url.includes('secrets')) {
+    // User is an admin, trust for all but secrets
     return;
   } else if (needsAdmin && !isAdmin) {
     // Not an admin, route needs one -- reject

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7834,7 +7834,7 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "optional": true
     },
     "gzip-size": {


### PR DESCRIPTION
Removed dashboard namespace direct allow for gets. We don't make any calls to the dashboard namespace aside from rolebinding and it is already covered in the checks.

Also removed the get all notebooks call, not used by frontend.

Tested as admin, can request resources without issue.

Tested with a basic user and was only able to get my resources and nothing out of dashboard.