### PR TITLE
 GPU serving setting

### DIFF
--- a/frontend/src/api/network/utils.ts
+++ b/frontend/src/api/network/utils.ts
@@ -1,0 +1,66 @@
+import {
+  PodAffinity,
+  ContainerResources,
+  PodToleration,
+  TolerationSettings,
+  ContainerResourceAttributes,
+} from '../../types';
+
+export const assemblePodSpecOptions = (
+  resourceSettings: ContainerResources,
+  gpus: number,
+  tolerationSettings?: TolerationSettings,
+  affinitySettings?: PodAffinity,
+): {
+  affinity: PodAffinity;
+  tolerations: PodToleration[];
+  resources: ContainerResources;
+} => {
+  let affinity: PodAffinity = structuredClone(affinitySettings || {});
+  const tolerations: PodToleration[] = [];
+  const resources = structuredClone(resourceSettings);
+  if (gpus > 0) {
+    if (!resources.limits) {
+      resources.limits = {};
+    }
+    if (!resources.requests) {
+      resources.requests = {};
+    }
+    resources.limits[ContainerResourceAttributes.NVIDIA_GPU] = gpus;
+    resources.requests[ContainerResourceAttributes.NVIDIA_GPU] = gpus;
+    tolerations.push({
+      effect: 'NoSchedule',
+      key: 'nvidia.com/gpu',
+      operator: 'Exists',
+    });
+  } else {
+    delete resources.limits?.[ContainerResourceAttributes.NVIDIA_GPU];
+    delete resources.requests?.[ContainerResourceAttributes.NVIDIA_GPU];
+    affinity = {
+      nodeAffinity: {
+        preferredDuringSchedulingIgnoredDuringExecution: [
+          {
+            preference: {
+              matchExpressions: [
+                {
+                  key: 'nvidia.com/gpu.present',
+                  operator: 'NotIn',
+                  values: ['true'],
+                },
+              ],
+            },
+            weight: 1,
+          },
+        ],
+      },
+    };
+  }
+  if (tolerationSettings?.enabled) {
+    tolerations.push({
+      effect: 'NoSchedule',
+      key: tolerationSettings.key,
+      operator: 'Exists',
+    });
+  }
+  return { affinity, tolerations, resources };
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1,5 +1,5 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { NotebookAffinity, NotebookContainer, NotebookToleration, Volume } from './types';
+import { PodAffinity, NotebookContainer, PodToleration, Volume, ContainerResources } from './types';
 
 /**
  * Annotations that we will use to allow the user flexibility in describing items outside of the
@@ -188,11 +188,11 @@ export type NotebookKind = K8sResourceCommon & {
   spec: {
     template: {
       spec: {
-        affinity?: NotebookAffinity;
+        affinity?: PodAffinity;
         enableServiceLinks?: boolean;
         containers: NotebookContainer[];
         volumes?: Volume[];
-        tolerations?: NotebookToleration[];
+        tolerations?: PodToleration[];
       };
     };
   };
@@ -254,16 +254,7 @@ export type ServingRuntimeKind = K8sResourceCommon & {
       args: string[];
       image: string;
       name: string;
-      resources: {
-        limits: {
-          cpu: string;
-          memory: string;
-        };
-        requests: {
-          cpu: string;
-          memory: string;
-        };
-      };
+      resources: ContainerResources;
     }[];
     supportedModelFormats: SupportedModelFormats[];
     replicas: number;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
@@ -11,6 +11,7 @@ import {
 import { ServingRuntimeKind } from '../../../../k8sTypes';
 import { AppContext } from '../../../../app/AppContext';
 import { getServingRuntimeSizes } from './utils';
+import { ContainerResourceAttributes } from '../../../../types';
 
 type ServingRuntimeDetailsProps = {
   obj: ServingRuntimeKind;
@@ -34,18 +35,19 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj }) =>
           <List isPlain>
             <ListItem>{size?.name || 'Custom'}</ListItem>
             <ListItem>
-              {`${container.resources.requests.cpu} CPUs, ${container.resources.requests.memory} Memory requested`}
+              {`${container.resources.requests?.cpu} CPUs, ${container.resources.requests?.memory} Memory requested`}
             </ListItem>
             <ListItem>
-              {`${container.resources.limits.cpu} CPUs, ${container.resources.limits.memory} Memory limit`}
+              {`${container.resources.limits?.cpu} CPUs, ${container.resources.limits?.memory} Memory limit`}
             </ListItem>
           </List>
         </DescriptionListDescription>
       </DescriptionListGroup>
-      {/* TODO: fetch GPUs, get metrics data */}
       <DescriptionListGroup>
         <DescriptionListTerm>Number of GPUs</DescriptionListTerm>
