### PR TITLE
Fix legacy model server display name

### DIFF
--- a/frontend/src/__mocks__/mockRouteK8sResource.ts
+++ b/frontend/src/__mocks__/mockRouteK8sResource.ts
@@ -2,7 +2,9 @@ import { RouteKind } from '~/k8sTypes';
 import { genUID } from '~/__mocks__/mockUtils';
 
 type MockResourceConfigType = {
+  name?: string;
   notebookName?: string;
+  inferenceServiceName?: string;
   namespace?: string;
 };
 
@@ -57,6 +59,72 @@ export const mockRouteK8sResource = ({
     ingress: [
       {
         host: `${notebookName}-${namespace}.apps.user.com`,
+        routerName: 'default',
+        conditions: [
+          {
+            type: 'Admitted',
+            status: 'True',
+            lastTransitionTime: '2023-02-14T21:44:13Z',
+          },
+        ],
+        wildcardPolicy: 'None',
+        routerCanonicalHostname: 'router-default.apps.user.com',
+      },
+    ],
+  },
+});
+
+export const mockRouteK8sResourceModelServing = ({
+  inferenceServiceName = 'test-inference',
+  namespace = 'test-project',
+}: MockResourceConfigType): RouteKind => ({
+  kind: 'Route',
+  apiVersion: 'route.openshift.io/v1',
+  metadata: {
+    name: inferenceServiceName,
+    namespace: namespace,
+    uid: genUID('route'),
+    resourceVersion: '4789458',
+    creationTimestamp: '2023-02-14T21:44:13Z',
+    labels: {
+      'inferenceservice-name': inferenceServiceName,
+    },
+    annotations: {
+      'openshift.io/host.generated': 'true',
+    },
+    ownerReferences: [
+      {
+        apiVersion: 'serving.kserve.io/v1beta1',
+        kind: 'InferenceService',
+        name: inferenceServiceName,
+        uid: genUID('notebook'),
+        controller: true,
+        blockOwnerDeletion: true,
+      },
+    ],
+    managedFields: [],
+  },
+  spec: {
+    path: '',
+    host: `${inferenceServiceName}-${namespace}.apps.user.com`,
+    to: {
+      kind: 'Service',
+      name: `${inferenceServiceName}-serving`,
+      weight: 100,
+    },
+    port: {
+      targetPort: 'oauth-proxy',
+    },
+    tls: {
+      termination: 'reencrypt',
+      insecureEdgeTerminationPolicy: 'Redirect',
+    },
+    wildcardPolicy: 'None',
+  },
+  status: {
+    ingress: [
+      {
+        host: `${inferenceServiceName}-${namespace}.apps.user.com`,
         routerName: 'default',
         conditions: [
           {

--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -2,25 +2,112 @@ import { KnownLabels, ServingRuntimeKind } from '~/k8sTypes';
 
 type MockResourceConfigType = {
   name?: string;
+  displayName?: string;
   namespace?: string;
   replicas?: number;
+  auth?: boolean;
+  route?: boolean;
 };
 
-export const mockServingRuntimeK8sResource = ({
-  name = 'test-model',
+export const mockServingRuntimeK8sResourceLegacy = ({
+  name = 'test-model-legacy',
   namespace = 'test-project',
   replicas = 0,
+  auth = false,
+  route = false,
 }: MockResourceConfigType): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
   metadata: {
     creationTimestamp: '2023-03-17T16:05:55Z',
     labels: {
-      name: name,
+      name,
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',
     },
-    name: name,
-    namespace: namespace,
+    annotations: {
+      'enable-auth': auth ? 'true' : 'false',
+      'enable-route': route ? 'true' : 'false',
+    },
+    name,
+    namespace,
+  },
+  spec: {
+    builtInAdapter: {
+      memBufferBytes: 134217728,
+      modelLoadingTimeoutMillis: 90000,
+      runtimeManagementPort: 8888,
+      serverType: 'ovms',
+    },
+    containers: [
+      {
+        args: [
+          '--port=8001',
+          '--rest_port=8888',
+          '--config_path=/models/model_config_list.json',
+          '--file_system_poll_wait_seconds=0',
+          '--grpc_bind_address=127.0.0.1',
+          '--rest_bind_address=127.0.0.1',
+        ],
+        image:
+          'registry.redhat.io/rhods/odh-openvino-servingruntime-rhel8@sha256:8af20e48bb480a7ba1ee1268a3cf0a507e05b256c5fcf988f8e4a3de8b87edc6',
+        name: 'ovms',
+        resources: {
+          limits: {
+            cpu: '2',
+            memory: '8Gi',
+          },
+          requests: {
+            cpu: '1',
+            memory: '4Gi',
+          },
+        },
+      },
+    ],
+    grpcDataEndpoint: 'port:8001',
+    grpcEndpoint: 'port:8085',
+    multiModel: true,
+    protocolVersions: ['grpc-v1'],
+    replicas: replicas,
+    supportedModelFormats: [
+      {
+        autoSelect: true,
+        name: 'openvino_ir',
+        version: 'opset1',
+      },
+      {
+        autoSelect: true,
+        name: 'onnx',
+        version: '1',
+      },
+    ],
+  },
+});
+
+export const mockServingRuntimeK8sResource = ({
+  name = 'test-model',
+  namespace = 'test-project',
+  replicas = 0,
+  auth = false,
+  route = false,
+  displayName = 'OVMS Model Serving',
+}: MockResourceConfigType): ServingRuntimeKind => ({
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  kind: 'ServingRuntime',
+  metadata: {
+    creationTimestamp: '2023-06-22T16:05:55Z',
+    labels: {
+      name,
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    },
+    annotations: {
+      'opendatahub.io/template-display-name': 'OpenVINO Serving Runtime (Supports GPUs)',
+      'opendatahub.io/template-name': 'ovms',
+      'enable-auth': auth ? 'true' : 'false',
+      'enable-route': route ? 'true' : 'false',
+      'openshift.io/display-name': displayName,
+    },
+    name,
+    namespace,
   },
   spec: {
     builtInAdapter: {

--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
@@ -60,9 +60,11 @@ test('Create model', async ({ page }) => {
   await page.getByRole('option', { name: 'Test Project' }).click();
   await page.getByLabel('Model Name *').fill('Test Name');
   await page.locator('#inference-service-model-selection').click();
-  await page.getByRole('option', { name: 'test-model' }).click();
+  await page.getByRole('option', { name: 'ovms' }).click();
   await page
-    .getByText('Project Test ProjectModel Name * Model servers * test-modelModel framework * Sel')
+    .getByText(
+      'Project Test ProjectModel Name * Model servers * OVMS Model ServingModel framework * Sel',
+    )
     .click();
   await page.getByRole('option', { name: 'onnx - 1' }).click();
   await expect(await page.getByRole('button', { name: 'Deploy' })).toBeDisabled();

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -31,3 +31,27 @@ test('Deploy model', async ({ page }) => {
     .fill('test-secret-key');
   await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeEnabled();
 });
+
+test('Legacy Serving Runtime', async ({ page }) => {
+  await page.goto(
+    './iframe.html?args=&id=tests-integration-pages-modelserving-servingruntimelist--list-available-models&viewMode=story',
+  );
+
+  // wait for page to load
+  await page.waitForSelector('text=Configure server');
+
+  // Check that the legacy serving runtime is shown with the default runtime name
+  expect(await page.getByText('ovms')).toBeTruthy();
+
+  // Check that the legacy serving runtime displays the correct Serving Runtime
+  expect(await page.getByText('OpenVINO Model Server')).toBeTruthy();
+
+  // Check that the legacy serving runtime has tokens disabled
+  expect(await page.getByText('Tokens disabled')).toBeTruthy();
+
+  // Check that the serving runtime is shown with the default runtime name
+  expect(await page.getByText('OVMS Model Serving')).toBeTruthy();
+
+  // Check that the serving runtime displays the correct Serving Runtime
+  expect(await page.getByText('OpenVINO Serving Runtime (Supports GPUs)')).toBeTruthy();
+});

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -38,7 +38,7 @@ test('Legacy Serving Runtime', async ({ page }) => {
   );
 
   // wait for page to load
-  await page.waitForSelector('text=Configure server');
+  await page.waitForSelector('text=Add server');
 
   // Check that the legacy serving runtime is shown with the default runtime name
   expect(await page.getByText('ovms')).toBeTruthy();

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
@@ -4,13 +4,19 @@ import { StoryFn, Meta } from '@storybook/react';
 import { rest } from 'msw';
 import { userEvent, within } from '@storybook/testing-library';
 import { Route } from 'react-router-dom';
-import { mockRouteK8sResource } from '~/__mocks__/mockRouteK8sResource';
+import {
+  mockRouteK8sResource,
+  mockRouteK8sResourceModelServing,
+} from '~/__mocks__/mockRouteK8sResource';
 import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockNotebookK8sResource } from '~/__mocks__/mockNotebookK8sResource';
 import ProjectDetailsContextProvider from '~/pages/projects/ProjectDetailsContext';
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
-import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
+import {
+  mockServingRuntimeK8sResource,
+  mockServingRuntimeK8sResourceLegacy,
+} from '~/__mocks__/mockServingRuntimeK8sResource';
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import ProjectsRoutes from '~/concepts/projects/ProjectsRoutes';
@@ -20,6 +26,7 @@ import { mockStatus } from '~/__mocks__/mockStatus';
 import useDetectUser from '~/utilities/useDetectUser';
 import { fetchDashboardConfig } from '~/services/dashboardConfigService';
 import ServingRuntimeList from '~/pages/modelServing/screens/projects/ServingRuntimeList';
+import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
 
 export default {
   component: ServingRuntimeList,
@@ -55,7 +62,12 @@ export default {
         ),
         rest.get(
           'api/k8s/apis/serving.kserve.io/v1beta1/namespaces/test-project/inferenceservices',
-          (req, res, ctx) => res(ctx.json(mockK8sResourceList([]))),
+          (req, res, ctx) =>
+            res(
+              ctx.json(
+                mockK8sResourceList([mockInferenceServiceK8sResource({ name: 'test-inference' })]),
+              ),
+            ),
         ),
         rest.get('/api/k8s/api/v1/namespaces/test-project/secrets', (req, res, ctx) =>
           res(ctx.json(mockK8sResourceList([mockSecretK8sResource({})]))),
@@ -63,7 +75,31 @@ export default {
         rest.get(
           'api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes',
           (req, res, ctx) =>
-            res(ctx.json(mockK8sResourceList([mockServingRuntimeK8sResource({})]))),
+            res(
+              ctx.json(
+                mockK8sResourceList([
+                  mockServingRuntimeK8sResourceLegacy({}),
+                  mockServingRuntimeK8sResource({
+                    name: 'test-model',
+                    namespace: 'test-project',
+                    auth: true,
+                    route: true,
+                  }),
+                ]),
+              ),
+            ),
+        ),
+        rest.get(
+          '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/test-inference',
+          (req, res, ctx) =>
+            res(
+              ctx.json(
+                mockRouteK8sResourceModelServing({
+                  inferenceServiceName: 'test-inference',
+                  namespace: 'test-project',
+                }),
+              ),
+            ),
         ),
         rest.get(
           '/api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes/test-model',
@@ -94,6 +130,17 @@ const Template: StoryFn<typeof ServingRuntimeList> = (args) => {
   );
 };
 
+export const ListAvailableModels = {
+  render: Template,
+
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('ovms', undefined, { timeout: 5000 });
+    await canvas.findByText('OVMS Model Serving', undefined, { timeout: 5000 });
+  },
+};
+
 export const DeployModel = {
   render: Template,
 
@@ -102,6 +149,6 @@ export const DeployModel = {
     const canvas = within(canvasElement);
     await canvas.findByText('ovms', undefined, { timeout: 5000 });
 
-    await userEvent.click(canvas.getByText('Deploy model', { selector: 'button' }));
+    await userEvent.click(canvas.getAllByText('Deploy model', { selector: 'button' })[0]);
   },
 };

--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.stories.tsx
@@ -3,14 +3,20 @@ import { StoryFn, Meta } from '@storybook/react';
 import { DefaultBodyType, MockedRequest, rest, RestHandler } from 'msw';
 import { within } from '@storybook/testing-library';
 import { Route } from 'react-router-dom';
-import { mockRouteK8sResource } from '~/__mocks__/mockRouteK8sResource';
+import {
+  mockRouteK8sResource,
+  mockRouteK8sResourceModelServing,
+} from '~/__mocks__/mockRouteK8sResource';
 import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockNotebookK8sResource } from '~/__mocks__/mockNotebookK8sResource';
 import ProjectDetailsContextProvider from '~/pages/projects/ProjectDetailsContext';
 import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
-import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
+import {
+  mockServingRuntimeK8sResource,
+  mockServingRuntimeK8sResourceLegacy,
+} from '~/__mocks__/mockServingRuntimeK8sResource';
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import useDetectUser from '~/utilities/useDetectUser';
@@ -63,7 +69,13 @@ const handlers = (isEmpty: boolean): RestHandler<MockedRequest<DefaultBodyType>>
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1beta1/namespaces/test-project/inferenceservices',
     (req, res, ctx) =>
-      res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockInferenceServiceK8sResource({})]))),
+      res(
+        ctx.json(
+          mockK8sResourceList(
+            isEmpty ? [] : [mockInferenceServiceK8sResource({ name: 'test-inference' })],
+          ),
+        ),
+      ),
   ),
   rest.get('/api/k8s/api/v1/namespaces/test-project/secrets', (req, res, ctx) =>
     res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockSecretK8sResource({})]))),
@@ -71,7 +83,35 @@ const handlers = (isEmpty: boolean): RestHandler<MockedRequest<DefaultBodyType>>
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes',
     (req, res, ctx) =>
-      res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockServingRuntimeK8sResource({})]))),
+      res(
+        ctx.json(
+          mockK8sResourceList(
+            isEmpty
+              ? []
+              : [
+                  mockServingRuntimeK8sResourceLegacy({}),
+                  mockServingRuntimeK8sResource({
+                    name: 'test-model',
+                    namespace: 'test-project',
+                    auth: true,
+                    route: true,
+                  }),
+                ],
+          ),
+        ),
+      ),
+  ),
+  rest.get(
+    '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/test-inference',
+    (req, res, ctx) =>
+      res(
+        ctx.json(
+          mockRouteK8sResourceModelServing({
+            inferenceServiceName: 'test-inference',
+            namespace: 'test-project',
+          }),
+        ),
+      ),
   ),
   rest.get(
     '/api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes/test-model',

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -49,9 +49,12 @@ export const getServingRuntimeFromTemplate = (
   return template.objects[0];
 };
 
-export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntimeKind): string =>
-  resource.metadata.annotations?.['opendatahub.io/template-display-name'] ||
-  resource.metadata.annotations?.['opendatahub.io/template-name'] ||
-  resource.spec.builtInAdapter?.serverType === 'ovms'
-    ? 'OpenVINO Model Server'
-    : undefined || 'Unknown Serving Runtime';
+export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntimeKind): string => {
+  const templateName =
+    resource.metadata.annotations?.['opendatahub.io/template-display-name'] ||
+    resource.metadata.annotations?.['opendatahub.io/template-name'];
+  const legacyTemplateName =
+    resource.spec.builtInAdapter?.serverType === 'ovms' ? 'OpenVINO Model Server' : undefined;
+
+  return templateName || legacyTemplateName || 'Unknown Serving Runtime';
+};

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -52,4 +52,6 @@ export const getServingRuntimeFromTemplate = (
 export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntimeKind): string =>
   resource.metadata.annotations?.['opendatahub.io/template-display-name'] ||
   resource.metadata.annotations?.['opendatahub.io/template-name'] ||
