### PR TITLE
Disable the KFNBC Admin Tabs

### DIFF
--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
 import QuickStarts from '../../app/QuickStarts';
-import { useUser } from '../../redux/selectors';
+// import { useUser } from '../../redux/selectors';
 import NotebookServerRoutes from './screens/server/NotebookServerRoutes';
-import NotebookControllerTabs from './screens/admin/NotebookControllerTabs';
+// import NotebookControllerTabs from './screens/admin/NotebookControllerTabs';
 import { NotebookControllerContextProvider } from './NotebookControllerContext';
 import ValidateNotebookNamespace from './ValidateNotebookNamespace';
 
 const NotebookController: React.FC = () => {
-  const { isAdmin } = useUser();
+  // TODO: Fix https://github.com/opendatahub-io/odh-dashboard/issues/564 -- causes shared storage issues
+  // const { isAdmin } = useUser();
 
   return (
     <QuickStarts>
       <NotebookControllerContextProvider>
         <ValidateNotebookNamespace>
-          {isAdmin ? <NotebookControllerTabs /> : <NotebookServerRoutes />}
+          {/*{isAdmin ? <NotebookControllerTabs /> : <NotebookServerRoutes />}*/}
+          <NotebookServerRoutes />
         </ValidateNotebookNamespace>
       </NotebookControllerContextProvider>
     </QuickStarts>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #566 

## Description
<!--- Describe your changes in detail -->
When an admin user spins up a Notebook for another user, it seems the PVC is hooked in from the Admin to that user's Notebook. Thus anything the user put into their storage, is stored erroneously in with the Admin's storage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
![Screen Shot 2022-09-15 at 10 31 37 PM](https://user-images.githubusercontent.com/8126518/190544185-e866d8b2-2803-4369-8ff0-63e57583f883.png)
I'm an admin, no tabs in the KFNBC page.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
