### PR TITLE
Retrieve bias metrics from thanos querier (#1472) (#1473)

### DIFF
--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -4,8 +4,9 @@ import {
   OauthFastifyRequest,
   PrometheusQueryRangeResponse,
   PrometheusQueryResponse,
+  QueryType,
 } from '../../../types';
-import { callPrometheusPVC, callPrometheusServing } from '../../../utils/prometheusUtils';
+import { callPrometheusThanos, callPrometheusServing } from '../../../utils/prometheusUtils';
 import { createCustomError } from '../../../utils/requestUtils';
 import { logRequestDetails } from '../../../utils/fileUtils';
 
@@ -35,7 +36,22 @@ module.exports = async (fastify: KubeFastifyInstance) => {
     ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
       const { query } = request.body;
 
-      return callPrometheusPVC(fastify, request, query).catch(handleError);
+      return callPrometheusThanos(fastify, request, query).catch(handleError);
+    },
+  );
+
+  fastify.post(
+    '/bias',
+    async (
+      request: OauthFastifyRequest<{
+        Body: { query: string };
+      }>,
+    ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
+      const { query } = request.body;
+
+      return callPrometheusThanos(fastify, request, query, QueryType.QUERY_RANGE).catch(
+        handleError,
+      );
     },
   );
 

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -84,17 +84,18 @@ const generatePrometheusHostURL = (
   return `https://${instanceName}.${namespace}.svc.cluster.local:${port}`;
 };
 
-export const callPrometheusPVC = (
+export const callPrometheusThanos = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   query: string,
+  queryType: QueryType = QueryType.QUERY,
 ): Promise<{ code: number; response: PrometheusQueryResponse }> =>
   callPrometheus(
     fastify,
     request,
     query,
     generatePrometheusHostURL(fastify, 'thanos-querier', 'openshift-monitoring', '9092'),
-    QueryType.QUERY,
+    queryType,
   );
 
 export const callPrometheusServing = (

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -101,6 +101,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     trustyResponsePredicate,
+    '/api/prometheus/bias',
   );
 
   const modelTrustyAIDIR = useQueryRangeResourceData(
@@ -109,6 +110,7 @@ export const useModelServingMetrics = (
     end,
     timeframe,
     trustyResponsePredicate,
+    '/api/prometheus/bias',
   );
 
   React.useEffect(() => {

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -11,11 +11,12 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   end: number,
   timeframe: TimeframeTitle,
   responsePredicate: ResponsePredicate<T>,
+  apiPath = '/api/prometheus/serving',
 ): ContextResourceData<T> =>
   useRestructureContextResourceData<T>(
     usePrometheusQueryRange<T>(
       active,
-      '/api/prometheus/serving',
+      apiPath,
       query,
       TimeframeTimeRange[timeframe],
       end,


### PR DESCRIPTION
cherry-pick fix for issue #1472 from f/mserving-metrics to incubation branch.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The commits have meaningful messages (squashes happen on merge by the bot).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
