### PR TITLE
Control model serving related fetching based on the feature flags

### DIFF
--- a/frontend/src/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled.ts
@@ -1,0 +1,18 @@
+import { useAppContext } from '~/app/AppContext';
+import { featureFlagEnabled } from '~/utilities/utils';
+
+const useCustomServingRuntimesEnabled = (): boolean => {
+  const {
+    dashboardConfig: {
+      spec: {
+        dashboardConfig: { disableModelServing, disableCustomServingRuntimes },
+      },
+    },
+  } = useAppContext();
+
+  return (
+    featureFlagEnabled(disableModelServing) && featureFlagEnabled(disableCustomServingRuntimes)
+  );
+};
+
+export default useCustomServingRuntimesEnabled;

--- a/frontend/src/pages/modelServing/customServingRuntimes/useTemplateOrder.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useTemplateOrder.ts
@@ -1,19 +1,27 @@
 import * as React from 'react';
 import { getDashboardConfigTemplateOrder } from '~/api';
-import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import useCustomServingRuntimesEnabled from '~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 
 const useTemplateOrder = (namespace?: string): FetchState<string[]> => {
+  const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
+
   const getTemplateOrder = React.useCallback(() => {
     if (!namespace) {
       return Promise.reject(new Error('No namespace provided'));
     }
+
+    if (!customServingRuntimesEnabled) {
+      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
+    }
+
     return getDashboardConfigTemplateOrder(namespace).catch((e) => {
       if (e.statusObject?.code === 404) {
         throw new Error('Dashboard config template order is not configured.');
       }
       throw e;
     });
-  }, [namespace]);
+  }, [namespace, customServingRuntimesEnabled]);
 
   return useFetchState<string[]>(getTemplateOrder, []);
 };

--- a/frontend/src/pages/modelServing/customServingRuntimes/useTemplates.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useTemplates.ts
@@ -1,20 +1,28 @@
 import * as React from 'react';
 import { listTemplates } from '~/api';
 import { TemplateKind } from '~/k8sTypes';
-import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import useCustomServingRuntimesEnabled from '~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 
 const useTemplates = (namespace?: string): FetchState<TemplateKind[]> => {
+  const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
+
   const getTemplates = React.useCallback(() => {
     if (!namespace) {
-      return Promise.reject(new Error('No namespace provided'));
+      return Promise.reject(new NotReadyError('No namespace provided'));
     }
+
+    if (!customServingRuntimesEnabled) {
+      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
+    }
+
     return listTemplates(namespace, 'opendatahub.io/dashboard=true').catch((e) => {
       if (e.statusObject?.code === 404) {
         throw new Error('Serving Runtime templates is not properly configured.');
       }
       throw e;
     });
-  }, [namespace]);
+  }, [namespace, customServingRuntimesEnabled]);
 
   return useFetchState<TemplateKind[]>(getTemplates, []);
 };

--- a/frontend/src/pages/modelServing/screens/projects/useServingRuntimeSecrets.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingRuntimeSecrets.ts
@@ -1,13 +1,20 @@
 import * as React from 'react';
 import { getSecretsByLabel } from '~/api';
 import { SecretKind } from '~/k8sTypes';
+import useModelServingEnabled from '~/pages/modelServing/useModelServingEnabled';
 import { getModelServiceAccountName } from '~/pages/modelServing/utils';
 import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 
 const useServingRuntimeSecrets = (namespace?: string): FetchState<SecretKind[]> => {
+  const modelServingEnabled = useModelServingEnabled();
+
   const fetchSecrets = React.useCallback(() => {
     if (!namespace) {
       return Promise.reject(new NotReadyError('No namespace'));
+    }
+
+    if (!modelServingEnabled) {
+      return Promise.reject(new NotReadyError('Model serving is not enabled'));
     }
 
     return getSecretsByLabel('opendatahub.io/dashboard=true', namespace).then((secrets) =>
@@ -17,7 +24,7 @@ const useServingRuntimeSecrets = (namespace?: string): FetchState<SecretKind[]> 
           getModelServiceAccountName(namespace),
       ),
     );
-  }, [namespace]);
+  }, [namespace, modelServingEnabled]);
 
   return useFetchState<SecretKind[]>(fetchSecrets, []);
 };

