### PR TITLE
Handle Prometheus OAuth Issue

### DIFF
--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -1,5 +1,6 @@
 import { KubeFastifyInstance, OauthFastifyRequest, PrometheusResponse } from '../../../types';
 import { callPrometheus } from '../../../utils/prometheusUtils';
+import { createCustomError } from '../../../utils/requestUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   /**
@@ -13,7 +14,16 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     ): Promise<{ code: number; response: PrometheusResponse }> => {
       const { query, namespace } = request.body;
 
-      return callPrometheus(fastify, request, query, namespace);
+      return callPrometheus(fastify, request, query, namespace).catch((e) => {
+        if (e?.code) {
+          throw createCustomError(
+            'Error with prometheus call',
+            e.response || 'Prometheus call error',
+            e.code,
+          );
+        }
+        throw e;
+      });
     },
   );
 };

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -43,7 +43,12 @@ export const callPrometheus = async (
             fastify.log.info('Successful response from Prometheus.');
             resolve({ code: 200, response: parsedData });
           } catch (e) {
-            fastify.log.error(`Failure parsing the response from Prometheus. ${e.message || e}`);
+            const errorMessage = e.message || e.toString();
+            fastify.log.error(`Failure parsing the response from Prometheus. ${errorMessage}`);
+            if (errorMessage.includes('Unexpected token < in JSON')) {
+              reject({ code: 422, response: 'Unprocessable prometheus response' });
+              return;
+            }
             fastify.log.error(`Unparsed Prometheus data. ${rawData}`);
             reject({ code: 500, response: rawData });
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #832

## Description
<!--- Describe your changes in detail -->
When the OAuth token expires, it triggers a 500 error from a prometheus call for DS Projects when it tries to get the fill-size of the PVCs that are created.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by suffixing the Authorization header with extra characters -- thus mimicking an invalid token.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
