### PR TITLE
Add performance overlay and sync deployment to odh-manifest

### DIFF
--- a/.env
+++ b/.env
@@ -15,4 +15,5 @@ DOC_LINK ='https://opendatahub.io/docs.html'
 COMMUNITY_LINK ='https://opendatahub.io/community.html'
 ENABLED_APPS_CM = 'odh-enabled-applications-config'
 KUSTOMIZE_MANIFEST_DIR=manifests
+KUSTOMIZE_DEFAULT_OVERLAY=/overlays/dev
 DASHBOARD_CONFIG = 'odh-dashboard-config'

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -79,5 +79,4 @@ Once we reach a date in which we want to do a release (see other sections for mo
          - Exclude the `overlays` folder as this is for internal testing purposes
       - Copy the OWNERS file into the root of the odh-dashboard manifest folder
       - Update the `./base/kustomization.yaml` so that the `odh-dashboard` images section has the `newTag` equal to the current release version (aka the tag we created earlier)
-      - In the `./base/deployment.yaml` we'll want to set the ODH replicas to `2`
       - Update the top row of the component versions table on the root readme to have the latest release version (aka the tag we created earlier)

--- a/install/deploy.sh
+++ b/install/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-printf "\n\n######## deploy ########\n"
+printf "\n\n######## deploy overlay ${KUSTOMIZE_DEFAULT_OVERLAY} ########\n"
 
-KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV="${KUSTOMIZE_MANIFEST_DIR}/overlays/dev"
+KUSTOMIZE_MANIFEST_DIR_OVERLAY="${KUSTOMIZE_MANIFEST_DIR}${KUSTOMIZE_DEFAULT_OVERLAY}"
 
 if [[ -z "${OC_PROJECT}" ]]; then
   echo "ERROR: No value defined for OC_PROJECT env var"
@@ -19,7 +19,7 @@ oc config set-context --current --namespace=${OC_PROJECT}
 oc label namespace ${OC_PROJECT} openshift.io/cluster-monitoring='true' --overwrite
 
 # Deploy dashboard manifests using kustomize
-pushd ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV}
+pushd ${KUSTOMIZE_MANIFEST_DIR_OVERLAY}
 kustomize edit set namespace ${OC_PROJECT}
 kustomize edit set image quay.io/opendatahub/odh-dashboard=${IMAGE_REPOSITORY}
 if [[ ! -z "${OAUTH_IMAGE_REPOSITORY}" ]]; then
@@ -28,4 +28,4 @@ fi
 popd
 
 # Use kustomize to build the yaml objects so we get full support for all the kustomize standards
-kustomize build ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV} | oc apply -f -
+kustomize build ${KUSTOMIZE_MANIFEST_DIR_OVERLAY} | oc apply -f -

--- a/install/undeploy.sh
+++ b/install/undeploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-printf "\n\n######## undeploy ########\n"
+printf "\n\n######## undeploy overlay ${KUSTOMIZE_DEFAULT_OVERLAY} ########\n"
 
-KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV="${KUSTOMIZE_MANIFEST_DIR}/overlays/dev"
+KUSTOMIZE_MANIFEST_DIR_OVERLAY="${KUSTOMIZE_MANIFEST_DIR}${KUSTOMIZE_DEFAULT_OVERLAY}"
 
 if [[ -z "${OC_PROJECT}" ]]; then
   echo "ERROR: No value defined for OC_PROJECT env var"
@@ -19,9 +19,9 @@ oc config set-context --current --namespace=${OC_PROJECT}
 oc label namespace ${OC_PROJECT} openshift.io/cluster-monitoring-
 
 # Uninstall dashboard using kustomize
-pushd ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV}
+pushd ${KUSTOMIZE_MANIFEST_DIR_OVERLAY}
 kustomize edit set namespace ${OC_PROJECT}
 popd
 
 # Use kustomize to build the yaml objects so we get full support for all the kustomize standards
-kustomize build ${KUSTOMIZE_MANIFEST_DIR_OVERLAY_DEV} | oc delete --ignore-not-found=true -f -
+kustomize build ${KUSTOMIZE_MANIFEST_DIR_OVERLAY} | oc delete --ignore-not-found=true -f -

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: odh-dashboard
 spec:
-  replicas: 5
+  replicas: 2
   selector:
     matchLabels:
       deployment: odh-dashboard

--- a/manifests/kfdef/odh-dashboard-kfnbc-test.yaml
+++ b/manifests/kfdef/odh-dashboard-kfnbc-test.yaml
@@ -23,10 +23,8 @@ spec:
     name: odh-notebook-controller
   - kustomizeConfig:
       overlays:
-      # Uncomment the odhdashboard overlay below to have the operator deploy the configs
-      # This should be removed from the deployed kfdef immediately after the operator deploys the configs
-      # This will prevent the operator from reconciling the configs when they have been modified externally
-      #- odhdashboardconfig
+      # Uncomment the performance overlay below to have the operator deploy more dashboard replicas
+      #- performance
       repoRef:
         name: manifests-dashboard  # Use the odh-dashboard repo as the source for this kustomize manifest
         path: manifests

--- a/manifests/overlays/performance/deployment.yaml
+++ b/manifests/overlays/performance/deployment.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/replicas
+  value: 5

--- a/manifests/overlays/performance/kustomization.yaml
+++ b/manifests/overlays/performance/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+patchesJson6902:
+  - path: deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: odh-dashboard


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes: #1613 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run `make deploy` in your cluster
2. Check that the odh-dashboard deployment has 2 replicas
3. Add `KUSTOMIZE_DEFAULT_OVERLAY=/overlays/performance` in your `.env.local` file
4. Run `make deploy`
5. Check that the odh-dashboard deployment has 5 replicas now

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test impact so far

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
