### PR TITLE
Make Jupyter tile have a proper link

### DIFF
--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import {
   Button,
   Card,
@@ -22,7 +23,6 @@ import EnableModal from '../pages/exploreApplication/EnableModal';
 import { removeComponent } from '../services/componentsServices';
 import { addNotification, forceComponentsUpdate } from '../redux/actions/actions';
 import { ODH_PRODUCT_NAME } from '../utilities/const';
-import { useHistory } from 'react-router-dom';
 import { useAppContext } from '../app/AppContext';
 
 import './OdhCard.scss';
@@ -40,7 +40,6 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
   );
   const disabled = !odhApp.spec.isEnabled;
   const { dashboardConfig } = useAppContext();
-  const history = useHistory();
   const dispatch = useDispatch();
 
   const onToggle = (value) => {
@@ -123,12 +122,9 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
   const cardFooter = (
     <CardFooter className="odh-card__footer">
       {odhApp.metadata.name === 'jupyter' ? (
-        <a
-          className="odh-card__footer__link"
-          onClick={() => history.push(odhApp.spec.internalRoute)}
-        >
+        <Link to={odhApp.spec.internalRoute} className="odh-card__footer__link">
           Launch application
-        </a>
+        </Link>
       ) : (
         <a
           className={launchClasses}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #527 

## Description
<!--- Describe your changes in detail -->
Using an `onClick` without a `href` on an anchor will prevent the browser from detecting that it is an official link reference. To make it cleanly work with React-Router, I just decided to use `Link`, it supports this functionality for both internal routing and proper a11y on links.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enabled page => Jupyter (KFNBC) enabled
2. Same tab works: normal click
3. New tab works: "CTRL+Click" & "Right Click & Open In new tab"

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
