### PR TITLE
Use ${HOME} envvar as root dir for .npm folder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --chown=default:root --from=builder /usr/src/app/.npmrc /usr/src/app/backen
 COPY --chown=default:root --from=builder /usr/src/app/.env /usr/src/app/.env
 COPY --chown=default:root --from=builder /usr/src/app/data /usr/src/app/data
 
-RUN cd backend && npm cache clean --force && npm ci --omit=dev --omit=optional && chmod -R g+w /opt/app-root/src/.npm
+RUN cd backend && npm cache clean --force && npm ci --omit=dev --omit=optional && chmod -R g+w ${HOME}/.npm
 
 WORKDIR /usr/src/app/backend
 


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
This is a follow-up to #1256 that replaces the hardcoded reference to `/opt/app-root/src` which is the `$HOME` directory inherited from the `ubi8-nodejs18` base image.  This add portability so that the home directory can be changed without breaking the image since the [npm cache](https://docs.npmjs.com/cli/v9/using-npm/config#cache) location default to `$HOME/.npm`

You can verify the $HOME env var is defined using the [skopeo](https://github.com/containers/skopeo) tool to query the image metadata
```
# odh-dashboard base image
skopeo inspect docker://registry.access.redhat.com/ubi8/nodejs-18:1 | jq '.Env'

# odh-dashboard release image
skopeo inspect docker://quay.io/opendatahub/odh-dashboard:v2.10.0 | jq '.Env'
```

## How Has This Been Tested?
Manually built the image using `make build` and deployed in my dev environment

## Test Impact
There is no change to functionality

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
