### PR TITLE
Fix Graphs & Configure Infrastructure

### DIFF
--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -47,9 +47,16 @@ export const useModelServingMetrics = (
     timeframe,
   );
 
-  const inferenceRequestCount = useQueryRangeResourceData(
+  const inferenceRequestSuccessCount = useQueryRangeResourceData(
     type === 'inference',
-    queries[InferenceMetricType.REQUEST_COUNT],
+    queries[InferenceMetricType.REQUEST_COUNT_SUCCESS],
+    end,
+    timeframe,
+  );
+
+  const inferenceRequestFailedCount = useQueryRangeResourceData(
+    type === 'inference',
+    queries[InferenceMetricType.REQUEST_COUNT_FAILED],
     end,
     timeframe,
   );
@@ -63,7 +70,8 @@ export const useModelServingMetrics = (
     runtimeAverageResponseTime,
     runtimeCPUUtilization,
     runtimeMemoryUtilization,
-    inferenceRequestCount,
+    inferenceRequestSuccessCount,
+    inferenceRequestFailedCount,
   ]);
 
   const refreshAllMetrics = React.useCallback(() => {
@@ -77,7 +85,8 @@ export const useModelServingMetrics = (
         [RuntimeMetricType.AVG_RESPONSE_TIME]: runtimeAverageResponseTime,
         [RuntimeMetricType.CPU_UTILIZATION]: runtimeCPUUtilization,
         [RuntimeMetricType.MEMORY_UTILIZATION]: runtimeMemoryUtilization,
-        [InferenceMetricType.REQUEST_COUNT]: inferenceRequestCount,
+        [InferenceMetricType.REQUEST_COUNT_SUCCESS]: inferenceRequestSuccessCount,
+        [InferenceMetricType.REQUEST_COUNT_FAILED]: inferenceRequestFailedCount,
       },
       refresh: refreshAllMetrics,
     }),
@@ -86,7 +95,8 @@ export const useModelServingMetrics = (
       runtimeAverageResponseTime,
       runtimeCPUUtilization,
       runtimeMemoryUtilization,
-      inferenceRequestCount,
+      inferenceRequestSuccessCount,
+      inferenceRequestFailedCount,
       refreshAllMetrics,
     ],
   );

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,19 +1,22 @@
-import { TimeframeStep, TimeframeTime } from '~/pages/modelServing/screens/const';
+import { TimeframeStep, TimeframeTimeRange } from '~/pages/modelServing/screens/const';
 import { TimeframeTitle } from '~/pages/modelServing/screens/types';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
 import { useContextResourceData } from '~/utilities/useContextResourceData';
 import usePrometheusQueryRange from './usePrometheusQueryRange';
 
 const useQueryRangeResourceData = (
+  /** Is the query active -- should we be fetching? */
+  active: boolean,
   query: string,
   end: number,
   timeframe: TimeframeTitle,
 ): ContextResourceData<PrometheusQueryRangeResultValue> =>
   useContextResourceData<PrometheusQueryRangeResultValue>(
     usePrometheusQueryRange(
+      active,
       '/api/prometheus/serving',
       query,
-      TimeframeTime[timeframe],
+      TimeframeTimeRange[timeframe],
       end,
       TimeframeStep[timeframe],
     ),

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Navigate, Routes, Route } from 'react-router-dom';
 import ModelServingContextProvider from './ModelServingContext';
-import ModelServingMetricsWrapper from './screens/metrics/ModelServingMetricsWrapper';
+import GlobalInferenceMetricsWrapper from './screens/metrics/GlobalInferenceMetricsWrapper';
 import ModelServingGlobal from './screens/global/ModelServingGlobal';
 import useModelMetricsEnabled from './useModelMetricsEnabled';
 
@@ -15,9 +15,10 @@ const ModelServingRoutes: React.FC = () => {
         <Route
           path="/metrics/:project/:inferenceService"
           element={
-            modelMetricsEnabled ? <ModelServingMetricsWrapper /> : <Navigate replace to="/" />
+            modelMetricsEnabled ? <GlobalInferenceMetricsWrapper /> : <Navigate replace to="/" />
           }
         />
+        {/* TODO: Global Runtime metrics?? */}
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -122,18 +122,30 @@ export const DEFAULT_MODEL_SERVING_TEMPLATE: ServingRuntimeKind = {
   },
 };
 
