### PR TITLE
Switch to Kubernetes secret instead of users credentials

### DIFF
--- a/frontend/src/concepts/pipelines/context/useManageElyraSecret.ts
+++ b/frontend/src/concepts/pipelines/context/useManageElyraSecret.ts
@@ -28,7 +28,12 @@ const useManageElyraSecret = (
   React.useEffect(() => {
     if (fullLoadedState && !elyraSecret && dataConnection && routePath) {
       createSecret(
-        generateElyraSecret(dataConnection.data, dataConnection.metadata.namespace, routePath),
+        generateElyraSecret(
+          dataConnection.data,
+          dataConnection.metadata.name,
+          dataConnection.metadata.namespace,
+          routePath,
+        ),
       );
     }
   }, [fullLoadedState, routePath, elyraSecret, dataConnection]);

--- a/frontend/src/concepts/pipelines/elyra/utils.ts
+++ b/frontend/src/concepts/pipelines/elyra/utils.ts
@@ -37,6 +37,7 @@ export const currentlyHasPipelines = (notebook: NotebookKind): boolean =>
 
 export const generateElyraSecret = (
   dataConnectionData: AWSSecretKind['data'],
+  dataConnectionName: string,
   namespace: string,
   route: string,
 ): SecretKind => ({
@@ -58,7 +59,8 @@ export const generateElyraSecret = (
         auth_type: 'KUBERNETES_SERVICE_ACCOUNT_TOKEN',
         api_endpoint: route,
         public_api_endpoint: `${location.origin}/pipelineRuns/${namespace}`,
-        cos_auth_type: 'USER_CREDENTIALS',
+        cos_auth_type: 'KUBERNETES_SECRET',
+        cos_secret: dataConnectionName,
         cos_endpoint: atob(dataConnectionData[AWS_KEYS.S3_ENDPOINT]),
         cos_bucket: atob(dataConnectionData[AWS_KEYS.AWS_S3_BUCKET]),
         cos_username: atob(dataConnectionData[AWS_KEYS.ACCESS_KEY_ID]),


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Switch to Kubernetes secret instead of users credentials
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/1415

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- switch the `cos_auth_type`: KUBERNETES_SECRET
https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html#cloud-object-storage-authentication-type-cos-auth-type
- include `cos_secret` which reference the secret in the cluster with details of auth

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
