### PR TITLE
Deprecate kfdefApplication field in OdhApplications

### DIFF
--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -4,7 +4,6 @@ import {
   K8sResourceCommon,
   KubeFastifyInstance,
   RouteKind,
-  KfDefApplication,
   CSVKind,
 } from '../types';
 import {
@@ -207,12 +206,18 @@ const getCSVForApp = (
     });
 };
 
-const getKfDefForApp = (appDef: OdhApplication): KfDefApplication | undefined => {
+const hasKfDefForApp = (appDef: OdhApplication): boolean => {
   if (!appDef.spec.kfdefApplications?.length) {
-    return undefined;
+    return false;
   }
+
   const kfdefApps = getInstalledKfdefs();
-  return kfdefApps.find((kfdefApp) => appDef.spec.kfdefApplications.includes(kfdefApp.name));
+  if (kfdefApps.length === 0) {
+    // Only way we can have no KfDef applications is if we are no longer using the KfDef
+    return true;
+  }
+
+  return !!kfdefApps.find((kfdefApp) => appDef.spec.kfdefApplications.includes(kfdefApp.name));
 };
 
 // eslint-disable-next-line
@@ -255,7 +260,7 @@ export const getIsAppEnabled = async (
   fastify: KubeFastifyInstance,
   appDef: OdhApplication,
 ): Promise<boolean> => {
-  if (getKfDefForApp(appDef)) {
+  if (hasKfDefForApp(appDef)) {
     return true;
   }
 

--- a/manifests/crd/odhapplications.dashboard.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhapplications.dashboard.opendatahub.io.crd.yaml
@@ -116,6 +116,7 @@ spec:
                 isEnabled:
                   type: boolean
                 kfdefApplications:
+                  description: "(Deprecated) Apps do not rely on other deployments, they are deployed by those components."
                   items:
                     type: string
                   type: array


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1510

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Remove the reliance on `kfdefApplications` field in the `OdhApplication` CRs (when there are no KfDefs installed).

When the new Operator is installed, it does not use KfDefs... the CRD does not exist, the items do not exist. In https://github.com/opendatahub-io/odh-dashboard/pull/1537 we removed the error when no KfDef CRD exists. 

This is to adjust us back to working -- `kfdefApplications` is not needed when no KfDefs are found and are completely ignored. Moving forward we'll use the "component model" and each component will offer resources if they wish for Dashboard to render.

Couple screenshots...

<img width="1666" alt="Screenshot 2023-07-26 at 2 11 17 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/8126518/c48d0bcb-384c-4d65-bc70-264b40d32837">

Should be noted, I could not actually deprecate the field. [K8s doesn't allow it](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation).

![Screenshot 2023-07-26 at 2 18 24 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/c979b3a6-e95b-4690-944f-85e515f4c847)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

> Note: I started on a fresh cluster and not one that had the existing Operator on it -- this PR is not about how to upgrade the operator nor is it about issues with installing the operator. Seek out https://github.com/opendatahub-io/opendatahub-operator with issues and questions for more information

1. Install the Operator ([steps](https://github.com/opendatahub-io/opendatahub-operator/blob/feature-rearchitecture/docs/Dev-Preview.md)) -- I used Cluster Bot to create me a short lived OpenShift instance so nothing else was left around -- if you have remaining KfDefs then you'll fall back into the other model (this is expected -- since you'll have duplicate deployments of resources)
    * Install the Operator ([link](https://github.com/opendatahub-io/opendatahub-operator/blob/feature-rearchitecture/docs/Dev-Preview.md#deploying-custom-catalog))
    * Use the Operator by creating the CR ([link](https://github.com/opendatahub-io/opendatahub-operator/blob/feature-rearchitecture/docs/Dev-Preview.md#usage))
3. Fire up the Dashboard and see if the Jupyter tile is showing
4. You can disable the Jupyter tile (`notebookController.enabled = false`) but that'll fallback on JupyterHub tile (which we should be getting rid of in https://github.com/opendatahub-io/odh-dashboard/issues/534)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests were changed or added.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
