### PR TITLE
Disable start server when env is in error

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -94,6 +94,9 @@ const SpawnerPage: React.FC = () => {
   const [variableRows, setVariableRows] = React.useState<VariableRow[]>([]);
   const [submitError, setSubmitError] = React.useState<Error | null>(null);
 
+  const disableSubmit =
+    createInProgress || variableRows.some(({ errors }) => Object.keys(errors).length > 0);
+
   React.useEffect(() => {
     const setFirstValidImage = () => {
       const getDefaultImageTag = () => {
@@ -400,7 +403,7 @@ const SpawnerPage: React.FC = () => {
                     setSubmitError(e);
                   });
                 }}
-                isDisabled={createInProgress}
+                isDisabled={disableSubmit}
               >
                 Start server
               </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #635 

## Description
<!--- Describe your changes in detail -->
We didn't disable the submit button when env was in error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Make an env and cause it to be in an error -- button should disable.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
