### PR TITLE
Enhance modal to delete project by pressing enter key

### DIFF
--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Button, Modal, Stack, StackItem, TextInput, Form } from '@patternfly/react-core';
+import { Alert, Button, Modal, Stack, StackItem, TextInput } from '@patternfly/react-core';
 
 type DeleteModalProps = {
   title: string;

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -74,7 +74,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
             value={value}
             onChange={(newValue) => setValue(newValue)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && value === deleteName) {
+              if (event.key === 'Enter' && value === deleteName && !deleting) {
                 onDelete();
               }
             }}

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Button, Modal, Stack, StackItem, TextInput } from '@patternfly/react-core';
+import { Alert, Button, Modal, Stack, StackItem, TextInput, Form } from '@patternfly/react-core';
 
 type DeleteModalProps = {
   title: string;
@@ -73,6 +73,11 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
             aria-label="Delete modal input"
             value={value}
             onChange={(newValue) => setValue(newValue)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && value === deleteName) {
+                onDelete();
+              }
+            }}
           />
         </StackItem>
         {error && (


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->

Closes: #1387

## Description
When trying to confirm to delete the project the user can press the "Enter" key  to confirm the deletion.


## How Has This Been Tested?

https://github.com/opendatahub-io/odh-dashboard/assets/2117670/7ce3468c-e4eb-4a37-aed3-1f6088c1524d


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
