### PR TITLE
Make sure nonexistent user group not change the permission of current admin permission

### DIFF
--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -132,8 +132,8 @@ const checkUserInGroups = async (
   groupList: string[],
   userName: string,
 ): Promise<boolean> => {
-  try {
-    for (const group of groupList) {
+  for (const group of groupList) {
+    try {
       const groupUsers = await getGroup(customObjectApi, group);
       if (
         groupUsers?.includes(userName) ||
@@ -141,9 +141,9 @@ const checkUserInGroups = async (
       ) {
         return true;
       }
+    } catch (e) {
+      fastify.log.error(e.toString());
     }
-  } catch (e) {
-    fastify.log.error(e.toString());
   }
   return false;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #878 
The reason is when a group is not found, an error will be thrown, which will break the whole check access loop. If we put the try-catch block inside the loop, the problem will be fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See the instructions in the issue, the same way to test it.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
