### PR TITLE
Keep the enabled/disabled status after editing the custom notebook image

### DIFF
--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -368,7 +368,7 @@ export const updateImage = async (
       );
     }
 
-    if (typeof body.visible !== undefined) {
+    if (body.visible !== undefined) {
       if (body.visible) {
         imageStream.metadata.labels['opendatahub.io/notebook-image'] = 'true';
       } else {


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1434 

## Description
#1434  A quick fix to keep the enabled/disabled status after editing the custom notebook image

## How Has This Been Tested?
![ezgif-3-00918c5f7e](https://github.com/opendatahub-io/odh-dashboard/assets/2117670/d792a81b-304b-4b23-a04c-2ffc376a234a)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
