### PR TITLE
render SVG in the card header when height and width are not set

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -16,6 +16,10 @@ html, body, #root {
     opacity: 1;
     color: var(--pf-global--icon--Color--light);
   }
+  &__brand {
+    height: 36px;
+    width: 100%;
+  }
 }
 // specificity targeting form elements to override --pf-global--FontSize--md
 .pf-c-page, .pf-c-modal-box {

--- a/frontend/src/app/Header.tsx
+++ b/frontend/src/app/Header.tsx
@@ -31,9 +31,11 @@ const Header: React.FC<HeaderProps> = ({ onNotificationsClick }) => {
       )}
       <MastheadMain>
         <MastheadBrand component={(props) => <Link {...props} to="/" />}>
-          <Brand heights={{ default: '36px' }} alt={`${ODH_PRODUCT_NAME} Logo`}>
-            <source srcSet={`${window.location.origin}/images/${ODH_LOGO}`} />
-          </Brand>
+          <Brand
+            className="odh-dashboard__brand"
+            src={`${window.location.origin}/images/${ODH_LOGO}`}
+            alt={`${ODH_PRODUCT_NAME} Logo`}
+          />
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>

--- a/frontend/src/components/BrandImage.tsx
+++ b/frontend/src/components/BrandImage.tsx
@@ -35,6 +35,7 @@ const BrandImage: React.FC<BrandImageProps> = ({ src, ...props }) => {
     <Brand
       {...props}
       heights={{ default: '40px' }}
+      widths={{ default: '100%' }}
       onError={() => setImage((prevImage) => ({ imgSrc: prevImage.imgSrc, isValid: false }))}
     >
       <source srcSet={image.imgSrc} />

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -184,7 +184,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
       isSelectable={!disabled}
     >
       <CardHeader>
-        <CardHeaderMain style={{ maxWidth: '33%' }}>
+        <CardHeaderMain style={{ maxWidth: '33%', width: '100%' }}>
           <BrandImage src={odhApp.spec.img} alt={odhApp.spec.displayName} />
         </CardHeaderMain>
         <CardActions hasNoOffset>

--- a/frontend/src/components/OdhDocCard.tsx
+++ b/frontend/src/components/OdhDocCard.tsx
@@ -141,7 +141,7 @@ const OdhDocCard: React.FC<OdhDocCardProps> = ({ odhDoc, favorite, updateFavorit
       isSelectable
     >
       <CardHeader>
-        <CardHeaderMain style={{ maxWidth: '33%' }}>
+        <CardHeaderMain style={{ maxWidth: '33%', width: '100%' }}>
           <BrandImage
             src={odhDoc.spec.img || odhDoc.spec.icon || ''}
             alt={odhDoc.spec.displayName}

--- a/frontend/src/components/OdhExploreCard.tsx
+++ b/frontend/src/components/OdhExploreCard.tsx
@@ -61,7 +61,7 @@ const OdhExploreCard: React.FC<OdhExploreCardProps> = ({
       onClick={() => !disabled && onSelect()}
     >
       <CardHeader>
-        <CardHeaderMain style={{ maxWidth: '33%' }}>
+        <CardHeaderMain style={{ maxWidth: '33%', width: '100%' }}>
           <BrandImage src={odhApp.spec.img} alt={odhApp.spec.displayName} />
         </CardHeaderMain>
         {!dashboardConfig.spec.dashboardConfig.disableISVBadges && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #867 
![Screen Shot 2023-01-03 at 10 03 19 AM](https://user-images.githubusercontent.com/37624318/210384228-158f3826-f153-4b1d-867d-b38dade76915.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add OpenVino CR or any other CRs which doesn't contain `width` and `height` in their SVG definition, use firefox to open the explore page and check whether the icon is shown.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
