### PR TITLE
 Automation Beats Out Pipeline Auto-Selection

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -38,6 +38,9 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange }) => (
       />
     </FormSection>
     <PipelineSection
+      onLoaded={(loaded) => {
+        onValueChange('pipelinesLoaded', loaded);
+      }}
       value={data.pipeline}
       onChange={(pipeline) => {
         onValueChange('pipeline', pipeline);

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormSection, Stack, StackItem } from '@patternfly/react-core';
+import { FormSection, Skeleton, Stack, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   CreateRunPageSections,
@@ -11,13 +11,19 @@ import ImportPipelineButton from '~/concepts/pipelines/content/import/ImportPipe
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 
 type PipelineSectionProps = {
+  onLoaded: (loaded: boolean) => void;
   value: PipelineKF | null;
   onChange: (pipeline: PipelineKF) => void;
 };
 
-const PipelineSection: React.FC<PipelineSectionProps> = ({ value, onChange }) => {
-  const [pipelines] = usePipelines();
-
+const PipelineSection: React.FC<PipelineSectionProps> = ({ onLoaded, value, onChange }) => {
+  const [pipelines, loaded] = usePipelines();
+  React.useEffect(() => {
+    onLoaded(loaded);
+  }, [onLoaded, loaded]);
+  if (!loaded) {
+    return <Skeleton />;
+  }
   return (
     <FormSection
       id={CreateRunPageSections.PIPELINE}

--- a/frontend/src/concepts/pipelines/content/createRun/types.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/types.ts
@@ -43,6 +43,7 @@ export type RunParam = {
 export type RunFormData = {
   project: ProjectKind;
   nameDesc: { name: string; description: string };
+  pipelinesLoaded: boolean;
   pipeline: PipelineKF | null;
   // experiment: ExperimentKF | null;
   runType: RunType;

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -174,6 +174,7 @@ const useRunFormData = (
       name: initialData?.name ? `Duplicate of ${initialData.name}` : '',
       description: initialData?.description ?? '',
     },
+    pipelinesLoaded: false,
     pipeline: lastPipeline ?? null,
     // experiment: null,
     runType: { type: RunTypeOption.ONE_TRIGGER },

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -39,6 +39,7 @@ const runTypeSafeDates = (runType: RunFormData['runType']): boolean =>
 
 export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData =>
   !!formData.nameDesc.name &&
+  formData.pipelinesLoaded &&
   !!formData.pipeline &&
   !!formData.params &&
   runTypeSafeData(formData.runType) &&


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1344 

## Description
#1344 
close the gap by making sure the form data waits until we are properly selected in all aspects.
The submit button needs to be locked until all required fields are filled.

[Screencast from 2023-07-10 10-48-39.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/9274ce43-7365-4f26-880e-e2cd42233268)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Create a Pipeline
2. Create a run for this Pipeline
Slow browser network traffic just before the call is made. Might be hard to test this manually, but programatically this can be seen, so perhaps use console logs and other means to test the flow speed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
No testing coverage
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The commits have meaningful messages (squashes happen on merge by the bot).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
