### PR TITLE
Add volume to change shared memory limit on notebook

### DIFF
--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -179,8 +179,14 @@ export const assembleNotebook = async (
     );
   }
 
-  const volumes = [{ name: pvcName, persistentVolumeClaim: { claimName: pvcName } }];
-  const volumeMounts: VolumeMount[] = [{ mountPath: MOUNT_PATH, name: pvcName }];
+  const volumes = [
+    { name: pvcName, persistentVolumeClaim: { claimName: pvcName } },
+    { name: 'shm', emptyDir: { medium: 'Memory' } },
+  ];
+  const volumeMounts: VolumeMount[] = [
+    { mountPath: MOUNT_PATH, name: pvcName },
+    { mountPath: '/dev/shm', name: 'shm' },
+  ];
 
   const resources: NotebookResources = { ...notebookSize.resources };
   const tolerations: NotebookToleration[] = [];

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -17,6 +17,7 @@ import { translateDisplayNameForK8s } from '~/pages/projects/utils';
 import { getTolerationPatch, TolerationChanges } from '~/utilities/tolerations';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import {
+  ELYRA_VOLUME_NAME,
   generateElyraServiceAccountRoleBinding,
   getElyraVolume,
   getElyraVolumeMount,
@@ -26,6 +27,16 @@ import {
 import { createRoleBinding } from '~/api';
 import { Volume, VolumeMount } from '~/types';
 import { assemblePodSpecOptions } from './utils';
+
+const getshmVolumeMount = (): VolumeMount => ({
+  name: 'shm',
+  mountPath: '/dev/shm',
+});
+
+const getshmVolume = (): Volume => ({
+  name: 'shm',
+  emptyDir: { medium: 'Memory' },
+});
 
 const assembleNotebook = (
   data: StartNotebookData,
@@ -64,10 +75,22 @@ const assembleNotebook = (
   let volumeMounts: VolumeMount[] | undefined = formVolumeMounts && [...formVolumeMounts];
   if (canEnablePipelines) {
     volumes = volumes || [];
-    volumes.push(getElyraVolume());
+    if (!volumes.find((volume) => volume.name === ELYRA_VOLUME_NAME)) {
+      volumes.push(getElyraVolume());
+    }
 
     volumeMounts = volumeMounts || [];
-    volumeMounts.push(getElyraVolumeMount());
+    if (!volumeMounts.find((volumeMount) => volumeMount.name === ELYRA_VOLUME_NAME)) {
+      volumeMounts.push(getElyraVolumeMount());
+    }
+  }
+  volumes = volumes || [];
+  if (!volumes.find((volume) => volume.name === 'shm')) {
+    volumes.push(getshmVolume());
+  }
+  volumeMounts = volumeMounts || [];
+  if (!volumeMounts.find((volumeMount) => volumeMount.name === 'shm')) {
+    volumeMounts.push(getshmVolumeMount());
   }
 
   return {

--- a/frontend/src/concepts/pipelines/elyra/utils.ts
+++ b/frontend/src/concepts/pipelines/elyra/utils.ts
@@ -11,7 +11,7 @@ import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
 import { Volume, VolumeMount } from '~/types';
 import { RUNTIME_MOUNT_PATH } from '~/pages/projects/pvc/const';
 
-const ELYRA_VOLUME_NAME = 'elyra-dsp-details';
+export const ELYRA_VOLUME_NAME = 'elyra-dsp-details';
 
 export const getElyraVolumeMount = (): VolumeMount => ({
   name: ELYRA_VOLUME_NAME,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Related-to: https://github.com/opendatahub-io/kubeflow/pull/110
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/1593

## Description

This includes a volumeMount onto each Notebook on creation. 
which would allow user to have shard memory based on their node size.

## How Has This Been Tested?

- Deploy ODH or RHODS with odh-deployer switch with this PR image.
`quay.io/opendatahub/odh-dashboard:pr-1594`
- Create a Notebook via jupyter tile or project workbenches
- Check if the notebook is set up with the required volume mount.

![Screenshot from 2023-07-27 12-37-20](https://github.com/opendatahub-io/odh-dashboard/assets/14028058/58e5bd83-eb87-4fca-ac23-d396a32c114e)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Tested this behavior by creating notebook both on jupyter tile and project notebook.
Not sure, how to include test, if some one can provide example. 
the code change would be caught by an end to end test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
