### PR TITLE
Secure Routes for Empty Name Property

### DIFF
--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -95,13 +95,18 @@ const requestSecurityGuard = async (
     );
   }
 
+  // Requested a resource with an explicit empty name, doesn't matter who you are, bad API request
+  if (name === '' || name?.trim() === '') {
+    throw createCustomError('404 Endpoint Not Found', 'Not Found', 404);
+  }
+
   // Admins have the ability to interact with other resources that is not theirs
   if (await testAdmin(fastify, request, needsAdmin)) {
     return;
   }
 
   // Api with no name object, allow reads
-  if (!name && namespace === notebookNamespace && isReadRequest) {
+  if (name == null && namespace === notebookNamespace && isReadRequest) {
     return;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #553 

## Description
<!--- Describe your changes in detail -->
When requesting resources with an empty name (aka a GET call `/api/<something>/namespaceName/`) some endpoints would sometimes work if the underly API supported a no-name option. `nb-events` fetches a list of events with a label... if the label is empty, it fetches everything.

Apparently `getNamespacedCustomObject` also does that for Notebooks 🤷 

Fix is to just not allow an empty string name. the security layer will make the name `undefined` if it's actually a route without a name but with a namespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
