### PR TITLE
Fix OpenVINO Workbench Creation

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -146,7 +146,7 @@ export type ImageStreamKind = K8sResourceCommon & {
 export type ImageStreamSpecTagType = {
   name: string;
   annotations?: ImageStreamSpecTagAnnotations;
-  from: {
+  from?: {
     kind: string;
     name: string;
   };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -80,7 +80,11 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     fireTrackingEvent(`Workbench ${type}`, {
       GPU: gpus,
       lastSelectedSize: notebookSize.name,
-      lastSelectedImage: `${image.imageVersion?.from.name}`,
+      lastSelectedImage: image.imageVersion?.from
+        ? `${image.imageVersion.from.name}`
+        : `${image.imageStream?.metadata?.name || 'unknown image'} - ${
+            image.imageVersion?.name || 'unknown version'
+          }`,
       projectName,
       notebookName: name,
     });


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1111

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When OpenVINO image is used in the Workbench creation, it doesn't possess the property on the tag `from.name` -- we use this to track our segment.io even when it is disabled. This gave us an NPE -- but after the form was done but before we routed... so it caused a successful completion of the form but not the submitting to segment.io (or to our wrapper when it was disabled).

Fixed by simply changing it to `imageStream.metadata.name` + `imageVersion.name` with some fallbacks if the image tag doesn't have the metadata of `from`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On a RHODS cluster with OpenVINO installed. Create workbench using the image + submit. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
