### PR TITLE
Add empty view and empty dsg section

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -16,6 +16,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableAppLauncher: boolean;
       disableUserManagement: boolean;
       disableProjects: boolean;
+      disableModelServing: boolean;
     };
     groupsConfig?: {
       adminGroups: string;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -40,6 +40,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableAppLauncher: false,
       disableUserManagement: false,
       disableProjects: false,
+      disableModelServing: false,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -13,6 +13,9 @@ const NotebookLogoutRedirectPage = React.lazy(
   () => import('../pages/notebookController/NotebookLogoutRedirect'),
 );
 const ProjectViewRoutes = React.lazy(() => import('../pages/projects/ProjectViewRoutes'));
+const ModelViewRoutes = React.lazy(
+  () => import('../pages/modelServing/screens/global/ModelServingGlobal'),
+);
 const NotebookController = React.lazy(
   () => import('../pages/notebookController/NotebookController'),
 );
@@ -35,6 +38,7 @@ const AppRoutes: React.FC = () => {
         <Route path="/explore" element={<ExploreApplications />} />
         <Route path="/resources" element={<LearningCenterPage />} />
         {isAllowed && <Route path="/projects/*" element={<ProjectViewRoutes />} />}
+        {isAllowed && <Route path="/modelServing/*" element={<ModelViewRoutes />} />}
         {isAllowed && <Route path="/notebookController/*" element={<NotebookController />} />}
         {isAllowed && (
           <Route

--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+
+const EmptyModelServing: React.FC = () => {
+  const navigate = useNavigate();
+  // TODO: Add logic to display either configure a server when there's no one or allow to deploy model
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={PlusCircleIcon} />
+      <Title headingLevel="h4" size="lg">
+        No model servers.
+      </Title>
+      <EmptyStateBody>
+        Before deploying a model, you must first configure a model server.
+      </EmptyStateBody>
+      <Button variant="primary" onClick={() => navigate('/projects')}>
+        Create server
+      </Button>
+    </EmptyState>
+  );
+};
+
+export default EmptyModelServing;

--- a/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ApplicationsPage from '../../../ApplicationsPage';
+import EmptyModelServing from './EmptyModelServing';
+
+const ModelServingGlobal: React.FC = () => {
+  return (
+    <ApplicationsPage
+      title="Deployed models"
+      description="Manage and view the health and performance of your deployed models."
+      loaded
+      empty
+      emptyStatePage={<EmptyModelServing />}
+    />
+  );
+};
+
+export default ModelServingGlobal;

--- a/frontend/src/pages/projects/screens/detail/EmptyDetailsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/EmptyDetailsList.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 type EmptyDetailsListProps = {
   title: string;
   description: string;
+  icon?: React.ComponentClass<SVGIconProps>;
 };
 
-const EmptyDetailsList: React.FC<EmptyDetailsListProps> = ({ title, description }) => {
+const EmptyDetailsList: React.FC<EmptyDetailsListProps> = ({ title, description, icon }) => {
   return (
     <EmptyState variant="xs">
-      <EmptyStateIcon icon={CubesIcon} />
+      <EmptyStateIcon icon={icon ?? CubesIcon} />
       <Title headingLevel="h5" size="lg">
         {title}
       </Title>

--- a/frontend/src/pages/projects/screens/detail/ModelServerList.tsx
+++ b/frontend/src/pages/projects/screens/detail/ModelServerList.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import EmptyDetailsList from './EmptyDetailsList';
+import DetailsSection from './DetailsSection';
+import { ProjectSectionTitlesExtended } from './const';
+import { ProjectSectionID } from './types';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+const ModelServerList: React.FC = () => {
+  return (
+    <DetailsSection
+      id={ProjectSectionID.MODEL_SERVER}
+      title={ProjectSectionTitlesExtended[ProjectSectionID.MODEL_SERVER] || ''}
+      actions={[
+        <Button key={`action-${ProjectSectionID.MODEL_SERVER}`} variant="secondary">
+          Configure server
+        </Button>,
+      ]}
+      isLoading={false}
+      isEmpty
+      loadError={undefined}
+      emptyState={
+        <EmptyDetailsList
+          title="No model servers"
+          description="Before deploying a model, you must first configure a model server."
+          icon={PlusCircleIcon}
+        />
+      }
+    >
+      No content
+    </DetailsSection>
+  );
+};
+
+export default ModelServerList;

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -2,12 +2,14 @@ import { Divider, PageSection, Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 import ApplicationsPage from '../../../ApplicationsPage';
 import { useCurrentProjectDisplayName } from '../../utils';
-import { ProjectSectionTitles } from './const';
 import DataConnectionsList from './data-connections/DataConnectionsList';
+import { ProjectSectionTitles, ProjectSectionTitlesExtended } from './const';
 import GenericSidebar from '../../components/GenericSidebar';
 import StorageList from './storage/StorageList';
 import { ProjectSectionID } from './types';
 import WorkspacesList from './workspaces/WorkspacesList';
+import { useAppContext } from 'app/AppContext';
+import ModelServerList from './ModelServerList';
 
 type SectionType = {
   id: ProjectSectionID;
@@ -17,11 +19,16 @@ type SectionType = {
 const ProjectDetails: React.FC = () => {
   const scrollableSelectorID = 'project-details-list';
   const displayName = useCurrentProjectDisplayName();
+  const { dashboardConfig } = useAppContext();
+  const modelServingEnabled = dashboardConfig.spec.dashboardConfig.disableModelServing;
 
   const sections: SectionType[] = [
     { id: ProjectSectionID.WORKSPACE, component: <WorkspacesList /> },
     { id: ProjectSectionID.STORAGE, component: <StorageList /> },
     { id: ProjectSectionID.DATA_CONNECTIONS, component: <DataConnectionsList /> },
+    ...(!modelServingEnabled
+      ? [{ id: ProjectSectionID.MODEL_SERVER, component: <ModelServerList /> }]
+      : []),
   ];
 
   const mapSections = (
@@ -50,8 +57,12 @@ const ProjectDetails: React.FC = () => {
         variant="light"
       >
         <GenericSidebar
-          sections={Object.values(ProjectSectionID)}
-          titles={ProjectSectionTitles}
+          sections={Object.keys(
+            modelServingEnabled
+              ? ProjectSectionTitles
+              : { ...ProjectSectionTitles, ...ProjectSectionTitlesExtended },
+          )}
+          titles={modelServingEnabled ? ProjectSectionTitles : ProjectSectionTitlesExtended}
           scrollableSelector={`#${scrollableSelectorID}`}
         >
           <Stack hasGutter>

--- a/frontend/src/pages/projects/screens/detail/const.ts
+++ b/frontend/src/pages/projects/screens/detail/const.ts
@@ -5,3 +5,8 @@ export const ProjectSectionTitles: ProjectSectionTitlesType = {
   [ProjectSectionID.STORAGE]: 'Storage',
   [ProjectSectionID.DATA_CONNECTIONS]: 'Data connections',
 };
+
+export const ProjectSectionTitlesExtended: ProjectSectionTitlesType = {
+  ...ProjectSectionTitles,
+  [ProjectSectionID.MODEL_SERVER]: 'Model server',
+};

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
@@ -13,7 +13,7 @@ const DataConnectionsList: React.FC = () => {
   return (
     <DetailsSection
       id={ProjectSectionID.DATA_CONNECTIONS}
-      title={ProjectSectionTitles[ProjectSectionID.DATA_CONNECTIONS]}
+      title={ProjectSectionTitles[ProjectSectionID.DATA_CONNECTIONS] || ''}
       actions={[
         <Button key={`action-${ProjectSectionID.DATA_CONNECTIONS}`} variant="secondary">
           Add data connection

--- a/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
@@ -19,7 +19,7 @@ const StorageList: React.FC = () => {
     <>
       <DetailsSection
         id={ProjectSectionID.STORAGE}
-        title={ProjectSectionTitles[ProjectSectionID.STORAGE]}
+        title={ProjectSectionTitles[ProjectSectionID.STORAGE] || ''}
         actions={[
           <Button
             onClick={() => setOpen(true)}

--- a/frontend/src/pages/projects/screens/detail/types.ts
+++ b/frontend/src/pages/projects/screens/detail/types.ts
@@ -2,8 +2,9 @@ export enum ProjectSectionID {
   WORKSPACE = 'data-science-workspaces',
   STORAGE = 'storage',
   DATA_CONNECTIONS = 'data-connections',
+  MODEL_SERVER = 'model-server',
 }
 
 export type ProjectSectionTitlesType = {
-  [key in ProjectSectionID]: string;
+  [key in ProjectSectionID]?: string;
 };

--- a/frontend/src/pages/projects/screens/detail/workspaces/WorkspacesList.tsx
+++ b/frontend/src/pages/projects/screens/detail/workspaces/WorkspacesList.tsx
@@ -16,7 +16,7 @@ const WorkspacesList: React.FC = () => {
   return (
     <DetailsSection
       id={ProjectSectionID.WORKSPACE}
-      title={ProjectSectionTitles[ProjectSectionID.WORKSPACE]}
+      title={ProjectSectionTitles[ProjectSectionID.WORKSPACE] || ''}
       actions={[
         <Button key={`action-${ProjectSectionID.WORKSPACE}`} variant="secondary">
           {/* this will generate an underscore under the text when hover it, maybe we need to override the style */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,6 +43,7 @@ export type DashboardCommonConfig = {
   disableAppLauncher: boolean;
   disableUserManagement: boolean;
   disableProjects: boolean;
+  disableModelServing: boolean;
 };
 
 export type NotebookControllerUserState = {

--- a/frontend/src/utilities/NavData.ts
+++ b/frontend/src/utilities/NavData.ts
@@ -80,6 +80,10 @@ export const getNavBarData = (
     navItems.push({ id: 'dsg', label: 'Data Science Projects', href: '/projects' });
   }
 
+  if (!dashboardConfig.spec.dashboardConfig.disableModelServing) {
+    navItems.push({ id: 'modelServing', label: 'Model Serving', href: '/modelServing' });
+  }
+
   navItems.push({ id: 'resources', label: 'Resources', href: '/resources' });
 
   const settingsNav = getSettingsNav(isAdmin, dashboardConfig);

--- a/manifests/crd/odh-dashboard-crd.yaml
+++ b/manifests/crd/odh-dashboard-crd.yaml
@@ -43,6 +43,8 @@ spec:
                       type: boolean
                     disableProjects:
                       type: boolean
+                    disableModelServing:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -14,6 +14,7 @@ spec:
     disableTracking: true
     enablement: true
     disableProjects: true
+    disableModelServing: true
   notebookController:
     enabled: true
   notebookSizes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Work for #639 

* Add feature flag for model serving
* Add nav section for global model serving view
* Add dsg section behind the feature flag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy the dashboard
2. Check the route and dsg are not available
3. Change the OdhDashboardConfig CRD to turnt to `false` `disableProjects` and `disableModelServing`.
4. Check that both sections are displayed

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
