### PR TITLE
Parse BYON repository URL correctly

### DIFF
--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -99,7 +99,7 @@ const getBYONImageErrorMessage = (imageStream: ImageStream) => {
   const activeTag = imageStream.status?.tags?.find(
     (statusTag) => statusTag.tag === imageStream.spec.tags?.[0].name,
   );
-  return activeTag?.items === null ? activeTag.conditions?.[0].message : undefined;
+  return activeTag?.conditions?.[0]?.message;
 };
 
 export const processImageInfo = (imageStream: ImageStream): ImageInfo => {

--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -1,4 +1,4 @@
-import { IMAGE_ANNOTATIONS } from '../../../utils/constants';
+import { IMAGE_ANNOTATIONS, imageUrlRegex } from '../../../utils/constants';
 import { convertLabelsToString } from '../../../utils/componentUtils';
 import {
   ImageStreamTag,
@@ -11,7 +11,6 @@ import {
   BYONImageUpdateRequest,
   BYONImagePackage,
   BYONImage,
-  BYONImageStatus,
 } from '../../../types';
 import { FastifyRequest } from 'fastify';
 import createError from 'http-errors';
@@ -91,6 +90,18 @@ const getImageStreams = async (
   return await requestPromise;
 };
 
+const isBYONImage = (imageStream: ImageStream) =>
+  imageStream.metadata.labels?.['app.kubernetes.io/created-by'] === 'byon';
+
+const getBYONImageErrorMessage = (imageStream: ImageStream) => {
+  // there will be always only 1 tag in the spec for BYON images
+  // status tags could be more than one
+  const activeTag = imageStream.status?.tags?.find(
+    (statusTag) => statusTag.tag === imageStream.spec.tags?.[0].name,
+  );
+  return activeTag?.items === null ? activeTag.conditions?.[0].message : undefined;
+};
+
 export const processImageInfo = (imageStream: ImageStream): ImageInfo => {
   const annotations = imageStream.metadata.annotations || {};
 
@@ -102,6 +113,7 @@ export const processImageInfo = (imageStream: ImageStream): ImageInfo => {
     tags: getTagInfo(imageStream),
     order: +annotations[IMAGE_ANNOTATIONS.IMAGE_ORDER] || 100,
     dockerImageRepo: imageStream.status?.dockerImageRepository || '',
+    error: isBYONImage && getBYONImageErrorMessage(imageStream),
   };
 
   return imageInfo;
@@ -180,11 +192,8 @@ const mapImageStreamToBYONImage = (is: ImageStream): BYONImage => ({
   id: is.metadata.name,
   name: is.metadata.annotations['opendatahub.io/notebook-image-name'],
   description: is.metadata.annotations['opendatahub.io/notebook-image-desc'],
-  phase: is.metadata.annotations['opendatahub.io/notebook-image-phase'] as BYONImageStatus,
   visible: is.metadata.labels['opendatahub.io/notebook-image'] === 'true',
-  error: is.metadata.annotations['opendatahub.io/notebook-image-messages']
-    ? JSON.parse(is.metadata.annotations['opendatahub.io/notebook-image-messages'])
-    : [],
+  error: getBYONImageErrorMessage(is),
   packages:
     is.spec.tags &&
     (JSON.parse(
@@ -207,7 +216,14 @@ export const postImage = async (
   const customObjectsApi = fastify.kube.customObjectsApi;
   const namespace = fastify.kube.namespace;
   const body = request.body as BYONImageCreateRequest;
-  const imageTag = body.url.split(':')[1];
+  const fullUrl = body.url;
+  const matchArray = fullUrl.match(imageUrlRegex);
+  // check if the host is valid
+  if (!matchArray[1]) {
+    fastify.log.error('Invalid repository URL unable to add notebook image');
+    return { success: false, error: 'Invalid repository URL: ' + fullUrl };
+  }
+  const imageTag = matchArray[4];
   const labels = {
     'app.kubernetes.io/created-by': 'byon',
     'opendatahub.io/notebook-image': 'true',
@@ -228,11 +244,8 @@ export const postImage = async (
       annotations: {
         'opendatahub.io/notebook-image-desc': body.description ? body.description : '',
         'opendatahub.io/notebook-image-name': body.name,
-        'opendatahub.io/notebook-image-url': body.url,
+        'opendatahub.io/notebook-image-url': fullUrl,
         'opendatahub.io/notebook-image-creator': body.user,
-        'opendatahub.io/notebook-image-phase': 'Succeeded',
-        'opendatahub.io/notebook-image-origin': 'Admin',
-        'opendatahub.io/notebook-image-messages': '',
       },
       name: `byon-${Date.now()}`,
       namespace: namespace,
@@ -247,13 +260,13 @@ export const postImage = async (
           annotations: {
             'opendatahub.io/notebook-software': packagesToString(body.software),
             'opendatahub.io/notebook-python-dependencies': packagesToString(body.packages),
-            'openshift.io/imported-from': body.url,
+            'openshift.io/imported-from': fullUrl,
           },
           from: {
             kind: 'DockerImage',
-            name: body.url,
+            name: fullUrl,
           },
-          name: imageTag,
+          name: imageTag || 'latest',
         },
       ],
     },

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -464,19 +464,11 @@ export type ODHSegmentKey = {
   segmentKey: string;
 };
 
-export type BYONImageError = {
-  severity: string;
-  message: string;
-};
-
-export type BYONImageStatus = 'Importing' | 'Validating' | 'Succeeded' | 'Failed';
-
 export type BYONImage = {
   id: string;
-  phase?: BYONImageStatus;
   user?: string;
   uploaded?: Date;
-  error?: BYONImageError;
+  error?: string;
 } & BYONImageCreateRequest &
   BYONImageUpdateRequest;
 
@@ -530,6 +522,14 @@ export type ImageStreamStatusTagItem = {
 export type ImageStreamStatusTag = {
   tag: string;
   items: ImageStreamStatusTagItem[];
+  conditions?: ImageStreamStatusTagCondition[];
+};
+
+export type ImageStreamStatusTagCondition = {
+  type: string;
+  status: string;
+  reason: string;
+  message: string;
 };
 
 export type ImageStreamStatus = {
@@ -589,6 +589,7 @@ export type ImageInfo = {
   default?: boolean;
   order?: number;
   dockerImageRepo?: string;
+  error?: string;
 };
 
 export type ImageType = 'byon' | 'jupyter' | 'other';

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -130,3 +130,6 @@ export const DEFAULT_NOTEBOOK_SIZES: NotebookSize[] = [
     },
   },
 ];
+
+export const imageUrlRegex =
+  /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(?::([\w.\-_]{1,127})|)/;

--- a/frontend/src/__tests__/dockerRepositoryURL.spec.ts
+++ b/frontend/src/__tests__/dockerRepositoryURL.spec.ts
@@ -1,0 +1,50 @@
+// https://cloud.google.com/artifact-registry/docs/docker/names
+// The full name for a container image is one of the following formats:
+// LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/IMAGE
+// LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/IMAGE:TAG
+// LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/IMAGE@IMAGE-DIGEST
+
+const repositoryUrlRegex =
+  /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(?::([\w.\-_]{1,127})|)/;
+
+test('Invalid URL', () => {
+  const url = 'docker.io';
+  const match = url.match(repositoryUrlRegex);
+  expect(match?.[1]).toBe('');
+});
+
+test('Docker container URL without tag', () => {
+  const url = 'docker.io/library/mysql';
+  const match = url.match(repositoryUrlRegex);
+  expect(match?.[1]).toBe('docker.io');
+  expect(match?.[4]).toBe(undefined);
+});
+
+test('Docker container URL with tag', () => {
+  const url = 'docker.io/library/mysql:test-tag';
+  const match = url.match(repositoryUrlRegex);
+  expect(match?.[1]).toBe('docker.io');
+  expect(match?.[4]).toBe('test-tag');
+});
+
+test('OpenShift internal registry URL without tag', () => {
+  const url = 'image-registry.openshift-image-registry.svc:5000/opendatahub/s2i-minimal-notebook';
+  const match = url.match(repositoryUrlRegex);
+  expect(match?.[1]).toBe('image-registry.openshift-image-registry.svc:5000');
+  expect(match?.[4]).toBe(undefined);
+});
+
+test('OpenShift internal registry URL with tag', () => {
+  const url =
+    'image-registry.openshift-image-registry.svc:5000/opendatahub/s2i-minimal-notebook:v0.3.0-py36';
+  const match = url.match(repositoryUrlRegex);
+  expect(match?.[1]).toBe('image-registry.openshift-image-registry.svc:5000');
+  expect(match?.[4]).toBe('v0.3.0-py36');
+});
+
+test('Quay URL with port and tag', () => {
+  const url = 'quay.io:443/opendatahub/odh-dashboard:main-55e19fa';
+  const match = url.match(repositoryUrlRegex);
+  expect(match?.[1]).toBe('quay.io:443');
+  expect(match?.[4]).toBe('main-55e19fa');
+});

--- a/frontend/src/__tests__/dockerRepositoryURL.spec.ts
+++ b/frontend/src/__tests__/dockerRepositoryURL.spec.ts
@@ -4,32 +4,31 @@
 // LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/IMAGE:TAG
 // LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/IMAGE@IMAGE-DIGEST
 
-const repositoryUrlRegex =
-  /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(?::([\w.\-_]{1,127})|)/;
+import { REPOSITORY_URL_REGEX } from '~/utilities/const';
 
 test('Invalid URL', () => {
   const url = 'docker.io';
-  const match = url.match(repositoryUrlRegex);
+  const match = url.match(REPOSITORY_URL_REGEX);
   expect(match?.[1]).toBe('');
 });
 
 test('Docker container URL without tag', () => {
   const url = 'docker.io/library/mysql';
-  const match = url.match(repositoryUrlRegex);
+  const match = url.match(REPOSITORY_URL_REGEX);
   expect(match?.[1]).toBe('docker.io');
   expect(match?.[4]).toBe(undefined);
 });
 
 test('Docker container URL with tag', () => {
   const url = 'docker.io/library/mysql:test-tag';
-  const match = url.match(repositoryUrlRegex);
+  const match = url.match(REPOSITORY_URL_REGEX);
   expect(match?.[1]).toBe('docker.io');
   expect(match?.[4]).toBe('test-tag');
 });
 
 test('OpenShift internal registry URL without tag', () => {
   const url = 'image-registry.openshift-image-registry.svc:5000/opendatahub/s2i-minimal-notebook';
-  const match = url.match(repositoryUrlRegex);
+  const match = url.match(REPOSITORY_URL_REGEX);
   expect(match?.[1]).toBe('image-registry.openshift-image-registry.svc:5000');
   expect(match?.[4]).toBe(undefined);
 });
@@ -37,14 +36,14 @@ test('OpenShift internal registry URL without tag', () => {
 test('OpenShift internal registry URL with tag', () => {
   const url =
     'image-registry.openshift-image-registry.svc:5000/opendatahub/s2i-minimal-notebook:v0.3.0-py36';
-  const match = url.match(repositoryUrlRegex);
+  const match = url.match(REPOSITORY_URL_REGEX);
   expect(match?.[1]).toBe('image-registry.openshift-image-registry.svc:5000');
   expect(match?.[4]).toBe('v0.3.0-py36');
 });
 
 test('Quay URL with port and tag', () => {
   const url = 'quay.io:443/opendatahub/odh-dashboard:main-55e19fa';
-  const match = url.match(repositoryUrlRegex);
+  const match = url.match(REPOSITORY_URL_REGEX);
   expect(match?.[1]).toBe('quay.io:443');
   expect(match?.[4]).toBe('main-55e19fa');
 });

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -10,6 +10,8 @@ import {
   NotebookSize,
   GpuSettingString,
   TolerationSettings,
+  ImageStreamStatusTagItem,
+  ImageStreamStatusTagCondition,
 } from './types';
 import { ServingRuntimeSize } from './pages/modelServing/screens/types';
 
@@ -181,6 +183,8 @@ export type ImageStreamKind = K8sResourceCommon & {
     publicDockerImageRepository?: string;
     tags?: {
       tag: string;
+      items: ImageStreamStatusTagItem[] | null;
+      conditions?: ImageStreamStatusTagCondition[];
     }[];
   };
 };

--- a/frontend/src/pages/BYONImages/ImageErrorStatus.tsx
+++ b/frontend/src/pages/BYONImages/ImageErrorStatus.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { Text, Icon, Tooltip } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { BYONImage } from '~/types';
+
+type ImageErrorStatusProps = {
+  image: BYONImage;
+};
+
+const ImageErrorStatus: React.FC<ImageErrorStatusProps> = ({ image }) => {
+  if (!image.error) {
+    return null;
+  }
+  return (
+    <Tooltip removeFindDomNode role="none" content={<Text>{image.error}</Text>}>
+      <Icon role="button" aria-label="error icon" status="danger" isInline tabIndex={0}>
+        <ExclamationCircleIcon />
+      </Icon>
+    </Tooltip>
+  );
+};
+
+export default ImageErrorStatus;

--- a/frontend/src/pages/BYONImages/ImportImageModal.tsx
+++ b/frontend/src/pages/BYONImages/ImportImageModal.tsx
@@ -83,8 +83,8 @@ export const ImportImageModal: React.FC<ImportImageModalProps> = ({
                   dispatch(
                     addNotification({
                       status: 'danger',
-                      title: 'Error',
-                      message: `Unable to add notebook image ${name}`,
+                      title: `Unable to add notebook image ${name}`,
+                      message: value.error,
                       timestamp: new Date(),
                     }),
                   );

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -283,17 +283,20 @@ const SpawnerPage: React.FC = () => {
           <FormSection title="Notebook image">
             <FormGroup fieldId="modal-notebook-image">
               <Grid sm={12} md={12} lg={12} xl={6} xl2={6} hasGutter>
-                {[...images].sort(checkOrder).map((image) => (
-                  <GridItem key={image.name}>
-                    <ImageSelector
-                      data-id="image-selector"
-                      image={image}
-                      selectedImage={selectedImageTag.image}
-                      selectedTag={selectedImageTag.tag}
-                      handleSelection={handleImageTagSelection}
-                    />
-                  </GridItem>
-                ))}
+                {[...images]
+                  .filter((image) => !image.error)
+                  .sort(checkOrder)
+                  .map((image) => (
+                    <GridItem key={image.name}>
+                      <ImageSelector
+                        data-id="image-selector"
+                        image={image}
+                        selectedImage={selectedImageTag.image}
+                        selectedTag={selectedImageTag.tag}
+                        handleSelection={handleImageTagSelection}
+                      />
+                    </GridItem>
+                  ))}
               </Grid>
             </FormGroup>
           </FormSection>

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -4,6 +4,7 @@ import { ImageStreamKind } from '~/k8sTypes';
 import {
   getDefaultVersionForImageStream,
   getExistingVersionsForImageStream,
+  isInvalidBYONImageStream,
 } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { ImageStreamAndVersion } from '~/types';
 import useImageStreams from '~/pages/projects/screens/spawner/useImageStreams';
@@ -62,7 +63,9 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
       ) : (
         <>
           <ImageStreamSelector
-            imageStreams={imageStreams}
+            imageStreams={imageStreams.filter(
+              (imageStream) => !isInvalidBYONImageStream(imageStream),
+            )}
             buildStatuses={buildStatuses}
             onImageStreamSelect={onImageStreamSelect}
             selectedImageStream={selectedImage.imageStream}

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -376,3 +376,15 @@ export const checkRequiredFieldsForNotebookStart = (
     isDataConnectionValid
   );
 };
+
+export const isInvalidBYONImageStream = (imageStream: ImageStreamKind) => {
+  // there will be always only 1 tag in the spec for BYON images
+  // status tags could be more than one
+  const activeTag = imageStream.status?.tags?.find(
+    (statusTag) => statusTag.tag === imageStream.spec.tags?.[0].name,
+  );
+  return (
+    imageStream.metadata.labels?.['app.kubernetes.io/created-by'] === 'byon' &&
+    (activeTag === undefined || activeTag.items === null)
+  );
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -436,19 +436,11 @@ export type Route = {
   };
 };
 
-export type BYONImageError = {
-  severity: string;
-  message: string;
-};
-
-export type BYONImageStatus = 'Importing' | 'Validating' | 'Succeeded' | 'Failed';
-
 export type BYONImage = {
   id: string;
-  phase?: BYONImageStatus;
   user?: string;
   uploaded?: Date;
-  error?: BYONImageError;
+  error?: string;
 } & BYONImageCreateRequest &
   BYONImageUpdateRequest;
 
@@ -536,6 +528,13 @@ export type ImageStreamStatusTag = {
   items: ImageStreamStatusTagItem[];
 };
 
+export type ImageStreamStatusTagCondition = {
+  type: string;
+  status: string;
+  reason: string;
+  message: string;
+};
+
 export type ImageStreamStatus = {
   dockerImageRepository?: string;
   publicDockerImageRepository?: string;
@@ -593,6 +592,7 @@ export type ImageInfo = {
   default?: boolean;
   order: number;
   dockerImageRepo: string;
+  error?: string;
 };
 
 export type ImageType = 'byon' | 'jupyter' | 'other';

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -40,7 +40,7 @@ const getSettingsNav = (
   if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableBYONImageStream)) {
     settingsNavs.push({
       id: 'settings-notebook-images',
-      label: 'Notebook Images',
+      label: 'Notebook images',
       href: '/notebookImages',
     });
   }

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -42,3 +42,6 @@ export const DEFAULT_CONTEXT_DATA: ContextResourceData<never> = {
   loaded: false,
   refresh: () => undefined,
 };
+
+export const REPOSITORY_URL_REGEX =
+  /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(?::([\w.\-_]{1,127})|)/;


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1085 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The PR did the following things:
1. Use regex to match the repository URL, which could help correctly parse the hostname and the tag name
2. If the user doesn't input the tag name, we will set the tag name default to `latest`, because it will automatically fetch the latest tag if you create an image stream without specifying the tag name
3. If the user inputs the tag name, we will set the tag name of the BYON image to the same as the tag name user is importing

Because some docker container images might not have the `latest` tag or might not have the tag user specifies, it could throw an error if the tag cannot be found. In this situation, we show the error in the BYON image table to the admin users and hide the image from the spawner page of both the KFNBC and DS projects.

UX/UI change: Add an error state and tooltip to invalid BYON images

<img width="1792" alt="Screenshot 2023-05-17 at 9 50 18 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ae77fce5-6361-4048-9b51-189e1c0ba6bb">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Try to create some custom images, you can use the images here https://quay.io/repository/opendatahub/workbench-images?tab=tags with the tag starting with `jupyter`, also you can go to search the OpenShift internal image streams like `image-registry.openshift-image-registry.svc:5000/opendatahub/s2i-minimal-notebook`. Try to create some with and without the tags
2. Go to the spawner page to see if you can create a notebook/workbench with the custom image
3. Try to find an image without the `latest` tag and import that image without specifying the tag
4. Check whether there is an error state in the table for that image
5. Check whether the error image is not visible in the spawner page image selections

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add some jest tests to make sure the regex could parse the URL correctly.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
