### PR TITLE
Follow up fix for the warning in the console due to PF version bump

### DIFF
--- a/frontend/src/pages/projects/notebook/NotebookImagePackageDetails.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookImagePackageDetails.tsx
@@ -28,9 +28,9 @@ const NotebookImagePackageDetails: React.FC<NotebookPackageDetailsProps> = ({
         <DescriptionListTerm>{title || 'Packages'}</DescriptionListTerm>
         <DescriptionListDescription>
           {dependencies.map(getNameVersionString).map((pkg) => (
-            <p key={pkg}>
+            <div key={pkg}>
               <Truncate removeFindDomNode content={pkg} />
-            </p>
+            </div>
           ))}
         </DescriptionListDescription>
       </DescriptionListGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a follow-up simple fix for #870 to get rid of the warning in the DOM.

<img width="741" alt="Screenshot 2023-01-20 at 10 42 56 AM" src="https://user-images.githubusercontent.com/37624318/213745516-fb8238e0-1e63-4f79-bef9-92dddda529fd.png">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
