### PR TITLE
Default and restrict threshold, add tooltips, default duplicate name and set feature flag

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -29,6 +29,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableCustomServingRuntimes: boolean;
       modelMetricsNamespace: string;
       disablePipelines: boolean;
+      disableBiasMetrics: boolean;
     };
     groupsConfig?: {
       adminGroups: string;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -53,6 +53,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableCustomServingRuntimes: false,
       modelMetricsNamespace: '',
       disablePipelines: true,
+      disableBiasMetrics: false,
     },
     notebookController: {
       enabled: true,

--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -23,6 +23,7 @@ The following are a list of features that are supported, along with there defaul
 | disableProjectSharing        | false   | Disables Project Sharing from Data Science Projects.                                                 |
 | disableCustomServingRuntimes | false   | Disables Custom Serving Runtimes from the Admin Panel.                                               |
 | modelMetricsNamespace        | false   | Enables the namespace in which the Model Serving Metrics' Prometheus Operator is installed.          |
+| disableBiasMetrics          | false   | Disables Model Bias from Model Serving metrics.                                                      |
 
 ## Defaults
 
@@ -46,6 +47,7 @@ spec:
     disableProjectSharing: false
     disableCustomServingRuntimes: false
     modelMetricsNamespace: ''
+    disableBiasMetrics: false
 ```
 
 ## Additional fields
@@ -136,6 +138,7 @@ spec:
     disableProjectSharing: true
     disableCustomServingRuntimes: false
     modelMetricsNamespace: ''
+    disableBiasMetrics: false
   notebookController:
     enabled: true
   notebookSizes:

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -54,6 +54,7 @@ export const mockDashboardConfig = ({
       modelMetricsNamespace: 'test-project',
       disablePipelines: false,
       disableProjectSharing: false,
+      disableBiasMetrics: false,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -13,6 +13,7 @@ import {
   RefreshIntervalTitle,
   TimeframeTitle,
 } from '~/pages/modelServing/screens/types';
+import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
 import useQueryRangeResourceData, {
   useQueryRangeResourceDataTrusty,
 } from './useQueryRangeResourceData';
@@ -32,6 +33,7 @@ export const useModelServingMetrics = (
   refresh: () => void;
 } => {
   const [end, setEnd] = React.useState(lastUpdateTime);
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
 
   const runtimeRequestCount = useQueryRangeResourceData(
     type === 'runtime',
@@ -82,7 +84,7 @@ export const useModelServingMetrics = (
   );
 
   const inferenceTrustyAISPD = useQueryRangeResourceDataTrusty(
-    type === 'inference',
+    biasMetricsEnabled && type === 'inference',
     queries[InferenceMetricType.TRUSTY_AI_SPD],
     end,
     timeframe,
@@ -90,7 +92,7 @@ export const useModelServingMetrics = (
   );
 
   const inferenceTrustyAIDIR = useQueryRangeResourceDataTrusty(
-    type === 'inference',
+    biasMetricsEnabled && type === 'inference',
     queries[InferenceMetricType.TRUSTY_AI_DIR],
     end,
     timeframe,

--- a/frontend/src/api/prometheus/usePrometheusQueryRange.ts
+++ b/frontend/src/api/prometheus/usePrometheusQueryRange.ts
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import axios from 'axios';
 
-import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+import useFetchState, {
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '~/utilities/useFetchState';
 import {
   PrometheusQueryRangeResponse,
   PrometheusQueryRangeResponseData,
@@ -25,13 +29,17 @@ const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
     const endInS = endInMs / 1000;
     const start = endInS - span;
 
+    if (!active) {
+      return Promise.reject(new NotReadyError('Prometheus query is not active'));
+    }
+
     return axios
       .post<{ response: PrometheusQueryRangeResponse }>(apiPath, {
         query: `query=${queryLang}&start=${start}&end=${endInS}&step=${step}`,
       })
 
       .then((response) => responsePredicate(response.data?.response.data));
-  }, [endInMs, span, apiPath, queryLang, step, responsePredicate]);
+  }, [endInMs, span, apiPath, queryLang, step, responsePredicate, active]);
 
   return useFetchState<T[]>(fetchData, []);
 };

--- a/frontend/src/concepts/dashboard/DashboardEmptyTableView.tsx
+++ b/frontend/src/concepts/dashboard/DashboardEmptyTableView.tsx
@@ -10,11 +10,11 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
-type EmptyTableViewProps = {
+type DashboardEmptyTableViewProps = {
   onClearFilters: () => void;
 };
 
-const EmptyTableView: React.FC<EmptyTableViewProps> = ({ onClearFilters }) => (
+const DashboardEmptyTableView: React.FC<DashboardEmptyTableViewProps> = ({ onClearFilters }) => (
   <Bullseye>
     <EmptyState>
       <EmptyStateIcon icon={SearchIcon} />
@@ -33,4 +33,4 @@ const EmptyTableView: React.FC<EmptyTableViewProps> = ({ onClearFilters }) => (
   </Bullseye>
 );
 
-export default EmptyTableView;
+export default DashboardEmptyTableView;

--- a/frontend/src/concepts/dashboard/DashboardHelpTooltip.tsx
+++ b/frontend/src/concepts/dashboard/DashboardHelpTooltip.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
+type DashboardHelpTooltipProps = {
+  content: string;
+};
+
+const DashboardHelpTooltip: React.FC<DashboardHelpTooltipProps> = ({ content }) => (
+  <Tooltip removeFindDomNode content={content}>
+    <HelpIcon />
+  </Tooltip>
+);
+
+export default DashboardHelpTooltip;

--- a/frontend/src/concepts/explainability/ExplainabilityContext.tsx
+++ b/frontend/src/concepts/explainability/ExplainabilityContext.tsx
@@ -114,14 +114,14 @@ const useFetchContextData = (apiState: TrustyAPIState): ExplainabilityContextDat
 };
 
 const useFetchBiasMetricConfigs = (apiState: TrustyAPIState): FetchState<BiasMetricConfig[]> => {
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
   const callback = React.useCallback<FetchStateCallbackPromise<BiasMetricConfig[]>>(
     (opts) => {
-      if (!apiState.apiAvailable) {
-        return Promise.reject(new NotReadyError('API not yet available'));
-      }
       if (!biasMetricsEnabled) {
         return Promise.reject(new NotReadyError('Bias metrics is not enabled'));
+      }
+      if (!apiState.apiAvailable) {
+        return Promise.reject(new NotReadyError('API not yet available'));
       }
       return apiState.api
         .listRequests(opts)

--- a/frontend/src/concepts/explainability/ExplainabilityContext.tsx
+++ b/frontend/src/concepts/explainability/ExplainabilityContext.tsx
@@ -11,6 +11,7 @@ import useFetchState, {
   FetchStateCallbackPromise,
   NotReadyError,
 } from '~/utilities/useFetchState';
+import useBiasMetricsEnabled from './useBiasMetricsEnabled';
 
 // TODO create component for ensuring API availability, see pipelines for example.
 
@@ -113,10 +114,14 @@ const useFetchContextData = (apiState: TrustyAPIState): ExplainabilityContextDat
 };
 
 const useFetchBiasMetricConfigs = (apiState: TrustyAPIState): FetchState<BiasMetricConfig[]> => {
+  const biasMetricsEnabled = useBiasMetricsEnabled();
   const callback = React.useCallback<FetchStateCallbackPromise<BiasMetricConfig[]>>(
     (opts) => {
       if (!apiState.apiAvailable) {
         return Promise.reject(new NotReadyError('API not yet available'));
+      }
+      if (!biasMetricsEnabled) {
+        return Promise.reject(new NotReadyError('Bias metrics is not enabled'));
       }
       return apiState.api
         .listRequests(opts)
@@ -125,7 +130,7 @@ const useFetchBiasMetricConfigs = (apiState: TrustyAPIState): FetchState<BiasMet
           throw e;
         });
     },
-    [apiState.api, apiState.apiAvailable],
+    [apiState.api, apiState.apiAvailable, biasMetricsEnabled],
   );
 
   return useFetchState(callback, [], { initialPromisePurity: true });

--- a/frontend/src/concepts/explainability/useBiasMetricsEnabled.ts
+++ b/frontend/src/concepts/explainability/useBiasMetricsEnabled.ts
@@ -10,7 +10,7 @@ const useBiasMetricsEnabled = () => {
     },
   } = useAppContext();
 
-  return featureFlagEnabled(disableBiasMetrics);
+  return [featureFlagEnabled(disableBiasMetrics)];
 };
 
 export default useBiasMetricsEnabled;

--- a/frontend/src/concepts/explainability/useBiasMetricsEnabled.ts
+++ b/frontend/src/concepts/explainability/useBiasMetricsEnabled.ts
@@ -1,0 +1,16 @@
+import { useAppContext } from '~/app/AppContext';
+import { featureFlagEnabled } from '~/utilities/utils';
+
+const useBiasMetricsEnabled = () => {
+  const {
+    dashboardConfig: {
+      spec: {
+        dashboardConfig: { disableBiasMetrics },
+      },
+    },
+  } = useAppContext();
+
+  return featureFlagEnabled(disableBiasMetrics);
+};
+
+export default useBiasMetricsEnabled;

--- a/frontend/src/concepts/explainability/useTrustyAPIRoute.ts
+++ b/frontend/src/concepts/explainability/useTrustyAPIRoute.ts
@@ -11,16 +11,16 @@ import useBiasMetricsEnabled from './useBiasMetricsEnabled';
 
 type State = string | null;
 const useTrustyAPIRoute = (hasCR: boolean, namespace: string): FetchState<State> => {
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
     (opts) => {
+      if (!biasMetricsEnabled) {
+        return Promise.reject(new NotReadyError('Bias metrics is not enabled'));
+      }
       if (!hasCR) {
         return Promise.reject(new NotReadyError('CR not created'));
       }
 
-      if (!biasMetricsEnabled) {
-        return Promise.reject(new NotReadyError('Bias metrics is not enabled'));
-      }
       //TODO: API URI must use HTTPS before release.
       return getTrustyAIAPIRoute(namespace, opts)
         .then((result: RouteKind) => `${result.spec.port.targetPort}://${result.spec.host}`)

--- a/frontend/src/concepts/explainability/useTrustyAiNamespaceCR.ts
+++ b/frontend/src/concepts/explainability/useTrustyAiNamespaceCR.ts
@@ -1,13 +1,24 @@
 import React from 'react';
-import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+import useFetchState, {
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '~/utilities/useFetchState';
 import { TrustyAiKind } from '~/k8sTypes';
+import useBiasMetricsEnabled from './useBiasMetricsEnabled';
 
 type State = TrustyAiKind | null;
 const useTrustyAiNamespaceCR = (namespace: string): FetchState<State> => {
+  const biasMetricsEnabled = useBiasMetricsEnabled();
   // TODO: the logic needs to be fleshed out once the TrustyAI operator is complete.
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
-    (opts) => (namespace && opts ? Promise.resolve(null) : Promise.reject()),
-    [namespace],
+    (opts) => {
+      if (!biasMetricsEnabled) {
+        return Promise.reject(new NotReadyError('Bias metrics is not enabled'));
+      }
+      return namespace && opts ? Promise.resolve(null) : Promise.reject();
+    },
+    [namespace, biasMetricsEnabled],
   );
 
   const state = useFetchState<State>(callback, null, {

--- a/frontend/src/concepts/explainability/useTrustyAiNamespaceCR.ts
+++ b/frontend/src/concepts/explainability/useTrustyAiNamespaceCR.ts
@@ -9,7 +9,7 @@ import useBiasMetricsEnabled from './useBiasMetricsEnabled';
 
 type State = TrustyAiKind | null;
 const useTrustyAiNamespaceCR = (namespace: string): FetchState<State> => {
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
   // TODO: the logic needs to be fleshed out once the TrustyAI operator is complete.
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
     (opts) => {

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -5,7 +5,7 @@ import { PipelineCoreResourceKF, PipelineRunKF } from '~/concepts/pipelines/kfTy
 import { pipelineRunColumns } from '~/concepts/pipelines/content/tables/columns';
 import PipelineRunTableRow from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow';
 import useCheckboxTable from '~/components/table/useCheckboxTable';
-import EmptyTableView from '~/concepts/pipelines/content/tables/EmptyTableView';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import usePipelineRunFilter from '~/concepts/pipelines/content/tables/pipelineRun/usePipelineRunFilter';
 import PipelineRunTableToolbar from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar';
 import DeletePipelineCoreResourceModal from '~/concepts/pipelines/content/DeletePipelineCoreResourceModal';
@@ -32,7 +32,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({ runs }) => {
         data={filteredRuns}
         columns={pipelineRunColumns}
         enablePagination
-        emptyTableView={<EmptyTableView onClearFilters={toolbarProps.onClearFilters} />}
+        emptyTableView={<DashboardEmptyTableView onClearFilters={toolbarProps.onClearFilters} />}
         toolbarContent={
           <PipelineRunTableToolbar
             {...toolbarProps}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
@@ -7,7 +7,7 @@ import useCheckboxTable from '~/components/table/useCheckboxTable';
 import PipelineRunJobTableRow from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow';
 import PipelineRunJobTableToolbar from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar';
 import usePipelineRunJobFilter from '~/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobFilter';
-import EmptyTableView from '~/concepts/pipelines/content/tables/EmptyTableView';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import DeletePipelineCoreResourceModal from '~/concepts/pipelines/content/DeletePipelineCoreResourceModal';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 
@@ -30,7 +30,7 @@ const PipelineRunJobTable: React.FC<PipelineRunTableProps> = ({ jobs }) => {
         data={filterJobs}
         columns={pipelineRunJobColumns}
         enablePagination
-        emptyTableView={<EmptyTableView onClearFilters={toolbarProps.onClearFilters} />}
+        emptyTableView={<DashboardEmptyTableView onClearFilters={toolbarProps.onClearFilters} />}
         toolbarContent={
           <PipelineRunJobTableToolbar
             {...toolbarProps}

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Navigate, Route } from 'react-router-dom';
 import ProjectsRoutes from '~/concepts/projects/ProjectsRoutes';
 import { ExplainabilityProvider } from '~/concepts/explainability/ExplainabilityContext';
+import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
 import BiasConfigurationBreadcrumbPage from './screens/metrics/BiasConfigurationBreadcrumbPage';
 import GlobalInferenceMetricsPage from './screens/metrics/GlobalInferenceMetricsPage';
 import ModelServingContextProvider from './ModelServingContext';
@@ -11,6 +12,7 @@ import useModelMetricsEnabled from './useModelMetricsEnabled';
 
 const ModelServingRoutes: React.FC = () => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
+  const biasMetricsEnabled = useBiasMetricsEnabled();
 
   //TODO: Split route to project and mount provider here. This will allow you to load data when model switching is later implemented.
   return (
@@ -22,7 +24,9 @@ const ModelServingRoutes: React.FC = () => {
             <Route index element={<Navigate to=".." />} />
             <Route path=":inferenceService" element={<GlobalInferenceMetricsWrapper />}>
               <Route path=":tab?" element={<GlobalInferenceMetricsPage />} />
-              <Route path="configure" element={<BiasConfigurationBreadcrumbPage />} />
+              {biasMetricsEnabled && (
+                <Route path="configure" element={<BiasConfigurationBreadcrumbPage />} />
+              )}
             </Route>
             {/* TODO: Global Runtime metrics?? */}
             <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/pages/modelServing/ModelServingRoutes.tsx
+++ b/frontend/src/pages/modelServing/ModelServingRoutes.tsx
@@ -12,7 +12,7 @@ import useModelMetricsEnabled from './useModelMetricsEnabled';
 
 const ModelServingRoutes: React.FC = () => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
 
   //TODO: Split route to project and mount provider here. This will allow you to load data when model switching is later implemented.
   return (

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import Table from '~/components/table/Table';
-
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import InferenceServiceTableRow from './InferenceServiceTableRow';
 import { getGlobalInferenceServiceColumns, getProjectInferenceServiceColumns } from './data';
 import DeleteInferenceServiceModal from './DeleteInferenceServiceModal';
@@ -41,14 +40,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
         toolbarContent={toolbarContent}
         enablePagination={enablePagination}
         emptyTableView={
-          isGlobal ? (
-            <>
-              No projects match your filters.{' '}
-              <Button variant="link" isInline onClick={clearFilters}>
-                Clear filters
-              </Button>
-            </>
-          ) : undefined
+          isGlobal ? <DashboardEmptyTableView onClearFilters={clearFilters} /> : undefined
         }
         rowRenderer={(is) => (
           <InferenceServiceTableRow

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationEmptyState.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationEmptyState.tsx
@@ -6,18 +6,25 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { WrenchIcon } from '@patternfly/react-icons';
+import { EMPTY_BIAS_CONFIGURATION_DESC, EMPTY_BIAS_CONFIGURATION_TITLE } from './const';
 
-const BiasConfigurationEmptyState: React.FC = () => (
-  <EmptyState variant={EmptyStateVariant.large} data-id="empty-empty-state">
-    <EmptyStateIcon icon={PlusCircleIcon} />
+type BiasConfigurationEmptyStateProps = {
+  actionButton: React.ReactNode;
+  variant: EmptyStateVariant;
+};
+
+const BiasConfigurationEmptyState: React.FC<BiasConfigurationEmptyStateProps> = ({
+  actionButton,
+  variant,
+}) => (
+  <EmptyState variant={variant} data-id="bias-metrics-empty-state">
+    <EmptyStateIcon icon={WrenchIcon} />
     <Title headingLevel="h2" size="lg">
-      No bias metrics configured
+      {EMPTY_BIAS_CONFIGURATION_TITLE}
     </Title>
-    <EmptyStateBody>
-      No bias metrics for this model have been configured. To monitor model bias, you must first
-      configure metrics
-    </EmptyStateBody>
+    <EmptyStateBody>{EMPTY_BIAS_CONFIGURATION_DESC}</EmptyStateBody>
+    {actionButton}
   </EmptyState>
 );
 

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationPage.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Breadcrumb, Button } from '@patternfly/react-core';
+import {
+  Breadcrumb,
+  Button,
+  EmptyStateVariant,
+  PageSection,
+  PageSectionVariants,
+} from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { BreadcrumbItemType } from '~/types';
@@ -9,6 +15,8 @@ import { getInferenceServiceDisplayName } from '~/pages/modelServing/screens/glo
 import { MetricsTabKeys } from './types';
 import BiasConfigurationTable from './BiasConfigurationTable';
 import { getBreadcrumbItemComponents } from './utils';
+import BiasConfigurationEmptyState from './BiasConfigurationEmptyState';
+import ManageBiasConfigurationModal from './biasConfigurationModal/ManageBiasConfigurationModal';
 
 type BiasConfigurationPageProps = {
   breadcrumbItems: BreadcrumbItemType[];
@@ -19,27 +27,64 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
   breadcrumbItems,
   inferenceService,
 }) => {
-  const { biasMetricConfigs, loaded } = useExplainabilityModelData();
+  const { biasMetricConfigs, loaded, loadError, refresh } = useExplainabilityModelData();
   const navigate = useNavigate();
-  return (
-    <ApplicationsPage
-      title="Bias metric configuration"
-      description="Manage the configuration of model bias metrics."
-      breadcrumb={<Breadcrumb>{getBreadcrumbItemComponents(breadcrumbItems)}</Breadcrumb>}
-      headerAction={
-        <Button onClick={() => navigate(`../${MetricsTabKeys.BIAS}`, { relative: 'path' })}>
-          {biasMetricConfigs.length === 0
-            ? `Back to ${getInferenceServiceDisplayName(inferenceService)}`
-            : 'View metrics'}
-        </Button>
+  const firstRender = React.useRef(true);
+  const [isOpen, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (loaded && !loadError) {
+      if (firstRender.current) {
+        firstRender.current = false;
+        if (biasMetricConfigs.length === 0) {
+          setOpen(true);
+        }
       }
-      loaded={loaded}
-      provideChildrenPadding
-      // The page is not empty, we will handle the empty state in the table
-      empty={false}
-    >
-      <BiasConfigurationTable inferenceService={inferenceService} />
-    </ApplicationsPage>
+    }
+  }, [loaded, biasMetricConfigs, loadError]);
+
+  return (
+    <>
+      <ApplicationsPage
+        title="Bias metric configuration"
+        description="Manage the configuration of model bias metrics."
+        breadcrumb={<Breadcrumb>{getBreadcrumbItemComponents(breadcrumbItems)}</Breadcrumb>}
+        headerAction={
+          <Button onClick={() => navigate(`../${MetricsTabKeys.BIAS}`, { relative: 'path' })}>
+            {biasMetricConfigs.length === 0
+              ? `Back to ${getInferenceServiceDisplayName(inferenceService)}`
+              : 'View metrics'}
+          </Button>
+        }
+        loaded={loaded}
+        provideChildrenPadding
+        // The page is not empty, we will handle the empty state in the table
+        empty={biasMetricConfigs.length === 0}
+        emptyStatePage={
+          <PageSection isFilled variant={PageSectionVariants.light}>
+            <BiasConfigurationEmptyState
+              actionButton={<Button onClick={() => setOpen(true)}>Configure metric</Button>}
+              variant={EmptyStateVariant.large}
+            />
+          </PageSection>
+        }
+      >
+        <BiasConfigurationTable
+          inferenceService={inferenceService}
+          onConfigure={() => setOpen(true)}
+        />
+      </ApplicationsPage>
+      <ManageBiasConfigurationModal
+        isOpen={isOpen}
+        onClose={(submit) => {
+          if (submit) {
+            refresh();
+          }
+          setOpen(false);
+        }}
+        inferenceService={inferenceService}
+      />
+    </>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationPage.tsx
@@ -58,7 +58,6 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
         }
         loaded={loaded}
         provideChildrenPadding
-        // The page is not empty, we will handle the empty state in the table
         empty={biasMetricConfigs.length === 0}
         emptyStatePage={
           <PageSection isFilled variant={PageSectionVariants.light}>

--- a/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTable.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasConfigurationTable.tsx
@@ -1,22 +1,25 @@
 import * as React from 'react';
-import { Button, ToolbarItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, ToolbarItem } from '@patternfly/react-core';
 import Table from '~/components/table/Table';
 import DashboardSearchField, { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
 import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
 import { InferenceServiceKind } from '~/k8sTypes';
 import DeleteBiasConfigurationModal from '~/pages/modelServing/screens/metrics/biasConfigurationModal/DeleteBiasConfigurationModal';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import ManageBiasConfigurationModal from './biasConfigurationModal/ManageBiasConfigurationModal';
 import BiasConfigurationTableRow from './BiasConfigurationTableRow';
 import { columns } from './tableData';
-import BiasConfigurationEmptyState from './BiasConfigurationEmptyState';
-import BiasConfigurationButton from './BiasConfigurationButton';
 
 type BiasConfigurationTableProps = {
   inferenceService: InferenceServiceKind;
+  onConfigure: () => void;
 };
 
-const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ inferenceService }) => {
+const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({
+  inferenceService,
+  onConfigure,
+}) => {
   const { biasMetricConfigs, refresh } = useExplainabilityModelData();
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
   const [search, setSearch] = React.useState('');
@@ -75,18 +78,7 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ inferen
             onDeleteConfiguration={setDeleteConfiguration}
           />
         )}
-        emptyTableView={
-          search ? (
-            <>
-              No metric configurations match your filters.{' '}
-              <Button variant="link" isInline onClick={resetFilters}>
-                Clear filters
-              </Button>
-            </>
-          ) : (
-            <BiasConfigurationEmptyState />
-          )
-        }
+        emptyTableView={<DashboardEmptyTableView onClearFilters={resetFilters} />}
         toolbarContent={
           <>
             <ToolbarItem>
@@ -103,7 +95,9 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({ inferen
               />
             </ToolbarItem>
             <ToolbarItem>
-              <BiasConfigurationButton inferenceService={inferenceService} />
+              <Button onClick={onConfigure} variant={ButtonVariant.secondary}>
+                Configure metric
+              </Button>
             </ToolbarItem>
           </>
         }

--- a/frontend/src/pages/modelServing/screens/metrics/EmptyBiasConfigurationCard.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/EmptyBiasConfigurationCard.tsx
@@ -1,36 +1,25 @@
 import * as React from 'react';
-import {
-  Button,
-  Card,
-  CardBody,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Title,
-} from '@patternfly/react-core';
-import { WrenchIcon } from '@patternfly/react-icons';
+import { Button, Card, CardBody, EmptyStateVariant } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { EMPTY_BIAS_CONFIGURATION_DESC, EMPTY_BIAS_CONFIGURATION_TITLE } from './const';
+import BiasConfigurationEmptyState from './BiasConfigurationEmptyState';
 
 const EmptyBiasConfigurationCard: React.FC = () => {
   const navigate = useNavigate();
   return (
     <Card>
       <CardBody>
-        <EmptyState>
-          <EmptyStateIcon icon={WrenchIcon} />
-          <Title headingLevel="h2" size="lg">
-            {EMPTY_BIAS_CONFIGURATION_TITLE}
-          </Title>
-          <EmptyStateBody>{EMPTY_BIAS_CONFIGURATION_DESC}</EmptyStateBody>
-          <Button
-            onClick={() => {
-              navigate('../configure', { relative: 'path' });
-            }}
-          >
-            Configure
-          </Button>
-        </EmptyState>
+        <BiasConfigurationEmptyState
+          actionButton={
+            <Button
+              onClick={() => {
+                navigate('../configure', { relative: 'path' });
+              }}
+            >
+              Configure
+            </Button>
+          }
+          variant={EmptyStateVariant.full}
+        />
       </CardBody>
     </Card>
   );

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
@@ -15,7 +15,7 @@ import './MetricsPageTabs.scss';
 const MetricsPageTabs: React.FC = () => {
   const enabledTabs = useMetricsPageEnabledTabs();
   const { biasMetricConfigs, loaded } = useExplainabilityModelData();
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
   const { tab } = useParams<{ tab: MetricsTabKeys }>();
   const navigate = useNavigate();
 

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
@@ -3,26 +3,33 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Tabs, Tab, TabTitleText, TabAction } from '@patternfly/react-core';
 import { MetricsTabKeys } from '~/pages/modelServing/screens/metrics/types';
 import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
+import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
+import NotFound from '~/pages/NotFound';
 import PerformanceTab from './PerformanceTab';
 import BiasTab from './BiasTab';
 import BiasConfigurationAlertPopover from './BiasConfigurationAlertPopover';
+import useMetricsPageEnabledTabs from './useMetricsPageEnabledTabs';
 
 import './MetricsPageTabs.scss';
 
 const MetricsPageTabs: React.FC = () => {
-  const DEFAULT_TAB = MetricsTabKeys.PERFORMANCE;
+  const enabledTabs = useMetricsPageEnabledTabs();
   const { biasMetricConfigs, loaded } = useExplainabilityModelData();
-
+  const biasMetricsEnabled = useBiasMetricsEnabled();
   const { tab } = useParams<{ tab: MetricsTabKeys }>();
   const navigate = useNavigate();
 
   React.useEffect(() => {
     if (!tab) {
-      navigate(`./${DEFAULT_TAB}`, { replace: true });
-    } else if (!Object.values(MetricsTabKeys).includes(tab)) {
-      navigate(`../${DEFAULT_TAB}`, { replace: true });
+      navigate(`./${enabledTabs[0]}`, { replace: true });
+    } else if (!enabledTabs.includes(tab)) {
+      navigate(`../${enabledTabs[0]}`, { replace: true });
     }
-  }, [DEFAULT_TAB, navigate, tab]);
+  }, [enabledTabs, navigate, tab]);
+
+  if (enabledTabs.length === 0) {
+    return <NotFound />;
+  }
 
   return (
     <Tabs
@@ -45,26 +52,28 @@ const MetricsPageTabs: React.FC = () => {
       >
         <PerformanceTab />
       </Tab>
-      <Tab
-        eventKey={MetricsTabKeys.BIAS}
-        title={<TabTitleText>Model Bias</TabTitleText>}
-        aria-label="Bias tab"
-        className="odh-tabcontent-fix"
-        actions={
-          loaded &&
-          biasMetricConfigs.length === 0 && (
-            <TabAction>
-              <BiasConfigurationAlertPopover
-                onConfigure={() => {
-                  navigate('../configure', { relative: 'path' });
-                }}
-              />
-            </TabAction>
-          )
-        }
-      >
-        <BiasTab />
-      </Tab>
+      {biasMetricsEnabled && (
+        <Tab
+          eventKey={MetricsTabKeys.BIAS}
+          title={<TabTitleText>Model Bias</TabTitleText>}
+          aria-label="Bias tab"
+          className="odh-tabcontent-fix"
+          actions={
+            loaded &&
+            biasMetricConfigs.length === 0 && (
+              <TabAction>
+                <BiasConfigurationAlertPopover
+                  onConfigure={() => {
+                    navigate('../configure', { relative: 'path' });
+                  }}
+                />
+              </TabAction>
+            )
+          }
+        >
+          <BiasTab />
+        </Tab>
+      )}
     </Tabs>
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -101,28 +101,52 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
             setConfiguration('thresholdDelta', getThresholdDefaultDelta(value));
           }}
         />
-        <FormGroup label="Protected attribute" fieldId="protected-attribute">
+        <FormGroup
+          label="Protected attribute"
+          fieldId="protected-attribute"
+          labelIcon={
+            <DashboardHelpTooltip content="The protected attribute is the input feature that you want to investigate bias over." />
+          }
+        >
           <TextInput
             id="protected-attribute"
             value={configuration.protectedAttribute}
             onChange={(value) => setConfiguration('protectedAttribute', value)}
           />
         </FormGroup>
-        <FormGroup label="Privileged value" fieldId="privileged-value">
+        <FormGroup
+          label="Privileged value"
+          fieldId="privileged-value"
+          labelIcon={
+            <DashboardHelpTooltip content="The privileged value is the value of the protected attribute that the model might be biased towards." />
+          }
+        >
           <TextInput
             id="privileged-value"
             value={configuration.privilegedAttribute}
             onChange={(value) => setConfiguration('privilegedAttribute', value)}
           />
         </FormGroup>
-        <FormGroup label="Unprivileged value" fieldId="unprivileged-value">
+        <FormGroup
+          label="Unprivileged value"
+          fieldId="unprivileged-value"
+          labelIcon={
+            <DashboardHelpTooltip content="The unprivileged value is the value of the protected attribute that the model might be biased against." />
+          }
+        >
           <TextInput
             id="unprivileged-value"
             value={configuration.unprivilegedAttribute}
             onChange={(value) => setConfiguration('unprivilegedAttribute', value)}
           />
         </FormGroup>
-        <FormGroup label="Output" fieldId="output">
+        <FormGroup
+          label="Output"
+          fieldId="output"
+          labelIcon={
+            <DashboardHelpTooltip content="The output is the particular output of the model to monitor for bias." />
+          }
+        >
           <TextInput
             id="output"
             value={configuration.outcomeName}
@@ -133,7 +157,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           label="Output value"
           fieldId="output-value"
           labelIcon={
-            <DashboardHelpTooltip content='How far the metric value can be from "perfect fairness" to constitute "unfairness"' />
+            <DashboardHelpTooltip content="The output value is the value of the chosen output to monitor for bias." />
           }
         >
           <TextInput
@@ -146,7 +170,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           label="Violation threshold"
           fieldId="violation-threshold"
           labelIcon={
-            <DashboardHelpTooltip content='How far the metric value can be from "perfect fairness" to constitute "unfairness"' />
+            <DashboardHelpTooltip content='The violation threshold is how far the metric value can be from "perfect fairness" to constitute "unfairness".' />
           }
         >
           <TextInput
@@ -160,7 +184,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           label="Metric batch size"
           fieldId="metric-batch-size"
           labelIcon={
-            <DashboardHelpTooltip content="How many of the previous model inferences to considered in each metric calculation" />
+            <DashboardHelpTooltip content="The metric batch size is how many of the previous model inferences to consider in each metric calculation." />
           }
         >
           <TextInput

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -48,6 +48,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
     setError(undefined);
     setActionInProgress(false);
     resetData();
+    setMetricType(undefined);
   };
 
   const onCreateConfiguration = () => {

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/MetricTypeField.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/MetricTypeField.tsx
@@ -1,29 +1,22 @@
 import * as React from 'react';
-import { FormGroup, Select, SelectOption, Tooltip } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
-import { METRIC_TYPE_DISPLAY_NAME } from '~/pages/modelServing/screens/metrics/const';
+import { FormGroup, Select, SelectOption } from '@patternfly/react-core';
+import {
+  METRIC_TYPE_DESCRIPTION,
+  METRIC_TYPE_DISPLAY_NAME,
+} from '~/pages/modelServing/screens/metrics/const';
 import { MetricTypes } from '~/api';
 import { isMetricType } from '~/pages/modelServing/screens/metrics/utils';
 
 type MetricTypeFieldProps = {
   fieldId: string;
   value?: MetricTypes;
-  setValue: (value: MetricTypes) => void;
+  onChange: (value: MetricTypes) => void;
 };
 
-const MetricTypeField: React.FC<MetricTypeFieldProps> = ({ fieldId, value, setValue }) => {
+const MetricTypeField: React.FC<MetricTypeFieldProps> = ({ fieldId, value, onChange }) => {
   const [isOpen, setOpen] = React.useState(false);
   return (
-    // TODO: decide what to show in the helper tooltip
-    <FormGroup
-      label="Metric type"
-      fieldId={fieldId}
-      labelIcon={
-        <Tooltip content="TBD">
-          <HelpIcon />
-        </Tooltip>
-      }
-    >
+    <FormGroup label="Metric type" fieldId={fieldId}>
       <Select
         removeFindDomNode
         id={fieldId}
@@ -32,7 +25,7 @@ const MetricTypeField: React.FC<MetricTypeFieldProps> = ({ fieldId, value, setVa
         onToggle={(open) => setOpen(open)}
         onSelect={(_, option) => {
           if (isMetricType(option)) {
-            setValue(option);
+            onChange(option);
             setOpen(false);
           }
         }}
@@ -40,7 +33,7 @@ const MetricTypeField: React.FC<MetricTypeFieldProps> = ({ fieldId, value, setVa
         menuAppendTo="parent"
       >
         {Object.keys(MetricTypes).map((type) => (
-          <SelectOption key={type} value={type}>
+          <SelectOption key={type} value={type} description={METRIC_TYPE_DESCRIPTION[type]}>
             {METRIC_TYPE_DISPLAY_NAME[type]}
           </SelectOption>
         ))}

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/useBiasConfigurationObject.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/useBiasConfigurationObject.ts
@@ -3,7 +3,7 @@ import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
 import { BaseMetricRequestInput, MetricTypes } from '~/api';
-import { getThresholdDefaultDelta } from '../utils';
+import { getThresholdDefaultDelta } from '~/pages/modelServing/screens/metrics/utils';
 
 const useBiasConfigurationObject = (
   modelId: string,

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/useBiasConfigurationObject.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/useBiasConfigurationObject.ts
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
-import { BaseMetricRequestInput } from '~/api';
+import { BaseMetricRequestInput, MetricTypes } from '~/api';
+import { getThresholdDefaultDelta } from '../utils';
 
 const useBiasConfigurationObject = (
   modelId: string,
+  metricType?: MetricTypes,
   existingData?: BiasMetricConfig,
 ): [
   data: BaseMetricRequestInput,
@@ -20,26 +22,27 @@ const useBiasConfigurationObject = (
     unprivilegedAttribute: '',
     outcomeName: '',
     favorableOutcome: '',
-    thresholdDelta: 0.1,
+    thresholdDelta: undefined,
     batchSize: 5000,
   });
 
   const [, setCreateData] = createConfiguration;
 
   const existingModelId = existingData?.modelId ?? modelId;
-  const existingName = existingData?.name ?? '';
+  const existingName = existingData?.name ? `Copy of ${existingData.name}` : '';
   const existingProtectedAttribute = existingData?.protectedAttribute ?? '';
   const existingPrivilegedAttribute = existingData?.privilegedAttribute ?? '';
   const existingUnprivilegedAttribute = existingData?.unprivilegedAttribute ?? '';
   const existingOutcomeName = existingData?.outcomeName ?? '';
   const existingFavorableOutcome = existingData?.favorableOutcome ?? '';
-  const existingThresholdDelta = existingData?.thresholdDelta ?? 0.1;
+  const existingThresholdDelta =
+    existingData?.thresholdDelta ?? getThresholdDefaultDelta(metricType);
   const existingBatchSize = existingData?.batchSize ?? 5000;
 
   React.useEffect(() => {
     if (existingData) {
       setCreateData('modelId', existingModelId);
-      setCreateData('requestName', '');
+      setCreateData('requestName', existingName);
       setCreateData('protectedAttribute', existingProtectedAttribute);
       setCreateData('privilegedAttribute', existingPrivilegedAttribute);
       setCreateData('unprivilegedAttribute', existingUnprivilegedAttribute);

--- a/frontend/src/pages/modelServing/screens/metrics/const.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/const.ts
@@ -14,9 +14,9 @@ export const METRIC_TYPE_DISPLAY_NAME: { [key in MetricTypes]: string } = {
 
 export const METRIC_TYPE_DESCRIPTION: { [key in MetricTypes]: string } = {
   [MetricTypes.DIR]:
-    'Disparate Impact Ratio (DIR) measures imbalances in classifications by calculating the ratio between the proportion of the privileged and unprivileged groups getting a particular outcome',
+    'Calculates the ratio between the proportion of the privileged and unprivileged groups getting a particular outcome.',
   [MetricTypes.SPD]:
-    'Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the difference between the proportion of the privileged and unprivileged groups getting a particular outcome',
+    'Calculates the difference between the proportion of the privileged and unprivileged groups getting a particular outcome.',
 };
 
 export const EMPTY_BIAS_CHART_SELECTION_TITLE = 'No Bias metrics selected';

--- a/frontend/src/pages/modelServing/screens/metrics/const.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/const.ts
@@ -12,6 +12,13 @@ export const METRIC_TYPE_DISPLAY_NAME: { [key in MetricTypes]: string } = {
   [MetricTypes.SPD]: 'Statistical parity difference (SPD)',
 };
 
+export const METRIC_TYPE_DESCRIPTION: { [key in MetricTypes]: string } = {
+  [MetricTypes.DIR]:
+    'Disparate Impact Ratio (DIR) measures imbalances in classifications by calculating the ratio between the proportion of the privileged and unprivileged groups getting a particular outcome',
+  [MetricTypes.SPD]:
+    'Statistical Parity Difference (SPD) measures imbalances in classifications by calculating the difference between the proportion of the privileged and unprivileged groups getting a particular outcome',
+};
+
 export const EMPTY_BIAS_CHART_SELECTION_TITLE = 'No Bias metrics selected';
 export const EMPTY_BIAS_CHART_SELECTION_DESC =
   'No bias metrics have been selected. To display charts you must first select them using the metric selector.';

--- a/frontend/src/pages/modelServing/screens/metrics/useMetricsPageEnabledTabs.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/useMetricsPageEnabledTabs.ts
@@ -1,0 +1,15 @@
+import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
+import { MetricsTabKeys } from './types';
+
+const useMetricsPageEnabledTabs = () => {
+  const enabledTabs: MetricsTabKeys[] = [];
+  const biasMetricsEnabled = useBiasMetricsEnabled();
+  // TODO: when we have a feature flag for performance tab, check it
+  enabledTabs.push(MetricsTabKeys.PERFORMANCE);
+  if (biasMetricsEnabled) {
+    enabledTabs.push(MetricsTabKeys.BIAS);
+  }
+  return enabledTabs;
+};
+
+export default useMetricsPageEnabledTabs;

--- a/frontend/src/pages/modelServing/screens/metrics/useMetricsPageEnabledTabs.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/useMetricsPageEnabledTabs.ts
@@ -3,7 +3,7 @@ import { MetricsTabKeys } from './types';
 
 const useMetricsPageEnabledTabs = () => {
   const enabledTabs: MetricsTabKeys[] = [];
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
   // TODO: when we have a feature flag for performance tab, check it
   enabledTabs.push(MetricsTabKeys.PERFORMANCE);
   if (biasMetricsEnabled) {

--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -311,12 +311,5 @@ export const convertConfigurationRequestType = (
   favorableOutcome: convertInputType(configuration.favorableOutcome),
 });
 
-export const getThresholdDefaultDelta = (metricType?: MetricTypes) => {
-  if (metricType === MetricTypes.SPD) {
-    return 0.1;
-  }
-  if (metricType === MetricTypes.DIR) {
-    return 0.2;
-  }
-  return undefined;
-};
+export const getThresholdDefaultDelta = (metricType?: MetricTypes) =>
+  metricType && BIAS_CHART_CONFIGS[metricType].defaultDelta;

--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -178,18 +178,19 @@ export const getBreadcrumbItemComponents = (breadcrumbItems: BreadcrumbItemType[
   ));
 
 const checkThresholdValid = (metricType: MetricTypes, thresholdDelta?: number): boolean => {
-  if (thresholdDelta) {
+  if (thresholdDelta !== undefined) {
     if (metricType === MetricTypes.SPD) {
-      if (thresholdDelta > 0 && thresholdDelta < 1) {
-        // SPD, 0 < threshold < 1, valid
+      // SPD, no limitation, valid
+      return true;
+    }
+
+    if (metricType === MetricTypes.DIR) {
+      if (thresholdDelta >= 0 && thresholdDelta < 1) {
+        // 0<=DIR<1 , valid
         return true;
       }
-      // SPD, not within the range, invalid
+      // DIR, not within the range, invalid
       return false;
-    }
-    // DIR, no limitation, valid
-    if (metricType === MetricTypes.DIR) {
-      return true;
     }
     // not SPD not DIR, undefined for now, metricType should be selected, invalid
     return false;
@@ -199,10 +200,10 @@ const checkThresholdValid = (metricType: MetricTypes, thresholdDelta?: number): 
 };
 
 const checkBatchSizeValid = (batchSize?: number): boolean => {
-  if (batchSize) {
+  if (batchSize !== undefined) {
     if (Number.isInteger(batchSize)) {
       // size > 2, integer, valid
-      if (batchSize > 2) {
+      if (batchSize >= 2) {
         return true;
       }
       // size <= 2, invalid
@@ -309,3 +310,13 @@ export const convertConfigurationRequestType = (
   unprivilegedAttribute: convertInputType(configuration.unprivilegedAttribute),
   favorableOutcome: convertInputType(configuration.favorableOutcome),
 });
+
+export const getThresholdDefaultDelta = (metricType?: MetricTypes) => {
+  if (metricType === MetricTypes.SPD) {
+    return 0.1;
+  }
+  if (metricType === MetricTypes.DIR) {
+    return 0.2;
+  }
+  return undefined;
+};

--- a/frontend/src/pages/pipelines/global/pipelines/PipelinesView.tsx
+++ b/frontend/src/pages/pipelines/global/pipelines/PipelinesView.tsx
@@ -4,7 +4,7 @@ import GlobalNoPipelines from '~/pages/pipelines/global/pipelines/GlobalNoPipeli
 import PipelinesTable from '~/concepts/pipelines/content/tables/pipeline/PipelinesTable';
 import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
-import EmptyTableView from '~/concepts/pipelines/content/tables/EmptyTableView';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import GlobalPipelinesTableToolbar, { FilterType, FilterData } from './GlobalPipelinesTableToolbar';
 
 const DEFAULT_FILTER_DATA: FilterData = {
@@ -61,7 +61,9 @@ const PipelinesView: React.FC = () => {
           onClearFilters={() => setFilterData(DEFAULT_FILTER_DATA)}
         />
       }
-      emptyTableView={<EmptyTableView onClearFilters={() => setFilterData(DEFAULT_FILTER_DATA)} />}
+      emptyTableView={
+        <DashboardEmptyTableView onClearFilters={() => setFilterData(DEFAULT_FILTER_DATA)} />
+      }
       refreshPipelines={refresh}
       pipelineDetailsPath={(namespace, id) => `/pipelines/${namespace}/pipeline/view/${id}`}
     />

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -21,7 +21,7 @@ import EditSpawnerPage from './screens/spawner/EditSpawnerPage';
 
 const ProjectViewRoutes: React.FC = () => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
-  const biasMetricsEnabled = useBiasMetricsEnabled();
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
 
   return (
     <ProjectsRoutes>

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -12,6 +12,7 @@ import CloneRunPage from '~/concepts/pipelines/content/createRun/CloneRunPage';
 import { ExplainabilityProvider } from '~/concepts/explainability/ExplainabilityContext';
 import ProjectInferenceMetricsConfigurationPage from '~/pages/modelServing/screens/projects/ProjectInferenceMetricsConfigurationPage';
 import ProjectInferenceMetricsPage from '~/pages/modelServing/screens/projects/ProjectInferenceMetricsPage';
+import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
 import ProjectDetails from './screens/detail/ProjectDetails';
 import ProjectView from './screens/projects/ProjectView';
 import ProjectDetailsContextProvider from './ProjectDetailsContext';
@@ -20,6 +21,7 @@ import EditSpawnerPage from './screens/spawner/EditSpawnerPage';
 
 const ProjectViewRoutes: React.FC = () => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
+  const biasMetricsEnabled = useBiasMetricsEnabled();
 
   return (
     <ProjectsRoutes>
@@ -34,7 +36,9 @@ const ProjectViewRoutes: React.FC = () => {
               <Route index element={<Navigate to=".." />} />
               <Route path=":inferenceService" element={<ProjectInferenceMetricsWrapper />}>
                 <Route path=":tab?" element={<ProjectInferenceMetricsPage />} />
-                <Route path="configure" element={<ProjectInferenceMetricsConfigurationPage />} />
+                {biasMetricsEnabled && (
+                  <Route path="configure" element={<ProjectInferenceMetricsConfigurationPage />} />
+                )}
               </Route>
               <Route path="*" element={<Navigate to="." />} />
             </Route>

--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonVariant, ToolbarItem } from '@patternfly/react-core';
+import { ButtonVariant, ToolbarItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import Table from '~/components/table/Table';
 import useTableColumnSort from '~/components/table/useTableColumnSort';
@@ -8,6 +8,7 @@ import { getProjectDisplayName, getProjectOwner } from '~/pages/projects/utils';
 import LaunchJupyterButton from '~/pages/projects/screens/projects/LaunchJupyterButton';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import DashboardSearchField, { SearchType } from '~/concepts/dashboard/DashboardSearchField';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import NewProjectButton from './NewProjectButton';
 import { columns } from './tableData';
 import ProjectTableRow from './ProjectTableRow';
@@ -61,14 +62,7 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({ allowCreate }) => {
         enablePagination
         data={filteredProjects}
         columns={columns}
-        emptyTableView={
-          <>
-            No projects match your filters.{' '}
-            <Button variant="link" isInline onClick={resetFilters}>
-              Clear filters
-            </Button>
-          </>
-        }
+        emptyTableView={<DashboardEmptyTableView onClearFilters={resetFilters} />}
         rowRenderer={(project) => (
           <ProjectTableRow
             key={project.metadata.uid}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -89,6 +89,7 @@ export type DashboardCommonConfig = {
   disableCustomServingRuntimes: boolean;
   modelMetricsNamespace: string;
   disablePipelines: boolean;
+  disableBiasMetrics: boolean;
 };
 
 export type NotebookControllerUserState = {

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -53,6 +53,8 @@ spec:
                       type: string
                     disablePipelines:
                       type: boolean
+                    disableBiasMetrics:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -19,6 +19,7 @@ spec:
     disableProjectSharing: true
     disableCustomServingRuntimes: true
     modelMetricsNamespace: ''
+    disableBiasMetrics: true
   notebookController:
     enabled: true
   notebookSizes:


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1383 #1384 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Do the following things:
1. Set the default value of threshold delta based on the metric type
2. Limit the threshold delta based on the metric type (there will be no error message or helper text, but the creation will be disabled if the user input invalid values)
3.  Add tooltips for all the input fields and descriptions for metrics type dropdown, documentation: https://docs.google.com/document/d/1qq0lobOJQpXD1IowclSWaKhTT_qEPz56IMzvCeOfczY/edit
4. When duplicating the configuration, set the default duplicated name as mentioned in the issue
5. Add `disableBiasMetrics` feature flag in the dashboard config. When the flag is `true`, we do following:
a. Hide the bias tab
b. Disable all the routes related to bias metrics
c. Disabled all the trusty API network calls

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test description 1:
Go to bias metrics configuration modal, change the metric type and see how the threshold delta value changes

To test description 2:
Go to bias metrics configuration modal, try to input some invalid batch size and threshold delta to see if the submit button is disabled

To test description 3:
Go to bias metrics configuration modal, and hover all the tooltips to see if the texts are accurate. Open metrics type dropdown to check the descriptions on the dropdown items

To test description 4:
Duplicate one bias configuration, see if the name field is set as expected

To test description 5:
1. Go to dashboard config CR
2. Set `disableBiasMetrics` to `true`
3. Go to the global model serving page, click on one of the models
4. There should be only the performance tab on the page, no bias tab
5. Change the tab in the URL from `performance` to `bias`, it should navigate you back to `performance`
6. Access the configuration page from the URL, it should navigate you back to `performance`
7. Check the network calls to make sure there is no call for the trusty AI server
8. Repeat every step from 4-7 on the project details page (because they have different URLs), and make sure the results are the same
9. Set Set `disableBiasMetrics` to `false`
10. Wait for 2 mins (or whenever the dashboard re-fetch the dashboard config again)
11. Repeat 3-8, make sure you can use bias metrics as normal

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
TBD

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
