### PR TITLE
Uploading a malformed pipeline yaml results in a blank page

### DIFF
--- a/frontend/src/concepts/pipelines/topology/core/PipelineVisualizationSurface.tsx
+++ b/frontend/src/concepts/pipelines/topology/core/PipelineVisualizationSurface.tsx
@@ -11,6 +11,8 @@ import {
   VisualizationSurface,
   getSpacerNodes,
 } from '@patternfly/react-topology';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 type PipelineVisualizationSurfaceProps = {
   nodes: PipelineNodeModel[];
@@ -22,7 +24,7 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
   selectedIds,
 }) => {
   const controller = useVisualizationController();
-
+  const [error, setError] = React.useState<Error | null>();
   React.useEffect(() => {
     // PF Bug
     // TODO: Pipeline Topology weirdly doesn't set a width and height on spacer nodes -- but they do when using finally spacer nodes
@@ -30,15 +32,34 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
     const renderNodes = [...spacerNodes, ...nodes];
     // TODO: We can have a weird edge issue if the node is off by a few pixels vertically from the center
     const edges = getEdgesFromNodes(renderNodes);
-
-    controller.fromModel(
-      {
-        nodes: renderNodes,
-        edges,
-      },
-      true,
-    );
+    try {
+      controller.fromModel(
+        {
+          nodes: renderNodes,
+          edges,
+        },
+        true,
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        setError(error);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Unknown error occurred rendering Pipeline Graph', error);
+      }
+    }
   }, [controller, nodes]);
+  if (error) {
+    return (
+      <EmptyState data-id="error-empty-state">
+        <EmptyStateIcon icon={ExclamationCircleIcon} />
+        <Title headingLevel="h4" size="lg">
+          Incorrect pipeline definition
+        </Title>
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
 
   return (
     <TopologyView


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1522  

## Description
#1522 
Error page is being displayed instead of redirecting it to blank page
![Screenshot from 2023-07-20 12-02-59](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/89cec001-8b18-4473-b04c-c3ea2885d87e)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Import this pipleline yaml file
[TestPipeline01-modified.yaml.txt](https://github.com/opendatahub-io/odh-dashboard/files/12102879/TestPipeline01-modified.yaml.txt)
and check for the error page 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
no test coverage
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
