### PR TITLE
Pipeline API Framework

### DIFF
--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -17,6 +17,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
           const apiPath = fastify.kube.config.getCurrentCluster().server;
           const namedHost = apiPath.slice('https://api.'.length).split(':')[0];
           const url = `https://oauth-openshift.apps.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
+          // Custom call, don't use proxy
           const httpsRequest = https
             .get(
               url,

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -105,6 +105,7 @@ export const getGPUData = async (
       protocol: 'https:',
       rejectUnauthorized: false,
     };
+    // TODO: fix this so this works with the proxyCall functionality
     const httpsRequest = https
       .get(url, options, (res) => {
         res.setEncoding('utf8');

--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -1,4 +1,3 @@
-import https, { RequestOptions } from 'https';
 import {
   K8sResourceCommon,
   K8sStatus,
@@ -6,7 +5,7 @@ import {
   OauthFastifyRequest,
 } from '../../../types';
 import { DEV_MODE } from '../../../utils/constants';
-import { getDirectCallOptions } from '../../../utils/directCallUtils';
+import { proxyCall, ProxyError, ProxyErrorType } from '../../../utils/httpUtils';
 
 type PassThroughData = {
   method: string;
@@ -16,21 +15,6 @@ type PassThroughData = {
 
 export const isK8sStatus = (data: unknown): data is K8sStatus =>
   (data as K8sStatus).kind === 'Status';
-
-const setupRequest = async (
-  fastify: KubeFastifyInstance,
-  request: OauthFastifyRequest,
-  data: PassThroughData,
-): Promise<RequestOptions> => {
-  const { method, url } = data;
-
-  const requestOptions = await getDirectCallOptions(fastify, request, url);
-
-  return {
-    ...requestOptions,
-    method,
-  };
-};
 
 export const passThrough = <T extends K8sResourceCommon>(
   fastify: KubeFastifyInstance,
@@ -65,85 +49,62 @@ export const safeURLPassThrough = <T extends K8sResourceCommon>(
   request: OauthFastifyRequest,
   data: PassThroughData,
 ): Promise<T | K8sStatus> => {
-  const { method, requestData, url } = data;
-
-  return new Promise((resolve, reject) => {
-    setupRequest(fastify, request, data).then((requestOptions) => {
-      if (requestData) {
-        requestOptions.headers = {
-          ...requestOptions.headers,
-          'Content-Type': `application/${
-            method === 'PATCH' ? 'json-patch+json' : 'json'
-          };charset=UTF-8`,
-          'Content-Length': requestData.length,
-        };
+  return proxyCall(fastify, request, data)
+    .then((rawData) => {
+      let parsedData: T | K8sStatus;
+      try {
+        parsedData = JSON.parse(rawData);
+      } catch (e) {
+        if (rawData.trim() === '404 page not found') {
+          // API on k8s doesn't exist, generate a status.
+          parsedData = {
+            kind: 'Status',
+            apiVersion: 'v1',
+            status: 'Failure',
+            message: rawData,
+            reason: 'NotFound',
+            code: 404,
+          };
+        } else {
+          // Likely not JSON, print the error and return the content to the client
+          fastify.log.error(`Parsing response error: ${e}, ${data}`);
+          throw { code: 500, response: data };
+        }
       }
 
-      fastify.log.info(`Making API ${method} request to ${url}`);
-
-      const httpsRequest = https
-        .request(url, requestOptions, (res) => {
-          let data = '';
-          res
-            .setEncoding('utf8')
-            .on('data', (chunk) => {
-              data += chunk;
-            })
-            .on('end', () => {
-              let parsedData: T | K8sStatus;
-              try {
-                parsedData = JSON.parse(data);
-              } catch (e) {
-                if (data.trim() === '404 page not found') {
-                  // API on k8s doesn't exist, generate a status.
-                  parsedData = {
-                    kind: 'Status',
-                    apiVersion: 'v1',
-                    status: 'Failure',
-                    message: data,
-                    reason: 'NotFound',
-                    code: 404,
-                  };
-                } else {
-                  // Likely not JSON, print the error and return the content to the client
-                  fastify.log.error(`Parsing response error: ${e}, ${data}`);
-                  reject({ code: 500, response: data });
-                  return;
-                }
-              }
-
-              if (isK8sStatus(parsedData)) {
-                if (parsedData.status !== 'Success') {
-                  fastify.log.warn(
-                    `Unsuccessful status Object, ${
-                      DEV_MODE ? JSON.stringify(parsedData, null, 2) : JSON.stringify(parsedData)
-                    }`,
-                  );
-                  reject({ code: parsedData.code, response: parsedData });
-                  return;
-                }
-              }
-
-              fastify.log.info('Successful request, returning data to caller.');
-              resolve(parsedData);
-            })
-            .on('error', (error) => {
-              if (error) {
-                fastify.log.error(`Kube parsing response error: ${error}`);
-                reject({ code: 500, response: error });
-              }
-            });
-        })
-        .on('error', (error) => {
-          fastify.log.error(`Kube request error: ${error}`);
-          reject({ code: 500, response: error });
-        });
-
-      if (requestData) {
-        httpsRequest.write(requestData);
+      if (isK8sStatus(parsedData)) {
+        if (parsedData.status !== 'Success') {
+          fastify.log.warn(
+            `Unsuccessful status Object, ${
+              DEV_MODE ? JSON.stringify(parsedData, null, 2) : JSON.stringify(parsedData)
+            }`,
+          );
+          throw { code: parsedData.code, response: parsedData };
+        }
       }
 
-      httpsRequest.end();
+      fastify.log.info('Successful request, returning data to caller.');
+      return parsedData;
+    })
+    .catch((error) => {
+      let errorMessage = 'Unknown error';
+      if (error instanceof ProxyError) {
+        errorMessage = error.message || errorMessage;
+        switch (error.proxyErrorType) {
+          case ProxyErrorType.CALL_FAILURE:
+            fastify.log.error(`Kube parsing response error: ${errorMessage}`);
+            throw { code: 500, response: error };
+          case ProxyErrorType.HTTP_FAILURE:
+            fastify.log.error(`Kube request error: ${errorMessage}`);
+            throw { code: 500, response: error };
+          default:
+          // unhandled type, fall-through
+        }
+      } else if (!(error instanceof Error)) {
+        errorMessage = JSON.stringify(error);
+      }
+
+      fastify.log.error(`Unhandled error during Kube call: ${errorMessage}`);
+      throw error;
     });
-  });
 };

--- a/backend/src/routes/api/proxy/index.ts
+++ b/backend/src/routes/api/proxy/index.ts
@@ -1,0 +1,40 @@
+import { FastifyReply } from 'fastify';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
+import { proxyCall } from '../../../utils/httpUtils';
+import { logRequestDetails } from '../../../utils/fileUtils';
+
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.post(
+    '/*',
+    (
+      req: OauthFastifyRequest<{
+        // Querystring: Record<string, string>; // TODO
+        Params: { '*': string };
+        Body: {
+          method: string;
+          host: string;
+          data: Record<string, unknown>;
+        };
+      }>,
+      reply: FastifyReply,
+    ) => {
+      logRequestDetails(fastify, req);
+
+      const { method, host, data } = req.body;
+      const requestData = JSON.stringify(data);
+
+      const path = req.params['*'];
+      const url = `${host}/${path}`;
+
+      return proxyCall(fastify, req, { method, url, requestData }).catch((error) => {
+        if (error.code && error.response) {
+          const { code, response } = error;
+          reply.code(code);
+          reply.send(response);
+        } else {
+          throw error;
+        }
+      });
+    },
+  );
+};

--- a/backend/src/utils/httpUtils.ts
+++ b/backend/src/utils/httpUtils.ts
@@ -1,0 +1,82 @@
+import https from 'https';
+import { getDirectCallOptions } from './directCallUtils';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
+
+export enum ProxyErrorType {
+  /** Failed during startup */
+  SETUP_FAILURE,
+  /** Failed at the http call level */
+  HTTP_FAILURE,
+  /** Failed after the connection was made but the request terminated before finishing */
+  CALL_FAILURE,
+}
+
+export class ProxyError extends Error {
+  public proxyErrorType: ProxyErrorType;
+
+  constructor(type: ProxyErrorType, message: string) {
+    super(message);
+
+    this.proxyErrorType = type;
+  }
+}
+
+type ProxyData = {
+  method: string;
+  url: string;
+  requestData?: string;
+};
+
+/** Make a very basic pass-on / proxy call to another endpoint */
+export const proxyCall = (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  data: ProxyData,
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const { method, requestData, url } = data;
+
+    getDirectCallOptions(fastify, request, url)
+      .then((requestOptions) => {
+        if (requestData) {
+          requestOptions.headers = {
+            ...requestOptions.headers,
+            'Content-Type': `application/${
+              method === 'PATCH' ? 'json-patch+json' : 'json'
+            };charset=UTF-8`,
+            'Content-Length': requestData.length,
+          };
+        }
+
+        fastify.log.info(`Making ${method} proxy request to ${url}`);
+
+        const httpsRequest = https
+          .request(url, { method, ...requestOptions }, (res) => {
+            let data = '';
+            res
+              .setEncoding('utf8')
+              .on('data', (chunk) => {
+                data += chunk;
+              })
+              .on('end', () => {
+                resolve(data);
+              })
+              .on('error', (error) => {
+                reject(new ProxyError(ProxyErrorType.CALL_FAILURE, error.message));
+              });
+          })
+          .on('error', (error) => {
+            reject(new ProxyError(ProxyErrorType.HTTP_FAILURE, error.message));
+          });
+
+        if (requestData) {
+          httpsRequest.write(requestData);
+        }
+
+        httpsRequest.end();
+      })
+      .catch((error) => {
+        reject(new ProxyError(ProxyErrorType.SETUP_FAILURE, error.message));
+      });
+  });
+};

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -5,12 +5,11 @@ import {
   PrometheusQueryResponse,
   QueryType,
 } from '../types';
-import https from 'https';
-import { getDirectCallOptions } from './directCallUtils';
 import { DEV_MODE } from './constants';
 import { getNamespaces } from './notebookUtils';
 import { getDashboardConfig } from './resourceUtils';
 import { createCustomError } from './requestUtils';
+import { proxyCall, ProxyError, ProxyErrorType } from './httpUtils';
 
 const callPrometheus = async <T>(
   fastify: KubeFastifyInstance,
@@ -30,54 +29,45 @@ const callPrometheus = async <T>(
   }
 
   const url = `${host}/api/v1/${queryType}?${query}`;
-  const rawOptions = await getDirectCallOptions(fastify, request, url);
-  const options = {
-    ...rawOptions,
-    headers: {
-      ...rawOptions.headers,
-      Accept: 'application/json',
-    },
-    rejectUnauthorized: false,
-  };
 
-  return new Promise((resolve, reject) => {
-    fastify.log.info(`Making Prometheus call: ${url}`);
-    fastify.log.info(`Prometheus query: ${query}`);
+  fastify.log.info(`Prometheus query: ${query}`);
+  return proxyCall(fastify, request, { method: 'GET', url })
+    .then((rawData) => {
+      try {
+        const parsedData = JSON.parse(rawData);
+        if (parsedData.status === 'error') {
+          throw { code: 400, response: parsedData.error };
+        }
+        fastify.log.info('Successful response from Prometheus.');
+        return { code: 200, response: parsedData };
+      } catch (e) {
+        const errorMessage = e.message || e.toString();
+        fastify.log.error(`Failure parsing the response from Prometheus. ${errorMessage}`);
+        if (errorMessage.includes('Unexpected token < in JSON')) {
+          throw { code: 422, response: 'Unprocessable prometheus response' };
+        }
+        fastify.log.error(`Unparsed Prometheus data. ${rawData}`);
+        throw { code: 500, response: rawData };
+      }
+    })
+    .catch((error) => {
+      let errorMessage = 'Unknown error';
+      if (error instanceof ProxyError) {
+        errorMessage = error.message || errorMessage;
+        switch (error.proxyErrorType) {
+          case ProxyErrorType.HTTP_FAILURE:
+            fastify.log.error(`Failure calling Prometheus. ${errorMessage}`);
+            throw { code: 500, response: `Cannot fetch prometheus data, ${errorMessage}` };
+          default:
+          // unhandled type, fall-through
+        }
+      } else if (!(error instanceof Error)) {
+        errorMessage = JSON.stringify(error);
+      }
 
-    const httpsRequest = https
-      .get(url, options, (res) => {
-        res.setEncoding('utf8');
-        let rawData = '';
-        res.on('data', (chunk: any) => {
-          rawData += chunk;
-        });
-        res.on('end', () => {
-          try {
-            const parsedData = JSON.parse(rawData);
-            fastify.log.info('Successful response from Prometheus.');
-            if (parsedData.status === 'error') {
-              reject({ code: 400, response: parsedData.error });
-              return;
-            }
-            resolve({ code: 200, response: parsedData });
-          } catch (e) {
-            const errorMessage = e.message || e.toString();
-            fastify.log.error(`Failure parsing the response from Prometheus. ${errorMessage}`);
-            if (errorMessage.includes('Unexpected token < in JSON')) {
-              reject({ code: 422, response: 'Unprocessable prometheus response' });
-              return;
-            }
-            fastify.log.error(`Unparsed Prometheus data. ${rawData}`);
-            reject({ code: 500, response: rawData });
-          }
-        });
-      })
-      .on('error', (e) => {
-        fastify.log.error(`Failure calling Prometheus. ${e.message}`);
-        reject({ code: 500, response: `Cannot fetch prometheus data, ${e.message}` });
-      });
-    httpsRequest.end();
-  });
+      fastify.log.error(`Unhandled error during prometheus call: ${errorMessage}`);
+      throw error;
+    });
 };
 
 const generatePrometheusHostURL = (

--- a/frontend/src/api/apiMergeUtils.ts
+++ b/frontend/src/api/apiMergeUtils.ts
@@ -9,7 +9,7 @@ const mergeK8sQueryParams = (
   ...(opts.dryRun && { dryRun: 'All' }),
 });
 
-const mergeRequestInit = (
+export const mergeRequestInit = (
   opts: K8sAPIOptions = {},
   specificOpts: RequestInit = {},
 ): RequestInit => ({

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,10 @@ export * from './k8s/secrets';
 export * from './k8s/serviceAccounts';
 export * from './k8s/servingRuntimes';
 
+// Pipelines uses special redirected API
+export * from './pipelines/custom';
+export * from './pipelines/k8s';
+
 // Prometheus queries
 export * from './prometheus/pvcs';
 export * from './prometheus/serving';

--- a/frontend/src/api/models/index.ts
+++ b/frontend/src/api/models/index.ts
@@ -1,3 +1,4 @@
 export * from './k8s';
 export * from './odh';
 export * from './openShift';
+export * from './pipelines';

--- a/frontend/src/api/models/pipelines.ts
+++ b/frontend/src/api/models/pipelines.ts
@@ -1,0 +1,8 @@
+import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+export const DataSciencePipelineApplicationModel: K8sModelCommon = {
+  apiVersion: 'v1alpha1',
+  apiGroup: 'datasciencepipelinesapplications.opendatahub.io',
+  kind: 'DataSciencePipelinesApplication',
+  plural: 'datasciencepipelinesapplications',
+};

--- a/frontend/src/api/pipelines/callTypes.ts
+++ b/frontend/src/api/pipelines/callTypes.ts
@@ -1,0 +1,10 @@
+import { K8sAPIOptions } from '~/k8sTypes';
+import { ListPipelines } from '~/concepts/pipelines/types';
+
+type KubeflowSpecificAPICall = (...args: unknown[]) => Promise<unknown>;
+type KubeflowAPICall<ActualCall extends KubeflowSpecificAPICall = KubeflowSpecificAPICall> = (
+  hostPath: string,
+  opts?: K8sAPIOptions,
+) => ActualCall;
+
+export type ListPipelinesAPI = KubeflowAPICall<ListPipelines>;

--- a/frontend/src/api/pipelines/callUtils.ts
+++ b/frontend/src/api/pipelines/callUtils.ts
@@ -1,0 +1,51 @@
+import { mergeRequestInit } from '~/api/apiMergeUtils';
+import { K8sAPIOptions } from '~/k8sTypes';
+
+const callPipelines = <T>(
+  host: string,
+  path: string,
+  options: RequestInit,
+  data?: Record<string, unknown>,
+): Promise<T> => {
+  const { method, ...otherOptions } = options;
+
+  // Add the path to the end of the proxy call, so it's easier to notice different proxy requests from each other
+  return fetch(`/api/proxy${path}`, {
+    ...otherOptions,
+    headers: {
+      'Content-Type': `application/${
+        method === 'PATCH' ? 'json-patch+json' : 'json'
+      };charset=UTF-8`,
+    },
+    method: 'POST', // we always post so we can send data
+    body: JSON.stringify({
+      method,
+      host,
+      path, // Not part of the request -- but easier to read from the network tab
+      data,
+    }),
+  }).then((response) => response.text().then((data) => JSON.parse(data)));
+};
+
+export const pipelinesGET = <T>(host: string, path: string, options?: K8sAPIOptions): Promise<T> =>
+  callPipelines<T>(host, path, mergeRequestInit(options, { method: 'GET' }));
+
+export const pipelinesCREATE = <T>(
+  host: string,
+  path: string,
+  data: Record<string, unknown>,
+  options?: K8sAPIOptions,
+): Promise<T> => callPipelines<T>(host, path, mergeRequestInit(options, { method: 'POST' }), data);
+
+export const pipelinesUPDATE = <T>(
+  host: string,
+  path: string,
+  data: Record<string, unknown>,
+  options?: K8sAPIOptions,
+): Promise<T> => callPipelines<T>(host, path, mergeRequestInit(options, { method: 'PUT' }), data);
+
+export const pipelinesDELETE = <T>(
+  host: string,
+  path: string,
+  options?: K8sAPIOptions,
+): Promise<T> => callPipelines<T>(host, path, mergeRequestInit(options, { method: 'DELETE' }));

--- a/frontend/src/api/pipelines/custom.ts
+++ b/frontend/src/api/pipelines/custom.ts
@@ -1,0 +1,10 @@
+import { pipelinesGET } from '~/api/pipelines/callUtils';
+import { ListPipelinesAPI } from './callTypes';
+
+// TODO: Kubeflow endpoints
+
+// eg uploadPipeline: POST /apis/v1beta1/pipelines/upload
+// https://www.kubeflow.org/docs/components/pipelines/v1/reference/api/kubeflow-pipeline-api-spec/#operation--apis-v1beta1-pipelines-upload-post
+
+export const listPipelines: ListPipelinesAPI = (hostPath, opts?) => () =>
+  pipelinesGET(hostPath, '/apis/v1beta1/pipelines', opts);

--- a/frontend/src/api/pipelines/k8s.ts
+++ b/frontend/src/api/pipelines/k8s.ts
@@ -1,0 +1,56 @@
+import { k8sCreateResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { DataSciencePipelineApplicationModel } from '~/api/models';
+import { DSPipelineKind, K8sAPIOptions, RouteKind } from '~/k8sTypes';
+import { getRoute } from '~/api';
+import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
+
+const PIPELINE_ROUTE_NAME = 'ds-pipeline-pipelines-definition';
+const PIPELINE_DEFINITION_NAME = 'pipelines-definition';
+
+export const getPipelineAPIRoute = async (
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<RouteKind> => getRoute(PIPELINE_ROUTE_NAME, namespace, opts);
+
+export const createPipelinesCR = async (
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<DSPipelineKind> => {
+  const resource: DSPipelineKind = {
+    apiVersion: `${DataSciencePipelineApplicationModel.apiGroup}/${DataSciencePipelineApplicationModel.apiVersion}`,
+    kind: DataSciencePipelineApplicationModel.kind,
+    metadata: {
+      name: PIPELINE_DEFINITION_NAME,
+      namespace,
+    },
+    spec: {
+      // TODO: populate info from the modal
+      objectStorage: {
+        minio: {
+          image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance',
+        },
+      },
+      mlpipelineUI: {
+        image: 'quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui',
+      },
+    },
+  };
+
+  return k8sCreateResource<DSPipelineKind>(
+    applyK8sAPIOptions(opts, {
+      model: DataSciencePipelineApplicationModel,
+      resource,
+    }),
+  );
+};
+
+export const getPipelinesCR = async (
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<DSPipelineKind> =>
+  k8sGetResource<DSPipelineKind>(
+    applyK8sAPIOptions(opts, {
+      model: DataSciencePipelineApplicationModel,
+      queryOptions: { name: PIPELINE_DEFINITION_NAME, ns: namespace },
+    }),
+  );

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -19,6 +19,8 @@ const NotebookController = React.lazy(
   () => import('../pages/notebookController/NotebookController'),
 );
 
+const TestPipelines = React.lazy(() => import('../concepts/pipelines/TestPipelines'));
+
 const ClusterSettingsPage = React.lazy(() => import('../pages/clusterSettings/ClusterSettings'));
 const GroupSettingsPage = React.lazy(() => import('../pages/groupSettings/GroupSettings'));
 const LearningCenterPage = React.lazy(() => import('../pages/learningCenter/LearningCenter'));
@@ -54,6 +56,10 @@ const AppRoutes: React.FC = () => {
         {isAdmin && <Route path="/notebookImages" element={<BYONImagesPage />} />}
         {isAdmin && <Route path="/clusterSettings" element={<ClusterSettingsPage />} />}
         {isAdmin && <Route path="/groupSettings" element={<GroupSettingsPage />} />}
+
+        {/* TODO: REMOVE DEBUG CODE */}
+        <Route path="/pipelines/:namespace" element={<TestPipelines />} />
+
         <Route path="*" element={<NotFound />} />
       </Routes>
     </React.Suspense>

--- a/frontend/src/concepts/README.md
+++ b/frontend/src/concepts/README.md
@@ -1,0 +1,3 @@
+# Concepts
+
+Each folder in here is about generically dealing with a particular type of resource. Co-locate all needed utilities, constants, hooks, and components that can be reused throughout the app.

--- a/frontend/src/concepts/pipelines/TestPipelines.tsx
+++ b/frontend/src/concepts/pipelines/TestPipelines.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import { Alert, Button, Bullseye, Spinner } from '@patternfly/react-core';
+import { ValueOf } from '~/typeHelpers';
+import { PipelineContextProvider, usePipelinesAPI, CreateCR } from './context';
+
+/** TEMP FILE TO TEST PIPELINE API */
+const TestPipelines: React.FC = () => {
+  const pipelinesAPI = usePipelinesAPI();
+
+  if (!pipelinesAPI.pipelinesEnabled) {
+    return <CreateCR />;
+  }
+  if (!pipelinesAPI.apiAvailable) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  const apis: { key: string; trigger: ValueOf<typeof pipelinesAPI.api> }[] = [
+    { key: 'listPipelines', trigger: () => pipelinesAPI.api.listPipelines() },
+  ];
+
+  return (
+    <div>
+      <h1>Pipeline API Methods (see console for responses)</h1>
+      <ul>
+        {apis.length === 0 && <li>No Apis</li>}
+        {apis.map(({ key, trigger }) => (
+          <li key={key}>
+            <Button
+              variant="link"
+              // eslint-disable-next-line no-console
+              onClick={() => trigger().then(console.log).catch(console.error)}
+            >
+              {key}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const TestPipelinesWrapper: React.FC = () => {
+  const { namespace } = useParams();
+
+  if (!namespace) {
+    return (
+      <Bullseye>
+        <Alert title="Oh no!">Need route to have namespace</Alert>
+      </Bullseye>
+    );
+  }
+
+  return (
+    <PipelineContextProvider namespace={namespace}>
+      <TestPipelines />
+    </PipelineContextProvider>
+  );
+};
+
+export default TestPipelinesWrapper;

--- a/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
+++ b/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import {
+  Alert,
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { PipelineAPIs } from '~/concepts/pipelines/types';
+import { createPipelinesCR, listPipelines } from '~/api';
+import useProject from '~/pages/projects/useProject';
+import usePipelineNamespaceCR from './usePipelineNamespaceCR';
+import usePipelinesAPIRoute from './usePipelinesAPIRoute';
+
+type PipelineContext = {
+  hasCR: boolean;
+  hostPath: string | null;
+  namespace: string;
+  refreshState: () => void;
+};
+
+const PipelinesContext = React.createContext<PipelineContext>({
+  hasCR: false,
+  hostPath: null,
+  namespace: '',
+  refreshState: () => undefined,
+});
+
+type PipelineContextProviderProps = {
+  children: React.ReactNode;
+  namespace: string;
+};
+
+export const PipelineContextProvider: React.FC<PipelineContextProviderProps> = ({
+  children,
+  namespace,
+}) => {
+  const [, projectLoaded, projectLoadError] = useProject(namespace);
+  const [pipelineNamespaceCR, crLoaded, crLoadError, refreshCR] = usePipelineNamespaceCR(namespace);
+  // TODO: Do we need more than just knowing it exists?
+  const isCRPresent = !!pipelineNamespaceCR;
+  // TODO: Manage the route being free but the pods not being spun up yet
+  const [pipelineAPIRouteHost, routeLoaded, routeLoadError, refreshRoute] = usePipelinesAPIRoute(
+    isCRPresent,
+    namespace,
+  );
+
+  const refreshState = React.useCallback(() => {
+    refreshCR();
+    refreshRoute();
+  }, [refreshRoute, refreshCR]);
+
+  if (projectLoadError) {
+    return (
+      <Bullseye>
+        <Alert title="Project does not exist" variant="danger" isInline>
+          {projectLoadError.message}
+        </Alert>
+      </Bullseye>
+    );
+  }
+
+  const error = crLoadError || routeLoadError;
+  if (error) {
+    return (
+      <Bullseye>
+        <Alert title="Pipelines load error" variant="danger" isInline>
+          {error.message}
+        </Alert>
+      </Bullseye>
+    );
+  }
+
+  const isLoading = !projectLoaded || !crLoaded || (isCRPresent && !routeLoaded);
+  if (isLoading) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <PipelinesContext.Provider
+      value={{
+        hasCR: isCRPresent,
+        hostPath: pipelineAPIRouteHost || null,
+        namespace,
+        refreshState,
+      }}
+    >
+      {children}
+    </PipelinesContext.Provider>
+  );
+};
+
+type UsePipelinesAPI = {
+  pipelinesEnabled: boolean;
+} & (
+  | {
+      apiAvailable: true;
+      api: PipelineAPIs;
+    }
+  | {
+      apiAvailable: false;
+    }
+);
+
+export const usePipelinesAPI = (): UsePipelinesAPI => {
+  const { hasCR, hostPath } = React.useContext(PipelinesContext);
+
+  if (!hostPath) {
+    return {
+      pipelinesEnabled: hasCR,
+      apiAvailable: false,
+    };
+  }
+
+  return {
+    pipelinesEnabled: hasCR,
+    apiAvailable: true,
+    api: {
+      // TODO: apis!
+      // eg uploadPipeline: (content: string) => uploadPipeline(hostPath, content),
+      listPipelines: listPipelines(hostPath),
+    },
+  };
+};
+
+export const CreateCR: React.FC = () => {
+  const { namespace, refreshState } = React.useContext(PipelinesContext);
+  const [creating, setCreating] = React.useState(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  const createCR = () => {
+    setCreating(true);
+    setError(null);
+    createPipelinesCR(namespace)
+      .then(() => {
+        refreshState();
+        setCreating(false);
+      })
+      .catch((e) => {
+        setCreating(false);
+        setError(e);
+      });
+  };
+
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={PlusCircleIcon} />
+      <Title headingLevel="h1" size="lg">
+        Pipelines is not setup
+      </Title>
+      <EmptyStateBody>You&rsquo;ll need to setup Pipelines for this namespace.</EmptyStateBody>
+      <Button variant="primary" onClick={createCR} isDisabled={creating}>
+        Enable Pipelines!
+      </Button>
+      {error && (
+        <Alert isInline variant="danger" title="Error creating">
+          {error.message}
+        </Alert>
+      )}
+    </EmptyState>
+  );
+};

--- a/frontend/src/concepts/pipelines/context/index.ts
+++ b/frontend/src/concepts/pipelines/context/index.ts
@@ -1,0 +1,1 @@
+export { CreateCR, PipelineContextProvider, usePipelinesAPI } from './PipelinesContext';

--- a/frontend/src/concepts/pipelines/context/usePipelineNamespaceCR.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelineNamespaceCR.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { DSPipelineKind } from '~/k8sTypes';
+import { getPipelinesCR } from '~/api';
+import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+
+type State = DSPipelineKind | null;
+
+const usePipelineNamespaceCR = (namespace: string): FetchState<State> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<State>>(
+    (opts) =>
+      getPipelinesCR(namespace, opts).catch((e) => {
+        if (e.statusObject?.code === 404) {
+          // Not finding is okay, not an error
+          return null;
+        }
+        throw e;
+      }),
+    [namespace],
+  );
+
+  return useFetchState<State>(callback, null);
+};
+
+export default usePipelineNamespaceCR;

--- a/frontend/src/concepts/pipelines/context/usePipelinesAPIRoute.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelinesAPIRoute.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { RouteKind } from '~/k8sTypes';
+import { getPipelineAPIRoute } from '~/api';
+import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+import { FAST_POLL_INTERVAL } from '~/utilities/const';
+
+type State = string | null;
+
+const usePipelinesAPIRoute = (hasCR: boolean, namespace: string): FetchState<State> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<State>>(
+    (opts) =>
+      // TODO: fetch from namespace only when we have CR
+      getPipelineAPIRoute(namespace, opts)
+        .then((result: RouteKind) => `https://${result.spec.host}`)
+        .catch((e) => {
+          if (e.statusObject?.code === 404) {
+            // Not finding is okay, not an error
+            return null;
+          }
+          throw e;
+        }),
+    [namespace],
+  );
+
+  const ref = React.useRef(false);
+  const refreshInterval = !ref.current && hasCR ? FAST_POLL_INTERVAL : undefined;
+  const fetchState = useFetchState<State>(callback, null, refreshInterval);
+
+  if (fetchState[0]) {
+    ref.current = true;
+  }
+
+  return fetchState;
+};
+
+export default usePipelinesAPIRoute;

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -1,0 +1,65 @@
+/* Types pulled from https://www.kubeflow.org/docs/components/pipelines/v1/reference/api/kubeflow-pipeline-api-spec */
+// TODO: Determine what is optional and what is not
+
+export enum ResourceTypeKF {
+  UNKNOWN_RESOURCE_TYPE = 'UNKNOWN_RESOURCE_TYPE',
+  EXPERIMENT = 'EXPERIMENT',
+  JOB = 'JOB',
+  PIPELINE = 'PIPELINE',
+  PIPELINE_VERSION = 'PIPELINE_VERSION',
+  NAMESPACE = 'NAMESPACE',
+}
+export enum RelationshipKF {
+  UNKNOWN_RELATIONSHIP = 'UNKNOWN_RELATIONSHIP',
+  OWNER = 'OWNER',
+  CREATOR = 'CREATOR',
+}
+
+export type ParameterKF = {
+  name: string;
+  value: string;
+};
+
+export type PipelineVersionKF = {
+  id: string;
+  name: string;
+  created_at: string;
+  parameters?: ParameterKF[];
+  code_source_url?: string;
+  package_url?: UrlKF;
+  resource_references: ResourceReferenceKF[];
+  description?: string;
+};
+
+export type ResourceKeyKF = {
+  type: ResourceTypeKF;
+  id: string;
+};
+
+export type ResourceReferenceKF = {
+  key: ResourceKeyKF;
+  name?: string;
+  relationship: RelationshipKF;
+};
+
+export type UrlKF = {
+  pipeline_url: string;
+};
+
+export type PipelineKF = {
+  id: string;
+  created_at: string;
+  name: string;
+  description: string;
+  parameters?: ParameterKF[];
+  url?: UrlKF;
+  error?: string;
+  default_version: PipelineVersionKF;
+  resource_references?: ResourceReferenceKF;
+};
+
+export type ListPipelinesResponseKF = {
+  pipelines: PipelineKF[];
+  total_size: number;
+  next_page_token?: string;
+};

