### PR TITLE
Change Elyra public API endpoint to ensure a correct URL for redirect

### DIFF
--- a/frontend/src/concepts/pipelines/elyra/const.ts
+++ b/frontend/src/concepts/pipelines/elyra/const.ts
@@ -3,4 +3,5 @@ import { PIPELINE_DEFINITION_NAME } from '~/concepts/pipelines/const';
 export const ELYRA_SECRET_NAME = 'ds-pipeline-config';
 export const ELYRA_SECRET_DATA_KEY = 'odh_dsp.json';
 export const ELYRA_SECRET_DATA_TYPE = 'cos_auth_type';
+export const ELYRA_SECRET_DATA_ENDPOINT = 'public_api_endpoint';
 export const ELYRA_ROLE_NAME = `ds-pipeline-user-access-${PIPELINE_DEFINITION_NAME}`;

--- a/frontend/src/concepts/pipelines/elyra/utils.ts
+++ b/frontend/src/concepts/pipelines/elyra/utils.ts
@@ -2,6 +2,7 @@ import { Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import { AWSSecretKind, KnownLabels, NotebookKind, RoleBindingKind, SecretKind } from '~/k8sTypes';
 import {
   ELYRA_ROLE_NAME,
+  ELYRA_SECRET_DATA_ENDPOINT,
   ELYRA_SECRET_DATA_KEY,
   ELYRA_SECRET_DATA_TYPE,
   ELYRA_SECRET_NAME,
@@ -63,7 +64,8 @@ export const generateElyraSecret = (
         engine: 'Tekton',
         auth_type: 'KUBERNETES_SERVICE_ACCOUNT_TOKEN',
         api_endpoint: route,
-        public_api_endpoint: `${location.origin}/pipelineRuns/${namespace}`,
+        // Append the id on the end to navigate to the details page for that PipelineRun
+        [ELYRA_SECRET_DATA_ENDPOINT]: `${location.origin}/pipelineRuns/${namespace}/pipelineRun/view/`,
         [ELYRA_SECRET_DATA_TYPE]: 'KUBERNETES_SECRET',
         cos_secret: dataConnectionName,
         cos_endpoint: atob(dataConnectionData[AWS_KEYS.S3_ENDPOINT]),


### PR DESCRIPTION
Resolves:opendatahub-io/notebooks#130

Complementary PR from notebooks: opendatahub-io/notebooks#137

## Description
Change the Elyra public API endpoint URL so that it correctly references to the desired data science pipeline run details.

## How Has This Been Tested?
Not fully tested yet, testing in progress

## Test Impact

## Request review criteria:
- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