-  'Unknown Serving Runtime';
+  resource.spec.builtInAdapter?.serverType === 'ovms'
+    ? 'OpenVINO Model Server'
+    : undefined || 'Unknown Serving Runtime';


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes #1395 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. In a cluster with a legacy model server (Model server deployed before serving runtime)
2. Check that the label is displaying `OpenVINO Model Server` rather than 'Unknown Serving Runtime'

or

1. Deploy an OVMS serving runtime
2. Remove `opendatahub.io/template-display-name` and `opendatahub.io/template-name`
3. Check that the label is displaying `OpenVINO Model Server` rather than 'Unknown Serving Runtime'
4. Now deploy another model with no ovms spec
5. Remove `opendatahub.io/template-display-name` and `opendatahub.io/template-name`
6. Check that the label is displaying 'Unknown Serving Runtime'

[before]
<img width="1208" alt="Screenshot 2023-06-15 at 14 25 27" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/1b103001-d8a9-4a23-a678-b8be04c4f458">

[after]
<img width="1272" alt="Screenshot 2023-06-15 at 18 00 47" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/16d8435d-eb02-40a5-aa47-3320ddcee9f2">


[after not ovms]
<img width="1220" alt="Screenshot 2023-06-15 at 14 58 12" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/f999ec64-33eb-4fb9-95f7-c7f5bd13e94c">

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added test coverage in the PR

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits have meaningful messages (squashes happen on merge by the bot).
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