--- a/frontend/src/concepts/pipelines/types.ts
+++ b/frontend/src/concepts/pipelines/types.ts
@@ -1,0 +1,9 @@
+import { ListPipelinesResponseKF } from './kfTypes';
+
+export type ListPipelines = () => Promise<ListPipelinesResponseKF>;
+
+export type PipelineAPIs = {
+  // TODO: fill out with all the APIs
+  // eg: uploadPipeline: (content: string) => SomeReturnedStructure;
+  listPipelines: ListPipelines;
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -366,3 +366,73 @@ export type AWSSecretKind = SecretKind & {
     };
   };
 };
+
+export type DSPipelineKind = K8sResourceCommon & {
+  spec: Partial<{
+    apiServer: Partial<{
+      apiServerImage: string;
+      artifactImage: string;
+      artifactScriptConfigMap: Partial<{
+        key: string;
+        name: string;
+      }>;
+    }>;
+    database: Partial<{
+      customDB: Partial<{
+        host: string;
+        passwordSecret: Partial<{
+          key: string;
+          name: string;
+        }>;
+        pipelineDBName: string;
+        port: string;
+        username: string;
+      }>;
+      image: string;
+      mariaDB: Partial<{
+        image: string;
+        passwordSecret: Partial<{
+          key: string;
+          name: string;
+        }>;
+        pipelineDBName: string;
+        username: string;
+      }>;
+    }>;
+    mlpipelineUI: Partial<{
+      configMap: string;
+      image: string;
+    }>;
+    persistentAgent: Partial<{
+      image: string;
+      pipelineAPIServerName: string;
+    }>;
+    scheduledWorkflow: Partial<{
+      image: string;
+    }>;
+    objectStorage: Partial<{
+      customStorage: Partial<{
+        bucket: string;
+        host: string;
+        port: string;
+        s3CredentialsSecret: Partial<{
+          accessKey: string;
+          secretKey: string;
+          secretName: string;
+        }>;
+      }>;
+      minio: Partial<{
+        bucket: string;
+        image: string;
+        s3CredentialsSecret: Partial<{
+          accessKey: string;
+          secretKey: string;
+          secretName: string;
+        }>;
+      }>;
+    }>;
+    viewerCRD: Partial<{
+      image: string;
+    }>;
+  }>;
+};

