### PR TITLE
replace EmptyState to Spinner component in Pipeline runs details tab

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -5,8 +5,16 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
+  Title,
+  Bullseye,
+  Spinner,
 } from '@patternfly/react-core';
 import { useNavigate, useParams } from 'react-router-dom';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { PipelineTopology, usePipelineTaskTopology } from '~/concepts/pipelines/topology';
 import { PipelineRunKind } from '~/k8sTypes';
@@ -52,6 +60,26 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
   const pipelineRuntime = getPipelineRunKind(runResource?.pipeline_runtime);
   const { taskMap, nodes } = usePipelineTaskTopology(pipelineRuntime);
   const run = runResource?.run;
+
+  if (!loaded && !error) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState variant={EmptyStateVariant.large} data-id="error-empty-state">
+        <EmptyStateIcon icon={ExclamationCircleIcon} />
+        <Title headingLevel="h4" size="lg">
+          Error loading pipeline run details
+        </Title>
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { Spinner, EmptyStateVariant, EmptyState, Title } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import {
@@ -15,7 +14,6 @@ import {
   DetailItem,
   renderDetailItems,
 } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
-
 type PipelineRunTabDetailsProps = {
   pipelineRunKF?: PipelineRunKF;
   workflowName?: string;
@@ -29,14 +27,11 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({
 
   if (!pipelineRunKF || !workflowName) {
     return (
-      <EmptyState>
-        <EmptyStateIcon icon={ExclamationCircleIcon} />
-        <Title headingLevel="h2" size="lg">
-          Error with the run
+      <EmptyState variant={EmptyStateVariant.large} data-id="loading-empty-state">
+        <Spinner size="xl" />
+        <Title headingLevel="h4" size="lg">
+          Loading
         </Title>
-        <EmptyStateBody>
-          There was an issue trying to render the details information.
-        </EmptyStateBody>
       </EmptyState>
     );
   }


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [#1288](https://github.com/opendatahub-io/odh-dashboard/issues/1288)

## Description
When you start a Pipeline Run you will be navigated to the Run Details page. As it loads, you see an error among other states of "loading".

## How Has This Been Tested?
<img width="1725" alt="Screenshot 2023-06-28 at 3 41 56 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/2d3f05b2-c44a-4530-9a96-4b963b263ea3">


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
