### PR TITLE
Set oauth cookie expiration to less than OpenShift default

### DIFF
--- a/manifests/overlays/authentication/deployment.yaml
+++ b/manifests/overlays/authentication/deployment.yaml
@@ -12,6 +12,7 @@
       - --client-secret-file=/etc/oauth/client/secret
       - --scope=user:full
       - --cookie-secret-file=/etc/oauth/config/cookie_secret
+      - --cookie-expire=23h0m0s
       - --pass-access-token
       - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard"}}'
       - --skip-auth-regex=^/metrics
@@ -53,7 +54,7 @@
         name: oauth-config
       - mountPath: /etc/oauth/client
         name: oauth-client
-        
+
 - op: add
   path: /spec/template/spec/volumes
   value:


### PR DESCRIPTION
Resolves: #838 

## Description
When OpenShift expires the token before the dashboard, we get some weird behavior:
![Screenshot from 2022-12-01 20-21-21](https://user-images.githubusercontent.com/1448375/205313638-812555b0-2c0b-4965-976c-be110672e6a8.png)
![Screenshot from 2022-12-01 22-41-36](https://user-images.githubusercontent.com/1448375/205313655-9cf9d15e-f133-4266-934e-145a11fe6d91.png)
As per https://github.com/openshift/oauth-proxy/issues/225#issuecomment-1074908450 we can mitigate this by lowering the cookie expiration time on the dashboard.

## How Has This Been Tested?
Scaled down the operator and set the cookie-expire to low values to make sure it worked.

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
