### PR TITLE
Fetch Jupyter tile nb-events by pod uid not nb name

### DIFF
--- a/backend/src/routes/api/nb-events/eventUtils.ts
+++ b/backend/src/routes/api/nb-events/eventUtils.ts
@@ -4,7 +4,7 @@ import { KubeFastifyInstance } from '../../../types';
 export const getNotebookEvents = async (
   fastify: KubeFastifyInstance,
   namespace: string,
-  nbName: string,
+  podUID: string,
 ): Promise<V1Event[]> => {
   return fastify.kube.coreV1Api
     .listNamespacedEvent(
@@ -12,7 +12,7 @@ export const getNotebookEvents = async (
       undefined,
       undefined,
       undefined,
-      `involvedObject.kind=Pod,involvedObject.name=${nbName}-0`,
+      `involvedObject.kind=Pod,involvedObject.uid=${podUID}`,
     )
     .then((res) => {
       const body = res.body as V1EventList;

--- a/backend/src/routes/api/nb-events/index.ts
+++ b/backend/src/routes/api/nb-events/index.ts
@@ -4,13 +4,13 @@ import { secureRoute } from '../../../utils/route-security';
 
 export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
-    '/:namespace/:name',
+    '/:namespace/:podUID',
     secureRoute(fastify)(
       async (
         request: FastifyRequest<{
           Params: {
             namespace: string;
-            name: string;
+            podUID: string;
           };
           Querystring: {
             // TODO: Support server side filtering
@@ -18,8 +18,8 @@ export default async (fastify: FastifyInstance): Promise<void> => {
           };
         }>,
       ) => {
-        const { namespace, name } = request.params;
-        return getNotebookEvents(fastify, namespace, name);
+        const { namespace, podUID } = request.params;
+        return getNotebookEvents(fastify, namespace, podUID);
       },
     ),
   );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2515,13 +2515,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -2662,7 +2662,7 @@
     "alphanum-sort": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "integrity": "sha512-0FcBfdcmaumGPQ0qPn7Q5qTgz/ooXgIyp1rf8ik5bGX8mpE2YHjC0P/eyQvxu1GURYQgq9ozf2mteQ5ZD9YiyQ==",
       "dev": true
     },
     "ansi-colors": {
@@ -3261,7 +3261,7 @@
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -3520,7 +3520,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         }
       }
@@ -3829,7 +3829,7 @@
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
       "requires": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -3839,7 +3839,7 @@
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "integrity": "sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==",
       "dev": true
     },
     "css-declaration-sorter": {
@@ -4074,13 +4074,13 @@
     "cssnano-util-get-arguments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
-      "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+      "integrity": "sha512-6RIcwmV3/cBMG8Aj5gucQRsJb4vv4I4rn6YjPbVWd5+Pn/fuG+YseGvXGk00XLkoZkaj31QOD7vMUpNPC4FIuw==",
       "dev": true
     },
     "cssnano-util-get-match": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
-      "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+      "integrity": "sha512-JPMZ1TSMRUPVIqEalIBNoBtAYbi8okvcFns4O0YIhcdGebeYZK7dMyHJiQ6GqNBA9kE0Hym4Aqym5rPdsV/4Cw==",
       "dev": true
     },
     "cssnano-util-raw-cache": {
@@ -5182,7 +5182,7 @@
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
       "requires": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -5788,7 +5788,7 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ=="
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -5863,7 +5863,7 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
       "optional": true
     },
