### PR TITLE
feat: add GH action to scan files in repo on PR basis

### DIFF
--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -1,0 +1,4 @@
+format: sarif
+exit-code: 0
+severity: 'CRITICAL,HIGH'
+output: 'scan_result.sarif'

--- a/.github/workflows/vuln_scan.yml
+++ b/.github/workflows/vuln_scan.yml
@@ -1,0 +1,29 @@
+name: Value Scan
+
+on:
+  pull_request:
+
+jobs:
+  scan:
+    name: Scan Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner for filesystem
+        uses: aquasecurity/trivy-action@0.10.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          trivy-config: .github/trivy.yaml
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'scan_result.sarif'
+
+      - name: Archive scan results to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivyResult
+          path: 'scan_result.sarif'
+          if-no-files-found: error


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
Add new GitHub Action to do vulnerability scanning on static file in the repo on any PR
Result stored as artifacts in json format can be downloaded from Action runs' Artifacts zip file.
Only record if vuln in high or critical level

## How Has This Been Tested?
Create a PR in forked repo https://github.com/zdtsw/odh-dashboard/actions/runs/4799075808
Action was run and result can be download as artifacts

## Test Impact
N.A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