-        <DescriptionListDescription>0</DescriptionListDescription>
+        <DescriptionListDescription>
+          {container.resources.limits?.[ContainerResourceAttributes.NVIDIA_GPU] || 0}
+        </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>
   );

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -36,6 +36,7 @@ import ServingRuntimeSizeSection from './ServingRuntimeSizeSection';
 import ServingRuntimeTokenSection from './ServingRuntimeTokenSection';
 import { translateDisplayNameForK8s } from 'pages/projects/utils';
 import { useDashboardNamespace } from 'redux/selectors';
+import { ContainerResourceAttributes } from '../../../../../types';
 
 type ManageServingRuntimeModalProps = {
   isOpen: boolean;
@@ -51,7 +52,8 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
   onClose,
   editInfo,
 }) => {
-  const [createData, setCreateData, resetData, sizes] = useCreateServingRuntimeObject(editInfo);
+  const [createData, setCreateData, resetData, sizes, gpuSetting] =
+    useCreateServingRuntimeObject(editInfo);
 
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
@@ -64,16 +66,17 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
 
   const tokenErrors = createData.tokens.filter((token) => token.error !== '').length > 0;
 
+  const resourceIsSet = (fieldName, min = 1) => {
+    const requests = createData.modelSize.resources.requests?.[fieldName];
+    const limits = createData.modelSize.resources.limits?.[fieldName];
+    return (
+      requests && limits && min <= parseInt(requests) && parseInt(requests) <= parseInt(limits)
+    );
+  };
+
   const inputValueValid =
-    createData.numReplicas > 0 &&
-    parseInt(createData.modelSize.resources.limits.cpu) > 0 &&
-    parseInt(createData.modelSize.resources.limits.memory) > 0 &&
-    parseInt(createData.modelSize.resources.requests.cpu) > 0 &&
-    parseInt(createData.modelSize.resources.requests.memory) > 0 &&
-    parseInt(createData.modelSize.resources.limits.cpu) >
-      parseInt(createData.modelSize.resources.requests.cpu) &&
-    parseInt(createData.modelSize.resources.limits.memory) >
-      parseInt(createData.modelSize.resources.requests.memory);
+    resourceIsSet(ContainerResourceAttributes.CPU) &&
+    resourceIsSet(ContainerResourceAttributes.MEMORY);
 
   const canCreate = !actionInProgress && !tokenErrors && inputValueValid;
 
@@ -210,7 +213,12 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
             <ServingRuntimeReplicaSection data={createData} setData={setCreateData} />
           </StackItem>
           <StackItem>
-            <ServingRuntimeSizeSection data={createData} setData={setCreateData} sizes={sizes} />
+            <ServingRuntimeSizeSection
+              data={createData}
+              setData={setCreateData}
+              sizes={sizes}
+              gpuSetting={gpuSetting}
+            />
           </StackItem>
           <StackItem>
             <FormSection title="Model route" titleElement="div">

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeExpandedField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeExpandedField.tsx
@@ -2,19 +2,16 @@ import * as React from 'react';
 import { FormGroup, Grid, NumberInput, ValidatedOptions } from '@patternfly/react-core';
 import IndentSection from 'pages/projects/components/IndentSection';
 import { UpdateObjectAtPropAndValue } from 'pages/projects/types';
-import { CreatingServingRuntimeObject, ServingRuntimeResources } from '../../types';
+import { CreatingServingRuntimeObject } from '../../types';
 import { isHTMLInputElement, normalizeBetween } from 'utilities/utils';
+import { ContainerResourceAttributes, ContainerResources } from '../../../../../types';
 
 type ServingRuntimeSizeExpandedFieldProps = {
   data: CreatingServingRuntimeObject;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
 };
 
-type ResourceKeys = keyof ServingRuntimeResources;
-enum ResourceAttributes {
-  CPU = 'cpu',
-  MEMORY = 'memory',
-}
+type ResourceKeys = keyof ContainerResources;
 
 const ServingRuntimeSizeExpandedField: React.FC<ServingRuntimeSizeExpandedFieldProps> = ({
   data,
@@ -25,7 +22,7 @@ const ServingRuntimeSizeExpandedField: React.FC<ServingRuntimeSizeExpandedFieldP
   const onChangeResources = (
     event: React.FormEvent<HTMLInputElement>,
     resourceKey: ResourceKeys,
-    resourceAttribute: ResourceAttributes,
+    resourceAttribute: ContainerResourceAttributes,
   ) => {
     if (isHTMLInputElement(event.target)) {
       const newSize = Number(event.target.value);
@@ -50,7 +47,7 @@ const ServingRuntimeSizeExpandedField: React.FC<ServingRuntimeSizeExpandedFieldP
     currentValue: number,
     step: number,
     resourceKey: ResourceKeys,
-    resourceAttribute: ResourceAttributes,
+    resourceAttribute: ContainerResourceAttributes,
   ) => {
     const suffix = resourceAttribute === 'memory' ? 'Gi' : '';
 
@@ -73,108 +70,116 @@ const ServingRuntimeSizeExpandedField: React.FC<ServingRuntimeSizeExpandedFieldP
     return parseInt(resourceValue.split('Gi')[0]);
   };
 
-  const validateInput = (value: string): ValidatedOptions =>
-    parseInt(value) >= 0 ? ValidatedOptions.default : ValidatedOptions.error;
+  const validateInput = (value: string | undefined): ValidatedOptions =>
+    value && parseInt(value) >= 0 ? ValidatedOptions.default : ValidatedOptions.error;
 
   return (
     <IndentSection>
       <Grid hasGutter md={6}>
         <FormGroup label="CPUs requested">
           <NumberInput
-            value={parseResourceInput(data.modelSize?.resources.requests.cpu)}
+            value={parseResourceInput(data.modelSize?.resources.requests?.cpu)}
             widthChars={10}
             min={1}
-            validated={validateInput(data.modelSize?.resources.requests.cpu)}
-            onChange={(event) => onChangeResources(event, 'requests', ResourceAttributes.CPU)}
+            validated={validateInput(data.modelSize?.resources.requests?.cpu)}
+            onChange={(event) =>
+              onChangeResources(event, 'requests', ContainerResourceAttributes.CPU)
+            }
             onMinus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.requests.cpu),
+                parseResourceInput(data.modelSize?.resources.requests?.cpu),
                 -1,
                 'requests',
-                ResourceAttributes.CPU,
+                ContainerResourceAttributes.CPU,
               )
             }
             onPlus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.requests.cpu),
+                parseResourceInput(data.modelSize?.resources.requests?.cpu),
                 +1,
                 'requests',
-                ResourceAttributes.CPU,
+                ContainerResourceAttributes.CPU,
               )
             }
           />
         </FormGroup>
         <FormGroup label="Memory requested">
           <NumberInput
