### PR TITLE
Add useAccessReview hook and apply it to create project button

### DIFF
--- a/backend/src/routes/api/k8s/index.ts
+++ b/backend/src/routes/api/k8s/index.ts
@@ -32,7 +32,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
 
       // Apply query params
       const query = req.query;
-      if (Object.keys(query)) {
+      if (Object.keys(query).length > 0) {
         url += `?${Object.keys(query)
           .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
           .join('&')}`;

--- a/backend/src/routes/api/k8s/index.ts
+++ b/backend/src/routes/api/k8s/index.ts
@@ -1,8 +1,16 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { KubeFastifyInstance } from '../../../types';
 import { USER_ACCESS_TOKEN } from '../../../utils/constants';
-import { passThrough } from './pass-through';
+import { passThrough, safeURLPassThrough } from './pass-through';
 import { logRequestDetails } from '../../../utils/fileUtils';
+
+// TODO: Remove when bug is fixed - https://issues.redhat.com/browse/HAC-1825
+// Some resources don't allow metadata.name when creating such as SelfSubjectAccessReview
+// this will cause the URL error when we call pass-through function
+// we will check this value below to call safeURLPassThrough instead of passThrough
+enum resourceWithoutMetadataName {
+  'SelfSubjectAccessReview',
+}
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   const kc = fastify.kube.config;
@@ -36,6 +44,20 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         url += `?${Object.keys(query)
           .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
           .join('&')}`;
+      }
+
+      if (
+        req.method.toLowerCase() === 'post' &&
+        Object.keys(resourceWithoutMetadataName).includes(`${req.body.kind}`)
+      ) {
+        return safeURLPassThrough(fastify, req, {
+          url,
+          method: req.method,
+          requestData: data,
+        }).catch(({ code, response }) => {
+          reply.code(code);
+          reply.send(response);
+        });
       }
 
       return passThrough(fastify, req, { url, method: req.method, requestData: data }).catch(

--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -41,7 +41,7 @@ export const passThrough = <T extends K8sResourceCommon>(
 
   // TODO: Remove when bug is fixed - https://issues.redhat.com/browse/HAC-1825
   let safeURL = url;
-  if (method.toLowerCase() === 'post') {
+  if (method.toLowerCase() === 'post' && !url.endsWith('selfsubjectaccessreviews')) {
     // Core SDK builds the wrong path for k8s -- can't post to a resource name; remove the name from the url
     // eg: POST /.../configmaps/my-config-map => POST /.../configmaps
     const urlParts = url.split('/');

--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -44,6 +44,7 @@ export const passThrough = <T extends K8sResourceCommon>(
   if (method.toLowerCase() === 'post' && !url.endsWith('selfsubjectaccessreviews')) {
     // Core SDK builds the wrong path for k8s -- can't post to a resource name; remove the name from the url
     // eg: POST /.../configmaps/my-config-map => POST /.../configmaps
+    // Note: SelfSubjectAccessReviews do not include a resource name
     const urlParts = url.split('/');
     const queryParams = urlParts[urlParts.length - 1].split('?');
     urlParts.pop();

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -20,3 +20,6 @@ export * from './prometheus/serving';
 
 // Network error handling
 export * from './errorUtils';
+
+// User access review hook
+export * from './useAccessReview';

--- a/frontend/src/api/models/k8s.ts
+++ b/frontend/src/api/models/k8s.ts
@@ -43,6 +43,13 @@ export const SecretModel: K8sModelCommon = {
   plural: 'secrets',
 };
 
+export const SelfSubjectAccessReviewModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'authorization.k8s.io',
+  kind: 'SelfSubjectAccessReview',
+  plural: 'selfsubjectaccessreviews',
+};
+
 export const ServiceAccountModel: K8sModelCommon = {
   apiVersion: 'v1',
   kind: 'ServiceAccount',

--- a/frontend/src/api/useAccessReview.ts
+++ b/frontend/src/api/useAccessReview.ts
@@ -45,7 +45,7 @@ export const useAccessReview = (
     group = '',
     resource = '',
     subresource = '',
-    verb = '*',
+    verb,
     name = '',
     namespace = '',
   } = resourceAttributes;

--- a/frontend/src/api/useAccessReview.ts
+++ b/frontend/src/api/useAccessReview.ts
@@ -2,16 +2,15 @@ import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import * as React from 'react';
 import { ProjectModel, SelfSubjectAccessReviewModel } from '~/api/models';
 import { AccessReviewResourceAttributes, SelfSubjectAccessReviewKind } from '~/k8sTypes';
-import { K8sVerb } from '~/k8sTypes';
 
-const checkAccess = (
-  group: string,
-  resource: string,
-  subresource: string,
-  verb: K8sVerb,
-  name: string,
-  namespace: string,
-): Promise<SelfSubjectAccessReviewKind> => {
+const checkAccess = ({
+  group,
+  resource,
+  subresource,
+  verb,
+  name,
+  namespace,
+}: Required<AccessReviewResourceAttributes>): Promise<SelfSubjectAccessReviewKind> => {
   // Projects are a special case. `namespace` must be set to the project name
   // even though it's a cluster-scoped resource.
   const reviewNamespace =
@@ -46,13 +45,13 @@ export const useAccessReview = (
     group = '',
     resource = '',
     subresource = '',
-    verb = '' as K8sVerb,
+    verb = '*',
     name = '',
     namespace = '',
   } = resourceAttributes;
 
   React.useEffect(() => {
-    checkAccess(group, resource, subresource, verb, name, namespace)
+    checkAccess({ group, resource, subresource, verb, name, namespace })
       .then((result) => {
         if (result.status) {
           setAllowed(result.status.allowed);

--- a/frontend/src/api/useAccessReview.ts
+++ b/frontend/src/api/useAccessReview.ts
@@ -1,0 +1,73 @@
+import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
+import * as React from 'react';
+import { ProjectModel, SelfSubjectAccessReviewModel } from '~/api/models';
+import { AccessReviewResourceAttributes, SelfSubjectAccessReviewKind } from '~/k8sTypes';
+import { K8sVerb } from '~/k8sTypes';
+
+const checkAccess = (
+  group: string,
+  resource: string,
+  subresource: string,
+  verb: K8sVerb,
+  name: string,
+  namespace: string,
+): Promise<SelfSubjectAccessReviewKind> => {
+  // Projects are a special case. `namespace` must be set to the project name
+  // even though it's a cluster-scoped resource.
+  const reviewNamespace =
+    group === ProjectModel.apiGroup && resource === ProjectModel.plural ? name : namespace;
+  const selfSubjectAccessReview: SelfSubjectAccessReviewKind = {
+    apiVersion: 'authorization.k8s.io/v1',
+    kind: 'SelfSubjectAccessReview',
+    spec: {
+      resourceAttributes: {
+        group,
+        resource,
+        subresource,
+        verb,
+        name,
+        namespace: reviewNamespace,
+      },
+    },
+  };
+  return k8sCreateResource<SelfSubjectAccessReviewKind>({
+    model: SelfSubjectAccessReviewModel,
+    resource: selfSubjectAccessReview,
+  });
+};
+
+export const useAccessReview = (
+  resourceAttributes: AccessReviewResourceAttributes,
+): [boolean, boolean] => {
+  const [loaded, setLoaded] = React.useState(false);
+  const [isAllowed, setAllowed] = React.useState(false);
+
+  const {
+    group = '',
+    resource = '',
+    subresource = '',
+    verb = '' as K8sVerb,
+    name = '',
+    namespace = '',
+  } = resourceAttributes;
+
+  React.useEffect(() => {
+    checkAccess(group, resource, subresource, verb, name, namespace)
+      .then((result) => {
+        if (result.status) {
+          setAllowed(result.status.allowed);
+        } else {
+          setAllowed(true);
+        }
+        setLoaded(true);
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.warn('SelfSubjectAccessReview failed', e);
+        setAllowed(true);
+        setLoaded(true);
+      });
+  }, [group, name, namespace, resource, subresource, verb]);
+
+  return [isAllowed, loaded];
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -377,11 +377,17 @@ export type AWSSecretKind = SecretKind & {
 };
 
 export type AccessReviewResourceAttributes = {
-  group?: string;
+  /** CRD group, '*' for all groups, omit for core resources */
+  group?: '*' | string;
+  /** Plural resource name, omit for all */
   resource?: string;
-  subresource?: string;
-  verb?: K8sVerb;
+  /** TODO: Not a full list, could be expanded, "" means none */
+  subresource?: '' | 'spec' | 'status';
+  /** Must provide the verb you are trying to do; '*' means all verbs */
+  verb: '*' | K8sVerb;
+  /** A resource name, omit when not interested in a specific resource */
   name?: string;
+  /** The namespace the check is in, omit for unbounded check */
   namespace?: string;
 };
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1,6 +1,16 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { PodAffinity, NotebookContainer, PodToleration, Volume, ContainerResources } from './types';
 
+export type K8sVerb =
+  | 'create'
+  | 'get'
+  | 'list'
+  | 'update'
+  | 'patch'
+  | 'delete'
+  | 'deletecollection'
+  | 'watch';
+
 /**
  * Annotations that we will use to allow the user flexibility in describing items outside of the
  * k8s structure.
@@ -363,5 +373,26 @@ export type AWSSecretKind = SecretKind & {
     labels?: {
       'opendatahub.io/managed': 'true';
     };
+  };
+};
+
+export type AccessReviewResourceAttributes = {
+  group?: string;
+  resource?: string;
+  subresource?: string;
+  verb?: K8sVerb;
+  name?: string;
+  namespace?: string;
+};
+
+export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
+  spec: {
+    resourceAttributes?: AccessReviewResourceAttributes;
+  };
+  status?: {
+    allowed: boolean;
+    denied?: boolean;
+    reason?: string;
+    evaluationError?: string;
   };
 };

--- a/frontend/src/pages/projects/screens/projects/EmptyProjects.tsx
+++ b/frontend/src/pages/projects/screens/projects/EmptyProjects.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  Button,
+  ButtonVariant,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -8,7 +8,8 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
-import { Link } from 'react-router-dom';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
+import LaunchJupyterButton from '~/pages/projects/screens/projects/LaunchJupyterButton';
 import NewProjectButton from './NewProjectButton';
 
 type EmptyProjectsProps = {
@@ -22,15 +23,20 @@ const EmptyProjects: React.FC<EmptyProjectsProps> = ({ allowCreate }) => (
       No data science projects yet.
     </Title>
     <EmptyStateBody>
-      To get started, create a data science project or launch a notebook with Jupyter.
+      {allowCreate
+        ? 'To get started, create a data science project or launch a notebook with Jupyter.'
+        : `To get started, ask your ${ODH_PRODUCT_NAME} admin for a data science project or launch a notebook with Jupyter.`}
     </EmptyStateBody>
-    {allowCreate && <NewProjectButton />}
-    <EmptyStateSecondaryActions>
-      <Button
-        variant="link"
-        component={() => <Link to="/notebookController">Launch Jupyter</Link>}
-      />
-    </EmptyStateSecondaryActions>
+    {allowCreate ? (
+      <>
+        <NewProjectButton />
+        <EmptyStateSecondaryActions>
+          <LaunchJupyterButton variant={ButtonVariant.link} />
+        </EmptyStateSecondaryActions>
+      </>
+    ) : (
+      <LaunchJupyterButton variant={ButtonVariant.primary} />
+    )}
   </EmptyState>
 );
 

--- a/frontend/src/pages/projects/screens/projects/EmptyProjects.tsx
+++ b/frontend/src/pages/projects/screens/projects/EmptyProjects.tsx
@@ -11,7 +11,11 @@ import { CubesIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import NewProjectButton from './NewProjectButton';
 
-const EmptyProjects: React.FC = () => (
+type EmptyProjectsProps = {
+  allowCreate: boolean;
+};
+
+const EmptyProjects: React.FC<EmptyProjectsProps> = ({ allowCreate }) => (
   <EmptyState>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h2" size="lg">
@@ -20,7 +24,7 @@ const EmptyProjects: React.FC = () => (
     <EmptyStateBody>
       To get started, create a data science project or launch a notebook with Jupyter.
     </EmptyStateBody>
-    <NewProjectButton />
+    {allowCreate && <NewProjectButton />}
     <EmptyStateSecondaryActions>
       <Button
         variant="link"

--- a/frontend/src/pages/projects/screens/projects/LaunchJupyterButton.tsx
+++ b/frontend/src/pages/projects/screens/projects/LaunchJupyterButton.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+
+type LaunchJupyterButtonProps = {
+  variant: ButtonVariant;
+};
+
+const LaunchJupyterButton: React.FC<LaunchJupyterButtonProps> = ({ variant }) => {
+  const navigate = useNavigate();
+  return (
+    <Button
+      href="/notebookController"
+      variant={variant}
+      onClick={(e) => {
+        e.preventDefault();
+        navigate('/notebookController');
+      }}
+    >
+      Launch Jupyter
+    </Button>
+  );
+};
+
+export default LaunchJupyterButton;

--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Button, ToolbarItem } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import Table from '~/components/Table';
-
 import useTableColumnSort from '~/utilities/useTableColumnSort';
 import SearchField, { SearchType } from '~/pages/projects/components/SearchField';
 import { ProjectKind } from '~/k8sTypes';
@@ -16,11 +15,13 @@ import ManageProjectModal from './ManageProjectModal';
 type ProjectListViewProps = {
   projects: ProjectKind[];
   refreshProjects: () => Promise<void>;
+  allowCreate: boolean;
 };
 
 const ProjectListView: React.FC<ProjectListViewProps> = ({
   projects: unfilteredProjects,
   refreshProjects,
+  allowCreate,
 }) => {
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
   const [search, setSearch] = React.useState('');
@@ -88,9 +89,11 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({
                 }}
               />
             </ToolbarItem>
-            <ToolbarItem>
-              <NewProjectButton />
-            </ToolbarItem>
+            {allowCreate && (
+              <ToolbarItem>
+                <NewProjectButton />
+              </ToolbarItem>
+            )}
             <ToolbarItem>
               <Button
                 variant="link"

--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { Button, ToolbarItem } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Button, ButtonVariant, ToolbarItem } from '@patternfly/react-core';
 import Table from '~/components/Table';
 import useTableColumnSort from '~/utilities/useTableColumnSort';
 import SearchField, { SearchType } from '~/pages/projects/components/SearchField';
 import { ProjectKind } from '~/k8sTypes';
 import { getProjectDisplayName, getProjectOwner } from '~/pages/projects/utils';
+import LaunchJupyterButton from '~/pages/projects/screens/projects/LaunchJupyterButton';
 import NewProjectButton from './NewProjectButton';
 import { columns } from './tableData';
 import ProjectTableRow from './ProjectTableRow';
@@ -89,17 +89,20 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({
                 }}
               />
             </ToolbarItem>
-            {allowCreate && (
+            {allowCreate ? (
+              <>
+                <ToolbarItem>
+                  <NewProjectButton />
+                </ToolbarItem>
+                <ToolbarItem>
+                  <LaunchJupyterButton variant={ButtonVariant.link} />
+                </ToolbarItem>
+              </>
+            ) : (
               <ToolbarItem>
-                <NewProjectButton />
+                <LaunchJupyterButton variant={ButtonVariant.primary} />
               </ToolbarItem>
             )}
-            <ToolbarItem>
-              <Button
-                variant="link"
-                component={() => <Link to="/notebookController">Launch Jupyter</Link>}
-              />
-            </ToolbarItem>
           </React.Fragment>
         }
       />

--- a/frontend/src/pages/projects/screens/projects/ProjectView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectView.tsx
@@ -1,23 +1,36 @@
 import * as React from 'react';
 import ApplicationsPage from '~/pages/ApplicationsPage';
+import { useAccessReview } from '~/api';
+import { AccessReviewResourceAttributes } from '~/k8sTypes';
 import EmptyProjects from './EmptyProjects';
 import useUserProjects from './useUserProjects';
 import ProjectListView from './ProjectListView';
 
+const accessReviewResource: AccessReviewResourceAttributes = {
+  group: 'project.openshift.io',
+  resource: 'projects',
+  verb: 'create',
+};
+
 const ProjectView: React.FC = () => {
   const [projects, loaded, loadError, refreshProjects] = useUserProjects();
+  const [allowCreate, rbacLoaded] = useAccessReview(accessReviewResource);
 
   return (
     <ApplicationsPage
       title="Data science projects"
       description="View your existing projects or create new projects."
-      loaded={loaded}
+      loaded={loaded && rbacLoaded}
       empty={projects.length === 0}
       loadError={loadError}
-      emptyStatePage={<EmptyProjects />}
+      emptyStatePage={<EmptyProjects allowCreate={allowCreate} />}
       provideChildrenPadding
     >
-      <ProjectListView projects={projects} refreshProjects={refreshProjects} />
+      <ProjectListView
+        projects={projects}
+        refreshProjects={refreshProjects}
+        allowCreate={allowCreate}
+      />
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/projects/screens/projects/ProjectView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectView.tsx
@@ -8,7 +8,7 @@ import ProjectListView from './ProjectListView';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'project.openshift.io',
-  resource: 'projects',
+  resource: 'projectrequests',
   verb: 'create',
 };
 
@@ -19,7 +19,11 @@ const ProjectView: React.FC = () => {
   return (
     <ApplicationsPage
       title="Data science projects"
-      description="View your existing projects or create new projects."
+      description={
+        rbacLoaded
+          ? `View your existing projects${allowCreate ? ' or create new projects' : ''}.`
+          : undefined
+      }
       loaded={loaded && rbacLoaded}
       empty={projects.length === 0}
       loadError={loadError}


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #619 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add a hook called `useAccessReview` that makes a k8s API call and creates [`SelfSubjectAccessReview`](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/), which you can get whether you are allowed to do some specific operations to resources.
Apply that hook to the DSG page and check the permission of creating the `Project` resource. When a user is not permitted to create a new project, we hide the create button for both the empty project page and the project list view page.

Sorry I didn't attach the screenshots of the UX changes, thanks @andrewballantyne for helping add that in the [comment](https://github.com/opendatahub-io/odh-dashboard/pull/1013#discussion_r1136181096). Please review the changes and give feedback. cc @kywalker-rh 

Changed UI screenshots:

As a regular user without permission to create a project.
When there is no project:
<img width="1904" alt="Screenshot 2023-03-15 at 11 12 14 PM" src="https://user-images.githubusercontent.com/37624318/225354763-f0e64af8-806c-46e6-b633-6b0842fb6777.png">
When there are projects:
<img width="1904" alt="Screenshot 2023-03-15 at 11 11 33 PM" src="https://user-images.githubusercontent.com/37624318/225354837-0feb079d-7a15-448e-a86b-d9dc95e765ea.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pre-requisite: You have a cluster with 2 users, one could create a project (admin), while the other cannot (without the `self-provisioner` role)
1. Log in as the admin user and set the other user as the impersonated user
2. Go to the projects page to check if the create project button is visible. (it should be visible)
3. Impersonate the other user, the page will refresh and the create button should disappear

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
After a conversation with @andrewballantyne , we will skip the test for this PR, but we will swing back in the future to add the test cases.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
