### PR TITLE
Fix bug limiting access to global view to regular users:

### DIFF
--- a/frontend/src/api/network/projects.ts
+++ b/frontend/src/api/network/projects.ts
@@ -95,7 +95,7 @@ export const createProject = (
 };
 
 export const getModelServingProjects = (): Promise<ProjectKind[]> => {
-  return getProjects('modelmesh-enabled=true');
+  return getProjects('opendatahub.io/dashboard=true,modelmesh-enabled=true');
 };
 
 async function filter(arr, callback) {

--- a/frontend/src/api/network/servingRuntimes.ts
+++ b/frontend/src/api/network/servingRuntimes.ts
@@ -10,6 +10,7 @@ import { ServingRuntimeModel } from '../models';
 import { ServingRuntimeKind } from '../../k8sTypes';
 import { CreatingServingRuntimeObject } from 'pages/modelServing/screens/types';
 import { getModelServingRuntimeName } from 'pages/modelServing/utils';
+import { getModelServingProjects } from './projects';
 
 const assembleServingRuntime = (
   data: CreatingServingRuntimeObject,
@@ -97,6 +98,27 @@ export const listServingRuntimes = (
     model: ServingRuntimeModel,
     queryOptions,
   }).then((listResource) => listResource.items);
+};
+
+export const listScopedServingRuntimes = (
+  labelSelector?: string,
+): Promise<ServingRuntimeKind[]> => {
+  return getModelServingProjects().then((projects) => {
+    return Promise.all(
+      projects.map((project) => listServingRuntimes(project.metadata.name, labelSelector)),
+    ).then((listServingRuntimes) => _.uniq(_.flatten(listServingRuntimes)));
+  });
+};
+
+export const getServingRuntimeContext = (
+  namespace?: string,
+  labelSelector?: string,
+): Promise<ServingRuntimeKind[]> => {
+  if (namespace) {
+    return listServingRuntimes(namespace, labelSelector);
+  } else {
+    return listScopedServingRuntimes(labelSelector);
+  }
 };
 
 export const getServingRuntime = (name: string, namespace: string): Promise<ServingRuntimeKind> => {

--- a/frontend/src/pages/modelServing/useInferenceServices.ts
+++ b/frontend/src/pages/modelServing/useInferenceServices.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { listInferenceService } from '../../api';
+import { getInferenceServiceContext } from '../../api';
 import { InferenceServiceKind } from '../../k8sTypes';
 
 const useInferenceServices = (
@@ -15,7 +15,7 @@ const useInferenceServices = (
   const [loadError, setLoadError] = React.useState<Error | undefined>(undefined);
 
   const fetchInferenceServices = React.useCallback(() => {
-    return listInferenceService(namespace)
+    return getInferenceServiceContext(namespace, 'opendatahub.io/dashboard=true')
       .then((newInferenceServices) => {
         setInferenceServices(newInferenceServices);
       })

--- a/frontend/src/pages/modelServing/useServingRuntimes.ts
+++ b/frontend/src/pages/modelServing/useServingRuntimes.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { listServingRuntimes } from '../../api/network/servingRuntimes';
+import { getServingRuntimeContext } from '../../api/network/servingRuntimes';
 import { ServingRuntimeKind } from '../../k8sTypes';
 
 const useServingRuntimes = (
@@ -16,7 +16,7 @@ const useServingRuntimes = (
 
   // Now there's only one model server in the cluster, in the future, we may have multiple model servers
   const fetchServingRuntimes = React.useCallback(() => {
-    return listServingRuntimes(namespace, 'opendatahub.io/dashboard=true')
+    return getServingRuntimeContext(namespace, 'opendatahub.io/dashboard=true')
       .then((newServingRuntimes) => {
         setModelServers(newServingRuntimes);
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #801 
* Now it will just list objects in namespaces they have access.
* Limits a clusterrole list of InferenceService and ServingRuntime.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a regular user with no clusterrole permissions
2. With the code added in #806 use the token to fake pass-through API calls
3. Check that you can create new projects, create Model Servers, Models and check the global view

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
