### PR TITLE
Change wrong "Memory requests" text occurences to "Requests" in notebook controller

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
@@ -102,7 +102,7 @@ const NotebookServerDetails: React.FC = () => {
           <DescriptionListDescription>{`${container.resources?.limits?.cpu} CPU, ${container.resources?.limits?.memory} Memory`}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Memory Requests</DescriptionListTerm>
+          <DescriptionListTerm>Requests</DescriptionListTerm>
           <DescriptionListDescription>{`${container.resources?.requests?.cpu} CPU, ${container.resources?.requests?.memory} Memory`}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/frontend/src/pages/notebookController/screens/server/SizeSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SizeSelectField.tsx
@@ -22,7 +22,7 @@ const SizeSelectField: React.FC<SizeSelectFieldProps> = ({ value, setValue, size
       const name = size.name;
       const desc =
         `Limits: ${size.resources.limits?.cpu || '??'} CPU, ` +
-        `${size.resources.limits?.memory || '??'} Memory ` +
+        `${size.resources.limits?.memory || '??'} Memory | ` +
         `Requests: ${size.resources.requests?.cpu || '??'} CPU, ` +
         `${size.resources.requests?.memory || '??'} Memory`;
       return <SelectOption key={name} value={name} description={desc} />;


### PR DESCRIPTION
Resolves: #690

## Description
Changed the "Memory requests" text to "Requests" in launched notebook control panel -> Deployment size details

Added a separator between Limits and Requests in GPU dropdown item descriptions for clarity

## How Has This Been Tested?
Tested locally, examine the edited pages

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
