### PR TITLE
removed upper limit on pvc size

### DIFF
--- a/frontend/src/pages/projects/components/PVSizeField.tsx
+++ b/frontend/src/pages/projects/components/PVSizeField.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { FormGroup, InputGroup, InputGroupText, NumberInput } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { isHTMLInputElement, normalizeBetween } from '~/utilities/utils';
-import useDefaultPvcSize from '~/pages/projects/screens/spawner/storage/useAvailablePvcSize';
+import { isHTMLInputElement } from '~/utilities/utils';
 
 type PVSizeFieldProps = {
   fieldID: string;
@@ -13,11 +12,9 @@ type PVSizeFieldProps = {
 
 const PVSizeField: React.FC<PVSizeFieldProps> = ({ fieldID, size, setSize, currentSize }) => {
   const minSize = parseInt(currentSize || '') || 1;
-  const defaultSize = useDefaultPvcSize();
-  const availableSize = defaultSize * 2;
 
   const onStep = (step: number) => {
-    setSize(normalizeBetween(size + step, minSize, availableSize));
+    setSize(Math.max(size + step, minSize));
   };
   return (
     <FormGroup
@@ -36,14 +33,13 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({ fieldID, size, setSize, curre
           id={fieldID}
           name={fieldID}
           value={size}
-          max={availableSize}
           min={minSize}
           onPlus={() => onStep(1)}
           onMinus={() => onStep(-1)}
           onChange={(event) => {
             if (isHTMLInputElement(event.target)) {
               const newSize = Number(event.target.value);
-              setSize(isNaN(newSize) ? size : normalizeBetween(newSize, minSize, availableSize));
+              setSize(isNaN(newSize) ? size : Math.max(newSize, minSize));
             }
           }}
         />


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1030

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
removed upper limit on create pvc. You can now set it to any cluster and the cluster should limit if it has to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
try setting the pvc size to a large number

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
@DaoDaoNoCode is creating the story for this page in one of his PRs, so I will wait until that is in to avoid having to merge two implementations of the same story

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

not really a UI change (just removing a limit)