### PR TITLE
Add description to "cluster settings saved" toast

### DIFF
--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -146,6 +146,7 @@ const ClusterSettings: React.FC = () => {
                 addNotification({
                   status: 'success',
                   title: 'Settings changes saved.',
+                  message: 'It takes a few seconds for configuration changes to be applied.',
                   timestamp: new Date(),
                 }),
               );

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -145,7 +145,7 @@ const ClusterSettings: React.FC = () => {
               dispatch(
                 addNotification({
                   status: 'success',
-                  title: 'Settings changes saved.',
+                  title: 'Settings changes saved',
                   message: 'It takes a few seconds for configuration changes to be applied.',
                   timestamp: new Date(),
                 }),


### PR DESCRIPTION
Signed-off-by: Luca Giorgi <lgiorgi@redhat.com>

Resolves: #580 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a description to the successful variation of the notification received when saving new settings, as requested in #580 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran dashboard locally and confirmed the description appears in the notification
![settings](https://user-images.githubusercontent.com/82518733/191712405-37b4eed0-d8de-4d7f-9b46-69ccf4d1634d.png)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
