### PR TITLE
Update resources for oauth-proxy container

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -97,11 +97,11 @@ spec:
           failureThreshold: 3
         resources:
           limits:
-            cpu: 100m
-            memory: 256Mi
+            cpu: 1000m
+            memory: 2Gi
           requests:
-            cpu: 100m
-            memory: 256Mi
+            cpu: 500m
+            memory: 1Gi
         volumeMounts:
           - mountPath: /etc/tls/private
             name: proxy-tls


### PR DESCRIPTION
Closes: #942

This PR updates the resource limit to `oauth-proxy` container in dashboard deployment.

This is required to allow large number of concurrent requests during scale testing.
