### PR TITLE
Check user permissions before promoting data science projects

### DIFF
--- a/backend/src/routes/api/namespaces/index.ts
+++ b/backend/src/routes/api/namespaces/index.ts
@@ -13,7 +13,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
 
       const context = parseInt(contextAsString) as NamespaceApplicationCase;
 
-      return applyNamespaceChange(fastify, name, context);
+      return applyNamespaceChange(fastify, request, name, context);
     },
   );
 };

--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -68,9 +68,7 @@ export const applyNamespaceChange = async (
 
   return fastify.kube.coreV1Api
     .patchNamespace(name, { metadata: { labels } }, undefined, undefined, undefined, undefined, {
-      headers: {
-        'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH,
-      },
+      headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
     })
     .then(() => ({ applied: true }))
     .catch((e) => {


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #963 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We can use [SelfSubjectReviewAccess](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/) to check the permissions of a specific user to some resources. For this issue, we need to check the update permission to the given project, but everything needs to be done at the backend so we need to call `passThrough` and the k8s API endpoint directly before the service account do the labels patching.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Prerequisite: You must have 2 accounts on the cluster, 1 as the cluster admin (ADMIN) and one as the regular user (USER).
1. Deploy the image of this PR `pr-991` to your dashboard pod
2. Create a regular project (non-DSG project) using the OpenShift console or the oc command with the ADMIN account
3. Login to the dashboard with both the ADMIN account and USER account and go to the URL `${dashboardURL}/api/namespaces/${projectYouCreated}/1`, this command will patch a label and promote the project to a model serving project
4. Check the result of these 2 accounts, for ADMIN, it should return `{ applied: true }`, and for the USER account, it should return a 403 error
5. Add a RoleBinding to the namespace, the role is `admin` and the subject is the regular user, which gives the regular user admin permission to the project
6. Use the USER account to request that URL again, you will see `{ applied: true }`
7. Delete the RoleBinding and create a new RoleBinding but change the role to `edit`
8. Repeat step 6 and you will find it returns a 403 error again
9. Use the USER account to create a new project as in step 2, and test the permission in the dashboard as in steps 3 and 4

Follow the test instructions in the last section, you will see this if you have admin permission for the project you are trying to promote:
<img width="1860" alt="Screenshot 2023-03-09 at 4 22 40 PM" src="https://user-images.githubusercontent.com/37624318/223963026-dccbd55f-3567-49a5-86d0-06bc4a7b59b5.png">

And the project will be promoted:
<img width="1904" alt="Screenshot 2023-03-09 at 4 26 02 PM" src="https://user-images.githubusercontent.com/37624318/223963816-a1eef182-ac7c-4175-833d-72a70f823b48.png">

If you don't have permission:
<img width="1904" alt="Screenshot 2023-03-09 at 4 25 11 PM" src="https://user-images.githubusercontent.com/37624318/223963433-de2adee5-e215-4f8b-bf12-fc39d42b9488.png">

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, this needs to be tested on the cluster since we need the service account.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
