### PR TITLE
Improve event filtering to avoid scary messages

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -76,7 +76,9 @@ const SpawnerPage: React.FC = () => {
   const { notebookNamespace: projectName } = useNamespaces();
   const currentUserState = useNotebookUserState();
   const username = currentUserState.user;
-  const { startShown, hideStartShown, refreshNotebookForStart } = useSpawnerNotebookModalState();
+  const [createInProgress, setCreateInProgress] = React.useState<boolean>(false);
+  const { startShown, hideStartShown, refreshNotebookForStart } =
+    useSpawnerNotebookModalState(createInProgress);
   const [selectedImageTag, setSelectedImageTag] = React.useState<ImageTag>({
     image: undefined,
     tag: undefined,
@@ -84,7 +86,6 @@ const SpawnerPage: React.FC = () => {
   const { selectedSize, setSelectedSize, sizes } = usePreferredNotebookSize();
   const [selectedGpu, setSelectedGpu] = React.useState<string>('0');
   const [variableRows, setVariableRows] = React.useState<VariableRow[]>([]);
-  const [createInProgress, setCreateInProgress] = React.useState<boolean>(false);
   const [submitError, setSubmitError] = React.useState<Error | null>(null);
 
   React.useEffect(() => {

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -49,6 +49,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
   const notebookStatus = useDeepCompareMemoize(unstableNotebookStatus);
   const getNotebookLink = useNotebookRedirectLink();
   const history = useHistory();
+  const spawnFailed = spawnStatus?.status === AlertVariant.danger;
 
   React.useEffect(() => {
     if (!open) {
@@ -58,8 +59,6 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
       setSpawnStatus(null);
     }
   }, [open]);
-
-  const spawnFailed = spawnStatus?.status === AlertVariant.danger;
 
   const navigateToNotebook = React.useCallback(
     (useCurrentTab: boolean): void => {
@@ -86,7 +85,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
 
   React.useEffect(() => {
     let timer;
-    if (isNotebookRunning) {
+    if (isNotebookRunning && open) {
       setSpawnPercentile(100);
       setSpawnStatus({
         status: AlertVariant.success,
@@ -102,10 +101,10 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
     return () => {
       clearTimeout(timer);
     };
-  }, [isNotebookRunning, navigateToNotebook, isUsingCurrentTab]);
+  }, [isNotebookRunning, open, isUsingCurrentTab, navigateToNotebook]);
 
   React.useEffect(() => {
-    if (spawnInProgress && !isNotebookRunning) {
+    if (spawnInProgress && !isNotebookRunning && open) {
       if (!notebookStatus) {
         return;
       }
@@ -132,7 +131,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
         });
       }
     }
-  }, [notebookStatus, spawnInProgress, isNotebookRunning]);
+  }, [notebookStatus, spawnInProgress, isNotebookRunning, open]);
 
   const renderProgress = () => {
     let variant: ProgressVariant | undefined;
@@ -181,7 +180,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
         onClick={onClose}
         isDisabled={!open}
       >
-        {spawnFailed ? 'Close' : 'Cancel'}
+        Cancel
       </Button>
     ) : isUsingCurrentTab ? null : (
       <ActionList>

--- a/frontend/src/pages/notebookController/screens/server/useSpawnerNotebookModalState.ts
+++ b/frontend/src/pages/notebookController/screens/server/useSpawnerNotebookModalState.ts
@@ -3,6 +3,8 @@ import { useHistory } from 'react-router-dom';
 import { NotebookControllerContext } from '../../NotebookControllerContext';
 import { FAST_POLL_INTERVAL } from '../../../../utilities/const';
 import { NotebookControllerContextProps } from '../../notebookControllerContextTypes';
+import { stopNotebook } from '../../../../services/notebookService';
+import useNamespaces from '../../useNamespaces';
 
 const useRefreshNotebookAndCleanup = (startShown: boolean) => {
   const { requestNotebookRefresh } = React.useContext(NotebookControllerContext);
@@ -24,13 +26,16 @@ const useRefreshNotebookAndCleanup = (startShown: boolean) => {
   }, []);
 };
 
-const useSpawnerNotebookModalState = (): {
+const useSpawnerNotebookModalState = (
+  createInProgress: boolean,
+): {
   startShown: boolean;
   hideStartShown: () => void;
   refreshNotebookForStart: () => void;
 } => {
   const { currentUserNotebook: notebook, currentUserNotebookIsRunning: isNotebookRunning } =
     React.useContext(NotebookControllerContext);
+  const { notebookNamespace } = useNamespaces();
   const history = useHistory();
   const [startShown, setStartShown] = React.useState<boolean>(false);
 
@@ -41,7 +46,14 @@ const useSpawnerNotebookModalState = (): {
         const notStopped = !notebook.metadata.annotations?.['kubeflow-resource-stopped'];
         if (notStopped) {
           // Not stopped means we are spawning (as it is not running)
-          setStartShown(true);
+          if (!createInProgress) {
+            // We are not creating, make sure the Notebook is stopped
+            stopNotebook(notebookNamespace, notebook.metadata.name).catch(() => {
+              console.error('Failed to stop notebook on refresh');
+            });
+          } else {
+            setStartShown(true);
+          }
         } else {
           // Stopped, no need for a modal (if it is open)
           setStartShown(false);
@@ -52,7 +64,7 @@ const useSpawnerNotebookModalState = (): {
         history.replace('/notebookController');
       }
     }
-  }, [notebook, history, startShown, isNotebookRunning]);
+  }, [notebook, history, startShown, isNotebookRunning, createInProgress, notebookNamespace]);
 
   const refreshNotebookForStart = useRefreshNotebookAndCleanup(startShown);
   const hideStartShown = React.useCallback(() => setStartShown(false), []);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -614,7 +614,7 @@ export type K8sEvent = {
   lastTimestamp: string | null; // if it never starts, the value is null
   message: string;
   reason: string;
-  type: string;
+  type: 'Warning' | 'Normal';
 };
 
 export type NotebookStatus = {

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -325,7 +325,7 @@ export const getEventTimestamp = (event: K8sEvent): string =>
 const filterEvents = (
   allEvents: K8sEvent[],
   lastActivity: Date,
-): [filterEvents: K8sEvent[], allEvents: K8sEvent[], gracePeroid: boolean] => {
+): [filterEvents: K8sEvent[], thisInstanceEvents: K8sEvent[], gracePeroid: boolean] => {
   const thisInstanceEvents = allEvents.filter(
     (event) => new Date(getEventTimestamp(event)) >= lastActivity,
   );
@@ -343,7 +343,7 @@ const filterEvents = (
   const maxCap = new Date(lastActivity).setMinutes(lastActivity.getMinutes() + 20);
   if (now <= maxCap) {
     // Haven't hit the cap yet, filter events for accepted scenarios
-    const infoEvents = filteredEvents.filter((event) => event.type !== 'Warning');
+    const infoEvents = filteredEvents.filter((event) => event.type === 'Normal');
     const idleTime = new Date(lastActivity).setSeconds(lastActivity.getSeconds() + 30);
     gracePeriod = idleTime - now > 0;
 

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -266,9 +266,6 @@ export const validateNotebookNamespaceRoleBinding = async (
   );
 };
 
-export const getEventTimestamp = (event: K8sEvent): string =>
-  event.lastTimestamp || event.eventTime;
-
 export const useNotebookRedirectLink = (): (() => Promise<string>) => {
   const { currentUserNotebook } = React.useContext(NotebookControllerContext);
   const { notebookNamespace } = useNamespaces();
@@ -322,6 +319,59 @@ export const useNotebookRedirectLink = (): (() => Promise<string>) => {
   }, [backupRoute, notebookNamespace, routeName]);
 };
 
+export const getEventTimestamp = (event: K8sEvent): string =>
+  event.lastTimestamp || event.eventTime;
+
+const filterEvents = (
+  allEvents: K8sEvent[],
+  lastActivity: Date,
+): [filterEvents: K8sEvent[], allEvents: K8sEvent[], gracePeroid: boolean] => {
+  const thisInstanceEvents = allEvents.filter(
+    (event) => new Date(getEventTimestamp(event)) >= lastActivity,
+  );
+  if (thisInstanceEvents.length === 0) {
+    // Filtered out all of the events, exit early
+    return [[], [], false];
+  }
+
+  let filteredEvents = thisInstanceEvents;
+
+  const now = Date.now();
+  let gracePeriod = false;
+
+  // Ignore the rest of the filter logic if we pass 20 minutes
+  const maxCap = new Date(lastActivity).setMinutes(lastActivity.getMinutes() + 20);
+  if (now <= maxCap) {
+    // Haven't hit the cap yet, filter events for accepted scenarios
+    const infoEvents = filteredEvents.filter((event) => event.type !== 'Warning');
+    const idleTime = new Date(lastActivity).setSeconds(lastActivity.getSeconds() + 30);
+    gracePeriod = idleTime - now > 0;
+
+    // Suppress the warnings when we are idling
+    if (gracePeriod) {
+      filteredEvents = infoEvents;
+    }
+
+    // If we are scaling up, we want to focus on that
+    const hasScaleUp = infoEvents.some((event) => event.reason === 'TriggeredScaleUp');
+    if (hasScaleUp) {
+      // Scaling up event is present -- look for issues with it
+      const hasScaleUpIssueIndex = thisInstanceEvents.findIndex(
+        (event) => event.reason === 'NotTriggerScaleUp',
+      );
+      if (hasScaleUpIssueIndex >= 0) {
+        // Has scale up issue, show that
+        filteredEvents = [thisInstanceEvents[hasScaleUpIssueIndex]];
+      } else {
+        // Haven't hit a failure in scale up, show just infos
+        filteredEvents = infoEvents;
+      }
+    }
+  }
+
+  return [filteredEvents, thisInstanceEvents, gracePeriod];
+};
+
 export const useNotebookStatus = (
   spawnInProgress: boolean,
 ): [status: NotebookStatus | null, events: K8sEvent[]] => {
@@ -337,18 +387,16 @@ export const useNotebookStatus = (
   const annotationTime = notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
   const lastActivity = annotationTime ? new Date(annotationTime) : null;
   if (!lastActivity) {
-    // Modal is closed, we don't have a filter time, ignore
+    // Notebook not started, we don't have a filter time, ignore
     return [null, []];
   }
 
-  const filteredEvents = events.filter(
-    (event) => new Date(getEventTimestamp(event)) >= lastActivity,
-  );
+  const [filteredEvents, thisInstanceEvents, gracePeriod] = filterEvents(events, lastActivity);
   if (filteredEvents.length === 0) {
-    // We filter out all the events, nothing to show
-    return [null, []];
+    return [null, thisInstanceEvents];
   }
 
+  // Parse the last event
   let percentile = 0;
   let status: EventStatus = EventStatus.IN_PROGRESS;
   const lastItem = filteredEvents[filteredEvents.length - 1];
@@ -381,8 +429,8 @@ export const useNotebookStatus = (
         break;
       }
       default: {
-        currentEvent = 'Error creating oauth proxy container';
-        status = EventStatus.ERROR;
+        currentEvent = 'Issue creating oauth proxy container';
+        status = EventStatus.WARNING;
       }
     }
   } else {
@@ -427,14 +475,23 @@ export const useNotebookStatus = (
         percentile = 64;
         break;
       }
+      case 'NotTriggerScaleUp':
+        currentEvent = 'Failed to scale-up';
+        status = EventStatus.ERROR;
+        break;
       case 'TriggeredScaleUp': {
         currentEvent = 'Pod triggered scale-up';
         status = EventStatus.INFO;
         break;
       }
       default: {
-        currentEvent = 'Error creating notebook container';
-        status = EventStatus.ERROR;
+        if (!gracePeriod && lastItem.reason === 'FailedScheduling') {
+          currentEvent = 'Insufficient resources to start';
+          status = EventStatus.ERROR;
+        } else {
+          currentEvent = 'Issue creating notebook container';
+          status = EventStatus.WARNING;
+        }
       }
     }
   }
@@ -447,7 +504,7 @@ export const useNotebookStatus = (
       currentEventDescription: lastItem.message,
       currentStatus: status,
     },
-    filteredEvents,
+    thisInstanceEvents,
   ];
 };
 

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -429,8 +429,10 @@ export const useNotebookStatus = (
         break;
       }
       default: {
-        currentEvent = 'Issue creating oauth proxy container';
-        status = EventStatus.WARNING;
+        if (lastItem.type === 'Warning') {
+          currentEvent = 'Issue creating oauth proxy container';
+          status = EventStatus.WARNING;
+        }
       }
     }
   } else {
@@ -488,7 +490,7 @@ export const useNotebookStatus = (
         if (!gracePeriod && lastItem.reason === 'FailedScheduling') {
           currentEvent = 'Insufficient resources to start';
           status = EventStatus.ERROR;
-        } else {
+        } else if (lastItem.type === 'Warning') {
           currentEvent = 'Issue creating notebook container';
           status = EventStatus.WARNING;
         }

--- a/frontend/src/utilities/useWatchNotebookEvents.tsx
+++ b/frontend/src/utilities/useWatchNotebookEvents.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { getNotebookEvents } from '../services/notebookEventsService';
 import useNotification from './useNotification';
 import { K8sEvent } from '../types';
+import { FAST_POLL_INTERVAL } from './const';
 
 export const useWatchNotebookEvents = (
   projectName: string,
   notebookName: string,
-  watch: boolean,
+  activeFetch: boolean,
 ): K8sEvent[] => {
   const [notebookEvents, setNoteBookEvents] = React.useState<K8sEvent[]>([]);
   const notification = useNotification();
@@ -17,31 +18,31 @@ export const useWatchNotebookEvents = (
 
     const clear = () => {
       cancelled = true;
-      if (watchHandle) {
-        clearTimeout(watchHandle);
-      }
+      clearTimeout(watchHandle);
     };
 
-    const watchNotebookEvents = () => {
-      if (projectName && notebookName && watch) {
-        getNotebookEvents(projectName, notebookName)
-          .then((data: K8sEvent[]) => {
-            if (cancelled) {
-              return;
-            }
-            setNoteBookEvents(data);
-          })
-          .catch((e) => {
-            notification.error('Error fetching notebook events', e.response.data.message);
-            clear();
-          });
-        watchHandle = setTimeout(watchNotebookEvents, 1000);
-      }
-    };
+    if (activeFetch) {
+      const watchNotebookEvents = () => {
+        if (projectName && notebookName) {
+          getNotebookEvents(projectName, notebookName)
+            .then((data: K8sEvent[]) => {
+              if (cancelled) {
+                return;
+              }
+              setNoteBookEvents(data);
+            })
+            .catch((e) => {
+              notification.error('Error fetching notebook events', e.response.data.message);
+              clear();
+            });
+          watchHandle = setTimeout(watchNotebookEvents, FAST_POLL_INTERVAL);
+        }
+      };
 
-    watchNotebookEvents();
+      watchNotebookEvents();
+    }
     return clear;
-  }, [projectName, notebookName, notification, watch]);
+  }, [projectName, notebookName, notification, activeFetch]);
 
   return notebookEvents;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #559 

## Description
<!--- Describe your changes in detail -->
We need to filter the events more so the experience is not jarring and "scary" for users. Having red alerts appear often in the lifecycle of a Notebook starting can make it feel like it does not work.

Filters events for:
- In the first 30s, no `warning` level events are shown -- we only show the normal info events so if there is progress (or a special events like scaling) it can be displayed
    - After 30s, the `FailedScheduling` event will become visible and an error -- this is likely because there is a lack of space for your notebook pods
- In the case of auto-scaling... when we get the first event, we suppress all warning events until the failed scaling event (`NotTriggerScaleUp`) is visible
    - If the `NotTriggerScaleUp` event happens, we ignore all other events for purpose of displaying, and just show that as an error
- Max cap for filtering is 20 minutes -- if the modal is still fetching at that point we do not filter the events anymore and whatever the last event is will present itself
    - If it is a warning event, it will be shown as a warning Alert -- unless it is `FailedScheduling` in which it will be an error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Using a cluster with auto-scaling (still needs to be done)
- Using a Notebook Size that is took large for the cluster to handle
- Using a Notebook Size that fits on the cluster without issue

## Screenshot scenarios:

### Too large to fit

First 30s:
![Screen Shot 2022-09-15 at 9 11 40 PM](https://user-images.githubusercontent.com/8126518/190536205-9e49c95f-14ee-4f83-96fe-73f98bdbd330.png)

After 30s:
![Screen Shot 2022-09-15 at 9 11 46 PM](https://user-images.githubusercontent.com/8126518/190536217-b283db64-9e70-4bd5-aec2-d5e92432948f.png)

### Auto Scaling

For when Scaling starts it shows:
![Screen Shot 2022-09-15 at 10 00 35 PM](https://user-images.githubusercontent.com/8126518/190542007-d83c70a5-4c39-479a-ab35-f09ccae349c1.png)

When it starts:
![InitalStartupWorked](https://user-images.githubusercontent.com/8126518/190700240-92a1781f-3251-4f5b-bd95-e1fcc8e0020e.gif)

When it stays at that for several minutes then kicks over to spinning up:
![ScalingUpWorked](https://user-images.githubusercontent.com/8126518/190700290-09557f58-d243-43b5-afe4-964d5fc3c1a0.gif)

> Note this does not happen anymore, we do not show `Normal` events as warnings anymore.

For when you try to spin up a notebook for someone else and there is a conflict with your PVCs - Bug #564
<img width="795" alt="Screen Shot 2022-09-15 at 10 15 19 PM" src="https://user-images.githubusercontent.com/8126518/190542009-d987ece6-0bf9-4fa7-ab82-71a2832b29b7.png">

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Test on a auto-scaling cluster to verify fix
