### PR TITLE
Add faker for the pass through api to enable regular user testing

### DIFF
--- a/backend/src/devFlags.ts
+++ b/backend/src/devFlags.ts
@@ -1,9 +1,10 @@
 import { DEV_MODE } from './utils/constants';
 
-let impersonating = false;
+let accessToken = '';
 
-export const setImpersonate = (impersonate: boolean): void => {
-  impersonating = impersonate;
+export const setImpersonateAccessToken = (token?: string): void => {
+  accessToken = token || '';
 };
 
-export const isImpersonating = (): boolean => (DEV_MODE ? impersonating : false);
+export const isImpersonating = (): boolean => accessToken !== '';
+export const getImpersonateAccessToken = (): string => (DEV_MODE ? accessToken : '');

--- a/backend/src/devFlags.ts
+++ b/backend/src/devFlags.ts
@@ -1,0 +1,7 @@
+let impersonating = false;
+
+export const setImpersonate = (impersonate: boolean): void => {
+  impersonating = impersonate || false;
+};
+
+export const isImpersonating = (): boolean => impersonating;

--- a/backend/src/devFlags.ts
+++ b/backend/src/devFlags.ts
@@ -1,7 +1,9 @@
+import { DEV_MODE } from './utils/constants';
+
 let impersonating = false;
 
 export const setImpersonate = (impersonate: boolean): void => {
-  impersonating = impersonate || false;
+  impersonating = impersonate;
 };
 
-export const isImpersonating = (): boolean => impersonating;
+export const isImpersonating = (): boolean => (DEV_MODE ? impersonating : false);

--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -70,7 +70,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         if (e?.code) {
           throw createCustomError(
             'Error impersonating user',
-            e.response || 'Impersonating user error',
+            e.response?.message || 'Impersonating user error',
             e.code,
           );
         }

--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance, FastifyRequest } from 'fastify';
+import { setImpersonate } from '../../../devFlags';
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  fastify.post('/', async (request: FastifyRequest<{ Body: { impersonate: boolean } }>) => {
+    setImpersonate(request.body.impersonate);
+    return null;
+  });
+};

--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -1,9 +1,51 @@
-import { FastifyInstance, FastifyRequest } from 'fastify';
-import { setImpersonate } from '../../../devFlags';
+import { FastifyRequest } from 'fastify';
+import https from 'https';
+import { setImpersonateAccessToken } from '../../../devFlags';
+import { KubeFastifyInstance } from '../../../types';
+import { DEV_IMPERSONATE_PASSWORD, DEV_IMPERSONATE_USER } from '../../../utils/constants';
+import { devRoute } from '../../../utils/route-security';
 
