### PR TITLE
fixed data connection flow

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -194,18 +194,19 @@ export const updateConfigMapsAndSecretsForNotebook = async (
 ): Promise<EnvironmentFromVariable[]> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
   const newDataConnection =
-    dataConnection && dataConnection.type === 'creating' && dataConnection.creating
+    dataConnection?.enabled && dataConnection.type === 'creating' && dataConnection.creating
       ? dataConnection.creating
       : undefined;
   const replaceDataConnection =
-    dataConnection && dataConnection.type === 'existing' && dataConnection.existing
+    dataConnection?.enabled &&
+    dataConnection.type === 'existing' &&
+    dataConnection.existing?.secretRef.name !== existingDataConnection?.data.metadata.name
       ? dataConnection.existing
       : undefined;
+
   const removeDataConnections =
-    (existingDataConnection && !dataConnection?.enabled) ||
-    (existingDataConnection &&
-      replaceDataConnection &&
-      replaceDataConnection.secretRef.name !== existingDataConnection.data.metadata.name)
+    existingDataConnection &&
+    (replaceDataConnection || newDataConnection || !dataConnection?.enabled)
       ? [existingDataConnection.data.metadata.name]
       : [];
 


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1071

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
fixed the spawner form data connection section submit flow. Issue was that there was no check to remove the existing data connection when a new connection was added. It only checked when an existing connection was used.

Now the flow is:
- use new data connection var: only defined when data connections are enabled and new data connection is selected 
- use existing data connection var: only defined when data connections are enabled and existing data connection is selected and that data connection is not equal to the old data connection

So now we remove the old data connection if a new var is defined, existing var is defined or data connection have been disabled


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- create a new workbench with a data connection
- edit workbench
    - create new data connection in form section
    - submit
- there should be two data connections with only the new data connection assigned to the workbench. The old one should of had its connection removed
- you can also test that replacing data connections and disabling data connections work as well

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
test coverage is already here/ no changes (this is also an e2e test so we cant test it with unit testing)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
