### PR TITLE
When we get an OAuth Failure, we logout

### DIFF
--- a/backend/src/utils/userUtils.ts
+++ b/backend/src/utils/userUtils.ts
@@ -39,7 +39,9 @@ export const getUser = async (
     );
     return userResponse.body as OpenShiftUser;
   } catch (e) {
-    throw new Error(`Error getting Oauth Info for user, ${e.response?.data?.message || e.message}`);
+    throw new Error(
+      `Error getting Oauth Info for user, ${e.code} - ${e.response?.data?.message || e.message}`,
+    );
   }
 };
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import '@patternfly/patternfly/patternfly.min.css';
 import '@patternfly/patternfly/patternfly-addons.css';
-import { Alert, Bullseye, Page, PageSection, Spinner } from '@patternfly/react-core';
+import {
+  Alert,
+  Bullseye,
+  Button,
+  Page,
+  PageSection,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { detectUser } from '../redux/actions/actions';
 import { useDesktopWidth } from '../utilities/useDesktopWidth';
 import Header from './Header';
@@ -15,6 +24,7 @@ import { AppContext } from './AppContext';
 import { useApplicationSettings } from './useApplicationSettings';
 import { useUser } from '../redux/selectors';
 import TelemetrySetup from './TelemetrySetup';
+import { logout } from './appUtils';
 
 import './App.scss';
 
@@ -45,18 +55,31 @@ const App: React.FC = () => {
   };
 
   if (!username || !configLoaded || !dashboardConfig) {
-    // We do not have the data yet for who they are, we can't show the app. If we allow anything
-    // to render right now, the username is going to be blank and we won't know permissions
-    // If we don't get the config we cannot show the pages, either
+    // We lack the critical data to startup the app
     if (userError || fetchConfigError) {
-      // We likely don't have a username still so just show the error
-      // or we likely meet something wrong when fetching the dashboard config, we also show the error
+      // There was an error fetching critical data
       return (
         <Page>
           <PageSection>
-            <Alert variant="danger" isInline title="General loading error">
-              {userError ? userError.message : fetchConfigError?.message}
-            </Alert>
+            <Stack hasGutter>
+              <StackItem>
+                <Alert variant="danger" isInline title="General loading error">
+                  <p>
+                    {(userError ? userError.message : fetchConfigError?.message) ||
+                      'Unknown error occurred during startup.'}
+                  </p>
+                  <p>Logging out and logging back in may solve the issue.</p>
+                </Alert>
+              </StackItem>
+              <StackItem>
+                <Button
+                  variant="secondary"
+                  onClick={() => logout().then(() => window.location.reload())}
+                >
+                  Logout
+                </Button>
+              </StackItem>
+            </Stack>
           </PageSection>
         </Page>
       );

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -15,6 +15,7 @@ import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK } from '../utilities/const';
 import { AppNotification, State } from '../redux/types';
 import AppLauncher from './AppLauncher';
 import { useAppContext } from './AppContext';
+import { logout } from './appUtils';
 
 interface HeaderToolsProps {
   onNotificationsClick: () => void;
@@ -35,10 +36,10 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
 
   const handleLogout = () => {
     setUserMenuOpen(false);
-    fetch('/oauth/sign_out')
-      .then(() => console.log('logged out'))
-      .catch((err) => console.error(err))
-      .finally(() => window.location.reload());
+    logout().then(() => {
+      console.log('logged out');
+      window.location.reload();
+    });
   };
 
   const userMenuItems = [

--- a/frontend/src/app/appUtils.ts
+++ b/frontend/src/app/appUtils.ts
@@ -1,0 +1,3 @@
+export const logout = (): Promise<unknown> => {
+  return fetch('/oauth/sign_out').catch((err) => console.error('Error logging out', err));
+};

--- a/frontend/src/app/useApplicationSettings.tsx
+++ b/frontend/src/app/useApplicationSettings.tsx
@@ -3,6 +3,7 @@ import { DashboardConfig } from '../types';
 import { POLL_INTERVAL } from '../utilities/const';
 import { useDeepCompareMemoize } from '../utilities/useDeepCompareMemoize';
 import { fetchDashboardConfig } from '../services/dashboardConfigService';
+import { logout } from './appUtils';
 
 export const useApplicationSettings = (): {
   dashboardConfig: DashboardConfig | null;
@@ -27,6 +28,17 @@ export const useApplicationSettings = (): {
           setLoadError(undefined);
         })
         .catch((e) => {
+          if (e?.message?.includes('Error getting Oauth Info for user')) {
+            // NOTE: this endpoint only requests ouath because of the security layer, this is not an ironclad use-case
+            // Something went wrong on the server with the Oauth, let us just log them out and refresh for them
+            console.error(
+              'Something went wrong with the oauth token, logging out...',
+              e.message,
+              e,
+            );
+            logout().then(() => window.location.reload()); // note this is a bad side-effect, never do this
+            return;
+          }
           setLoadError(e);
         });
       watchHandle = setTimeout(watchDashboardConfig, POLL_INTERVAL);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #551 

Another effort behind the hotfix: #532 

## Description
<!--- Describe your changes in detail -->
When our OAuth error happens (around the getting/using of the `x-forwarded-access-token` header, we just redirect to an error page.

We should logout instead now. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Hard to say, the issue doesn't happen often. Current theory is you wait 24h or redeploy to your cluster ... or both?

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

/cc @lucferbux @dlabaj @DaoDaoNoCode 