-// unit: seconds
-export const TimeframeTime: TimeframeTimeType = {
-  [TimeframeTitle.FIVE_MINUTES]: 5 * 60,
+/**
+ * The desired range (x-axis) of the charts.
+ * Unit is in seconds
+ */
+export const TimeframeTimeRange: TimeframeTimeType = {
   [TimeframeTitle.ONE_HOUR]: 60 * 60,
   [TimeframeTitle.ONE_DAY]: 24 * 60 * 60,
   [TimeframeTitle.ONE_WEEK]: 7 * 24 * 60 * 60,
+  [TimeframeTitle.ONE_MONTH]: 30 * 7 * 24 * 60 * 60,
+  // [TimeframeTitle.UNLIMITED]: 0,
 };
 
-// make sure we always get ~300 data points
+/**
+ * How large a step is -- value is in how many seconds to combine to great an individual data response
+ * Each should be getting ~300 data points (assuming data fills the gap)
+ *
+ * eg. [TimeframeTitle.ONE_DAY]: 24 * 12,
+ *   24h * 60m * 60s => 86,400 seconds of space
+ *   86,400 / (24 * 12) => 300 points of prometheus data
+ */
 export const TimeframeStep: TimeframeStepType = {
-  [TimeframeTitle.FIVE_MINUTES]: 1,
   [TimeframeTitle.ONE_HOUR]: 12,
   [TimeframeTitle.ONE_DAY]: 24 * 12,
   [TimeframeTitle.ONE_WEEK]: 7 * 24 * 12,
+  [TimeframeTitle.ONE_MONTH]: 30 * 7 * 24 * 12,
+  // [TimeframeTitle.UNLIMITED]: 30 * 7 * 24 * 12, // TODO: determine if we "zoom out" more
 };

--- a/frontend/src/pages/modelServing/screens/metrics/GlobalInferenceMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/GlobalInferenceMetricsWrapper.tsx
@@ -4,11 +4,13 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import NotFound from '~/pages/NotFound';
 import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
 import { getInferenceServiceDisplayName } from '~/pages/modelServing/screens/global/utils';
+import InferenceGraphs from '~/pages/modelServing/screens/metrics/InferenceGraphs';
+import { MetricType } from '~/pages/modelServing/screens/types';
 import { ModelServingMetricsProvider } from './ModelServingMetricsContext';
 import MetricsPage from './MetricsPage';
 import { getInferenceServiceMetricsQueries } from './utils';
 
-const ModelServingMetricsWrapper: React.FC = () => {
+const GlobalInferenceMetricsWrapper: React.FC = () => {
   const { project: projectName, inferenceService: modelName } = useParams<{
     project: string;
     inferenceService: string;
@@ -33,7 +35,7 @@ const ModelServingMetricsWrapper: React.FC = () => {
   const modelDisplayName = getInferenceServiceDisplayName(inferenceService);
 
   return (
-    <ModelServingMetricsProvider queries={queries}>
+    <ModelServingMetricsProvider queries={queries} type={MetricType.INFERENCE}>
       <MetricsPage
         title={`${modelDisplayName} metrics`}
         breadcrumbItems={[
@@ -43,9 +45,11 @@ const ModelServingMetricsWrapper: React.FC = () => {
             isActive: true,
           },
         ]}
-      />
+      >
+        <InferenceGraphs />
+      </MetricsPage>
     </ModelServingMetricsProvider>
   );
 };
 
-export default ModelServingMetricsWrapper;
+export default GlobalInferenceMetricsWrapper;

--- a/frontend/src/pages/modelServing/screens/metrics/InferenceGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/InferenceGraphs.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Stack, StackItem } from '@patternfly/react-core';
+import MetricsChart from '~/pages/modelServing/screens/metrics/MetricsChart';
+import {
+  InferenceMetricType,
+  ModelServingMetricsContext,
+} from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
+import { TimeframeTitle } from '~/pages/modelServing/screens/types';
+
+const InferenceGraphs: React.FC = () => {
+  const { data, currentTimeframe } = React.useContext(ModelServingMetricsContext);
+
+  const inHours =
+    currentTimeframe === TimeframeTitle.ONE_HOUR || currentTimeframe === TimeframeTitle.ONE_DAY;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <MetricsChart
+          // TODO: This needs to be an improved inference metric
+          // TODO: This needs to be two values -- stacked line
+          metrics={data[InferenceMetricType.REQUEST_COUNT]}
+          color="blue"
+          // TODO: Make sure this is handled per day and is dividing by 100
+          title={`Http requests per ${inHours ? 'hour' : 'day'} (x100)`}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default InferenceGraphs;

--- a/frontend/src/pages/modelServing/screens/metrics/InferenceGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/InferenceGraphs.tsx
@@ -6,6 +6,7 @@ import {
   ModelServingMetricsContext,
 } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { TimeframeTitle } from '~/pages/modelServing/screens/types';
+import { per100 } from './utils';
 
 const InferenceGraphs: React.FC = () => {
   const { data, currentTimeframe } = React.useContext(ModelServingMetricsContext);
@@ -17,11 +18,23 @@ const InferenceGraphs: React.FC = () => {
     <Stack hasGutter>
       <StackItem>
         <MetricsChart
-          // TODO: This needs to be an improved inference metric
-          // TODO: This needs to be two values -- stacked line
-          metrics={data[InferenceMetricType.REQUEST_COUNT]}
-          color="blue"
-          // TODO: Make sure this is handled per day and is dividing by 100
+          metrics={[
+            {
+              name: 'Success http requests (x100)',
+              metric: data[InferenceMetricType.REQUEST_COUNT_SUCCESS],
+              translatePoint: per100,
+            },
+            {
+              name: 'Failed http requests (x100)',
+              metric: data[InferenceMetricType.REQUEST_COUNT_FAILED],
+              translatePoint: (point) => {
+                // TODO: remove when real values are used
+                const newPoint = per100(point);
+                const y = Math.floor(newPoint.y / (Math.floor(Math.random() * 2) + 2));
+                return { ...newPoint, y };
+              },
+            },
+          ]}
           title={`Http requests per ${inHours ? 'hour' : 'day'} (x100)`}
         />
       </StackItem>

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -19,7 +19,7 @@ import {
 } from '@patternfly/react-charts';
 import { CubesIcon } from '@patternfly/react-icons';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
-import { TimeframeTime } from '~/pages/modelServing/screens/const';
+import { TimeframeTimeRange } from '~/pages/modelServing/screens/const';
 import { ModelServingMetricsContext } from './ModelServingMetricsContext';
 import { convertTimestamp, formatToShow, getThresholdData } from './utils';
 
@@ -27,11 +27,10 @@ type MetricsChartProps = {
   title: string;
   color: string;
   metrics: ContextResourceData<PrometheusQueryRangeResultValue>;
-  unit?: string;
   threshold?: number;
 };
 
-const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, unit, threshold }) => {
+const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, threshold }) => {
   const bodyRef = React.useRef<HTMLDivElement>(null);
   const [chartWidth, setChartWidth] = React.useState(0);
   const { currentTimeframe, lastUpdateTime } = React.useContext(ModelServingMetricsContext);
@@ -61,11 +60,11 @@ const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, unit
       handleResize();
     }
     return () => observer();
-  }, [bodyRef]);
+  }, []);
 
   return (
     <Card>
-      <CardTitle>{`${title}${unit ? ` (${unit})` : ''}`}</CardTitle>
+      <CardTitle>{title}</CardTitle>
       <CardBody style={{ height: hasData ? 400 : 200, padding: 0 }}>
         <div ref={bodyRef}>
           {hasData ? (
@@ -77,17 +76,17 @@ const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, unit
                   constrainToVisibleArea
                 />
               }
-              domain={{ y: maxValue === 0 ? [-1, 1] : [0, maxValue + 1] }}
+              domain={{ y: maxValue === 0 ? [0, 1] : [0, maxValue + 1] }}
               height={400}
               width={chartWidth}
               padding={{ left: 70, right: 50, bottom: 70, top: 50 }}
               themeColor={color}
             >
               <ChartAxis
-                tickCount={10}
                 tickFormat={(x) => convertTimestamp(x, formatToShow(currentTimeframe))}
+                tickValues={[]}
                 domain={{
-                  x: [lastUpdateTime - TimeframeTime[currentTimeframe] * 1000, lastUpdateTime],
+                  x: [lastUpdateTime - TimeframeTimeRange[currentTimeframe] * 1000, lastUpdateTime],
                 }}
                 fixLabelOverlap
               />

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -13,41 +13,61 @@ import {
   ChartArea,
   ChartAxis,
   ChartGroup,
+  ChartThemeColor,
   ChartThreshold,
   ChartVoronoiContainer,
   getResizeObserver,
 } from '@patternfly/react-charts';
 import { CubesIcon } from '@patternfly/react-icons';
-import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
 import { TimeframeTimeRange } from '~/pages/modelServing/screens/const';
 import { ModelServingMetricsContext } from './ModelServingMetricsContext';
-import { convertTimestamp, formatToShow, getThresholdData } from './utils';
+import { MetricChartLine, ProcessedMetrics } from './types';
+import {
+  convertTimestamp,
+  formatToShow,
+  getThresholdData,
+  createGraphMetricLine,
+  useStableMetrics,
+} from './utils';
 
 type MetricsChartProps = {
   title: string;
-  color: string;
-  metrics: ContextResourceData<PrometheusQueryRangeResultValue>;
+  color?: string;
+  metrics: MetricChartLine;
   threshold?: number;
 };
 
-const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, threshold }) => {
+const MetricsChart: React.FC<MetricsChartProps> = ({
+  title,
+  color,
+  metrics: unstableMetrics,
+  threshold,
+}) => {
   const bodyRef = React.useRef<HTMLDivElement>(null);
   const [chartWidth, setChartWidth] = React.useState(0);
   const { currentTimeframe, lastUpdateTime } = React.useContext(ModelServingMetricsContext);
+  const metrics = useStableMetrics(unstableMetrics, title);
 
-  const processedData = React.useMemo(
+  const { data: graphLines, maxYValue } = React.useMemo(
     () =>
-      metrics.data?.map((data) => ({
-        x: data[0] * 1000,
-        y: parseInt(data[1]),
-        name: title,
-      })) || [],
-    [metrics, title],
+      metrics.reduce<ProcessedMetrics>(
+        (acc, metric) => {
+          const lineValues = createGraphMetricLine(metric);
+          const newMaxValue = Math.max(...lineValues.map((v) => v.y));
+
+          return {
+            data: [...acc.data, lineValues],
+            maxYValue: Math.max(acc.maxYValue, newMaxValue),
+          };
+        },
+        { data: [], maxYValue: 0 },
+      ),
+    [metrics],
   );
 
-  const maxValue = Math.max(...processedData.map((e) => e.y));
-
-  const hasData = processedData.length > 0;
+  const error = metrics.find((line) => line.metric.error)?.metric.error;
+  const isAllLoaded = metrics.every((line) => line.metric.loaded);
+  const hasSomeData = graphLines.some((line) => line.length > 0);
 
   React.useEffect(() => {
     const ref = bodyRef.current;
@@ -62,12 +82,22 @@ const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, thre
     return () => observer();
   }, []);
 
+  let legendProps: Partial<React.ComponentProps<typeof Chart>> = {};
+  if (metrics.length > 1 && metrics.every(({ name }) => !!name)) {
+    // We don't need a label if there is only one line & we need a name for every item (or it won't align)
+    legendProps = {
+      legendData: metrics.map(({ name }) => ({ name })),
+      legendOrientation: 'horizontal',
+      legendPosition: 'bottom-left',
+    };
+  }
+
   return (
     <Card>
       <CardTitle>{title}</CardTitle>
-      <CardBody style={{ height: hasData ? 400 : 200, padding: 0 }}>
+      <CardBody style={{ height: hasSomeData ? 400 : 200, padding: 0 }}>
         <div ref={bodyRef}>
-          {hasData ? (
+          {hasSomeData ? (
             <Chart
               ariaTitle={title}
               containerComponent={
@@ -76,11 +106,12 @@ const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, thre
                   constrainToVisibleArea
                 />
               }
-              domain={{ y: maxValue === 0 ? [0, 1] : [0, maxValue + 1] }}
+              domain={{ y: maxYValue === 0 ? [0, 1] : [0, maxYValue + 1] }}
               height={400}
               width={chartWidth}
               padding={{ left: 70, right: 50, bottom: 70, top: 50 }}
-              themeColor={color}
+              themeColor={color ?? ChartThemeColor.multi}
+              {...legendProps}
             >
               <ChartAxis
                 tickFormat={(x) => convertTimestamp(x, formatToShow(currentTimeframe))}
@@ -92,17 +123,19 @@ const MetricsChart: React.FC<MetricsChartProps> = ({ title, color, metrics, thre
               />
               <ChartAxis dependentAxis tickCount={10} fixLabelOverlap />
               <ChartGroup>
-                <ChartArea data={processedData} />
+                {graphLines.map((line, i) => (
+                  <ChartArea key={i} data={line} />
+                ))}
               </ChartGroup>
-              {threshold && <ChartThreshold data={getThresholdData(processedData, threshold)} />}
+              {threshold && <ChartThreshold data={getThresholdData(graphLines, threshold)} />}
             </Chart>
           ) : (
             <EmptyState>
-              {metrics.loaded ? (
+              {isAllLoaded ? (
                 <>
                   <EmptyStateIcon icon={CubesIcon} />
                   <Title headingLevel="h4" size="lg">
-                    {metrics.error ? metrics.error.message : 'No available data'}
+                    {error ? error.message : 'No available data'}
                   </Title>
                 </>
               ) : (

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
@@ -5,78 +5,37 @@ import { BreadcrumbItemType } from '~/types';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import MetricsChart from './MetricsChart';
 import MetricsPageToolbar from './MetricsPageToolbar';
-import { ModelServingMetricsContext, ModelServingMetricType } from './ModelServingMetricsContext';
+import { ModelServingMetricsContext, RuntimeMetricType } from './ModelServingMetricsContext';
 
 type MetricsPageProps = {
+  children: React.ReactNode;
   title: string;
   breadcrumbItems: BreadcrumbItemType[];
 };
 
-const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems }) => {
-  const { data } = React.useContext(ModelServingMetricsContext);
-  return (
-    <ApplicationsPage
-      title={title}
-      breadcrumb={
-        <Breadcrumb>
-          {breadcrumbItems.map((item) => (
-            <BreadcrumbItem
-              isActive={item.isActive}
-              key={item.label}
-              render={() =>
-                item.link ? <Link to={item.link}>{item.label}</Link> : <>{item.label}</>
-              }
-            />
-          ))}
-        </Breadcrumb>
-      }
-      toolbar={<MetricsPageToolbar />}
-      loaded
-      description={null}
-      empty={false}
-    >
-      <PageSection isFilled>
-        <Stack hasGutter>
-          <StackItem>
-            <MetricsChart
-              metrics={data[ModelServingMetricType.ENDPOINT_HEALTH]}
-              color="orange"
-              title="Endpoint health"
-            />
-          </StackItem>
-          <StackItem>
-            <MetricsChart
-              metrics={data[ModelServingMetricType.INFERENCE_PERFORMANCE]}
-              color="purple"
-              title="Inference performance"
-            />
-          </StackItem>
-          <StackItem>
-            <MetricsChart
-              metrics={data[ModelServingMetricType.AVG_RESPONSE_TIME]}
-              color="blue"
-              title="Average response time"
-              unit="ms"
-            />
-          </StackItem>
-          <StackItem>
-            <MetricsChart
-              metrics={data[ModelServingMetricType.REQUEST_COUNT]}
-              color="green"
-              title="Total request"
-            />
-          </StackItem>
-          <StackItem>
-            <MetricsChart
-              metrics={data[ModelServingMetricType.FAILED_REQUEST_COUNT]}
-              color="cyan"
-              title="Failed request"
-            />
-          </StackItem>
-        </Stack>
-      </PageSection>
-    </ApplicationsPage>
-  );
-};
+const MetricsPage: React.FC<MetricsPageProps> = ({ children, title, breadcrumbItems }) => (
+  <ApplicationsPage
+    title={title}
+    breadcrumb={
+      <Breadcrumb>
+        {breadcrumbItems.map((item) => (
+          <BreadcrumbItem
+            isActive={item.isActive}
+            key={item.label}
+            render={() =>
+              item.link ? <Link to={item.link}>{item.label}</Link> : <>{item.label}</>
+            }
+          />
+        ))}
+      </Breadcrumb>
+    }
+    toolbar={<MetricsPageToolbar />}
+    loaded
+    description={null}
+    empty={false}
+  >
+    <PageSection isFilled>{children}</PageSection>
+  </ApplicationsPage>
+);
 
 export default MetricsPage;

--- a/frontend/src/pages/modelServing/screens/metrics/ModelServingMetricsContext.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelServingMetricsContext.tsx
@@ -12,7 +12,8 @@ export enum RuntimeMetricType {
 }
 
 export enum InferenceMetricType {
-  REQUEST_COUNT = 'inference_request-count',
+  REQUEST_COUNT_SUCCESS = 'inference_request-count-successes',
+  REQUEST_COUNT_FAILED = 'inference_request-count-fails',
 }
 
 type ModelServingMetricsContext = {
@@ -33,7 +34,8 @@ export const ModelServingMetricsContext = React.createContext<ModelServingMetric
     [RuntimeMetricType.AVG_RESPONSE_TIME]: DEFAULT_CONTEXT_DATA,
     [RuntimeMetricType.CPU_UTILIZATION]: DEFAULT_CONTEXT_DATA,
     [RuntimeMetricType.MEMORY_UTILIZATION]: DEFAULT_CONTEXT_DATA,
-    [InferenceMetricType.REQUEST_COUNT]: DEFAULT_CONTEXT_DATA,
+    [InferenceMetricType.REQUEST_COUNT_FAILED]: DEFAULT_CONTEXT_DATA,
+    [InferenceMetricType.REQUEST_COUNT_SUCCESS]: DEFAULT_CONTEXT_DATA,
   },
   currentTimeframe: TimeframeTitle.ONE_HOUR,
   setCurrentTimeframe: () => undefined,

--- a/frontend/src/pages/modelServing/screens/metrics/RuntimeGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/RuntimeGraphs.tsx
@@ -6,6 +6,7 @@ import {
   RuntimeMetricType,
 } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { TimeframeTitle } from '~/pages/modelServing/screens/types';
+import { per100 } from '~/pages/modelServing/screens/metrics/utils';
 
 const RuntimeGraphs: React.FC = () => {
   const { data, currentTimeframe } = React.useContext(ModelServingMetricsContext);
@@ -17,30 +18,29 @@ const RuntimeGraphs: React.FC = () => {
     <Stack hasGutter>
       <StackItem>
         <MetricsChart
-          metrics={data[RuntimeMetricType.REQUEST_COUNT]}
+          metrics={{ metric: data[RuntimeMetricType.REQUEST_COUNT], translatePoint: per100 }}
           color="blue"
-          // TODO: Make sure this is handled per day and is dividing by 100
           title={`Http requests per ${inHours ? 'hour' : 'day'} (x100)`}
         />
       </StackItem>
       <StackItem>
         <MetricsChart
-          metrics={data[RuntimeMetricType.AVG_RESPONSE_TIME]}
+          metrics={{ metric: data[RuntimeMetricType.AVG_RESPONSE_TIME] }}
           color="green"
           title="Average response time (ms)"
         />
       </StackItem>
       <StackItem>
         <MetricsChart
-          metrics={data[RuntimeMetricType.CPU_UTILIZATION]}
+          metrics={{ metric: data[RuntimeMetricType.CPU_UTILIZATION] }}
           color="purple"
           title="CPU utilization %"
         />
       </StackItem>
       <StackItem>
         <MetricsChart
-          metrics={data[RuntimeMetricType.MEMORY_UTILIZATION]}
-          color="purple"
+          metrics={{ metric: data[RuntimeMetricType.MEMORY_UTILIZATION] }}
+          color="orange"
           title="Memory utilization %"
         />
       </StackItem>

--- a/frontend/src/pages/modelServing/screens/metrics/RuntimeGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/RuntimeGraphs.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Stack, StackItem } from '@patternfly/react-core';
+import MetricsChart from '~/pages/modelServing/screens/metrics/MetricsChart';
+import {
+  ModelServingMetricsContext,
+  RuntimeMetricType,
+} from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
+import { TimeframeTitle } from '~/pages/modelServing/screens/types';
+
+const RuntimeGraphs: React.FC = () => {
+  const { data, currentTimeframe } = React.useContext(ModelServingMetricsContext);
+
+  const inHours =
+    currentTimeframe === TimeframeTitle.ONE_HOUR || currentTimeframe === TimeframeTitle.ONE_DAY;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <MetricsChart
+          metrics={data[RuntimeMetricType.REQUEST_COUNT]}
+          color="blue"
+          // TODO: Make sure this is handled per day and is dividing by 100
+          title={`Http requests per ${inHours ? 'hour' : 'day'} (x100)`}
+        />
+      </StackItem>
+      <StackItem>
+        <MetricsChart
+          metrics={data[RuntimeMetricType.AVG_RESPONSE_TIME]}
+          color="green"
+          title="Average response time (ms)"
+        />
+      </StackItem>
+      <StackItem>
+        <MetricsChart
+          metrics={data[RuntimeMetricType.CPU_UTILIZATION]}
+          color="purple"
+          title="CPU utilization %"
+        />
+      </StackItem>
+      <StackItem>
+        <MetricsChart
+          metrics={data[RuntimeMetricType.MEMORY_UTILIZATION]}
+          color="purple"
+          title="Memory utilization %"
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default RuntimeGraphs;

--- a/frontend/src/pages/modelServing/screens/metrics/types.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/types.ts
@@ -1,0 +1,28 @@
+import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
+
+export type TranslatePoint = (line: GraphMetricPoint) => GraphMetricPoint;
+
+type MetricChartLineBase = {
+  metric: ContextResourceData<PrometheusQueryRangeResultValue>;
+  translatePoint?: TranslatePoint;
+};
+export type NamedMetricChartLine = MetricChartLineBase & {
+  name: string;
+};
+export type UnnamedMetricChartLine = MetricChartLineBase & {
+  /** Assumes chart title */
+  name?: string;
+};
+export type MetricChartLine = UnnamedMetricChartLine | NamedMetricChartLine[];
+
+export type GraphMetricPoint = {
+  x: number;
+  y: number;
+  name: string;
+};
+export type GraphMetricLine = GraphMetricPoint[];
+
+export type ProcessedMetrics = {
+  data: GraphMetricLine[];
+  maxYValue: number;
+};

--- a/frontend/src/pages/modelServing/screens/metrics/utils.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.ts
@@ -1,9 +1,9 @@
 import * as _ from 'lodash';
 import { SelectOptionObject } from '@patternfly/react-core';
 import { TimeframeTitle } from '~/pages/modelServing/screens/types';
-import { InferenceServiceKind } from '~/k8sTypes';
+import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { DashboardConfig } from '~/types';
-import { ModelServingMetricType } from './ModelServingMetricsContext';
+import { InferenceMetricType, RuntimeMetricType } from './ModelServingMetricsContext';
 
 export const isModelMetricsEnabled = (
   dashboardNamespace: string,
@@ -15,17 +15,26 @@ export const isModelMetricsEnabled = (
   return dashboardConfig.spec.dashboardConfig.modelMetricsNamespace !== '';
 };
 
+export const getRuntimeMetricsQueries = (
+  runtime: ServingRuntimeKind,
+): Record<RuntimeMetricType, string> => {
+  const namespace = runtime.metadata.namespace;
+  return {
+    [RuntimeMetricType.REQUEST_COUNT]: `TBD`,
+    [RuntimeMetricType.AVG_RESPONSE_TIME]: `rate(modelmesh_api_request_milliseconds_sum{exported_namespace="${namespace}"}[1m])/rate(modelmesh_api_request_milliseconds_count{exported_namespace="${namespace}"}[1m])`,
+    [RuntimeMetricType.CPU_UTILIZATION]: `TBD`,
+    [RuntimeMetricType.MEMORY_UTILIZATION]: `TBD`,
+  };
+};
+
 export const getInferenceServiceMetricsQueries = (
   inferenceService: InferenceServiceKind,
-): Record<ModelServingMetricType, string> => {
+): Record<InferenceMetricType, string> => {
   const namespace = inferenceService.metadata.namespace;
   const name = inferenceService.metadata.name;
   return {
-    [ModelServingMetricType.AVG_RESPONSE_TIME]: `query=sum(haproxy_backend_http_average_response_latency_milliseconds{exported_namespace="${namespace}", route="${name}"})`,
-    [ModelServingMetricType.ENDPOINT_HEALTH]: `query=sum(rate(haproxy_backend_http_responses_total{exported_namespace="${namespace}", route="${name}", code=~"5xx"}[5m])) > 0`,
-    [ModelServingMetricType.FAILED_REQUEST_COUNT]: `query=sum(haproxy_backend_http_responses_total{exported_namespace="${namespace}", route="${name}", code=~"4xx|5xx"})`,
-    [ModelServingMetricType.INFERENCE_PERFORMANCE]: `query=sum(rate(modelmesh_api_request_milliseconds_sum{namespace="${namespace}"}[5m]))`,
-    [ModelServingMetricType.REQUEST_COUNT]: `query=sum(haproxy_backend_http_responses_total{exported_namespace="${namespace}", route="${name}"})`,
+    // TODO: Do we have two queries? one for success and one for failure?
+    [InferenceMetricType.REQUEST_COUNT]: `sum(haproxy_backend_http_responses_total{exported_namespace="${namespace}", route="${name}"})`,
   };
 };
 
@@ -76,8 +85,6 @@ export const getThresholdData = (
 
 export const formatToShow = (timeframe: TimeframeTitle): 'date' | 'second' | undefined => {
   switch (timeframe) {
-    case TimeframeTitle.FIVE_MINUTES:
-      return 'second';
     case TimeframeTitle.ONE_HOUR:
     case TimeframeTitle.ONE_DAY:
       return undefined;

--- a/frontend/src/pages/modelServing/screens/projects/ProjectInferenceMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectInferenceMetricsWrapper.tsx
@@ -8,19 +8,18 @@ import { getInferenceServiceMetricsQueries } from '~/pages/modelServing/screens/
 import NotFound from '~/pages/NotFound';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { getProjectDisplayName } from '~/pages/projects/utils';
+import InferenceGraphs from '~/pages/modelServing/screens/metrics/InferenceGraphs';
+import { MetricType } from '~/pages/modelServing/screens/types';
 
-const DetailsPageMetricsWrapper: React.FC = () => {
-  const { namespace: projectName, inferenceService: modelName } = useParams<{
-    namespace: string;
+const ProjectInferenceMetricsWrapper: React.FC = () => {
+  const { inferenceService: modelName } = useParams<{
     inferenceService: string;
   }>();
   const {
     currentProject,
     inferenceServices: { data: models, loaded },
   } = React.useContext(ProjectDetailsContext);
-  const inferenceService = models.find(
-    (model) => model.metadata.name === modelName && model.metadata.namespace === projectName,
-  );
+  const inferenceService = models.find((model) => model.metadata.name === modelName);
   if (!loaded) {
     return (
       <Bullseye>
@@ -36,9 +35,9 @@ const DetailsPageMetricsWrapper: React.FC = () => {
   const modelDisplayName = getInferenceServiceDisplayName(inferenceService);
 
   return (
-    <ModelServingMetricsProvider queries={queries}>
+    <ModelServingMetricsProvider queries={queries} type={MetricType.INFERENCE}>
       <MetricsPage
-        title={`${projectDisplayName} - ${modelDisplayName} metrics`}
+        title={`${modelDisplayName} metrics`}
         breadcrumbItems={[
           { label: 'Data Science Projects', link: '/projects' },
           {
@@ -50,9 +49,11 @@ const DetailsPageMetricsWrapper: React.FC = () => {
             isActive: true,
           },
         ]}
-      />
+      >
+        <InferenceGraphs />
+      </MetricsPage>
     </ModelServingMetricsProvider>
   );
 };
 
-export default DetailsPageMetricsWrapper;
+export default ProjectInferenceMetricsWrapper;

--- a/frontend/src/pages/modelServing/screens/projects/ProjectRuntimeMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectRuntimeMetricsWrapper.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import MetricsPage from '~/pages/modelServing/screens/metrics/MetricsPage';
+import { ModelServingMetricsProvider } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
+import { getRuntimeMetricsQueries } from '~/pages/modelServing/screens/metrics/utils';
+import NotFound from '~/pages/NotFound';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { getProjectDisplayName } from '~/pages/projects/utils';
+import RuntimeGraphs from '~/pages/modelServing/screens/metrics/RuntimeGraphs';
+import { MetricType } from '~/pages/modelServing/screens/types';
+
+const ProjectInferenceMetricsWrapper: React.FC = () => {
+  const {
+    currentProject,
+    servingRuntimes: { data: runtimes, loaded },
+  } = React.useContext(ProjectDetailsContext);
+  const runtime = runtimes[0];
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+  if (!runtime) {
+    return <NotFound />;
+  }
+  const queries = getRuntimeMetricsQueries(runtime);
+  const projectDisplayName = getProjectDisplayName(currentProject);
+
+  return (
+    <ModelServingMetricsProvider queries={queries} type={MetricType.RUNTIME}>
+      <MetricsPage
+        title={`${projectDisplayName} - model server metrics`}
+        breadcrumbItems={[
+          { label: 'Data Science Projects', link: '/projects' },
+          {
+            label: projectDisplayName,
+            link: `/projects/${currentProject.metadata.name}`,
+          },
+          {
+            label: `Model server metrics`,
+            isActive: true,
+          },
+        ]}
+      >
+        <RuntimeGraphs />
+      </MetricsPage>
+    </ModelServingMetricsProvider>
+  );
+};
+
+export default ProjectInferenceMetricsWrapper;

--- a/frontend/src/pages/modelServing/screens/projects/ProjectRuntimeMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectRuntimeMetricsWrapper.tsx
@@ -31,7 +31,7 @@ const ProjectInferenceMetricsWrapper: React.FC = () => {
   return (
     <ModelServingMetricsProvider queries={queries} type={MetricType.RUNTIME}>
       <MetricsPage
-        title={`${projectDisplayName} - model server metrics`}
+        title={`ovm metrics`}
         breadcrumbItems={[
           { label: 'Data Science Projects', link: '/projects' },
           {
@@ -39,7 +39,7 @@ const ProjectInferenceMetricsWrapper: React.FC = () => {
             link: `/projects/${currentProject.metadata.name}`,
           },
           {
-            label: `Model server metrics`,
+            label: `ovm metrics`,
             isActive: true,
           },
         ]}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Button, Icon, Skeleton, Tooltip } from '@patternfly/react-core';
+import { Button, DropdownDirection, Icon, Skeleton, Tooltip } from '@patternfly/react-core';
 import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import EmptyTableCellForAlignment from '~/pages/projects/components/EmptyTableCellForAlignment';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
@@ -27,8 +28,11 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
   expandedColumn,
   onExpandColumn,
 }) => {
+  const navigate = useNavigate();
+
   const isRowExpanded = !!expandedColumn;
   const {
+    currentProject,
     inferenceServices: {
       data: inferenceServices,
       loaded: inferenceServicesLoaded,
@@ -122,6 +126,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
         </Td>
         <Td isActionCell>
           <ActionsColumn
+            dropdownDirection={DropdownDirection.up}
             items={[
               {
                 title: 'Edit model server',
@@ -130,6 +135,11 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
               {
                 title: 'Delete model server',
                 onClick: () => onDeleteServingRuntime(obj),
+              },
+              {
+                title: 'View metrics',
+                onClick: () =>
+                  navigate(`/projects/${currentProject.metadata.name}/metrics/runtime`),
               },
             ]}
           />

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -1,11 +1,17 @@
 import { EnvVariableDataEntry } from '~/pages/projects/types';
 import { ContainerResources } from '~/types';
 
+export enum MetricType {
+  RUNTIME = 'runtime',
+  INFERENCE = 'inference',
+}
+
 export enum TimeframeTitle {
-  FIVE_MINUTES = '5 minutes',
   ONE_HOUR = '1 hour',
   ONE_DAY = '24 hours',
-  ONE_WEEK = '1 week',
+  ONE_WEEK = '7 days',
+  ONE_MONTH = '30 days',
+  // UNLIMITED = 'Unlimited',
 }
 
 export type TimeframeTimeType = {

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Navigate, Routes, Route } from 'react-router-dom';
-import DetailsPageMetricsWrapper from '~/pages/modelServing/screens/projects/DetailsPageMetricsWrapper';
+import ProjectInferenceMetricsWrapper from '~/pages/modelServing/screens/projects/ProjectInferenceMetricsWrapper';
 import useModelMetricsEnabled from '~/pages/modelServing/useModelMetricsEnabled';
+import ProjectRuntimeMetricsWrapper from '~/pages/modelServing/screens/projects/ProjectRuntimeMetricsWrapper';
 import ProjectDetails from './screens/detail/ProjectDetails';
 import ProjectView from './screens/projects/ProjectView';
 import ProjectDetailsContextProvider from './ProjectDetailsContext';
@@ -18,12 +19,15 @@ const ProjectViewRoutes: React.FC = () => {
         <Route index element={<ProjectDetails />} />
         <Route path="spawner" element={<SpawnerPage />} />
         <Route path="spawner/:notebookName" element={<EditSpawnerPage />} />
-        <Route
-          path="metrics/model/:inferenceService"
-          element={
-            modelMetricsEnabled ? <DetailsPageMetricsWrapper /> : <Navigate replace to="/" />
-          }
-        />
+        {modelMetricsEnabled && (
+          <>
+            <Route
+              path="metrics/model/:inferenceService"
+              element={<ProjectInferenceMetricsWrapper />}
+            />
+            <Route path="metrics/runtime" element={<ProjectRuntimeMetricsWrapper />} />
+          </>
+        )}
         <Route path="*" element={<Navigate to="." />} />
       </Route>
       <Route path="*" element={<Navigate to="." />} />


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Work towards: https://github.com/opendatahub-io/odh-dashboard/issues/1022

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added the Runtime Metrics page & reworked the Inference Metrics page. Added a stacked line chart.

### **----Queries do not represent data right now----**

Global - Inference Metrics
![Screenshot 2023-03-17 at 2 18 53 PM](https://user-images.githubusercontent.com/8126518/225988200-4b33afd1-5a05-423c-805e-bef43f2db74e.png)
![Screenshot 2023-03-17 at 2 19 46 PM](https://user-images.githubusercontent.com/8126518/225988204-c710d2a0-c85b-40ed-bb8a-a830c7bf90b4.png)

Project - Metrics kebab item added to Runtime:
![Screenshot 2023-03-17 at 2 20 30 PM](https://user-images.githubusercontent.com/8126518/225988207-2f74f65e-63aa-4725-80a9-8c1d5de736fc.png)

Project - Runtime Metrics
![Screenshot 2023-03-17 at 2 21 01 PM](https://user-images.githubusercontent.com/8126518/225988211-22f70bb5-e20e-4c43-90e9-c7513de78049.png)
![Screenshot 2023-03-17 at 2 21 11 PM](https://user-images.githubusercontent.com/8126518/225988212-8f5b93f9-9298-4c29-b9ad-4b707508995a.png)
![Screenshot 2023-03-17 at 2 21 26 PM](https://user-images.githubusercontent.com/8126518/225988215-aa093b3c-79a8-4e12-829a-83e87bcf62c3.png)

Project - Inference Metrics
![Screenshot 2023-03-17 at 2 34 02 PM](https://user-images.githubusercontent.com/8126518/225990308-6f8d3292-b0d2-449d-9a7f-e05b46b0e8ff.png)
![Screenshot 2023-03-17 at 2 34 12 PM](https://user-images.githubusercontent.com/8126518/225990310-d193771f-7a2f-4497-9719-83289ed9b770.png)

Scale options
![image](https://user-images.githubusercontent.com/8126518/225990780-7bfa2752-1629-4874-a356-df497176d540.png)

Stacked Line Chart (random data):
![image](https://user-images.githubusercontent.com/8126518/226118971-58d9d868-a834-4c15-abbd-595dbefe010e.png)


Things that still need to be done (post this PR):
- [ ] ~Improve x-axis to have more desired and static number of items (disable the auto x-axis from Victory)~
- [ ] Improve tooltips -- stacked charts should have one tooltip & it should be styled with the x-axis in the tooltip
- [ ] Get queries from @VedantMahabaleshwarkar and add them to the utilities


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### KFDef

```
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: odh-with-modelmesh
  namespace: opendatahub
spec:
  applications:
    # Base -- NB Images, Manifest, NB Controller
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-common
      name: odh-common
    - kustomizeConfig:
        overlays:
          - additional
        repoRef:
          name: manifests
          path: notebook-images
      name: notebook-images
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-notebook-controller
      name: odh-notebook-controller
    # Model Mesh
    - kustomizeConfig:
        overlays:
          - odh-model-controller
        parameters:
          - name: monitoring-namespace
            value: opendatahub
        repoRef:
          name: manifests-modelmesh
          path: manifests/opendatahub
      name: model-mesh
    - kustomizeConfig:
        parameters:
          - name: deployment-namespace
            value: opendatahub
        repoRef:
          name: manifests
          path: modelmesh-monitoring
      name: modelmesh-monitoring
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: prometheus/cluster
      name: prometheus-cluster
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: prometheus/operator
      name: prometheus-operator
  repos:
    - name: manifests
      uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
    - name: manifests-modelmesh
      uri: https://github.com/opendatahub-io/modelmesh-serving/tarball/main
```

### Dashboard steps

- Create a project
- Create a runtime
- Create a model (DM me if you need one, mino used to work, might be able to try that - [slack link for setup steps](https://redhat-internal.slack.com/archives/C03UA0RLSQM/p1677598442681629?thread_ts=1677598116.265919&cid=C03UA0RLSQM))
- Fire requests off to the model's route

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

At this time, no tests are being done. Will need to look at what we can really test here -- it's all dependant on graph values -- and testing the graphs themselves is more like testing Victory. Not sure we have a Storybook test. Might have unit tests, I'll look to see if any utilities could benefit from it. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
