### PR TITLE
Address a11y violations in Settings screens

### DIFF
--- a/frontend/src/components/FormGroupSettings.tsx
+++ b/frontend/src/components/FormGroupSettings.tsx
@@ -34,6 +34,7 @@ export const FormGroupSettings: React.FC<FormGroupSettingsProps> = ({
   <FormGroup fieldId={groupsField} label={title}>
     <Text>{body}</Text>
     <MultiSelection
+      ariaLabel={body}
       value={items}
       setValue={(newState) => handleMenuItemSelection(newState, groupsField)}
     />

--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -11,9 +11,10 @@ import { MenuItemStatus } from '~/pages/groupSettings/groupTypes';
 type MultiSelectionProps = {
   value: MenuItemStatus[];
   setValue: (itemSelection: MenuItemStatus[]) => void;
+  ariaLabel: string;
 };
 
-export const MultiSelection: React.FC<MultiSelectionProps> = ({ value, setValue }) => {
+export const MultiSelection: React.FC<MultiSelectionProps> = ({ value, setValue, ariaLabel }) => {
   const [showMenu, setShowMenu] = React.useState(false);
 
   const toggleMenu = (isOpen: React.SetStateAction<boolean>) => {
@@ -44,7 +45,8 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({ value, setValue 
         onClear={clearSelection}
         selections={value?.filter((element) => element.enabled).map((element) => element.name)}
         isOpen={showMenu}
-        aria-labelledby="Select a group"
+        aria-label="Select groups menu"
+        typeAheadAriaLabel={ariaLabel}
         isCreatable={false}
         onCreateOption={undefined}
         validated={noSelectedItems ? 'error' : 'default'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #967 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
User and Group Settings - Before:
<img width="1726" alt="Screen Shot 2023-02-23 at 3 53 58 PM" src="https://user-images.githubusercontent.com/32821331/221619933-680f7e14-5952-49d1-8041-34940f24f703.png">

User and Group Settings - After:
<img width="1719" alt="Screen Shot 2023-02-27 at 9 45 12 AM" src="https://user-images.githubusercontent.com/32821331/221619971-8095aae1-5755-44ec-9deb-f54c65d4a5de.png">

Cluster Settings - no violations:
<img width="1727" alt="Screen Shot 2023-02-23 at 3 52 41 PM" src="https://user-images.githubusercontent.com/32821331/221620018-6f90bfac-6cd8-4116-b450-0e7bb853b563.png">


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
