### PR TITLE
Data Connections List

### DIFF
--- a/frontend/src/api/network/secrets.ts
+++ b/frontend/src/api/network/secrets.ts
@@ -2,6 +2,7 @@ import {
   k8sCreateResource,
   k8sDeleteResource,
   k8sGetResource,
+  k8sListResource,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { K8sStatus, SecretKind } from '../../k8sTypes';
@@ -12,6 +13,13 @@ export const getSecret = (projectName: string, secretName: string): Promise<Secr
     model: SecretModel,
     queryOptions: { name: secretName, ns: projectName },
   });
+};
+
+export const getSecretsByLabel = (label: string, namespace: string): Promise<SecretKind[]> => {
+  return k8sListResource<SecretKind>({
+    model: SecretModel,
+    queryOptions: { ns: namespace, queryParams: { labelSelector: label } },
+  }).then((result) => result.items);
 };
 
 export const createSecret = (data: SecretKind): Promise<SecretKind> => {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -10,6 +10,10 @@ type DisplayNameAnnotations = Partial<{
   'openshift.io/display-name': string; // the name provided by the user
 }>;
 
+type RelatedToNotebookAnnotations = Partial<{
+  'opendatahub.io/related-notebooks': string; // a JSON array of notebook.metadata.names
+}>;
+
 export type K8sDSGResource = K8sResourceCommon & {
   metadata: {
     annotations?: DisplayNameAnnotations;
@@ -220,7 +224,19 @@ export type RouteKind = K8sResourceCommon & {
 };
 
 export type SecretKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+  };
   data?: Record<string, string>;
   stringData?: Record<string, string>;
   type?: string;
+};
+
+export type AWSSecretKind = SecretKind & {
+  metadata: {
+    annotations?: DisplayNameAnnotations & RelatedToNotebookAnnotations;
+    labels?: {
+      'opendatahub.io/managed': 'true';
+    };
+  };
 };

--- a/frontend/src/pages/projects/notebook/ConnectedWorkspaces.tsx
+++ b/frontend/src/pages/projects/notebook/ConnectedWorkspaces.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { List, ListItem, Spinner } from '@patternfly/react-core';
+import { getNotebookDisplayName } from '../utils';
+import useConnectedNotebooks from './useConnectedNotebooks';
+
+type ConnectedWorkspacesProps = {
+  /** @see RelatedToNotebookAnnotations type */
+  connectedAnnotation: string; // JSON array value of metadata.name notebooks
+};
+
+const ConnectedWorkspaces: React.FC<ConnectedWorkspacesProps> = ({ connectedAnnotation }) => {
+  const [connectedNotebooks, loaded, error] = useConnectedNotebooks(connectedAnnotation);
+
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+
+  if (error) {
+    // TODO: What is the best way to handle this??
+    return <>N/A</>;
+  }
+
+  if (connectedNotebooks.length === 0) {
+    return <>No connections</>;
+  }
+
+  return (
+    <List isPlain>
+      {connectedNotebooks.map((notebook) => (
+        <ListItem key={notebook.metadata.uid}>{getNotebookDisplayName(notebook)}</ListItem>
+      ))}
+    </List>
+  );
+};
+
+export default ConnectedWorkspaces;

--- a/frontend/src/pages/projects/notebook/useConnectedNotebooks.ts
+++ b/frontend/src/pages/projects/notebook/useConnectedNotebooks.ts
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { NotebookKind } from '../../../k8sTypes';
+import { getNotebook } from '../../../api';
+import { ProjectDetailsContext } from '../ProjectDetailsContext';
+
+const useConnectedNotebooks = (
+  connectedAnnotation: string,
+): [notebooks: NotebookKind[], loaded: boolean, loadError: Error | undefined] => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const [notebookNames, setNotebookNames] = React.useState<string[]>([]);
+  const [notebooks, setNotebooks] = React.useState<NotebookKind[]>([]);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+
+  const namespace = currentProject.metadata.name;
+  React.useEffect(() => {
+    if (!connectedAnnotation) {
+      setLoaded(true);
+      return;
+    }
+
+    try {
+      const relatedNotebookNames = JSON.parse(connectedAnnotation);
+      setNotebookNames(relatedNotebookNames.filter((name) => typeof name === 'string'));
+    } catch (e) {
+      console.error('Failed to parse connected annotations', connectedAnnotation, e);
+      setLoaded(true);
+    }
+  }, [connectedAnnotation]);
+
+  React.useEffect(() => {
+    if (notebookNames.length > 0) {
+      Promise.all(notebookNames.map((name) => getNotebook(name, namespace)))
+        .then((notebooks) => {
+          setNotebooks(notebooks);
+          setLoaded(true);
+        })
+        .catch((e) => {
+          setError(e);
+        });
+    }
+  }, [namespace, notebookNames]);
+
+  return [notebooks, loaded, error];
+};
+
+export default useConnectedNotebooks;

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import ApplicationsPage from '../../../ApplicationsPage';
 import { useCurrentProjectDisplayName } from '../../utils';
 import { ProjectSectionTitles } from './const';
