### PR TITLE
Fix Prometheus PVC Fill Status Call (for basic users)

### DIFF
--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -100,7 +100,7 @@ export const callPrometheusPVC = (
     fastify,
     request,
     query,
-    generatePrometheusHostURL(fastify, 'thanos-querier', 'openshift-monitoring', '9091'),
+    generatePrometheusHostURL(fastify, 'thanos-querier', 'openshift-monitoring', '9092'),
     QueryType.QUERY,
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves: #862 

## Description
<!--- Describe your changes in detail -->
Using the wrong port for simple metrics the user can get.

- Port 9091 is for users who can see all metrics in the cluster (get namespace permission)
- Port 9092 is for users who can only get metrics in certain namespaces

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Turn down the ODH operator on your cluster
- Replace the ODH Dashboard container's image with the one from the PR
- Log into the Dashboard with your basic user
- Create a project & workbench -- then view the status of the PVC

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
