### PR TITLE
Add custom serving runtimes table

### DIFF
--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -1,8 +1,8 @@
-import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sListResource, k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { TemplateKind } from '~/k8sTypes';
 import { TemplateModel } from '~/api/models';
 
-export const listTemplates = (
+export const listTemplates = async (
   namespace?: string,
   labelSelector?: string,
 ): Promise<TemplateKind[]> => {
@@ -14,4 +14,26 @@ export const listTemplates = (
     model: TemplateModel,
     queryOptions,
   }).then((listResource) => listResource.items);
+};
+
+export const toggleTemplateEnabledStatus = (
+  name: string,
+  namespace: string,
+  enable: boolean,
+): Promise<TemplateKind> => {
+  const patch = enable
+    ? {
+        op: 'remove',
+        path: '/metadata/annotations/opendatahub.io~1template-enabled',
+      }
+    : {
+        op: 'add',
+        path: '/metadata/annotations/opendatahub.io~1template-enabled',
+        value: 'false',
+      };
+  return k8sPatchResource<TemplateKind>({
+    model: TemplateModel,
+    queryOptions: { name, ns: namespace },
+    patches: [patch],
+  });
 };

--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -20,20 +20,15 @@ export const toggleTemplateEnabledStatus = (
   name: string,
   namespace: string,
   enable: boolean,
-): Promise<TemplateKind> => {
-  const patch = enable
-    ? {
-        op: 'remove',
-        path: '/metadata/annotations/opendatahub.io~1template-enabled',
-      }
-    : {
-        op: 'add',
-        path: '/metadata/annotations/opendatahub.io~1template-enabled',
-        value: 'false',
-      };
-  return k8sPatchResource<TemplateKind>({
+): Promise<TemplateKind> =>
+  k8sPatchResource<TemplateKind>({
     model: TemplateModel,
     queryOptions: { name, ns: namespace },
-    patches: [patch],
+    patches: [
+      {
+        op: 'replace',
+        path: '/metadata/annotations/opendatahub.io~1template-enabled',
+        value: enable ? 'true' : 'false',
+      },
+    ],
   });
-};

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -116,6 +116,7 @@ const Table = <T,>({
                 key={col.field + i}
                 sort={col.sortable ? sort.getColumnSort(i) : undefined}
                 width={col.width}
+                info={col.info}
               >
                 {col.label}
               </Th>

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -421,6 +421,7 @@ export type TemplateKind = K8sResourceCommon & {
       description: string;
       tags: string;
       iconClass: string;
+      'opendatahub.io/template-enabled': string;
     }>;
     name: string;
     namespace: string;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeContext.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeContext.tsx
@@ -40,13 +40,13 @@ const CustomServingRuntimeContextProvider: React.FC = () => {
     useTemplateOrder(dashboardNamespace),
   );
 
-  const servingRuntimeTeamplateRefresh = servingRuntimeTemplates.refresh;
-  const servingRuntimeTeamplateOrderRefresh = servingRuntimeTemplateOrder.refresh;
+  const servingRuntimeTemplateRefresh = servingRuntimeTemplates.refresh;
+  const servingRuntimeTemplateOrderRefresh = servingRuntimeTemplateOrder.refresh;
 
   const refreshData = React.useCallback(() => {
-    servingRuntimeTeamplateRefresh();
-    servingRuntimeTeamplateOrderRefresh();
-  }, [servingRuntimeTeamplateRefresh, servingRuntimeTeamplateOrderRefresh]);
+    servingRuntimeTemplateRefresh();
+    servingRuntimeTemplateOrderRefresh();
+  }, [servingRuntimeTemplateRefresh, servingRuntimeTemplateOrderRefresh]);
 
   if (servingRuntimeTemplates.error || servingRuntimeTemplateOrder.error) {
     return (

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle.tsx
@@ -21,7 +21,6 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
     toggleTemplateEnabledStatus(template.metadata.name, template.metadata.namespace, checked)
       .then(() => {
         setEnabled(checked);
-        setLoading(false);
       })
       .catch((e) => {
         notification.error(
@@ -29,6 +28,8 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
           e.message,
         );
         setEnabled(!checked);
+      })
+      .finally(() => {
         setLoading(false);
       });
   };

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Switch } from '@patternfly/react-core';
+import { TemplateKind } from '~/k8sTypes';
+import { toggleTemplateEnabledStatus } from '~/api';
+import useNotification from '~/utilities/useNotification';
+import { getTemplateEnabled } from './utils';
+
+type CustomServingRuntimeEnabledToggleProps = {
+  template: TemplateKind;
+};
+
+const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledToggleProps> = ({
+  template,
+}) => {
+  const [isEnabled, setEnabled] = React.useState(getTemplateEnabled(template));
+  const [isLoading, setLoading] = React.useState(false);
+  const notification = useNotification();
+
+  const handleChange = (checked: boolean) => {
+    setLoading(true);
+    toggleTemplateEnabledStatus(template.metadata.name, template.metadata.namespace, checked)
+      .then(() => {
+        setEnabled(checked);
+        setLoading(false);
+      })
+      .catch((e) => {
+        notification.error(
+          `Error ${checked ? 'enable' : 'disable'} the serving runtime`,
+          e.message,
+        );
+        setEnabled(!checked);
+        setLoading(false);
+      });
+  };
+
+  return (
+    <Switch
+      id={`custom-serving-runtime-enabled-toggle-${template.metadata.name}`}
+      aria-label={`${template.metadata.name}-enabled-toggle`}
+      isChecked={isEnabled}
+      onChange={handleChange}
+      isDisabled={isLoading}
+    />
+  );
+};
+
+export default CustomServingRuntimeEnabledToggle;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesListView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesListView.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Button, ToolbarItem } from '@patternfly/react-core';
+import Table from '~/components/Table';
+import SearchField, { SearchType } from '~/pages/projects/components/SearchField';
+import { TemplateKind } from '~/k8sTypes';
+import { patchDashboardConfigTemplateOrder } from '~/api';
+import { useDashboardNamespace } from '~/redux/selectors';
+import useNotification from '~/utilities/useNotification';
+import { compareTemplateKinds } from './utils';
+import { columns } from './templatedData';
+import CustomServingRuntimesTableRow from './CustomServingRuntimesTableRow';
+
+type CustomServingRuntimesListViewProps = {
+  templates: TemplateKind[];
+  templateOrder: string[];
+  refresh: () => void;
+};
+
+const CustomServingRuntimesListView: React.FC<CustomServingRuntimesListViewProps> = ({
+  templates: unfilteredTemplates,
+  templateOrder,
+  refresh,
+}) => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const notification = useNotification();
+  const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
+  const [search, setSearch] = React.useState('');
+
+  // TODO: should we disabled drag&drop when using search function?
+  const filteredTemplates = unfilteredTemplates
+    .sort(compareTemplateKinds(templateOrder))
+    .filter((template) => {
+      if (!search) {
+        return true;
+      }
+
+      switch (searchType) {
+        case SearchType.NAME:
+          return template.metadata.name.includes(search.toLowerCase());
+        default:
+          return true;
+      }
+    });
+
+  const resetFilters = () => {
+    setSearch('');
+  };
+
+  const searchTypes = React.useMemo(
+    () => Object.keys(SearchType).filter((key) => SearchType[key] === SearchType.NAME),
+    [],
+  );
+
+  const onDropCallback = React.useCallback(
+    (newTemplateOrder) => {
+      if (!_.isEqual(newTemplateOrder, templateOrder)) {
+        patchDashboardConfigTemplateOrder(newTemplateOrder, dashboardNamespace)
+          .then(refresh)
+          .catch((e) => notification.error(`Error update the serving runtimes order`, e.message));
+      }
+    },
+    [templateOrder, dashboardNamespace, refresh, notification],
+  );
+
+  return (
+    <>
+      <Table
+        enablePagination
+        isDraggable
+        data={filteredTemplates}
+        columns={columns}
+        initialItemOrder={filteredTemplates.map((template) => template.metadata.name)}
+        emptyTableView={
+          <>
+            No serving runtimes match your filters.{' '}
+            <Button variant="link" isInline onClick={resetFilters}>
+              Clear filters
+            </Button>
+          </>
+        }
+        rowRenderer={(template, rowIndex, trDragFunctions) => (
+          <CustomServingRuntimesTableRow
+            key={template.metadata.uid}
+            obj={template}
+            rowIndex={rowIndex}
+            dragFunctions={trDragFunctions}
+          />
+        )}
+        toolbarContent={
+          <ToolbarItem>
+            <SearchField
+              types={searchTypes}
+              searchType={searchType}
+              searchValue={search}
+              onSearchTypeChange={(searchType) => {
+                setSearchType(searchType);
+              }}
+              onSearchValueChange={(searchValue) => {
+                setSearch(searchValue);
+              }}
+            />
+          </ToolbarItem>
+        }
+        onDropCallback={onDropCallback}
+      />
+    </>
+  );
+};
+
+export default CustomServingRuntimesListView;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesListView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesListView.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Button, ToolbarItem } from '@patternfly/react-core';
 import Table from '~/components/Table';
