### PR TITLE
Add github dispatch for operator sync workflow

### DIFF
--- a/.github/workflows/dispatch_on_crd_change.yaml
+++ b/.github/workflows/dispatch_on_crd_change.yaml
@@ -1,0 +1,28 @@
+name: Send dispatch on CRD change
+
+on:
+  pull_request:
+    types: 
+    - closed
+    branches:
+    - main
+    paths:
+    - 'manifests/crd/**'
+
+jobs:
+  operator-sync:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send dispatch to operator
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const result = await github.rest.actions.createWorkflowDispatch({
+            owner: 'opendatahub-io',
+            repo: 'opendatahub-operator',
+            workflow_id: 'sync_dashboard_crds.yml',
+            ref: 'actions/dashboard-sync'
+          })
+          console.log(result)


### PR DESCRIPTION
Prerequisite for: https://github.com/opendatahub-io/opendatahub-operator/pull/205

## Description
This workflow sends a dispatch whenever a pull request is merged that modifies the crd folder of the dashboard repository. The operator has a workflow that then copies these changes automatically.

## How Has This Been Tested?
This PR was tested using https://github.com/nektos/act to locally verify that the workflow is sending the dispatch correctly.

To test this in real conditions, a fork of the operator and dashboard is required:

1. Create a pull request in the odh-dashboard fork that changes a file in /manifests/crd folder 
2. Merge the PR into the main branch of the fork
3. Verify that the action has been triggered
4. Verify dispatch reached opendatahub-operator fork sync workflow and has triggered it.

## Test Impact
No tests are done for github workflows (afaik)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
