### PR TITLE
Add quay expires-after label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
 # Build arguments
 ARG SOURCE_CODE=.
+ARG EXPIRATION=""
 
 # Use ubi8/nodejs-14 as default base image
 ARG BASE_IMAGE="registry.access.redhat.com/ubi8/nodejs-14:latest"
-
 
 FROM ${BASE_IMAGE}
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
+ARG EXPIRATION
 
 LABEL io.opendatahub.component="odh-dashboard" \
       io.k8s.display-name="odh-dashboard" \
       name="open-data-hub/odh-dashboard-ubi8" \
       summary="odh-dashboard" \
-      description="Open Data Hub Dashboard"
+      description="Open Data Hub Dashboard" \
+      quay.expires-after=${EXPIRATION}
 
 
 ## Switch to root as required for some operations


### PR DESCRIPTION
Related to: #761 (Partially resolves), https://github.com/openshift/release/pull/34505 (needs to be merged before)

## Description
This PR just adds a quay label that can contain a time after which an image expires. A second PR in https://github.com/openshift/release/tree/master/ci-operator/step-registry/opendatahub-io/ci/image-mirror will contian an assignment of this value to 1 or 2 months for pr-xxx tags

## How Has This Been Tested?
1. Added a 1h value to the label and verified that quay picked it up
![image](https://user-images.githubusercontent.com/60748071/203983579-d932b149-19d8-4d52-b3a8-891b65c6fef1.png)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
