### PR TITLE
Change the way comparing notebook container size to make sure it matches correctly

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -1,4 +1,6 @@
-export const mockDashboardConfig = {
+import { DashboardConfig } from '~/types';
+
+export const mockDashboardConfig: DashboardConfig = {
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',
   metadata: {
@@ -6,13 +8,7 @@ export const mockDashboardConfig = {
     labels: {
       'opendatahub.io/dashboard': 'true',
     },
-    annotations: {},
-    creationTimestamp: '2023-02-08T13:35:42Z',
-    generation: 15,
-    managedFields: [],
     namespace: 'redhat-ods-applications',
-    resourceVersion: '1926467',
-    uid: '1e4fb39d-1d61-45c6-93ff-f4872a838a68',
   },
   spec: {
     dashboardConfig: {
@@ -27,6 +23,7 @@ export const mockDashboardConfig = {
       disableUserManagement: false,
       disableProjects: false,
       disableModelServing: false,
+      modelMetricsNamespace: 'test-project',
     },
     notebookController: {
       enabled: true,
@@ -83,6 +80,19 @@ export const mockDashboardConfig = {
       },
     ],
     notebookSizes: [
+      {
+        name: 'XSmall',
+        resources: {
+          limits: {
+            cpu: '0.5',
+            memory: '500Mi',
+          },
+          requests: {
+            cpu: '0.1',
+            memory: '100Mi',
+          },
+        },
+      },
       {
         name: 'Small',
         resources: {

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -1,4 +1,6 @@
 import { NotebookKind } from '~/k8sTypes';
+import { DEFAULT_NOTEBOOK_SIZES } from '~/pages/projects/screens/spawner/const';
+import { ContainerResources } from '~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -6,6 +8,7 @@ type MockResourceConfigType = {
   namespace?: string;
   user?: string;
   description?: string;
+  resources?: ContainerResources;
 };
 
 export const mockNotebookK8sResource = ({
@@ -14,6 +17,7 @@ export const mockNotebookK8sResource = ({
   namespace = 'test-project',
   user = 'test-user',
   description = '',
+  resources = DEFAULT_NOTEBOOK_SIZES[0].resources,
 }: MockResourceConfigType): NotebookKind => ({
   apiVersion: 'kubeflow.org/v1',
   kind: 'Notebook',
@@ -120,16 +124,7 @@ export const mockNotebookK8sResource = ({
               successThreshold: 1,
               timeoutSeconds: 1,
             },
-            resources: {
-              limits: {
-                cpu: '2',
-                memory: '8Gi',
-              },
-              requests: {
-                cpu: '1',
-                memory: '8Gi',
-              },
-            },
+            resources,
             volumeMounts: [
               {
                 mountPath: '/opt/app-root/src',

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.stories.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.stories.tsx
@@ -27,8 +27,30 @@ const handlers = (isEmpty: boolean): RestHandler<MockedRequest<DefaultBodyType>>
     '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/test-notebook',
     (req, res, ctx) => res(ctx.json(mockRouteK8sResource({}))),
   ),
+  rest.get(
+    '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/test-size',
+    (req, res, ctx) => res(ctx.json(mockRouteK8sResource({ notebookName: 'test-size' }))),
+  ),
   rest.get('/api/k8s/apis/kubeflow.org/v1/namespaces/test-project/notebooks', (req, res, ctx) =>
-    res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockNotebookK8sResource({})]))),
+    res(
+      ctx.json(
+        mockK8sResourceList(
+          isEmpty
+            ? []
+            : [
+                mockNotebookK8sResource({}),
+                mockNotebookK8sResource({
+                  name: 'test-size',
+                  displayName: 'Test Size X-small',
+                  resources: {
+                    limits: { cpu: '500m', memory: '500Mi' },
+                    requests: { cpu: '100m', memory: '100Mi' },
+                  },
+                }),
+              ],
+        ),
+      ),
+    ),
   ),
   rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
     res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockProjectK8sResource({})]))),
@@ -94,6 +116,9 @@ Default.play = async ({ canvasElement }) => {
 
   // we fill in the page with data, so there should be no dividers on the page
   expect(canvas.queryAllByTestId('details-page-section-divider')).toHaveLength(0);
+
+  // check the x-small size shown correctly
+  expect(canvas.getByText('XSmall')).toBeInTheDocument();
 };
 
 export const EmptyDetailsPage = Template.bind({});

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
@@ -3,6 +3,7 @@ import { AppContext } from '~/app/AppContext';
 import { NotebookContainer, NotebookSize } from '~/types';
 import { getNotebookSizes } from '~/pages/notebookController/screens/server/usePreferredNotebookSize';
 import { NotebookKind } from '~/k8sTypes';
+import { isCpuLimitEqual, isMemoryLimitEqual } from '~/utilities/valueUnits';
 
 const useNotebookDeploymentSize = (
   notebook?: NotebookKind,
@@ -20,8 +21,8 @@ const useNotebookDeploymentSize = (
   const sizes = getNotebookSizes(dashboardConfig);
   const size = sizes.find(
     (size) =>
-      size.resources.limits?.cpu === container.resources?.limits?.cpu &&
-      size.resources.limits?.memory === container.resources?.limits?.memory,
+      isCpuLimitEqual(size.resources.limits?.cpu, container.resources?.limits?.cpu) &&
+      isMemoryLimitEqual(size.resources.limits?.memory, container.resources?.limits?.memory),
   );
 
   if (!size) {

--- a/frontend/src/utilities/valueUnits.ts
+++ b/frontend/src/utilities/valueUnits.ts
@@ -45,7 +45,6 @@ const calculateDelta = (
   return val1 * unit1.weight - val2 * unit2.weight;
 };
 
-/** value1 is larger that value2 */
 export const isEqual = (
   value1: ValueUnitString,
   value2: ValueUnitString,

--- a/frontend/src/utilities/valueUnits.ts
+++ b/frontend/src/utilities/valueUnits.ts
@@ -24,15 +24,51 @@ export const splitValueUnit = (
   value: ValueUnitString,
   options: UnitOption[],
 ): [value: number, unit: UnitOption] => {
-  const match = value.match(/^(\d+)(.*)$/);
+  const match = value.match(/^(\d*\.?\d*)(.*)$/);
   if (!match) {
     // Unable to match a legit value -- default back to base
     return [1, options[0]];
   }
-  const newValue = parseInt(match[1]) || 1; // avoid NaN
+  const newValue = Number(match[1]) || 1; // avoid NaN
   const foundUnit = options.find((o) => o.unit === match[2]);
   const newUnit = foundUnit || options[0]; // escape hatch -- unsure what the unit can be
   return [newValue, newUnit];
+};
+
+const calculateDelta = (
+  value1: ValueUnitString,
+  value2: ValueUnitString,
+  units: UnitOption[],
+): number => {
+  const [val1, unit1] = splitValueUnit(value1, units);
+  const [val2, unit2] = splitValueUnit(value2, units);
+  return val1 * unit1.weight - val2 * unit2.weight;
+};
+
+/** value1 is larger that value2 */
+export const isEqual = (
+  value1: ValueUnitString,
+  value2: ValueUnitString,
+  units: UnitOption[],
+): boolean => calculateDelta(value1, value2, units) === 0;
+
+export const isCpuLimitEqual = (cpu1?: ValueUnitString, cpu2?: ValueUnitString): boolean => {
+  if (!cpu1 || !cpu2) {
+    return false;
+  }
+
+  return isEqual(cpu1, cpu2, CPU_UNITS);
+};
+
+export const isMemoryLimitEqual = (
+  memory1?: ValueUnitString,
+  memory2?: ValueUnitString,
+): boolean => {
+  if (!memory1 || !memory2) {
+    return false;
+  }
+
+  return isEqual(memory1, memory2, MEMORY_UNITS);
 };
 
 /** value1 is larger that value2 */
@@ -42,10 +78,7 @@ export const isLarger = (
   units: UnitOption[],
   isEqualOkay = false,
 ): boolean => {
-  const [val1, unit1] = splitValueUnit(value1, units);
-  const [val2, unit2] = splitValueUnit(value2, units);
-
-  const delta = val1 * unit1.weight - val2 * unit2.weight;
+  const delta = calculateDelta(value1, value2, units);
   return isEqualOkay ? delta >= 0 : delta > 0;
 };
 


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1012 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Creates 2 functions named `isCpuLimitEqual` and `isMemoryLimitEqual` to compare size limit CPU and memory. There were some problems with the regex `/^(\d+)(.*)$/` before. For example, if you use `0.5` to match it, you will get back the match array `['0.5', '0', '.5']`. However, what we want is actually `['0.5', '0.5', '']`, so I made some changes to the regex to make sure it can separate value and unit and not mix unit and float up.

Before: 
<img width="1449" alt="Screenshot 2023-03-28 at 2 50 23 PM" src="https://user-images.githubusercontent.com/37624318/228172282-da024796-6311-414f-869f-c3db581570fd.png">

After: 
<img width="1449" alt="Screenshot 2023-03-28 at 4 04 07 PM" src="https://user-images.githubusercontent.com/37624318/228172322-63e9c4b5-e0cc-487f-8f25-2d5fba2e019f.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Add the size snippet as described in the issue to your dashboard config CR
2. Create a workbench using that size
3. Check if the size is correctly found on the workbench list

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add XSmall size to the mock dashboard config and add a mock notebook using that size but in a different format. Check the text to make sure the size show correctly on the page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
