### PR TITLE
Modify logout and control panel redirect for project notebooks

### DIFF
--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -115,7 +115,7 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
       annotations: {
         'openshift.io/display-name': notebookName,
         'openshift.io/description': description || '',
-        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebook_logout=${notebookName}`,
+        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookName}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'notebooks.opendatahub.io/inject-oauth': 'true',

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -115,7 +115,7 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
       annotations: {
         'openshift.io/display-name': notebookName,
         'openshift.io/description': description || '',
-        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/notebookController/${translatedUsername}/home`,
+        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebook_logout=${notebookName}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'notebooks.opendatahub.io/inject-oauth': 'true',
@@ -143,7 +143,7 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
                   --ServerApp.password=''
                   --ServerApp.base_url=/notebook/${projectName}/${notebookId}
                   --ServerApp.quit_button=False
-                  --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${origin}","hub_prefix":"/notebookController/${translatedUsername}"}`,
+                  --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${origin}","hub_prefix":"/projects/${projectName}"}`,
                 },
                 {
                   name: 'JUPYTER_IMAGE',

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -115,7 +115,7 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
       annotations: {
         'openshift.io/display-name': notebookName,
         'openshift.io/description': description || '',
-        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookName}`,
+        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'notebooks.opendatahub.io/inject-oauth': 'true',

--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -45,6 +45,10 @@ const NotebookLogoutRedirect: React.FC = () => {
   }, [namespace, notebookName, navigate, notification, notebookNamespace]);
 
   React.useEffect(() => {
+    let cancelled = false;
+    if (cancelled) {
+      return;
+    }
     if (namespace && notebookName && namespace !== notebookNamespace) {
       if (loaded) {
         if (error) {
@@ -56,6 +60,9 @@ const NotebookLogoutRedirect: React.FC = () => {
         }
       }
     }
+    return () => {
+      cancelled = true;
+    };
   }, [
     routeLink,
     loaded,

--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -3,15 +3,24 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { getNotebook } from '../../services/notebookService';
 import ApplicationsPage from '../../pages/ApplicationsPage';
 import useNotification from '../../utilities/useNotification';
+import useRouteForNotebook from '../projects/notebook/useRouteForNotebook';
+import useNamespaces from './useNamespaces';
 
 const NotebookLogoutRedirect: React.FC = () => {
   const { namespace, notebookName } = useParams<{ namespace: string; notebookName: string }>();
   const notification = useNotification();
   const navigate = useNavigate();
+  const { notebookNamespace } = useNamespaces();
+  const [routeLink, loaded, error] = useRouteForNotebook(notebookName, namespace);
+
   React.useEffect(() => {
-    if (namespace && notebookName) {
+    let cancelled = false;
+    if (namespace && notebookName && namespace === notebookNamespace) {
       getNotebook(namespace, notebookName)
         .then((notebook) => {
+          if (cancelled) {
+            return;
+          }
           if (notebook?.metadata.annotations?.['opendatahub.io/link']) {
             const location = new URL(notebook.metadata.annotations['opendatahub.io/link']);
             window.location.href = `${location.origin}/oauth/sign_out`;
@@ -24,10 +33,40 @@ const NotebookLogoutRedirect: React.FC = () => {
           }
         })
         .catch((e) => {
+          if (cancelled) {
+            return;
+          }
           console.error(e);
         });
     }
-  }, [namespace, notebookName, navigate, notification]);
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, notebookName, navigate, notification, notebookNamespace]);
+
+  React.useEffect(() => {
+    if (namespace && notebookName && namespace !== notebookNamespace) {
+      if (loaded) {
+        if (error) {
+          notification.error(`Error when logging out ${notebookName}`, error.message);
+          navigate(`/projects/${namespace}`);
+        } else if (routeLink) {
+          const location = new URL(routeLink);
+          window.location.href = `${location.origin}/oauth/sign_out`;
+        }
+      }
+    }
+  }, [
+    routeLink,
+    loaded,
+    error,
+    notification,
+    namespace,
+    notebookName,
+    navigate,
+    notebookNamespace,
+  ]);
+
   return (
     <ApplicationsPage title="Logging out..." description={null} loaded={false} empty={false} />
   );

--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -21,7 +21,10 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
   variant,
   isLarge,
 }) => {
-  const [routeLink, loaded, error] = useRouteForNotebook(notebook);
+  const [routeLink, loaded, error] = useRouteForNotebook(
+    notebook.metadata.name,
+    notebook.metadata.namespace,
+  );
   const isStopped = hasStopAnnotation(notebook);
   const canLink = loaded && !!routeLink && !error && !isStopped && isRunning;
 

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -1,33 +1,32 @@
 import * as React from 'react';
 import { getRoute } from '../../../api';
-import { NotebookKind } from '../../../k8sTypes';
 
 const useRouteForNotebook = (
-  notebook: NotebookKind,
+  notebookName?: string,
+  projectName?: string,
 ): [routeLink: string | null, loaded: boolean, loadError: Error | null] => {
   const [route, setRoute] = React.useState<string | null>(null);
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error | null>(null);
 
-  const routeName = notebook.metadata.name;
-  const routeNamespace = notebook.metadata.namespace;
-
   React.useEffect(() => {
     let watchHandle;
     const watchRoute = () => {
-      getRoute(routeName, routeNamespace)
-        .then((route) => {
-          setRoute(`https://${route.spec.host}/notebook/${routeNamespace}/${routeName}`);
-          setLoaded(true);
-        })
-        .catch((e) => {
-          setLoadError(e);
-          watchHandle = setTimeout(watchRoute, 1000);
-        });
+      if (notebookName && projectName) {
+        getRoute(notebookName, projectName)
+          .then((route) => {
+            setRoute(`https://${route.spec.host}/notebook/${projectName}/${notebookName}`);
+            setLoaded(true);
+          })
+          .catch((e) => {
+            setLoadError(e);
+            watchHandle = setTimeout(watchRoute, 1000);
+          });
+      }
     };
     watchRoute();
     return () => clearTimeout(watchHandle);