-            value={parseResourceInput(data.modelSize?.resources.requests.memory)}
+            value={parseResourceInput(data.modelSize?.resources.requests?.memory)}
             widthChars={10}
             min={1}
-            validated={validateInput(data.modelSize?.resources.requests.memory)}
-            onChange={(event) => onChangeResources(event, 'requests', ResourceAttributes.MEMORY)}
+            validated={validateInput(data.modelSize?.resources.requests?.memory)}
+            onChange={(event) =>
+              onChangeResources(event, 'requests', ContainerResourceAttributes.MEMORY)
+            }
             onMinus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.requests.memory),
+                parseResourceInput(data.modelSize?.resources.requests?.memory),
                 -1,
                 'requests',
-                ResourceAttributes.MEMORY,
+                ContainerResourceAttributes.MEMORY,
               )
             }
             onPlus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.requests.memory),
+                parseResourceInput(data.modelSize?.resources.requests?.memory),
                 +1,
                 'requests',
-                ResourceAttributes.MEMORY,
+                ContainerResourceAttributes.MEMORY,
               )
             }
           />
         </FormGroup>
         <FormGroup label="CPU limit">
           <NumberInput
-            value={parseResourceInput(data.modelSize?.resources.limits.cpu)}
+            value={parseResourceInput(data.modelSize?.resources.limits?.cpu)}
             widthChars={10}
             min={1}
