### PR TITLE
Added dry-run to submit actions

### DIFF
--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -25,12 +25,12 @@ const setupRequest = async (
     // Core SDK builds the wrong path for k8s -- can't post to a resource name; remove the name from the url
     // eg: POST /.../configmaps/my-config-map => POST /.../configmaps
     const urlParts = url.split('/');
-    const queryParams = urlParts[urlParts.length - 1].split("?")
+    const queryParams = urlParts[urlParts.length - 1].split('?');
     urlParts.pop();
     queryParams.shift();
     safeURL = urlParts.join('/');
-    queryParams.unshift(safeURL)
-    safeURL = queryParams.join("?")
+    queryParams.unshift(safeURL);
+    safeURL = queryParams.join('?');
   }
 
   const requestOptions = await getDirectCallOptions(fastify, request, url);

--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -25,8 +25,12 @@ const setupRequest = async (
     // Core SDK builds the wrong path for k8s -- can't post to a resource name; remove the name from the url
     // eg: POST /.../configmaps/my-config-map => POST /.../configmaps
     const urlParts = url.split('/');
+    const queryParams = urlParts[urlParts.length - 1].split("?")
     urlParts.pop();
+    queryParams.shift();
     safeURL = urlParts.join('/');
+    queryParams.unshift(safeURL)
+    safeURL = queryParams.join("?")
   }
 
   const requestOptions = await getDirectCallOptions(fastify, request, url);

--- a/frontend/src/api/apiMergeUtils.ts
+++ b/frontend/src/api/apiMergeUtils.ts
@@ -1,8 +1,12 @@
 import { QueryParams } from '@openshift/dynamic-plugin-sdk-utils';
-import { K8sAPIOptions } from 'k8sTypes';
+import { K8sAPIOptions } from '../k8sTypes';
 
-export const mergeK8sQueryParams = (opts: K8sAPIOptions = {}): QueryParams => {
+export const mergeK8sQueryParams = (
+  opts: K8sAPIOptions = {},
+  specificOpts: QueryParams = {},
+): QueryParams => {
   return {
+    ...specificOpts,
     ...(opts.dryRun && { dryRun: 'All' }),
   };
 };

--- a/frontend/src/api/apiMergeUtils.ts
+++ b/frontend/src/api/apiMergeUtils.ts
@@ -1,0 +1,8 @@
+import { QueryParams } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sAPIOptions } from 'k8sTypes';
+
+export const mergeK8sQueryParams = (opts: K8sAPIOptions = {}): QueryParams => {
+  return {
+    ...(opts.dryRun && { dryRun: 'All' }),
+  };
+};

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -9,13 +9,14 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import * as _ from 'lodash';
 import { NotebookModel } from '../models';
-import { K8sStatus, NotebookKind } from '../../k8sTypes';
+import { K8sAPIOptions, K8sStatus, NotebookKind } from '../../k8sTypes';
 import { usernameTranslate } from '../../utilities/notebookControllerUtils';
 import { EnvironmentFromVariable, StartNotebookData } from '../../pages/projects/types';
 import { ROOT_MOUNT_PATH } from '../../pages/projects/pvc/const';
 import { translateDisplayNameForK8s } from '../../pages/projects/utils';
 import { assemblePodSpecOptions } from './utils';
 import { getTolerationPatch, TolerationChanges } from '../../utilities/tolerations';
