### PR TITLE
Add bias metrics configuration modal

### DIFF
--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
+import {
+  ContextResourceData,
+  PrometheusQueryRangeResponseDataResult,
+  PrometheusQueryRangeResultValue,
+} from '~/types';
 import {
   InferenceMetricType,
   RuntimeMetricType,
@@ -16,7 +20,10 @@ export const useModelServingMetrics = (
   lastUpdateTime: number,
   setLastUpdateTime: (time: number) => void,
 ): {
-  data: Record<RuntimeMetricType, ContextResourceData<PrometheusQueryRangeResultValue>>;
+  data: Record<
+    RuntimeMetricType | InferenceMetricType,
+    ContextResourceData<PrometheusQueryRangeResultValue | PrometheusQueryRangeResponseDataResult>
+  >;
   refresh: () => void;
 } => {
   const [end, setEnd] = React.useState(lastUpdateTime);
@@ -88,6 +95,8 @@ export const useModelServingMetrics = (
     runtimeMemoryUtilization,
     inferenceRequestSuccessCount,
     inferenceRequestFailedCount,
+    inferenceTrustyAIDIR,
+    inferenceTrustyAISPD,
   ]);
 
   const refreshAllMetrics = React.useCallback(() => {

--- a/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
+++ b/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
@@ -1,0 +1,48 @@
+import {
+  ActionList,
+  ActionListItem,
+  Alert,
+  Button,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import * as React from 'react';
+
+type DashboardModalFooterProps = {
+  submitLabel: string;
+  onSubmit: () => void;
+  onCancel: () => void;
+  isSubmitDisabled: boolean;
+  alertTitle: string;
+  error?: Error;
+};
+
+const DashboardModalFooter: React.FC<DashboardModalFooterProps> = (
+  { submitLabel, onSubmit, onCancel, isSubmitDisabled, error, alertTitle }, // make sure alert uses the full width
+) => (
+  <Stack hasGutter style={{ flex: 'auto' }}>
+    {error && (
+      <StackItem>
+        <Alert isInline variant="danger" title={alertTitle}>
+          {error.message}
+        </Alert>
+      </StackItem>
+    )}
+    <StackItem>
+      <ActionList>
+        <ActionListItem>
+          <Button key="submit" variant="primary" isDisabled={isSubmitDisabled} onClick={onSubmit}>
+            {submitLabel}
+          </Button>
+        </ActionListItem>
+        <ActionListItem>
+          <Button key="cancel" variant="link" onClick={onCancel}>
+            Cancel
+          </Button>
+        </ActionListItem>
+      </ActionList>
+    </StackItem>
+  </Stack>
+);
+
+export default DashboardModalFooter;

--- a/frontend/src/concepts/explainability/types.ts
+++ b/frontend/src/concepts/explainability/types.ts
@@ -36,7 +36,7 @@ export type ExplainabilityAPI = {
 export type BiasMetricConfig = {
   id: string;
   name: string;
-  metricType: MetricTypes;
+  metricType?: MetricTypes;
   protectedAttribute: string;
   outcomeName: string;
   favorableOutcome: string;

--- a/frontend/src/concepts/explainability/types.ts
+++ b/frontend/src/concepts/explainability/types.ts
@@ -36,7 +36,7 @@ export type ExplainabilityAPI = {
 export type BiasMetricConfig = {
   id: string;
   name: string;
-  metricType?: MetricTypes;
+  metricType: MetricTypes;
   protectedAttribute: string;
   outcomeName: string;
   favorableOutcome: string;

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -18,6 +18,7 @@ const ModelServingRoutes: React.FC = () => {
       <Route path="/" element={<ModelServingContextProvider />}>
         <Route index element={<ModelServingGlobal />} />
         {modelMetricsEnabled && (
+          // TODO: /metrics/:project will lead to an blank page without 404
           <Route path="/metrics/:project" element={<ExplainabilityProvider />}>
             <Route path=":inferenceService" element={<GlobalInferenceMetricsWrapper />}>
               <Route path=":tab?" element={<GlobalInferenceMetricsPage />} />

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -18,8 +18,8 @@ const ModelServingRoutes: React.FC = () => {
       <Route path="/" element={<ModelServingContextProvider />}>
         <Route index element={<ModelServingGlobal />} />
         {modelMetricsEnabled && (
-          // TODO: /metrics/:project will lead to an blank page without 404
           <Route path="/metrics/:project" element={<ExplainabilityProvider />}>
+            <Route index element={<Navigate to=".." />} />
             <Route path=":inferenceService" element={<GlobalInferenceMetricsWrapper />}>
               <Route path=":tab?" element={<GlobalInferenceMetricsPage />} />
               <Route path="configure" element={<BiasConfigurationBreadcrumbPage />} />
@@ -28,6 +28,7 @@ const ModelServingRoutes: React.FC = () => {
             <Route path="*" element={<Navigate to="." />} />
           </Route>
         )}
+        <Route path="*" element={<Navigate to="." />} />
       </Route>
     </ProjectsRoutes>
   );

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationAlertPopover.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationAlertPopover.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Button, Icon, Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { EMPTY_BIAS_CONFIGURATION_DESC, EMPTY_BIAS_CONFIGURATION_TITLE } from './const';
+
+type BiasConfigurationAlertPopoverProps = {
+  onConfigure: () => void;
+};
+
+const BiasConfigurationAlertPopover: React.FC<BiasConfigurationAlertPopoverProps> = ({
+  onConfigure,
+}) => (
+  <Popover
+    aria-label={EMPTY_BIAS_CONFIGURATION_TITLE}
+    alertSeverityVariant="info"
+    headerContent={EMPTY_BIAS_CONFIGURATION_TITLE}
+    headerIcon={<InfoCircleIcon />}
+    bodyContent={EMPTY_BIAS_CONFIGURATION_DESC}
+    footerContent={
+      <Button variant="secondary" isSmall onClick={onConfigure}>
+        Configure
+      </Button>
+    }
+  >
+    <Icon status="info">
+      <InfoCircleIcon />
+    </Icon>
+  </Popover>
+);
+
+export default BiasConfigurationAlertPopover;

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationBreadcrumbPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationBreadcrumbPage.tsx
@@ -18,7 +18,7 @@ const BiasConfigurationBreadcrumbPage: React.FC = () => {
         },
         { label: 'Metric configuration', isActive: true },
       ]}
-      modelDisplayName={modelDisplayName}
+      inferenceService={inferenceService}
     />
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationButton.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationButton.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
+import { InferenceServiceKind } from '~/k8sTypes';
+import ManageBiasConfigurationModal from './biasConfigurationModal/ManageBiasConfigurationModal';
+
+type BiasConfigurationButtonProps = {
+  inferenceService: InferenceServiceKind;
+};
+
+const BiasConfigurationButton: React.FC<BiasConfigurationButtonProps> = ({ inferenceService }) => {
+  const [isOpen, setOpen] = React.useState(false);
+  const { biasMetricConfigs, loaded, refresh } = useExplainabilityModelData();
+
+  React.useEffect(() => {
+    if (loaded && biasMetricConfigs.length === 0) {
+      setOpen(true);
+    }
+  }, [loaded, biasMetricConfigs]);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} variant="secondary">
+        Configure metric
+      </Button>
+      <ManageBiasConfigurationModal
+        isOpen={isOpen}
+        onClose={(submit) => {
+          if (submit) {
+            refresh();
+          }
+          setOpen(false);
+        }}
+        inferenceService={inferenceService}
+      />
+    </>
+  );
+};
+
+export default BiasConfigurationButton;

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationPage.tsx
@@ -4,21 +4,22 @@ import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { BreadcrumbItemType } from '~/types';
 import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
+import { InferenceServiceKind } from '~/k8sTypes';
+import { getInferenceServiceDisplayName } from '~/pages/modelServing/screens/global/utils';
 import { MetricsTabKeys } from './types';
 import BiasConfigurationTable from './BiasConfigurationTable';
 import { getBreadcrumbItemComponents } from './utils';
 
 type BiasConfigurationPageProps = {
   breadcrumbItems: BreadcrumbItemType[];
-  modelDisplayName: string;
+  inferenceService: InferenceServiceKind;
 };
 
 const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
   breadcrumbItems,
-  modelDisplayName,
+  inferenceService,
 }) => {
   const { biasMetricConfigs, loaded } = useExplainabilityModelData();
-  const emptyConfiguration = biasMetricConfigs.length === 0;
   const navigate = useNavigate();
   return (
     <ApplicationsPage
@@ -27,7 +28,9 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
       breadcrumb={<Breadcrumb>{getBreadcrumbItemComponents(breadcrumbItems)}</Breadcrumb>}
       headerAction={
         <Button onClick={() => navigate(`../${MetricsTabKeys.BIAS}`, { relative: 'path' })}>
-          {emptyConfiguration ? `Back to ${modelDisplayName}` : 'View metrics'}
+          {biasMetricConfigs.length === 0
+            ? `Back to ${getInferenceServiceDisplayName(inferenceService)}`
+            : 'View metrics'}
         </Button>
       }
       loaded={loaded}
@@ -35,7 +38,7 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
       // The page is not empty, we will handle the empty state in the table
       empty={false}
     >
-      <BiasConfigurationTable configurations={biasMetricConfigs} />
+      <BiasConfigurationTable inferenceService={inferenceService} />
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTable.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTable.tsx
@@ -28,10 +28,11 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ inferen
       return true;
     }
 
-    // TODO: add more search types
     switch (searchType) {
       case SearchType.NAME:
         return configuration.name.toLowerCase().includes(search.toLowerCase());
+      case SearchType.METRIC:
+        return configuration.metricType.toLowerCase().includes(search.toLocaleLowerCase());
       case SearchType.PROTECTED_ATTRIBUTE:
         return configuration.protectedAttribute.toLowerCase().includes(search.toLowerCase());
       case SearchType.OUTPUT:
@@ -52,6 +53,7 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ inferen
       Object.keys(SearchType).filter(
         (key) =>
           SearchType[key] === SearchType.NAME ||
+          SearchType[key] === SearchType.METRIC ||
           SearchType[key] === SearchType.PROTECTED_ATTRIBUTE ||
           SearchType[key] === SearchType.OUTPUT,
       ),

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTable.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTable.tsx
@@ -3,18 +3,27 @@ import { Button, ToolbarItem } from '@patternfly/react-core';
 import Table from '~/components/table/Table';
 import DashboardSearchField, { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
+import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
+import { InferenceServiceKind } from '~/k8sTypes';
+import DeleteBiasConfigurationModal from '~/pages/modelServing/screens/metrics/biasConfigurationModal/DeleteBiasConfigurationModal';
+import ManageBiasConfigurationModal from './biasConfigurationModal/ManageBiasConfigurationModal';
 import BiasConfigurationTableRow from './BiasConfigurationTableRow';
 import { columns } from './tableData';
 import BiasConfigurationEmptyState from './BiasConfigurationEmptyState';
+import BiasConfigurationButton from './BiasConfigurationButton';
 
 type BiasConfigurationTableProps = {
-  configurations: BiasMetricConfig[];
+  inferenceService: InferenceServiceKind;
 };
 
-const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ configurations }) => {
+const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ inferenceService }) => {
+  const { biasMetricConfigs, refresh } = useExplainabilityModelData();
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
   const [search, setSearch] = React.useState('');
-  const filteredConfigurations = configurations.filter((configuration) => {
+  const [cloneConfiguration, setCloneConfiguration] = React.useState<BiasMetricConfig>();
+  const [deleteConfiguration, setDeleteConfiguration] = React.useState<BiasMetricConfig>();
+
+  const filteredConfigurations = biasMetricConfigs.filter((configuration) => {
     if (!search) {
       return true;
     }
@@ -49,47 +58,75 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ configu
     [],
   );
   return (
-    <Table
-      data={filteredConfigurations}
-      columns={columns}
-      disableRowRenderSupport
-      rowRenderer={(configuration, i) => (
-        <BiasConfigurationTableRow key={configuration.id} obj={configuration} rowIndex={i} />
-      )}
-      emptyTableView={
-        search ? (
+    <>
+      <Table
+        data={filteredConfigurations}
+        columns={columns}
+        defaultSortColumn={1}
+        disableRowRenderSupport
+        rowRenderer={(configuration, i) => (
+          <BiasConfigurationTableRow
+            key={configuration.id}
+            obj={configuration}
+            rowIndex={i}
+            onCloneConfiguration={setCloneConfiguration}
+            onDeleteConfiguration={setDeleteConfiguration}
+          />
+        )}
+        emptyTableView={
+          search ? (
+            <>
+              No metric configurations match your filters.{' '}
+              <Button variant="link" isInline onClick={resetFilters}>
+                Clear filters
+              </Button>
+            </>
+          ) : (
+            <BiasConfigurationEmptyState />
+          )
+        }
+        toolbarContent={
           <>
-            No metric configurations match your filters.{' '}
-            <Button variant="link" isInline onClick={resetFilters}>
-              Clear filters
-            </Button>
+            <ToolbarItem>
+              <DashboardSearchField
+                types={searchTypes}
+                searchType={searchType}
+                searchValue={search}
+                onSearchTypeChange={(searchType) => {
+                  setSearchType(searchType);
+                }}
+                onSearchValueChange={(searchValue) => {
+                  setSearch(searchValue);
+                }}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <BiasConfigurationButton inferenceService={inferenceService} />
+            </ToolbarItem>
           </>
-        ) : (
-          <BiasConfigurationEmptyState />
-        )
-      }
-      toolbarContent={
-        <>
-          <ToolbarItem>
-            <DashboardSearchField
-              types={searchTypes}
-              searchType={searchType}
-              searchValue={search}
-              onSearchTypeChange={(searchType) => {
-                setSearchType(searchType);
-              }}
-              onSearchValueChange={(searchValue) => {
-                setSearch(searchValue);
-              }}
-            />
-          </ToolbarItem>
-          <ToolbarItem>
-            {/* TODO: add configure metric action */}
-            <Button variant="secondary">Configure metric</Button>
-          </ToolbarItem>
-        </>
-      }
-    />
+        }
+      />
+      <ManageBiasConfigurationModal
+        existingConfiguration={cloneConfiguration}
+        isOpen={!!cloneConfiguration}
+        onClose={(submit) => {
+          if (submit) {
+            refresh();
+          }
+          setCloneConfiguration(undefined);
+        }}
+        inferenceService={inferenceService}
+      />
+      <DeleteBiasConfigurationModal
+        configurationToDelete={deleteConfiguration}
+        onClose={(deleted) => {
+          if (deleted) {
+            refresh();
+          }
+          setDeleteConfiguration(undefined);
+        }}
+      />
+    </>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTableRow.tsx
@@ -42,7 +42,6 @@ const BiasConfigurationTableRow: React.FC<BiasConfigurationTableRowProps> = ({
         <Td dataLabel="Output">{obj.outcomeName}</Td>
         <Td dataLabel="Output value">{obj.favorableOutcome}</Td>
         <Td isActionCell>
-          {/* TODO: add actions */}
           <ActionsColumn
             items={[
               {

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTableRow.tsx
@@ -11,9 +11,16 @@ import { BiasMetricConfig } from '~/concepts/explainability/types';
 type BiasConfigurationTableRowProps = {
   obj: BiasMetricConfig;
   rowIndex: number;
+  onCloneConfiguration: (obj: BiasMetricConfig) => void;
+  onDeleteConfiguration: (obj: BiasMetricConfig) => void;
 };
 
-const BiasConfigurationTableRow: React.FC<BiasConfigurationTableRowProps> = ({ obj, rowIndex }) => {
+const BiasConfigurationTableRow: React.FC<BiasConfigurationTableRowProps> = ({
+  obj,
+  rowIndex,
+  onCloneConfiguration,
+  onDeleteConfiguration,
+}) => {
   const [isExpanded, setExpanded] = React.useState(false);
 
   return (
@@ -36,7 +43,22 @@ const BiasConfigurationTableRow: React.FC<BiasConfigurationTableRowProps> = ({ o
         <Td dataLabel="Output value">{obj.favorableOutcome}</Td>
         <Td isActionCell>
           {/* TODO: add actions */}
-          <ActionsColumn items={[]} />
+          <ActionsColumn
+            items={[
+              {
+                title: 'Duplicate',
+                onClick: () => {
+                  onCloneConfiguration(obj);
+                },
+              },
+              {
+                title: 'Delete',
+                onClick: () => {
+                  onDeleteConfiguration(obj);
+                },
+              },
+            ]}
+          />
         </Td>
       </Tr>
       <Tr isExpanded={isExpanded}>

--- a/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
@@ -1,25 +1,38 @@
 import React from 'react';
 import { PageSection, Stack, StackItem } from '@patternfly/react-core';
-import DIRGraph from '~/pages/modelServing/screens/metrics/DIRChart';
+import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
+import DIRGraph from './DIRChart';
 import MetricsPageToolbar from './MetricsPageToolbar';
 import SPDChart from './SPDChart';
+import EmptyBiasConfigurationCard from './EmptyBiasConfigurationCard';
 
-const BiasTab = () => (
-  <Stack>
-    <StackItem>
-      <MetricsPageToolbar />
-    </StackItem>
-    <PageSection isFilled>
-      <Stack hasGutter>
-        <StackItem>
-          <SPDChart />
-        </StackItem>
-        <StackItem>
-          <DIRGraph />
-        </StackItem>
-      </Stack>
-    </PageSection>
-  </Stack>
-);
+const BiasTab = () => {
+  const { biasMetricConfigs } = useExplainabilityModelData();
+  return (
+    <Stack>
+      <StackItem>
+        <MetricsPageToolbar />
+      </StackItem>
+      <PageSection isFilled>
+        <Stack hasGutter>
+          {biasMetricConfigs.length === 0 ? (
+            <StackItem>
+              <EmptyBiasConfigurationCard />
+            </StackItem>
+          ) : (
+            <>
+              <StackItem>
+                <SPDChart />
+              </StackItem>
+              <StackItem>
+                <DIRGraph />
+              </StackItem>
+            </>
+          )}
+        </Stack>
+      </PageSection>
+    </Stack>
+  );
+};
 
 export default BiasTab;

--- a/frontend/src/pages/modelServing/screens/metrics/EmptyBiasConfigurationCard.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/EmptyBiasConfigurationCard.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  Button,
+  Card,
+  CardBody,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Title,
+} from '@patternfly/react-core';
+import { WrenchIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+import { EMPTY_BIAS_CONFIGURATION_DESC, EMPTY_BIAS_CONFIGURATION_TITLE } from './const';
+
+const EmptyBiasConfigurationCard: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <Card>
+      <CardBody>
+        <EmptyState>
+          <EmptyStateIcon icon={WrenchIcon} />
+          <Title headingLevel="h2" size="lg">
+            {EMPTY_BIAS_CONFIGURATION_TITLE}
+          </Title>
+          <EmptyStateBody>{EMPTY_BIAS_CONFIGURATION_DESC}</EmptyStateBody>
+          <Button
+            onClick={() => {
+              navigate('../configure', { relative: 'path' });
+            }}
+          >
+            Configure
+          </Button>
+        </EmptyState>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default EmptyBiasConfigurationCard;

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
-import { Breadcrumb } from '@patternfly/react-core';
+import { Breadcrumb, Button } from '@patternfly/react-core';
+import { useNavigate, useParams } from 'react-router-dom';
+import { CogIcon } from '@patternfly/react-icons';
 import { BreadcrumbItemType } from '~/types';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import MetricsPageTabs from '~/pages/modelServing/screens/metrics/MetricsPageTabs';
+import { MetricsTabKeys } from '~/pages/modelServing/screens/metrics/types';
 import { getBreadcrumbItemComponents } from './utils';
 
 type MetricsPageProps = {
@@ -10,16 +13,32 @@ type MetricsPageProps = {
   breadcrumbItems: BreadcrumbItemType[];
 };
 
-const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems }) => (
-  <ApplicationsPage
-    title={title}
-    breadcrumb={<Breadcrumb>{getBreadcrumbItemComponents(breadcrumbItems)}</Breadcrumb>}
-    loaded
-    description={null}
-    empty={false}
-  >
-    <MetricsPageTabs />
-  </ApplicationsPage>
-);
+const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems }) => {
+  const { tab } = useParams();
+  const navigate = useNavigate();
+  return (
+    <ApplicationsPage
+      title={title}
+      breadcrumb={<Breadcrumb>{getBreadcrumbItemComponents(breadcrumbItems)}</Breadcrumb>}
+      // TODO: decide whether we need to set the loaded based on the feature flag and explainability loaded
+      loaded
+      description={null}
+      empty={false}
+      headerAction={
+        tab === MetricsTabKeys.BIAS && (
+          <Button
+            variant="link"
+            icon={<CogIcon />}
+            onClick={() => navigate('../configure', { replace: true })}
+          >
+            Configure
+          </Button>
+        )
+      }
+    >
+      <MetricsPageTabs />
+    </ApplicationsPage>
+  );
+};
 
 export default MetricsPage;

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText, TabAction } from '@patternfly/react-core';
 import { MetricsTabKeys } from '~/pages/modelServing/screens/metrics/types';
+import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
 import PerformanceTab from './PerformanceTab';
 import BiasTab from './BiasTab';
+import BiasConfigurationAlertPopover from './BiasConfigurationAlertPopover';
+
 import './MetricsPageTabs.scss';
 
 const MetricsPageTabs: React.FC = () => {
   const DEFAULT_TAB = MetricsTabKeys.PERFORMANCE;
+  const { biasMetricConfigs, loaded } = useExplainabilityModelData();
 
-  const { tab } = useParams();
+  const { tab } = useParams<{ tab: MetricsTabKeys }>();
   const navigate = useNavigate();
 
   React.useEffect(() => {
     if (!tab) {
       navigate(`./${DEFAULT_TAB}`, { replace: true });
+    } else if (!Object.values(MetricsTabKeys).includes(tab)) {
+      navigate(`../${DEFAULT_TAB}`, { replace: true });
     }
   }, [DEFAULT_TAB, navigate, tab]);
 
@@ -44,6 +50,18 @@ const MetricsPageTabs: React.FC = () => {
         title={<TabTitleText>Bias</TabTitleText>}
         aria-label="Bias tab"
         className="odh-tabcontent-fix"
+        actions={
+          loaded &&
+          biasMetricConfigs.length === 0 && (
+            <TabAction>
+              <BiasConfigurationAlertPopover
+                onConfigure={() => {
+                  navigate('../configure', { relative: 'path' });
+                }}
+              />
+            </TabAction>
+          )
+        }
       >
         <BiasTab />
       </Tab>

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/DeleteBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/DeleteBiasConfigurationModal.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { MetricTypes } from '~/api';
+import { ExplainabilityContext } from '~/concepts/explainability/ExplainabilityContext';
+import { BiasMetricConfig } from '~/concepts/explainability/types';
+import DeleteModal from '~/pages/projects/components/DeleteModal';
+
+type DeleteBiasConfigurationModalProps = {
+  configurationToDelete?: BiasMetricConfig;
+  onClose: (deleted: boolean) => void;
+};
+
+const DeleteBiasConfigurationModal: React.FC<DeleteBiasConfigurationModalProps> = ({
+  onClose,
+  configurationToDelete,
+}) => {
+  const [isDeleting, setDeleting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+  const {
+    apiState: { api },
+  } = React.useContext(ExplainabilityContext);
+
+  const onBeforeClose = (deleted: boolean) => {
+    onClose(deleted);
+    setDeleting(false);
+    setError(undefined);
+  };
+
+  const displayName = configurationToDelete ? configurationToDelete.name : 'this bias metric';
+  return (
+    <DeleteModal
+      title="Delete bias metric?"
+      isOpen={!!configurationToDelete}
+      onClose={() => onBeforeClose(false)}
+      submitButtonLabel="Delete bias metric"
+      onDelete={() => {
+        if (configurationToDelete) {
+          setDeleting(true);
+          const deleteFunc =
+            configurationToDelete.metricType === MetricTypes.DIR
+              ? api.deleteDirRequest
+              : api.deleteSpdRequest;
+          deleteFunc({}, configurationToDelete.id)
+            .then(() => onBeforeClose(true))
+            .catch((e) => {
+              setError(e);
+              setDeleting(false);
+            });
+        }
+      }}
+      deleting={isDeleting}
+      error={error}
+      deleteName={displayName}
+    >
+      This action cannot be undone.
+    </DeleteModal>
+  );
+};
+
+export default DeleteBiasConfigurationModal;

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -67,7 +67,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           onCancel={() => onBeforeClose(false)}
           onSubmit={onCreateConfiguration}
           submitLabel="Configure"
-          alertTitle="Error configure bias metric"
+          alertTitle="Failed to configure bias metric"
           isSubmitDisabled={
             !checkConfigurationFieldsValid(configuration, metricType) || actionInProgress
           }

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { Form, FormGroup, Modal, TextInput, Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import { BiasMetricConfig } from '~/concepts/explainability/types';
+import { checkConfigurationFieldsValid } from '~/pages/modelServing/screens/metrics/utils';
+import { MetricTypes } from '~/api';
+import { InferenceServiceKind } from '~/k8sTypes';
+import { ExplainabilityContext } from '~/concepts/explainability/ExplainabilityContext';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import useBiasConfigurationObject from './useBiasConfigurationObject';
+import MetricTypeField from './MetricTypeField';
+
+type ManageBiasConfigurationModalProps = {
+  existingConfiguration?: BiasMetricConfig;
+  isOpen: boolean;
+  onClose: (submit: boolean) => void;
+  inferenceService: InferenceServiceKind;
+};
+
+const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> = ({
+  existingConfiguration,
+  isOpen,
+  onClose,
+  inferenceService,
+}) => {
+  const {
+    apiState: { api },
+  } = React.useContext(ExplainabilityContext);
+  const [configuration, setConfiguration] = useBiasConfigurationObject(
+    inferenceService.metadata.name,
+    existingConfiguration,
+  );
+  const [actionInProgress, setActionInProgress] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+  const [metricType, setMetricType] = React.useState<MetricTypes>();
+
+  React.useEffect(() => {
+    setMetricType(existingConfiguration?.metricType);
+  }, [existingConfiguration]);
+
+  const onBeforeClose = (submitted: boolean) => {
+    onClose(submitted);
+    setError(undefined);
+    setActionInProgress(false);
+  };
+
+  const onCreateConfiguration = () => {
+    const createFunc = metricType === MetricTypes.SPD ? api.createSpdRequest : api.createDirRequest;
+    setActionInProgress(true);
+    createFunc({}, configuration)
+      .then(() => onBeforeClose(true))
+      .catch((e) => {
+        setError(e);
+        setActionInProgress(false);
+      });
+  };
+
+  return (
+    <Modal
+      variant="medium"
+      title="Configure bias metric"
+      isOpen={isOpen}
+      onClose={() => onBeforeClose(false)}
+      footer={
+        <DashboardModalFooter
+          error={error}
+          onCancel={() => onBeforeClose(false)}
+          onSubmit={onCreateConfiguration}
+          submitLabel="Configure"
+          alertTitle="Error configure bias metric"
+          isSubmitDisabled={
+            !checkConfigurationFieldsValid(configuration, metricType) || actionInProgress
+          }
+        />
+      }
+      description="All fields are required."
+    >
+      <Form>
+        <FormGroup
+          label="Metric name"
+          fieldId="metric-name"
+          helperText="This is the name that will be used to select the metric for monitoring."
+        >
+          <TextInput
+            id="metric-name"
+            value={configuration.requestName}
+            onChange={(value) => setConfiguration('requestName', value)}
+          />
+        </FormGroup>
+        <MetricTypeField fieldId="metric-type" value={metricType} setValue={setMetricType} />
+        <FormGroup label="Protected attribute" fieldId="protected-attribute">
+          <TextInput
+            id="protected-attribute"
+            value={configuration.protectedAttribute}
+            onChange={(value) => setConfiguration('protectedAttribute', value)}
+          />
+        </FormGroup>
+        <FormGroup label="Privileged value" fieldId="privileged-value">
+          <TextInput
+            id="privileged-value"
+            value={configuration.privilegedAttribute}
+            onChange={(value) => setConfiguration('privilegedAttribute', value)}
+          />
+        </FormGroup>
+        <FormGroup label="Unprivileged value" fieldId="unprivileged-value">
+          <TextInput
+            id="unprivileged-value"
+            value={configuration.unprivilegedAttribute}
+            onChange={(value) => setConfiguration('unprivilegedAttribute', value)}
+          />
+        </FormGroup>
+        <FormGroup label="Output" fieldId="output">
+          <TextInput
+            id="output"
+            value={configuration.outcomeName}
+            onChange={(value) => setConfiguration('outcomeName', value)}
+          />
+        </FormGroup>
+        <FormGroup label="Output value" fieldId="output-value">
+          <TextInput
+            id="output-value"
+            value={configuration.favorableOutcome}
+            onChange={(value) => setConfiguration('favorableOutcome', value)}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Violation threshold"
+          fieldId="violation-threshold"
+          labelIcon={
+            <Tooltip content="TBD">
+              <HelpIcon />
+            </Tooltip>
+          }
+        >
+          <TextInput
+            id="violation-threshold"
+            value={configuration.thresholdDelta}
+            type="number"
+            onChange={(value) => setConfiguration('thresholdDelta', Number(value))}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Metric batch size"
+          fieldId="metric-batch-size"
+          labelIcon={
+            <Tooltip content="TBD">
+              <HelpIcon />
+            </Tooltip>
+          }
+        >
+          <TextInput
+            id="metric-batch-size"
+            value={configuration.batchSize}
+            type="number"
+            onChange={(value) => setConfiguration('batchSize', Number(value))}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default ManageBiasConfigurationModal;

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/MetricTypeField.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/MetricTypeField.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { FormGroup, Select, SelectOption, Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import { METRIC_TYPE_DISPLAY_NAME } from '~/pages/modelServing/screens/metrics/const';
+import { MetricTypes } from '~/api';
+import { isMetricType } from '~/pages/modelServing/screens/metrics/utils';
+
+type MetricTypeFieldProps = {
+  fieldId: string;
+  value?: MetricTypes;
+  setValue: (value: MetricTypes) => void;
+};
+
+const MetricTypeField: React.FC<MetricTypeFieldProps> = ({ fieldId, value, setValue }) => {
+  const [isOpen, setOpen] = React.useState(false);
+  return (
+    // TODO: decide what to show in the helper tooltip
+    <FormGroup
+      label="Metric type"
+      fieldId={fieldId}
+      labelIcon={
+        <Tooltip content="TBD">
+          <HelpIcon />
+        </Tooltip>
+      }
+    >
+      <Select
+        removeFindDomNode
+        id={fieldId}
+        isOpen={isOpen}
+        placeholderText="Select"
+        onToggle={(open) => setOpen(open)}
+        onSelect={(_, option) => {
+          if (isMetricType(option)) {
+            setValue(option);
+            setOpen(false);
+          }
+        }}
+        selections={value}
+        menuAppendTo="parent"
+      >
+        {Object.keys(MetricTypes).map((type) => (
+          <SelectOption key={type} value={type}>
+            {METRIC_TYPE_DISPLAY_NAME[type]}
+          </SelectOption>
+        ))}
+      </Select>
+    </FormGroup>
+  );
+};
+
+export default MetricTypeField;

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/useBiasConfigurationObject.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/useBiasConfigurationObject.ts
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
+import { BiasMetricConfig } from '~/concepts/explainability/types';
+import { BaseMetricRequest } from '~/api';
+
+const useBiasConfigurationObject = (
+  modelId: string,
+  existingData?: BiasMetricConfig,
+): [
+  data: BaseMetricRequest,
+  setData: UpdateObjectAtPropAndValue<BaseMetricRequest>,
+  resetDefaults: () => void,
+] => {
+  const createConfiguration = useGenericObjectState<BaseMetricRequest>({
+    modelId: modelId,
+    requestName: '',
+    protectedAttribute: '',
+    privilegedAttribute: '',
+    unprivilegedAttribute: '',
+    outcomeName: '',
+    favorableOutcome: '',
+    thresholdDelta: 0.1,
+    batchSize: 5000,
+  });
+
+  const [, setCreateData] = createConfiguration;
+
+  const existingModelId = existingData?.modelId ?? modelId;
+  const existingName = existingData?.name ?? '';
+  const existingProtectedAttribute = existingData?.protectedAttribute ?? '';
+  const existingPrivilegedAttribute = existingData?.privilegedAttribute ?? '';
+  const existingUnprivilegedAttribute = existingData?.unprivilegedAttribute ?? '';
+  const existingOutcomeName = existingData?.outcomeName ?? '';
+  const existingFavorableOutcome = existingData?.favorableOutcome ?? '';
+  const existingThresholdDelta = existingData?.thresholdDelta ?? 0.1;
+  const existingBatchSize = existingData?.batchSize ?? 5000;
+
+  React.useEffect(() => {
+    if (existingData) {
+      setCreateData('modelId', existingModelId);
+      setCreateData('requestName', '');
+      setCreateData('protectedAttribute', existingProtectedAttribute);
+      setCreateData('privilegedAttribute', existingPrivilegedAttribute);
+      setCreateData('unprivilegedAttribute', existingUnprivilegedAttribute);
+      setCreateData('outcomeName', existingOutcomeName);
+      setCreateData('favorableOutcome', existingFavorableOutcome);
+      setCreateData('thresholdDelta', existingThresholdDelta);
+      setCreateData('batchSize', existingBatchSize);
+    }
+  }, [
+    setCreateData,
+    existingData,
+    existingModelId,
+    existingName,
+    existingProtectedAttribute,
+    existingPrivilegedAttribute,
+    existingUnprivilegedAttribute,
+    existingOutcomeName,
+    existingFavorableOutcome,
+    existingThresholdDelta,
+    existingBatchSize,
+  ]);
+
+  return createConfiguration;
+};
+
+export default useBiasConfigurationObject;

--- a/frontend/src/pages/modelServing/screens/metrics/const.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/const.ts
@@ -1,0 +1,10 @@
+import { MetricTypes } from '~/api';
+
+export const EMPTY_BIAS_CONFIGURATION_TITLE = 'Bias metrics not configured';
+export const EMPTY_BIAS_CONFIGURATION_DESC =
+  'Bias metrics for this model have not been configured. To monitor model bias, you must first configure metrics.';
+
+export const METRIC_TYPE_DISPLAY_NAME = {
+  [MetricTypes.DIR]: 'Disparate impact ratio (DIR)',
+  [MetricTypes.SPD]: 'Statistical parity difference (SPD)',
+};

--- a/frontend/src/pages/modelServing/screens/metrics/tableData.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/tableData.tsx
@@ -1,7 +1,6 @@
 import { SortableData } from '~/components/table/useTableColumnSort';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
 
-// TODO: add sortable
 export const columns: SortableData<BiasMetricConfig>[] = [
   {
     field: 'expand',

--- a/frontend/src/pages/modelServing/screens/projects/ProjectInferenceMetricsConfigurationPage.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectInferenceMetricsConfigurationPage.tsx
@@ -8,7 +8,6 @@ import { ProjectInferenceMetricsOutletContextProps } from './ProjectInferenceMet
 const ProjectInferenceMetricsConfigurationPage: React.FC = () => {
   const { currentProject, inferenceService } =
     useOutletContext<ProjectInferenceMetricsOutletContextProps>();
-  const modelDisplayName = getInferenceServiceDisplayName(inferenceService);
   return (
     <BiasConfigurationPage
       breadcrumbItems={[
@@ -18,12 +17,12 @@ const ProjectInferenceMetricsConfigurationPage: React.FC = () => {
           link: `/projects/${currentProject.metadata.name}`,
         },
         {
-          label: modelDisplayName,
+          label: getInferenceServiceDisplayName(inferenceService),
           link: `/projects/${currentProject.metadata.name}/metrics/model/${inferenceService.metadata.name}`,
         },
         { label: 'Metric configuration', isActive: true },
       ]}
-      modelDisplayName={modelDisplayName}
+      inferenceService={inferenceService}
     />
   );
 };

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -31,10 +31,12 @@ const ProjectViewRoutes: React.FC = () => {
         {modelMetricsEnabled && (
           <>
             <Route path="metrics/model" element={<ExplainabilityProvider />}>
+              <Route index element={<Navigate to=".." />} />
               <Route path=":inferenceService" element={<ProjectInferenceMetricsWrapper />}>
                 <Route path=":tab?" element={<ProjectInferenceMetricsPage />} />
                 <Route path="configure" element={<ProjectInferenceMetricsConfigurationPage />} />
               </Route>
+              <Route path="*" element={<Navigate to="." />} />
             </Route>
             <Route path="metrics/runtime" element={<ProjectRuntimeMetricsWrapper />} />
           </>


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1274 #1162 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Added a modal that allows you to configure the bias metrics. However, this won't work until https://github.com/trustyai-explainability/trustyai-explainability/pull/186 is merged.

<img width="1790" alt="Screenshot 2023-06-06 at 5 01 30 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/3e1fd0e8-3344-41bd-8f64-85d2f8c91d4e">

2. Added `Duplicate` and `Delete` for modal metric configuration rows

<img width="1790" alt="Screenshot 2023-06-06 at 5 04 38 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/bae72e4a-f4f5-4d9c-bb61-dc93ec1e9b8b">

3. Added popover on the tab when there is no bias metric configured

<img width="1790" alt="Screenshot 2023-06-06 at 5 05 59 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/286fdef6-5b5f-49aa-a25c-c6b7cbcb279e">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to model -> go to bias tab -> click configure button on the page title -> get into the configuration page -> try to create (not working for now) and delete the configuration

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
TBD

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
