### PR TITLE
made env upload category more specific

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -321,6 +321,7 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
       case ConfigMapCategory.GENERIC:
       case SecretCategory.GENERIC:
       case ConfigMapCategory.UPLOAD:
+      case SecretCategory.UPLOAD:
         return values.every(({ key, value }) => isValidGenericKey(key) && !!value);
       case SecretCategory.AWS:
         return isAWSValid(values);

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -130,9 +130,9 @@ export enum EnvironmentVariableType {
 export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
-  UPLOAD = 'upload',
+  UPLOAD = 'secret upload',
 }
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',
-  UPLOAD = 'upload',
+  UPLOAD = 'configmap upload',
 }


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1206

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When secret upload was added, the category for the env upload was "upload" for both secrets and config maps. B/c the upload for secret was checked first, uploaded envs would always be created as secrets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
create a workbench with an uploaded config map and make sure it is created as a config map and not a secret

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
no ux changes