### PR TITLE
Workbenches don't conflict when sharing a name

### DIFF
--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -50,7 +50,7 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({ notebookSta
           <Switch
             aria-label={label}
             isDisabled={inProgress}
-            id={notebookName}
+            id={`${notebookName}-${notebookNamespace}`}
             isChecked={isChecked}
             onClick={() => {
               if (isRunningOrStarting) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #741 

## Description
<!--- Describe your changes in detail -->
PF still uses IDs for Switches -- workbench name is not unique enough -- combine it with the project name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create two projects with one workbench (both named the same thing).

Test the Project view by turning off the 2nd Workbench.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