@@ -6019,13 +6019,13 @@
     "hsl-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+      "integrity": "sha512-M5ezZw4LzXbBKMruP+BNANf0k+19hDQMgpzBIYnya//Al+fjNct9Wf3b1WedLqdEs2hKBvxq/jh+DsHJLj0F9A==",
       "dev": true
     },
     "hsla-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+      "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA==",
       "dev": true
     },
     "html-entities": {
@@ -6419,7 +6419,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -6518,7 +6518,7 @@
     "is-color-stop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+      "integrity": "sha512-H1U8Vz0cfXNujrJzEcvvwMDW9Ra+biSYA3ThdQvAnMLJkEHQXn6bWzLkxHtVYJ+Sdbx0b6finn3jZiaVe7MAHA==",
       "dev": true,
       "requires": {
         "css-color-names": "^0.0.4",
@@ -8859,7 +8859,7 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -8936,7 +8936,7 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "lodash.merge": {
@@ -8954,7 +8954,7 @@
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true
     },
     "log-symbols": {
@@ -8998,13 +8998,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -9057,7 +9057,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true
     },
     "make-dir": {
@@ -9122,7 +9122,7 @@
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "integrity": "sha512-nOBDrc/wgpkd3X/JOhMqYR+/eLqlfLP4oQfoBA6QExIxEl+GU01oyEkwWyueyO8110pUKijtiHGhEmYoOn88oQ==",
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -11285,7 +11285,7 @@
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -11354,13 +11354,13 @@
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
+      "integrity": "sha512-gDK5mkALDFER2YLqH6imYvK6g02gpNGM4ILDZ472EwWfXZnC2ZEpoB2ECXTyOVUKuk/bPJZMzwQPBYICzP+D3w==",
       "dev": true
     },
     "rgba-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+      "integrity": "sha512-zgn5OjNQXLUTdq8m17KdaicF6w89TZs8ZU8y0AYENIU6wG8GG6LLm0yLSiPY8DmaYmHdgRW8rnApjoT0fQRfMg==",
       "dev": true
     },
     "rimraf": {
@@ -12055,7 +12055,7 @@
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
@@ -13061,7 +13061,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
     },
     "tippy.js": {
@@ -13415,7 +13415,7 @@
     "uniqs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "integrity": "sha512-mZdDpf3vBV5Efh29kMw5tXoup/buMgxLzOt/XKFKcVmi+15ManNQWr6HfZ2aiZTYlYixbdNJ0KFmIZIv52tHSQ==",
       "dev": true
     },
     "unique-filename": {
@@ -14217,7 +14217,7 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -14226,12 +14226,12 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14239,7 +14239,7 @@
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14249,7 +14249,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "requires": {
             "ansi-regex": "^2.0.0"
           }

--- a/frontend/src/pages/notebookController/NotebookControllerContext.tsx
+++ b/frontend/src/pages/notebookController/NotebookControllerContext.tsx
@@ -12,6 +12,7 @@ const defaultNotebookControllerContext: NotebookControllerContextProps = {
   currentUserNotebook: null,
   requestNotebookRefresh: () => undefined,
   currentUserNotebookIsRunning: false,
+  currentUserNotebookPodUID: '',
   setImpersonating: () => undefined,
   impersonatedUsername: null,
   setCurrentAdminTab: () => undefined,
@@ -30,6 +31,7 @@ export const NotebookControllerContextProvider: React.FC<
   const [notebookState, setNotebookState] = React.useState<NotebookContextStorage>({
     current: undefined,
     currentIsRunning: false,
+    currentPodUID: '',
     former: null,
     requestRefresh: () => undefined,
   });
@@ -47,6 +49,7 @@ export const NotebookControllerContextProvider: React.FC<
         // Don't return undefined -- that's for the loading
         currentUserNotebook: notebookState.current ?? null,
         currentUserNotebookIsRunning: notebookState.currentIsRunning,
+        currentUserNotebookPodUID: notebookState.currentPodUID,
       }}
     >
       <SetupCurrentNotebook

--- a/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
+++ b/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
@@ -28,6 +28,7 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
     : undefined;
   const notebook = notebookRunningState?.notebook;
   const isCurrentlyRunning = notebookRunningState?.isRunning;
+  const currentPodUID = notebookRunningState?.podUID;
 
   React.useEffect(() => {
     if (notebook !== undefined && isCurrentlyRunning !== undefined) {
@@ -35,6 +36,7 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
         ...prevState,
         current: notebook,
         currentIsRunning: isCurrentlyRunning,
+        currentPodUID: currentPodUID || '',
         requestRefresh: (speed?: number) => {
           forceRefresh();
           setPollInterval(speed);
@@ -48,6 +50,7 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
     setNotebookState,
     isCurrentlyRunning,
     setPollInterval,
+    currentPodUID,
   ]);
 
   if (currentNotebook === undefined || loadError) {

--- a/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
+++ b/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
@@ -13,6 +13,8 @@ export type NotebookControllerContextProps = {
   requestNotebookRefresh: (changeSpeed?: number) => void;
   /** Status on if the current notebook is in a state we can consider it running */
   currentUserNotebookIsRunning: boolean;
+  /** The current pod associated with the running Notebook - empty string if not running -- assumes 1 pod */
+  currentUserNotebookPodUID: string;
 
   /**
    * Setup impersonating against a user's notebook & username (need both, see below)
@@ -37,6 +39,7 @@ export type NotebookContextStorage = {
    */
   current: Notebook | null | undefined;
   currentIsRunning: boolean;
+  currentPodUID: string;
   requestRefresh: NotebookControllerContextProps['requestNotebookRefresh'];
   former: Omit<NotebookContextStorage, 'former'> | null;
 };

--- a/frontend/src/pages/notebookController/useImpersonationForContext.ts
+++ b/frontend/src/pages/notebookController/useImpersonationForContext.ts
@@ -36,6 +36,7 @@ const useImpersonationForContext = (
           const currentState: NotebookContextStorage['former'] = {
             current: prevState.current,
             currentIsRunning: prevState.currentIsRunning,
+            currentPodUID: prevState.currentPodUID,
             requestRefresh: prevState.requestRefresh,
           };
           return {

--- a/frontend/src/services/notebookEventsService.ts
+++ b/frontend/src/services/notebookEventsService.ts
@@ -1,11 +1,8 @@
 import axios from 'axios';
 import { K8sEvent } from '../types';
 
-export const getNotebookEvents = (
-  projectName: string,
-  notebookName: string,
-): Promise<K8sEvent[]> => {
-  const url = `/api/nb-events/${projectName}/${notebookName}`;
+export const getNotebookEvents = (projectName: string, podUID: string): Promise<K8sEvent[]> => {
+  const url = `/api/nb-events/${projectName}/${podUID}`;
   return axios.get(url).then((response) => {
     return response.data;
   });

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { RecursivePartial } from 'typeHelpers';
-import { Notebook, NotebookState, NotebookData } from '../types';
+import { Notebook, NotebookState, NotebookData, NotebookRunningState } from '../types';
 
 export const getNotebook = (namespace: string, name: string): Promise<Notebook> => {
   const url = `/api/notebooks/${namespace}/${name}`;
@@ -18,7 +18,7 @@ export const getNotebookAndStatus = (
   namespace: string,
   name: string,
   notebook: Notebook | null,
-): Promise<{ notebook: Notebook | null; isRunning: boolean }> => {
+): Promise<NotebookRunningState> => {
   const url = `/api/notebooks/${namespace}/${name}/status`;
 
   return axios

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -343,6 +343,7 @@ export type Notebook = K8sResourceCommon & {
 export type NotebookRunningState = {
   notebook: Notebook | null;
   isRunning: boolean;
+  podUID: string;
 };
 
 export type NotebookList = {
@@ -606,6 +607,9 @@ export type ResourceReplacer<T extends K8sResourceCommon> = (resource: T) => Pro
 export type ResourceDeleter = (projectName: string, resourceName: string) => Promise<DeleteStatus>;
 
 export type K8sEvent = {
+  involvedObject: {
+    uid: string;
+  };
   metadata: K8sMetadata;
   eventTime: string;
   lastTimestamp: string | null; // if it never starts, the value is null

--- a/frontend/src/utilities/useWatchNotebookEvents.tsx
+++ b/frontend/src/utilities/useWatchNotebookEvents.tsx
@@ -6,7 +6,7 @@ import { FAST_POLL_INTERVAL } from './const';
 
 export const useWatchNotebookEvents = (
   projectName: string,
-  notebookName: string,
+  podUID: string,
   activeFetch: boolean,
 ): K8sEvent[] => {
   const [notebookEvents, setNoteBookEvents] = React.useState<K8sEvent[]>([]);
@@ -23,8 +23,8 @@ export const useWatchNotebookEvents = (
 
     if (activeFetch) {
       const watchNotebookEvents = () => {
-        if (projectName && notebookName) {
-          getNotebookEvents(projectName, notebookName)
+        if (projectName && podUID) {
+          getNotebookEvents(projectName, podUID)
             .then((data: K8sEvent[]) => {
               if (cancelled) {
                 return;
@@ -43,7 +43,7 @@ export const useWatchNotebookEvents = (
       watchNotebookEvents();
     }
     return clear;
-  }, [projectName, notebookName, notification, activeFetch]);
+  }, [projectName, podUID, notification, activeFetch]);
 
   return notebookEvents;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes: #899

## Description
<!--- Describe your changes in detail -->
We fixed DS Projects to use uid in fetching, but the old Jupyter tile code did not get updated. This updates that -- although due to the frontend/backend separation, this was more convoluted. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Start a Juptyer Notebook - once the oauth container is in the nb events, cancel. Restarting immediately used to show events from the terminating pod -- now we only see the latest pod events. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
