### PR TITLE
Compare workbench size correctly and add error message

### DIFF
--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import { ActionsColumn, ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
-import { Spinner, Text, TextVariants, Title } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  Icon,
+  Spinner,
+  Text,
+  TextVariants,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
 import { NotebookState } from '../../../notebook/types';
 import { getNotebookDescription, getNotebookDisplayName } from '../../../utils';
 import NotebookRouteLink from '../../../notebook/NotebookRouteLink';
@@ -14,6 +23,7 @@ import NotebookStorageBars from './NotebookStorageBars';
 import ResourceNameTooltip from '../../../components/ResourceNameTooltip';
 import { useNavigate } from 'react-router-dom';
 import { ProjectDetailsContext } from '../../../ProjectDetailsContext';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 type NotebookTableRowProps = {
   obj: NotebookState;
@@ -29,7 +39,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const navigate = useNavigate();
   const [isExpanded, setExpanded] = React.useState(false);
-  const notebookSize = useNotebookDeploymentSize(obj.notebook);
+  const { size: notebookSize, error: sizeError } = useNotebookDeploymentSize(obj.notebook);
   const [notebookImage, loaded] = useNotebookImage(obj.notebook);
 
   return (
@@ -54,7 +64,21 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             <Text component={TextVariants.small}>{notebookImage.tagSoftware}</Text>
           )}
         </Td>
-        <Td dataLabel="Container size">{notebookSize?.name ?? 'Unknown'}</Td>
+        <Td dataLabel="Container size">
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <FlexItem>{notebookSize?.name ?? 'Unknown'}</FlexItem>
+            {sizeError && (
+              <Tooltip removeFindDomNode content={sizeError}>
+                <Icon status="danger">
+                  <ExclamationCircleIcon />
+                </Icon>
+              </Tooltip>
+            )}
+          </Flex>
+        </Td>
         <Td dataLabel="Status">
           <NotebookStatusToggle notebookState={obj} doListen={false} />
         </Td>

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
@@ -28,7 +28,7 @@ const useNotebookDeploymentSize = (
     return {
       size: null,
       error:
-        'Failed to get size information, the size might be changed after the workbench creation, please check your dashboard config.',
+        'Workbench size is currently unavailable. Check your dashboard configuration to view size information.',
     };
   }
 

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
@@ -1,33 +1,38 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { AppContext } from '../../../../../app/AppContext';
 import { NotebookContainer, NotebookSize } from '../../../../../types';
 import { getNotebookSizes } from '../../../../notebookController/screens/server/usePreferredNotebookSize';
 import { NotebookKind } from '../../../../../k8sTypes';
 
-const useNotebookDeploymentSize = (notebook?: NotebookKind): NotebookSize | null => {
+const useNotebookDeploymentSize = (
+  notebook?: NotebookKind,
+): { size: NotebookSize | null; error: string } => {
   const { dashboardConfig } = React.useContext(AppContext);
-
-  if (!notebook) {
-    return null;
-  }
 
   const container: NotebookContainer | undefined = notebook?.spec.template.spec.containers.find(
     (container) => container.name === notebook.metadata.name,
   );
 
   if (!container) {
-    return null;
+    return { size: null, error: 'Failed to get workbench information.' };
   }
 
   const sizes = getNotebookSizes(dashboardConfig);
-  const size = sizes.find((size) => _.isEqual(size.resources.limits, container.resources?.limits));
+  const size = sizes.find(
+    (size) =>
+      size.resources.limits?.cpu === container.resources?.limits?.cpu &&
+      size.resources.limits?.memory === container.resources?.limits?.memory,
+  );
 
   if (!size) {
-    return null;
+    return {
+      size: null,
+      error:
+        'Failed to get size information, the size might be changed after the workbench creation, please check your dashboard config.',
+    };
   }
 
-  return size;
+  return { size, error: '' };
 };
 
 export default useNotebookDeploymentSize;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -72,7 +72,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     }
   }, [data, loaded]);
 
-  const notebookSize = useNotebookDeploymentSize(existingNotebook);
+  const { size: notebookSize } = useNotebookDeploymentSize(existingNotebook);
   React.useEffect(() => {
     if (notebookSize) {
       setSelectedSize(notebookSize.name);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #826 
When the size cannot be correctly found, we have an error tooltip next to the size which might give you some hint on what's the problem.
<img width="1279" alt="Screenshot 2023-01-10 at 4 08 49 PM" src="https://user-images.githubusercontent.com/37624318/211662937-563ba50d-de55-4f19-898e-cfb83f7e3e39.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For GPUs:
Add GPU to workbench -> Make sure the size is not unknown
For error messages:
Create a workbench -> Change the size in dashboard config CR -> See the error icon and hover to see the tooltip

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