-import SearchField, { SearchType } from '~/pages/projects/components/SearchField';
 import { TemplateKind } from '~/k8sTypes';
 import { patchDashboardConfigTemplateOrder } from '~/api';
 import { useDashboardNamespace } from '~/redux/selectors';
@@ -18,39 +17,12 @@ type CustomServingRuntimesListViewProps = {
 };
 
 const CustomServingRuntimesListView: React.FC<CustomServingRuntimesListViewProps> = ({
-  templates: unfilteredTemplates,
+  templates,
   templateOrder,
   refresh,
 }) => {
   const { dashboardNamespace } = useDashboardNamespace();
   const notification = useNotification();
-  const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
-  const [search, setSearch] = React.useState('');
-
-  // TODO: should we disabled drag&drop when using search function?
-  const filteredTemplates = unfilteredTemplates
-    .sort(compareTemplateKinds(templateOrder))
-    .filter((template) => {
-      if (!search) {
-        return true;
-      }
-
-      switch (searchType) {
-        case SearchType.NAME:
-          return template.metadata.name.includes(search.toLowerCase());
-        default:
-          return true;
-      }
-    });
-
-  const resetFilters = () => {
-    setSearch('');
-  };
-
-  const searchTypes = React.useMemo(
-    () => Object.keys(SearchType).filter((key) => SearchType[key] === SearchType.NAME),
-    [],
-  );
 
   const onDropCallback = React.useCallback(
     (newTemplateOrder) => {
@@ -66,19 +38,12 @@ const CustomServingRuntimesListView: React.FC<CustomServingRuntimesListViewProps
   return (
     <>
       <Table
-        enablePagination
         isDraggable
-        data={filteredTemplates}
+        data={templates}
         columns={columns}
-        initialItemOrder={filteredTemplates.map((template) => template.metadata.name)}
-        emptyTableView={
-          <>
-            No serving runtimes match your filters.{' '}
-            <Button variant="link" isInline onClick={resetFilters}>
-              Clear filters
-            </Button>
-          </>
-        }
+        initialItemOrder={templates
+          .sort(compareTemplateKinds(templateOrder))
+          .map((template) => template.metadata.name)}
         rowRenderer={(template, rowIndex, trDragFunctions) => (
           <CustomServingRuntimesTableRow
             key={template.metadata.uid}
@@ -89,17 +54,8 @@ const CustomServingRuntimesListView: React.FC<CustomServingRuntimesListViewProps
         )}
         toolbarContent={
           <ToolbarItem>
-            <SearchField
-              types={searchTypes}
-              searchType={searchType}
-              searchValue={search}
-              onSearchTypeChange={(searchType) => {
-                setSearchType(searchType);
-              }}
-              onSearchValueChange={(searchValue) => {
-                setSearch(searchValue);
-              }}
-            />
+            {/* TODO: Add navigation to the adding serving runtime page */}
+            <Button>Add serving runtime</Button>
           </ToolbarItem>
         }
         onDropCallback={onDropCallback}

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesTableRow.tsx
@@ -37,7 +37,6 @@ const CustomServingRuntimesTableRow: React.FC<CustomServingRuntimesTableRowProps
       <Td dataLabel="Workbench">
         <CustomServingRuntimeEnabledToggle template={template} />
       </Td>
-      <Td dataLabel="Status">TODO</Td>
       <Td isActionCell>
         <ActionsColumn items={[]} />
       </Td>

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesTableRow.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { TemplateKind } from '~/k8sTypes';
+import { TrDragFunctionsType } from '~/utilities/useDraggableTable';
+
+type CustomServingRuntimesTableRowProps = {
+  obj: TemplateKind;
+  rowIndex: number;
+  dragFunctions?: TrDragFunctionsType;
+};
+
+const CustomServingRuntimesTableRow: React.FC<CustomServingRuntimesTableRowProps> = ({
+  obj: template,
+  rowIndex,
+  dragFunctions,
+}) => {
+  if (!dragFunctions) {
+    return null;
+  }
+  const { onDragEnd, onDragStart, onDrop } = dragFunctions;
+  return (
+    <Tr
+      key={rowIndex}
+      id={template.metadata.name}
+      draggable
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      onDragStart={onDragStart}
+    >
+      <Td
+        draggableRow={{
+          id: `draggable-row-${template.metadata.name}`,
+        }}
+      />
+      <Td dataLabel="Name">{template.metadata.name}</Td>
+      <Td dataLabel="Workbench">TODO</Td>
+      <Td dataLabel="Status">TODO</Td>
+      <Td isActionCell>
+        <ActionsColumn items={[]} />
+      </Td>
+    </Tr>
+  );
+};
+
+export default CustomServingRuntimesTableRow;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesTableRow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { TemplateKind } from '~/k8sTypes';
 import { TrDragFunctionsType } from '~/utilities/useDraggableTable';
+import CustomServingRuntimeEnabledToggle from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle';
 
 type CustomServingRuntimesTableRowProps = {
   obj: TemplateKind;
@@ -33,7 +34,9 @@ const CustomServingRuntimesTableRow: React.FC<CustomServingRuntimesTableRowProps
         }}
       />
       <Td dataLabel="Name">{template.metadata.name}</Td>
-      <Td dataLabel="Workbench">TODO</Td>
+      <Td dataLabel="Workbench">
+        <CustomServingRuntimeEnabledToggle template={template} />
+      </Td>
       <Td dataLabel="Status">TODO</Td>
       <Td isActionCell>
         <ActionsColumn items={[]} />

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimesView.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import ApplicationsPage from '~/pages/ApplicationsPage';
+import CustomServingRuntimesListView from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimesListView';
 import EmptyCustomServingRuntime from './EmptyCustomServingRuntime';
 import { CustomServingRuntimeContext } from './CustomServingRuntimeContext';
-import { compareTemplateKinds } from './utils';
 
 const CustomServingRuntimesView: React.FC = () => {
   const {
     servingRuntimeTemplates: { data: servingRuntimeTemplates },
     servingRuntimeTemplateOrder: { data: order },
+    refreshData,
   } = React.useContext(CustomServingRuntimeContext);
 
   return (
@@ -19,12 +20,11 @@ const CustomServingRuntimesView: React.FC = () => {
       emptyStatePage={<EmptyCustomServingRuntime />}
       provideChildrenPadding
     >
-      {servingRuntimeTemplates.sort(compareTemplateKinds(order)).map((servingRuntime) => (
-        <div key={servingRuntime.metadata.name}>
-          <p>{servingRuntime.metadata.name}</p>
-          <p>{servingRuntime.metadata.annotations?.description || ''}</p>
-        </div>
-      ))}
+      <CustomServingRuntimesListView
+        templates={servingRuntimeTemplates}
+        templateOrder={order}
+        refresh={refreshData}
+      />
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
@@ -1,0 +1,25 @@
+import { SortableData } from '~/utilities/useTableColumnSort';
+import { TemplateKind } from '~/k8sTypes';
+
+export const columns: SortableData<TemplateKind>[] = [
+  {
+    field: 'name',
+    label: 'Name',
+    sortable: false,
+  },
+  {
+    field: 'enabled',
+    label: 'Enabled',
+    sortable: false,
+  },
+  {
+    field: 'models-deployed',
+    label: 'Models Deployed',
+    sortable: false,
+  },
+  {
+    field: 'kebab',
+    label: '',
+    sortable: false,
+  },
+];

--- a/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
@@ -11,6 +11,12 @@ export const columns: SortableData<TemplateKind>[] = [
     field: 'enabled',
     label: 'Enabled',
     sortable: false,
+    info: {
+      popover: 'Select which runtimes are available to users when serving models.',
+      popoverProps: {
+        showClose: false,
+      },
+    },
   },
   {
     field: 'models-deployed',

--- a/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
@@ -19,11 +19,6 @@ export const columns: SortableData<TemplateKind>[] = [
     },
   },
   {
-    field: 'models-deployed',
-    label: 'Models Deployed',
-    sortable: false,
-  },
-  {
     field: 'kebab',
     label: '',
     sortable: false,

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -12,3 +12,6 @@ export const compareTemplateKinds =
     }
     return 0;
   };
+
+export const getTemplateEnabled = (template: TemplateKind) =>
+  !(template.metadata.annotations?.['opendatahub.io/template-enabled'] === 'false');

--- a/frontend/src/utilities/useDebounce.ts
+++ b/frontend/src/utilities/useDebounce.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+function useDebounce<T>(value: T, delay?: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState<T>(value);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/frontend/src/utilities/useDraggableTable.ts
+++ b/frontend/src/utilities/useDraggableTable.ts
@@ -1,0 +1,162 @@
+import * as React from 'react';
+import { TbodyProps, TrProps } from '@patternfly/react-table';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+import useDebounce from '~/utilities/useDebounce';
+
+export type TrDragFunctionsType = {
+  onDragStart: React.DragEventHandler<HTMLTableRowElement>;
+  onDragEnd: React.DragEventHandler<HTMLTableRowElement>;
+  onDrop: React.DragEventHandler<HTMLTableRowElement>;
+};
+
+const useDraggableTable = (
+  bodyRef: React.RefObject<HTMLTableSectionElement>,
+  initialItemOrder: string[],
+) => {
+  const [draggedItemId, setDraggedItemId] = React.useState('');
+  const [draggingToItemIndex, setDraggingToItemIndex] = React.useState(-1);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [itemOrder, setItemOrder] = React.useState(initialItemOrder);
+  const [tempItemOrder, setTempItemOrder] = React.useState<string[]>([]);
+
+  const debouncedItemOrder = useDebounce(itemOrder, 5000);
+
+  const onDragStart: TrProps['onDragStart'] = (evt) => {
+    evt.dataTransfer.effectAllowed = 'move';
+    evt.dataTransfer.setData('text/plain', evt.currentTarget.id);
+    const draggedItemId = evt.currentTarget.id;
+
+    evt.currentTarget.classList.add(styles.modifiers.ghostRow);
+    evt.currentTarget.setAttribute('aria-pressed', 'true');
+
+    setDraggedItemId(draggedItemId);
+    setIsDragging(true);
+  };
+
+  const moveItem = (arr: string[], i1: string, toIndex: number) => {
+    const fromIndex = arr.indexOf(i1);
+    if (fromIndex === toIndex) {
+      return arr;
+    }
+    const temp = arr.splice(fromIndex, 1);
+    arr.splice(toIndex, 0, temp[0]);
+
+    return arr;
+  };
+
+  const move = (itemOrder: string[]) => {
+    if (!bodyRef.current) {
+      return;
+    }
+    const ulNode = bodyRef.current;
+    const nodes = Array.from(ulNode.children);
+    if (nodes.map((node) => node.id).every((id, i) => id === itemOrder[i])) {
+      return;
+    }
+    while (ulNode.firstChild) {
+      if (ulNode.lastChild) {
+        ulNode.removeChild(ulNode.lastChild);
+      }
+    }
+
+    itemOrder.forEach((id) => {
+      const node = nodes.find((n) => n.id === id);
+      if (node) {
+        ulNode.appendChild(node);
+      }
+    });
+  };
+
+  const onDragCancel = () => {
+    if (!bodyRef.current) {
+      return;
+    }
+    Array.from(bodyRef.current.children).forEach((el) => {
+      el.classList.remove(styles.modifiers.ghostRow);
+      el.setAttribute('aria-pressed', 'false');
+    });
+    setDraggedItemId('');
+    setDraggingToItemIndex(-1);
+    setIsDragging(false);
+  };
+
+  const onDragLeave: TbodyProps['onDragLeave'] = (evt) => {
+    if (!isValidDrop(evt)) {
+      move(itemOrder);
+      setDraggingToItemIndex(-1);
+    }
+  };
+
+  const isValidDrop = (evt: React.DragEvent<HTMLTableSectionElement | HTMLTableRowElement>) => {
+    if (!bodyRef.current) {
+      return;
+    }
+    const ulRect = bodyRef.current.getBoundingClientRect();
+    return (
+      evt.clientX > ulRect.x &&
+      evt.clientX < ulRect.x + ulRect.width &&
+      evt.clientY > ulRect.y &&
+      evt.clientY < ulRect.y + ulRect.height
+    );
+  };
+
+  const onDrop: TrProps['onDrop'] = (evt) => {
+    if (isValidDrop(evt)) {
+      setItemOrder(tempItemOrder);
+    } else {
+      onDragCancel();
+    }
+  };
+
+  const onDragOver: TbodyProps['onDragOver'] = (evt) => {
+    evt.preventDefault();
+
+    if (!bodyRef.current) {
+      return;
+    }
+
+    const curListItem = (evt.target as HTMLTableSectionElement).closest('tr');
+    if (
+      !curListItem ||
+      !bodyRef.current.contains(curListItem) ||
+      curListItem.id === draggedItemId
+    ) {
+      return;
+    }
+    const dragId = curListItem.id;
+    const newDraggingToItemIndex = Array.from(bodyRef.current.children).findIndex(
+      (item) => item.id === dragId,
+    );
+    if (newDraggingToItemIndex !== draggingToItemIndex) {
+      const tempItemOrder = moveItem([...itemOrder], draggedItemId, newDraggingToItemIndex);
+      move(tempItemOrder);
+      setDraggingToItemIndex(newDraggingToItemIndex);
+      setTempItemOrder(tempItemOrder);
+    }
+  };
+
+  const onDragEnd: TrProps['onDragEnd'] = (evt) => {
+    const target = evt.target as HTMLTableRowElement;
+    target.classList.remove(styles.modifiers.ghostRow);
+    target.setAttribute('aria-pressed', 'false');
+    setDraggedItemId('');
+    setDraggingToItemIndex(-1);
+    setIsDragging(false);
+  };
+
+  return {
+    isDragging,
+    tbodyDragFunctions: {
+      onDragOver,
+      onDragLeave,
+    },
+    trDragFunctions: {
+      onDragStart,
+      onDragEnd,
+      onDrop,
+    },
+    itemOrder: debouncedItemOrder,
+  };
+};
+
+export default useDraggableTable;

--- a/frontend/src/utilities/useTableColumnSort.ts
+++ b/frontend/src/utilities/useTableColumnSort.ts
@@ -14,6 +14,7 @@ export type SortableData<T> = {
    * Assume ASC -- the result will be inverted internally if needed.
    */
   sortable: boolean | ((a: T, b: T, keyField: string) => number);
+  info?: ThProps['info'];
 };
 
 /**


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1077 
Closes #1079 
Closes #1146 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Add a table that reads the `Templates` and shows them
- Order the table based on the dashboard config `templateOrder` field
- Add a drag and drop function to the table rows, which could update the order with 5 seconds debounce
- Add the annotation `opendatahub.io/template-enabled` to reflect whether a serving runtime template is enabled. If the annotation doesn't exist, we can think it's enabled. So only when the annotation is `false`, we think it's disabled.

<img width="1791" alt="Screenshot 2023-04-21 at 9 46 33 AM" src="https://user-images.githubusercontent.com/37624318/233521628-baa10c0b-0cae-49f3-be22-c3b35150fba9.png">

TODO:
~~1. Finish Deployed Models column #1157~~
2. Add dropdown items to the table row #1083 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create 2 or more templates on the cluster, you can use the template [here](https://github.com/opendatahub-io/odh-dashboard/pull/1098#issuecomment-1506006377), just change the name to make them unique
2. Add `templateOrder` field in the dashboard config CR under `spec`, it could be empty at first because every time when you first fetch the templates it will compare and update the order
3. Try to drag and drop the serving runtimes in the table
4. Check the dashboard config to see if the order is changed
5. Refresh the page to see if the new order is applied
6. Try to toggle the Enabled column and check the template annotations to see if the annotation is applied/removed.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Decide to finish the tests after we implement all the features. Currently, we use `useDashboardNamespace` in the context, and I cannot mock that hook in the storybook test. Spent half day to investigate and give up for now.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
