### PR TITLE
Revert configurable thanos port

### DIFF
--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -9,7 +9,6 @@ import {
 import { callPrometheusThanos } from '../../../utils/prometheusUtils';
 import { createCustomError } from '../../../utils/requestUtils';
 import { logRequestDetails } from '../../../utils/fileUtils';
-import { THANOS_DEFAULT_OAUTH_PORT } from '../../../utils/constants';
 
 const handleError = (e: createError.HttpError) => {
   if (e?.code) {
@@ -57,7 +56,6 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         request,
         query,
         QueryType.QUERY_RANGE,
-        THANOS_DEFAULT_OAUTH_PORT,
       ).catch(handleError);
     },
   );

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -135,6 +135,3 @@ export const DEFAULT_NOTEBOOK_SIZES: NotebookSize[] = [
 
 export const imageUrlRegex =
   /^([\w.\-_]+((?::\d+|)(?=\/[a-z0-9._-]+\/[a-z0-9._-]+))|)(?:\/|)([a-z0-9.\-_]+(?:\/[a-z0-9.\-_]+|))(?::([\w.\-_]{1,127})|)/;
-
-export const THANOS_DEFAULT_RBAC_PORT = '9092';
-export const THANOS_DEFAULT_OAUTH_PORT = '9091';

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -4,7 +4,7 @@ import {
   PrometheusQueryRangeResponse,
   QueryType,
 } from '../types';
-import { DEV_MODE, THANOS_DEFAULT_RBAC_PORT } from './constants';
+import { DEV_MODE } from './constants';
 import { getNamespaces } from './notebookUtils';
 import { getDashboardConfig } from './resourceUtils';
 import { createCustomError } from './requestUtils';
@@ -88,13 +88,12 @@ export const callPrometheusThanos = <T>(
   request: OauthFastifyRequest,
   query: string,
   queryType: QueryType = QueryType.QUERY,
-  port = THANOS_DEFAULT_RBAC_PORT,
 ): Promise<{ code: number; response: T }> =>
   callPrometheus<T>(
     fastify,
     request,
     query,
-    generatePrometheusHostURL(fastify, 'thanos-querier', 'openshift-monitoring', port),
+    generatePrometheusHostURL(fastify, 'thanos-querier', 'openshift-monitoring', '9092'),
     queryType,
   );
 


### PR DESCRIPTION
This reverts the PR allowing changing the port used to query Thanos metrics. The dashboard should only make RBAC queries and not OAuth queries (which the previous PR allowed). This is due to the Thanos OAuth proxy only allowing cluster-admin users to log in. Our dashboard must work for users with lower privileges as in a real world scenario no user will have that level of privilege for day to day work.