### PR TITLE
create error boundaries for app and content

### DIFF
--- a/frontend/src/__tests__/integration/components/error/ErrorBoundary.stories.tsx
+++ b/frontend/src/__tests__/integration/components/error/ErrorBoundary.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import ErrorBoundary from '~/components/error/ErrorBoundary';
+
+export default {
+  component: ErrorBoundary,
+} as Meta<typeof ErrorBoundary>;
+
+const Throw = () => {
+  throw new SyntaxError('This is only a test.');
+};
+
+export const CatchError: StoryObj<React.ComponentProps<typeof ErrorBoundary>> = {
+  render: () => (
+    <ErrorBoundary>
+      <Throw />
+    </ErrorBoundary>
+  ),
+};

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
+import ErrorBoundary from '~/components/error/ErrorBoundary';
 import ToastNotifications from '~/components/ToastNotifications';
 import { useWatchBuildStatus } from '~/utilities/useWatchBuildStatus';
 import { useUser } from '~/redux/selectors';
@@ -95,11 +96,13 @@ const App: React.FC = () => {
         isNotificationDrawerExpanded={notificationsOpen}
         mainContainerId="dashboard-page-main"
       >
-        <ProjectsContextProvider>
-          <AppRoutes />
-        </ProjectsContextProvider>
-        <ToastNotifications />
-        <TelemetrySetup />
+        <ErrorBoundary>
+          <ProjectsContextProvider>
+            <AppRoutes />
+          </ProjectsContextProvider>
+          <ToastNotifications />
+          <TelemetrySetup />
+        </ErrorBoundary>
       </Page>
     </AppContext.Provider>
   );

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Title } from '@patternfly/react-core';
+import ErrorDetails from './ErrorDetails';
+type ErrorBoundaryProps = {
+  children?: React.ReactNode;
+};
+
+type ErrorBoundaryState =
+  | { hasError: false }
+  | {
+      hasError: true;
+      error: Error;
+      errorInfo: React.ErrorInfo;
+    };
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo,
+    });
+    // eslint-disable-next-line no-console
+    console.error('Caught error:', error, errorInfo);
+  }
+
+  render() {
+    const { children } = this.props;
+
+    if (this.state.hasError) {
+      return (
+        <div className="pf-u-p-lg">
+          <Title headingLevel="h1" className="pf-u-mb-lg">
+            An error occurred.
+          </Title>
+          <ErrorDetails
+            title={this.state.error.name}
+            errorMessage={this.state.error.message}
+            componentStack={this.state.errorInfo.componentStack}
+            stack={this.state.error.stack}
+          />
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/error/ErrorDetails.tsx
+++ b/frontend/src/components/error/ErrorDetails.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import {
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Title,
+} from '@patternfly/react-core';
+
+type ErrorDetailsProps = {
+  title: string;
+  errorMessage?: string;
+  componentStack: string;
+  stack?: string;
+};
+
+const ErrorDetails: React.FC<ErrorDetailsProps> = ({
+  title,
+  errorMessage,
+  componentStack,
+  stack,
+}) => (
+  <>
+    <Title headingLevel="h3" className="pf-u-mb-lg">
+      {title}
+    </Title>
+    <DescriptionList>
+      {errorMessage ? (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Description:</DescriptionListTerm>
+          <DescriptionListDescription>{errorMessage}</DescriptionListDescription>
+        </DescriptionListGroup>
+      ) : null}
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Component trace:</DescriptionListTerm>
+        <DescriptionListDescription>
+          <ClipboardCopy
+            isExpanded
+            isCode
+            hoverTip="Copy"
+            clickTip="Copied"
+            variant={ClipboardCopyVariant.expansion}
+          >
+            {componentStack.trim()}
+          </ClipboardCopy>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      {stack ? (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Stack trace:</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              isExpanded
+              isCode
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant={ClipboardCopyVariant.expansion}
+            >
+              {stack.trim()}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      ) : null}
+    </DescriptionList>
+  </>
+);
+
+export default ErrorDetails;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,7 @@ import { store } from './redux/store/store';
 import App from './app/App';
 import SDKInitialize from './SDKInitialize';
 import { BrowserStorageContextProvider } from './components/browserStorage/BrowserStorageContext';
+import ErrorBoundary from './components/error/ErrorBoundary';
 
 /**
 /**
@@ -17,14 +18,16 @@ import { BrowserStorageContextProvider } from './components/browserStorage/Brows
 const root = createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <Router>
-        <SDKInitialize>
-          <BrowserStorageContextProvider>
-            <App />
-          </BrowserStorageContextProvider>
-        </SDKInitialize>
-      </Router>
-    </Provider>
+    <ErrorBoundary>
+      <Provider store={store}>
+        <Router>
+          <SDKInitialize>
+            <BrowserStorageContextProvider>
+              <App />
+            </BrowserStorageContextProvider>
+          </SDKInitialize>
+        </Router>
+      </Provider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1554

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Whenever an uncaught exception occurs in the UI, an error page will display the error details instead of simply rendering a blank page.

The error boundary is installed at two different locations:
- top level
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/3b415d3c-375f-468f-8beb-c46c55cf8bee)


- main content
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/602f2d8b-7592-4f38-8605-a1dc5212c0eb)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a storybook story for rendering the ErrorBoundary.

Created a component which throws an exception:
```
const Throw = () => {
  throw new SyntaxError('This is only a test.');
};
```

Render this component in various parts of the app; both inside the main content area and outside (eg navigation).
```
<Throw />
```

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Impacts, in a positive way, uncaught exceptions thrown by the application to display errors instead of blank page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @kaedward @kywalker-rh 