### PR TITLE
added accelerator detection

### DIFF
--- a/backend/src/routes/api/accelerators/acceleratorUtils.ts
+++ b/backend/src/routes/api/accelerators/acceleratorUtils.ts
@@ -1,0 +1,46 @@
+import { AcceleratorInfo, KubeFastifyInstance } from "../../../types"
+
+const RESOURCE_TYPES = ["cpu", "memory", "pods", "ephemeral-storage", "hugepages-1Gi", "hugepages-2Mi"]
+
+const getIdentifiersFromResources = (resources: {[key: string]: string} = {}) => {
+	return Object.entries(resources)
+	.filter(([key,]) => !RESOURCE_TYPES.includes(key))
+	.reduce<{[key: string]: number}>((identifiers, [key, value]) => {
+		identifiers[key] = isNaN(parseInt(value)) ? 0 : parseInt(value)
+		return identifiers
+	}, {})
+}
+
+export const getAcceleratorNumbers = async (fastify: KubeFastifyInstance): Promise<AcceleratorInfo> => (
+	fastify.kube.coreV1Api.listNode()
+	.then((res) => res.body.items.reduce<AcceleratorInfo>((info, node) => {
+		// reduce resources down to just the accelerators and their counts
+		const allocatable = getIdentifiersFromResources(node.status.allocatable)
+		const capacity = getIdentifiersFromResources(node.status.capacity)
+
+		// update the max count for each accelerator
+		Object.entries(allocatable).forEach(([key, value]) => (
+			info.available[key] = Math.max((info.available[key] || 0), value)
+		))
+
+		// update the total count for each accelerator
+		Object.entries(capacity).forEach(([key, value]) => (
+			info.total[key] = (info.total[key] || 0) + value
+		))
+		
+
+		// update the allocated count for each accelerator
+		Object.entries(capacity).forEach(([key, value]) => (
+			info.allocated[key] = (info.allocated[key] || 0) + value - (allocatable[key] || 0)
+		))
+
+		// if any accelerators are available, the cluster is configured
+		const configured = info.configured || Object.values(info.available).some((value) => value > 0)
+
+		return {total: info.total, available: info.available, allocated: info.allocated, configured}
+	}, {configured: false, available: {}, total: {}, allocated: {}}))
+	.catch((e) => {
+		fastify.log.error(`Exception when listing cluster nodes: ${e}`);
+		return  {configured: false, available: {}, total: {}, allocated: {}}
+	})
+)

--- a/backend/src/routes/api/accelerators/index.ts
+++ b/backend/src/routes/api/accelerators/index.ts
@@ -1,14 +1,11 @@
 import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
-import { getGPUNumber } from './gpuUtils';
+import { getAcceleratorNumbers } from './acceleratorUtils';
 import { logRequestDetails } from '../../../utils/fileUtils';
 
-/**
- * @deprecated - use accelerators instead
- */
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   fastify.get('/', async (request: OauthFastifyRequest) => {
     logRequestDetails(fastify, request);
 
-    return getGPUNumber(fastify);
+    return getAcceleratorNumbers(fastify);
   });
 };

--- a/backend/src/routes/api/gpu/gpuUtils.ts
+++ b/backend/src/routes/api/gpu/gpuUtils.ts
@@ -16,6 +16,9 @@ const storage: { lastFetch: number; lastValue: GPUInfo } = {
   lastFetch: 0,
 };
 
+/**
+ * @deprecated - use getAcceleratorNumbers instead
+ */
 export const getGPUNumber = async (fastify: KubeFastifyInstance): Promise<GPUInfo> => {
   if (storage.lastFetch >= Date.now() - 30_000) {
     fastify.log.info(`Returning cached gpu value (${JSON.stringify(storage)})`);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -748,6 +748,14 @@ export type GPUInfo = {
   available: number;
   autoscalers: gpuScale[];
 };
+
+export type AcceleratorInfo = {
+  configured: boolean;
+  available: {[key: string]: number};
+  total: {[key: string]: number};
+  allocated: {[key: string]: number};
+}
+
 export type EnvironmentVariable = EitherNotBoth<
   { value: string | number },
   { valueFrom: Record<string, unknown> }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1441

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds accelerator detection by looking at cluster node resources. This creates a new `/accelerators` end point which returns a object with the available, allocated, and total number of accelerators.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
get a GPU cluster, call the new endpoint, test to see accelerators are detected

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
backend n/a

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
