### PR TITLE
Update liveness/readiness probe with an endpoint without auth.

### DIFF
--- a/backend/src/routes/api/health/healthUtils.ts
+++ b/backend/src/routes/api/health/healthUtils.ts
@@ -1,0 +1,13 @@
+import { KubeFastifyInstance } from '../../../types';
+import { createCustomError } from '../../../utils/requestUtils';
+
+export const health = async (fastify: KubeFastifyInstance): Promise<{ health: string }> => {
+  const kubeContext = fastify.kube?.currentContext || '';
+  if (!kubeContext && !kubeContext.trim()) {
+    const error = createCustomError('failed to get kube status', 'Failed to get Kube context', 503);
+    fastify.log.error(error, 'failed to get status');
+    throw error;
+  } else {
+    return { health: 'ok' };
+  }
+};

--- a/backend/src/routes/api/health/index.ts
+++ b/backend/src/routes/api/health/index.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { health } from './healthUtils';
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  // Unsecured route for health check
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return health(fastify);
+  });
+};

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -39,10 +39,8 @@ spec:
             cpu: 1000m
             memory: 2Gi
         livenessProbe:
-          httpGet:
-            path: /api/config
+          tcpSocket:
             port: 8080
-            scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 15
           periodSeconds: 30
@@ -50,7 +48,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /api/config
+            path: /api/health
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30


### PR DESCRIPTION
## Description
Added an insecure API call for general health.  Unauthorized users should still be blocked by oauth-proxy, but readiness probe should be able to get a `{"health": "ok""}` message without any kind of token.  Also changed liveness probe to a tcp check for when the server is up.

## How Has This Been Tested?
Deployed image and tested to make sure crashlooping stopped.
Curled `/api/health`
Dashboard image `quay.io/cfchase/odh-dashboard:pr-543`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
