### PR TITLE
Add logging for admin groups manipulation within dashboard config instance

### DIFF
--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -7,7 +7,7 @@ import { KubeFastifyInstance } from '../types';
 import { getAdminGroups, getAllGroupsByUser, getAllowedGroups, getGroup } from './groupsUtils';
 import { flatten, uniq } from 'lodash';
 
-const SYSTEM_AUTHENTICATED = 'system:authenticated';
+export const SYSTEM_AUTHENTICATED = 'system:authenticated';
 /** Usernames with invalid characters can start with `b64:` to keep their unwanted characters */
 export const KUBE_SAFE_PREFIX = 'b64:';
 


### PR DESCRIPTION
Resolves: #463 

## Description
Adds logging for the mentioned cases of changing the odh-dashboard-config CRD instance.

## How Has This Been Tested?
Tested locally through modifying the odh-dashboard-config CRD instance on the cluster and checking responses from ```config``` GET calls on the backend.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
