### PR TITLE
Refactor Custom Serving Runtime enablement

### DIFF
--- a/backend/src/routes/api/dashboardConfig/index.ts
+++ b/backend/src/routes/api/dashboardConfig/index.ts
@@ -13,14 +13,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       ) => {
         const { namespace, name } = request.params;
         try {
-          const rbResponse = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
+          const response = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
             'opendatahub.io',
             'v1alpha',
             namespace,
             'odhdashboardconfigs',
             name,
           );
-          return rbResponse.body;
+          return response.body;
         } catch (e) {
           fastify.log.error(
             `Dashboard ${name} could not be read, ${e.response?.body?.message || e.message}`,

--- a/backend/src/routes/api/rolebindings/index.ts
+++ b/backend/src/routes/api/rolebindings/index.ts
@@ -14,14 +14,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         const rbName = request.params.name;
         const rbNamespace = request.params.namespace;
         try {
-          const rbResponse = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
+          const response = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
             'rbac.authorization.k8s.io',
             'v1',
             rbNamespace,
             'rolebindings',
             rbName,
           );
-          return rbResponse.body;
+          return response.body;
         } catch (e) {
           fastify.log.error(
             `rolebinding ${rbName} could not be read, ${e.response?.body?.message || e.message}`,
@@ -38,14 +38,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       async (request: FastifyRequest<{ Body: V1RoleBinding }>, reply: FastifyReply) => {
         const rbRequest = request.body;
         try {
-          const rbResponse = await fastify.kube.customObjectsApi.createNamespacedCustomObject(
+          const response = await fastify.kube.customObjectsApi.createNamespacedCustomObject(
             'rbac.authorization.k8s.io',
             'v1',
             rbRequest.metadata.namespace,
             'rolebindings',
             rbRequest,
           );
-          return rbResponse.body;
+          return response.body;
         } catch (e) {
           if (e.response?.statusCode === 409) {
             fastify.log.warn(`Rolebinding already present, skipping creation.`);

--- a/backend/src/routes/api/templates/index.ts
+++ b/backend/src/routes/api/templates/index.ts
@@ -13,14 +13,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       ) => {
         const { namespace, name } = request.params;
         try {
-          const rbResponse = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
+          const response = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
             'template.openshift.io',
             'v1',
             namespace,
             'templates',
             name,
           );
-          return rbResponse.body;
+          return response.body;
         } catch (e) {
           fastify.log.error(
             `Template ${name} could not be read, ${e.response?.body?.message || e.message}`,
@@ -44,7 +44,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         const { namespace } = request.params;
         const { labelSelector } = request.query;
         try {
-          const rbResponse = await fastify.kube.customObjectsApi.listNamespacedCustomObject(
+          const response = await fastify.kube.customObjectsApi.listNamespacedCustomObject(
             'template.openshift.io',
             'v1',
             namespace,
@@ -54,7 +54,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
             undefined,
             labelSelector,
           );
-          return rbResponse.body;
+          return response.body;
         } catch (e) {
           fastify.log.error(
             `Templates could not be listed, ${e.response?.body?.message || e.message}`,
@@ -147,14 +147,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       ) => {
         const { namespace, name } = request.params;
         try {
-          const rbResponse = await fastify.kube.customObjectsApi.deleteNamespacedCustomObject(
+          const response = await fastify.kube.customObjectsApi.deleteNamespacedCustomObject(
             'template.openshift.io',
             'v1',
             namespace,
             'templates',
             name,
           );
-          return rbResponse.body;
+          return response.body;
         } catch (e) {
           fastify.log.error(
             `Template ${name} could not be deleted, ${e.response?.body?.message || e.message}`,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -47,6 +47,7 @@ export type DashboardConfig = K8sResourceCommon & {
       storageClassName?: string;
     };
     templateOrder?: string[];
+    templateDisablement?: string[];
   };
   /** Faux status object -- will be replaced in the long run by a Dashboard Controller */
   status: {
@@ -826,7 +827,6 @@ export type TemplateParameter = {
   required: boolean;
 };
 
-
 export type Template = K8sResourceCommon & {
   metadata: {
     annotations?: Partial<{
@@ -869,7 +869,6 @@ export type ContainerResources = {
     'nvidia.com/gpu'?: GPUCount;
   };
 };
-
 
 export type ServingRuntime = K8sResourceCommon & {
   metadata: {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -841,6 +841,13 @@ export type Template = K8sResourceCommon & {
   parameters: TemplateParameter[];
 };
 
+export type TemplateList = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: Record<string, unknown>;
+  items: Template[];
+} & K8sResourceCommon;
+
 export type ServingRuntimeAnnotations = Partial<{
   'opendatahub.io/template-name': string;
   'opendatahub.io/template-display-name': string;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -62,6 +62,7 @@ export const blankDashboardCR: DashboardConfig = {
       allowedGroups: 'system:authenticated',
     },
     templateOrder: [],
+    templateDisablement: [],
   },
   status: {
     dependencyOperators: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -62,7 +62,7 @@ export const blankDashboardCR: DashboardConfig = {
       allowedGroups: 'system:authenticated',
     },
     templateOrder: [],
-    templateDisablement: [],
+    // templateDisablement: [], Don't create this field, will be used in migration
   },
   status: {
     dependencyOperators: {

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -15,6 +15,8 @@ import {
   OdhDocument,
   QuickStart,
   SubscriptionKind,
+  Template,
+  TemplateList,
 } from '../types';
 import {
   DEFAULT_ACTIVE_TIMEOUT,
@@ -31,6 +33,7 @@ import {
   getRouteForClusterId,
 } from './componentUtils';
 import { createCustomError } from './requestUtils';
+import fastify from 'fastify';
 
 const dashboardConfigMapName = 'odh-dashboard-config';
 const consoleLinksGroup = 'console.openshift.io';
@@ -80,7 +83,18 @@ const fetchOperatorExistence = async (
 
 const fetchDashboardCR = async (fastify: KubeFastifyInstance): Promise<DashboardConfig[]> => {
   const dashboardName = process.env['DASHBOARD_CONFIG'] || dashboardConfigMapName;
-  const dashboardConfig: DashboardConfig[] = await fastify.kube.customObjectsApi
+  return fetchOrCreateDashboardCR(fastify, dashboardName).then((dashboardCR) => {
+    return manageOperatorStatus(fastify, dashboardCR).then((dashboardCR) => {
+      return migrateTemplateDisablement(fastify, dashboardCR).then((dashboardCR) => [dashboardCR]);
+    });
+  });
+};
+
+const fetchOrCreateDashboardCR = async (
+  fastify: KubeFastifyInstance,
+  dashboardName: string,
+): Promise<DashboardConfig> => {
+  return fastify.kube.customObjectsApi
     .getNamespacedCustomObject(
       'opendatahub.io',
       'v1alpha',
@@ -90,7 +104,7 @@ const fetchDashboardCR = async (fastify: KubeFastifyInstance): Promise<Dashboard
     )
     .then((res) => {
       const dashboardCR = res?.body as DashboardConfig;
-      return [_.merge({}, blankDashboardCR, dashboardCR)]; // merge with blank CR to prevent any missing values
+      return _.merge({}, blankDashboardCR, dashboardCR); // merge with blank CR to prevent any missing values
     })
     .catch((e) => {
       fastify.log.warn(
@@ -98,32 +112,35 @@ const fetchDashboardCR = async (fastify: KubeFastifyInstance): Promise<Dashboard
       );
       return createDashboardCR(fastify);
     });
+};
 
-  if (dashboardConfig?.[0].spec.dashboardConfig.disablePipelines === false) {
+const manageOperatorStatus = async (
+  fastify: KubeFastifyInstance,
+  dashboardConfig: DashboardConfig,
+): Promise<DashboardConfig> => {
+  if (dashboardConfig.spec.dashboardConfig.disablePipelines === false) {
     fastify.log.info('Pipelines feature enabled, computing operator state...');
     return fetchOperatorExistence(fastify, 'openshift-pipelines-operator-rh').then((exists) => {
       fastify.log.info(`Pipeline Operator status: ${exists}`);
-      return [
-        _.merge({}, dashboardConfig[0], {
-          status: {
-            ...dashboardConfig[0].status,
-            dependencyOperators: {
-              redhatOpenshiftPipelines: {
-                queriedForStatus: true,
-                available: exists,
-              },
+      return _.merge({}, dashboardConfig, {
+        status: {
+          ...dashboardConfig.status,
+          dependencyOperators: {
+            redhatOpenshiftPipelines: {
+              queriedForStatus: true,
+              available: exists,
             },
           },
-        }),
-      ];
+        },
+      });
     });
   }
 
   return dashboardConfig;
 };
 
-const createDashboardCR = (fastify: KubeFastifyInstance): Promise<DashboardConfig[]> => {
-  const createResponse: Promise<DashboardConfig[]> = fastify.kube.customObjectsApi
+const createDashboardCR = (fastify: KubeFastifyInstance): Promise<DashboardConfig> => {
+  return fastify.kube.customObjectsApi
     .createNamespacedCustomObject(
       'opendatahub.io',
       'v1alpha',
@@ -136,8 +153,6 @@ const createDashboardCR = (fastify: KubeFastifyInstance): Promise<DashboardConfi
       fastify.log.error('Error creating Dashboard CR: ', e);
       return null;
     });
-
-  return createResponse;
 };
 
 const fetchSubscriptions = (fastify: KubeFastifyInstance): Promise<SubscriptionKind[]> => {
@@ -724,3 +739,72 @@ export const cleanupDSPSuffix = async (fastify: KubeFastifyInstance): Promise<vo
     fastify.log.info('Completed updating Namespaces');
   });
 };
+
+/**
+ * @deprecated - Look to remove asap (see comments below)
+ * Migrate the template enablement from a current annotation in the Template Object to a list in ODHDashboardConfig
+ * We are migrating this from v2.11.0, so we can remove this code when we no longer support that version.
+ */
+export const migrateTemplateDisablement = async (
+  fastify: KubeFastifyInstance,
+  dashboardConfig: DashboardConfig,
+): Promise<DashboardConfig> => {
+  if (dashboardConfig.spec.templateDisablement) {
+    return dashboardConfig;
+  }
+
+  const namespace = fastify.kube.namespace;
+  return fastify.kube.customObjectsApi
+    .listNamespacedCustomObject(
+      'template.openshift.io',
+      'v1',
+      namespace,
+      'templates',
+      undefined,
+      undefined,
+      undefined,
+      'opendatahub.io/dashboard=true',
+    )
+    .then((response) => response.body as TemplateList)
+    .then((templateList) => {
+      const templatesDisabled = templateList.items
+        .filter(
+          (template) =>
+            template.metadata.annotations['opendatahub.io/template-enabled'] === 'false',
+        )
+        .map((template) => getServingRuntimeNameFromTemplate(template));
+      if (templatesDisabled.length > 0) {
+        const options = {
+          headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_PATCH },
+        };
+
+        return fastify.kube.customObjectsApi
+          .patchNamespacedCustomObject(
+            'opendatahub.io',
+            'v1alpha',
+            dashboardConfig.metadata.namespace,
+            'odhdashboardconfigs',
+            dashboardConfig.metadata.name,
+            [
+              {
+                op: 'replace',
+                path: '/spec/templateDisablement',
+                value: templatesDisabled,
+              },
+            ],
+            undefined,
+            undefined,
+            undefined,
+            options,
+          )
+          .then((response) => {
+            return response.body as DashboardConfig;
+          });
+      } else {
+        return dashboardConfig;
+      }
+    });
+};
+
+export const getServingRuntimeNameFromTemplate = (template: Template): string =>
+  template.objects[0].metadata.name;

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -33,7 +33,6 @@ import {
   getRouteForClusterId,
 } from './componentUtils';
 import { createCustomError } from './requestUtils';
-import fastify from 'fastify';
 
 const dashboardConfigMapName = 'odh-dashboard-config';
 const consoleLinksGroup = 'console.openshift.io';

--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -193,5 +193,7 @@ spec:
     allowedGroups: 'system:authenticated'
   templateOrder:
     - 'ovms'
+  templateDisablement:
+    - 'ovms'
 
 ```

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -177,6 +177,7 @@ export const mockDashboardConfig = ({
       },
     ],
     templateOrder: ['test-model'],
+    templateDisablement: ['test-model'],
   },
   status: {
     dependencyOperators: {

--- a/frontend/src/api/k8s/dashboardConfig.ts
+++ b/frontend/src/api/k8s/dashboardConfig.ts
@@ -64,7 +64,7 @@ export const patchDashboardConfigTemplateDisablement = (
   }).then((dashboardConfig) => {
     // Patch doesn't return an error if the attribute is disabled, it just return the object without changes
     if (dashboardConfig.spec?.templateDisablement === undefined) {
-      throw new Error('Template order is not configured');
+      throw new Error('Template disablement is not configured');
     }
     return dashboardConfig.spec?.templateDisablement;
   });

--- a/frontend/src/api/k8s/dashboardConfig.ts
+++ b/frontend/src/api/k8s/dashboardConfig.ts
@@ -19,12 +19,6 @@ export const getDashboardConfigTemplateOrder = (ns: string): Promise<string[]> =
 export const getDashboardConfigTemplateDisablement = (ns: string): Promise<string[]> =>
   getDashboardConfig(ns).then((dashboardConfig) => dashboardConfig.spec.templateDisablement || []);
 
-export const getDashboardTemplateConfig = (ns: string): Promise<[string[], string[]]> =>
-  getDashboardConfig(ns).then((dashboardConfig) => [
-    dashboardConfig.spec.templateOrder || [],
-    dashboardConfig.spec.templateDisablement || [],
-  ]);
-
 export const updateDashboardConfig = (resource: DashboardConfigKind) =>
   k8sUpdateResource<DashboardConfigKind>({
     model: ODHDashboardConfigModel,
@@ -69,8 +63,8 @@ export const patchDashboardConfigTemplateDisablement = (
     ],
   }).then((dashboardConfig) => {
     // Patch doesn't return an error if the attribute is disabled, it just return the object without changes
-    if (dashboardConfig.spec?.templateOrder === undefined) {
+    if (dashboardConfig.spec?.templateDisablement === undefined) {
       throw new Error('Template order is not configured');
     }
-    return dashboardConfig.spec?.templateOrder;
+    return dashboardConfig.spec?.templateDisablement;
   });

--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -32,10 +32,6 @@ export const assembleServingRuntimeTemplate = (
       labels: {
         'opendatahub.io/dashboard': 'true',
       },
-      annotations: {
-        'opendatahub.io/template-enabled': 'true',
-        tags: `${servingRuntimeName},servingruntime`,
-      },
     },
     objects: [servingRuntime],
     parameters: [],

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -713,5 +713,6 @@ export type DashboardConfigKind = K8sResourceCommon & {
       notebookTolerationSettings?: TolerationSettings;
     };
     templateOrder?: string[];
+    templateDisablement?: string[];
   };
 };

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeContext.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeContext.tsx
@@ -16,17 +16,20 @@ import { useContextResourceData } from '~/utilities/useContextResourceData';
 import { useDashboardNamespace } from '~/redux/selectors';
 import useTemplates from './useTemplates';
 import useTemplateOrder from './useTemplateOrder';
+import useTemplateDisablement from './useTemplateDisablement';
 
 type CustomServingRuntimeContextType = {
   refreshData: () => void;
   servingRuntimeTemplates: ContextResourceData<TemplateKind>;
   servingRuntimeTemplateOrder: ContextResourceData<string>;
+  servingRuntimeTemplateDisablement: ContextResourceData<string>;
 };
 
 export const CustomServingRuntimeContext = React.createContext<CustomServingRuntimeContextType>({
   refreshData: () => undefined,
   servingRuntimeTemplates: DEFAULT_CONTEXT_DATA,
   servingRuntimeTemplateOrder: DEFAULT_CONTEXT_DATA,
+  servingRuntimeTemplateDisablement: DEFAULT_CONTEXT_DATA,
 });
 
 const CustomServingRuntimeContextProvider: React.FC = () => {
@@ -43,15 +46,31 @@ const CustomServingRuntimeContextProvider: React.FC = () => {
     2 * 60 * 1000,
   );
 
+  // TODO: Disable backend workaround when we migrate admin panel to Passthrough API
+  const servingRuntimeTemplateDisablement = useContextResourceData<string>(
+    useTemplateDisablement(dashboardNamespace, true),
+    2 * 60 * 1000,
+  );
+
   const servingRuntimeTemplateRefresh = servingRuntimeTemplates.refresh;
   const servingRuntimeTemplateOrderRefresh = servingRuntimeTemplateOrder.refresh;
+  const servingRuntimeTemplateDisablementRefresh = servingRuntimeTemplateOrder.refresh;
 
   const refreshData = React.useCallback(() => {
     servingRuntimeTemplateRefresh();
     servingRuntimeTemplateOrderRefresh();
-  }, [servingRuntimeTemplateRefresh, servingRuntimeTemplateOrderRefresh]);
+    servingRuntimeTemplateDisablementRefresh();
+  }, [
+    servingRuntimeTemplateRefresh,
+    servingRuntimeTemplateOrderRefresh,
+    servingRuntimeTemplateDisablementRefresh,
+  ]);
 
-  if (servingRuntimeTemplates.error || servingRuntimeTemplateOrder.error) {
+  if (
+    servingRuntimeTemplates.error ||
+    servingRuntimeTemplateOrder.error ||
+    servingRuntimeTemplateDisablement.error
+  ) {
     return (
       <Bullseye>
         <EmptyState>
@@ -67,7 +86,11 @@ const CustomServingRuntimeContextProvider: React.FC = () => {
     );
   }
 
-  if (!servingRuntimeTemplates.loaded || !servingRuntimeTemplateOrder.loaded) {
+  if (
+    !servingRuntimeTemplates.loaded ||
+    !servingRuntimeTemplateOrder.loaded ||
+    !servingRuntimeTemplateDisablement.loaded
+  ) {
     return (
       <Bullseye>
         <Spinner />
@@ -80,6 +103,7 @@ const CustomServingRuntimeContextProvider: React.FC = () => {
       value={{
         servingRuntimeTemplates,
         servingRuntimeTemplateOrder,
+        servingRuntimeTemplateDisablement,
         refreshData,
       }}
     >

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeEnabledToggle.tsx
@@ -20,6 +20,7 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
       loaded: templateDisablementLoaded,
       refresh: refreshDisablement,
     },
+    servingRuntimeTemplates: { data: templates },
   } = React.useContext(CustomServingRuntimeContext);
   const { dashboardNamespace } = useDashboardNamespace();
   const [isEnabled, setEnabled] = React.useState(true);
@@ -34,7 +35,12 @@ const CustomServingRuntimeEnabledToggle: React.FC<CustomServingRuntimeEnabledTog
 
   const handleChange = (checked: boolean) => {
     setLoading(true);
-    const templateDisablemetUpdated = setListDisabled(template, templateDisablement, !checked);
+    const templateDisablemetUpdated = setListDisabled(
+      template,
+      templates,
+      templateDisablement,
+      !checked,
+    );
     // TODO: Revert back to pass through api once we migrate admin panel
     patchDashboardConfigTemplateDisablementBackend(templateDisablemetUpdated, dashboardNamespace)
       .then(() => {

--- a/frontend/src/pages/modelServing/customServingRuntimes/useTemplateDisablement.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useTemplateDisablement.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { getDashboardConfigTemplateDisablement } from '~/api';
+import useCustomServingRuntimesEnabled from '~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
+import { getDashboardConfigTemplateDisablementBackend } from '~/services/dashboardService';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
+
+const useTemplateDisablement = (namespace?: string, adminPanel?: boolean): FetchState<string[]> => {
+  const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
+
+  const getTemplateOrder = React.useCallback(() => {
+    if (!namespace) {
+      return Promise.reject(new Error('No namespace provided'));
+    }
+
+    if (!customServingRuntimesEnabled) {
+      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
+    }
+
+    // TODO: Remove this when we migrate admin panel to Passthrough API
+    if (adminPanel) {
+      return getDashboardConfigTemplateDisablementBackend(namespace).catch((e) => {
+        if (e.statusObject?.code === 404) {
+          throw new Error('Dashboard config template order is not configured.');
+        }
+        throw e;
+      });
+    }
+
+    return getDashboardConfigTemplateDisablement(namespace).catch((e) => {
+      if (e.statusObject?.code === 404) {
+        throw new Error('Dashboard config template order is not configured.');
+      }
+      throw e;
+    });
+  }, [namespace, customServingRuntimesEnabled, adminPanel]);
+
+  return useFetchState<string[]>(getTemplateOrder, []);
+};
+
+export default useTemplateDisablement;

--- a/frontend/src/pages/modelServing/customServingRuntimes/useTemplateDisablement.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useTemplateDisablement.ts
@@ -7,7 +7,7 @@ import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchSt
 const useTemplateDisablement = (namespace?: string, adminPanel?: boolean): FetchState<string[]> => {
   const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
 
-  const getTemplateOrder = React.useCallback(() => {
+  const getTemplateEnablement = React.useCallback(() => {
     if (!namespace) {
       return Promise.reject(new Error('No namespace provided'));
     }
@@ -20,7 +20,7 @@ const useTemplateDisablement = (namespace?: string, adminPanel?: boolean): Fetch
     if (adminPanel) {
       return getDashboardConfigTemplateDisablementBackend(namespace).catch((e) => {
         if (e.statusObject?.code === 404) {
-          throw new Error('Dashboard config template order is not configured.');
+          throw new Error('Dashboard config template enablement is not configured.');
         }
         throw e;
       });
@@ -28,13 +28,13 @@ const useTemplateDisablement = (namespace?: string, adminPanel?: boolean): Fetch
 
     return getDashboardConfigTemplateDisablement(namespace).catch((e) => {
       if (e.statusObject?.code === 404) {
-        throw new Error('Dashboard config template order is not configured.');
+        throw new Error('Dashboard config template enablement is not configured.');
       }
       throw e;
     });
   }, [namespace, customServingRuntimesEnabled, adminPanel]);
 
-  return useFetchState<string[]>(getTemplateOrder, []);
+  return useFetchState<string[]>(getTemplateEnablement, []);
 };
 
 export default useTemplateDisablement;

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -2,8 +2,8 @@ import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource } from '~/pages/projects/utils';
 
-export const getTemplateEnabled = (template: TemplateKind) =>
-  !(template.metadata.annotations?.['opendatahub.io/template-enabled'] === 'false');
+export const getTemplateEnabled = (template: TemplateKind, templateDisablement: string[]) =>
+  !templateDisablement.includes(getServingRuntimeNameFromTemplate(template));
 
 export const isTemplateOOTB = (template: TemplateKind) =>
   template.metadata.labels?.['opendatahub.io/ootb'] === 'true';
@@ -14,6 +14,22 @@ export const getSortedTemplates = (templates: TemplateKind[], order: string[]) =
       order.indexOf(getServingRuntimeNameFromTemplate(a)) -
       order.indexOf(getServingRuntimeNameFromTemplate(b)),
   );
+
+export const setListDisabled = (
+  template: TemplateKind,
+  templateDisablement: string[],
+  isDisabled: boolean,
+): string[] => {
+  const servingRuntimeName = getServingRuntimeNameFromTemplate(template);
+  if (isDisabled) {
+    if (!templateDisablement.includes(servingRuntimeName)) {
+      return [...templateDisablement, servingRuntimeName];
+    }
+  } else {
+    return templateDisablement.filter((item) => item !== servingRuntimeName);
+  }
+  return templateDisablement;
+};
 
 export const getServingRuntimeDisplayNameFromTemplate = (template: TemplateKind) =>
   getDisplayNameFromK8sResource(template.objects[0]);

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -17,18 +17,22 @@ export const getSortedTemplates = (templates: TemplateKind[], order: string[]) =
 
 export const setListDisabled = (
   template: TemplateKind,
+  listTemplates: TemplateKind[],
   templateDisablement: string[],
   isDisabled: boolean,
 ): string[] => {
   const servingRuntimeName = getServingRuntimeNameFromTemplate(template);
+  const templateDisablementFiltered = templateDisablement.filter((item) =>
+    listTemplates.find((t) => getServingRuntimeNameFromTemplate(t) === item),
+  );
   if (isDisabled) {
-    if (!templateDisablement.includes(servingRuntimeName)) {
-      return [...templateDisablement, servingRuntimeName];
+    if (!templateDisablementFiltered.includes(servingRuntimeName)) {
+      return [...templateDisablementFiltered, servingRuntimeName];
     }
   } else {
-    return templateDisablement.filter((item) => item !== servingRuntimeName);
+    return templateDisablementFiltered.filter((item) => item !== servingRuntimeName);
   }
-  return templateDisablement;
+  return templateDisablementFiltered;
 };
 
 export const getServingRuntimeDisplayNameFromTemplate = (template: TemplateKind) =>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeList.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeList.tsx
@@ -5,10 +5,7 @@ import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { ProjectSectionTitles } from '~/pages/projects/screens/detail/const';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-} from '~/pages/modelServing/customServingRuntimes/utils';
+import { getSortedTemplates } from '~/pages/modelServing/customServingRuntimes/utils';
 import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 import ServingRuntimeTable from './ServingRuntimeTable';
 import ServingRuntimeListButtonAction from './ServingRuntimeListButtonAction';
@@ -25,13 +22,16 @@ const ServingRuntimeList: React.FC = () => {
     },
     servingRuntimeTemplates: { data: templates, loaded: templatesLoaded, error: templateError },
     servingRuntimeTemplateOrder: { data: templateOrder },
+    servingRuntimeTemplateDisablement: { data: templateDisablement },
     serverSecrets: { refresh: refreshTokens },
     inferenceServices: { refresh: refreshInferenceServices },
     currentProject,
   } = React.useContext(ProjectDetailsContext);
 
   const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter(getTemplateEnabled);
+  const templatesEnabled = templatesSorted.filter(
+    (template) => !templateDisablement.includes(template.metadata.name),
+  );
 
   const emptyTemplates = templatesEnabled?.length === 0;
   const emptyModelServer = servingRuntimes.length === 0;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeList.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeList.tsx
@@ -5,7 +5,10 @@ import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { ProjectSectionTitles } from '~/pages/projects/screens/detail/const';
-import { getSortedTemplates } from '~/pages/modelServing/customServingRuntimes/utils';
+import {
+  getSortedTemplates,
+  getTemplateEnabled,
+} from '~/pages/modelServing/customServingRuntimes/utils';
 import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 import ServingRuntimeTable from './ServingRuntimeTable';
 import ServingRuntimeListButtonAction from './ServingRuntimeListButtonAction';
@@ -29,8 +32,8 @@ const ServingRuntimeList: React.FC = () => {
   } = React.useContext(ProjectDetailsContext);
 
   const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter(
-    (template) => !templateDisablement.includes(template.metadata.name),
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, templateDisablement),
   );
 
   const emptyTemplates = templatesEnabled?.length === 0;

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -24,6 +24,7 @@ import InvalidProject from '~/concepts/projects/InvalidProject';
 import useSyncPreferredProject from '~/concepts/projects/useSyncPreferredProject';
 import useTemplates from '~/pages/modelServing/customServingRuntimes/useTemplates';
 import useTemplateOrder from '~/pages/modelServing/customServingRuntimes/useTemplateOrder';
+import useTemplateDisablement from '~/pages/modelServing/customServingRuntimes/useTemplateDisablement';
 import { useDashboardNamespace } from '~/redux/selectors';
 import { getTokenNames } from '~/pages/modelServing/utils';
 import { NotebookState } from './notebook/types';
@@ -44,6 +45,7 @@ type ProjectDetailsContextType = {
   servingRuntimes: ContextResourceData<ServingRuntimeKind>;
   servingRuntimeTemplates: ContextResourceData<TemplateKind>;
   servingRuntimeTemplateOrder: ContextResourceData<string>;
+  servingRuntimeTemplateDisablement: ContextResourceData<string>;
   inferenceServices: ContextResourceData<InferenceServiceKind>;
   serverSecrets: ContextResourceData<SecretKind>;
   projectSharingRB: ContextResourceData<RoleBindingKind>;
@@ -61,6 +63,7 @@ export const ProjectDetailsContext = React.createContext<ProjectDetailsContextTy
   servingRuntimes: DEFAULT_CONTEXT_DATA,
   servingRuntimeTemplates: DEFAULT_CONTEXT_DATA,
   servingRuntimeTemplateOrder: DEFAULT_CONTEXT_DATA,
+  servingRuntimeTemplateDisablement: DEFAULT_CONTEXT_DATA,
   inferenceServices: DEFAULT_CONTEXT_DATA,
   serverSecrets: DEFAULT_CONTEXT_DATA,
   projectSharingRB: DEFAULT_CONTEXT_DATA,
@@ -84,6 +87,9 @@ const ProjectDetailsContextProvider: React.FC = () => {
   const servingRuntimeTemplateOrder = useContextResourceData<string>(
     useTemplateOrder(dashboardNamespace),
   );
+  const servingRuntimeTemplateDisablement = useContextResourceData<string>(
+    useTemplateDisablement(dashboardNamespace),
+  );
   const inferenceServices = useContextResourceData<InferenceServiceKind>(
     useInferenceServices(namespace),
   );
@@ -97,6 +103,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
   const servingRuntimeRefresh = servingRuntimes.refresh;
   const servingRuntimeTemplateRefresh = servingRuntimeTemplates.refresh;
   const servingRuntimeTemplateOrderRefresh = servingRuntimeTemplateOrder.refresh;
+  const servingRuntimeTemplateDisablementRefresh = servingRuntimeTemplateDisablement.refresh;
   const inferenceServiceRefresh = inferenceServices.refresh;
   const projectSharingRefresh = projectSharingRB.refresh;
   const groupsRefresh = groups.refresh;
@@ -111,6 +118,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
     groupsRefresh();
     servingRuntimeTemplateRefresh();
     servingRuntimeTemplateOrderRefresh();
+    servingRuntimeTemplateDisablementRefresh();
   }, [
     notebookRefresh,
     pvcRefresh,
@@ -118,6 +126,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
     servingRuntimeRefresh,
     servingRuntimeTemplateRefresh,
     servingRuntimeTemplateOrderRefresh,
+    servingRuntimeTemplateDisablementRefresh,
     inferenceServiceRefresh,
     projectSharingRefresh,
     groupsRefresh,
@@ -169,6 +178,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
         servingRuntimes,
         servingRuntimeTemplates,
         servingRuntimeTemplateOrder,
+        servingRuntimeTemplateDisablement,
         inferenceServices,
         refreshAllProjectData,
         filterTokens,

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -12,6 +12,11 @@ export const getDashboardConfigBackend = (namespace: string): Promise<DashboardC
 export const getDashboardConfigTemplateOrderBackend = (ns: string): Promise<string[]> =>
   getDashboardConfigBackend(ns).then((dashboardConfig) => dashboardConfig.spec.templateOrder || []);
 
+export const getDashboardConfigTemplateDisablementBackend = (ns: string): Promise<string[]> =>
+  getDashboardConfigBackend(ns).then(
+    (dashboardConfig) => dashboardConfig.spec.templateDisablement || [],
+  );
+
 export const updateDashboardConfigBackend = (
   resource: DashboardConfigKind,
 ): Promise<DashboardConfigKind> =>
@@ -36,6 +41,27 @@ export const patchDashboardConfigTemplateOrderBackend = (
       // Patch doesn't return an error if the attribute is disabled, it just return the object without changes
       if (response.data.spec?.templateOrder === undefined) {
         throw new Error('Template order is not configured');
+      }
+      return response.data.spec?.templateOrder;
+    })
+    .catch((e) => Promise.reject(e));
+
+export const patchDashboardConfigTemplateDisablementBackend = (
+  templateDisablement: string[],
+  namespace: string,
+): Promise<string[]> =>
+  axios
+    .patch<DashboardConfigKind>(`/api/dashboardConfig/${namespace}/${DASHBOARD_CONFIG}`, [
+      {
+        op: 'replace',
+        path: '/spec/templateDisablement',
+        value: templateDisablement,
+      },
+    ])
+    .then((response) => {
+      // Patch doesn't return an error if the attribute is disabled, it just return the object without changes
+      if (response.data.spec?.templateOrder === undefined) {
+        throw new Error('Template disablement is not configured');
       }
       return response.data.spec?.templateOrder;
     })

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -60,9 +60,9 @@ export const patchDashboardConfigTemplateDisablementBackend = (
     ])
     .then((response) => {
       // Patch doesn't return an error if the attribute is disabled, it just return the object without changes
-      if (response.data.spec?.templateOrder === undefined) {
+      if (response.data.spec?.templateDisablement === undefined) {
         throw new Error('Template disablement is not configured');
       }
-      return response.data.spec?.templateOrder;
+      return response.data.spec?.templateDisablement;
     })
     .catch((e) => Promise.reject(e));

--- a/frontend/src/services/templateService.ts
+++ b/frontend/src/services/templateService.ts
@@ -13,22 +13,6 @@ export const listTemplatesBackend = async (
     .then((response) => response.data.items)
     .catch((e) => Promise.reject(e));
 
-export const toggleTemplateEnabledStatusBackend = (
-  name: string,
-  namespace: string,
-  enable: boolean,
-): Promise<TemplateKind> =>
-  axios
-    .patch<TemplateKind>(`/api/templates/${namespace}/${name}`, [
-      {
-        op: 'replace',
-        path: '/metadata/annotations/opendatahub.io~1template-enabled',
-        value: enable ? 'true' : 'false',
-      },
-    ])
-    .then((response) => response.data)
-    .catch((e) => Promise.reject(e));
-
 const dryRunServingRuntimeForTemplateCreationBackend = (
   servingRuntime: ServingRuntimeKind,
   namespace: string,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -64,6 +64,7 @@ export type DashboardConfig = K8sResourceCommon & {
       notebookTolerationSettings?: TolerationSettings;
     };
     templateOrder?: string[];
+    templateDisablement?: string[];
   };
   /** Faux status object -- computed by the service account */
   status: {

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -144,3 +144,7 @@ spec:
                   type: array
                   items:
                     type: string
+                templateDisablement:
+                  type: array
+                  items:
+                    type: string

--- a/manifests/modelserving/ovms-gpu-ootb.yaml
+++ b/manifests/modelserving/ovms-gpu-ootb.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
-    opendatahub.io/configurable: 'true'
   annotations:
     tags: 'ovms,servingruntime'
     description: 'OpenVino with GPU Support Model Serving Definition'

--- a/manifests/modelserving/ovms-gpu-ootb.yaml
+++ b/manifests/modelserving/ovms-gpu-ootb.yaml
@@ -56,7 +56,4 @@ objects:
         - autoSelect: true
           name: onnx
           version: '1'
-        - autoSelect: true
-          name: tensorflow
-          version: "2" 
 parameters: []

--- a/manifests/modelserving/ovms-gpu-ootb.yaml
+++ b/manifests/modelserving/ovms-gpu-ootb.yaml
@@ -56,4 +56,7 @@ objects:
         - autoSelect: true
           name: onnx
           version: '1'
+        - autoSelect: true
+          name: tensorflow
+          version: "2" 
 parameters: []

--- a/manifests/modelserving/ovms-ootb.yaml
+++ b/manifests/modelserving/ovms-ootb.yaml
@@ -54,7 +54,4 @@ objects:
         - autoSelect: true
           name: onnx
           version: '1'
-        - autoSelect: true
-          name: tensorflow
-          version: "2"
 parameters: []

--- a/manifests/modelserving/ovms-ootb.yaml
+++ b/manifests/modelserving/ovms-ootb.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
-    opendatahub.io/configurable: 'true'
   annotations:
     tags: 'ovms,servingruntime'
     description: 'OpenVino Model Serving Definition'
@@ -15,7 +14,7 @@ objects:
     metadata:
       name: ovms
       annotations:
-        openshift.io/display-name: 'OpenVINO Model Server (config works)'
+        openshift.io/display-name: 'OpenVINO Model Server'
         opendatahub.io/disable-gpu: 'true'
       labels:
         opendatahub.io/dashboard: 'true'

--- a/manifests/modelserving/ovms-ootb.yaml
+++ b/manifests/modelserving/ovms-ootb.yaml
@@ -15,7 +15,7 @@ objects:
     metadata:
       name: ovms
       annotations:
-        openshift.io/display-name: 'OpenVINO Model Server'
+        openshift.io/display-name: 'OpenVINO Model Server (config works)'
         opendatahub.io/disable-gpu: 'true'
       labels:
         opendatahub.io/dashboard: 'true'

--- a/manifests/modelserving/ovms-ootb.yaml
+++ b/manifests/modelserving/ovms-ootb.yaml
@@ -54,4 +54,7 @@ objects:
         - autoSelect: true
           name: onnx
           version: '1'
+        - autoSelect: true
+          name: tensorflow
+          version: "2" 
 parameters: []

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -75,3 +75,4 @@ spec:
     adminGroups: 'odh-admins'
     allowedGroups: 'system:authenticated'
   templateOrder: []
+  templateDisablement: []


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes: #1205 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Custom Serving Runtime Panel Admin
1. Create several Custom Serving Runtimes
2. Start to enable/disable
3. You should see the serving runtime names added into the `OdhDashboardConfig` attribute `templateDisablement`
<img width="2529" alt="Screenshot 2023-06-16 at 18 18 14" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/dec24086-5a6c-4609-81ad-bd9fa7558c07">

## Custom Serving Runtimes available in DS Projects
1. Enable/Disable Custom Serving Runtimes
2. Go to DS Projects
3. Check that users only list the enables Serving Runtimes
4. Go back to Custom Serving Runtime
5. Check that the state of enablement is correct for every Serving Runtime
<img width="809" alt="Screenshot 2023-06-16 at 18 18 26" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/5541d6c8-820f-4d1f-847e-ac9389bb06d9">

## Migration with no OdhDashboardConfig
1. Add the annotation `opendatahub.io/template-enabled: 'false'` to existing templates
2. Delete the existing `OdhDashboardConfig` object
3. Restart the backend/restart the pods
4. A new OdhDashboardConfig object should be created
5. This object should contain a list in `templateDisablement` with the templates with the `opendatahub.io/template-enabled: 'false'` annotation
6. This object should have all the attributes
7. Inspecting `api/config` should contain  `status.dependencyOperators` field

## Migration with OdhDashboardConfig
1. Add the annotation `opendatahub.io/template-enabled: 'false'` to existing templates
2. Ensure `OdhDashboardConfig` does not contain `templateDisablement`
3. Restart the backend/restart the pods
4. `OdhDashboardConfig` should now contain a list in `templateDisablement` with the templates with the `opendatahub.io/template-enabled: 'false'` annotation
5. Inspecting `api/config` should contain  `status.dependencyOperators` field if `disablePipelines` is set to `false`

## Migration with OdhDashboardConfig and templateDisablement
1. Add the annotation `opendatahub.io/template-enabled: 'false'` to existing templates
2. Ensure `OdhDashboardConfig` has the attribute `templateDisablement``
3. Restart the backend/restart the pods
4. `OdhDashboardConfig` should maintain the same `templateDisablement` list
5. Inspecting `api/config` should contain  `status.dependencyOperators` field if `disablePipelines` is set to `false`


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I'm going to add this testsuite alongside the testing efforts for https://github.com/opendatahub-io/odh-dashboard/issues/1198

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits have meaningful messages (squashes happen on merge by the bot).
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
