### PR TITLE
Improve Model Server modal error handling with dynamic spec

### DIFF
--- a/frontend/src/api/network/servingRuntimes.ts
+++ b/frontend/src/api/network/servingRuntimes.ts
@@ -7,43 +7,14 @@ import {
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { ServingRuntimeModel } from '../models';
-import { ServingRuntimeKind } from '../../k8sTypes';
+import { ConfigMapKind, ServingRuntimeKind } from '../../k8sTypes';
 import { CreatingServingRuntimeObject } from 'pages/modelServing/screens/types';
 import { getModelServingRuntimeName } from 'pages/modelServing/utils';
 import { getModelServingProjects } from './projects';
-import { getConfigMap } from './configMaps';
-import { DEFAULT_MODEL_SERVING_TEMPLATE } from 'pages/modelServing/screens/const';
-import YAML from 'yaml';
 import { assemblePodSpecOptions } from './utils';
 import { ContainerResources } from '../../types';
-
-const fetchServingRuntime = (
-  data: CreatingServingRuntimeObject,
-  configNamespace: string,
-  namespace: string,
-): Promise<ServingRuntimeKind> => {
-  //TODO: remove fetch servingruntimes-config here and pass in the previously fetched valued.
-  // Leaving it in for now to keep the original behavior when no GPU is configured.
-  return getConfigMap(configNamespace, 'servingruntimes-config')
-    .then((configmap) => {
-      const overrideServingRuntime = YAML.parse(configmap.data?.['override-config'] || '');
-      if (overrideServingRuntime) {
-        return assembleServingRuntime(data, namespace, overrideServingRuntime);
-      }
-      const defaultServingRuntime = YAML.parse(configmap.data?.['default-config'] || '');
-      if (defaultServingRuntime === null) {
-        throw new Error(
-          'servingruntimes-config is misconfigured or key might be missing from the ConfigMap',
-        );
-      }
-      return assembleServingRuntime(data, namespace, defaultServingRuntime);
-    })
-    .catch((e) => {
-      console.error(`${e}, using default config.`);
-      const servingRuntime = DEFAULT_MODEL_SERVING_TEMPLATE;
-      return assembleServingRuntime(data, namespace, servingRuntime);
-    });
-};
+import { getDefaultServingRuntime } from 'pages/modelServing/screens/projects/utils';
+import { DEFAULT_MODEL_SERVING_TEMPLATE } from 'pages/modelServing/screens/const';
 
 const assembleServingRuntime = (
   data: CreatingServingRuntimeObject,
@@ -163,16 +134,30 @@ export const updateServingRuntime = (
   });
 };
 
+const getAssembledServingRuntime = (
+  data: CreatingServingRuntimeObject,
+  servingRuntimeConfig: ConfigMapKind | undefined,
+  namespace: string,
+): ServingRuntimeKind => {
+  const servingRuntime = getDefaultServingRuntime(servingRuntimeConfig);
+
+  try {
+    return assembleServingRuntime(data, namespace, servingRuntime);
+  } catch {
+    return assembleServingRuntime(data, namespace, DEFAULT_MODEL_SERVING_TEMPLATE);
+  }
+};
+
 export const createServingRuntime = (
   data: CreatingServingRuntimeObject,
-  configNamespace: string,
+  servingRuntimeConfig: ConfigMapKind | undefined,
   namespace: string,
 ): Promise<ServingRuntimeKind> => {
-  return fetchServingRuntime(data, configNamespace, namespace).then((servingRuntime) => {
-    return k8sCreateResource<ServingRuntimeKind>({
-      model: ServingRuntimeModel,
-      resource: servingRuntime,
-    });
+  const assembledServingRuntime = getAssembledServingRuntime(data, servingRuntimeConfig, namespace);
+
+  return k8sCreateResource<ServingRuntimeKind>({
+    model: ServingRuntimeModel,
+    resource: assembledServingRuntime,
   });
 };
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix #893 
Add error handling for the dynamic spec of the ServingRuntime object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Delete the `servingruntimes-config` ConfigMap
2. Create a new Model Server
3. Check there's a warning now in the modal
4. Create a new `servingruntimes-config` ConfigMap with a `default-config` key
5. Check that the alert is gone

![model-serving](https://user-images.githubusercontent.com/16117276/217520021-0f0ef483-858d-4f64-ab2e-d87fab17af4a.gif)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
