### PR TITLE
Require config for further checks if enabled

### DIFF
--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -255,23 +255,20 @@ export const getIsAppEnabled = async (
   fastify: KubeFastifyInstance,
   appDef: OdhApplication,
 ): Promise<boolean> => {
-  if (getKfDefForApp(appDef)) {
-    return true;
-  }
-
   const enabledCM = await getApplicationEnabledConfigMap(fastify, appDef);
   if (enabledCM) {
-    return true;
-  }
-  const crEnabled = await getCREnabledForApp(fastify, appDef);
-  if (crEnabled) {
-    return true;
-  }
+    if (getKfDefForApp(appDef)) {
+      return true;
+    }
+    const crEnabled = await getCREnabledForApp(fastify, appDef);
+    if (crEnabled) {
+      return true;
+    }
 
-  if (await getCSVForApp(fastify, appDef)) {
-    return true;
+    if (await getCSVForApp(fastify, appDef)) {
+      return true;
+    }
   }
-
   // Failed all checks
   return false;
 };


### PR DESCRIPTION
Resolves #611 

## Description
Moves CR and CSV checks into the condition checking if the app is enabled in the configmap so that the configmap has higher authority than the applications just being there. It also means applications must have a CR, a CSV or be present in a kfdef, otherwise the app is considered disabled.

## How Has This Been Tested:
1. Deployed odh-dashboard with changes
2. Deployed jupyterhub app manifests
3. Verified jupyterhub is present in enabled tab
4. Set jupyterhub to false in odh-enabled-applications-config
5. Verifed jupyterhub is not present

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
