### PR TITLE
Notebook Spawner reachable when disabled

### DIFF
--- a/frontend/src/pages/projects/screens/projects/EmptyProjects.tsx
+++ b/frontend/src/pages/projects/screens/projects/EmptyProjects.tsx
@@ -10,6 +10,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
 import { ODH_PRODUCT_NAME } from '~/utilities/const';
+import { useAppContext } from '~/app/AppContext';
 import LaunchJupyterButton from '~/pages/projects/screens/projects/LaunchJupyterButton';
 import NewProjectButton from './NewProjectButton';
 
@@ -19,7 +20,7 @@ type EmptyProjectsProps = {
 
 const EmptyProjects: React.FC<EmptyProjectsProps> = ({ allowCreate }) => {
   const navigate = useNavigate();
-
+  const { dashboardConfig } = useAppContext();
   return (
     <EmptyState>
       <EmptyStateIcon icon={CubesIcon} />
@@ -28,17 +29,27 @@ const EmptyProjects: React.FC<EmptyProjectsProps> = ({ allowCreate }) => {
       </Title>
       <EmptyStateBody>
         {allowCreate
-          ? 'To get started, create a data science project or launch a notebook with Jupyter.'
-          : `To get started, ask your ${ODH_PRODUCT_NAME} admin for a data science project or launch a notebook with Jupyter.`}
+          ? `To get started, create a data science project${
+              dashboardConfig.spec.notebookController?.enabled
+                ? ' or launch a notebook with Jupyter'
+                : ''
+            }.`
+          : `To get started, ask your ${ODH_PRODUCT_NAME} admin for a data science project${
+              dashboardConfig.spec.notebookController?.enabled
+                ? ' or launch a notebook with Jupyter'
+                : ''
+            }.`}
       </EmptyStateBody>
       {allowCreate ? (
         <>
           <NewProjectButton
             onProjectCreated={(projectName) => navigate(`/projects/${projectName}`)}
           />
-          <EmptyStateSecondaryActions>
-            <LaunchJupyterButton variant={ButtonVariant.link} />
-          </EmptyStateSecondaryActions>
+          {dashboardConfig.spec.notebookController?.enabled && (
+            <EmptyStateSecondaryActions>
+              <LaunchJupyterButton variant={ButtonVariant.link} />
+            </EmptyStateSecondaryActions>
+          )}
         </>
       ) : (
         <LaunchJupyterButton variant={ButtonVariant.primary} />

--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -6,6 +6,7 @@ import useTableColumnSort from '~/components/table/useTableColumnSort';
 import SearchField, { SearchType } from '~/pages/projects/components/SearchField';
 import { ProjectKind } from '~/k8sTypes';
 import { getProjectDisplayName, getProjectOwner } from '~/pages/projects/utils';
+import { useAppContext } from '~/app/AppContext';
 import LaunchJupyterButton from '~/pages/projects/screens/projects/LaunchJupyterButton';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import NewProjectButton from './NewProjectButton';
@@ -19,6 +20,7 @@ type ProjectListViewProps = {
 };
 
 const ProjectListView: React.FC<ProjectListViewProps> = ({ allowCreate }) => {
+  const { dashboardConfig } = useAppContext();
   const { projects: unfilteredProjects } = React.useContext(ProjectsContext);
   const navigate = useNavigate();
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
@@ -87,20 +89,16 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({ allowCreate }) => {
                 }}
               />
             </ToolbarItem>
-            {allowCreate ? (
-              <>
-                <ToolbarItem>
-                  <NewProjectButton
-                    onProjectCreated={(projectName) => navigate(`/projects/${projectName}`)}
-                  />
-                </ToolbarItem>
-                <ToolbarItem>
-                  <LaunchJupyterButton variant={ButtonVariant.link} />
-                </ToolbarItem>
-              </>
-            ) : (
+            {allowCreate && (
               <ToolbarItem>
-                <LaunchJupyterButton variant={ButtonVariant.primary} />
+                <NewProjectButton
+                  onProjectCreated={(projectName) => navigate(`/projects/${projectName}`)}
+                />
+              </ToolbarItem>
+            )}
+            {dashboardConfig.spec.notebookController?.enabled && (
+              <ToolbarItem>
+                <LaunchJupyterButton variant={ButtonVariant.link} />
               </ToolbarItem>
             )}
           </React.Fragment>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1462 

## Description
#1462 
Not to be able to find a route to the notebookController part of the app when it is disabled.
![NotebookSpawner](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/8a61ebd2-49d6-407c-a356-24e7fa9c7239)
The empty state page
![image](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/302761a8-2857-4264-a4a1-60dd48a1337f)



<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Modifying the OdhDashboardConfig is required to test this.
Enable DS Projects spec.dashboardConfig.disableProjects = false
Disable NotebookController spec.notebookController.enable = false 
You can see in DS project , you cannot find a route to notebookController
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
no test coverage
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