--- a/frontend/src/typeHelpers.ts
+++ b/frontend/src/typeHelpers.ts
@@ -1,4 +1,13 @@
 /**
+ * The type `{}` doesn't mean "any empty object", it means "any non-nullish value".
+ *
+ * Use the `AnyObject` type for objects whose structure is unknown.
+ *
+ * @see https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
+ */
+export type AnyObject = Record<string, unknown>;
+
+/**
  * Takes a type and makes all properties partial within it.
  *
  * TODO: Implement the SDK & Patch logic -- this should stop being needed as things will be defined as Patches


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #924

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Pipelines API will be a little different than other APIs we have. It will have two layers of being enabled.

At the Dashboard level - A feature flag (not included in this PR) -- this will eventually show/hide UI elements
At the Namespace level - A custom Pipeline CR needs to be present to interact with the 

- (setup) From Client -- when the user "enables" Pipelines
  - Create Pipelines CR (namespaced)
    - Call node backend (K8s API)
- (in the background) Pipeline stack watching the CRs
    - Creates a k8s Route object in namespace<sup>1</sup>
- (setup) From Client
  - Fetch KF Route & store the value
- (pipeline functionality) From Client
    - Using stored route
        - Call node backend (Proxy API<sup>2</sup>)

Notes:
- K8s Route object in namespace<sup>1</sup>: This route will be the target of all API calls for KF Pipeline data -- with the exception of anything needing to communicate with a k8s resource (outside of KF)
- Proxy API<sup>2</sup>: New API with this PR, it takes a fully qualified URL, method, and data and makes the call for you
    - This is so we can get around insecure routes in development and around CORS for the short term on production

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

First -- install OpenShift Pipelines Operator.

### KFDef



```
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: odh-with-pipelines
  namespace: opendatahub
spec:
  applications:
    # Base -- NB Images, Manifest, NB Controller
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-common
      name: odh-common
    - kustomizeConfig:
        overlays:
          - additional
        repoRef:
          name: manifests
          path: jupyterhub/notebook-images
      name: notebook-images
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-notebook-controller
      name: odh-notebook-controller
    # DS Pipelines
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: data-science-pipelines-operator/
      name: data-science-pipelines-operator
  repos:
    - name: manifests
      uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
```

### From the UI

For the time being -- we will mount a page on `<host>/pipelines/:namespace` (eg: `http://localhost:4010/pipelines/andrews-test`) that will give you access to enabling Pipelines in your namespace & testing API in a more pure fashion while we build out the API.

It doesn't look like much, but once you go through the create CR step it should look something like this:
![image](https://user-images.githubusercontent.com/8126518/226124354-c4c40ab6-6702-4352-ae38-c7892d0b333a.png)

### Purely with API

- You'll need to create a Pipelines CR (see the code here for [an example](https://github.com/opendatahub-io/odh-dashboard/blob/fe7601ac191859c55ab6f70f1497f4cd47a895b2/frontend/src/api/pipelines/k8s.ts#L19-L37) of the bare min setup).
- This will generate you a route called `ds-pipeline-pipelines-definition` in your namespace
- Using this route value and suffixing it with the API found on the [Kubeflow API docs](https://www.kubeflow.org/docs/components/pipelines/v1/reference/api/kubeflow-pipeline-api-spec/)
    - Using Postman or another API calling tools will allow you to test the API outside of the UI

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
We don't have the infra to setup tests to the Pipeline backend -- nothing to test here from the UI side in Storybook.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)