### PR TITLE
add copy to clipboard icon to tooltips

### DIFF
--- a/frontend/src/components/ResourceNameTooltip.tsx
+++ b/frontend/src/components/ResourceNameTooltip.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import {
+  ClipboardCopy,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  Icon,
+  Popover,
   Stack,
   StackItem,
-  Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import '~/pages/notebookController/NotebookController.scss';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 
 type ResourceNameTooltipProps = {
   resource: K8sResourceCommon;
@@ -23,10 +24,10 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({ children, res
     {children}{' '}
     {resource.metadata?.name && (
       <div style={{ display: 'inline-block' }}>
-        <Tooltip
+        <Popover
           removeFindDomNode
           position="right"
-          content={
+          bodyContent={
             <Stack hasGutter>
               <StackItem>
                 Resource names and types are used to find your resources in OpenShift.
@@ -36,7 +37,9 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({ children, res
                   <DescriptionListGroup>
                     <DescriptionListTerm>Resource name</DescriptionListTerm>
                     <DescriptionListDescription>
-                      {resource.metadata.name}
+                      <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
+                        {resource.metadata?.name}
+                      </ClipboardCopy>
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                   <DescriptionListGroup>
@@ -48,10 +51,8 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({ children, res
             </Stack>
           }
         >
-          <Icon isInline aria-label="More info" role="button" tabIndex={0}>
-            <OutlinedQuestionCircleIcon />
-          </Icon>
-        </Tooltip>
+          <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+        </Popover>
       </div>
     )}
   </div>

--- a/frontend/src/concepts/dashboard/DashboardPopupIconButton.tsx
+++ b/frontend/src/concepts/dashboard/DashboardPopupIconButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Button, ButtonProps, Icon } from '@patternfly/react-core';
+
+type DashboardPopupIconButtonProps = Omit<ButtonProps, 'variant' | 'isInline' | 'style'> & {
+  icon: React.ReactNode;
+};
+
+/**
+ * Overriding PF's button styles to allow for a11y in opening tooltips or popovers on a single item
+ */
+const DashboardPopupIconButton = ({ icon, ...props }: DashboardPopupIconButtonProps) => (
+  <Button variant="plain" isInline style={{ padding: 0 }} {...props}>
+    <Icon tabIndex={0} isInline style={{ marginLeft: 'var(--pf-global--spacer--xs)' }}>
+      {icon}
+    </Icon>
+  </Button>
+);
+
+export default DashboardPopupIconButton;

--- a/frontend/src/pages/BYONImages/BYONImagesTable.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTable.tsx
@@ -35,6 +35,8 @@ import { BYONImage } from '~/types';
 import { relativeTime } from '~/utilities/time';
 import { updateBYONImage } from '~/services/imagesService';
 import ImageErrorStatus from '~/pages/BYONImages/ImageErrorStatus';
+import ResourceNameTooltip from '~/components/ResourceNameTooltip';
+import { convertBYONImageToK8sResource } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { ImportImageModal } from './ImportImageModal';
 import { DeleteImageModal } from './DeleteBYONImageModal';
 import { UpdateImageModal } from './UpdateImageModal';
@@ -329,7 +331,11 @@ export const BYONImagesTable: React.FC<BYONImagesTableProps> = ({ images, forceU
                       spaceItems={{ default: 'spaceItemsSm' }}
                       alignItems={{ default: 'alignItemsCenter' }}
                     >
-                      <FlexItem>{image.name}</FlexItem>
+                      <FlexItem>
+                        <ResourceNameTooltip resource={convertBYONImageToK8sResource(image)}>
+                          {image.name}
+                        </ResourceNameTooltip>
+                      </FlexItem>
                       <FlexItem>
                         <ImageErrorStatus image={image} />
                       </FlexItem>

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import compareVersions from 'compare-versions';
-import { NotebookSize, Volume, VolumeMount } from '~/types';
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { BYONImage, NotebookSize, Volume, VolumeMount } from '~/types';
 import { BuildKind, ImageStreamKind, ImageStreamSpecTagType, NotebookKind } from '~/k8sTypes';
 import {
   ConfigMapCategory,
@@ -388,3 +389,14 @@ export const isInvalidBYONImageStream = (imageStream: ImageStreamKind) => {
     (activeTag === undefined || activeTag.items === null)
   );
 };
+
+export const convertBYONImageToK8sResource = (image: BYONImage): K8sResourceCommon => ({
+  kind: 'ImageStream',
+  apiVersion: 'image.openshift.io/v1',
+  metadata: {
+    name: image.id,
+    annotations: {
+      'openshift.io/display-name': image.name,
+    },
+  },
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1476

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
added a copy icon to the resource name tooltip
_design:_
    - Add the helper text to the bottom of the tooltip
    - copy icon uses <Icon /> still to preserve padding, however this means i had to set the style of the pointer manually
    - there is currently no confirmation when copied
    - the BYONImages from the backend is not returned as a standard k8 object... so i added a eitherNotBoth to allow for manual input of name and kind or a k8 resource.

_Outdated_
<img width="386" alt="Screenshot 2023-07-20 at 2 23 12 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/0c6a78c8-4dfe-44a3-aa50-45287294b85b">

_Outdated_

https://github.com/opendatahub-io/odh-dashboard/assets/12587674/5e896138-bd9b-4395-9bdc-5eaa42ad637b


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- go to notebook images in settings
- make sure it is not empty
- see help icon
- hover on help icon and click
- make sure it copied

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no impact - all labels are preserved

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.


@kaedward does this text look good on this?
@vconzola @kywalker-rh Is this what you were envisioning?

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
