### PR TITLE
DO NOT MERGE: Test nodejs-18:1 floating tag as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi8/nodejs-18 as default base image
-ARG BASE_IMAGE="registry.access.redhat.com/ubi8/nodejs-18:1-32.1679484519"
+ARG BASE_IMAGE="registry.access.redhat.com/ubi8/nodejs-18:1"
 
 FROM ${BASE_IMAGE} as builder
 


### PR DESCRIPTION
#DO NO MERGE
Testing runtime errors in the v2.9.z build outlined in https://github.com/opendatahub-io/odh-manifests/pull/793#issuecomment-1527642292 to see if the issue is only occurring in the openshift-ci build system

I will close this after debugging some issues