### PR TITLE
Enable model serving metrics upstream

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -18,6 +18,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableUserManagement: boolean;
       disableProjects: boolean;
       disableModelServing: boolean;
+      modelMetricsNamespace: string;
     };
     groupsConfig?: {
       adminGroups: string;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -46,6 +46,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableUserManagement: false,
       disableProjects: false,
       disableModelServing: false,
+      modelMetricsNamespace: '',
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -3,13 +3,10 @@ import { Navigate, Routes, Route } from 'react-router-dom';
 import ModelServingContextProvider from './ModelServingContext';
 import ModelServingMetricsWrapper from './screens/metrics/ModelServingMetricsWrapper';
 import ModelServingGlobal from './screens/global/ModelServingGlobal';
-import { isModelMetricsEnabled } from './screens/metrics/utils';
-import { useDashboardNamespace } from 'redux/selectors';
-import { useAppContext } from 'app/AppContext';
+import useModelMetricsEnabled from './useModelMetricsEnabled';
 
 const ModelServingRoutes: React.FC = () => {
-  const { dashboardNamespace } = useDashboardNamespace();
-  const { dashboardConfig } = useAppContext();
+  const { modelMetricsEnabled } = useModelMetricsEnabled();
 
   return (
     <Routes>
@@ -18,11 +15,7 @@ const ModelServingRoutes: React.FC = () => {
         <Route
           path="/metrics/:project/:inferenceService"
           element={
-            isModelMetricsEnabled(dashboardNamespace, dashboardConfig) ? (
-              <ModelServingMetricsWrapper />
-            ) : (
-              <Navigate replace to="/" />
-            )
+            modelMetricsEnabled() ? <ModelServingMetricsWrapper /> : <Navigate replace to="/" />
           }
         />
         <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -3,15 +3,27 @@ import { Navigate, Routes, Route } from 'react-router-dom';
 import ModelServingContextProvider from './ModelServingContext';
 import ModelServingMetricsWrapper from './screens/metrics/ModelServingMetricsWrapper';
 import ModelServingGlobal from './screens/global/ModelServingGlobal';
+import { isModelMetricsEnabled } from './screens/metrics/utils';
+import { useDashboardNamespace } from 'redux/selectors';
+import { useAppContext } from 'app/AppContext';
 
 const ModelServingRoutes: React.FC = () => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const { dashboardConfig } = useAppContext();
+
   return (
     <Routes>
       <Route path="/" element={<ModelServingContextProvider />}>
         <Route index element={<ModelServingGlobal />} />
         <Route
           path="/metrics/:project/:inferenceService"
-          element={<ModelServingMetricsWrapper />}
+          element={
+            isModelMetricsEnabled(dashboardNamespace, dashboardConfig) ? (
+              <ModelServingMetricsWrapper />
+            ) : (
+              <Navigate replace to="/" />
+            )
+          }
         />
         <Route path="*" element={<Navigate to="." />} />
       </Route>

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -6,7 +6,7 @@ import ModelServingGlobal from './screens/global/ModelServingGlobal';
 import useModelMetricsEnabled from './useModelMetricsEnabled';
 
 const ModelServingRoutes: React.FC = () => {
-  const { modelMetricsEnabled } = useModelMetricsEnabled();
+  const [modelMetricsEnabled] = useModelMetricsEnabled();
 
   return (
     <Routes>
@@ -15,7 +15,7 @@ const ModelServingRoutes: React.FC = () => {
         <Route
           path="/metrics/:project/:inferenceService"
           element={
-            modelMetricsEnabled() ? <ModelServingMetricsWrapper /> : <Navigate replace to="/" />
+            modelMetricsEnabled ? <ModelServingMetricsWrapper /> : <Navigate replace to="/" />
           }
         />
         <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -8,6 +8,9 @@ import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
 import { Link } from 'react-router-dom';
+import { isModelMetricsEnabled } from '../metrics/utils';
+import { useDashboardNamespace } from 'redux/selectors';
+import { useAppContext } from 'app/AppContext';
 
 type InferenceServiceTableRowProps = {
   obj: InferenceServiceKind;
@@ -24,20 +27,27 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
   onEditInferenceService,
   isGlobal,
 }) => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const { dashboardConfig } = useAppContext();
+
   return (
     <Tbody>
       <Tr>
         <Td dataLabel="Name">
           <ResourceNameTooltip resource={inferenceService}>
-            <Link
-              to={
-                isGlobal
-                  ? `/modelServing/metrics/${inferenceService.metadata.namespace}/${inferenceService.metadata.name}`
-                  : `/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`
-              }
-            >
-              {getInferenceServiceDisplayName(inferenceService)}
-            </Link>
+            {isModelMetricsEnabled(dashboardNamespace, dashboardConfig) ? (
+              <Link
+                to={
+                  isGlobal
+                    ? `/modelServing/metrics/${inferenceService.metadata.namespace}/${inferenceService.metadata.name}`
+                    : `/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`
+                }
+              >
+                {getInferenceServiceDisplayName(inferenceService)}
+              </Link>
+            ) : (
+              getInferenceServiceDisplayName(inferenceService)
+            )}
           </ResourceNameTooltip>
         </Td>
         {isGlobal && (

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -8,9 +8,7 @@ import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
 import { Link } from 'react-router-dom';
-import { isModelMetricsEnabled } from '../metrics/utils';
-import { useDashboardNamespace } from 'redux/selectors';
-import { useAppContext } from 'app/AppContext';
+import useModelMetricsEnabled from 'pages/modelServing/useModelMetricsEnabled';
 
 type InferenceServiceTableRowProps = {
   obj: InferenceServiceKind;
@@ -27,15 +25,14 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
   onEditInferenceService,
   isGlobal,
 }) => {
-  const { dashboardNamespace } = useDashboardNamespace();
-  const { dashboardConfig } = useAppContext();
+  const { modelMetricsEnabled } = useModelMetricsEnabled();
 
   return (
     <Tbody>
       <Tr>
         <Td dataLabel="Name">
           <ResourceNameTooltip resource={inferenceService}>
-            {isModelMetricsEnabled(dashboardNamespace, dashboardConfig) ? (
+            {modelMetricsEnabled() ? (
               <Link
                 to={
                   isGlobal

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -25,14 +25,14 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
   onEditInferenceService,
   isGlobal,
 }) => {
-  const { modelMetricsEnabled } = useModelMetricsEnabled();
+  const [modelMetricsEnabled] = useModelMetricsEnabled();
 
   return (
     <Tbody>
       <Tr>
         <Td dataLabel="Name">
           <ResourceNameTooltip resource={inferenceService}>
-            {modelMetricsEnabled() ? (
+            {modelMetricsEnabled ? (
               <Link
                 to={
                   isGlobal

--- a/frontend/src/pages/modelServing/screens/metrics/utils.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.ts
@@ -3,6 +3,18 @@ import { SelectOptionObject } from '@patternfly/react-core';
 import { TimeframeTitle } from '../types';
 import { InferenceServiceKind } from '../../../../k8sTypes';
 import { ModelServingMetricType } from './ModelServingMetricsContext';
+import { DashboardConfig } from 'types';
+
+export const isModelMetricsEnabled = (
+  dashboardNamespace: string,
+  dashboardConfig: DashboardConfig,
+): boolean => {
+  if (dashboardNamespace === 'redhat-ods-applications') {
+    return true;
+  } else {
+    return dashboardConfig.spec.dashboardConfig.modelMetricsNamespace !== '';
+  }
+};
 
 export const getInferenceServiceMetricsQueries = (
   inferenceService: InferenceServiceKind,

--- a/frontend/src/pages/modelServing/useModelMetricsEnabled.ts
+++ b/frontend/src/pages/modelServing/useModelMetricsEnabled.ts
@@ -1,0 +1,14 @@
+import { useAppContext } from 'app/AppContext';
+import { useDashboardNamespace } from 'redux/selectors';
+import { isModelMetricsEnabled } from './screens/metrics/utils';
+
+const useModelMetricsEnabled = (): { modelMetricsEnabled: () => boolean } => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const { dashboardConfig } = useAppContext();
+
+  const modelMetricsEnabled = () => isModelMetricsEnabled(dashboardNamespace, dashboardConfig);
+
+  return { modelMetricsEnabled };
+};
+
+export default useModelMetricsEnabled;

--- a/frontend/src/pages/modelServing/useModelMetricsEnabled.ts
+++ b/frontend/src/pages/modelServing/useModelMetricsEnabled.ts
@@ -2,13 +2,13 @@ import { useAppContext } from 'app/AppContext';
 import { useDashboardNamespace } from 'redux/selectors';
 import { isModelMetricsEnabled } from './screens/metrics/utils';
 
-const useModelMetricsEnabled = (): { modelMetricsEnabled: () => boolean } => {
+const useModelMetricsEnabled = (): [modelMetricsEnabled: boolean] => {
   const { dashboardNamespace } = useDashboardNamespace();
   const { dashboardConfig } = useAppContext();
 
-  const modelMetricsEnabled = () => isModelMetricsEnabled(dashboardNamespace, dashboardConfig);
+  const checkModelMetricsEnabled = () => isModelMetricsEnabled(dashboardNamespace, dashboardConfig);
 
-  return { modelMetricsEnabled };
+  return [checkModelMetricsEnabled()];
 };
 
 export default useModelMetricsEnabled;

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -6,8 +6,14 @@ import ProjectDetailsContextProvider from './ProjectDetailsContext';
 import SpawnerPage from './screens/spawner/SpawnerPage';
 import EditSpawnerPage from './screens/spawner/EditSpawnerPage';
 import DetailsPageMetricsWrapper from '../modelServing/screens/projects/DetailsPageMetricsWrapper';
+import { isModelMetricsEnabled } from 'pages/modelServing/screens/metrics/utils';
+import { useDashboardNamespace } from 'redux/selectors';
+import { useAppContext } from 'app/AppContext';
 
 const ProjectViewRoutes: React.FC = () => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const { dashboardConfig } = useAppContext();
+
   return (
     <Routes>
       <Route path="/" element={<ProjectView />} />
@@ -15,7 +21,16 @@ const ProjectViewRoutes: React.FC = () => {
         <Route index element={<ProjectDetails />} />
         <Route path="spawner" element={<SpawnerPage />} />
         <Route path="spawner/:notebookName" element={<EditSpawnerPage />} />
-        <Route path="metrics/model/:inferenceService" element={<DetailsPageMetricsWrapper />} />
+        <Route
+          path="metrics/model/:inferenceService"
+          element={
+            isModelMetricsEnabled(dashboardNamespace, dashboardConfig) ? (
+              <DetailsPageMetricsWrapper />
+            ) : (
+              <Navigate replace to="/" />
+            )
+          }
+        />
         <Route path="*" element={<Navigate to="." />} />
       </Route>
       <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -6,13 +6,10 @@ import ProjectDetailsContextProvider from './ProjectDetailsContext';
 import SpawnerPage from './screens/spawner/SpawnerPage';
 import EditSpawnerPage from './screens/spawner/EditSpawnerPage';
 import DetailsPageMetricsWrapper from '../modelServing/screens/projects/DetailsPageMetricsWrapper';
-import { isModelMetricsEnabled } from 'pages/modelServing/screens/metrics/utils';
-import { useDashboardNamespace } from 'redux/selectors';
-import { useAppContext } from 'app/AppContext';
+import useModelMetricsEnabled from 'pages/modelServing/useModelMetricsEnabled';
 
 const ProjectViewRoutes: React.FC = () => {
-  const { dashboardNamespace } = useDashboardNamespace();
-  const { dashboardConfig } = useAppContext();
+  const { modelMetricsEnabled } = useModelMetricsEnabled();
 
   return (
     <Routes>
@@ -24,11 +21,7 @@ const ProjectViewRoutes: React.FC = () => {
         <Route
           path="metrics/model/:inferenceService"
           element={
-            isModelMetricsEnabled(dashboardNamespace, dashboardConfig) ? (
-              <DetailsPageMetricsWrapper />
-            ) : (
-              <Navigate replace to="/" />
-            )
+            modelMetricsEnabled() ? <DetailsPageMetricsWrapper /> : <Navigate replace to="/" />
           }
         />
         <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -9,7 +9,7 @@ import DetailsPageMetricsWrapper from '../modelServing/screens/projects/DetailsP
 import useModelMetricsEnabled from 'pages/modelServing/useModelMetricsEnabled';
 
 const ProjectViewRoutes: React.FC = () => {
-  const { modelMetricsEnabled } = useModelMetricsEnabled();
+  const [modelMetricsEnabled] = useModelMetricsEnabled();
 
   return (
     <Routes>
@@ -21,7 +21,7 @@ const ProjectViewRoutes: React.FC = () => {
         <Route
           path="metrics/model/:inferenceService"
           element={
-            modelMetricsEnabled() ? <DetailsPageMetricsWrapper /> : <Navigate replace to="/" />
+            modelMetricsEnabled ? <DetailsPageMetricsWrapper /> : <Navigate replace to="/" />
           }
         />
         <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -71,6 +71,7 @@ export type DashboardCommonConfig = {
   disableUserManagement: boolean;
   disableProjects: boolean;
   disableModelServing: boolean;
+  modelMetricsNamespace: string;
 };
 
 export type NotebookControllerUserState = {

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -45,6 +45,8 @@ spec:
                       type: boolean
                     disableModelServing:
                       type: boolean
+                    modelMetricsNamespace:
+                      type: string
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -15,6 +15,7 @@ spec:
     enablement: true
     disableProjects: true
     disableModelServing: true
+    modelMetricsNamespace: ''
   notebookController:
     enabled: true
   notebookSizes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: #946

## Description
<!--- Describe your changes in detail -->
Follow up of #916 
Enable model serving upstream

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested both in downstream clusters and upstream clusters.

**For odh**

1. Follow the instructions on https://github.com/opendatahub-io/odh-manifests/pull/732 to deploy latest model and parametrize the deployment
2. Add to the `odhDashboardConfig` the value of the namespace where the model is deployed in `modelMetricsNamespace `
3. Test that you can deploy a model and access the metrics
4. Now remove the value in `modelMetricsNamespace`
5. Check that you cannot access  the model visualization (changes need to propagate due to the watcher)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
