### PR TITLE
standard ose-oauth-proxy image in digest format as used in all other …

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -27,4 +27,4 @@ images:
   newTag: main
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
-  newTag: v4.10
+  digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33


### PR DESCRIPTION
## Description

related to odh-manifests PR https://github.com/opendatahub-io/odh-manifests/pull/869

Make ose-oauth-proxy container version or sha256 digest reference consistent across all components e.g. odh-dashboard.

Agree on v4.10

registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33

Since ose-oauth-proxy tag reference image behind, the digest, regardless which openshift 4 minor version, changes regularly. Thus, and to be compatible with restricted network environment ImageContentSourcePolicy as well with node image caching with imagePullPolicy: IfNotPresent, change to digest notation.

Latest manifest link digest for v4.10 from July 6 2023 

https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?architecture=amd64&tag=v4.10.0-202306170106.p0.g799d414.assembly.stream&push_date=1688610772000&container-tabs=gti

included in this PR.

alternative way with downloading, just to show it is in fact the most current v4.10 digest:

```
docker pull registry.redhat.io/openshift4/ose-oauth-proxy:v4.10
v4.10: Pulling from openshift4/ose-oauth-proxy
1df162fae087: Already exists 
d20a374ee8f7: Already exists 
e88a8f7a57fc: Pull complete 
dcbbfecd111e: Pull complete 
Digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
Status: Downloaded newer image for registry.redhat.io/openshift4/ose-oauth-proxy:v4.10
registry.redhat.io/openshift4/ose-oauth-proxy:v4.10
```


## How Has This Been Tested?
Used this image version in copied manifests, manually modified, zipped and tarred, running on an on-prem OCP 4.10 cluster with odh core components installed (except monitoring).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work