### PR TITLE
Delete any envFrom sections from notebook containers.

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -44,6 +44,11 @@ export type NotebookResources = {
   };
 };
 
+type EnvFrom = {
+  configMapRef?: { name: string };
+  secretRef?: { name: string };
+};
+
 type EnvValue = {
   key: string;
   name: string;
@@ -328,6 +333,7 @@ export type NotebookContainer = {
   image: string;
   imagePullPolicy?: string;
   workingDir?: string;
+  envFrom?: EnvFrom[];
   env: EnvironmentVariable[];
   ports?: NotebookPort[];
   resources?: NotebookResources;

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -261,6 +261,12 @@ export const sanitizeNotebookForSecurity = async <
     if (container.name === 'oauth-proxy') {
       return;
     }
+
+    if (container.envFrom) {
+      fastify.log.warn(`${username} submitted a Notebook that contained an envFrom`);
+      delete container.envFrom;
+    }
+
     container.env?.forEach((env) => {
       if (
         env.valueFrom?.configMapKeyRef?.name &&


### PR DESCRIPTION
## Description
Sanitize notebook resource that tries to inject an envFrom to access secrets or configmaps/

## How Has This Been Tested?
Create a patch.json file that includes `"envFrom": [{"secretRef": {"name": "jupyterhub-singleuser-profile-victim-envs"}}]` and patch a notebook with curl.
```
curl 'http://localhost:4000/api/notebooks/rhods-notebooks/jupyter-nb-cchase-40redhat-2ecom' \
  -X 'PATCH' \
  -H 'Content-Type: application/json' \
  -d @patch.json
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Sample patch.json:
```
{
  "apiVersion": "kubeflow.org/v1",
  "kind": "Notebook",
  "metadata": {
    "name": "jupyter-nb-$USERNAME",
    "namespace": "rhods-notebooks"
  },
  "spec": {
    "template": {
      "spec": {
        "containers": [
          {
            "image": "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-1.17.0-3",
            "imagePullPolicy": "Always",
            "workingDir": "/opt/app-root/src",
            "name": "jupyter-nb-$USERNAME",
            "envFrom": [{"secretRef": {"name": "jupyterhub-singleuser-profile-$VICTIM-envs"}}],
            "env": [
              {
                "name": "NOTEBOOK_ARGS",
                "value": "--ServerApp.port=8888\n                  --ServerApp.token=''\n                  --ServerApp.password=''\n                  --ServerApp.base_url=/notebook/rhods-notebooks/jupyter-nb-$USERNAME\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={\"user\":\"$USERNAME\",\"hub_host\":\"https://rhods-dashboard-redhat-ods-applications.apps.aisrhods-kfnbc1.ro0g.p1.openshiftapps.com\",\"hub_prefix\":\"/notebookController/$USERNAME\"}"
              },
              {
                "name": "JUPYTER_IMAGE",
                "value": "image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-1.17.0-3"
              }
            ],
            "resources": {
              "limits": {
                "cpu": "2",
                "memory": "8Gi"
              },
              "requests": {
                "cpu": "1",
                "memory": "8Gi"
              }
            },
            "volumeMounts": [
              {
                "mountPath": "/opt/app-root/src",
                "name": "jupyterhub-nb-$USERNAME-pvc"
              }
            ],
            "ports": [
              {
                "name": "notebook-port",
                "containerPort": 8888,
                "protocol": "TCP"
              }
            ],
            "livenessProbe": {
              "initialDelaySeconds": 10,
              "periodSeconds": 5,
              "timeoutSeconds": 1,
              "successThreshold": 1,
              "failureThreshold": 3,
              "httpGet": {
                "scheme": "HTTP",
                "path": "/notebook/rhods-notebooks/jupyter-nb-$USERNAME/api",
                "port": "notebook-port"
              }
            },
            "readinessProbe": {
              "initialDelaySeconds": 10,
              "periodSeconds": 5,
              "timeoutSeconds": 1,
              "successThreshold": 1,
              "failureThreshold": 3,
              "httpGet": {
                "scheme": "HTTP",
                "path": "/notebook/rhods-notebooks/jupyter-nb-$USERNAME/api",
                "port": "notebook-port"
              }
            }
          }
        ]
      }
    }
  }
}
```
