### PR TITLE
Handle Model Serving addition cleaner

### DIFF
--- a/frontend/src/SDKInitialize.tsx
+++ b/frontend/src/SDKInitialize.tsx
@@ -14,7 +14,7 @@ const config: React.ComponentProps<typeof AppInitSDK>['configurations'] = {
         return response;
       }
 
-      const result = await response.text();
+      const result = await response.clone().text();
       let data: K8sStatus | unknown;
       try {
         data = JSON.parse(result);

--- a/frontend/src/pages/modelServing/useServingRuntimes.ts
+++ b/frontend/src/pages/modelServing/useServingRuntimes.ts
@@ -21,6 +21,10 @@ const useServingRuntimes = (
         setModelServers(newServingRuntimes);
       })
       .catch((e) => {
+        if (e.statusObject?.code === 404) {
+          setError(new Error('Model serving is not properly configured.'));
+          return;
+        }
         setError(e);
       });
   }, [namespace]);

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -12,6 +12,7 @@ import ServingRuntimeList from '../../../modelServing/screens/projects/ServingRu
 import NotebooksList from './notebooks/NotebookList';
 import { ProjectDetailsContext } from '../../ProjectDetailsContext';
 import { getProjectDescription, getProjectDisplayName } from '../../utils';
+import { featureFlagEnabled } from '../../../../utilities/utils';
 
 type SectionType = {
   id: ProjectSectionID;
@@ -23,7 +24,9 @@ const ProjectDetails: React.FC = () => {
   const displayName = getProjectDisplayName(currentProject);
   const description = getProjectDescription(currentProject);
   const { dashboardConfig } = useAppContext();
-  const modelServingEnabled = !dashboardConfig.spec.dashboardConfig.disableModelServing;
+  const modelServingEnabled = featureFlagEnabled(
+    dashboardConfig.spec.dashboardConfig.disableModelServing,
+  );
 
   const scrollableSelectorID = 'project-details-list';
   const sections: SectionType[] = [

--- a/frontend/src/utilities/NavData.ts
+++ b/frontend/src/utilities/NavData.ts
@@ -1,4 +1,5 @@
 import { DashboardConfig } from '../types';
+import { featureFlagEnabled } from './utils';
 
 type NavDataCommon = {
   id: string;
@@ -31,21 +32,21 @@ const getSettingsNav = (
   if (!isAdmin) return null;
 
   const settingsNavs: NavDataHref[] = [];
-  if (!dashboardConfig.spec.dashboardConfig.disableBYONImageStream)
+  if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableBYONImageStream))
     settingsNavs.push({
       id: 'settings-notebook-images',
       label: 'Notebook Images',
       href: '/notebookImages',
     });
 
-  if (!dashboardConfig.spec.dashboardConfig.disableClusterManager)
+  if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableClusterManager))
     settingsNavs.push({
       id: 'settings-cluster-settings',
       label: 'Cluster settings',
       href: '/clusterSettings',
     });
 
-  if (!dashboardConfig.spec.dashboardConfig.disableUserManagement)
+  if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableUserManagement))
     settingsNavs.push({
       id: 'settings-group-settings',
       label: 'User management',
@@ -76,11 +77,11 @@ export const getNavBarData = (
     ],
   });
 
-  if (!dashboardConfig.spec.dashboardConfig.disableProjects) {
+  if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableProjects)) {
     navItems.push({ id: 'dsg', label: 'Data Science Projects', href: '/projects' });
   }
 
-  if (!dashboardConfig.spec.dashboardConfig.disableModelServing) {
+  if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableModelServing)) {
     navItems.push({ id: 'modelServing', label: 'Model Serving', href: '/modelServing' });
   }
 

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -1,6 +1,13 @@
 import { OdhApplication, OdhDocument, OdhDocumentType } from '../types';
 import { CATEGORY_ANNOTATION, ODH_PRODUCT_NAME } from './const';
 
+/**
+ * Feature flags are required in the config -- but upgrades can be mixed and omission of the property
+ * usually ends up being enabled. This will prevent that as a general utility.
+ */
+export const featureFlagEnabled = (disabledSettingState?: boolean): boolean =>
+  disabledSettingState === false;
+
 export const makeCardVisible = (id: string): void => {
   setTimeout(() => {
     const element = document.getElementById(id);


### PR DESCRIPTION
Resolves: #782

Cleans up the feature flag usage and handles the 404 from k8s api that is missing (such as when model serving is not installed on the cluster but enabled in the dashboard)

When Model Serving is enabled, but not installed... this is the state:
![Screen Shot 2022-11-18 at 12 14 57 PM](https://user-images.githubusercontent.com/8126518/202763146-d3f48199-4c72-451a-8ad1-a58a1903b3a3.png)
![Screen Shot 2022-11-18 at 12 15 02 PM](https://user-images.githubusercontent.com/8126518/202763148-69f4b772-5620-4dd0-ad82-c185bebfe70e.png)
