### PR TITLE
handle white space in creation and deletion using display names

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
@@ -13,6 +13,9 @@ test('Delete model', async ({ page }) => {
 
   await page.getByRole('textbox', { name: 'Delete modal input' }).fill('Test Inference Service');
   await expect(page.getByRole('button', { name: 'Delete deployed model' })).toBeEnabled();
+
+  await page.getByRole('textbox', { name: 'Delete modal input' }).fill('Name with trailing space ');
+  await expect(page.getByRole('button', { name: 'Delete deployed model' })).toBeDisabled();
 });
 
 test('Edit model', async ({ page }) => {

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -34,7 +34,7 @@ const assembleInferenceService = (
         [KnownLabels.DASHBOARD_RESOURCE]: 'true',
       },
       annotations: {
-        'openshift.io/display-name': data.name,
+        'openshift.io/display-name': data.name.trim(),
         'serving.kserve.io/deploymentMode': 'ModelMesh',
       },
     },

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -104,7 +104,7 @@ const assembleNotebook = (
         [KnownLabels.DASHBOARD_RESOURCE]: 'true',
       },
       annotations: {
-        'openshift.io/display-name': notebookName,
+        'openshift.io/display-name': notebookName.trim(),
         'openshift.io/description': description || '',
         'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,

--- a/frontend/src/api/k8s/projects.ts
+++ b/frontend/src/api/k8s/projects.ts
@@ -132,7 +132,7 @@ export const updateProject = (
       ...editProjectData.metadata,
       annotations: {
         ...editProjectData.metadata.annotations,
-        'openshift.io/display-name': displayName,
+        'openshift.io/display-name': displayName.trim(),
         'openshift.io/description': description,
       },
     },

--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -25,7 +25,7 @@ export const assemblePvc = (
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',
     },
     annotations: {
-      'openshift.io/display-name': pvcName,
+      'openshift.io/display-name': pvcName.trim(),
       'openshift.io/description': description,
     },
   },

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -31,7 +31,7 @@ export const assembleSecret = (
     const { Name, ...secretBody } = data;
     stringData = secretBody;
     name = `${DATA_CONNECTION_PREFIX}-${translateDisplayNameForK8s(Name)}`;
-    annotations['openshift.io/display-name'] = Name;
+    annotations['openshift.io/display-name'] = Name.trim();
     annotations['opendatahub.io/connection-type'] = 's3';
     labels[KnownLabels.DATA_CONNECTION_AWS] = 'true';
   }
@@ -102,7 +102,7 @@ export const assembleSecretSA = (
       namespace,
       annotations: {
         'kubernetes.io/service-account.name': serviceAccountName,
-        'openshift.io/display-name': name,
+        'openshift.io/display-name': name.trim(),
       },
       labels: {
         [KnownLabels.DASHBOARD_RESOURCE]: 'true',

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -44,7 +44,7 @@ const assembleServingRuntime = (
         ...updatedServingRuntime.metadata.annotations,
         'enable-route': externalRoute ? 'true' : 'false',
         'enable-auth': tokenAuth ? 'true' : 'false',
-        ...(isCustomServingRuntimesEnabled && { 'openshift.io/display-name': displayName }),
+        ...(isCustomServingRuntimesEnabled && { 'openshift.io/display-name': displayName.trim() }),
         ...(isCustomServingRuntimesEnabled && {
           'opendatahub.io/template-name': servingRuntime.metadata.name,
         }),
@@ -60,7 +60,7 @@ const assembleServingRuntime = (
         ...updatedServingRuntime.metadata.annotations,
         'enable-route': externalRoute ? 'true' : 'false',
         'enable-auth': tokenAuth ? 'true' : 'false',
-        ...(isCustomServingRuntimesEnabled && { 'openshift.io/display-name': displayName }),
+        ...(isCustomServingRuntimesEnabled && { 'openshift.io/display-name': displayName.trim() }),
       },
     };
   }

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -67,7 +67,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
 
   const canCreate =
     !actionInProgress &&
-    createData.name !== '' &&
+    createData.name.trim() !== '' &&
     createData.project !== '' &&
     createData.format.name !== '' &&
     createData.project !== '' &&

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -26,6 +26,11 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
 }) => {
   const [value, setValue] = React.useState('');
 
+  const deleteNameSanitized = React.useMemo(
+    () => deleteName.trim().replace(/\s+/g, ' '),
+    [deleteName],
+  );
+
   const onBeforeClose = (deleted: boolean) => {
     if (deleted) {
       onDelete();
@@ -51,7 +56,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
           key="delete-button"
           variant="danger"
           isLoading={deleting}
-          isDisabled={deleting || value !== deleteName}
+          isDisabled={deleting || value !== deleteNameSanitized}
           onClick={() => onBeforeClose(true)}
         >
           {submitButtonLabel}
@@ -65,7 +70,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
       <Stack hasGutter>
         <StackItem>{children}</StackItem>
         <StackItem>
-          Confirm deletion by typing <strong>{deleteName}</strong> below:
+          Confirm deletion by typing <strong>{deleteNameSanitized}</strong> below:
         </StackItem>
         <StackItem>
           <TextInput
@@ -74,7 +79,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
             value={value}
             onChange={(newValue) => setValue(newValue)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && value === deleteName && !deleting) {
+              if (event.key === 'Enter' && value === deleteNameSanitized && !deleting) {
                 onDelete();
               }
             }}
@@ -82,7 +87,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
         </StackItem>
         {error && (
           <StackItem>
-            <Alert title={`Error deleting ${deleteName}`} isInline variant="danger">
+            <Alert title={`Error deleting ${deleteNameSanitized}`} isInline variant="danger">
               {error.message}
             </Alert>
           </StackItem>

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -58,7 +58,8 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
   const hasValidNotebookRelationship = createData.forNotebook.name
     ? !!createData.forNotebook.mountPath.value && !createData.forNotebook.mountPath.error
     : true;
-  const canCreate = !actionInProgress && createData.nameDesc.name && hasValidNotebookRelationship;
+  const canCreate =
+    !actionInProgress && createData.nameDesc.name.trim() && hasValidNotebookRelationship;
 
   const submit = async () => {
     setError(undefined);

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -351,7 +351,7 @@ export const checkRequiredFieldsForNotebookStart = (
   const { storageType, creating, existing } = storageData;
   const isNotebookDataValid = !!(
     projectName &&
-    notebookName &&
+    notebookName.trim() &&
     notebookSize &&
     image.imageStream &&
     image.imageVersion


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1587

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Creation of a resources accepts any display name and stores it within the annotation `openshift.io/display-name`, we then translate value into a valid resource name. However the display name may contain leading or trailing spaces. This doesn't cause any issues at display time however is an issue when it comes to the delete modal where we expect the user to re-ender the display name. Unfortunately the name value the user sees rendered in the UI does not contain these extra spaces (because HTML). Meanwhile in code the comparison to check if the user entered the correct name has these extra spaces. Therefore there's a disconnect between what we ask the user to enter and what we actually compare against.

Changes made:
- trim display name when setting display name annotation value
- disallow display name entry that contains only spaces within forms
- removed all leading, trailing, and whitespace containing 2+ characters from the delete modal display name and comparison value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This issue presents itself in many areas. eg. projects, deployed models, ...

1. Go to `Data Science Projects` in the left nav
2. Click `Create data science project` button
3. Enter a project name with leading and / or trailing spaces
4. Select the project's kebab menu and choose `Delete project`
5. Observe the name the model asks the user to enter does not display the same leading or trailing spaces (add some spaces in the middle as well eg. ` many       spaces `)
6. Observe when copying the name from the text into the input, the delete button is now enabled as this PR ignores leading and trailing spaces.

Additionally, inspect the YAML behind the project resource and look for the `openshift.io/display-name` annotation to no longer contain leading and trailing spaces.

Lastly, forms which accept a display name input value now will not enable the create button if the user enters just a space as a value.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added one test to the existing integration tests that ensures deployed model name form doesn't accept an empty string for a name.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
