### PR TITLE
Fixes issue with bias charts auto-refreshing with stale data (#1403)

### DIFF
--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -14,9 +14,8 @@ import {
   TimeframeTitle,
 } from '~/pages/modelServing/screens/types';
 import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
-import useQueryRangeResourceData, {
-  useQueryRangeResourceDataTrusty,
-} from './useQueryRangeResourceData';
+import { ResponsePredicate } from '~/api/prometheus/usePrometheusQueryRange';
+import useQueryRangeResourceData from './useQueryRangeResourceData';
 
 export const useModelServingMetrics = (
   type: MetricType,
@@ -35,12 +34,22 @@ export const useModelServingMetrics = (
   const [end, setEnd] = React.useState(lastUpdateTime);
   const [biasMetricsEnabled] = useBiasMetricsEnabled();
 
+  const defaultResponsePredicate = React.useCallback<ResponsePredicate>(
+    (data) => data.result?.[0]?.values || [],
+    [],
+  );
+
+  const trustyResponsePredicate = React.useCallback<
+    ResponsePredicate<PrometheusQueryRangeResponseDataResult>
+  >((data) => data.result, []);
+
   const runtimeRequestCount = useQueryRangeResourceData(
     type === 'runtime',
     queries[RuntimeMetricType.REQUEST_COUNT],
     end,
     timeframe,
     refreshInterval,
+    defaultResponsePredicate,
   );
 
   const runtimeAverageResponseTime = useQueryRangeResourceData(
@@ -49,6 +58,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     refreshInterval,
+    defaultResponsePredicate,
   );
 
   const runtimeCPUUtilization = useQueryRangeResourceData(
@@ -57,6 +67,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     refreshInterval,
+    defaultResponsePredicate,
   );
 
   const runtimeMemoryUtilization = useQueryRangeResourceData(
@@ -65,6 +76,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     refreshInterval,
+    defaultResponsePredicate,
   );
 
   const inferenceRequestSuccessCount = useQueryRangeResourceData(
@@ -73,6 +85,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     refreshInterval,
+    defaultResponsePredicate,
   );
 
   const inferenceRequestFailedCount = useQueryRangeResourceData(
@@ -81,22 +94,25 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     refreshInterval,
+    defaultResponsePredicate,
   );
 
-  const inferenceTrustyAISPD = useQueryRangeResourceDataTrusty(
+  const inferenceTrustyAISPD = useQueryRangeResourceData(
     biasMetricsEnabled && type === 'inference',
     queries[InferenceMetricType.TRUSTY_AI_SPD],
     end,
     timeframe,
     refreshInterval,
+    trustyResponsePredicate,
   );
 
-  const inferenceTrustyAIDIR = useQueryRangeResourceDataTrusty(
+  const inferenceTrustyAIDIR = useQueryRangeResourceData(
     biasMetricsEnabled && type === 'inference',
     queries[InferenceMetricType.TRUSTY_AI_DIR],
     end,
     timeframe,
     refreshInterval,
+    trustyResponsePredicate,
   );
 
   React.useEffect(() => {

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -15,6 +15,8 @@ import {
 } from '~/pages/modelServing/screens/types';
 import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
 import { ResponsePredicate } from '~/api/prometheus/usePrometheusQueryRange';
+import useRefreshInterval from '~/utilities/useRefreshInterval';
+import { RefreshIntervalValue } from '~/pages/modelServing/screens/const';
 import useQueryRangeResourceData from './useQueryRangeResourceData';
 
 export const useModelServingMetrics = (
@@ -133,6 +135,8 @@ export const useModelServingMetrics = (
   const refreshAllMetrics = React.useCallback(() => {
     setEnd(Date.now());
   }, []);
+
+  useRefreshInterval(RefreshIntervalValue[refreshInterval], refreshAllMetrics);
 
   return React.useMemo(
     () => ({

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -50,7 +50,6 @@ export const useModelServingMetrics = (
     queries[RuntimeMetricType.REQUEST_COUNT],
     end,
     timeframe,
-    refreshInterval,
     defaultResponsePredicate,
   );
 
@@ -59,7 +58,6 @@ export const useModelServingMetrics = (
     queries[RuntimeMetricType.AVG_RESPONSE_TIME],
     end,
     timeframe,
-    refreshInterval,
     defaultResponsePredicate,
   );
 
@@ -68,7 +66,6 @@ export const useModelServingMetrics = (
     queries[RuntimeMetricType.CPU_UTILIZATION],
     end,
     timeframe,
-    refreshInterval,
     defaultResponsePredicate,
   );
 
@@ -77,7 +74,6 @@ export const useModelServingMetrics = (
     queries[RuntimeMetricType.MEMORY_UTILIZATION],
     end,
     timeframe,
-    refreshInterval,
     defaultResponsePredicate,
   );
 
@@ -86,7 +82,6 @@ export const useModelServingMetrics = (
     queries[InferenceMetricType.REQUEST_COUNT_SUCCESS],
     end,
     timeframe,
-    refreshInterval,
     defaultResponsePredicate,
   );
 
@@ -95,7 +90,6 @@ export const useModelServingMetrics = (
     queries[InferenceMetricType.REQUEST_COUNT_FAILED],
     end,
     timeframe,
-    refreshInterval,
     defaultResponsePredicate,
   );
 
@@ -104,7 +98,6 @@ export const useModelServingMetrics = (
     queries[InferenceMetricType.TRUSTY_AI_SPD],
     end,
     timeframe,
-    refreshInterval,
     trustyResponsePredicate,
   );
 
@@ -113,7 +106,6 @@ export const useModelServingMetrics = (
     queries[InferenceMetricType.TRUSTY_AI_DIR],
     end,
     timeframe,
-    refreshInterval,
     trustyResponsePredicate,
   );
 

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,11 +1,7 @@
-import {
-  RefreshIntervalValue,
-  TimeframeStep,
-  TimeframeTimeRange,
-} from '~/pages/modelServing/screens/const';
+import { TimeframeStep, TimeframeTimeRange } from '~/pages/modelServing/screens/const';
 import { RefreshIntervalTitle, TimeframeTitle } from '~/pages/modelServing/screens/types';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
-import { useContextResourceData } from '~/utilities/useContextResourceData';
+import useRestructureContextResourceData from '~/utilities/useRestructureContextResourceData';
 import usePrometheusQueryRange, { ResponsePredicate } from './usePrometheusQueryRange';
 
 const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
@@ -17,7 +13,7 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   refreshInterval: RefreshIntervalTitle,
   responsePredicate: ResponsePredicate<T>,
 ): ContextResourceData<T> =>
-  useContextResourceData<T>(
+  useRestructureContextResourceData<T>(
     usePrometheusQueryRange<T>(
       active,
       '/api/prometheus/serving',
@@ -27,7 +23,6 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
       TimeframeStep[timeframe],
       responsePredicate,
     ),
-    RefreshIntervalValue[refreshInterval],
   );
 
 export default useQueryRangeResourceData;

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,32 +1,24 @@
-import * as React from 'react';
 import {
   RefreshIntervalValue,
   TimeframeStep,
   TimeframeTimeRange,
 } from '~/pages/modelServing/screens/const';
 import { RefreshIntervalTitle, TimeframeTitle } from '~/pages/modelServing/screens/types';
-import {
-  ContextResourceData,
-  PrometheusQueryRangeResponseDataResult,
-  PrometheusQueryRangeResultValue,
-} from '~/types';
+import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
 import { useContextResourceData } from '~/utilities/useContextResourceData';
 import usePrometheusQueryRange, { ResponsePredicate } from './usePrometheusQueryRange';
 
-const useQueryRangeResourceData = (
+const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   /** Is the query active -- should we be fetching? */
   active: boolean,
   query: string,
   end: number,
   timeframe: TimeframeTitle,
   refreshInterval: RefreshIntervalTitle,
-): ContextResourceData<PrometheusQueryRangeResultValue> => {
-  const responsePredicate = React.useCallback<ResponsePredicate>(
-    (data) => data.result?.[0]?.values || [],
-    [],
-  );
-  return useContextResourceData<PrometheusQueryRangeResultValue>(
-    usePrometheusQueryRange<PrometheusQueryRangeResultValue>(
+  responsePredicate: ResponsePredicate<T>,
+): ContextResourceData<T> =>
+  useContextResourceData<T>(
+    usePrometheusQueryRange<T>(
       active,
       '/api/prometheus/serving',
       query,
@@ -37,33 +29,5 @@ const useQueryRangeResourceData = (
     ),
     RefreshIntervalValue[refreshInterval],
   );
-};
 
-type TrustyData = PrometheusQueryRangeResponseDataResult;
-
-export const useQueryRangeResourceDataTrusty = (
-  /** Is the query active -- should we be fetching? */
-  active: boolean,
-  query: string,
-  end: number,
-  timeframe: TimeframeTitle,
-  refreshInterval: RefreshIntervalTitle,
-): ContextResourceData<TrustyData> => {
-  const responsePredicate = React.useCallback<ResponsePredicate<TrustyData>>(
-    (data) => data.result,
-    [],
-  );
-  return useContextResourceData<TrustyData>(
-    usePrometheusQueryRange<TrustyData>(
-      active,
-      '/api/prometheus/serving',
-      query,
-      TimeframeTimeRange[timeframe],
-      end,
-      TimeframeStep[timeframe],
-      responsePredicate,
-    ),
-    RefreshIntervalValue[refreshInterval],
-  );
-};
 export default useQueryRangeResourceData;

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,7 +1,7 @@
 import { TimeframeStep, TimeframeTimeRange } from '~/pages/modelServing/screens/const';
-import { RefreshIntervalTitle, TimeframeTitle } from '~/pages/modelServing/screens/types';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
 import useRestructureContextResourceData from '~/utilities/useRestructureContextResourceData';
+import { TimeframeTitle } from '~/pages/modelServing/screens/types';
 import usePrometheusQueryRange, { ResponsePredicate } from './usePrometheusQueryRange';
 
 const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
@@ -10,7 +10,6 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   query: string,
   end: number,
   timeframe: TimeframeTitle,
-  refreshInterval: RefreshIntervalTitle,
   responsePredicate: ResponsePredicate<T>,
 ): ContextResourceData<T> =>
   useRestructureContextResourceData<T>(

--- a/frontend/src/utilities/useRefreshInterval.ts
+++ b/frontend/src/utilities/useRefreshInterval.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const useRefreshInterval = (refreshInterval, callback: () => void) => {
+  const cb = React.useRef<typeof callback>(() => undefined);
+
+  cb.current = callback;
+
+  React.useEffect(() => {
+    const timer = setInterval(cb.current, refreshInterval);
+    return () => clearInterval(timer);
+  }, [refreshInterval]);
+};
+export default useRefreshInterval;

--- a/frontend/src/utilities/useRefreshInterval.ts
+++ b/frontend/src/utilities/useRefreshInterval.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const useRefreshInterval = (refreshInterval, callback: () => void) => {
+const useRefreshInterval = (refreshInterval: number, callback: () => void) => {
   const cb = React.useRef<typeof callback>(() => undefined);
 
   cb.current = callback;

--- a/frontend/src/utilities/useRestructureContextResourceData.tsx
+++ b/frontend/src/utilities/useRestructureContextResourceData.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { FetchState } from '~/utilities/useFetchState';
+import { ContextResourceData } from '~/types';
+
+const useRestructureContextResourceData = <T,>(
+  resourceData: FetchState<T[]>,
+): ContextResourceData<T> => {
+  const [data, loaded, error, refresh] = resourceData;
+  return React.useMemo(
+    () => ({
+      data,
+      loaded,
+      error,
+      refresh,
+    }),
+    [data, error, loaded, refresh],
+  );
+};
+
+export default useRestructureContextResourceData;


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
* Closes: #1403 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fixes bug described in ticket #1403 -- please read for detailed description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Go to the bias metric charts page, select a chart to display
* Set the timeframe to 1 hour and refresh interval to 1 minute, to make testing easier.
* Leave the chart open for a few minutes, check there is no gap in the data as seen in the image below.
![](https://user-images.githubusercontent.com/4092230/246424856-637a67c4-241b-4ecc-9c15-1b70168f3676.png)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests for this feature yet, so none to change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
