### PR TITLE
Allow overriding default servingruntime.

### DIFF
--- a/frontend/src/api/network/servingRuntimes.ts
+++ b/frontend/src/api/network/servingRuntimes.ts
@@ -12,7 +12,7 @@ import { CreatingServingRuntimeObject } from 'pages/modelServing/screens/types';
 import { getModelServingRuntimeName } from 'pages/modelServing/utils';
 import { getModelServingProjects } from './projects';
 import { getConfigMap } from './configMaps';
-import { DEFAULT_MODEL_SERVING_TEAMPLATE } from 'pages/modelServing/screens/const';
+import { DEFAULT_MODEL_SERVING_TEMPLATE } from 'pages/modelServing/screens/const';
 import YAML from 'yaml';
 
 const fetchServingRuntime = (
@@ -22,17 +22,21 @@ const fetchServingRuntime = (
 ): Promise<ServingRuntimeKind> => {
   return getConfigMap(configNamespace, 'servingruntimes-config')
     .then((configmap) => {
-      const servingRuntime = YAML.parse(configmap.data?.['default-config'] || '');
-      if (servingRuntime === null) {
+      const overrideServingRuntime = YAML.parse(configmap.data?.['override-config'] || '');
+      if (overrideServingRuntime) {
+        return assembleServingRuntime(data, namespace, overrideServingRuntime);
+      }
+      const defaultServingRuntime = YAML.parse(configmap.data?.['default-config'] || '');
+      if (defaultServingRuntime === null) {
         throw new Error(
           'servingruntimes-config is misconfigured or key might be missing from the ConfigMap',
         );
       }
-      return assembleServingRuntime(data, namespace, servingRuntime);
+      return assembleServingRuntime(data, namespace, defaultServingRuntime);
     })
     .catch((e) => {
       console.error(`${e}, using default config.`);
-      const servingRuntime = DEFAULT_MODEL_SERVING_TEAMPLATE;
+      const servingRuntime = DEFAULT_MODEL_SERVING_TEMPLATE;
       return assembleServingRuntime(data, namespace, servingRuntime);
     });
 };

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -58,7 +58,7 @@ export const STORAGE_KEYS_REQUIRED: STORAGE_KEYS[] = [
   STORAGE_KEYS.S3_ENDPOINT,
 ];
 
-export const DEFAULT_MODEL_SERVING_TEAMPLATE: ServingRuntimeKind = {
+export const DEFAULT_MODEL_SERVING_TEMPLATE: ServingRuntimeKind = {
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
   metadata: {

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -52,7 +52,9 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
           dataLabel="Type"
           compoundExpand={compoundExpandParams(ServingRuntimeTableTabs.TYPE, false)}
         >
-          {obj.spec.builtInAdapter.serverType}
+          {obj.metadata.annotations?.['openshift.io/display-name'] ||
+            obj.spec.builtInAdapter?.serverType ||
+            'Custom Runtime'}
         </Td>
         <Td
           dataLabel="Deployed models"


### PR DESCRIPTION
As a stopgap until we fully support multiple custom runtimes, we want to allow a backend only configuration to override the default custom Runtime

## Description
Fixes bug where UI would die when a custom runtime has not buildInAdapter (which is the case on any custom runtime)
Reads override-config from servingruntimes-config and uses that serving runtime if available

## How Has This Been Tested?
add the following key/value to servingruntimes-config
```yaml
  override-config: |
    apiVersion: serving.kserve.io/v1alpha1
    kind: ServingRuntime
    metadata:
      # metadata will be overwritten by the model's metadata
      name: ''
      namespace: ''
      labels:
        name: ''
        opendatahub.io/dashboard: 'true'
      annotations: 
        openshift.io/display-name: 'Watson NLP Custom'
    spec:
      supportedModelFormats:
        - autoSelect: true
          name: chris-watson-nlp-custom
      # replicas will be overwritten by the model's replica
      replicas: 1
      protocolVersions:
        - grpc-v1
      multiModel: true
      grpcEndpoint: 'port:8085'
      grpcDataEndpoint: 'port:8001'
      containers:
        - name: watson-nlp-runtime
          image: 'us.icr.io/watson-runtime/fmaas-runtime-ansible:0.0.3'
          env:
            - name: ACCEPT_LICENSE
              value: 'true'
            - name: LOG_LEVEL
              value: info
            - name: CAPACITY
              value: '28000000000'
            - name: DEFAULT_MODEL_SIZE
              value: '1773741824'
            - name: METRICS_PORT
              value: '2113'
            - name: GATEWAY_PORT
              value: '8060'
            - name: STRICT_RPC_MODE
              value: 'false'
            - name: HF_HOME
              value: /tmp/
          resources:
            limits:
              cpu: 2
              memory: 16Gi
            requests:
              cpu: 1
              memory: 16Gi
      storageHelper:
        disabled: false
```

You should be allowed to generate a Watson NLP Custom runtime, although pulling that image will not currently work.  The normal configmap should also work.

fixes #904 

<img src="https://user-images.githubusercontent.com/1448375/213607036-0c0377f8-b2f8-451e-80da-f2d8e8a9a008.png" width="300">


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
