### PR TITLE
Avoid backend crash when there is no annotation in image stream

### DIFF
--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -92,7 +92,7 @@ const getImageStreams = async (
 };
 
 export const processImageInfo = (imageStream: ImageStream): ImageInfo => {
-  const annotations = imageStream.metadata.annotations;
+  const annotations = imageStream.metadata.annotations || {};
 
   const imageInfo: ImageInfo = {
     name: imageStream.metadata.name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #857 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Try to remove the annotations of a custom image stream and go to the notebook controller spawner page. If this change is not applied, you will get errors when accessing the page because the backend is crashed.
After this change even if there is no annotations in the image stream, we can still get it and set it to some default values.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
