### PR TITLE
Remove the KfDef CRD reliance

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -192,6 +192,7 @@ const fetchSubscriptions = (fastify: KubeFastifyInstance): Promise<SubscriptionK
   return fetchAll();
 };
 
+/** @deprecated -- we are moving away from KfDefs */
 const fetchInstalledKfdefs = async (fastify: KubeFastifyInstance): Promise<KfDefApplication[]> => {
   const customObjectsApi = fastify.kube.customObjectsApi;
   const namespace = fastify.kube.namespace;
@@ -211,6 +212,16 @@ const fetchInstalledKfdefs = async (fastify: KubeFastifyInstance): Promise<KfDef
       return acc;
     }, [] as KfDefApplication[]);
   } catch (e) {
+    const errorResponse = e.response.body;
+    if (errorResponse?.trim() === '404 page not found') {
+      // 404s like this are because the CRD does not exist
+      // If there were no resources, we would get an empty array
+      // This is not an error case, we are supporting the new Operator that does not use KfDefs
+      fastify.log.info('Detected no KfDef CRD installed -- suppressing issue pulling KfDef');
+      return [];
+    }
+
+    // Old flow, if it fails in other ways, we'll need to still handle a failed KfDef issue
     fastify.log.error(e, 'failed to get kfdefs');
     const error = createError(500, 'failed to get kfdefs');
     error.explicitInternalServerError = true;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1508

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When the Dashboard starts under the new operator, KfDef CRD is not installed as we use a different component. This simply handles that situation by muting the problem when it cannot find them in K8s.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Using a fresh cluster
2. [Installing the new operator](https://github.com/opendatahub-io/opendatahub-operator/blob/feature-rearchitecture/docs/Dev-Preview.md)
3. Deleting their auto installed KfDef CRD (this was a work around I thought we would need, but turned out to be unrelated)
4. Starting the Dashboard locally (and testing restarting the pods)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
