### PR TITLE
Add update of the OWNERS file to the release doc

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -73,6 +73,7 @@ Once we reach a date in which we want to do a release (see other sections for mo
       - First delete everything in the folder -- git will do the diff of what changed for us
       - Copy all the child folders in the [manifest folder](../manifests)
          - Exclude the `overlays` folder as this is for internal testing purposes
+      - Copy the OWNERS file into the root of the odh-dashboard manifest folder
       - Update the `./base/kustomization.yaml` so that the `odh-dashboard` images section has the `newTag` equal to the current release version (aka the tag we created earlier)
       - In the `./base/deployment.yaml` we'll want to set the ODH replicas to `2`
       - Update the top row of the component versions table on the root readme to have the latest release version (aka the tag we created earlier)


### PR DESCRIPTION
Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

## Description
Update the release doc to include instruction for adding the OWNERS file to the release process for odh-manifests

## How Has This Been Tested?
N/A

## Merge criteria:
N/A

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
