### PR TITLE
Show FailedScheduling issues in the Start Modal

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -12,7 +12,10 @@ import {
   ProgressVariant,
 } from '@patternfly/react-core';
 import { useDeepCompareMemoize } from '../../../../utilities/useDeepCompareMemoize';
-import { useNotebookStatus } from '../../../../utilities/notebookControllerUtils';
+import {
+  getEventTimestamp,
+  useNotebookStatus,
+} from '../../../../utilities/notebookControllerUtils';
 import { EventStatus } from '../../../../types';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 
@@ -159,7 +162,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
       <List isPlain isBordered>
         {events.reverse().map((event, index) => (
           <ListItem key={`notebook-event-${event.metadata.uid ?? index}`}>
-            {`${event.lastTimestamp} [${event.type}] ${event.message}`}
+            {`${getEventTimestamp(event)} [${event.type}] ${event.message}`}
           </ListItem>
         ))}
         <ListItem>Server requested</ListItem>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -202,16 +202,18 @@ export type BuildStatus = {
   timestamp: string;
 };
 
+type K8sMetadata = {
+  name: string;
+  namespace?: string;
+  uid?: string;
+  labels?: { [key: string]: string };
+  annotations?: { [key: string]: string };
+};
+
 export type K8sResourceCommon = {
   apiVersion?: string;
   kind?: string;
-  metadata: {
-    name: string;
-    namespace?: string;
-    uid?: string;
-    labels?: { [key: string]: string };
-    annotations?: { [key: string]: string };
-  };
+  metadata: K8sMetadata;
 };
 
 // Minimal type for ConsoleLinks
@@ -608,11 +610,13 @@ export type ResourceReplacer<T extends K8sResourceCommon> = (resource: T) => Pro
 export type ResourceDeleter = (projectName: string, resourceName: string) => Promise<DeleteStatus>;
 
 export type K8sEvent = {
-  lastTimestamp: string;
+  metadata: K8sMetadata;
+  eventTime: string;
+  lastTimestamp: string | null; // if it never starts, the value is null
   message: string;
   reason: string;
   type: string;
-} & K8sResourceCommon;
+};
 
 export type NotebookStatus = {
   percentile: number;

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -265,21 +265,6 @@ export const validateNotebookNamespaceRoleBinding = async (
   );
 };
 
-const useLastOpenTime = (open: boolean): Date | null => {
-  // TODO: This is a hack until we get a cleaner way of using values that are immutable
-  // We may be able to use kube stop annotation and/or the last activity -- but stability is important atm
-  const ref = React.useRef<Date | null>(null);
-  if (ref.current && !open) {
-    // Modal closing, clean up
-    ref.current = null;
-  } else if (!ref.current && open) {
-    // Modal is opening, hold date
-    ref.current = new Date();
-  }
-
-  return ref.current;
-};
-
 export const useNotebookStatus = (
   spawnInProgress: boolean,
 ): [status: NotebookStatus | null, events: K8sEvent[]] => {
@@ -292,15 +277,16 @@ export const useNotebookStatus = (
     spawnInProgress,
   );
 
-  // TODO: Use last activity to fetch latest events
-  // const lastActivity = notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
-  const startOfOpen = useLastOpenTime(spawnInProgress);
-  if (!startOfOpen) {
+  const annotationTime = notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
+  const lastActivity = annotationTime ? new Date(annotationTime) : null;
+  if (!lastActivity) {
     // Modal is closed, we don't have a filter time, ignore
     return [null, []];
   }
 
-  const filteredEvents = events.filter((event) => new Date(event.lastTimestamp) > startOfOpen);
+  const filteredEvents = events.filter(
+    (event) => new Date(event.lastTimestamp || event.eventTime) >= lastActivity,
+  );
   if (filteredEvents.length === 0) {
     // We filter out all the events, nothing to show
     return [null, []];

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -265,6 +265,9 @@ export const validateNotebookNamespaceRoleBinding = async (
   );
 };
 
+export const getEventTimestamp = (event: K8sEvent): string =>
+  event.lastTimestamp || event.eventTime;
+
 export const useNotebookStatus = (
   spawnInProgress: boolean,
 ): [status: NotebookStatus | null, events: K8sEvent[]] => {
@@ -285,7 +288,7 @@ export const useNotebookStatus = (
   }
 
   const filteredEvents = events.filter(
-    (event) => new Date(event.lastTimestamp || event.eventTime) >= lastActivity,
+    (event) => new Date(getEventTimestamp(event)) >= lastActivity,
   );
   if (filteredEvents.length === 0) {
     // We filter out all the events, nothing to show


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #528 

## Description
<!--- Describe your changes in detail -->
The modal start time is not an accurate enough time to use. We need the immutable activity time from the Notebook to tell us when it was requested to do something. This way if there are events that are immediate, we can get those. The `FailedScheduling` error that prevents you from spinning up a Notebook when your size is too large happens before the modal opens so we didn't show it (to avoid showing previous attempt events).

![image](https://user-images.githubusercontent.com/8126518/189595311-4987c035-2262-4d8d-a539-d3067e574976.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using `x-large` size time from the defaults and not having the space on-cluster for it.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
