### PR TITLE
[Dev] Clean up logfile for dev starts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,8 +18,9 @@
   },
   "main": "src/server.ts",
   "scripts": {
+    "clean": "rm -f ../logs/adminActivity.log",
     "start": "npm run tsc && NODE_ENV=production node ./dist/server.js --log=1 --registry=localhost:50051",
-    "start:dev": "export NODE_TLS_REJECT_UNAUTHORIZED=0 && export NODE_ENV=development && nodemon src/server.ts --log=1 --registry=localhost:50051",
+    "start:dev": "npm run clean && export NODE_TLS_REJECT_UNAUTHORIZED=0 && export NODE_ENV=development && nodemon src/server.ts --log=1 --registry=localhost:50051",
     "debug": "npm run tsc && export NODE_TLS_REJECT_UNAUTHORIZED=0 && export NODE_ENV=development && node --inspect ./dist/server.js --log=1 --registry=localhost:50051",
     "build-only": "tsc -p . && node ./dist/server.js --log=1 --registry=localhost:50051 --buildonly",
     "build": "npm run build:clean; npm run tsc",


### PR DESCRIPTION
Cleans up the log file introduced in https://github.com/opendatahub-io/odh-dashboard/pull/914

Every time we start our dev environment is a good time to clean up the logfile. If we don't, it grows indefinitely. I hit over 5mb recently... it likely will grow indefinitely as there is no cleanup mechanism.

This is by design for production, but for development it's unnecessary. 