+import { mergeK8sQueryParams } from 'api/apiMergeUtils';
 
 const assembleNotebook = (data: StartNotebookData, username: string): NotebookKind => {
   const {
@@ -257,6 +258,7 @@ export const attachNotebookSecret = (
   namespace: string,
   secretName: string,
   hasExistingEnvFrom: boolean,
+  opts?: K8sAPIOptions,
 ): Promise<NotebookKind> => {
   const patches: Patch[] = [];
 
@@ -283,7 +285,7 @@ export const attachNotebookSecret = (
 
   return k8sPatchResource<NotebookKind>({
     model: NotebookModel,
-    queryOptions: { name: notebookName, ns: namespace },
+    queryOptions: { name: notebookName, ns: namespace, queryParams: mergeK8sQueryParams(opts) },
     patches,
   });
 };
@@ -292,6 +294,7 @@ export const replaceNotebookSecret = (
   notebookName: string,
   namespace: string,
   newEnvs: EnvironmentFromVariable[],
+  opts?: K8sAPIOptions,
 ): Promise<NotebookKind> => {
   const patches: Patch[] = [
     {
@@ -304,7 +307,7 @@ export const replaceNotebookSecret = (
 
   return k8sPatchResource<NotebookKind>({
     model: NotebookModel,
-    queryOptions: { name: notebookName, ns: namespace },
+    queryOptions: { name: notebookName, ns: namespace, queryParams: mergeK8sQueryParams(opts) },
     patches,
   });
 };

--- a/frontend/src/api/network/secrets.ts
+++ b/frontend/src/api/network/secrets.ts
@@ -5,11 +5,12 @@ import {
   k8sListResource,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import { K8sStatus, SecretKind } from '../../k8sTypes';
+import { K8sAPIOptions, K8sStatus, SecretKind } from '../../k8sTypes';
 import { SecretModel } from '../models';
 import { genRandomChars } from '../../utilities/string';
 import { translateDisplayNameForK8s } from '../../pages/projects/utils';
 import { getModelServiceAccountName } from '../../pages/modelServing/utils';
+import { mergeK8sQueryParams } from 'api/apiMergeUtils';
 
 export const DATA_CONNECTION_PREFIX = 'aws-connection';
 
@@ -126,12 +127,20 @@ export const getSecretsByLabel = (label: string, namespace: string): Promise<Sec
   }).then((result) => result.items);
 };
 
-export const createSecret = (data: SecretKind): Promise<SecretKind> => {
-  return k8sCreateResource<SecretKind>({ model: SecretModel, resource: data });
+export const createSecret = (data: SecretKind, opts?: K8sAPIOptions): Promise<SecretKind> => {
+  return k8sCreateResource<SecretKind>({
+    model: SecretModel,
+    resource: data,
+    queryOptions: { queryParams: mergeK8sQueryParams(opts) },
+  });
 };
 
-export const replaceSecret = (data: SecretKind): Promise<SecretKind> => {
-  return k8sUpdateResource<SecretKind>({ model: SecretModel, resource: data });
+export const replaceSecret = (data: SecretKind, opts?: K8sAPIOptions): Promise<SecretKind> => {
+  return k8sUpdateResource<SecretKind>({
+    model: SecretModel,
+    resource: data,
+    queryOptions: { queryParams: mergeK8sQueryParams(opts) },
+  });
 };
 
 export const deleteSecret = (projectName: string, secretName: string): Promise<K8sStatus> => {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -142,6 +142,10 @@ export type ImageStreamSpecTagType = {
   };
 };
 
+export type K8sAPIOptions = {
+  dryRun?: boolean;
+};
+
 /** A status object when Kube backend can't handle a request. */
 export type K8sStatus = {
   kind: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes: https://github.com/opendatahub-io/odh-dashboard/issues/898
## Description
<!--- Describe your changes in detail -->
I encapsulated the promise actions into an async function that takes a param `dryRun: boolean`. dryRun adds a queryParam to the k8 api call which calls the api, but does not save results to storage. With this we can run the promise actions in dry mode and if no errors occur, we can rerun the actions normally. This prevents the notebooks from being restarted on error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test the same way as described in the issue. However look at the network request going out.
- on successful adds: there should be the following requests (for adding secret and patching notebook (if it was defined in the form))
    - one request with ?dryRun:All query param
    - one request **after** without dryRun query param
 - on failed adds (duplicate names): there should be the following requests (for adding secret and patching notebook)
    - one request with ?dryRun:All query param

note failed request should **only** run the dry version


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
