### PR TITLE
Generate a random OAuth cookie secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ endif
 ##################################
 
 .PHONY: deploy
-deploy: login
+deploy:
 	./install/deploy.sh
 
 ##################################
 
 .PHONY: undeploy
-undeploy: login
+undeploy:
 	./install/undeploy.sh
 
 ##################################

--- a/install/undeploy.sh
+++ b/install/undeploy.sh
@@ -3,13 +3,25 @@ printf "\n\n######## undeploy ########\n"
 
 KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV="${KUSTOMIZE_MANIFEST_DIR}/overlays/dev"
 
-oc project ${OC_PROJECT} 2> /dev/null
-oc label namespace ${OC_PROJECT} openshift.io/cluster-monitoring-
-oc project
+if [[ -z "${OC_PROJECT}" ]]; then
+  echo "ERROR: No value defined for OC_PROJECT env var"
+  exit 1
+fi
 
+if ! oc get project ${OC_PROJECT} 2> /dev/null; then
+  echo "EROR: Project ${OC_PROJECT} does not exist"
+  exit 1
+fi
+
+oc config set-context --current --namespace=${OC_PROJECT}
+
+# Allow Prometheus metrics scraping in the namespace
+oc label namespace ${OC_PROJECT} openshift.io/cluster-monitoring-
+
+# Uninstall dashboard using kustomize
 pushd ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV}
 kustomize edit set namespace ${OC_PROJECT}
 popd
 
 # Use kustomize to build the yaml objects so we get full support for all the kustomize standards
-kustomize build ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV} | oc delete -f -
+kustomize build ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV} | oc delete --ignore-not-found=true -f -

--- a/manifests/overlays/authentication/deployment.yaml
+++ b/manifests/overlays/authentication/deployment.yaml
@@ -58,4 +58,4 @@
         secretName: dashboard-proxy-tls
     - name: oauth-config
       secret:
-        secretName: dashboard-oauth-config
+        secretName: dashboard-oauth-config-generated

--- a/manifests/overlays/authentication/secret.yaml
+++ b/manifests/overlays/authentication/secret.yaml
@@ -1,7 +1,10 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: dashboard-oauth-config
+  annotations:
+    secret-generator.opendatahub.io/name: "cookie_secret"
+    secret-generator.opendatahub.io/type: "oauth"
+    secret-generator.opendatahub.io/complexity: "16"
 type: Opaque
-data:
-  cookie_secret: VGtob01rbFVkRzFJUkdwNlkyTm1jSEZMZVdOQmR6MDk=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix https://github.com/opendatahub-io/odh-dashboard/issues/337

Also improve `deploy.sh` and `undeploy.sh` scripts to not mess up your local kubeconfig file.

## How Has This Been Tested?
Install the `opendatahub-operator` and patch the CSV image:

``` shell
$ oc edit csv opendatahub-operator.v1.3.0 -n openshift-operators
...
326                 image: quay.io/opendatahub/opendatahub-operator:v1.3.0 -> quay.io/vhire/opendatahub-operator:testoauth
...
```

Edit the `.env` file to use the following image:

```
IMAGE_REPOSITORY=quay.io/opendatahub/odh-dashboard:pr-590
```

Run `make deploy` and wait until the dashboard is deployed and running:

```
$ oc get pods -l app=odh-dashboard -n opendatahub
NAME                             READY   STATUS    RESTARTS   AGE
odh-dashboard-59d6fc4455-5mr9c   2/2     Running   0          3m32s
odh-dashboard-59d6fc4455-7wv59   2/2     Running   0          3m32s
odh-dashboard-59d6fc4455-89xml   2/2     Running   0          3m32s
odh-dashboard-59d6fc4455-m85lr   2/2     Running   0          3m32s
odh-dashboard-59d6fc4455-r9s4x   2/2     Running   0          3m32s
```

Check out the random secret has been generated:

```yaml
$ oc get secret dashboard-oauth-config-generated -o yaml                     
apiVersion: v1
data:
  cookie_secret: Wnk4MVNsQjBWMGRRYkVzeVowZzRkSFl6U25BeFp6MDk=
kind: Secret
metadata:
  creationTimestamp: "2022-10-25T09:47:55Z"
  name: dashboard-oauth-config-generated
  namespace: opendatahub
  ownerReferences:
  - apiVersion: v1
    blockOwnerDeletion: true
    controller: true
    kind: Secret
    name: dashboard-oauth-config
    uid: 1b24888f-aa5b-4f88-bc24-971500dd68f1
  resourceVersion: "47234719"
  uid: 572a09a2-2e3a-47d0-a18b-122fca31d4fe
type: Opaque
``` 
 
Check the oauth proxy logs to verify there are no errors:

```
$ oc logs -f -l app=odh-dashboard -c oauth-proxy  
2022/10/25 09:48:27 provider.go:120: Defaulting client-id to system:serviceaccount:opendatahub:odh-dashboard
2022/10/25 09:48:27 provider.go:125: Defaulting client-secret to service account token /var/run/secrets/kubernetes.io/serviceaccount/token
2022/10/25 09:48:27 provider.go:314: Delegation of authentication and authorization to OpenShift is enabled for bearer tokens and client certificates.
2022/10/25 09:48:28 oauthproxy.go:203: mapping path "/" => upstream "http://localhost:8080/"
2022/10/25 09:48:28 oauthproxy.go:224: compiled skip-auth-regex => "^/metrics"
2022/10/25 09:48:28 oauthproxy.go:230: OAuthProxy configured for  Client ID: system:serviceaccount:opendatahub:odh-dashboard
2022/10/25 09:48:28 oauthproxy.go:240: Cookie settings: name:_oauth_proxy secure(https):true httponly:true expiry:168h0m0s domain:<default> samesite: refresh:disabled
2022/10/25 09:48:28 http.go:61: HTTP: listening on 127.0.0.1:4180
2022/10/25 09:48:28 http.go:107: HTTPS: listening on [::]:8443
```