-            validated={validateInput(data.modelSize?.resources.limits.cpu)}
-            onChange={(event) => onChangeResources(event, 'limits', ResourceAttributes.CPU)}
+            validated={validateInput(data.modelSize?.resources.limits?.cpu)}
+            onChange={(event) =>
+              onChangeResources(event, 'limits', ContainerResourceAttributes.CPU)
+            }
             onMinus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.limits.cpu),
+                parseResourceInput(data.modelSize?.resources.limits?.cpu),
                 -1,
                 'limits',
-                ResourceAttributes.CPU,
+                ContainerResourceAttributes.CPU,
               )
             }
             onPlus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.limits.cpu),
+                parseResourceInput(data.modelSize?.resources.limits?.cpu),
                 +1,
                 'limits',
-                ResourceAttributes.CPU,
+                ContainerResourceAttributes.CPU,
               )
             }
           />
         </FormGroup>
         <FormGroup label="Memory limit">
           <NumberInput
-            value={parseResourceInput(data.modelSize?.resources.limits.memory)}
+            value={parseResourceInput(data.modelSize?.resources.limits?.memory)}
             widthChars={10}
             min={1}
-            validated={validateInput(data.modelSize?.resources.limits.memory)}
-            onChange={(event) => onChangeResources(event, 'limits', ResourceAttributes.MEMORY)}
+            validated={validateInput(data.modelSize?.resources.limits?.memory)}
+            onChange={(event) =>
+              onChangeResources(event, 'limits', ContainerResourceAttributes.MEMORY)
+            }
             onMinus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.limits.memory),
+                parseResourceInput(data.modelSize?.resources.limits?.memory),
                 -1,
                 'limits',
-                ResourceAttributes.MEMORY,
+                ContainerResourceAttributes.MEMORY,
               )
             }
             onPlus={() =>
               onStep(
-                parseResourceInput(data.modelSize?.resources.limits.memory),
+                parseResourceInput(data.modelSize?.resources.limits?.memory),
                 +1,
                 'limits',
-                ResourceAttributes.MEMORY,
+                ContainerResourceAttributes.MEMORY,
               )
             }
           />

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -1,27 +1,31 @@
 import * as React from 'react';
-import { FormGroup, FormSection, Select, SelectOption } from '@patternfly/react-core';
+import { FormGroup, FormSection, NumberInput, Select, SelectOption } from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from 'pages/projects/types';
 import { CreatingServingRuntimeObject, ServingRuntimeSize } from '../../types';
 import ServingRuntimeSizeExpandedField from './ServingRuntimeSizeExpandedField';
+import useGPUSetting from '../../../../notebookController/screens/server/useGPUSetting';
+import { GpuSettingString } from '../../../../../types';
 
 type ServingRuntimeSizeSectionProps = {
   data: CreatingServingRuntimeObject;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
   sizes: ServingRuntimeSize[];
+  gpuSetting: GpuSettingString;
 };
 
 const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
   data,
   setData,
   sizes,
+  gpuSetting,
 }) => {
   const [sizeDropdownOpen, setSizeDropdownOpen] = React.useState(false);
+  const { available: gpuAvailable, count: gpuCount } = useGPUSetting(gpuSetting || 'hidden');
 
-  // Leaving this to enable GPU in next release
-  // const onChangeGPU = (event: React.FormEvent<HTMLInputElement>) => {
-  //   const target = event.target as HTMLInputElement;
-  //   setData('gpus', parseInt(target.value));
-  // };
+  const onChangeGPU = (event: React.FormEvent<HTMLInputElement>) => {
+    const target = event.target as HTMLInputElement;
+    setData('gpus', parseInt(target.value) || 0);
+  };
 
   const sizeCustom = [
     ...sizes,
@@ -68,17 +72,20 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
           <ServingRuntimeSizeExpandedField data={data} setData={setData} />
         )}
       </FormGroup>
