### PR TITLE
Fix serving runtime validation

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -878,7 +878,7 @@ export type ServingRuntime = K8sResourceCommon & {
     namespace: string;
   };
   spec: {
-    builtInAdapter: {
+    builtInAdapter?: {
       serverType: string;
       runtimeManagementPort: number;
       memBufferBytes?: number;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -304,7 +304,7 @@ export type ServingRuntimeKind = K8sResourceCommon & {
     namespace: string;
   };
   spec: {
-    builtInAdapter: {
+    builtInAdapter?: {
       serverType: string;
       runtimeManagementPort: number;
       memBufferBytes?: number;

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -23,7 +23,6 @@ export const getServingRuntimeNameFromTemplate = (template: TemplateKind) =>
 
 export const isServingRuntimeKind = (obj: K8sResourceCommon): obj is ServingRuntimeKind =>
   obj.kind === 'ServingRuntime' &&
-  obj.spec?.builtInAdapter !== undefined &&
   obj.spec?.containers !== undefined &&
   obj.spec?.supportedModelFormats !== undefined;
 

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -118,7 +118,11 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
     setActionInProgress(true);
 
     if (!servingRuntimeSelected) {
-      setErrorModal(new Error('Error retrieving Serving Runtime'));
+      setErrorModal(
+        new Error(
+          'Error, the Serving Runtime selected might be malformed or could not have been retrieved.',
+        ),
+      );
       return;
     }
     const servingRuntimeData = {


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes #1352 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a Custom Serving Runtime without builtInAdapter
2. Deploy a model server with that serving runtime

```
apiVersion: serving.kserve.io/v1alpha1
kind: ServingRuntime
metadata:
  annotations:
    name: ovms-no-builtin
    opendatahub.io/disable-gpu: "true"
    openshift.io/display-name: OpenVINO Model Server No builtinAdapter
  labels:
    opendatahub.io/dashboard: "true"
  name: ovms
spec:
  containers:
    - args:
        - --port=8001
        - --rest_port=8888
        - --config_path=/models/model_config_list.json
        - --file_system_poll_wait_seconds=0
        - --grpc_bind_address=127.0.0.1
        - --rest_bind_address=127.0.0.1
      image: quay.io/opendatahub/openvino_model_server@sha256:20dbfbaf53d1afbd47c612d953984238cb0e207972ed544a5ea662c2404f276d
      name: ovms
      resources:
        limits:
          cpu: "0"
          memory: 0Gi
        requests:
          cpu: "0"
          memory: 0Gi
  grpcDataEndpoint: port:8001
  grpcEndpoint: port:8085
  multiModel: true
  protocolVersions:
    - grpc-v1
  replicas: 1
  supportedModelFormats:
    - autoSelect: true
      name: openvino_ir
      version: opset1
    - autoSelect: true
      name: onnx
      version: "1"
    - autoSelect: true
      name: tensorflow
      version: "2"
```

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
This will be added in the testing efforts of Custom Serving runtime

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
