### PR TITLE
Auto-add issues to ODH Dashboard Planning Project

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yaml
+++ b/.github/workflows/auto-add-issues-to-project.yaml
@@ -1,0 +1,14 @@
+name: Add Issues to ODH Dashboard Planning Project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/opendatahub-io/projects/24
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Closes #1095 

## Description
This workflow adds issues created in odh-dashboard to the [Dashboard Planning Project](https://github.com/orgs/opendatahub-io/projects/24/views/1). 

**Note** 
- This requires `GH_TOKEN` secret added to the repo. (GITHUB_TOKEN [cannot be used](https://github.com/actions/add-to-project/issues/264).)

## How Has This Been Tested?
- To test this, create an example issue in this test [repo](https://github.com/VaishnaviHire/test-workflows)
- This uses the same workflow to add issues to the sample project

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
