### PR TITLE
Fix error status icons with tooltips: added screenreader and tabIndex 

### DIFF
--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -21,13 +21,13 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({ inferen
       case InferenceServiceModelState.LOADED:
       case InferenceServiceModelState.STANDBY:
         return (
-          <Icon status="success" isInline>
+          <Icon role="button" aria-label="success icon" status="success" isInline tabIndex={0}>
             <CheckCircleIcon />
           </Icon>
         );
       case InferenceServiceModelState.FAILED_TO_LOAD:
         return (
-          <Icon status="danger" isInline>
+          <Icon role="button" aria-label="error icon" status="danger" isInline tabIndex={0}>
             <ExclamationCircleIcon />
           </Icon>
         );
@@ -40,13 +40,13 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({ inferen
         );
       case InferenceServiceModelState.UNKNOWN:
         return (
-          <Icon status="warning" isInline>
+          <Icon role="button" aria-label="warning icon" status="warning" isInline tabIndex={0}>
             <OutlinedQuestionCircleIcon />
           </Icon>
         );
       default:
         return (
-          <Icon status="warning" isInline>
+          <Icon role="button" aria-label="warning icon" status="warning" isInline tabIndex={0}>
             <OutlinedQuestionCircleIcon />
           </Icon>
         );
@@ -56,7 +56,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({ inferen
   return (
     <Tooltip
       removeFindDomNode
-      aria-label="State Info"
+      role="none"
       content={<Text>{getInferenceServiceErrorMessage(inferenceService)}</Text>}
     >
       {StatusIcon()}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -75,7 +75,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
                   aria-labelledby="Deployed models load error"
                   content={inferenceServicesLoadError.message}
                 >
-                  <Icon status="danger">
+                  <Icon role="button" status="danger" aria-label="error icon" tabIndex={0}>
                     <ExclamationCircleIcon />
                   </Icon>
                 </Tooltip>
@@ -101,7 +101,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
                   aria-labelledby="Tokens load error"
                   content={secretsLoadError.message}
                 >
-                  <Icon status="danger">
+                  <Icon role="button" status="danger" aria-label="error icon" tabIndex={0}>
                     <ExclamationCircleIcon />
                   </Icon>
                 </Tooltip>

--- a/frontend/src/pages/projects/components/StorageSizeBars.tsx
+++ b/frontend/src/pages/projects/components/StorageSizeBars.tsx
@@ -41,17 +41,21 @@ const StorageSizeBar: React.FC<StorageSizeBarProps> = ({ pvc }) => {
   const percentageLabel = error ? '' : `Storage is ${percentage}% full`;
 
   let inUseRender: React.ReactNode;
-  // if (error) {
+  if (error) {
     inUseRender = (
       <Tooltip removeFindDomNode content={`Unable to get storage data.`}>
-        <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" aria-label="error icon" tabIndex={0}/>
+        <ExclamationCircleIcon
+          color="var(--pf-global--danger-color--100)"
+          aria-label="error icon"
+          tabIndex={0}
+        />
       </Tooltip>
     );
-  // } else if (!loaded) {
-  //   inUseRender = <Spinner size="sm" />;
-  // } else {
-  //   inUseRender = inUseValue;
-  // }
+  } else if (!loaded) {
+    inUseRender = <Spinner size="sm" />;
+  } else {
+    inUseRender = inUseValue;
+  }
 
   const progressBar = (
     <Progress

--- a/frontend/src/pages/projects/components/StorageSizeBars.tsx
+++ b/frontend/src/pages/projects/components/StorageSizeBars.tsx
@@ -43,7 +43,7 @@ const StorageSizeBar: React.FC<StorageSizeBarProps> = ({ pvc }) => {
   let inUseRender: React.ReactNode;
   if (error) {
     inUseRender = (
-      <Tooltip removeFindDomNode content={`Unable to get storage data.`}>
+      <Tooltip removeFindDomNode content={`Unable to get storage data. ${error.message}`}>
         <ExclamationCircleIcon
           color="var(--pf-global--danger-color--100)"
           aria-label="error icon"

--- a/frontend/src/pages/projects/components/StorageSizeBars.tsx
+++ b/frontend/src/pages/projects/components/StorageSizeBars.tsx
@@ -41,17 +41,17 @@ const StorageSizeBar: React.FC<StorageSizeBarProps> = ({ pvc }) => {
   const percentageLabel = error ? '' : `Storage is ${percentage}% full`;
 
   let inUseRender: React.ReactNode;
-  if (error) {
+  // if (error) {
     inUseRender = (
-      <Tooltip removeFindDomNode content={`Unable to get storage data. ${error.message}`}>
-        <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
+      <Tooltip removeFindDomNode content={`Unable to get storage data.`}>
+        <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" aria-label="error icon" tabIndex={0}/>
       </Tooltip>
     );
-  } else if (!loaded) {
-    inUseRender = <Spinner size="sm" />;
-  } else {
-    inUseRender = inUseValue;
-  }
+  // } else if (!loaded) {
+  //   inUseRender = <Spinner size="sm" />;
+  // } else {
+  //   inUseRender = inUseValue;
+  // }
 
   const progressBar = (
     <Progress

--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -51,7 +51,7 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
       </FlexItem>
       {error && (
         <FlexItem>
-          <Tooltip content={"lalala"}>
+          <Tooltip content={error.message}>
             <Icon role="button" aria-label="error icon" status="danger" tabIndex={0}>
               <ExclamationCircleIcon />
             </Icon>

--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -57,7 +57,7 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
             </Icon>
           </Tooltip>
         </FlexItem>
-       )}
+      )}
     </Flex>
   );
 };

--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -51,13 +51,13 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
       </FlexItem>
       {error && (
         <FlexItem>
-          <Tooltip content={error.message}>
-            <Icon status="danger">
+          <Tooltip content={"lalala"}>
+            <Icon role="button" aria-label="error icon" status="danger" tabIndex={0}>
               <ExclamationCircleIcon />
             </Icon>
           </Tooltip>
         </FlexItem>
-      )}
+       )}
     </Flex>
   );
 };

--- a/frontend/src/pages/projects/notebook/NotebookStatusText.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusText.tsx
@@ -64,7 +64,7 @@ const NotebookStatusText: React.FC<NotebookStatusTextProps> = ({
           {labelText}{' '}
           {notebookStatus?.currentStatus === EventStatus.ERROR && (
             <Tooltip removeFindDomNode content={notebookStatus.currentEvent}>
-            <Icon isInline aria-label="error icon" role="button" status="danger" tabIndex={0}>
+              <Icon isInline aria-label="error icon" role="button" status="danger" tabIndex={0}>
                 <ExclamationCircleIcon />
               </Icon>
             </Tooltip>

--- a/frontend/src/pages/projects/notebook/NotebookStatusText.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusText.tsx
@@ -64,7 +64,7 @@ const NotebookStatusText: React.FC<NotebookStatusTextProps> = ({
           {labelText}{' '}
           {notebookStatus?.currentStatus === EventStatus.ERROR && (
             <Tooltip removeFindDomNode content={notebookStatus.currentEvent}>
-              <Icon isInline status="danger">
+            <Icon isInline aria-label="error icon" role="button" status="danger" tabIndex={0}>
                 <ExclamationCircleIcon />
               </Icon>
             </Tooltip>

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -81,7 +81,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             <FlexItem>{notebookSize?.name ?? 'Unknown'}</FlexItem>
             {sizeError && (
               <Tooltip removeFindDomNode content={sizeError}>
-                <Icon status="danger">
+                <Icon aria-label="error icon" role="button" status="danger" tabIndex={0}>
                   <ExclamationCircleIcon />
                 </Icon>
               </Tooltip>


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1155 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Add screenreader and tabIndex to error status icons wrapped by tooltips. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

For status icons wrapped by tooltips, added icon to tab order and made icon screenreader accessible.  

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