-export default async (fastify: FastifyInstance): Promise<void> => {
-  fastify.post('/', async (request: FastifyRequest<{ Body: { impersonate: boolean } }>) => {
-    setImpersonate(request.body.impersonate);
-    return null;
-  });
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.post(
+    '/',
+    devRoute(async (request: FastifyRequest<{ Body: { impersonate: boolean } }>) => {
+      const doImpersonate = request.body.impersonate;
+      if (doImpersonate) {
+        const apiPath = fastify.kube.config.getCurrentCluster().server;
+        const namedHost = apiPath.slice('https://api.'.length).split(':')[0];
+        const url = `https://oauth-openshift.apps.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
+        https
+          .get(
+            url,
+            {
+              headers: {
+                Authorization: `Basic ${Buffer.from(
+                  `${DEV_IMPERSONATE_USER}:${DEV_IMPERSONATE_PASSWORD}`,
+                ).toString('base64')}`,
+              },
+            },
+            (res) => {
+              // 302 Found means the success of this call
+              if (res.statusCode === 302) {
+                /**
+                 * we will get the location in the headers like:
+                 * https://oauth-openshift.apps.juntwang.dev.datahub.redhat.com/oauth/token/implicit#access_token={ACCESS_TOKEN_WE_WANT}
+                 * &expires_in=86400&scope=user%3Afull&token_type=Bearer
+                 */
+                const accessToken = res.headers.location.split('access_token=')[1]?.split('&')[0];
+                setImpersonateAccessToken(accessToken);
+              } else {
+                setImpersonateAccessToken('');
+              }
+            },
+          )
+          .on('error', () => {
+            setImpersonateAccessToken('');
+          });
+      } else {
+        setImpersonateAccessToken('');
+      }
+      return null;
+    }),
+  );
 };

--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -1,51 +1,81 @@
 import { FastifyRequest } from 'fastify';
 import https from 'https';
+import createError from 'http-errors';
 import { setImpersonateAccessToken } from '../../../devFlags';
 import { KubeFastifyInstance } from '../../../types';
 import { DEV_IMPERSONATE_PASSWORD, DEV_IMPERSONATE_USER } from '../../../utils/constants';
+import { createCustomError } from '../../../utils/requestUtils';
 import { devRoute } from '../../../utils/route-security';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   fastify.post(
     '/',
     devRoute(async (request: FastifyRequest<{ Body: { impersonate: boolean } }>) => {
-      const doImpersonate = request.body.impersonate;
-      if (doImpersonate) {
-        const apiPath = fastify.kube.config.getCurrentCluster().server;
-        const namedHost = apiPath.slice('https://api.'.length).split(':')[0];
-        const url = `https://oauth-openshift.apps.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
-        https
-          .get(
-            url,
-            {
-              headers: {
-                Authorization: `Basic ${Buffer.from(
-                  `${DEV_IMPERSONATE_USER}:${DEV_IMPERSONATE_PASSWORD}`,
-                ).toString('base64')}`,
+      return new Promise<{ code: number; response: string }>((resolve, reject) => {
+        const doImpersonate = request.body.impersonate;
+        if (doImpersonate) {
+          const apiPath = fastify.kube.config.getCurrentCluster().server;
+          const namedHost = apiPath.slice('https://api.'.length).split(':')[0];
+          const url = `https://oauth-openshift.apps.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
+          const httpsRequest = https
+            .get(
+              url,
+              {
+                headers: {
+                  Authorization: `Basic ${Buffer.from(
+                    `${DEV_IMPERSONATE_USER}:${DEV_IMPERSONATE_PASSWORD}`,
+                  ).toString('base64')}`,
+                },
               },
-            },
-            (res) => {
-              // 302 Found means the success of this call
-              if (res.statusCode === 302) {
-                /**
-                 * we will get the location in the headers like:
-                 * https://oauth-openshift.apps.juntwang.dev.datahub.redhat.com/oauth/token/implicit#access_token={ACCESS_TOKEN_WE_WANT}
-                 * &expires_in=86400&scope=user%3Afull&token_type=Bearer
-                 */
-                const accessToken = res.headers.location.split('access_token=')[1]?.split('&')[0];
-                setImpersonateAccessToken(accessToken);
-              } else {
-                setImpersonateAccessToken('');
-              }
-            },
-          )
-          .on('error', () => {
-            setImpersonateAccessToken('');
-          });
-      } else {
-        setImpersonateAccessToken('');
-      }
-      return null;
+              (res) => {
+                // 302 Found means the success of this call
+                if (res.statusCode === 302) {
+                  /**
+                   * we will get the location in the headers like:
+                   * https://oauth-openshift.apps.juntwang.dev.datahub.redhat.com/oauth/token/implicit#access_token={ACCESS_TOKEN_WE_WANT}
+                   * &expires_in=86400&scope=user%3Afull&token_type=Bearer
+                   */
+                  const searchParams = new URLSearchParams(res.headers.location.split('#')[1]);
+                  const accessToken = searchParams.get('access_token');
+                  if (accessToken) {
+                    setImpersonateAccessToken(accessToken);
+                    resolve({ code: 200, response: accessToken });
+                  } else {
+                    reject({
+                      code: 500,
+                      response: 'Cannot fetch the impersonate token from the server.',
+                    });
+                  }
+                } else {
+                  reject({
+                    code: 403,
+                    response:
+                      'Authorization error, please check the username and password in your local env file.',
+                  });
+                }
+              },
+            )
+            .on('error', () => {
+              reject({
+                code: 500,
+                response: 'There are some errors on the server, please try again later.',
+              });
+            });
+          httpsRequest.end();
+        } else {
+          setImpersonateAccessToken('');
+          resolve({ code: 200, response: '' });
+        }
+      }).catch((e: createError.HttpError) => {
+        if (e?.code) {
+          throw createCustomError(
+            'Error impersonating user',
+            e.response || 'Impersonating user error',
+            e.code,
+          );
+        }
+        throw e;
+      });
     }),
   );
 };

--- a/backend/src/routes/api/status/statusUtils.ts
+++ b/backend/src/routes/api/status/statusUtils.ts
@@ -3,6 +3,8 @@ import { KubeFastifyInstance, KubeStatus } from '../../../types';
 import { getUserName } from '../../../utils/userUtils';
 import { createCustomError } from '../../../utils/requestUtils';
 import { isUserAdmin, isUserAllowed } from '../../../utils/adminUtils';
+import { DEV_MODE } from '../../../utils/constants';
+import { isImpersonating } from '../../../devFlags';
 
 export const status = async (
   fastify: KubeFastifyInstance,
@@ -16,6 +18,7 @@ export const status = async (
   const userName = await getUserName(fastify, request);
   const isAdmin = await isUserAdmin(fastify, userName, namespace);
   const isAllowed = isAdmin ? true : await isUserAllowed(fastify, userName);
+  const impersonating = DEV_MODE ? isImpersonating() : undefined;
 
   if (!kubeContext && !kubeContext.trim()) {
     const error = createCustomError(
@@ -36,6 +39,7 @@ export const status = async (
         isAdmin,
         isAllowed,
         serverURL: server,
+        isImpersonating: impersonating,
       },
     };
   }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -218,6 +218,7 @@ export type KubeStatus = {
   isAdmin: boolean;
   isAllowed: boolean;
   serverURL: string;
+  isImpersonating?: boolean;
 };
 
 export type KubeDecorator = KubeStatus & {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -7,6 +7,8 @@ export const IP = process.env.IP || '0.0.0.0';
 export const LOG_LEVEL = process.env.FASTIFY_LOG_LEVEL || process.env.LOG_LEVEL || 'info';
 export const LOG_DIR = path.join(__dirname, '../../../logs');
 export const DEV_MODE = process.env.APP_ENV === 'development';
+/** Allows a user token to be used in place of the actual token for testing purposes */
+export const DEV_TOKEN_AUTH =  DEV_MODE ? process.env.DEV_TOKEN_AUTH : undefined;
 export const APP_ENV = process.env.APP_ENV;
 
 export const USER_ACCESS_TOKEN = 'x-forwarded-access-token';

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const LOG_DIR = path.join(__dirname, '../../../logs');
 export const DEV_MODE = process.env.APP_ENV === 'development';
 /** Allows a username to be impersonated in place of the logged in user for testing purposes -- impacts only some API */
 export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
+export const DEV_IMPERSONATE_PASSWORD = DEV_MODE ? process.env.DEV_IMPERSONATE_PASSWORD : undefined;
 export const APP_ENV = process.env.APP_ENV;
 
 export const USER_ACCESS_TOKEN = 'x-forwarded-access-token';

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -7,7 +7,7 @@ export const IP = process.env.IP || '0.0.0.0';
 export const LOG_LEVEL = process.env.FASTIFY_LOG_LEVEL || process.env.LOG_LEVEL || 'info';
 export const LOG_DIR = path.join(__dirname, '../../../logs');
 export const DEV_MODE = process.env.APP_ENV === 'development';
-/** Allows a user token to be used in place of the actual token for testing purposes */
+/** Allows a username to be impersonated in place of the logged in user for testing purposes -- impacts only some API */
 export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 export const APP_ENV = process.env.APP_ENV;
 

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -8,7 +8,7 @@ export const LOG_LEVEL = process.env.FASTIFY_LOG_LEVEL || process.env.LOG_LEVEL 
 export const LOG_DIR = path.join(__dirname, '../../../logs');
 export const DEV_MODE = process.env.APP_ENV === 'development';
 /** Allows a user token to be used in place of the actual token for testing purposes */
-export const DEV_TOKEN_AUTH =  DEV_MODE ? process.env.DEV_TOKEN_AUTH : undefined;
+export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 export const APP_ENV = process.env.APP_ENV;
 
 export const USER_ACCESS_TOKEN = 'x-forwarded-access-token';

--- a/backend/src/utils/directCallUtils.ts
+++ b/backend/src/utils/directCallUtils.ts
@@ -1,6 +1,7 @@
 import { RequestOptions } from 'https';
-import { DEV_MODE, DEV_TOKEN_AUTH, USER_ACCESS_TOKEN } from './constants';
+import { DEV_IMPERSONATE_USER, DEV_MODE, USER_ACCESS_TOKEN } from './constants';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
+import { isImpersonating } from '../devFlags';
 
 export const getDirectCallOptions = async (
   fastify: KubeFastifyInstance,
@@ -19,10 +20,16 @@ export const getDirectCallOptions = async (
     // In dev mode, we always are logged in fully -- no service accounts
     headers = kubeHeaders;
     // Fakes the call as another user to test permissions
-    if (DEV_TOKEN_AUTH) {
+    // if (DEV_TOKEN_AUTH) {
+    //   headers = {
+    //     ...headers,
+    //     Authorization: `Bearer ${DEV_TOKEN_AUTH}`,
+    //   };
+    // }
+    if (isImpersonating()) {
       headers = {
         ...headers,
-        Authorization: `Bearer ${DEV_TOKEN_AUTH}`,
+        'Impersonate-User': DEV_IMPERSONATE_USER,
       };
     }
   } else {

--- a/backend/src/utils/directCallUtils.ts
+++ b/backend/src/utils/directCallUtils.ts
@@ -20,17 +20,8 @@ export const getDirectCallOptions = async (
     // In dev mode, we always are logged in fully -- no service accounts
     headers = kubeHeaders;
     // Fakes the call as another user to test permissions
-    // if (DEV_TOKEN_AUTH) {
-    //   headers = {
-    //     ...headers,
-    //     Authorization: `Bearer ${DEV_TOKEN_AUTH}`,
-    //   };
-    // }
     if (isImpersonating()) {
-      headers = {
-        ...headers,
-        'Impersonate-User': DEV_IMPERSONATE_USER,
-      };
+      headers['Impersonate-User'] = DEV_IMPERSONATE_USER;
     }
   } else {
     // When not in dev mode, we want to switch the token from the service account to the user

--- a/backend/src/utils/directCallUtils.ts
+++ b/backend/src/utils/directCallUtils.ts
@@ -1,5 +1,5 @@
 import { RequestOptions } from 'https';
-import { DEV_MODE, USER_ACCESS_TOKEN } from './constants';
+import { DEV_MODE, DEV_TOKEN_AUTH, USER_ACCESS_TOKEN } from './constants';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
 
 export const getDirectCallOptions = async (
@@ -18,6 +18,13 @@ export const getDirectCallOptions = async (
   if (DEV_MODE) {
     // In dev mode, we always are logged in fully -- no service accounts
     headers = kubeHeaders;
+    // Fakes the call as another user to test permissions
+    if (DEV_TOKEN_AUTH) {
+      headers = {
+        ...headers,
+        Authorization: `Bearer ${DEV_TOKEN_AUTH}`,
+      };
+    }
   } else {
     // When not in dev mode, we want to switch the token from the service account to the user
     const accessToken = request.headers[USER_ACCESS_TOKEN];

--- a/backend/src/utils/directCallUtils.ts
+++ b/backend/src/utils/directCallUtils.ts
@@ -20,7 +20,9 @@ export const getDirectCallOptions = async (
     // In dev mode, we always are logged in fully -- no service accounts
     headers = kubeHeaders;
     // Fakes the call as another user to test permissions
-    if (isImpersonating()) {
+    if (isImpersonating() && !url.includes('thanos-querier-openshift-monitoring')) {
+      // We are impersonating an endpoint that is not thanos -- use the token from the impersonated user
+      // Thanos Querier does not grant basic user access on external routes
       headers = {
         ...kubeHeaders,
         Authorization: `Bearer ${getImpersonateAccessToken()}`,

--- a/backend/src/utils/directCallUtils.ts
+++ b/backend/src/utils/directCallUtils.ts
@@ -1,7 +1,7 @@
 import { RequestOptions } from 'https';
-import { DEV_IMPERSONATE_USER, DEV_MODE, USER_ACCESS_TOKEN } from './constants';
+import { DEV_MODE, USER_ACCESS_TOKEN } from './constants';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
-import { isImpersonating } from '../devFlags';
+import { getImpersonateAccessToken, isImpersonating } from '../devFlags';
 
 export const getDirectCallOptions = async (
   fastify: KubeFastifyInstance,
@@ -21,7 +21,10 @@ export const getDirectCallOptions = async (
     headers = kubeHeaders;
     // Fakes the call as another user to test permissions
     if (isImpersonating()) {
-      headers['Impersonate-User'] = DEV_IMPERSONATE_USER;
+      headers = {
+        ...kubeHeaders,
+        Authorization: `Bearer ${getImpersonateAccessToken()}`,
+      };
     }
   } else {
     // When not in dev mode, we want to switch the token from the service account to the user

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -11,6 +11,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { isUserAdmin } from './adminUtils';
 import { getNamespaces } from './notebookUtils';
 import { logRequestDetails } from './fileUtils';
+import { DEV_MODE } from './constants';
 
 const testAdmin = async (
   fastify: KubeFastifyInstance,
@@ -221,3 +222,15 @@ export const secureRoute =
  */
 export const secureAdminRoute = (fastify: KubeFastifyInstance): ReturnType<typeof secureRoute> =>
   secureRoute(fastify, true);
+
+/**
+ * Make sure the route can only be called in DEV MODE
+ */
+export const devRoute =
+  <T>(requestCall: (request: FastifyRequest, reply: FastifyReply) => Promise<T>) =>
+  async (request: OauthFastifyRequest, reply: FastifyReply): Promise<T> => {
+    if (!DEV_MODE) {
+      throw createCustomError('404 Endpoint Not Found', 'Not Found', 404);
+    }
+    return requestCall(request, reply);
+  };

--- a/backend/src/utils/userUtils.ts
+++ b/backend/src/utils/userUtils.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 import * as _ from 'lodash';
-import { USER_ACCESS_TOKEN } from './constants';
+import { DEV_TOKEN_AUTH, USER_ACCESS_TOKEN } from './constants';
 import { KubeFastifyInstance } from '../types';
 import { DEV_MODE } from './constants';
 import { createCustomError } from './requestUtils';
@@ -55,14 +55,18 @@ export const getUser = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest,
 ): Promise<OpenShiftUser> => {
-  const accessToken = request.headers[USER_ACCESS_TOKEN] as string;
+  let accessToken = request.headers[USER_ACCESS_TOKEN] as string;
   if (!accessToken) {
-    const error = createCustomError(
-      'Unauthorized',
-      `Error, missing x-forwarded-access-token header`,
-      401,
-    );
-    throw error;
+    if(DEV_TOKEN_AUTH){
+      accessToken = DEV_TOKEN_AUTH;
+    } else {
+      const error = createCustomError(
+        'Unauthorized',
+        `Error, missing x-forwarded-access-token header`,
+        401,
+      );
+      throw error;
+    }
   }
   try {
     const customObjectApiNoAuth = _.cloneDeep(fastify.kube.customObjectsApi);

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -38,12 +38,14 @@ See the [k8s pass through API](../backend/src/routes/api/k8s/pass-through.ts) he
 
 ### Pass Through Impersonate User Dev Mode
 
-In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add the `DEV_IMPERSONATE_USER` environment variable to your local setup with a valid k8s username in your cluster. This will bypass the regular pass-through flow and will add that specific headers to the calls. The steps to impersonate another user are listed as follows:
+In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add the `DEV_IMPERSONATE_USER` and `DEV_IMPERSONATE_PASSWORD` environment variables to your local setup with valid k8s username and password in your cluster. This will bypass the regular pass-through flow and will add that specific headers to the calls. The steps to impersonate another user are listed as follows:
 
-1. Create a new env variable in your `.env.local` file with this format `DEV_IMPERSONATE_USER=<username>`
+1. Create a new env variable in your `.env.local` file with this format `DEV_IMPERSONATE_USER=<username>` and `DEV_IMPERSONATE_PASSWORD=<password>` 
 2. Run the dev server for ODH dashboard. If you don't know how to run a local dev server, please refer to [CONTRIBUTING](../CONTRIBUTING.md) 
 3. Click on the username on the top right corner to open the dropdown menu, and choose `Start impersonate`, then the page will refresh and you will be impersonating as the user you set up in step 1
 4. To stop impersonating, click on the `Stop impersonate` button in the header toolbar
+
+If you cannot enter impersonating mode, you may check your username and password in the local env file to see if they are set correctly.
 
 ## Patches
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -45,7 +45,7 @@ In order to check regular user permissions without disabling the rest of the bac
 3. Click on the username on the top right corner to open the dropdown menu, and choose `Start impersonate`, then the page will refresh and you will be impersonating as the user you set up in step 1
 4. To stop impersonating, click on the `Stop impersonate` button in the header toolbar
 
-If you cannot enter impersonating mode, you may check your username and password in the local env file to see if they are set correctly.
+NOTE: You may not be able to read data from some Prometheus applications when impersonating another user. In the DEV_MODE, we use the external route to fetch Prometheus data, and the route might connect to a target port that's not accessible by a regular user even if the bearer token is set. To validate that, you may need to deploy the image to the cluster.
 
 ## Patches
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -36,6 +36,15 @@ We have set up a pass through API that will effectively take the path built by t
 
 See the [k8s pass through API](../backend/src/routes/api/k8s/pass-through.ts) here.
 
+### Pass Through Faker Token Dev Mode
+
+In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add the `DEV_TOKEN_AUTH` environment variable to your local setup with a valid k8s token for user in your cluster. This will bypass the regular pass-through flow and will add that specific token to the calls. The steps to obtain this token will be:
+
+1. Log in in your OpenShift cluster with the user you want to obtain the token.
+2. Click in the your username in the right corner of the console > *Copy login command*
+3. Copy the login command, should have the following format `sha256~<token>`
+4. Create a new env variable in your `.env.local` file with this format `DEV_TOKEN_AUTH=sha256~<token>`
+
 ## Patches
 
 Patches are based on [jsonpatch](https://jsonpatch.com/). For those who are unaware of the details let's do a quick breakdown on how they work. When making a `k8sPatchResource` call, it will ask for `Patches[]`. A `Patch` is just simply a straight forward operation on the existing resource.

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -36,14 +36,14 @@ We have set up a pass through API that will effectively take the path built by t
 
 See the [k8s pass through API](../backend/src/routes/api/k8s/pass-through.ts) here.
 
-### Pass Through Faker Token Dev Mode
+### Pass Through Impersonate User Dev Mode
 
-In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add the `DEV_TOKEN_AUTH` environment variable to your local setup with a valid k8s token for user in your cluster. This will bypass the regular pass-through flow and will add that specific token to the calls. The steps to obtain this token will be:
+In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add the `DEV_IMPERSONATE_USER` environment variable to your local setup with a valid k8s username in your cluster. This will bypass the regular pass-through flow and will add that specific headers to the calls. The steps to impersonate another user are listed as follows:
 
-1. Log in in your OpenShift cluster with the user you want to obtain the token.
-2. Click in the your username in the right corner of the console > *Copy login command*
-3. Copy the login command, should have the following format `sha256~<token>`
-4. Create a new env variable in your `.env.local` file with this format `DEV_TOKEN_AUTH=sha256~<token>`
+1. Create a new env variable in your `.env.local` file with this format `DEV_IMPERSONATE_USER=<username>`
+2. Run the dev server for ODH dashboard. If you don't know how to run a local dev server, please refer to [CONTRIBUTING](../CONTRIBUTING.md) 
+3. Click on the username on the top right corner to open the dropdown menu, and choose `Start impersonate`, then the page will refresh and you will be impersonating as the user you set up in step 1
+4. To stop impersonating, click on the `Stop impersonate` button in the header toolbar
 
 ## Patches
 

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -13,14 +13,9 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, QuestionCircleIcon } from '@patternfly/react-icons';
-import {
-  COMMUNITY_LINK,
-  DOC_LINK,
-  SUPPORT_LINK,
-  DEV_MODE,
-  DEV_IMPERSONATE_USER,
-} from '~/utilities/const';
+import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK, DEV_MODE } from '~/utilities/const';
 import useNotification from '~/utilities/useNotification';
+import { updateImpersonateSettings } from '~/services/impersonateService';
 import { AppNotification } from '~/redux/types';
 import { useAppSelector } from '~/redux/hooks';
 import AppLauncher from './AppLauncher';
@@ -65,14 +60,9 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
       <DropdownItem
         key="impersonate"
         onClick={() => {
-          if (!DEV_IMPERSONATE_USER) {
-            notification.error(
-              'Cannot impersonate user',
-              'Please check your .env or .env.local file to make sure you set DEV_IMPERSONATE_USER to the username you want to impersonate.',
-            );
-          } else {
-            updateImpersonateSettings(true).then(() => location.reload());
-          }
+          updateImpersonateSettings(true)
+            .then(() => location.reload())
+            .catch((e) => notification.error('Failed impersonating user', e.message));
         }}
       >
         Start impersonate
@@ -171,7 +161,11 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
               position="bottom"
             >
               <Button
-                onClick={() => updateImpersonateSettings(false).then(() => location.reload())}
+                onClick={() =>
+                  updateImpersonateSettings(false)
+                    .then(() => location.reload())
+                    .catch((e) => notification.error('Failed stopping impersonating', e.message))
+                }
               >
                 Stop impersonate
               </Button>

--- a/frontend/src/redux/actions/actions.ts
+++ b/frontend/src/redux/actions/actions.ts
@@ -17,6 +17,7 @@ export const getUserFulfilled = (response: {
     isAdmin: boolean;
     isAllowed: boolean;
     namespace: string;
+    isImpersonating?: boolean;
   };
 }): GetUserAction => ({
   type: Actions.GET_USER_FULFILLED,
@@ -27,6 +28,7 @@ export const getUserFulfilled = (response: {
     isAdmin: response.kube.isAdmin,
     isAllowed: response.kube.isAllowed,
     dashboardNamespace: response.kube.namespace,
+    isImpersonating: response.kube.isImpersonating,
   },
 });
 

--- a/frontend/src/redux/reducers/appReducer.ts
+++ b/frontend/src/redux/reducers/appReducer.ts
@@ -30,6 +30,7 @@ const appReducer = (state: AppState = initialState, action: GetUserAction): AppS
         isAdmin: action.payload.isAdmin,
         isAllowed: action.payload.isAllowed,
         dashboardNamespace: action.payload.dashboardNamespace,
+        isImpersonating: action.payload.isImpersonating,
       };
     case Actions.GET_USER_REJECTED:
       return {

--- a/frontend/src/redux/types.ts
+++ b/frontend/src/redux/types.ts
@@ -33,6 +33,7 @@ export interface GetUserAction {
     isAllowed?: boolean;
     error?: Error | null;
     notification?: AppNotification;
+    isImpersonating?: boolean;
   };
 }
 
@@ -42,6 +43,7 @@ export type AppState = {
   user?: string;
   userLoading: boolean;
   userError?: Error | null;
+  isImpersonating?: boolean;
 
   clusterID?: string;
   clusterBranding?: string;

--- a/frontend/src/services/impersonateService.ts
+++ b/frontend/src/services/impersonateService.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export const updateImpersonateSettings = (impersonate: boolean): Promise<void> => {
+  const url = '/api/dev-impersonate';
+  return axios
+    .post(url, { impersonate })
+    .then((response) => {
+      return response.data;
+    })
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};

--- a/frontend/src/services/impersonateService.ts
+++ b/frontend/src/services/impersonateService.ts
@@ -4,9 +4,7 @@ export const updateImpersonateSettings = (impersonate: boolean): Promise<void> =
   const url = '/api/dev-impersonate';
   return axios
     .post(url, { impersonate })
-    .then((response) => {
-      return response.data;
-    })
+    .then((response) => response.data)
     .catch((e) => {
       throw new Error(e.response.data.message);
     });

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -12,6 +12,7 @@ const SUPPORT_LINK = process.env.SUPPORT_LINK;
 const ODH_LOGO = process.env.ODH_LOGO || 'odh-logo.svg';
 const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const ODH_NOTEBOOK_REPO = process.env.ODH_NOTEBOOK_REPO;
+const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 
 export {
   DEV_MODE,
@@ -24,6 +25,7 @@ export {
   ODH_LOGO,
   ODH_PRODUCT_NAME,
   ODH_NOTEBOOK_REPO,
+  DEV_IMPERSONATE_USER,
 };
 
 export const DOC_TYPE_TOOLTIPS = {

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -12,7 +12,6 @@ const SUPPORT_LINK = process.env.SUPPORT_LINK;
 const ODH_LOGO = process.env.ODH_LOGO || 'odh-logo.svg';
 const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const ODH_NOTEBOOK_REPO = process.env.ODH_NOTEBOOK_REPO;
-const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 
 export {
   DEV_MODE,
@@ -25,7 +24,6 @@ export {
   ODH_LOGO,
   ODH_PRODUCT_NAME,
   ODH_NOTEBOOK_REPO,
-  DEV_IMPERSONATE_USER,
 };
 
 export const DOC_TYPE_TOOLTIPS = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: #949

## Description
<!--- Describe your changes in detail -->
This PR adds support for impersonating pass-through API calls with a regular user token.
The main goal here is just to avoid disabling backend functionality in development which needs special admin roles (admin settings, regular jupyter notebooks, dsg project creation...) but enabling pass-through requests with a regular user token.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To enable this:
1. Get a regular user Openshift username and password
2. Add the `DEV_IMPERSONATE_USER` and `DEV_IMPERSONATE_PASSWORD` variables to your env variables file with the regular user's username and password as the values.
3. Click on your username name in the upper right corner of the dashboard
4. Select `Start impersonate`
5. This way you can replicate some bugs like this:
<img width="1111" alt="Screenshot 2022-11-24 at 14 05 39" src="https://user-images.githubusercontent.com/16117276/203793873-ff84327f-0b52-4318-9f79-ad6c369b780a.png">

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
