### PR TITLE
Retrieve bias metrics from thanos querier (#1472)

### DIFF
--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -4,6 +4,7 @@ import {
   OauthFastifyRequest,
   PrometheusQueryRangeResponse,
   PrometheusQueryResponse,
+  QueryType,
 } from '../../../types';
 import { callPrometheusPVC, callPrometheusServing } from '../../../utils/prometheusUtils';
 import { createCustomError } from '../../../utils/requestUtils';
@@ -36,6 +37,19 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       const { query } = request.body;
 
       return callPrometheusPVC(fastify, request, query).catch(handleError);
+    },
+  );
+
+  fastify.post(
+    '/pvc-range',
+    async (
+      request: OauthFastifyRequest<{
+        Body: { query: string };
+      }>,
+    ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
+      const { query } = request.body;
+
+      return callPrometheusPVC(fastify, request, query, QueryType.QUERY_RANGE).catch(handleError);
     },
   );
 

--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -6,7 +6,7 @@ import {
   PrometheusQueryResponse,
   QueryType,
 } from '../../../types';
-import { callPrometheusPVC, callPrometheusServing } from '../../../utils/prometheusUtils';
+import { callPrometheusThanos, callPrometheusServing } from '../../../utils/prometheusUtils';
 import { createCustomError } from '../../../utils/requestUtils';
 import { logRequestDetails } from '../../../utils/fileUtils';
 
@@ -36,12 +36,12 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
       const { query } = request.body;
 
-      return callPrometheusPVC(fastify, request, query).catch(handleError);
+      return callPrometheusThanos(fastify, request, query).catch(handleError);
     },
   );
 
   fastify.post(
-    '/pvc-range',
+    '/bias',
     async (
       request: OauthFastifyRequest<{
         Body: { query: string };
@@ -49,7 +49,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
       const { query } = request.body;
 
-      return callPrometheusPVC(fastify, request, query, QueryType.QUERY_RANGE).catch(handleError);
+      return callPrometheusThanos(fastify, request, query, QueryType.QUERY_RANGE).catch(
+        handleError,
+      );
     },
   );
 

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -88,13 +88,14 @@ export const callPrometheusPVC = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   query: string,
+  queryType: QueryType = QueryType.QUERY,
 ): Promise<{ code: number; response: PrometheusQueryResponse }> =>
   callPrometheus(
     fastify,
     request,
     query,
     generatePrometheusHostURL(fastify, 'thanos-querier', 'openshift-monitoring', '9092'),
-    QueryType.QUERY,
+    queryType,
   );
 
 export const callPrometheusServing = (

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -84,7 +84,7 @@ const generatePrometheusHostURL = (
   return `https://${instanceName}.${namespace}.svc.cluster.local:${port}`;
 };
 
-export const callPrometheusPVC = (
+export const callPrometheusThanos = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   query: string,

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -101,7 +101,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     trustyResponsePredicate,
-    '/api/prometheus/pvc-range',
+    '/api/prometheus/bias',
   );
 
   const modelTrustyAIDIR = useQueryRangeResourceData(
@@ -110,7 +110,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     trustyResponsePredicate,
-    '/api/prometheus/pvc-range',
+    '/api/prometheus/bias',
   );
 
   React.useEffect(() => {

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -101,6 +101,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     trustyResponsePredicate,
+    '/api/prometheus/pvc-range',
   );
 
   const modelTrustyAIDIR = useQueryRangeResourceData(
@@ -109,6 +110,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     trustyResponsePredicate,
+    '/api/prometheus/pvc-range',
   );
 
   React.useEffect(() => {

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -11,11 +11,12 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   end: number,
   timeframe: TimeframeTitle,
   responsePredicate: ResponsePredicate<T>,
+  apiPath = '/api/prometheus/serving',
 ): ContextResourceData<T> =>
   useRestructureContextResourceData<T>(
     usePrometheusQueryRange<T>(
       active,
-      '/api/prometheus/serving',
+      apiPath,
       query,
       TimeframeTimeRange[timeframe],
       end,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1472 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
* Adds backend endpoint for making range queries to thanos
* Updates Bias Prometheus queries to use this new endpoint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Using a cluster with the latest version of trustyai: verify that model bias graphs correctly show data and that the Endpoint performance graph still works.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Minor change of queries to service that as too many dependencies.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