-import DataConnectionsList from './DataConnectionsList';
+import DataConnectionsList from './data-connections/DataConnectionsList';
 import GenericSidebar from '../../components/GenericSidebar';
 import StorageList from './storage/StorageList';
 import { ProjectSectionID } from './types';

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
-import EmptyDetailsList from './EmptyDetailsList';
-import { ProjectSectionID } from './types';
-import DetailsSection from './DetailsSection';
-import { ProjectSectionTitles } from './const';
+import EmptyDetailsList from '../EmptyDetailsList';
+import { ProjectSectionID } from '../types';
+import DetailsSection from '../DetailsSection';
+import { ProjectSectionTitles } from '../const';
+import DataConnectionsTable from './DataConnectionsTable';
+import useDataConnections from './useDataConnections';
 
 const DataConnectionsList: React.FC = () => {
+  const [connections, loaded, error] = useDataConnections();
+
   return (
     <DetailsSection
       id={ProjectSectionID.DATA_CONNECTIONS}
@@ -15,9 +19,9 @@ const DataConnectionsList: React.FC = () => {
           Add data connection
         </Button>,
       ]}
-      isLoading={false}
-      isEmpty
-      loadError={undefined}
+      isLoading={!loaded}
+      isEmpty={connections.length === 0}
+      loadError={error}
       emptyState={
         <EmptyDetailsList
           title="No data connections"
@@ -25,7 +29,7 @@ const DataConnectionsList: React.FC = () => {
         />
       }
     >
-      No content
+      <DataConnectionsTable connections={connections} />
     </DetailsSection>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTable.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { TableComposable, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import useTableColumnSort from '../../../../../utilities/useTableColumnSort';
+import { DataConnection } from '../../../types';
+import { columns } from './data';
+import DataConnectionsTableRow from './DataConnectionsTableRow';
+import { getDataConnectionId } from './utils';
+
+type DataConnectionsTableProps = {
+  connections: DataConnection[];
+};
+
+const DataConnectionsTable: React.FC<DataConnectionsTableProps> = ({
+  connections: unsortedDataConnections,
+}) => {
+  const sort = useTableColumnSort<DataConnection>(columns, 0);
+  const sortedDataConnections = sort.transformData(unsortedDataConnections);
+
+  return (
+    <TableComposable variant="compact">
+      <Thead>
+        <Tr>
+          {columns.map((col, i) => (
+            <Th key={col.field} sort={sort.getColumnSort(i)} width={col.width}>
+              {col.label}
+            </Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {sortedDataConnections.map((dataConnection) => (
+          <DataConnectionsTableRow key={getDataConnectionId(dataConnection)} obj={dataConnection} />
+        ))}
+      </Tbody>
+    </TableComposable>
+  );
+};
+
+export default DataConnectionsTable;

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { Text, Title } from '@patternfly/react-core';
+import { DataConnection } from '../../../types';
+import {
+  getDataConnectedNotebookAnnotation,
+  getDataConnectionDescription,
+  getDataConnectionName,
+  getDataConnectionProvider,
+  getDataConnectionType,
+} from './utils';
+import ConnectedWorkspaces from '../../../notebook/ConnectedWorkspaces';
+
+type DataConnectionsTableRowProps = {
+  obj: DataConnection;
+};
+
+const DataConnectionsTableRow: React.FC<DataConnectionsTableRowProps> = ({ obj }) => {
+  return (
+    <Tr>
+      <Td>
+        <Title headingLevel="h4">{getDataConnectionName(obj)}</Title>
+        <Text>{getDataConnectionDescription(obj)}</Text>
+      </Td>
+      <Td>{getDataConnectionType(obj)}</Td>
+      <Td>
+        <ConnectedWorkspaces connectedAnnotation={getDataConnectedNotebookAnnotation(obj)} />
+      </Td>
+      <Td>{getDataConnectionProvider(obj)}</Td>
+      <Td isActionCell>
+        <ActionsColumn
+          items={[
+            {
+              title: 'Edit data connection',
+              onClick: () => {
+                alert('Not implemented yet');
+              },
+            },
+            {
+              title: 'Delete data connection',
+              onClick: () => {
+                alert('Not implemented yet');
+              },
+            },
+          ]}
+        />
+      </Td>
+    </Tr>
+  );
+};
+
+export default DataConnectionsTableRow;

--- a/frontend/src/pages/projects/screens/detail/data-connections/connectionRenderers.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/connectionRenderers.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DataConnectionType } from '../../../types';
+import { CubeIcon } from '@patternfly/react-icons';
+
+export const DATA_CONNECTION_TYPES: { [key in DataConnectionType]: React.ReactNode } = {
+  [DataConnectionType.AWS]: (
+    <>
+      <CubeIcon /> Object storage
+    </>
+  ),
+};

--- a/frontend/src/pages/projects/screens/detail/data-connections/data.ts
+++ b/frontend/src/pages/projects/screens/detail/data-connections/data.ts
@@ -1,0 +1,33 @@
+import { SortableData } from '../../../../../utilities/useTableColumnSort';
+import { DataConnection } from '../../../types';
+
+export const columns: SortableData<DataConnection>[] = [
+  {
+    field: 'name',
+    label: 'Name',
+    width: 20,
+    sortable: false,
+  },
+  {
+    field: 'type',
+    label: 'Type',
+    width: 20,
+    sortable: false,
+  },
+  {
+    field: 'connections',
+    label: 'Connected workspaces',
+    width: 30,
+    sortable: false,
+  },
+  {
+    field: 'provider',
+    label: 'Provider',
+    sortable: false,
+  },
+  {
+    field: 'kebab',
+    label: '',
+    sortable: false,
+  },
+];

--- a/frontend/src/pages/projects/screens/detail/data-connections/useDataConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/data-connections/useDataConnections.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { DataConnection, DataConnectionAWS, DataConnectionType } from '../../../types';
+import { getSecretsByLabel } from '../../../../../api';
+import { ProjectDetailsContext } from '../../../ProjectDetailsContext';
+import { AWSSecretKind } from '../../../../../k8sTypes';
+
+const useDataConnections = (): [
+  connections: DataConnection[],
+  loaded: boolean,
+  loadError: Error | undefined,
+] => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const [connections, setConnections] = React.useState<DataConnection[]>([]);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+
+  const namespace = currentProject.metadata.name;
+
+  React.useEffect(() => {
+    getSecretsByLabel(`opendatahub.io/managed=true`, namespace)
+      .then((secrets) => {
+        setConnections((d) => [
+          ...d,
+          ...secrets
+            .filter<AWSSecretKind>( // TODO: this will make more sense when we have more data connection types
+              (secret): secret is AWSSecretKind =>
+                !!secret.metadata.labels?.[`opendatahub.io/managed`], // note, always true is fine for now
+            )
+            .map<DataConnectionAWS>((secret) => ({
+              type: DataConnectionType.AWS,
+              data: secret,
+            })),
+        ]);
+        setLoaded(true);
+      })
+      .catch((e) => {
+        setError(e);
+      });
+  }, [namespace]);
+
+  return [connections, loaded, error];
+};
+
+export default useDataConnections;

--- a/frontend/src/pages/projects/screens/detail/data-connections/utils.ts
+++ b/frontend/src/pages/projects/screens/detail/data-connections/utils.ts
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { DataConnection, DataConnectionAWS, DataConnectionType } from '../../../types';
+import { getSecretDescription, getSecretDisplayName } from '../../../utils';
+import { DATA_CONNECTION_TYPES } from './connectionRenderers';
+
+export const isDataConnectionAWS = (
+  dataConnection: DataConnection,
+): dataConnection is DataConnectionAWS => dataConnection.type === DataConnectionType.AWS;
+
+export const getDataConnectionId = (dataConnection: DataConnection): string => {
+  if (isDataConnectionAWS(dataConnection)) {
+    return dataConnection.data.metadata.uid || dataConnection.data.metadata.name;
+  }
+
+  throw new Error('Invalid data connection type');
+};
+
+export const getDataConnectionName = (dataConnection: DataConnection): string => {
+  if (isDataConnectionAWS(dataConnection)) {
+    return getSecretDisplayName(dataConnection.data);
+  }
+
+  throw new Error('Invalid data connection type');
+};
+
+export const getDataConnectionDescription = (dataConnection: DataConnection): string => {
+  if (isDataConnectionAWS(dataConnection)) {
+    return getSecretDescription(dataConnection.data);
+  }
+
+  return '';
+};
+
+export const getDataConnectionType = (dataConnection: DataConnection): React.ReactNode => {
+  const connectionType = DATA_CONNECTION_TYPES[dataConnection.type];
+  if (connectionType) {
+    return connectionType;
+  }
+
+  throw new Error('Invalid data connection type');
+};
+
+export const getDataConnectedNotebookAnnotation = (dataConnection: DataConnection): string => {
+  if (isDataConnectionAWS(dataConnection)) {
+    return dataConnection.data.metadata.annotations?.['opendatahub.io/related-notebooks'] || '';
+  }
+
+  throw new Error('Invalid data connection type');
+};
+
+export const getDataConnectionProvider = (dataConnection: DataConnection): string => {
+  switch (dataConnection.type) {
+    case DataConnectionType.AWS:
+      return 'AWS S3';
+    default:
+      throw new Error('Invalid data connection type');
+  }
+};

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -7,6 +7,7 @@ import {
   VolumeMount,
 } from '../../types';
 import { ValueOf } from '../../typeHelpers';
+import { AWSSecretKind } from '../../k8sTypes';
 
 export type UpdateObjectAtPropAndValue<T> = (propKey: keyof T, propValue: ValueOf<T>) => void;
 
@@ -47,3 +48,17 @@ export type StartNotebookData = {
   envVars?: EnvVarReducedType;
   description?: string;
 };
+
+export enum DataConnectionType {
+  AWS,
+}
+
+export type DataConnectionAWS = {
+  type: DataConnectionType.AWS;
+  data: AWSSecretKind;
+};
+
+export type DataConnection = {
+  type: DataConnectionType;
+  data: Record<string, unknown>; // likely will be a unified CR at some point
+} & DataConnectionAWS;

--- a/frontend/src/pages/projects/utils.ts
+++ b/frontend/src/pages/projects/utils.ts
@@ -4,6 +4,7 @@ import {
   NotebookKind,
   PersistentVolumeClaimKind,
   ProjectKind,
+  SecretKind,
 } from '../../k8sTypes';
 import { ProjectDetailsContext } from './ProjectDetailsContext';
 
@@ -38,3 +39,8 @@ export const getPvcDescription = (pvc: PersistentVolumeClaimKind): string =>
 
 export const getPvcTotalSize = (pvc: PersistentVolumeClaimKind): string =>
   pvc.status?.capacity?.storage || pvc.spec.resources.requests.storage;
+
+export const getSecretDisplayName = (secret: SecretKind): string =>
+  getDisplayNameFromK8sResource(secret);
+export const getSecretDescription = (secret: SecretKind): string =>
+  getDescriptionFromK8sResource(secret);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #491 

## Description
<!--- Describe your changes in detail -->
Adds a data connection list that currently only lists a subset of secrets that are AWS secrets.

Eg:
```
apiVersion: v1
kind: Secret
metadata:
  annotations:
    opendatahub.io/related-notebooks: '["notebook-td8hf5"]' # A notebook I had
  labels:
    opendatahub.io/managed: 'true' # the key search factor for the fetch all
  name: example
  namespace: kube-3aadmin-3djwta # my namespace
type: Opaque
stringData: # nonsense data for example
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: password
  AWS_S3_ENDPOINT: https://s3.amazonaws.com/
  AWS_DEFAULT_REGION: us-east-1
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a Notebook (from the UI), create an AWS Secret (from OpenShift Console -- #670 will cover this on the UI later).