-  }, [routeName, routeNamespace]);
+  }, [notebookName, projectName]);
 
   return [route, loaded, loadError];
 };

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -13,8 +13,7 @@ import NotebooksList from './notebooks/NotebookList';
 import { ProjectDetailsContext } from '../../ProjectDetailsContext';
 import { getProjectDescription, getProjectDisplayName } from '../../utils';
 import { featureFlagEnabled } from '../../../../utilities/utils';
-import { useQueryParams } from '../../../../utilities/useQueryParams';
-import useNotification from '../../../../utilities/useNotification';
+import useCheckLogoutParams from './useCheckLogoutParams';
 
 type SectionType = {
   id: ProjectSectionID;
@@ -29,16 +28,7 @@ const ProjectDetails: React.FC = () => {
   const modelServingEnabled = featureFlagEnabled(
     dashboardConfig.spec.dashboardConfig.disableModelServing,
   );
-  const queryParams = useQueryParams();
-  const notebookLogout = queryParams.get('notebook_logout');
-  const notification = useNotification();
-
-  // TODO: this will be triggered twice, don't know why
-  React.useEffect(() => {
-    if (notebookLogout) {
-      notification.success(`Logout workbench successfully`);
-    }
-  }, [notebookLogout, notification]);
+  useCheckLogoutParams();
 
   const scrollableSelectorID = 'project-details-list';
   const sections: SectionType[] = [

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -13,6 +13,8 @@ import NotebooksList from './notebooks/NotebookList';
 import { ProjectDetailsContext } from '../../ProjectDetailsContext';
 import { getProjectDescription, getProjectDisplayName } from '../../utils';
 import { featureFlagEnabled } from '../../../../utilities/utils';
+import { useQueryParams } from '../../../../utilities/useQueryParams';
+import useNotification from '../../../../utilities/useNotification';
 
 type SectionType = {
   id: ProjectSectionID;
@@ -27,6 +29,16 @@ const ProjectDetails: React.FC = () => {
   const modelServingEnabled = featureFlagEnabled(
     dashboardConfig.spec.dashboardConfig.disableModelServing,
   );
+  const queryParams = useQueryParams();
+  const notebookLogout = queryParams.get('notebook_logout');
+  const notification = useNotification();
+
+  // TODO: this will be triggered twice, don't know why
+  React.useEffect(() => {
+    if (notebookLogout) {
+      notification.success(`Logout workbench successfully`);
+    }
+  }, [notebookLogout, notification]);
 
   const scrollableSelectorID = 'project-details-list';
   const sections: SectionType[] = [

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import useNotification from '../../../../utilities/useNotification';
-import { useQueryParams } from '../../../../utilities/useQueryParams';
 
 const useCheckLogoutParams = (): void => {
-  const queryParams = useQueryParams();
+  const [queryParams, setQueryParams] = useSearchParams();
   const notification = useNotification();
 
   // TODO: this will be triggered twice, don't know why
@@ -11,8 +11,9 @@ const useCheckLogoutParams = (): void => {
     if (queryParams.get('notebookLogout')) {
       notification.success(`Logout workbench successfully`);
       queryParams.delete('notebookLogout');
+      setQueryParams(queryParams);
     }
-  }, [notification, queryParams]);
+  }, [notification, queryParams, setQueryParams]);
 };
 
 export default useCheckLogoutParams;

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -8,22 +8,22 @@ const useCheckLogoutParams = (): void => {
   const [queryParams, setQueryParams] = useSearchParams();
   const notification = useNotification();
   const {
-    notebooks: { data: notebooks, loaded },
+    notebooks: { data: notebooks },
   } = React.useContext(ProjectDetailsContext);
 
   React.useEffect(() => {
-    if (loaded) {
-      const notebookLogout = queryParams.get('notebookLogout');
+    const notebookLogout = queryParams.get('notebookLogout');
+    if (notebookLogout) {
       const notebook = notebooks.find((n) => n.notebook.metadata.name === notebookLogout);
       if (notebook?.notebook) {
         notification.success(
           `Logout workbench "${getNotebookDisplayName(notebook.notebook)}" successfully`,
         );
+        queryParams.delete('notebookLogout');
+        setQueryParams(queryParams);
       }
-      queryParams.delete('notebookLogout');
-      setQueryParams(queryParams);
     }
-  }, [notification, queryParams, setQueryParams, notebooks, loaded]);
+  }, [notification, queryParams, setQueryParams, notebooks]);
 };
 
 export default useCheckLogoutParams;

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -11,15 +11,16 @@ const useCheckLogoutParams = (): void => {
     notebooks: { data: notebooks, loaded },
   } = React.useContext(ProjectDetailsContext);
 
+  const notebookLogout = queryParams.get('notebookLogout');
+  const notebook = notebooks.find((n) => n.notebook.metadata.name === notebookLogout);
+
   React.useEffect(() => {
     const deleteLogoutParam = () => {
       queryParams.delete('notebookLogout');
       setQueryParams(queryParams);
     };
-    const notebookLogout = queryParams.get('notebookLogout');
     if (notebookLogout) {
-      const notebook = notebooks.find((n) => n.notebook.metadata.name === notebookLogout);
-      if (notebook?.notebook) {
+      if (notebook) {
         notification.success(
           `Logout workbench "${getNotebookDisplayName(notebook.notebook)}" successfully`,
         );
@@ -29,7 +30,7 @@ const useCheckLogoutParams = (): void => {
         deleteLogoutParam();
       }
     }
-  }, [notification, notebooks, loaded, setQueryParams, queryParams]);
+  }, [notification, notebook, setQueryParams, queryParams, loaded, notebookLogout]);
 };
 
 export default useCheckLogoutParams;

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -22,7 +22,7 @@ const useCheckLogoutParams = (): void => {
     if (notebookLogout) {
       if (notebook) {
         notification.success(
-          `Logout workbench "${getNotebookDisplayName(notebook.notebook)}" successfully`,
+          `Logged out of workbench "${getNotebookDisplayName(notebook.notebook)}" successfully`,
         );
         deleteLogoutParam();
       } else if (loaded) {

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -6,7 +6,6 @@ const useCheckLogoutParams = (): void => {
   const [queryParams, setQueryParams] = useSearchParams();
   const notification = useNotification();
 
-  // TODO: this will be triggered twice, don't know why
   React.useEffect(() => {
     if (queryParams.get('notebookLogout')) {
       notification.success(`Logout workbench successfully`);

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -1,18 +1,29 @@
 import * as React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import useNotification from '../../../../utilities/useNotification';
+import { ProjectDetailsContext } from '../../ProjectDetailsContext';
+import { getNotebookDisplayName } from '../../utils';
 
 const useCheckLogoutParams = (): void => {
   const [queryParams, setQueryParams] = useSearchParams();
   const notification = useNotification();
+  const {
+    notebooks: { data: notebooks, loaded },
+  } = React.useContext(ProjectDetailsContext);
 
   React.useEffect(() => {
-    if (queryParams.get('notebookLogout')) {
-      notification.success(`Logout workbench successfully`);
+    if (loaded) {
+      const notebookLogout = queryParams.get('notebookLogout');
+      const notebook = notebooks.find((n) => n.notebook.metadata.name === notebookLogout);
+      if (notebook?.notebook) {
+        notification.success(
+          `Logout workbench "${getNotebookDisplayName(notebook.notebook)}" successfully`,
+        );
+      }
       queryParams.delete('notebookLogout');
       setQueryParams(queryParams);
     }
-  }, [notification, queryParams, setQueryParams]);
+  }, [notification, queryParams, setQueryParams, notebooks, loaded]);
 };
 
 export default useCheckLogoutParams;

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -8,10 +8,14 @@ const useCheckLogoutParams = (): void => {
   const [queryParams, setQueryParams] = useSearchParams();
   const notification = useNotification();
   const {
-    notebooks: { data: notebooks },
+    notebooks: { data: notebooks, loaded },
   } = React.useContext(ProjectDetailsContext);
 
   React.useEffect(() => {
+    const deleteLogoutParam = () => {
+      queryParams.delete('notebookLogout');
+      setQueryParams(queryParams);
+    };
     const notebookLogout = queryParams.get('notebookLogout');
     if (notebookLogout) {
       const notebook = notebooks.find((n) => n.notebook.metadata.name === notebookLogout);
@@ -19,11 +23,13 @@ const useCheckLogoutParams = (): void => {
         notification.success(
           `Logout workbench "${getNotebookDisplayName(notebook.notebook)}" successfully`,
         );
-        queryParams.delete('notebookLogout');
-        setQueryParams(queryParams);
+        deleteLogoutParam();
+      } else if (loaded) {
+        notification.error('Error logging out', 'Unable to locate notebook to finalize logout');
+        deleteLogoutParam();
       }
     }
-  }, [notification, queryParams, setQueryParams, notebooks]);
+  }, [notification, notebooks, loaded, setQueryParams, queryParams]);
 };
 
 export default useCheckLogoutParams;

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import useNotification from '../../../../utilities/useNotification';
+import { useQueryParams } from '../../../../utilities/useQueryParams';
+
+const useCheckLogoutParams = (): void => {
+  const queryParams = useQueryParams();
+  const notification = useNotification();
+
+  // TODO: this will be triggered twice, don't know why
+  React.useEffect(() => {
+    if (queryParams.get('notebookLogout')) {
+      notification.success(`Logout workbench successfully`);
+      queryParams.delete('notebookLogout');
+    }
+  }, [notification, queryParams]);
+};
+
+export default useCheckLogoutParams;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #808 
There is no way to change the text Hub Control Panel, it's hardcoded in JupyterLab https://github.com/jupyterlab/jupyterlab/blob/master/packages/hub-extension/src/index.ts#L74-L80
The logout success prompt will be triggered twice, have no idea why, left a comment and waiting for reviews.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a notebook in DSG, login to the notebook, and try to click the logout and hub control panel button.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
