### PR TITLE
Suppress 404 error for notebook route when the notebook is not running

### DIFF
--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -11,7 +11,7 @@ const NotebookLogoutRedirect: React.FC = () => {
   const notification = useNotification();
   const navigate = useNavigate();
   const { notebookNamespace } = useNamespaces();
-  const [routeLink, loaded, error] = useRouteForNotebook(notebookName, namespace);
+  const [routeLink, loaded, error] = useRouteForNotebook(notebookName, namespace, true);
 
   React.useEffect(() => {
     let cancelled = false;

--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -24,6 +24,7 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
   const [routeLink, loaded, error] = useRouteForNotebook(
     notebook.metadata.name,
     notebook.metadata.namespace,
+    isRunning,
   );
   const isStopped = hasStopAnnotation(notebook);
   const canLink = loaded && !!routeLink && !error && !isStopped && isRunning;

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -5,6 +5,7 @@ import { FAST_POLL_INTERVAL } from '~/utilities/const';
 const useRouteForNotebook = (
   notebookName?: string,
   projectName?: string,
+  isRunning?: boolean,
 ): [routeLink: string | null, loaded: boolean, loadError: Error | null] => {
   const [route, setRoute] = React.useState<string | null>(null);
   const [loaded, setLoaded] = React.useState(false);
@@ -31,7 +32,11 @@ const useRouteForNotebook = (
             if (cancelled) {
               return;
             }
-            setLoadError(e);
+            if (!isRunning && e.statusObject?.code === 404) {
+              setLoadError(null);
+            } else {
+              setLoadError(e);
+            }
             watchHandle = setTimeout(watchRoute, FAST_POLL_INTERVAL);
           });
       }
@@ -41,7 +46,7 @@ const useRouteForNotebook = (
       cancelled = true;
       clearTimeout(watchHandle);
     };
-  }, [notebookName, projectName]);
+  }, [notebookName, projectName, isRunning]);
 
   return [route, loaded, loadError];
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #858 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There is no good way to test it because once you delete the route, it will recreate one immediately before re-fetching it. I tested it by changing the `notebookName` to something else, which will give you a 404 error when you are trying to get the route, but the `isRunning` status is always accurate. In this way, I can toggle the switch and see if the error is set or not when based on the notebook status.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
