### PR TITLE
Minor enhancements to bias chart (#1386)

### DIFF
--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -93,6 +93,13 @@ export const TimeframeStep: TimeframeStepType = {
 };
 
 export const RefreshIntervalValue: RefreshIntervalValueType = {
+  [RefreshIntervalTitle.FIFTEEN_SECONDS]: 15 * 1000,
+  [RefreshIntervalTitle.THIRTY_SECONDS]: 30 * 1000,
   [RefreshIntervalTitle.ONE_MINUTE]: 60 * 1000,
   [RefreshIntervalTitle.FIVE_MINUTES]: 5 * 60 * 1000,
+  [RefreshIntervalTitle.FIFTEEN_MINUTES]: 15 * 60 * 1000,
+  [RefreshIntervalTitle.THIRTY_MINUTES]: 30 * 60 * 1000,
+  [RefreshIntervalTitle.ONE_HOUR]: 60 * 60 * 1000,
+  [RefreshIntervalTitle.TWO_HOURS]: 2 * 60 * 60 * 1000,
+  [RefreshIntervalTitle.ONE_DAY]: 24 * 60 * 60 * 1000,
 };

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -88,7 +88,7 @@ export const TimeframeStep: TimeframeStepType = {
   [TimeframeTitle.ONE_HOUR]: 12,
   [TimeframeTitle.ONE_DAY]: 24 * 12,
   [TimeframeTitle.ONE_WEEK]: 7 * 24 * 12,
-  [TimeframeTitle.ONE_MONTH]: 30 * 7 * 24 * 12,
+  [TimeframeTitle.ONE_MONTH]: 30 * 24 * 12,
   // [TimeframeTitle.UNLIMITED]: 30 * 7 * 24 * 12, // TODO: determine if we "zoom out" more
 };
 

--- a/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
@@ -33,13 +33,27 @@ const BiasTab: React.FC = () => {
     true,
   );
 
+  const firstRender = React.useRef(true);
+
   React.useEffect(() => {
     if (loaded && !loadError) {
-      setSelectedBiasConfigs(
-        selectedBiasConfigs.filter((selection) =>
-          biasMetricConfigs.map((c) => c.id).includes(selection.id),
-        ),
-      );
+      if (firstRender.current) {
+        // If the user has just navigated here AND they haven't previously selected any charts to display,
+        // don't show them the "No selected" empty state, instead show them the first available chart.
+        // However, the user still needs to be shown said empty state if they deselect all charts.
+        firstRender.current = false;
+        if (selectedBiasConfigs.length === 0 && biasMetricConfigs.length > 0) {
+          // If biasMetricConfigs is empty, the "No Configured Metrics" empty state will be shown, so no need
+          // to set anything.
+          setSelectedBiasConfigs([biasMetricConfigs[0]]);
+        }
+      } else {
+        setSelectedBiasConfigs(
+          selectedBiasConfigs.filter((selection) =>
+            biasMetricConfigs.map((c) => c.id).includes(selection.id),
+          ),
+        );
+      }
     }
   }, [loaded, biasMetricConfigs, setSelectedBiasConfigs, selectedBiasConfigs, loadError]);
 

--- a/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
@@ -8,30 +8,20 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
 import MetricsPageToolbar from '~/pages/modelServing/screens/metrics/MetricsPageToolbar';
 import BiasMetricConfigSelector from '~/pages/modelServing/screens/metrics/BiasMetricConfigSelector';
-import { BiasMetricConfig } from '~/concepts/explainability/types';
 import { useExplainabilityModelData } from '~/concepts/explainability/useExplainabilityModelData';
 import TrustyChart from '~/pages/modelServing/screens/metrics/TrustyChart';
-import { useBrowserStorage } from '~/components/browserStorage';
 import EmptyBiasConfigurationCard from '~/pages/modelServing/screens/metrics/EmptyBiasConfigurationCard';
 import EmptyBiasChartSelectionCard from '~/pages/modelServing/screens/metrics/EmptyBiasChartSelectionCard';
 import DashboardExpandableSection from '~/concepts/dashboard/DashboardExpandableSection';
+import useBiasChartsBrowserStorage from '~/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage';
 
-const SELECTED_CHARTS_STORAGE_KEY_PREFIX = 'odh.dashboard.xai.selected_bias_charts';
 const OPEN_WRAPPER_STORAGE_KEY_PREFIX = `odh.dashboard.xai.bias_metric_chart_wrapper_open`;
 const BiasTab: React.FC = () => {
-  const { inferenceService } = useParams();
-
   const { biasMetricConfigs, loaded, loadError } = useExplainabilityModelData();
 
-  const [selectedBiasConfigs, setSelectedBiasConfigs] = useBrowserStorage<BiasMetricConfig[]>(
-    `${SELECTED_CHARTS_STORAGE_KEY_PREFIX}-${inferenceService}`,
-    [],
-    true,
-    true,
-  );
+  const [selectedBiasConfigs, setSelectedBiasConfigs] = useBiasChartsBrowserStorage();
 
   const firstRender = React.useRef(true);
 
@@ -47,12 +37,6 @@ const BiasTab: React.FC = () => {
           // to set anything.
           setSelectedBiasConfigs([biasMetricConfigs[0]]);
         }
-      } else {
-        setSelectedBiasConfigs(
-          selectedBiasConfigs.filter((selection) =>
-            biasMetricConfigs.map((c) => c.id).includes(selection.id),
-          ),
-        );
       }
     }
   }, [loaded, biasMetricConfigs, setSelectedBiasConfigs, selectedBiasConfigs, loadError]);

