### PR TITLE
Use the kube config to get the current logged in token

### DIFF
--- a/backend/src/plugins/kube.ts
+++ b/backend/src/plugins/kube.ts
@@ -27,13 +27,6 @@ export default fp(async (fastify: FastifyInstance) => {
     fastify.log.error(e, 'Failed to retrieve current namespace');
   }
 
-  let saToken;
-  try {
-    saToken = await getSAToken();
-  } catch (e) {
-    fastify.log.error(e, 'Failed to retrieve Service Account token');
-  }
-
   let clusterID;
   try {
     const clusterVersion = await customObjectsApi.getClusterCustomObject(
@@ -74,7 +67,6 @@ export default fp(async (fastify: FastifyInstance) => {
     clusterID,
     clusterBranding,
     rbac,
-    saToken,
   });
 
   // Initialize the watching of resources
@@ -98,19 +90,6 @@ const getCurrentNamespace = async () => {
       resolve(process.env.OC_PROJECT);
     } else {
       resolve(currentContext.split('/')[0]);
-    }
-  });
-};
-
-const getSAToken = async () => {
-  return new Promise<string>((resolve, reject) => {
-    if (currentContext === 'inClusterContext') {
-      fs.readFile('/var/run/secrets/kubernetes.io/serviceaccount/token', (err, data) => {
-        if (err) {
-          reject(err);
-        }
-        resolve(String(data));
-      });
     }
   });
 };

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -37,7 +37,9 @@ export const getGPUNumber = async (fastify: KubeFastifyInstance): Promise<GPUInf
     areGpusConfigured = true;
     const gpuDataResponses = [];
     for (let i = 0; i < gpuPodList.items.length; i++) {
-      gpuDataResponses.push(getGPUData(gpuPodList.items[i].status.podIP, fastify.kube.saToken));
+      gpuDataResponses.push(
+        getGPUData(gpuPodList.items[i].status.podIP, fastify.kube.config.getCurrentUser().token),
+      );
     }
 
     await Promise.all(gpuDataResponses).then((gpuDataList) => {

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -38,7 +38,7 @@ export const getGPUNumber = async (fastify: KubeFastifyInstance): Promise<GPUInf
     const gpuDataResponses = [];
     for (let i = 0; i < gpuPodList.items.length; i++) {
       gpuDataResponses.push(
-        getGPUData(gpuPodList.items[i].status.podIP, fastify.kube.config.getCurrentUser().token),
+        getGPUData(gpuPodList.items[i].status.podIP, fastify.kube.currentUser.token),
       );
     }
 

--- a/backend/src/routes/api/status/statusUtils.ts
+++ b/backend/src/routes/api/status/statusUtils.ts
@@ -9,8 +9,7 @@ export const status = async (
   request: FastifyRequest,
 ): Promise<{ kube: KubeStatus }> => {
   const kubeContext = fastify.kube.currentContext;
-  const { currentContext, namespace, currentUser, clusterID, clusterBranding, saToken } =
-    fastify.kube;
+  const { currentContext, namespace, currentUser, clusterID, clusterBranding } = fastify.kube;
 
   const userName = await getUserName(fastify, request);
   const isAdmin = await isUserAdmin(fastify, userName, namespace);
@@ -34,7 +33,6 @@ export const status = async (
         clusterBranding,
         isAdmin,
         isAllowed,
-        saToken,
       },
     };
   }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -185,7 +185,6 @@ export type KubeStatus = {
   clusterBranding: string;
   isAdmin: boolean;
   isAllowed: boolean;
-  saToken: string;
 };
 
 export type KubeDecorator = KubeStatus & {


### PR DESCRIPTION
Fixes a break in `main`. Introduced by #573

Effectively we need the token for whomever is logged in as far as the k8s library is concerned. The PR above sought that out through the direct path to get the service account token -- but this doesn't work for dev and because of the way the Promise was written, it crashes locally in dev mode because the Promise never finishes.