### PR TITLE
Make the .npm directory writable by the root group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=default:root ${SOURCE_CODE} /usr/src/app
 # Change file ownership to the assemble user
 USER default
 
-RUN npm cache clean --force 
+RUN npm cache clean --force
 
 RUN npm ci --omit=optional
 
@@ -39,7 +39,7 @@ COPY --chown=default:root --from=builder /usr/src/app/.npmrc /usr/src/app/backen
 COPY --chown=default:root --from=builder /usr/src/app/.env /usr/src/app/.env
 COPY --chown=default:root --from=builder /usr/src/app/data /usr/src/app/data
 
-RUN cd backend && npm cache clean --force && npm ci --omit=dev --omit=optional
+RUN cd backend && npm cache clean --force && npm ci --omit=dev --omit=optional && chmod -R g+w /opt/app-root/src/.npm
 
 WORKDIR /usr/src/app/backend
 


### PR DESCRIPTION
## Description
Addresses #1123 to make sure that when the container is running with a random UID in OpenShift, the `/opt/app-root/src/.npm` folder is writable by any user in the `root` group

I can reproduce this locally with a v2.9.2 image by running the container with a UID different from the `default` user ID (`1001`)
```
podman run --rm --user 65536 quay.io/opendatahub/odh-dashboard:v2.9.2 
````

## How Has This Been Tested?
Deployed into my dev cluster that was experiencing the issue with the quay.io/opendatahub/odh-dashboard:v2.9.2 image and patched in the quay.io/opendatahub/odh-dashboard:pr-1256 image with no issues

## Test Impact
No dashboard functionality was modified

## Request review criteria:
Deploy the PR container in OpenShift with `make deploy` to ensure that there are no CrashLoopErrors

- [ ] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
