### PR TITLE
Add image trigger annotation for filling in image-field-value of container. Use imagestream name and tag for JUPYTER_IMAGE

### DIFF
--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -160,7 +160,6 @@ export const assembleNotebook = async (
 
   const notebookSize = getNotebookSize(notebookSizeName);
 
-  let imageUrl = ``;
   let imageSelection = ``;
 
   try {
@@ -168,7 +167,6 @@ export const assembleNotebook = async (
 
     const selectedImage = getImageTag(image, imageTagName);
 
-    imageUrl = `${selectedImage.image?.dockerImageRepo}:${selectedImage.tag?.name}`;
     imageSelection = `${selectedImage.image?.name}:${selectedImage.tag?.name}`;
   } catch (e) {
     fastify.log.error(`Error getting the image for ${imageName}:${imageTagName}`);
@@ -268,6 +266,7 @@ export const assembleNotebook = async (
         'opendatahub.io/username': username,
         'kubeflow-resource-stopped': null,
         'opendatahub.io/accelerator-name': accelerator.accelerator?.metadata.name || '',
+        'image.openshift.io/triggers': `[{"from":{"kind":"ImageStreamTag","name":"${imageSelection}", "namespace":"${namespace}"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"${name}\\")].image"}]`,
       },
       name: name,
       namespace: namespace,
@@ -279,8 +278,8 @@ export const assembleNotebook = async (
           enableServiceLinks: false,
           containers: [
             {
-              image: imageUrl,
-              imagePullPolicy: 'Always',
+              image: name,
+              imagePullPolicy: 'IfNotPresent',
               workingDir: MOUNT_PATH,
               name: name,
               env: [
@@ -295,7 +294,7 @@ export const assembleNotebook = async (
                 },
                 {
                   name: 'JUPYTER_IMAGE',
-                  value: imageUrl,
+                  value: imageSelection,
                 },
                 ...configMapEnvs,
                 ...secretEnvs,

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -92,7 +92,7 @@ export const mockNotebookK8sResource = ({
             ],
             image:
               'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-v1',
-            imagePullPolicy: 'Always',
+            imagePullPolicy: 'IfNotPresent',
             livenessProbe: {
               failureThreshold: 3,
               httpGet: {
@@ -164,7 +164,7 @@ export const mockNotebookK8sResource = ({
             ],
             image:
               'registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46',
-            imagePullPolicy: 'Always',
+            imagePullPolicy: 'IfNotPresent',
             livenessProbe: {
               failureThreshold: 3,
               httpGet: {

--- a/frontend/src/__mocks__/mockPodK8sResource.ts
+++ b/frontend/src/__mocks__/mockPodK8sResource.ts
@@ -202,7 +202,7 @@ export const mockPodK8sResource = ({
         },
         terminationMessagePath: '/dev/termination-log',
         terminationMessagePolicy: 'File',
-        imagePullPolicy: 'Always',
+        imagePullPolicy: 'IfNotPresent',
         securityContext: {
           capabilities: {
             drop: ['ALL'],
@@ -302,7 +302,7 @@ export const mockPodK8sResource = ({
         },
         terminationMessagePath: '/dev/termination-log',
         terminationMessagePolicy: 'File',
-        imagePullPolicy: 'Always',
+        imagePullPolicy: 'IfNotPresent',
         securityContext: {
           capabilities: {
             drop: ['ALL'],

--- a/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
@@ -14,7 +14,7 @@ import {
 import { NotebookContainer } from '~/types';
 import {
   getDescriptionForTag,
-  getImageTagByContainer,
+  getImageAndTagByContainerEnvJupyterImage,
   getNameVersionString,
 } from '~/utilities/imageUtils';
 import { useAppContext } from '~/app/AppContext';
@@ -42,7 +42,7 @@ const NotebookServerDetails: React.FC = () => {
     );
   }
 
-  const { image, tag } = getImageTagByContainer(images, container);
+  const { image, tag } = getImageAndTagByContainerEnvJupyterImage(images, container);
 
   const tagSoftware = getDescriptionForTag(tag);
   const tagDependencies = tag?.content.dependencies ?? [];

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -25,7 +25,10 @@ const useNotebookImageData = (
     const container: NotebookContainer | undefined = notebook.spec.template.spec.containers.find(
       (container) => container.name === notebook.metadata.name,
     );
-    const imageTag = container?.image.split('/').at(-1)?.split(':');
+
+    const imageStreamTagAndName =
+      container?.env?.find((i) => i?.name === 'JUPYTER_IMAGE')?.value ?? '';
+    const imageTag = imageStreamTagAndName.toString().split('/').at(-1)?.split(':');
 
     if (!imageTag || imageTag.length < 2 || !container) {
       return [null, true];

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -16,6 +16,7 @@ import {
   DataConnectionData,
 } from '~/pages/projects/types';
 import { useUser } from '~/redux/selectors';
+import { useDashboardNamespace } from '~/redux/selectors';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { AppContext } from '~/app/AppContext';
 import { fireTrackingEvent } from '~/utilities/segmentIOUtils';
@@ -61,6 +62,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   );
   const editNotebook = notebookState?.notebook;
   const { projectName } = startNotebookData;
+  const { dashboardNamespace } = useDashboardNamespace();
   const navigate = useNavigate();
   const [createInProgress, setCreateInProgress] = React.useState(false);
   const isButtonDisabled =
@@ -154,7 +156,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
         envFrom,
         tolerationSettings,
       };
-      updateNotebook(editNotebook, newStartNotebookData, username)
+      updateNotebook(editNotebook, newStartNotebookData, username, dashboardNamespace)
         .then((notebook) => afterStart(notebook.metadata.name, 'updated'))
         .catch(handleError);
     }
@@ -212,7 +214,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       tolerationSettings,
     };
 
-    createNotebook(newStartData, username, canEnablePipelines)
+    createNotebook(newStartData, username, dashboardNamespace, canEnablePipelines)
       .then((notebook) => afterStart(notebook.metadata.name, 'created'))
       .catch(handleError);
   };

--- a/frontend/src/utilities/imageUtils.ts
+++ b/frontend/src/utilities/imageUtils.ts
@@ -151,11 +151,14 @@ export const getDescriptionForTag = (imageTag?: ImageTagInfo): string => {
   return softwareDescriptions.join(', ');
 };
 
-export const getImageTagByContainer = (
+export const getImageAndTagByContainerEnvJupyterImage = (
   images: ImageInfo[],
   container?: NotebookContainer,
 ): ImageTag => {
-  const imageTag = container?.image.split('/').at(-1)?.split(':');
+  const imageStreamTagAndName =
+    container?.env?.find((i) => i?.name === 'JUPYTER_IMAGE')?.value ?? '';
+  const imageTag = imageStreamTagAndName.toString().split('/').at(-1)?.split(':');
+
   if (!imageTag || imageTag.length < 2) {
     return { image: undefined, tag: undefined };
   }

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: odh-dashboard
         image: odh-dashboard
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
but not for Notebook container image ref

achieving independence from the internal openshift docker registry in handling images in conjunction with imagestreams.
See https://itnext.io/variations-on-imagestreams-in-openshift-4-f8ee5e8be633 for background. 

Jupyter uses referencepolicy type: Source, making an internal openshift image repo unneccessary.
However, the internal openshift repo can be used, just via imagestream name and tag, not via direct reference of the image location in the internal openshift docker repo.

to be tested in conjunction with [Kubeflow notebook controller PR-133](https://github.com/opendatahub-io/kubeflow/pull/133/files)

<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes #792 #813 #1340

no dependency on dockerImageRepository field of ImageStream in imageUrl variable, thereby no dependency on internal Docker registry when spawning images that are coming from an imageStream. 

Also, now, the image: field of Notebook spec has the combination of image name derived from imagestream name plus imagestream tag value (imageSelection variable).

The Notebook annotation `notebooks.opendatahub.io/last-image-selection` https://github.com/opendatahub-io/odh-dashboard/blob/main/backend/src/utils/notebookUtils.ts#L266, keeps the imageSelection variable, that is referencing imagestream name plus tag value.

With imagestreams, be they spec.tags.referencePolicy type Source (external) or Local (internal openshift registry), we can use the imagestream tag and name to reference the image, wherever it may be. So, we use the imageSelection variable in the container image-field.

That is so because spec.lookupPolicy.local is set to true, it is thus absolutely ok to reference the image stream name directly for any image: field of a container, as long as the ImageStream is in the same namespace as the dashboard and controller, which it is.

Even for the DSG feature in which you spawn Notebooks in different namespaces, you are already covering that correctly with[ system:image-puller](https://github.com/opendatahub-io/odh-dashboard/blob/c683fef35416e65d974711476e6b0396eceae673/frontend/src/utilities/notebookControllerUtils.ts#L159), making it even more logical _not_ to reference from the internal docker repo location in the image field of the notebook.

Image-field fill-in happens on StatefulSet creation via metadata annotation and image policy admission plugin of openshift. Image-field can either initially be set empty or even be left out completely, tested with StatefulSet outside of notebook controller context. 

Also, for JUPYTER_IMAGE env variable, I am using the value of imagestreammetadata.name:imgestreamtag / variable imageUrl, that is, the original location in the source repo. That is the only location where I could think of a direct image reference being useful, but I have not gotten any response on how JUPYTER_IMAGE is used in RHOSDS.

Do not merge until [changes in notebook controller reconciliation logic ](https://github.com/kubeflow/kubeflow/issues/6829)have been implemented.

## How Has This Been Tested?
Would like to test this with a sample docker image someone would provide. In an Openshift environment that does NOT have an internal openshift docker registry. Need assistence from odh-dashboard developers.

@andrewballantyne Would like to test how the Notebook CR is created with the latest changes. Coordination via slack. It will not lead to a working pod deployment, but I want to check the status of Notebook CR instance in a notebook namespace that is != dashboard namespace.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
