### PR TITLE
add dynamic namespace to delegate-url oauth arg

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -57,6 +57,12 @@ spec:
           successThreshold: 1
           failureThreshold: 3
       - name: oauth-proxy
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
         args:
           - --https-address=:8443
           - --provider=openshift
@@ -69,7 +75,7 @@ spec:
           - --cookie-secret-file=/etc/oauth/config/cookie_secret
           - --cookie-expire=23h0m0s
           - --pass-access-token
-          - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard"}}'
+          - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard", "namespace": "$(NAMESPACE)"}}'
           - --skip-auth-regex=^/metrics
         image: oauth-proxy
         ports:

--- a/manifests/overlays/authentication/deployment.yaml
+++ b/manifests/overlays/authentication/deployment.yaml
@@ -2,6 +2,12 @@
   path: /spec/template/spec/containers/-
   value:
     name: oauth-proxy
+    env:
+      - name: NAMESPACE
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
     args:
       - --https-address=:8443
       - --provider=openshift
@@ -14,7 +20,7 @@
       - --cookie-secret-file=/etc/oauth/config/cookie_secret
       - --cookie-expire=23h0m0s
       - --pass-access-token
-      - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard"}}'
+      - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard", "namespace": "$(NAMESPACE)"}}'
       - --skip-auth-regex=^/metrics
     image: oauth-proxy
     ports:


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes #1045 

## Description
Resolve issue with Service Accounts being unable to authenticate to the dashboard without cluster scope permissions

## How Has This Been Tested?
Deployed kfdef manually and followed reproducability instructions in #1045

1. Install ODH with a kfdef in a namespace called `opendatahub` with the following manifests url:

```
  repos:
    - name: manifests
      uri: >-
        https://github.com/strangiato/odh-manifests/tarball/dashboard-oauth-delegate-url-fix
```

2. Create a test service account:
```
oc create sa test-connection
```
3. Grant permissions to the service account:
```
oc policy add-role-to-user view system:serviceaccount:opendatahub:test-connection
```
4. Verify SA has permissions to list service:
```
TOKEN=$(oc create token test-connection -n opendatahub)
oc login --token=${TOKEN}
oc get services odh-dashboard -n opendatahub
```
5.  Attempt to authenticate to OAuth
```
URL="https://$(oc get routes odh-dashboard -n opendatahub -o jsonpath='{.spec.host}' )"
curl --location --request GET $URL \
--header "Authorization: Bearer ${TOKEN}" -I
```

Response will return a 200 instead of a 403.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [N/A] Included any necessary screenshots or gifs if it was a UI change.
- [N/A] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
