### PR TITLE
Add a GPU setting to the config to allow more control over the field & it's values

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/GPUSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/GPUSelectField.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FormGroup, Select, SelectOption, Skeleton } from '@patternfly/react-core';
-import { getGPU } from '../../../../services/gpuService';
-import useNotification from '../../../../utilities/useNotification';
+import useGPUSetting from './useGPUSetting';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 type GPUSelectFieldProps = {
   value: string;
@@ -10,82 +10,38 @@ type GPUSelectFieldProps = {
 
 const GPUSelectField: React.FC<GPUSelectFieldProps> = ({ value, setValue }) => {
   const [gpuDropdownOpen, setGpuDropdownOpen] = React.useState<boolean>(false);
-  const [gpuSize, setGpuSize] = React.useState<number>();
-  const [isFetching, setFetching] = React.useState(true);
-  const [areGpusAvailable, setAreGpusAvailable] = React.useState<boolean>(false);
-  const notification = useNotification();
+  const { available, count: gpuSize, loaded, untrustedGPUs } = useGPUSetting();
 
-  React.useEffect(() => {
-    let lastCall = 0;
-    let cancelled = false;
-    const fetchGPU = () => {
-      lastCall = Date.now();
-      return getGPU().then((gpuInfo) => {
-        if (cancelled) return;
-        setGpuSize(gpuInfo.available || 0);
-        setAreGpusAvailable(gpuInfo.configured);
-        setFetching(false);
-        let availableScaleableGPU = 0;
-        if (gpuInfo.autoscalers) {
-          availableScaleableGPU = gpuInfo.autoscalers.reduce(
-            (highestValue, { availableScale, gpuNumber }) =>
-              availableScale > 0 ? Math.max(highestValue, gpuNumber) : highestValue,
-            0,
-          );
-        }
-        if (gpuInfo.available < availableScaleableGPU) {
-          setGpuSize(availableScaleableGPU);
-        }
-      });
-    };
-
-    const errorCatch = (e: Error) => {
-      if (cancelled) return;
-      setFetching(false);
-      setAreGpusAvailable(false);
-      setGpuSize(0);
-      console.error(e);
-      notification.error('Failed to fetch GPU', e.message);
-    };
-
-    fetchGPU().catch(errorCatch);
-
-    const onUserClick = (): void => {
-      const now = Date.now();
-      if (now - lastCall > 60_000) {
-        // User has been idle for a while, let us check on GPUs again
-        fetchGPU().catch(errorCatch);
-      }
-    };
-    if (areGpusAvailable) {
-      window.addEventListener('click', onUserClick);
-    }
-
-    return () => {
-      cancelled = true;
-      window.removeEventListener('click', onUserClick);
-    };
-  }, [notification, areGpusAvailable]);
-
-  if (!areGpusAvailable) {
+  if (!available) {
     return null;
   }
 
   const gpuOptions = gpuSize === undefined ? [] : Array.from(Array(gpuSize + 1).keys());
   const noAvailableGPUs = gpuOptions.length === 1;
 
+  let helpText: string | undefined;
+  let helpTextIcon: React.ReactNode | undefined;
+  if (noAvailableGPUs) {
+    helpText = 'All GPUs are currently in use, try again later.';
+  } else if (untrustedGPUs && value !== '0') {
+    helpText = 'This GPU value has not been verified';
+    helpTextIcon = <ExclamationTriangleIcon />;
+  }
+
   return (
     <FormGroup
       label="Number of GPUs"
       fieldId="modal-notebook-gpu-number"
-      helperText={noAvailableGPUs ? 'All GPUs are currently in use, try again later.' : undefined}
+      helperText={helpText}
+      helperTextIcon={helpTextIcon}
+      validated={untrustedGPUs && value !== '0' ? 'warning' : undefined}
     >
-      {isFetching ? (
+      {!loaded ? (
         <Skeleton height="36px" width="70%" />
       ) : (
         <Select
           data-id="gpu-select"
-          isDisabled={isFetching || noAvailableGPUs}
+          isDisabled={!loaded || noAvailableGPUs}
           isOpen={gpuDropdownOpen}
           onToggle={() => setGpuDropdownOpen(!gpuDropdownOpen)}
           aria-labelledby="gpu-numbers"

--- a/frontend/src/pages/notebookController/screens/server/useGPUSetting.ts
+++ b/frontend/src/pages/notebookController/screens/server/useGPUSetting.ts
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import useNotification from '../../../../utilities/useNotification';
+import { getGPU } from '../../../../services/gpuService';
+import { useAppContext } from '../../../../app/AppContext';
+
+const useGPUSetting = (): {
+  available: boolean;
+  loaded: boolean;
+  count: number;
+  untrustedGPUs: boolean;
+} => {
+  const { dashboardConfig } = useAppContext();
+  const [gpuSize, setGpuSize] = React.useState<number>(0);
+  const [isFetching, setFetching] = React.useState(true);
+  const [areGpusAvailable, setAreGpusAvailable] = React.useState<boolean>(false);
+  const notification = useNotification();
+
+  const setting = dashboardConfig.spec.notebookController?.gpuSetting || 'autodetect';
+  const autodetect = setting === 'autodetect';
+  const hidden = setting === 'hidden';
+  const staticCount = Math.max(parseInt(setting), 0);
+
+  React.useEffect(() => {
+    if (!autodetect && !hidden) {
+      if (staticCount > 0) {
+        setAreGpusAvailable(true);
+        setGpuSize(staticCount);
+        setFetching(false);
+      } else {
+        setAreGpusAvailable(false);
+        setFetching(false);
+      }
+      return;
+    }
+    if (hidden) {
+      setAreGpusAvailable(false);
+      setFetching(false);
+      return;
+    }
+
+    // Auto detect logic
+    let lastCall = 0;
+    let cancelled = false;
+    const fetchGPU = () => {
+      lastCall = Date.now();
+      return getGPU().then((gpuInfo) => {
+        if (cancelled) return;
+        setGpuSize(gpuInfo.available || 0);
+        setAreGpusAvailable(gpuInfo.configured);
+        setFetching(false);
+        let availableScaleableGPU = 0;
+        if (gpuInfo.autoscalers) {
+          availableScaleableGPU = gpuInfo.autoscalers.reduce(
+            (highestValue, { availableScale, gpuNumber }) =>
+              availableScale > 0 ? Math.max(highestValue, gpuNumber) : highestValue,
+            0,
+          );
+        }
+        if (gpuInfo.available < availableScaleableGPU) {
+          setGpuSize(availableScaleableGPU);
+        }
+      });
+    };
+
+    const errorCatch = (e: Error) => {
+      if (cancelled) return;
+      setFetching(false);
+      setAreGpusAvailable(false);
+      setGpuSize(0);
+      console.error(e);
+      notification.error('Failed to fetch GPU', e.message);
+    };
+
+    fetchGPU().catch(errorCatch);
+
+    const onUserClick = (): void => {
+      const now = Date.now();
+      if (now - lastCall > 60_000) {
+        // User has been idle for a while, let us check on GPUs again
+        fetchGPU().catch(errorCatch);
+      }
+    };
+    if (areGpusAvailable) {
+      window.addEventListener('click', onUserClick);
+    }
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('click', onUserClick);
+    };
+  }, [notification, areGpusAvailable, staticCount, autodetect, hidden]);
+
+  return {
+    available: areGpusAvailable,
+    loaded: !isFetching,
+    count: gpuSize,
+    untrustedGPUs: staticCount > 0,
+  };
+};
+
+export default useGPUSetting;

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -25,6 +25,10 @@ export const getNotebookAndStatus = (
     .get(url)
     .then((response) => response.data)
     .catch((e) => {
+      if (e.response.status === 404) {
+        return { notebook, isRunning: false };
+      }
+
       console.error(
         'Checking notebook status failed, falling back on notebook check logic',
         e.response.data.message,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,12 @@
 
 import { EitherNotBoth } from './typeHelpers';
 
+/**
+ * In some YAML configs, we'll need to stringify a number -- this type just helps show it's not
+ * "any string" as a documentation touch point. Has no baring on the type checking.
+ */
+type NumberString = string;
+
 export type DashboardConfig = K8sResourceCommon & {
   spec: {
     dashboardConfig: DashboardCommonConfig;
@@ -16,6 +22,7 @@ export type DashboardConfig = K8sResourceCommon & {
       enabled: boolean;
       pvcSize?: string;
       notebookNamespace?: string;
+      gpuSetting?: 'autodetect' | 'hidden' | NumberString;
       notebookTolerationSettings?: NotebookTolerationSettings;
     };
   };

--- a/manifests/crd/odh-dashboard-crd.yaml
+++ b/manifests/crd/odh-dashboard-crd.yaml
@@ -89,6 +89,9 @@ spec:
                       type: string
                     pvcSize:
                       type: string
+                    gpuSetting:
+                      description: Configure how the GPU field works on the Jupyter tile. One of 'autodetect' (default, fetches for information), 'hidden' (remove the field) or a number-string (eg '5') to specify a hardcoded 0 to that number options
+                      type: string
                     notebookTolerationSettings:
                       type: object
                       properties:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#680 

## Description
<!--- Describe your changes in detail -->

Added `spec.notebookController.gpuSetting`, following are the possible values...
- Autodetect is what we have today
- Hidden is the field is missing
- A number-string "5"; see below for the new functionality

At zero:
![Screen Shot 2022-10-25 at 10 18 25 AM](https://user-images.githubusercontent.com/8126518/197799121-4c3189ae-c861-4d19-99ad-85653a3cbf05.png)

Dropdown goes from 0 to that desired number, in this case the setting was "5"
![image](https://user-images.githubusercontent.com/8126518/197799349-73734213-6da1-4c72-906d-5c72b0124ab8.png)

At any custom number has a warning
![Screen Shot 2022-10-25 at 10 18 19 AM](https://user-images.githubusercontent.com/8126518/197799120-f6d3da7a-d265-4ebb-beb1-ec5a5f550f31.png)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
