### PR TITLE
Add storageClassName field to dashboard config for notebook controller

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -34,6 +34,7 @@ export type DashboardConfig = K8sResourceCommon & {
         enabled: boolean;
         key: string;
       };
+      storageClassName?: string;
     };
   };
 };

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -593,7 +593,8 @@ const createPvc = async (
   pvcName: string,
 ): Promise<V1PersistentVolumeClaim> => {
   const pvcSize = getDashboardConfig().spec?.notebookController?.pvcSize ?? DEFAULT_PVC_SIZE;
-  const pvc = assemblePvc(pvcName, namespace, pvcSize);
+  const storageClassName = getDashboardConfig().spec.notebookController?.storageClassName;
+  const pvc = assemblePvc(pvcName, namespace, pvcSize, storageClassName);
 
   try {
     const pvcResponse = await fastify.kube.coreV1Api.createNamespacedPersistentVolumeClaim(
@@ -610,6 +611,7 @@ const assemblePvc = (
   pvcName: string,
   namespace: string,
   pvcSize: string,
+  storageClassName?: string,
 ): V1PersistentVolumeClaim => ({
   apiVersion: 'v1',
   kind: 'PersistentVolumeClaim',
@@ -628,6 +630,7 @@ const assemblePvc = (
       },
     },
     volumeMode: 'Filesystem',
+    storageClassName,
   },
   status: {
     phase: 'Pending',

--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -29,7 +29,7 @@ In its default state the Dashboard config is in this form:
 spec:
   dashboardConfig:
     enablement: true
-    disableInfo: fals
+    disableInfo: false
     disableSupport: false
     disableClusterManager: false
     disableTracking: true
@@ -88,6 +88,7 @@ notebookController:
   notebookTolerationSettings:
     enabled: true
     key: NotebooksOnly
+  storageClassName: gp2
 ```
 
 ### Notebook Controller State

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -132,3 +132,5 @@ spec:
                             type: boolean
                           key:
                             type: string
+                    storageClassName:
+                      type: string


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1029 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add `storageClassName` field under `notebookController` settings in dashboard config CR, which allows the user to specify the `storageClass` they want to use for the PVC of the Jupyter notebook they spawned with the notebook controller.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Edit odhDashboardConfig CR and add `storageClassName` as the storage class you want to set under the `notebookController` field
2. Wait for 2 mins for the dashboard to read the new settings
3. Go to the Jupyter tile to spawner a notebook (If you spawned one before, please delete the PVC of your notebook in the OpenShift console to make sure we can create a new PVC)
4. Go to the OpenShift console to check the new PVC storageClassName, it should change to the one you set just now
5. Remove the `storageClassName` in the dashboard config CR and wait for another 2 mins, and delete the PVC
6. Stop the notebook and start it again
7. Check the PVC and it should use the default storage class again

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests are not applicable because there is no way for us to check the PVC storage class in the dashboard, you can only manually check it on the OpenShift console.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
