### PR TITLE
Updates tolerations when workbench starts

### DIFF
--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -15,6 +15,7 @@ import { EnvironmentFromVariable, StartNotebookData } from '../../pages/projects
 import { ROOT_MOUNT_PATH } from '../../pages/projects/pvc/const';
 import { translateDisplayNameForK8s } from '../../pages/projects/utils';
 import { assemblePodSpecOptions } from './utils';
+import { TolerationChanges } from '../../utilities/tolerations';
 
 const assembleNotebook = (data: StartNotebookData, username: string): NotebookKind => {
   const {
@@ -171,11 +172,26 @@ export const stopNotebook = (name: string, namespace: string): Promise<NotebookK
   });
 };
 
-export const startNotebook = (name: string, namespace: string): Promise<NotebookKind> => {
+export const startNotebook = (
+  name: string,
+  namespace: string,
+  tolerationChanges: TolerationChanges,
+): Promise<NotebookKind> => {
+  const patches: Patch[] = [];
+  patches.push(startPatch);
+
+  if (tolerationChanges.type !== 'nothing') {
+    patches.push({
+      op: tolerationChanges.type,
+      path: '/spec/template/spec/tolerations',
+      value: tolerationChanges.settings,
+    });
+  }
+
   return k8sPatchResource<NotebookKind>({
     model: NotebookModel,
     queryOptions: { name, ns: namespace },
-    patches: [startPatch],
+    patches,
   });
 };
 

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -15,7 +15,7 @@ import { EnvironmentFromVariable, StartNotebookData } from '../../pages/projects
 import { ROOT_MOUNT_PATH } from '../../pages/projects/pvc/const';
 import { translateDisplayNameForK8s } from '../../pages/projects/utils';
 import { assemblePodSpecOptions } from './utils';
-import { TolerationChanges } from '../../utilities/tolerations';
+import { getTolerationPatch, TolerationChanges } from '../../utilities/tolerations';
 
 const assembleNotebook = (data: StartNotebookData, username: string): NotebookKind => {
   const {
@@ -180,12 +180,9 @@ export const startNotebook = (
   const patches: Patch[] = [];
   patches.push(startPatch);
 
-  if (tolerationChanges.type !== 'nothing') {
-    patches.push({
-      op: tolerationChanges.type,
-      path: '/spec/template/spec/tolerations',
-      value: tolerationChanges.settings,
-    });
+  const tolerationPatch = getTolerationPatch(tolerationChanges);
+  if (tolerationPatch) {
+    patches.push(tolerationPatch);
   }
 
   return k8sPatchResource<NotebookKind>({

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -9,6 +9,8 @@ import NotebookStatusText from './NotebookStatusText';
 import { fireTrackingEvent } from '../../../utilities/segmentIOUtils';
 import useNotebookGPUNumber from '../screens/detail/notebooks/useNotebookGPUNumber';
 import useNotebookDeploymentSize from '../screens/detail/notebooks/useNotebookDeploymentSize';
+import { computeNotebooksTolerations } from '../../../utilities/tolerations';
+import { useAppContext } from '../../../app/AppContext';
 
 type NotebookStatusToggleProps = {
   notebookState: NotebookState;
@@ -23,6 +25,7 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({ notebookSta
   const [inProgress, setInProgress] = React.useState(false);
   const listenToNotebookStart = useRefreshNotebookUntilStart(notebookState, doListen);
   const [dontShowModalValue] = useStopNotebookModalAvailability();
+  const { dashboardConfig } = useAppContext();
   const notebookName = notebook.metadata.name;
   const notebookNamespace = notebook.metadata.namespace;
   const isRunningOrStarting = isStarting || isRunning;
@@ -85,7 +88,11 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({ notebookSta
                 }
               } else {
                 setInProgress(true);
-                startNotebook(notebookName, notebookNamespace).then(() => {
+                const tolerationSettings = computeNotebooksTolerations(
+                  dashboardConfig,
+                  notebookState.notebook,
+                );
+                startNotebook(notebookName, notebookNamespace, tolerationSettings).then(() => {
                   fireNotebookTrackingEvent('started');
                   refresh().then(() => setInProgress(false));
                   listenToNotebookStart(true);

--- a/frontend/src/utilities/tolerations.ts
+++ b/frontend/src/utilities/tolerations.ts
@@ -1,0 +1,69 @@
+import { DashboardConfig, NotebookToleration, NotebookTolerationSettings } from '../types';
+import { NotebookKind } from '../k8sTypes';
+
+export type TolerationChanges = {
+  type: 'add' | 'remove' | 'replace' | 'nothing';
+  settings: NotebookToleration[];
+};
+
+export const determineTolerations = (
+  hasGpu: boolean,
+  tolerationSettings?: NotebookTolerationSettings,
+): NotebookToleration[] => {
+  const tolerations: NotebookToleration[] = [];
+
+  if (hasGpu) {
+    tolerations.push({
+      effect: 'NoSchedule',
+      key: 'nvidia.com/gpu',
+      operator: 'Exists',
+    });
+  }
+  if (tolerationSettings?.enabled) {
+    tolerations.push({
+      effect: 'NoSchedule',
+      key: tolerationSettings.key,
+      operator: 'Exists',
+    });
+  }
+
+  return tolerations;
+};
+
+export const computeNotebooksTolerations = (
+  dashboardConfig: DashboardConfig,
+  notebook: NotebookKind,
+): TolerationChanges => {
+  const hasGPU = !!notebook.spec.template.spec.containers.find(
+    (container) =>
+      !!container.resources?.limits?.['nvidia.com/gpu'] ||
+      !!container.resources?.requests?.['nvidia.com/gpu'],
+  );
+  const tolerations = notebook.spec.template.spec.tolerations || [];
+
+  const settings = determineTolerations(
+    hasGPU,
+    dashboardConfig.spec.notebookController?.notebookTolerationSettings,
+  );
+
+  const hasTolerations = !!tolerations && tolerations.length > 0;
+  const doNothing = settings.length === 0 && !hasTolerations;
+  const tolerationsRemoved = settings.length === 0 && hasTolerations;
+  const updateTolerations = settings.length > 0 && hasTolerations;
+
+  let type: TolerationChanges['type'];
+  if (tolerationsRemoved) {
+    type = 'remove';
+  } else if (updateTolerations) {
+    type = 'replace';
+  } else if (doNothing) {
+    type = 'nothing';
+  } else {
+    type = 'add';
+  }
+
+  return {
+    type,
+    settings,
+  };
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: #903 

## Description
<!--- Describe your changes in detail -->
DS Projects -- Updates tolerations as the Workbench starts (via the toggle). Edit should be unaffected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a Workbench with no toleration setting configured (see Settings => Cluster settings)
2. Enable the toleration settings
3. Turn off/on the Workbench -- see the change (added)
4. Change the toleration setting value
5. Turn off/on the Workbench -- see the change (updated)
6. Disable the toleration settings
7. Turn off/on the Workbench -- see the change (removed)

Note: It should be noted we do not update the config immediately after saving. There is a notification update in #939 that covers this scenario. In dev mode refresh or wait for the config to be returned from the server before testing a turn-on state for the Workbench.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
