### PR TITLE
Improve the Start Modal Opening

### DIFF
--- a/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
+++ b/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
@@ -18,7 +18,7 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
 }) => {
   const { notebookNamespace } = useNamespaces();
   const { user: username } = useSpecificNotebookUserState(currentNotebook ?? null);
-  const { notebooks, loaded, loadError, forceRefresh } = useWatchNotebooksForUsers(
+  const { notebooks, loaded, loadError, forceRefresh, setPollInterval } = useWatchNotebooksForUsers(
     notebookNamespace,
     [username],
   );
@@ -34,10 +34,20 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
         ...prevState,
         current: notebook,
         currentIsRunning: isCurrentlyRunning,
-        requestRefresh: forceRefresh,
+        requestRefresh: (speed?: number) => {
+          forceRefresh();
+          setPollInterval(speed);
+        },
       }));
     }
-  }, [notebook, currentNotebook, forceRefresh, setNotebookState, isCurrentlyRunning]);
+  }, [
+    notebook,
+    currentNotebook,
+    forceRefresh,
+    setNotebookState,
+    isCurrentlyRunning,
+    setPollInterval,
+  ]);
 
   if (currentNotebook === undefined || loadError) {
     return (

--- a/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
+++ b/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
@@ -6,8 +6,11 @@ import { SetCurrentAdminTab } from './useAdminTabState';
 export type NotebookControllerContextProps = {
   /** Current user's notebook -- set internally */
   currentUserNotebook: Notebook | null;
-  /** Requests the notebook be re-fetched now instead of waiting for polling intervals */
-  requestNotebookRefresh: () => void;
+  /**
+   * Requests the notebook be re-fetched now instead of waiting for polling intervals.
+   * The provided speed will change the cadence future fetches are done at. Omit to reset.
+   */
+  requestNotebookRefresh: (changeSpeed?: number) => void;
   /** Status on if the current notebook is in a state we can consider it running */
   currentUserNotebookIsRunning: boolean;
 

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -64,7 +64,7 @@ const SpawnerPage: React.FC = () => {
   const { notebookNamespace: projectName } = useNamespaces();
   const currentUserState = useNotebookUserState();
   const username = currentUserState.user;
-  const [startShown, setStartShown] = useSpawnerNotebookModalState();
+  const { startShown, hideStartShown, refreshNotebookForStart } = useSpawnerNotebookModalState();
   const [selectedImageTag, setSelectedImageTag] = React.useState<ImageTag>({
     image: undefined,
     tag: undefined,
@@ -255,13 +255,11 @@ const SpawnerPage: React.FC = () => {
     })
       .then(() => {
         fireStartServerEvent();
-        return true;
       })
       .catch((e) => {
         setSubmitError(e);
-        return false;
       });
-    requestNotebookRefresh();
+    refreshNotebookForStart();
   };
 
   return (
@@ -327,7 +325,7 @@ const SpawnerPage: React.FC = () => {
                 onClick={() => {
                   handleNotebookAction().catch((e) => {
                     setCreateInProgress(false);
-                    setStartShown(false);
+                    hideStartShown();
                     console.error(e);
                   });
                 }}
@@ -360,7 +358,7 @@ const SpawnerPage: React.FC = () => {
                 .catch((e) => notification.error(`Error stop notebook ${notebookName}`, e.message));
             } else {
               // Shouldn't happen, but if we don't have a notebook, there is nothing to stop
-              setStartShown(false);
+              hideStartShown();
             }
             setCreateInProgress(false);
           }}

--- a/frontend/src/utilities/useWatchNotebooksForUsers.tsx
+++ b/frontend/src/utilities/useWatchNotebooksForUsers.tsx
@@ -14,7 +14,7 @@ const useWatchNotebooksForUsers = (
   loaded: boolean;
   loadError: Error | undefined;
   forceRefresh: (usernames?: string[]) => void;
-  setPollInterval: (interval: number) => void;
+  setPollInterval: (interval?: number) => void;
 } => {
   const usernames = useDeepCompareMemoize(listOfUsers);
   const [loaded, setLoaded] = React.useState<boolean>(false);
@@ -75,6 +75,10 @@ const useWatchNotebooksForUsers = (
     [getNotebooks, usernames],
   );
 
+  const setPollIntervalSafe = React.useCallback((newPollInterval?: number) => {
+    setPollInterval(newPollInterval ?? POLL_INTERVAL);
+  }, []);
+
   React.useEffect(() => {
     getNotebooks(usernames);
     const watchHandle = setInterval(() => getNotebooks(usernames), pollInterval);
@@ -86,7 +90,7 @@ const useWatchNotebooksForUsers = (
     };
   }, [pollInterval, getNotebooks, usernames]);
 
-  return { notebooks, loaded, loadError, forceRefresh, setPollInterval };
+  return { notebooks, loaded, loadError, forceRefresh, setPollInterval: setPollIntervalSafe };
 };
 
 export default useWatchNotebooksForUsers;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #508 
~Contains parts of PR #520~

## Description
<!--- Describe your changes in detail -->
Immediately after creating a notebook resource (the `PATCH` or `POST` call) we refresh the notebook. It seems when the server is busy with other items, we don't always get back a clean enough version of the Notebook and the modal does not open. It takes up to 30s before we background poll to see if the Notebook changed. This 30s is an eternity. So we will fetch every 3 seconds (or whatever the `FAST_POLL_INTERVAL` env var is) and dial it back to 30s only when the modal opens up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Spawning a Notebook will speed up the speed we fetch it (can be seen in the network tab). Once the modal is shown, it should dial back down significantly (3s => 30s). 

This is a shot in the dark to fix a RHODS testing issue where sometimes the modal would not show up for 24s after the button was pushed. This is likely because of a bad refresh of the singular Notebook for the user at the completion of the submit call and it waited until the normal refresh cadence before kicking off again and then realizing it had a modal to show.
