### PR TITLE
Cleanup quay image after PR is closed

### DIFF
--- a/.github/workflows/pr-close-image-delete.yml
+++ b/.github/workflows/pr-close-image-delete.yml
@@ -1,0 +1,35 @@
+name: Delete quay image on PR closed
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  QUAY_ODH_DASHBOARD_IMAGE_REPO: ${{ secrets.QUAY_ODH_DASHBOARD_IMAGE_REPO }}
+
+jobs:
+  delete-pr-quay-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: Install skopeo
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install skopeo
+      - name: Login to quay.io
+        shell: bash
+        env:
+          QUAY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
+          QUAY_ROBOT_USERNAME: ${{ secrets.QUAY_ROBOT_USERNAME }}
+        run: |
+         skopeo login quay.io -u ${QUAY_ROBOT_USERNAME} -p ${QUAY_TOKEN}
+      - name: Delete PR image
+        shell: bash
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          skopeo delete docker://${QUAY_ODH_DASHBOARD_IMAGE_REPO}:pr-${{ env.PR }}


### PR DESCRIPTION
Resolves #761 
Replaces #811 

## Description
This PR implements a github action that automatically deletes a quay image for a PR that is closed.

## How Has This Been Tested?
1. Create a PR and its image
2. Trigger action by closing a PR 
3. Verify the associated image is deleted

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
