### PR TITLE
Fix kube sa token

### DIFF
--- a/backend/src/plugins/kube.ts
+++ b/backend/src/plugins/kube.ts
@@ -127,7 +127,7 @@ const getCurrentToken = async (currentUser: User) => {
         resolve(data);
       });
     } else {
-      resolve(currentUser?.token);
+      resolve(currentUser?.token || '');
     }
   });
 };

--- a/backend/src/plugins/kube.ts
+++ b/backend/src/plugins/kube.ts
@@ -119,6 +119,7 @@ const getCurrentToken = async (currentUser: User) => {
       fs.readFile(
         // '/var/run/secrets/kubernetes.io/serviceaccount/token',
         currentUser?.authProvider?.config?.tokenFile,
+        'utf8',
         (err, data) => {
           if (err) {
             reject(err);

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -38,7 +38,7 @@ export const getGPUNumber = async (fastify: KubeFastifyInstance): Promise<GPUInf
     const gpuDataResponses = [];
     for (let i = 0; i < gpuPodList.items.length; i++) {
       gpuDataResponses.push(
-        getGPUData(gpuPodList.items[i].status.podIP, fastify.kube.currentUser.token),
+        getGPUData(gpuPodList.items[i].status.podIP, fastify.kube.currentToken),
       );
     }
 

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -33,7 +33,7 @@ export const getGPUNumber = async (fastify: KubeFastifyInstance): Promise<GPUInf
       return { items: [] } as V1PodList;
     });
   const scalingLimit = await getGPUScaling(fastify);
-  if (gpuPodList.items.length != 0) {
+  if (gpuPodList.items.length != 0 && fastify.kube.currentToken) {
     areGpusConfigured = true;
     const gpuDataResponses = [];
     for (let i = 0; i < gpuPodList.items.length; i++) {

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -76,7 +76,10 @@ export const getGPUData = async (
     const options = {
       hostname: 'thanos-querier.openshift-monitoring.svc.cluster.local',
       port: 9091,
-      path: `/api/v1/query?query=count+(count+by+(UUID,GPU_I_ID)(DCGM_FI_PROF_GR_ENGINE_ACTIVE{instance="${podIP}:9400"})+or+vector(0))-count+(count+by+(UUID,GPU_I_ID)(DCGM_FI_PROF_GR_ENGINE_ACTIVE{instance="${podIP}:9400",exported_pod=~".%2b"})+or+vector(0))`,
+      //Encode the raw prometheus query to remove any need for manual encoding
+      path: encodeURI(
+        `/api/v1/query?query=count (count by (UUID,GPU_I_ID)(DCGM_FI_PROF_GR_ENGINE_ACTIVE{instance="${podIP}:9400"}) or vector(0))-count (count by (UUID,GPU_I_ID)(DCGM_FI_PROF_GR_ENGINE_ACTIVE{instance="${podIP}:9400",exported_pod=~".+"}) or vector(0))`,
+      ),
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -210,6 +210,7 @@ export type KfDefResource = K8sResourceCommon & {
 export type KubeStatus = {
   currentContext: string;
   currentUser: User;
+  currentToken: string;
   namespace: string;
   userName: string | string[];
   clusterID: string;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -210,7 +210,6 @@ export type KfDefResource = K8sResourceCommon & {
 export type KubeStatus = {
   currentContext: string;
   currentUser: User;
-  currentToken: string;
   namespace: string;
   userName: string | string[];
   clusterID: string;
@@ -227,6 +226,7 @@ export type KubeDecorator = KubeStatus & {
   batchV1Api: k8s.BatchV1Api;
   customObjectsApi: k8s.CustomObjectsApi;
   rbac: k8s.RbacAuthorizationV1Api;
+  currentToken: string;
 };
 
 export type KubeFastifyInstance = FastifyInstance & {


### PR DESCRIPTION
## Description
Add support for retrieving the oauth token for the `kube.currentUser` via `kube.currentToken`

## How Has This Been Tested?
- Tested with the local application against a dashboard cluster.  (Requires using the public route for the `thanos-querier` service)
- Built the image and deployed in an OCP cluster with GPU nodes

## Merge criteria:
Dashboard works as intended to spawn notebooks with and without GPU nodes

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
