### PR TITLE
base kustomization remove bases section and put elements under source…

### DIFF
--- a/manifests/apps/kustomization.yaml
+++ b/manifests/apps/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
-bases:
+resources:
   - ./jupyter

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,25 +3,24 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
-bases:
+resources:
   - ../apps
   - ../modelserving
-resources:
-- role.yaml
-- cluster-role.yaml
-- service-account.yaml
-- role-binding.yaml
-- cluster-role-binding.yaml
-- auth-delegator.clusterrolebinding.yaml
-- cluster-monitoring-role-binding.yaml
-- deployment.yaml
-- routes.yaml
-- service.yaml
-- oauth.secret.yaml
-- fetch-builds-and-images.rbac.yaml
-- image-puller.clusterrolebinding.yaml
-- model-serving-role.yaml
-- model-serving-role-binding.yaml
+  - role.yaml
+  - cluster-role.yaml
+  - service-account.yaml
+  - role-binding.yaml
+  - cluster-role-binding.yaml
+  - auth-delegator.clusterrolebinding.yaml
+  - cluster-monitoring-role-binding.yaml
+  - deployment.yaml
+  - routes.yaml
+  - service.yaml
+  - oauth.secret.yaml
+  - fetch-builds-and-images.rbac.yaml
+  - image-puller.clusterrolebinding.yaml
+  - model-serving-role.yaml
+  - model-serving-role-binding.yaml
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../crd
-  - ../../base
 resources:
+  - ../../base
+  - ../../crd
   - ./nvidia-dcgm-mock-exporter

--- a/manifests/overlays/odhdashboardconfig/kustomization.yaml
+++ b/manifests/overlays/odhdashboardconfig/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../../base
 resources:
-- odh-dashboard-config.yaml
-- odh-enabled-applications-config.configmap.yaml
+  - ../../base
+  - odh-dashboard-config.yaml
+  - odh-enabled-applications-config.configmap.yaml


### PR DESCRIPTION
/closes: #1459 

## Description
@lucferbux This change makes sure the deprecated bases notation of kustomize / Kfctl is not used anymore.
Making this change also ensure that things like optional labelTransformers (adding additional labels to e.g. Deployment), which work fine on all other ODH components, work on ODH dashboard elements as well.

## How Has This Been Tested?
Made the changes it this PR on custom odh-manifests. Dashboad including all elements previously under bases were still applied correctly.

Meaning the ovms and ovms-cpu templates, plus the OdhAplication, OdhQuickstart, and OdhDocument instances that are referenced via resources:
```
    -../apps
    -../modelserving
```
are applied correctly. 
Plus, I can now see my additional, custom labels on dashboard deployment and pods also :-)
podSelectors are not affected by this change, which is fine, they are handled by the two labels defined in [commonLabels](https://github.com/opendatahub-io/odh-dashboard/blob/main/manifests/base/kustomization.yaml#L3).
## Test Impact
Should also be changed like this in odh-manifests.

## Request review criteria:

- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