--- a/frontend/src/pages/modelServing/screens/metrics/EmptyBiasChartSelectionCard.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/EmptyBiasChartSelectionCard.tsx
@@ -7,7 +7,7 @@ import {
   EmptyStateIcon,
   Title,
 } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { SearchIcon } from '@patternfly/react-icons';
 import {
   EMPTY_BIAS_CHART_SELECTION_DESC,
   EMPTY_BIAS_CHART_SELECTION_TITLE,
@@ -17,7 +17,7 @@ const EmptyBiasChartSelectionCard = () => (
   <Card>
     <CardBody>
       <EmptyState>
-        <EmptyStateIcon icon={PlusCircleIcon} />
+        <EmptyStateIcon icon={SearchIcon} />
         <Title headingLevel="h2" size="lg">
           {EMPTY_BIAS_CHART_SELECTION_TITLE}
         </Title>

--- a/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/DeleteBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/biasConfigurationModal/DeleteBiasConfigurationModal.tsx
@@ -3,6 +3,8 @@ import { MetricTypes } from '~/api';
 import { ExplainabilityContext } from '~/concepts/explainability/ExplainabilityContext';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
+import useBiasChartsBrowserStorage from '~/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage';
+import { byNotId } from '~/pages/modelServing/screens/metrics/utils';
 
 type DeleteBiasConfigurationModalProps = {
   configurationToDelete?: BiasMetricConfig;
@@ -18,6 +20,12 @@ const DeleteBiasConfigurationModal: React.FC<DeleteBiasConfigurationModalProps> 
   const {
     apiState: { api },
   } = React.useContext(ExplainabilityContext);
+
+  const [selectedBiasConfigCharts, setSelectedBiasConfigCharts] = useBiasChartsBrowserStorage();
+
+  const deselectDeleted = (biasConfigId: string) => {
+    setSelectedBiasConfigCharts(selectedBiasConfigCharts.filter(byNotId(biasConfigId)));
+  };
 
   const onBeforeClose = (deleted: boolean) => {
     onClose(deleted);
@@ -41,6 +49,7 @@ const DeleteBiasConfigurationModal: React.FC<DeleteBiasConfigurationModalProps> 
               : api.deleteSpdRequest;
           deleteFunc({}, configurationToDelete.id)
             .then(() => onBeforeClose(true))
+            .then(() => deselectDeleted(configurationToDelete.id))
             .catch((e) => {
               setError(e);
               setDeleting(false);

--- a/frontend/src/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage.ts
@@ -1,0 +1,24 @@
+import { useParams } from 'react-router-dom';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { BiasMetricConfig } from '~/concepts/explainability/types';
+import { SetBrowserStorageHook } from '~/components/browserStorage/BrowserStorageContext';
+
+const SELECTED_CHARTS_STORAGE_KEY_PREFIX = 'odh.dashboard.xai.selected_bias_charts';
+
+const useBiasChartsBrowserStorage = (): [
+  BiasMetricConfig[],
+  SetBrowserStorageHook<BiasMetricConfig[]>,
+] => {
+  const { inferenceService } = useParams();
+
+  const [selectedBiasConfigs, setSelectedBiasConfigs] = useBrowserStorage<BiasMetricConfig[]>(
+    `${SELECTED_CHARTS_STORAGE_KEY_PREFIX}-${inferenceService}`,
+    [],
+    true,
+    true,
+  );
+
+  return [selectedBiasConfigs, setSelectedBiasConfigs];
+};
+
+export default useBiasChartsBrowserStorage;

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -21,8 +21,15 @@ export type TimeframeTimeType = {
 export type TimeframeStepType = TimeframeTimeType;
 
 export enum RefreshIntervalTitle {
+  FIFTEEN_SECONDS = '15 seconds',
+  THIRTY_SECONDS = '30 seconds',
   ONE_MINUTE = '1 minute',
   FIVE_MINUTES = '5 minutes',
+  FIFTEEN_MINUTES = '15 minutes',
+  THIRTY_MINUTES = '30 minutes',
+  ONE_HOUR = '1 hour',
+  TWO_HOURS = '2 hours',
+  ONE_DAY = '1 day',
 }
 
 export type RefreshIntervalValueType = {


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1386 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

* When a user navigates to the model bias tab and no charts are selected to display, automatically display the first chart
* Refresh interval dropdown updated with the same values as that of the OpenShift console Observability dashboard
* No charts selected empty state updated to:
  *  Show the Search icon instead of the Plus icon
 
![localhost_4010_modelServing_metrics_trustyai-e2e-modelmesh_demo-loan-nn-onnx-alpha_bias (5)](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/f84b5110-6986-4f3a-bc1e-e46882002f1e)

![localhost_4010_modelServing_metrics_trustyai-e2e-modelmesh_demo-loan-nn-onnx-alpha_bias (6)](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/ba92dbd4-d26f-4163-9d47-5982a6d16328)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Improvement 1:
* Navigate to bias metrics tab
* Deselect all charts
* Navigate away from the current model (i.e. back to Projects view) - so the context is cleared
* Navigate back to the bias model tab - instead of an empty state one chart should be automatically selected.

Improvement 2:
* Check refresh interval dropdown has options that match openshift console (image provided) 
<img width="284" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/3396d18b-d0ff-4896-b3af-52ee9ffd863c">

Improvement 3:
* Visit model bias tab, deselect all charts, verify the empty state has a magnifying glass icon.
* Verify new text is present *[NOT YET COMPLETE]*


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None, right now, TBD later.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
