### PR TITLE
Remove logging of 404 error responses for pvc, configmaps and secrets

### DIFF
--- a/backend/src/routes/api/configmaps/index.ts
+++ b/backend/src/routes/api/configmaps/index.ts
@@ -21,7 +21,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
               e.message || res.message,
               e.code,
             );
-            fastify.log.error(`Configmap ${cmName} could not be read, ${error}`);
+            if (res.statusCode !== 404) {
+              fastify.log.error(`Configmap ${cmName} could not be read, ${error}`);
+            }
             throw error;
           });
       },

--- a/backend/src/routes/api/pvc/index.ts
+++ b/backend/src/routes/api/pvc/index.ts
@@ -20,9 +20,11 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return pvcResponse.body;
         } catch (e) {
-          fastify.log.error(
-            `PVC ${pvcName} could not be read, ${e.response?.body?.message || e.message || e}`,
-          );
+          if (e.statusCode !== 404) {
+            fastify.log.error(
+              `PVC ${pvcName} could not be read, ${e.response?.body?.message || e.message || e}`,
+            );
+          }
           reply.send(e);
         }
       },

--- a/backend/src/routes/api/secrets/index.ts
+++ b/backend/src/routes/api/secrets/index.ts
@@ -20,11 +20,13 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return secretResponse.body;
         } catch (e) {
-          fastify.log.error(
-            `Secret ${secretName} could not be read, ${
-              e.response?.body?.message || e.message || e
-            }`,
-          );
+          if (e.statusCode !== 404) {
+            fastify.log.error(
+              `Secret ${secretName} could not be read, ${
+                e.response?.body?.message || e.message || e
+              }`,
+            );
+          }
           reply.send(e);
         }
       },


### PR DESCRIPTION
Resolves: #595

## Description
Removed logging of 404 error responses for (yet) non-existing pvcs, configmaps and secrets

## How Has This Been Tested?
1. delete the resources in question, simulating a new user startup
2. open notebook controller spawner
3. verify dashboard logs do not contain error records after completed GET requests on ```api/pvc```, ```api/configmaps``` and ```api/secrets``` 

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
