### PR TITLE
Admin logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .env*.local
 
 node_modules
+logs
 
 .docs
 .gitkeep

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,10 +1,17 @@
+import * as fs from 'fs';
 import * as path from 'path';
+import { LOG_DIR } from './utils/constants';
 import fastifyStatic from 'fastify-static';
 import fastifyAutoload from 'fastify-autoload';
 import fastifySensible from 'fastify-sensible';
 import { FastifyInstance } from 'fastify/types/instance';
 
 export const initializeApp = async (fastify: FastifyInstance, opts: any): Promise<void> => {
+  if (!fs.existsSync(LOG_DIR)) {
+    fastify.log.info(`${LOG_DIR} does not exist. Creating`);
+    fs.mkdirSync(LOG_DIR);
+  }
+
   fastify.register(fastifySensible);
 
   fastify.register(fastifyStatic, {

--- a/backend/src/routes/api/gpu/index.ts
+++ b/backend/src/routes/api/gpu/index.ts
@@ -1,8 +1,11 @@
-import { KubeFastifyInstance } from '../../../types';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { getGPUNumber } from './gpuUtils';
+import { logRequestDetails } from '../../../utils/fileUtils';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  fastify.get('/', async () => {
+  fastify.get('/', async (request: OauthFastifyRequest) => {
+    logRequestDetails(fastify, request);
+
     return getGPUNumber(fastify);
   });
 };

--- a/backend/src/routes/api/k8s/index.ts
+++ b/backend/src/routes/api/k8s/index.ts
@@ -2,6 +2,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { KubeFastifyInstance } from '../../../types';
 import { USER_ACCESS_TOKEN } from '../../../utils/constants';
 import { passThrough } from './pass-through';
+import { logRequestDetails } from '../../../utils/fileUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   const kc = fastify.kube.config;
@@ -23,6 +24,8 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       }>,
       reply: FastifyReply,
     ) => {
+      logRequestDetails(fastify, req);
+
       const data = JSON.stringify(req.body);
       const kubeUri = req.params['*'];
       let url = `${cluster.server}/${kubeUri}`;

--- a/backend/src/routes/api/namespaces/index.ts
+++ b/backend/src/routes/api/namespaces/index.ts
@@ -1,11 +1,14 @@
 import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { applyNamespaceChange } from './namespaceUtils';
 import { NamespaceApplicationCase } from './const';
+import { logRequestDetails } from '../../../utils/fileUtils';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   fastify.get(
     '/:name/:context',
     async (request: OauthFastifyRequest<{ Params: { name: string; context: string } }>) => {
+      logRequestDetails(fastify, request);
+
       const { name, context: contextAsString } = request.params;
 
       const context = parseInt(contextAsString) as NamespaceApplicationCase;

--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -1,6 +1,7 @@
 import { KubeFastifyInstance, OauthFastifyRequest, PrometheusResponse } from '../../../types';
 import { callPrometheus } from '../../../utils/prometheusUtils';
 import { createCustomError } from '../../../utils/requestUtils';
+import { logRequestDetails } from '../../../utils/fileUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   /**
@@ -12,6 +13,8 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     async (
       request: OauthFastifyRequest<{ Body: { query: string; namespace: string } }>,
     ): Promise<{ code: number; response: PrometheusResponse }> => {
+      logRequestDetails(fastify, request);
+
       const { query, namespace } = request.body;
 
       return callPrometheus(fastify, request, query, namespace).catch((e) => {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,9 +1,11 @@
+import * as path from 'path';
 import './dotenv';
 import { DashboardConfig, NotebookSize } from '../types';
 
 export const PORT = process.env.PORT || process.env.BACKEND_PORT || 8080;
 export const IP = process.env.IP || '0.0.0.0';
 export const LOG_LEVEL = process.env.FASTIFY_LOG_LEVEL || process.env.LOG_LEVEL || 'info';
+export const LOG_DIR = path.join(__dirname, '../../../logs');
 export const DEV_MODE = process.env.APP_ENV === 'development';
 export const APP_ENV = process.env.APP_ENV;
 

--- a/backend/src/utils/fileUtils.ts
+++ b/backend/src/utils/fileUtils.ts
@@ -1,15 +1,47 @@
 import * as fs from 'fs';
-import { KubeFastifyInstance } from '../types';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
 import { LOG_DIR } from './constants';
+import { getUserName } from './userUtils';
+import { getNamespaces } from './notebookUtils';
+import { isUserAdmin } from './adminUtils';
 
 export type AdminLogRecord = {
   user: string;
   namespace: string;
   action: string;
   endpoint: string;
-  payload: string;
   isAdmin: boolean;
   needsAdmin: boolean;
+};
+
+export const logRequestDetails = (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  routeNeedsAdmin?: boolean,
+): void => {
+  const data: Omit<AdminLogRecord, 'user' | 'isAdmin'> = {
+    namespace: fastify.kube.namespace,
+    action: request.method.toUpperCase(),
+    endpoint: request.url.replace(request.headers.origin, ''),
+    needsAdmin: routeNeedsAdmin ?? false,
+  };
+
+  const writeLogAsync = async () => {
+    const username = await getUserName(fastify, request);
+    const { dashboardNamespace } = getNamespaces(fastify);
+    const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
+
+    writeAdminLog(fastify, {
+      ...data,
+      user: username,
+      isAdmin: isAdmin,
+    });
+  };
+  // break the thread so the request is not held up logging / determing permissions of the user
+  setTimeout(
+    () => writeLogAsync().catch((e) => fastify.log.error(`Error writing log. ${e.message}`)),
+    0,
+  );
 };
 
 export const writeAdminLog = (fastify: KubeFastifyInstance, data: AdminLogRecord): void => {

--- a/backend/src/utils/fileUtils.ts
+++ b/backend/src/utils/fileUtils.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs';
+import { KubeFastifyInstance } from '../types';
+import { LOG_DIR } from './constants';
+
+export type AdminLogRecord = {
+  user: string;
+  namespace: string;
+  action: string;
+  endpoint: string;
+  payload: string;
+  isAdmin: boolean;
+  needsAdmin: boolean;
+};
+
+export const writeAdminLog = (fastify: KubeFastifyInstance, data: AdminLogRecord): void => {
+  try {
+    fs.appendFile(
+      `${LOG_DIR}/adminActivity.log`,
+      `${new Date().toISOString()}: ${JSON.stringify(data)}\n`,
+      function (err) {
+        if (err) {
+          fastify.log.error(`ERROR: Unable to write to admin log - ${err}`);
+        }
+      },
+    );
+  } catch (e) {
+    fastify.log.error('Failed to log admin activity!');
+  }
+};

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -10,7 +10,7 @@ import { createCustomError } from './requestUtils';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { isUserAdmin } from './adminUtils';
 import { getNamespaces } from './notebookUtils';
-import { writeAdminLog } from './fileUtils';
+import { logRequestDetails } from './fileUtils';
 
 const testAdmin = async (
   fastify: KubeFastifyInstance,
@@ -154,19 +154,7 @@ const handleSecurityOnRouteData = async (
   request: OauthFastifyRequest,
   needsAdmin: boolean,
 ): Promise<void> => {
-  const username = await getUserName(fastify, request);
-  const { dashboardNamespace } = getNamespaces(fastify);
-  const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
-
-  writeAdminLog(fastify, {
-    user: username,
-    namespace: fastify.kube.namespace,
-    action: request.method.toUpperCase(),
-    endpoint: request.url.replace(request.headers.origin, ''),
-    payload: JSON.stringify(request.body),
-    isAdmin: isAdmin,
-    needsAdmin: needsAdmin,
-  });
+  logRequestDetails(fastify, request, needsAdmin);
 
   if (isRequestBody(request)) {
     await requestSecurityGuard(
@@ -202,6 +190,9 @@ const handleSecurityOnRouteData = async (
     }
 
     // Not getting a resource, mutating something that is not verify-able theirs -- log the user encase of malicious behaviour
+    const username = await getUserName(fastify, request);
+    const { dashboardNamespace } = getNamespaces(fastify);
+    const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
     fastify.log.warn(
       `${isAdmin ? 'Admin ' : ''}User ${username} interacted with a resource that was not secure.`,
     );


### PR DESCRIPTION
Closes #717 
Replaces #743

## Description
Adds user activity logging in the security layer of the dashboard.

## How Has This Been Tested?
Deployed locally and into a running cluster with ODH Core components.  

## Merge criteria:
- There is no change to existing functionality of any features. 
- Log in to the Dashboard as an admin user
- Navigate to any page that requires Admin permissions
- Check the odh-dashboard pod for logs at `/opt/app-root/src/logs` to confirm that api requests by admin users is properly logged

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
