### PR TITLE
feat(make): allows overwriting CONTAINER_ vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,11 @@ or
 npm run make:build
 ```
 
-in the root of this repository. By default, we use [podman](https://podman.io/) as the default container tool, but you can change it by setting the `CONTAINER_BUILDER` environment variable to `docker`.
+in the root of this repository. 
+
+By default, we use [podman](https://podman.io/) as the default container tool, but you can change it by 
+- setting the `CONTAINER_BUILDER` environment variable to `docker`
+- passing it as environment overrides when using `make build -e CONTAINER_BUILDER=docker`
 
 After building the image, you need to push it to a container registry accessible by your cluster. You can do that by running
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ include ${ENV_FILE}
 export $(shell sed 's/=.*//' ${ENV_FILE})
 endif
 
-CONTAINER_BUILDER=podman
-CONTAINER_DOCKERFILE=Dockerfile
+CONTAINER_BUILDER?=podman
+CONTAINER_DOCKERFILE?=Dockerfile
 
 ##################################
 


### PR DESCRIPTION
With this change you can call `CONTAINER_BUILDER=docker make build` or rely on your `.env` file instead of editing `Makefile` by hand.