-      {/* // Leaving this to enable GPU in next release <FormGroup label="Number of GPUs (Not implemented)">
-        <NumberInput
-          isDisabled
-          value={data.gpus}
-          widthChars={10}
-          min={0}
-          onChange={onChangeGPU}
-          onMinus={() => setData('gpus', data.gpus - 1)}
-          onPlus={() => setData('gpus', data.gpus + 1)}
-        />
-      </FormGroup> */}
+      {gpuAvailable && (
+        <FormGroup label="Model server gpus">
+          <NumberInput
+            isDisabled={!gpuCount}
+            value={data.gpus}
+            widthChars={10}
+            min={0}
+            max={gpuCount}
+            onChange={onChangeGPU}
+            onMinus={() => setData('gpus', data.gpus - 1)}
+            onPlus={() => setData('gpus', data.gpus + 1)}
+          />
+        </FormGroup>
+      )}
     </FormSection>
   );
 };

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -1,4 +1,5 @@
 import { EnvVariableDataEntry } from 'pages/projects/types';
+import { ContainerResources } from '../../../types';
 
 export enum ServingRuntimeTableTabs {
   TYPE = 1,
@@ -31,20 +32,9 @@ export type ServingRuntimeToken = {
   editName?: string;
 };
 
-export type ServingRuntimeResources = {
-  limits: {
-    cpu: string;
-    memory: string;
-  };
-  requests: {
-    cpu: string;
-    memory: string;
-  };
-};
-
 export type ServingRuntimeSize = {
   name: string;
-  resources: ServingRuntimeResources;
+  resources: ContainerResources;
 };
 
 export type CreatingInferenceServiceObject = {

--- a/frontend/src/pages/modelServing/useServingRuntimesConfig.ts
+++ b/frontend/src/pages/modelServing/useServingRuntimesConfig.ts
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { ConfigMapKind } from '../../k8sTypes';
+import { getConfigMap } from '../../api';
+import { useDashboardNamespace } from '../../redux/selectors';
+
+export type ServingRuntimesConfigResourceData = {
+  servingRuntimesConfig: ConfigMapKind | undefined;
+  loaded: boolean;
+  error?: Error;
+  refresh: () => void;
+};
+
+export const useServingRuntimesConfig = (): {
+  servingRuntimesConfig: ConfigMapKind | undefined;
+  loaded: boolean;
+  error: Error | undefined;
+  refresh: () => void;
+} => {
+  const [servingRuntimesConfig, setServingRuntimesConfig] = React.useState<
+    ConfigMapKind | undefined
+  >(undefined);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>(undefined);
+  const { dashboardNamespace } = useDashboardNamespace();
+
+  // Now there's only one model server in the cluster, in the future, we may have multiple model servers
+  const fetchServingRuntimesConfig = React.useCallback(() => {
+    return getConfigMap(dashboardNamespace, 'servingruntimes-config')
+      .then((srcm) => {
+        setServingRuntimesConfig(srcm);
+      })
+      .catch((e) => {
+        if (e.statusObject?.code === 404) {
+          setError(new Error('Model Servers settings are not properly configured.'));
+          return;
+        }
+        setError(e);
+      });
+  }, [dashboardNamespace]);
+
+  React.useEffect(() => {
+    if (!loaded) {
+      fetchServingRuntimesConfig().then(() => {
+        setLoaded(true);
+      });
+    }
+  }, [loaded, fetchServingRuntimesConfig]);
+
+  return { servingRuntimesConfig, loaded, error, refresh: fetchServingRuntimesConfig };
+};

--- a/frontend/src/pages/notebookController/screens/server/GPUSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/GPUSelectField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FormGroup, Select, SelectOption, Skeleton } from '@patternfly/react-core';
 import useGPUSetting from './useGPUSetting';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { useAppContext } from '../../../../app/AppContext';
 
 type GPUSelectFieldProps = {
   value: string;
@@ -10,7 +11,8 @@ type GPUSelectFieldProps = {
 
 const GPUSelectField: React.FC<GPUSelectFieldProps> = ({ value, setValue }) => {
   const [gpuDropdownOpen, setGpuDropdownOpen] = React.useState(false);
-  const { available, count: gpuSize, loaded, untrustedGPUs } = useGPUSetting();
+  const gpuSetting = useAppContext().dashboardConfig.spec.notebookController?.gpuSetting;
+  const { available, count: gpuSize, loaded, untrustedGPUs } = useGPUSetting(gpuSetting);
 
   if (!available) {
     return null;

--- a/frontend/src/pages/notebookController/screens/server/useGPUSetting.ts
+++ b/frontend/src/pages/notebookController/screens/server/useGPUSetting.ts
@@ -1,21 +1,22 @@
 import * as React from 'react';
 import useNotification from '../../../../utilities/useNotification';
 import { getGPU } from '../../../../services/gpuService';
-import { useAppContext } from '../../../../app/AppContext';
+import { GpuSettingString } from '../../../../types';
 
-const useGPUSetting = (): {
+const useGPUSetting = (
+  gpuSetting: GpuSettingString,
+): {
   available: boolean;
   loaded: boolean;
   count: number;
   untrustedGPUs: boolean;
 } => {
-  const { dashboardConfig } = useAppContext();
   const [gpuSize, setGpuSize] = React.useState(0);
   const [isFetching, setFetching] = React.useState(true);
   const [areGpusAvailable, setAreGpusAvailable] = React.useState(false);
   const notification = useNotification();
 
-  const setting = dashboardConfig.spec.notebookController?.gpuSetting || 'autodetect';
+  const setting = gpuSetting || 'autodetect';
   const autodetect = setting === 'autodetect';
   const hidden = setting === 'hidden';
   const staticCount = Math.max(parseInt(setting), 0);

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -30,6 +30,10 @@ import useInferenceServices from '../modelServing/useInferenceServices';
 import { ContextResourceData } from '../../types';
 import { useContextResourceData } from '../../utilities/useContextResourceData';
 import useServingRuntimeSecrets from '../modelServing/screens/projects/useServingRuntimeSecrets';
+import {
+  useServingRuntimesConfig,
+  ServingRuntimesConfigResourceData,
+} from '../modelServing/useServingRuntimesConfig';
 
 type ProjectDetailsContextType = {
   currentProject: ProjectKind;
@@ -37,6 +41,7 @@ type ProjectDetailsContextType = {
   notebooks: ContextResourceData<NotebookState>;
   pvcs: ContextResourceData<PersistentVolumeClaimKind>;
   dataConnections: ContextResourceData<DataConnection>;
+  servingRuntimesConfig: ServingRuntimesConfigResourceData;
   servingRuntimes: ContextResourceData<ServingRuntimeKind>;
   inferenceServices: ContextResourceData<InferenceServiceKind>;
   serverSecrets: ContextResourceData<SecretKind>;
@@ -49,6 +54,11 @@ export const ProjectDetailsContext = React.createContext<ProjectDetailsContextTy
   notebooks: DEFAULT_CONTEXT_DATA,
   pvcs: DEFAULT_CONTEXT_DATA,
   dataConnections: DEFAULT_CONTEXT_DATA,
+  servingRuntimesConfig: {
+    servingRuntimesConfig: undefined,
+    loaded: false,
+    refresh: () => undefined,
+  },
   servingRuntimes: DEFAULT_CONTEXT_DATA,
   inferenceServices: DEFAULT_CONTEXT_DATA,
   serverSecrets: DEFAULT_CONTEXT_DATA,
@@ -61,6 +71,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
   const notebooks = useContextResourceData<NotebookState>(useProjectNotebookStates(namespace));
   const pvcs = useContextResourceData<PersistentVolumeClaimKind>(useProjectPvcs(namespace));
   const dataConnections = useContextResourceData<DataConnection>(useDataConnections(namespace));
+  const servingRuntimesConfig = useServingRuntimesConfig();
   const servingRuntimes = useContextResourceData<ServingRuntimeKind>(useServingRuntimes(namespace));
   const inferenceServices = useContextResourceData<InferenceServiceKind>(
     useInferenceServices(namespace),
@@ -70,6 +81,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
   const notebookRefresh = notebooks.refresh;
   const pvcRefresh = pvcs.refresh;
   const dataConnectionRefresh = dataConnections.refresh;
+  const servingRuntimesConfigRefresh = servingRuntimesConfig.refresh;
   const servingRuntimeRefresh = servingRuntimes.refresh;
   const inferenceServiceRefresh = inferenceServices.refresh;
   const refreshAllProjectData = React.useCallback(() => {
@@ -77,12 +89,14 @@ const ProjectDetailsContextProvider: React.FC = () => {
     setTimeout(notebookRefresh, 2000);
     pvcRefresh();
     dataConnectionRefresh();
+    servingRuntimesConfigRefresh();
     servingRuntimeRefresh();
     inferenceServiceRefresh();
   }, [
     notebookRefresh,
     pvcRefresh,
     dataConnectionRefresh,
+    servingRuntimesConfigRefresh,
     servingRuntimeRefresh,
     inferenceServiceRefresh,
   ]);
@@ -119,6 +133,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
         notebooks,
         pvcs,
         dataConnections,
+        servingRuntimesConfig,
         servingRuntimes,
         inferenceServices,
         refreshAllProjectData,

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookGPUNumber.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookGPUNumber.ts
@@ -1,12 +1,12 @@
 import { NotebookKind } from '../../../../../k8sTypes';
-import { GPUCount, NotebookContainer } from '../../../../../types';
+import { ContainerResourceAttributes, GPUCount, NotebookContainer } from '../../../../../types';
 
 const useNotebookGPUNumber = (notebook?: NotebookKind): GPUCount => {
   const container: NotebookContainer | undefined = notebook?.spec.template.spec.containers.find(
     (container) => container.name === notebook.metadata.name,
   );
 
-  const gpuNumbers = container?.resources?.limits?.['nvidia.com/gpu'];
+  const gpuNumbers = container?.resources?.limits?.[ContainerResourceAttributes.NVIDIA_GPU];
 
   return gpuNumbers || 0;
 };

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -1,7 +1,7 @@
 import {
   ImageStreamAndVersion,
   NotebookSize,
-  NotebookTolerationSettings,
+  TolerationSettings,
   Volume,
   VolumeMount,
 } from '../../types';
@@ -64,7 +64,7 @@ export type StartNotebookData = {
   image: ImageStreamAndVersion;
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
-  tolerationSettings?: NotebookTolerationSettings;
+  tolerationSettings?: TolerationSettings;
   envFrom?: EnvironmentFromVariable[];
   description?: string;
   /** An override for the assembleNotebook so it doesn't regen an id */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,7 @@ export type PrometheusResponse = {
  * "any string" as a documentation touch point. Has no baring on the type checking.
  */
 type NumberString = string;
+export type GpuSettingString = 'autodetect' | 'hidden' | NumberString | undefined;
 
 export type DashboardConfig = K8sResourceCommon & {
   spec: {
@@ -36,8 +37,8 @@ export type DashboardConfig = K8sResourceCommon & {
       enabled: boolean;
       pvcSize?: string;
       notebookNamespace?: string;
-      gpuSetting?: 'autodetect' | 'hidden' | NumberString;
-      notebookTolerationSettings?: NotebookTolerationSettings;
+      gpuSetting?: GpuSettingString;
+      notebookTolerationSettings?: TolerationSettings;
     };
   };
 };
@@ -70,7 +71,13 @@ export type NotebookControllerUserState = {
  */
 export type GPUCount = string | number;
 
-export type NotebookResources = {
+export enum ContainerResourceAttributes {
+  CPU = 'cpu',
+  MEMORY = 'memory',
+  NVIDIA_GPU = 'nvidia.com/gpu',
+}
+
+export type ContainerResources = {
   requests?: {
     cpu?: string;
     memory?: string;
@@ -97,15 +104,15 @@ export type EnvVarReducedTypeKeyValues = {
 
 export type NotebookSize = {
   name: string;
-  resources: NotebookResources;
+  resources: ContainerResources;
   notUserDefined?: boolean;
 };
 
-export type NotebookTolerationSettings = {
+export type TolerationSettings = {
   enabled: boolean;
   key: string;
 };
-export type NotebookTolerationFormSettings = NotebookTolerationSettings & {
+export type NotebookTolerationFormSettings = TolerationSettings & {
   error?: string;
 };
 
@@ -113,7 +120,7 @@ export type ClusterSettings = {
   userTrackingEnabled: boolean;
   pvcSize: number | string;
   cullerTimeout: number;
-  notebookTolerationSettings: NotebookTolerationSettings | null;
+  notebookTolerationSettings: TolerationSettings | null;
 };
 
 /** @deprecated -- use SDK type */
@@ -296,7 +303,7 @@ export type NotebookPort = {
   protocol: string;
 };
 
-export type NotebookToleration = {
+export type PodToleration = {
   effect: string;
   key: string;
   operator: string;
@@ -310,13 +317,13 @@ export type NotebookContainer = {
   env: EnvironmentVariable[];
   envFrom?: EnvironmentFromVariable[];
   ports?: NotebookPort[];
-  resources?: NotebookResources;
+  resources?: ContainerResources;
   livenessProbe?: Record<string, unknown>;
   readinessProbe?: Record<string, unknown>;
   volumeMounts?: VolumeMount[];
 };
 
-export type NotebookAffinity = {
+export type PodAffinity = {
   nodeAffinity?: { [key: string]: unknown };
 };
 
@@ -337,11 +344,11 @@ export type Notebook = K8sResourceCommon & {
   spec: {
     template: {
       spec: {
-        affinity?: NotebookAffinity;
+        affinity?: PodAffinity;
         enableServiceLinks?: boolean;
         containers: NotebookContainer[];
         volumes?: Volume[];
-        tolerations?: NotebookToleration[];
+        tolerations?: PodToleration[];
       };
     };
   };

--- a/frontend/src/utilities/imageUtils.ts
+++ b/frontend/src/utilities/imageUtils.ts
@@ -8,6 +8,7 @@ import {
   ImageTag,
   ImageTagInfo,
   NotebookContainer,
+  ContainerResourceAttributes,
 } from '../types';
 
 const PENDING_PHASES = [
@@ -66,7 +67,7 @@ export const getNameVersionString = (software: ImageSoftwareType): string =>
   `${software.name}${getVersion(software.version, ' v')}`;
 
 export const getNumGpus = (container?: NotebookContainer): GPUCount => {
-  return container?.resources?.limits?.['nvidia.com/gpu'] || 0;
+  return container?.resources?.limits?.[ContainerResourceAttributes.NVIDIA_GPU] || 0;
 };
 
 export const getDefaultTag = (


### PR DESCRIPTION
Allow ServingRuntimes to specify allowed number of GPUs

Closes: #940 

## Description
I've added an annotation to the ServingRuntime specification in the servingruntimes-configmap.yaml
```yaml
data:
  override-config: |
    apiVersion: serving.kserve.io/v1alpha1
    kind: ServingRuntime
    metadata:
      annotations:
        opendatahub.io/gpu-setting: '1' #same as notebook gpuSetting
```
This is meant as a stopgap feature until full support for GPUs is implemented and tested, but hopefully follows the same development flow for servingruntimes-configs without the annotation.

## How Has This Been Tested?
Change redhat-ods-applications servingruntimes-config to add an annotation to the override servingruntime 

`opendatahub.io/gpu-setting: '1'`
`opendatahub.io/gpu-setting: '5'`
`opendatahub.io/gpu-setting: '0'`
`opendatahub.io/gpu-setting: 'hidden'`
no annotation

Verify the gpu selection shows as expected and test .
<img src="https://user-images.githubusercontent.com/1448375/217579397-b3d8e4f5-1069-4e20-aaed-1dbf30cf4325.png" width="400" />

Configure a model server is spawned with correct limits/requests/affinities

Verify any pods spawned for the model server contain the correct limits/requests/affinities 

Tested on OCP 4.11 with GPU operator installed using live build `quay.io/cfchase/rhods-operator-live-catalog:1.22.0-w7`

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
