### PR TITLE
Fix Oauth Issues when retrieving username

### DIFF
--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -16,13 +16,7 @@ const testAdmin = async (
   request: OauthFastifyRequest,
   needsAdmin: boolean,
 ): Promise<boolean> => {
-  const username = await getUserName(fastify, request).catch((error) => {
-    throw createCustomError(
-      'Error retrieving username',
-      error.response?.data?.message || error.message,
-      500,
-    );
-  });
+  const username = await getUserName(fastify, request);
   const { dashboardNamespace } = getNamespaces(fastify);
   const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
   if (isAdmin) {

--- a/frontend/src/app/useApplicationSettings.tsx
+++ b/frontend/src/app/useApplicationSettings.tsx
@@ -3,7 +3,6 @@ import { DashboardConfig } from '../types';
 import { POLL_INTERVAL } from '../utilities/const';
 import { useDeepCompareMemoize } from '../utilities/useDeepCompareMemoize';
 import { fetchDashboardConfig } from '../services/dashboardConfigService';
-import { logout } from './appUtils';
 
 export const useApplicationSettings = (): {
   dashboardConfig: DashboardConfig | null;
@@ -32,11 +31,10 @@ export const useApplicationSettings = (): {
             // NOTE: this endpoint only requests ouath because of the security layer, this is not an ironclad use-case
             // Something went wrong on the server with the Oauth, let us just log them out and refresh for them
             console.error(
-              'Something went wrong with the oauth token, logging out...',
+              'Something went wrong with the oauth token, please log out...',
               e.message,
               e,
             );
-            logout().then(() => window.location.reload()); // note this is a bad side-effect, never do this
             return;
           }
           setLoadError(e);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR contains the following:

* Add custom error code when retrieving username
   * It will return 401 when the token is deprecated or there is no token
   * It will return the default error code of the oc get request in other cases (when there's a cluster problem it will be 500)
   
* Fixes an issue when the dashboard cannot redirect to oauth proxy and keeps a loop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In local:
1. Comment [this line](https://github.com/opendatahub-io/odh-dashboard/blob/main/backend/src/utils/userUtils.ts#L90) to trigger the error.
2. Now the frontend should not reload when displaying the error message.
3. Check that is returning a 401 since the token is not provided.
4. Get a /status call with the cookie session of the cluster.
5. It should return a 200 response.
6. Now disconnect from the VPN to emulate connection issues.
7. It should return a 500 response.

In the cluster:
1. Deploy the cluster without the oauth proxy.
2. It will display the error page, with a 401 error response. It won't auto-reload all the time.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
