### PR TITLE
Support handling pass-through K8sStatus errors in our network flow

### DIFF
--- a/frontend/src/api/errorUtils.ts
+++ b/frontend/src/api/errorUtils.ts
@@ -1,0 +1,14 @@
+import { K8sStatus } from '../k8sTypes';
+
+export const isK8sStatus = (data: unknown): data is K8sStatus =>
+  (data as K8sStatus).kind === 'Status';
+
+export class K8sStatusError extends Error {
+  public statusObject: K8sStatus;
+
+  constructor(statusObject: K8sStatus) {
+    super(statusObject.message);
+
+    this.statusObject = statusObject;
+  }
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -13,3 +13,6 @@ export * from './network/secrets';
 
 // Prometheus queries
 export * from './prometheus/pvcs';
+
+// Network error handling
+export * from './errorUtils';

--- a/frontend/src/api/network/projects.ts
+++ b/frontend/src/api/network/projects.ts
@@ -35,7 +35,7 @@ export const getDSGProjects = (): Promise<ProjectKind[]> => {
 
 export const createProject = (
   username: string,
-  name: string,
+  displayName: string,
   description: string,
   k8sName?: string,
 ): Promise<string> => {
@@ -53,6 +53,8 @@ export const createProject = (
     displayName?: string;
     description?: string;
   };
+
+  const name = k8sName || translateDisplayNameForK8s(displayName);
 
   return k8sCreateResource<ProjectRequestKind, ProjectKind>({
     model: ProjectRequest,

--- a/frontend/src/pages/projects/screens/projects/ManageProjectModal.tsx
+++ b/frontend/src/pages/projects/screens/projects/ManageProjectModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Alert, Button, Form, Modal } from '@patternfly/react-core';
 import { createProject, updateProject } from '../../../../api';
+import { Alert, Button, Form, Modal, Stack, StackItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from '../../../../redux/selectors';
 import { ProjectKind } from '../../../../k8sTypes';
@@ -82,27 +82,33 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({
         </Button>,
       ]}
     >
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit();
-        }}
-      >
-        <NameDescriptionField
-          nameFieldId="manage-project-modal-name"
-          descriptionFieldId="manage-project-modal-description"
-          data={nameDesc}
-          setData={setNameDesc}
-          autoFocusName
-          showK8sName
-          disableK8sName={!!editProjectData}
-        />
-      </Form>
-      {error && (
-        <Alert variant="danger" isInline title="Error creating project">
-          {error.message}
-        </Alert>
-      )}
+      <Stack hasGutter>
+        <StackItem>
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              submit();
+            }}
+          >
+            <NameDescriptionField
+              nameFieldId="manage-project-modal-name"
+              descriptionFieldId="manage-project-modal-description"
+              data={nameDesc}
+              setData={setNameDesc}
+              autoFocusName
+              showK8sName
+              disableK8sName={!!editProjectData}
+            />
+          </Form>
+        </StackItem>
+        {error && (
+          <StackItem>
+            <Alert variant="danger" isInline title="Error creating project">
+              {error.message}
+            </Alert>
+          </StackItem>
+        )}
+      </Stack>
     </Modal>
   );
 };


### PR DESCRIPTION
Resolves: #719

Allows us to handle k8s errors more cleanly. This is needed because the SDK swallows errors and we end up in weird .then cases that don't always pan out.