--- a/frontend/src/pages/modelServing/useInferenceServices.ts
+++ b/frontend/src/pages/modelServing/useInferenceServices.ts
@@ -1,13 +1,19 @@
 import * as React from 'react';
 import { getInferenceServiceContext } from '~/api';
 import { InferenceServiceKind } from '~/k8sTypes';
-import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import useModelServingEnabled from '~/pages/modelServing/useModelServingEnabled';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 
 const useInferenceServices = (namespace?: string): FetchState<InferenceServiceKind[]> => {
-  const getServingInferences = React.useCallback(
-    () => getInferenceServiceContext(namespace, 'opendatahub.io/dashboard=true'),
-    [namespace],
-  );
+  const modelServingEnabled = useModelServingEnabled();
+
+  const getServingInferences = React.useCallback(() => {
+    if (!modelServingEnabled) {
+      return Promise.reject(new NotReadyError('Model serving is not enabled'));
+    }
+
+    return getInferenceServiceContext(namespace, 'opendatahub.io/dashboard=true');
+  }, [namespace, modelServingEnabled]);
 
   return useFetchState<InferenceServiceKind[]>(getServingInferences, []);
 };

--- a/frontend/src/pages/modelServing/useModelServingEnabled.ts
+++ b/frontend/src/pages/modelServing/useModelServingEnabled.ts
@@ -1,0 +1,16 @@
+import { useAppContext } from '~/app/AppContext';
+import { featureFlagEnabled } from '~/utilities/utils';
+
+const useModelServingEnabled = (): boolean => {
+  const {
+    dashboardConfig: {
+      spec: {
+        dashboardConfig: { disableModelServing },
+      },
+    },
+  } = useAppContext();
+
+  return featureFlagEnabled(disableModelServing);
+};
+
+export default useModelServingEnabled;

--- a/frontend/src/pages/modelServing/useServingRuntimes.ts
+++ b/frontend/src/pages/modelServing/useServingRuntimes.ts
@@ -1,19 +1,24 @@
 import * as React from 'react';
 import { getServingRuntimeContext } from '~/api';
 import { ServingRuntimeKind } from '~/k8sTypes';
-import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import useModelServingEnabled from '~/pages/modelServing/useModelServingEnabled';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 
 const useServingRuntimes = (namespace?: string): FetchState<ServingRuntimeKind[]> => {
-  const getServingRuntimes = React.useCallback(
-    () =>
-      getServingRuntimeContext(namespace, 'opendatahub.io/dashboard=true').catch((e) => {
-        if (e.statusObject?.code === 404) {
-          throw new Error('Model serving is not properly configured.');
-        }
-        throw e;
-      }),
-    [namespace],
-  );
+  const modelServingEnabled = useModelServingEnabled();
+
+  const getServingRuntimes = React.useCallback(() => {
+    if (!modelServingEnabled) {
+      return Promise.reject(new NotReadyError('Model serving is not enabled'));
+    }
+
+    return getServingRuntimeContext(namespace, 'opendatahub.io/dashboard=true').catch((e) => {
+      if (e.statusObject?.code === 404) {
+        throw new Error('Model serving is not properly configured.');
+      }
+      throw e;
+    });
+  }, [namespace, modelServingEnabled]);
 
   return useFetchState<ServingRuntimeKind[]>(getServingRuntimes, []);
 };


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1089 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Check if model serving and custom serving runtimes are enabled in all the fetch hooks that are related to these features. If it's disabled, return NotReadyError instead of the fetch function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the project details page
2. Go to the network tab of the dev console of your browser (Chrome or Firefox)
3. Check the API calls to see if it's fetch `servingruntimes` and `inferenceservices`
4. Go to the dashboard config to disable the model serving feature
5. Wait for ~2 mins until the dashboard fetch the last config
6. Refresh the page to see the API calls, now the page shouldn't fetch `servingruntimes` and `inferenceservices`
7. Enable the model serving feature again
8. Check if the resources are fetched again

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
