### PR TITLE
Rename 'Upload a new pipeline' to 'Import pipeline' to keep consistency

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -43,7 +43,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({ value, onChange }) =>
             icon={<PlusCircleIcon />}
             onCreate={(pipeline) => onChange(pipeline)}
           >
-            Upload new pipeline
+            Import pipeline
           </ImportPipelineButton>
         </StackItem>
       </Stack>


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1300 

## Description
#1300 

## How Has This Been Tested?
While the UI to create a new pipeline usually reports Import pipeline as button text, both in DS Project details page and Data Science Pipelines > Pipelines page, the form to create a new Run reports Upload a new pipeline for doing the same operation:

![Import](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/a1cf92ca-2ec0-4ba0-9987-091bb9eb768e)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
