### PR TITLE
change const DEFAULT_PVC_SIZE from 20 to 20Gi as in frontend notebook const ts

### DIFF
--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -75,7 +75,7 @@ export const blankDashboardCR: DashboardConfig = {
 };
 
 export const MOUNT_PATH = '/opt/app-root/src';
-export const DEFAULT_PVC_SIZE = '20';
+export const DEFAULT_PVC_SIZE = '20Gi';
 
 export const DEFAULT_NOTEBOOK_SIZES: NotebookSize[] = [
   {


### PR DESCRIPTION
closes: #1333

## Description

The PVC Size Default in odh dashboard code is set to 20 in both backend and frontend code.

It should be taken from a default entry in odh dashboard config and not be set to a value explicitely in all sorts of places frontend and backend. There is always an auto-generated odh dashboard config, and pvc size is non-optional.
https://github.com/search?q=repo%3Aopendatahub-io%2Fodh-dashboard%20DEFAULT_PVC_SIZE&type=code

In Jupyter tile, the error with number 20 leads to a PVC being pending forever, with event message saying 

**"20 bytes is not a valid size"**

Default should be set to 20Gi.

This is only happening if no other value is specified in OdhDashboardConfig odh-dashboard-config at notebook controller level. 


## How Has This Been Tested?
set this manually in OdhDashboardConfig to 20Gi and then PVC was created correctly in both Jupyter tile and Data science projects workbenches.

## Test Impact
install ODH
do not set in ODH Dashboard GUI or OdhDashboardConfig any default pvc size
see error appearing and, after merging this PR, not appearing anymore

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
