### PR TITLE
Edit default betaText to be more generic

### DIFF
--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -21,9 +21,7 @@ import { useAppContext } from '../../app/AppContext';
 import './GetStartedPanel.scss';
 
 const DEFAULT_BETA_TEXT =
-  'This application is available for early access prior to official ' +
-  ' release. It won’t appear in the *Enabled* view, but you can access it by' +
-  ' [signing up for beta access.](https://www.starburst.io/platform/starburst-galaxy/).';
+  'This application is available for early access in a beta pre-release stage. You might find bugs or issues with availability, stability, data, or performance.';
 
 type GetStartedPanelProps = {
   selectedApp?: OdhApplication;
@@ -106,17 +104,15 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
             <Alert
               variantLabel="error"
               variant="info"
-              title={
-                selectedApp.spec.betaTitle ||
-                `${selectedApp.spec.displayName} is currently in beta.`
-              }
+              title={selectedApp.spec.betaTitle || `${selectedApp.spec.displayName} is in beta.`}
               aria-live="polite"
               isInline
             >
               <div
                 dangerouslySetInnerHTML={{
                   __html: markdownConverter.makeHtml(
-                    selectedApp.spec.betaText || DEFAULT_BETA_TEXT,
+                    selectedApp.spec.betaText ||
+                      DEFAULT_BETA_TEXT.replace('This application', selectedApp.spec.displayName),
                   ),
                 }}
               />


### PR DESCRIPTION
Resolves: #623

## Description
Edited the previous default betaText value to a generic one
![image](https://user-images.githubusercontent.com/73712209/194537160-5cbec2e1-37bf-4a82-946a-75cc80f61372.png)

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work