### PR TITLE
show event details when starting a new notebook server 

### DIFF
--- a/frontend/src/pages/projects/notebook/utils.ts
+++ b/frontend/src/pages/projects/notebook/utils.ts
@@ -124,7 +124,11 @@ export const useNotebookStatus = (
   const events = useWatchNotebookEvents(notebook.metadata.namespace, podUid, spawnInProgress);
 
   const annotationTime = notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
-  const lastActivity = annotationTime ? new Date(annotationTime) : null;
+  const lastActivity = annotationTime
+    ? new Date(annotationTime)
+    : spawnInProgress || podUid
+    ? new Date(notebook.metadata.creationTimestamp ?? 0)
+    : null;
 
   if (!lastActivity) {
     // Notebook not started, we don't have a filter time, ignore

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -284,6 +284,7 @@ type K8sMetadata = {
   uid?: string;
   labels?: { [key: string]: string };
   annotations?: { [key: string]: string };
+  creationTimestamp?: string;
 };
 
 /**

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -330,10 +330,15 @@ export const useNotebookStatus = (
       evt.involvedObject.uid === currentUserNotebookPodUID,
   );
 
-  const lastActivity = useLastActivity(
-    open,
-    notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'],
-  );
+  const lastActivity =
+    useLastActivity(
+      open,
+      notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'],
+    ) ||
+    (notebook && (spawnInProgress || isNotebookRunning)
+      ? new Date(notebook.metadata.creationTimestamp ?? 0)
+      : null);
+
   if (!lastActivity) {
     // Notebook not started, we don't have a filter time, ignore
     return [null, []];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1607

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The notebook server is starting but cannot start due to insufficient resources. If the Notebook resource doesn't have a `notebooks.kubeflow.org/last-activity` annotation, the UI doesn't display any errors.

Now the user gets an error:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/dbe58d11-115c-4aae-9566-8cfcf9ff1de2)
And events log:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/a630d53d-d4f3-44b8-8a05-21957077f234)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. create a new project
2. create a new workbench and use a large size. Consider adding a new notebookSizes entry to the OdhDashboardConfig if your notebook server still starts.
3. Observe the pod not starting.
4. Check the dashboard UI by clicking on Starting... and viewing the event log 
5. Expect errors to be displayed if there is insufficient resources to start the server
6. Check the `Notebook` k8s resource for the `notebooks.kubeflow.org/last-activity` annotation. It should not be present.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no new tests added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
