### PR TITLE
Support proper errors for configmap requests

### DIFF
--- a/backend/src/routes/api/configmaps/index.ts
+++ b/backend/src/routes/api/configmaps/index.ts
@@ -1,90 +1,96 @@
-import { KubeFastifyInstance } from '../../../types';
-import { FastifyReply, FastifyRequest } from 'fastify';
+import { FastifyRequest } from 'fastify';
 import { V1ConfigMap } from '@kubernetes/client-node';
+import { KubeFastifyInstance } from '../../../types';
 import { secureRoute } from '../../../utils/route-security';
+import { createCustomError } from '../../../utils/requestUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get(
     '/:namespace/:name',
     secureRoute(fastify)(
-      async (
-        request: FastifyRequest<{ Params: { namespace: string; name: string } }>,
-        reply: FastifyReply,
-      ) => {
+      async (request: FastifyRequest<{ Params: { namespace: string; name: string } }>) => {
         const cmName = request.params.name;
         const cmNamespace = request.params.namespace;
-        try {
-          const cmResponse = await fastify.kube.coreV1Api.readNamespacedConfigMap(
-            cmName,
-            cmNamespace,
-          );
-          return cmResponse.body;
-        } catch (e) {
-          fastify.log.error(`Configmap ${cmName} could not be read, ${e}`);
-          reply.send(e);
-        }
+        return fastify.kube.coreV1Api
+          .readNamespacedConfigMap(cmName, cmNamespace)
+          .then((res) => res.body)
+          .catch((res) => {
+            const e = res.response.body;
+            const error = createCustomError(
+              `ConfigMap could not be read`,
+              e.message || res.message,
+              e.code,
+            );
+            fastify.log.error(`Configmap ${cmName} could not be read, ${error}`);
+            throw error;
+          });
       },
     ),
   );
 
   fastify.post(
     '/',
-    secureRoute(fastify)(
-      async (request: FastifyRequest<{ Body: V1ConfigMap }>, reply: FastifyReply) => {
-        const cmRequest = request.body;
-        try {
-          const cmResponse = await fastify.kube.coreV1Api.createNamespacedConfigMap(
-            cmRequest.metadata.namespace,
-            cmRequest,
+    secureRoute(fastify)(async (request: FastifyRequest<{ Body: V1ConfigMap }>) => {
+      const cmRequest = request.body;
+      return fastify.kube.coreV1Api
+        .createNamespacedConfigMap(cmRequest.metadata.namespace, cmRequest)
+        .then((res) => res.body)
+        .catch((res) => {
+          const e = res.response.body;
+          const error = createCustomError(
+            `ConfigMap could not be created`,
+            e.message || res.message,
+            e.code,
           );
-          return cmResponse.body;
-        } catch (e) {
-          fastify.log.error(`Configmap could not be created: ${e}`);
-          reply.send(e);
-        }
-      },
-    ),
+          fastify.log.error(`Configmap ${cmRequest.metadata.name} could not be created, ${error}`);
+          throw error;
+        });
+    }),
   );
 
   fastify.put(
     '/',
-    secureRoute(fastify)(
-      async (request: FastifyRequest<{ Body: V1ConfigMap }>, reply: FastifyReply) => {
-        const cmRequest = request.body;
-        try {
-          const cmResponse = await fastify.kube.coreV1Api.replaceNamespacedConfigMap(
-            cmRequest.metadata.name,
-            cmRequest.metadata.namespace,
-            cmRequest,
+    secureRoute(fastify)(async (request: FastifyRequest<{ Body: V1ConfigMap }>) => {
+      const cmRequest = request.body;
+      return fastify.kube.coreV1Api
+        .replaceNamespacedConfigMap(
+          cmRequest.metadata.name,
+          cmRequest.metadata.namespace,
+          cmRequest,
+        )
+        .then((res) => res.body)
+        .catch((res) => {
+          const e = res.response.body;
+          const error = createCustomError(
+            `ConfigMap could not be updated`,
+            e.message || res.message,
+            e.code,
           );
-          return cmResponse.body;
-        } catch (e) {
-          fastify.log.error(`Configmap ${cmRequest.metadata.name} could not be replaced: ${e}`);
-          reply.send(e);
-        }
-      },
-    ),
+          fastify.log.error(`Configmap ${cmRequest.metadata.name} could not be updated, ${error}`);
+          throw error;
+        });
+    }),
   );
 
   fastify.delete(
     '/:namespace/:name',
     secureRoute(fastify)(
-      async (
-        request: FastifyRequest<{ Params: { namespace: string; name: string } }>,
-        reply: FastifyReply,
-      ) => {
+      async (request: FastifyRequest<{ Params: { namespace: string; name: string } }>) => {
         const cmName = request.params.name;
         const cmNamespace = request.params.namespace;
-        try {
-          const cmResponse = await fastify.kube.coreV1Api.deleteNamespacedConfigMap(
-            cmName,
-            cmNamespace,
-          );
-          return cmResponse.body;
-        } catch (e) {
-          fastify.log.error(`Configmap ${cmName} could not be deleted, ${e}`);
-          reply.send(e);
-        }
+        return fastify.kube.coreV1Api
+          .deleteNamespacedConfigMap(cmName, cmNamespace)
+          .then((res) => res.body)
+          .catch((res) => {
+            const e = res.response.body;
+            const error = createCustomError(
+              `ConfigMap could not be deleted`,
+              e.message || res.message,
+              e.code,
+            );
+            fastify.log.error(`Configmap ${cmName} could not be deleted, ${error}`);
+            throw error;
+          });
       },
     ),
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #513 

## Description
<!--- Describe your changes in detail -->
Improved error handling. `toString` on an error (or using the variable in a string template) simply makes the kube library show "HTTP request failed" as that's the basic `.message` on the error. We want to dig into the k8s status object so we can get a meaningful message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Faking errors on the backend to check different calls. GET => 404 happens when you have not created a notebook before.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
