### PR TITLE
Fix data connections indentation issue on the spawner page

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/dataConnection/DataConnectionField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/dataConnection/DataConnectionField.tsx
@@ -18,74 +18,70 @@ const DataConnectionField: React.FC<DataConnectionFieldProps> = ({
   setDataConnection,
 }) => (
   <FormGroup fieldId="cluster-storage" role="radiogroup">
-    <Stack hasGutter>
-      <StackItem>
-        <Checkbox
-          className="checkbox-radio-fix-body-width"
-          name="enable-data-connection-checkbox"
-          id="enable-data-connection-checkbox"
-          label="Use a data connection"
-          isChecked={dataConnection.enabled}
-          onChange={() =>
-            setDataConnection({ ...dataConnection, enabled: !dataConnection.enabled })
-          }
-        />
-      </StackItem>
-      {dataConnection.enabled && (
-        <>
-          <StackItem>
-            <Radio
-              className="checkbox-radio-fix-body-width"
-              name="new-data-connection-radio"
-              id="new-data-connection-radio"
-              label="Create new data connection"
-              isChecked={dataConnection.type === 'creating'}
-              onChange={() => setDataConnection({ ...dataConnection, type: 'creating' })}
-              body={
-                dataConnection.type === 'creating' && (
-                  <AWSField
-                    values={dataConnection.creating?.values?.data ?? EMPTY_AWS_SECRET_DATA}
-                    onUpdate={(newEnvData) => {
-                      setDataConnection({
-                        ...dataConnection,
-                        creating: {
-                          type: EnvironmentVariableType.SECRET,
-                          values: { category: SecretCategory.AWS, data: newEnvData },
-                        },
-                      });
-                    }}
-                  />
-                )
-              }
-            />
-          </StackItem>
-          <StackItem>
-            <Radio
-              className="checkbox-radio-fix-body-width"
-              name="existing-data-connection-type-radio"
-              id="existing-data-connection-type-radio"
-              label="Use existing data connection"
-              isChecked={dataConnection.type === 'existing'}
-              onChange={() => setDataConnection({ ...dataConnection, type: 'existing' })}
-              body={
-                dataConnection.type === 'existing' && (
-                  <ExistingDataConnectionField
-                    fieldId="select-existing-data-connection"
-                    selectedDataConnection={dataConnection?.existing?.secretRef.name}
-                    setDataConnection={(name) =>
-                      setDataConnection({
-                        ...dataConnection,
-                        existing: { secretRef: { name: name ?? '' } },
-                      })
-                    }
-                  />
-                )
-              }
-            />
-          </StackItem>
-        </>
-      )}
-    </Stack>
+    <Checkbox
+      className="checkbox-radio-fix-body-width"
+      name="enable-data-connection-checkbox"
+      id="enable-data-connection-checkbox"
+      label="Use a data connection"
+      isChecked={dataConnection.enabled}
+      onChange={() => setDataConnection({ ...dataConnection, enabled: !dataConnection.enabled })}
+      body={
+        dataConnection.enabled && (
+          <Stack hasGutter>
+            <StackItem>
+              <Radio
+                className="checkbox-radio-fix-body-width"
+                name="new-data-connection-radio"
+                id="new-data-connection-radio"
+                label="Create new data connection"
+                isChecked={dataConnection.type === 'creating'}
+                onChange={() => setDataConnection({ ...dataConnection, type: 'creating' })}
+                body={
+                  dataConnection.type === 'creating' && (
+                    <AWSField
+                      values={dataConnection.creating?.values?.data ?? EMPTY_AWS_SECRET_DATA}
+                      onUpdate={(newEnvData) => {
+                        setDataConnection({
+                          ...dataConnection,
+                          creating: {
+                            type: EnvironmentVariableType.SECRET,
+                            values: { category: SecretCategory.AWS, data: newEnvData },
+                          },
+                        });
+                      }}
+                    />
+                  )
+                }
+              />
+            </StackItem>
+            <StackItem>
+              <Radio
+                className="checkbox-radio-fix-body-width"
+                name="existing-data-connection-type-radio"
+                id="existing-data-connection-type-radio"
+                label="Use existing data connection"
+                isChecked={dataConnection.type === 'existing'}
+                onChange={() => setDataConnection({ ...dataConnection, type: 'existing' })}
+                body={
+                  dataConnection.type === 'existing' && (
+                    <ExistingDataConnectionField
+                      fieldId="select-existing-data-connection"
+                      selectedDataConnection={dataConnection?.existing?.secretRef.name}
+                      setDataConnection={(name) =>
+                        setDataConnection({
+                          ...dataConnection,
+                          existing: { secretRef: { name: name ?? '' } },
+                        })
+                      }
+                    />
+                  )
+                }
+              />
+            </StackItem>
+          </Stack>
+        )
+      }
+    />
   </FormGroup>
 );
 


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1072 
@kywalker-rh @vconzola Please check the UX changes when you are available.

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Put the radio sections for choosing new or existing data connections into the `body` of the checkbox.
Before:
<img width="590" alt="Screenshot 2023-05-03 at 4 43 18 PM" src="https://user-images.githubusercontent.com/37624318/235871784-0b66be70-befc-4c96-853e-b1277fb496e6.png">
<img width="590" alt="Screenshot 2023-05-03 at 4 43 00 PM" src="https://user-images.githubusercontent.com/37624318/235871705-2e383c83-a1df-461a-abfa-64f2cdada91c.png">

After:
<img width="590" alt="Screenshot 2023-05-03 at 4 41 29 PM" src="https://user-images.githubusercontent.com/37624318/235871783-90b46ad4-1c49-48ed-838d-6c32989c756b.png">
<img width="590" alt="Screenshot 2023-05-03 at 4 41 39 PM" src="https://user-images.githubusercontent.com/37624318/235871790-9da5fd68-cd47-4bf4-b60d-05eba810fcaf.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to project workbench spawner page
2. Check the `Use a data connection` checkbox at the bottom
3. Check if there is an indentation in the body section

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Only UX changes, and tests are not applicable.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
