### PR TITLE
Create model serving page skeleton (#1006)

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/BiasGraph.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasGraph.tsx
@@ -1,0 +1,15 @@
+import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';
+import React from 'react';
+
+const BiasGraph = () => (
+  <Stack hasGutter>
+    <StackItem>
+      <Card>
+        <CardTitle>Bias Graph Placeholder</CardTitle>
+        <CardBody>Lorem Ipsum</CardBody>
+      </Card>
+    </StackItem>
+  </Stack>
+);
+
+export default BiasGraph;

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { Breadcrumb, BreadcrumbItem, PageSection, Stack, StackItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { BreadcrumbItemType } from '~/types';
 import ApplicationsPage from '~/pages/ApplicationsPage';
-import MetricsChart from './MetricsChart';
-import MetricsPageToolbar from './MetricsPageToolbar';
-import { ModelServingMetricsContext, RuntimeMetricType } from './ModelServingMetricsContext';
+import MetricsPageTabs from './MetricsPageTabs';
 
 type MetricsPageProps = {
   children: React.ReactNode;
@@ -13,7 +11,7 @@ type MetricsPageProps = {
   breadcrumbItems: BreadcrumbItemType[];
 };
 
-const MetricsPage: React.FC<MetricsPageProps> = ({ children, title, breadcrumbItems }) => (
+const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems }) => (
   <ApplicationsPage
     title={title}
     breadcrumb={
@@ -29,12 +27,11 @@ const MetricsPage: React.FC<MetricsPageProps> = ({ children, title, breadcrumbIt
         ))}
       </Breadcrumb>
     }
-    toolbar={<MetricsPageToolbar />}
     loaded
     description={null}
     empty={false}
   >
-    <PageSection isFilled>{children}</PageSection>
+    <MetricsPageTabs />
   </ApplicationsPage>
 );
 

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.scss
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.scss
@@ -1,0 +1,4 @@
+// This is a hack to get around a bug in PatternFly TabContent.
+.odh-tabcontent-fix {
+  flex-grow: 1;
+}

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import PerformanceTab from './PerformanceTab';
+import QualityTab from './QualityTab';
+import './MetricsPageTabs.scss';
+
+const MetricsPageTabs: React.FC = () => {
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+
+  // Toggle currently active tab
+  const handleTabClick = (
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent | MouseEvent,
+    tabIndex: string | number,
+  ) => {
+    setActiveTabKey(tabIndex);
+  };
+
+  return (
+    <Tabs
+      activeKey={activeTabKey}
+      onSelect={handleTabClick}
+      isBox={false}
+      aria-label="Tabs in the metrics page"
+      role="region"
+    >
+      <Tab
+        eventKey={0}
+        title={<TabTitleText>Performance</TabTitleText>}
+        aria-label="Default content - performance"
+        className="odh-tabcontent-fix"
+      >
+        <PerformanceTab />
+      </Tab>
+      <Tab eventKey={1} title={<TabTitleText>Quality</TabTitleText>} className="odh-tabcontent-fix">
+        <QualityTab />
+      </Tab>
+    </Tabs>
+  );
+};
+
+export default MetricsPageTabs;

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageToolbar.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageToolbar.tsx
@@ -20,7 +20,7 @@ const MetricsPageToolbar: React.FC = () => {
     ModelServingMetricsContext,
   );
   return (
-    <Toolbar style={{ paddingBottom: 0 }}>
+    <Toolbar>
       <ToolbarContent>
         <ToolbarItem>
           <Select

--- a/frontend/src/pages/modelServing/screens/metrics/PerformanceTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/PerformanceTab.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PageSection, Stack, StackItem } from '@patternfly/react-core';
+import InferenceGraphs from '~/pages/modelServing/screens/metrics/InferenceGraphs';
+import MetricsPageToolbar from '~/pages/modelServing/screens/metrics/MetricsPageToolbar';
+
+const PerformanceTab = () => (
+  <Stack>
+    <StackItem>
+      <MetricsPageToolbar />
+    </StackItem>
+    <PageSection isFilled>
+      <InferenceGraphs />
+    </PageSection>
+  </Stack>
+);
+
+export default PerformanceTab;

--- a/frontend/src/pages/modelServing/screens/metrics/QualityTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/QualityTab.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PageSection, Stack, StackItem } from '@patternfly/react-core';
+import MetricsPageToolbar from './MetricsPageToolbar';
+import BiasGraph from './BiasGraph';
+
+const QualityTab = () => (
+  <Stack>
+    <StackItem>
+      <MetricsPageToolbar />
+    </StackItem>
+    <PageSection isFilled>
+      <BiasGraph />
+    </PageSection>
+  </Stack>
+);
+
+export default QualityTab;


### PR DESCRIPTION
Closes: #1006 

## Description
Adds a tab interface to the Model Serving page in preparation for adding the explainability: fairness and bias charts.  
![localhost_4010_modelServing_metrics_aardvark_test (1)](https://user-images.githubusercontent.com/4092230/228673644-677fc0ec-362f-4da6-96fd-656a336c7b2f.png)

![localhost_4010_modelServing_metrics_aardvark_test (2)](https://user-images.githubusercontent.com/4092230/228673651-710aac60-51e1-4f6a-ae9a-e22e6e2ad9eb.png)

## How Has This Been Tested?
1. Open the model serving page
2. Click between tabs and watch the content change

## Test Impact
No tests yet, will look to add these as part of the wider tracker containing this issue.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
