### PR TITLE
[WIP] Add endpoint for moving volumes

### DIFF
--- a/backend/src/routes/api/volumes/index.ts
+++ b/backend/src/routes/api/volumes/index.ts
@@ -1,0 +1,24 @@
+import { FastifyRequest } from 'fastify';
+import { movePVC } from '../../../utils/volumeUtils';
+import { KubeFastifyInstance } from '../../../types';
+import { secureAdminRoute } from '../../../utils/route-security';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.patch(
+    '/',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Body: { name: string; tgtNamespace: string; srcNamespace?: string };
+        }>,
+      ) => {
+        return movePVC(
+          fastify,
+          request.body.name,
+          request.body.tgtNamespace,
+          request.body.srcNamespace,
+        );
+      },
+    ),
+  );
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -571,6 +571,7 @@ export type PersistentVolumeClaimKind = {
     };
     storageClassName?: string;
     volumeMode: 'Filesystem' | 'Block';
+    volumeName: string;
   };
   status?: Record<string, any>;
 };

--- a/backend/src/utils/volumeUtils.ts
+++ b/backend/src/utils/volumeUtils.ts
@@ -1,0 +1,70 @@
+import { PatchUtils } from '@kubernetes/client-node';
+import { KubeFastifyInstance, PersistentVolumeClaimKind } from '../types';
+
+export const movePVC = async (
+  fastify: KubeFastifyInstance,
+  pvcName: string,
+  targetNS: string,
+  sourceNS?: string,
+): Promise<PersistentVolumeClaimKind> => {
+  let namespace = fastify.kube.namespace;
+  if (sourceNS) {
+    namespace = sourceNS;
+  }
+  const PVC = await fastify.kube.coreV1Api
+    .readNamespacedPersistentVolumeClaim(pvcName, namespace)
+    .then((res) => {
+      return res.body as PersistentVolumeClaimKind;
+    });
+  fastify.kube.coreV1Api.patchPersistentVolume(
+    PVC.spec.volumeName,
+    { spec: { persistentVolumeReclaimPolicy: 'Retain' } },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+    },
+  );
+  fastify.kube.coreV1Api.deleteNamespacedPersistentVolumeClaim(pvcName, namespace);
+  fastify.kube.coreV1Api.patchPersistentVolume(
+    PVC.spec.volumeName,
+    { spec: { claimRef: { namespace: targetNS, name: PVC.metadata.name, uid: null } } },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+    },
+  );
+  // Hardcoded timeout to give the PV some time to unbind itself properly
+  await new Promise((f) => setTimeout(f, 500));
+  const copyPVC: PersistentVolumeClaimKind = {
+    apiVersion: PVC.apiVersion,
+    kind: PVC.kind,
+    metadata: {
+      name: pvcName,
+      namespace: targetNS,
+    },
+    spec: PVC.spec,
+  };
+  await fastify.kube.coreV1Api.createNamespacedPersistentVolumeClaim(targetNS, copyPVC);
+  const newPVC = await fastify.kube.coreV1Api.readNamespacedPersistentVolumeClaim(
+    copyPVC.metadata.name,
+    targetNS,
+  );
+  fastify.kube.coreV1Api.patchPersistentVolume(
+    PVC.spec.volumeName,
+    { spec: { claimRef: { uid: newPVC.body.metadata.uid, name: null } } },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+    },
+  );
+  return newPVC.body as PersistentVolumeClaimKind;
+};

--- a/backend/src/utils/volumeUtils.ts
+++ b/backend/src/utils/volumeUtils.ts
@@ -27,6 +27,19 @@ export const movePVC = async (
       headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
     },
   );
+  // DEBUG PATCH, THIS SHOULD BE REMOVED BEFORE MERGING
+  fastify.kube.coreV1Api.patchNamespacedPersistentVolumeClaim(
+    PVC.metadata.name,
+    namespace,
+    { metadata: { finalizers: undefined}},
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+    },
+  );
   fastify.kube.coreV1Api.deleteNamespacedPersistentVolumeClaim(pvcName, namespace);
   fastify.kube.coreV1Api.patchPersistentVolume(
     PVC.spec.volumeName,


### PR DESCRIPTION
Resolves: #603 

## Description
This PR adds a utility function adn an endpoint which allows the dashboard to move PVCs.

Note:
If the PVC has a consumer, even if the dashboard sends a delete command, it will be stuck terminating due to being protected by a finalizer. These have to be deleted manually by patching out the finalizer.
The PV is mostly untouched, but it probably should be documented somewhere that this is a somewhat dangerous operation and data should be backed up just in case.

## How Has This Been Tested?
1. Create a target namespace
2. Send a PATCH request to the `/api/volumes` endpoint with the following body: `{"name": <copied PVC name>, "tgtNamespace": <target Namespace>, "srcNamespace": <source Namespace>}` (srcNamespace is optional, if left out, dashboard namespace is used)
3. The request should return the newly created PVC which is a copy of the previous one, but in the target namespace.
4. Verify that the PVC and PV are correctly bound.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
