### PR TITLE
add utility to make it easier and more robust to test hooks

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,6 +45,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.21.0",
+        "@testing-library/react": "^14.0.0",
         "@types/dompurify": "^2.2.6",
         "@types/lodash-es": "^4.17.8",
         "@types/node": "^17.0.29",
@@ -8826,6 +8827,113 @@
         "node": ">=8"
       }
     },
+    "node_modules/@testing-library/react": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -8848,7 +8956,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
       "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -10666,7 +10774,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
@@ -10819,7 +10927,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -13918,7 +14026,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
       "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-get-iterator": "^1.1.2",
@@ -14025,7 +14133,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
       "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -14235,7 +14343,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -14619,7 +14727,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -16254,7 +16362,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -16569,7 +16677,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "optional": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16869,7 +16977,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -16981,7 +17089,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "optional": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16999,7 +17107,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -17035,7 +17143,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -17763,7 +17871,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
       "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
@@ -17826,7 +17934,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -17842,7 +17950,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
       "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.0",
@@ -17862,7 +17970,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -17885,7 +17993,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -17901,7 +18009,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -17925,7 +18033,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -18081,7 +18189,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "optional": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -18132,7 +18240,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -18192,7 +18300,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18208,7 +18316,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "optional": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -18217,7 +18325,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
       "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -18241,7 +18349,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -18256,7 +18364,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -18271,7 +18379,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -18320,7 +18428,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
       "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "optional": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -18341,7 +18449,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
       "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -18381,7 +18489,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -23067,7 +23175,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "optional": true,
+      "devOptional": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -24330,7 +24438,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -24346,7 +24454,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -24355,7 +24463,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
       "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -25364,7 +25472,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -25378,7 +25486,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -25390,7 +25498,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
@@ -26323,7 +26431,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
       "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -27590,7 +27698,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
       "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "internal-slot": "^1.0.4"
       },
@@ -30533,7 +30641,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -30549,7 +30657,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
       "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "is-map": "^2.0.1",
         "is-set": "^2.0.1",
@@ -30569,7 +30677,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
       "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",
+    "@testing-library/react": "^14.0.0",
     "@types/dompurify": "^2.2.6",
     "@types/lodash-es": "^4.17.8",
     "@types/node": "^17.0.29",

--- a/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
+++ b/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { expectHook, renderHook, standardUseFetchState, testHook } from './hooks';
+
+const useSayHello = (who: string, showCount = false) => {
+  const countRef = React.useRef(0);
+  countRef.current++;
+  return `Hello ${who}!${showCount && countRef.current > 1 ? ` x${countRef.current}` : ''}`;
+};
+
+const useSayHelloDelayed = (who: string, delay = 0) => {
+  const [speech, setSpeech] = React.useState('');
+  React.useEffect(() => {
+    const handle = setTimeout(() => setSpeech(`Hello ${who}!`), delay);
+    return () => clearTimeout(handle);
+  }, [who, delay]);
+  return speech;
+};
+
+describe('hook test utils', () => {
+  it('simple testHook', () => {
+    const renderResult = testHook((who: string) => `Hello ${who}!`, 'world');
+    expectHook(renderResult).toBe('Hello world!').toHaveUpdateCount(1);
+    renderResult.rerender('world');
+    expectHook(renderResult).toBe('Hello world!').toBeStable().toHaveUpdateCount(2);
+  });
+
+  it('use testHook for rendering', () => {
+    const renderResult = testHook(useSayHello, 'world');
+    expectHook(renderResult)
+      .toHaveUpdateCount(1)
+      .toBe('Hello world!')
+      .toStrictEqual('Hello world!');
+
+    renderResult.rerender('world', false);
+
+    expectHook(renderResult)
+      .toHaveUpdateCount(2)
+      .toBe('Hello world!')
+      .toStrictEqual('Hello world!')
+      .toBeStable();
+
+    renderResult.rerender('world', true);
+
+    expectHook(renderResult)
+      .toHaveUpdateCount(3)
+      .toBe('Hello world! x3')
+      .toStrictEqual('Hello world! x3')
+      .toBeStable(false);
+  });
+
+  it('use renderHook for rendering', () => {
+    type Props = {
+      who: string;
+      showCount?: boolean;
+    };
+    const renderResult = renderHook(({ who, showCount }: Props) => useSayHello(who, showCount), {
+      initialProps: {
+        who: 'world',
+      },
+    });
+
+    expectHook(renderResult)
+      .toHaveUpdateCount(1)
+      .toBe('Hello world!')
+      .toStrictEqual('Hello world!');
+
+    renderResult.rerender({
+      who: 'world',
+    });
+
+    expectHook(renderResult)
+      .toHaveUpdateCount(2)
+      .toBe('Hello world!')
+      .toStrictEqual('Hello world!')
+      .toBeStable();
+
+    renderResult.rerender({ who: 'world', showCount: true });
+
+    expectHook(renderResult)
+      .toHaveUpdateCount(3)
+      .toBe('Hello world! x3')
+      .toStrictEqual('Hello world! x3')
+      .toBeStable(false);
+  });
+
+  it('should use waitForNextUpdate for async update testing', async () => {
+    const renderResult = testHook(useSayHelloDelayed, 'world');
+    expectHook(renderResult).toHaveUpdateCount(1).toBe('');
+
+    await renderResult.waitForNextUpdate();
+    expectHook(renderResult).toHaveUpdateCount(2).toBe('Hello world!');
+  });
+
+  it('should throw error if waitForNextUpdate times out', async () => {
+    const renderResult = renderHook(() => useSayHelloDelayed('', 20));
+
+    await expect(renderResult.waitForNextUpdate({ timeout: 10, interval: 5 })).rejects.toThrow();
+    expectHook(renderResult).toHaveUpdateCount(1);
+
+    // unmount to test waiting for an update that will never happen
+    renderResult.unmount();
+
+    await expect(renderResult.waitForNextUpdate({ timeout: 50, interval: 10 })).rejects.toThrow();
+
+    expectHook(renderResult).toHaveUpdateCount(1);
+  });
+
+  it('should not throw if waitForNextUpdate timeout is sufficient', async () => {
+    const renderResult = renderHook(() => useSayHelloDelayed('', 20));
+
+    await expect(
+      renderResult.waitForNextUpdate({ timeout: 50, interval: 10 }),
+    ).resolves.not.toThrow();
+
+    expectHook(renderResult).toHaveUpdateCount(2);
+  });
+
+  it('should assert stability of results using isStable', () => {
+    let testValue = 'test';
+    const renderResult = renderHook(() => testValue);
+    expectHook(renderResult).toHaveUpdateCount(1);
+
+    renderResult.rerender();
+    expectHook(renderResult).toHaveUpdateCount(2).toBeStable(true);
+
+    testValue = 'new';
+    renderResult.rerender();
+    expectHook(renderResult).toHaveUpdateCount(3).toBeStable(false);
+
+    renderResult.rerender();
+    expectHook(renderResult).toHaveUpdateCount(4).toBeStable(true);
+  });
+
+  it('should assert stability of results using isStableArray', () => {
+    let testValue = 'test';
+    // explicitly returns a new array each render to show the difference between `isStable` and `isStableArray`
+    const renderResult = renderHook(() => [testValue]);
+    expectHook(renderResult).toHaveUpdateCount(1);
+
+    renderResult.rerender();
+    expectHook(renderResult).toHaveUpdateCount(2).toBeStable(false);
+    expectHook(renderResult).toHaveUpdateCount(2).toBeStable([true]);
+
+    testValue = 'new';
+    renderResult.rerender();
+    expectHook(renderResult).toHaveUpdateCount(3).toBeStable(false);
+    expectHook(renderResult).toHaveUpdateCount(3).toBeStable([false]);
+
+    renderResult.rerender();
+    expectHook(renderResult).toHaveUpdateCount(4).toBeStable(false);
+    expectHook(renderResult).toHaveUpdateCount(4).toBeStable([true]);
+  });
+
+  it('standardUseFetchState should return an array matching the state of useFetchState', () => {
+    expect(['test', false, undefined, () => null]).toStrictEqual(standardUseFetchState('test'));
+    expect(['test', true, undefined, () => null]).toStrictEqual(
+      standardUseFetchState('test', true),
+    );
+    expect(['test', false, new Error('error'), () => null]).toStrictEqual(
+      standardUseFetchState('test', false, new Error('error')),
+    );
+  });
+});

--- a/frontend/src/__tests__/unit/testUtils/hooks.ts
+++ b/frontend/src/__tests__/unit/testUtils/hooks.ts
@@ -1,0 +1,253 @@
+import {
+  renderHook as renderHookRTL,
+  RenderHookOptions,
+  RenderHookResult,
+  waitFor,
+  waitForOptions,
+} from '@testing-library/react';
+import { queries, Queries } from '@testing-library/dom';
+
+/**
+ * Set of helper functions used to perform assertions on the hook result.
+ */
+export type RenderHookResultExpect<Result, Props> = {
+  /**
+   * Check that a value is what you expect. It uses `Object.is` to check strict equality.
+   * Don't use `toBe` with floating-point numbers.
+   */
+  toBe: (expected: Result) => RenderHookResultExpect<Result, Props>;
+
+  /**
+   * Check that the result has the same types as well as structure.
+   */
+  toStrictEqual: (expected: Result) => RenderHookResultExpect<Result, Props>;
+
+  /**
+   * Check the stability of the result.
+   * If the expected value is a boolean array, uses `isStableArray` for comparison, otherwise uses `isStable`.
+   *
+   * Stability is checked against the previous update.
+   */
+  toBeStable: (expected?: boolean | boolean[]) => RenderHookResultExpect<Result, Props>;
+
+  /**
+   * Check the update count is the expected number.
+   * Update count increases every time the hook is called.
+   */
+  toHaveUpdateCount: (expected: number) => RenderHookResultExpect<Result, Props>;
+};
+
+/**
+ * Extension of RTL RenderHookResult providing functions used query the current state of the result.
+ */
+export type RenderHookResultExt<Result, Props> = RenderHookResult<Result, Props> & {
+  /**
+   * Returns `true` if the previous result is equal to the current result. Uses `Object.is` for comparison.
+   */
+  isStable: () => boolean;
+
+  /**
+   * Returns `true` if the previous result array items are equal to the current result array items. Uses `Object.is` for comparison.
+   * The equality of the array instances is not checked.
+   */
+  isStableArray: () => boolean[];
+
+  /**
+   * Get the update count for how many times the hook has been rendered.
+   * An update occurs initially on render, subsequently when re-rendered, and also whenever the hook itself triggers a re-render.
+   * eg. An `useEffect` triggering a state update.
+   */
+  getUpdateCount: () => number;
+
+  /**
+   * Returns a Promise that resolves the next time the hook renders, commonly when state is updated as the result of an asynchronous update.
+   *
+   * Since `waitForNextUpdate` works using interval checks (backed by `waitFor`), it's possible that multiple updates may occur while waiting.
+   */
+  waitForNextUpdate: (options?: Pick<waitForOptions, 'interval' | 'timeout'>) => Promise<void>;
+};
+
+/**
+ * Helper function that wraps a render result and provides a small set of jest Matcher equivalent functions that act directly on the result.
+ *
+ * ```
+ * expectHook(renderResult).toBeStable().toHaveUpdateCount(2);
+ * ```
+ * Equivalent to:
+ * ```
+ * expect(renderResult.isStable()).toBe(true);
+ * expect(renderResult.getUpdateCount()).toBe(2);
+ * ```
+ *
+ * See `RenderHookResultExpect`
+ */
+export const expectHook = <Result, Props>(
+  renderResult: Pick<
+    RenderHookResultExt<Result, Props>,
+    'result' | 'getUpdateCount' | 'isStableArray' | 'isStable'
+  >,
+): RenderHookResultExpect<Result, Props> => {
+  const expectUtil: RenderHookResultExpect<Result, Props> = {
+    toBe: (expected) => {
+      expect(renderResult.result.current).toBe(expected);
+      return expectUtil;
+    },
+
+    toStrictEqual: (expected) => {
+      expect(renderResult.result.current).toStrictEqual(expected);
+      return expectUtil;
+    },
+
+    toBeStable: (expected = true) => {
+      if (renderResult.getUpdateCount() > 1) {
+        if (Array.isArray(expected)) {
+          expect(renderResult.isStableArray()).toStrictEqual(expected);
+        } else {
+          expect(renderResult.isStable()).toBe(expected);
+        }
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'expectHook#toBeStable cannot assert stability as the hook has not run at least 2 times.',
+        );
+      }
+      return expectUtil;
+    },
+
+    toHaveUpdateCount: (expected) => {
+      expect(renderResult.getUpdateCount()).toBe(expected);
+      return expectUtil;
+    },
+  };
+  return expectUtil;
+};
+
+/**
+ * Wrapper on top of RTL `renderHook` returning a result that implements the `RenderHookResultExt` interface.
+ *
+ * `renderHook` provides full control over the rendering of your hook including the ability to wrap the test component.
+ * This is usually used to add context providers from `React.createContext` for the hook to access with `useContext`.
+ * `initialProps` and props subsequently set by `rerender` will be provided to the wrapper.
+ *
+ * ```
+ * const renderResult = renderHook(({ who }: { who: string }) => useSayHello(who), { initialProps: { who: 'world' }});
+ * expectHook(renderResult).toBe('Hello world!');
+ * renderResult.rerender({ who: 'there' });
+ * expectHook(renderResult).toBe('Hello there!');
+ * ```
+ */
+export const renderHook = <
+  Result,
+  Props,
+  Q extends Queries = typeof queries,
+  Container extends Element | DocumentFragment = HTMLElement,
+  BaseElement extends Element | DocumentFragment = Container,
+>(
+  render: (initialProps: Props) => Result,
+  options?: RenderHookOptions<Props, Q, Container, BaseElement>,
+): RenderHookResultExt<Result, Props> => {
+  let updateCount = 0;
+  let prevResult: Result | undefined;
+  let currentResult: Result | undefined;
+
+  const renderResult = renderHookRTL((props) => {
+    updateCount++;
+    prevResult = currentResult;
+    currentResult = render(props);
+    return currentResult;
+  }, options);
+
+  const renderResultExt: RenderHookResultExt<Result, Props> = {
+    ...renderResult,
+
+    isStable: () => (updateCount > 1 ? Object.is(renderResult.result.current, prevResult) : false),
+
+    isStableArray: () => {
+      // prefill return array with `false`
+      const stable: boolean[] = Array(
+        Math.max(
+          Array.isArray(prevResult) ? prevResult?.length : 0,
+          Array.isArray(renderResult.result.current) ? renderResult.result.current.length : 0,
+        ),
+      ).fill(false);
+
+      if (
+        updateCount > 1 &&
+        Array.isArray(prevResult) &&
+        Array.isArray(renderResult.result.current)
+      ) {
+        renderResult.result.current.forEach((v, i) => {
+          stable[i] = Object.is(v, (prevResult as unknown[])[i]);
+        });
+      }
+      return stable;
+    },
+
+    getUpdateCount: () => updateCount,
+
+    waitForNextUpdate: async (options) => {
+      const expected = updateCount;
+      try {
+        await waitFor(() => expect(updateCount).toBeGreaterThan(expected), options);
+      } catch {
+        throw new Error('waitForNextUpdate timed out');
+      }
+    },
+  };
+
+  return renderResultExt;
+};
+
+/**
+ * Lightweight API for testing a single hook.
+ *
+ * Prefer this method of testing over `renderHook` for simplicity.
+ *
+ * ```
+ * const renderResult = testHook(useSayHello, 'world');
+ * expectHook(renderResult).toBe('Hello world!');
+ * renderResult.rerender('there');
+ * expectHook(renderResult).toBe('Hello there!');
+ * ```
+ */
+
+export const testHook = <Result, Hook extends (...params: P) => Result, P extends unknown[]>(
+  hook: (...params: P) => Result,
+  ...initialParams: Parameters<Hook>
+) => {
+  type Params = Parameters<Hook>;
+  const renderResult = renderHook(({ $params }: { $params: Params }) => hook(...$params), {
+    initialProps: {
+      $params: initialParams,
+    },
+  });
+
+  return {
+    ...renderResult,
+
+    rerender: (...params: Params) => renderResult.rerender({ $params: params }),
+  };
+};
+
+/**
+ * A helper function for asserting the return value of hooks based on `useFetchState`.
+ *
+ * eg.
+ * ```
+ * expectHook(renderResult).isStrictEqual(standardUseFetchState('test value', true))
+ * ```
+ * is equivalent to:
+ * ```
+ * expectHook(renderResult).isStrictEqual(['test value', true, undefined, expect.any(Function)])
+ * ```
+ */
+export const standardUseFetchState = <D>(
+  data: D,
+  loaded = false,
+  error?: Error,
+): [
+  data: D,
+  loaded: boolean,
+  loadError: Error | undefined,
+  refresh: () => Promise<D | undefined>,
+] => [data, loaded, error, expect.any(Function)];

--- a/frontend/src/__tests__/unit/useFetchState.spec.ts
+++ b/frontend/src/__tests__/unit/useFetchState.spec.ts
@@ -1,0 +1,97 @@
+import { act } from '@testing-library/react';
+import useFetchState from '~/utilities/useFetchState';
+import { expectHook, standardUseFetchState, testHook } from './testUtils/hooks';
+
+jest.useFakeTimers();
+
+describe('useFetchState', () => {
+  it('should be successful', async () => {
+    const renderResult = testHook(
+      useFetchState,
+      () => Promise.resolve('success-test-state'),
+      'default-test-state',
+    );
+
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState('default-test-state'))
+      .toHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState('success-test-state', true))
+      .toHaveUpdateCount(2)
+      .toBeStable([false, false, true, true]);
+  });
+
+  it('should fail', async () => {
+    const renderResult = testHook(
+      useFetchState,
+      () => Promise.reject<string>(new Error('error-test-state')),
+      'default-test-state',
+    );
+
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState('default-test-state'))
+      .toHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+
+    expectHook(renderResult)
+      .toStrictEqual(
+        standardUseFetchState('default-test-state', false, new Error('error-test-state')),
+      )
+      .toHaveUpdateCount(2)
+      .toBeStable([true, true, false, true]);
+  });
+
+  it('should refresh', async () => {
+    const renderResult = testHook(useFetchState, () => Promise.resolve([1, 2, 3]), [], {
+      refreshRate: 1000,
+    });
+    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([1, 2, 3], true))
+      .toHaveUpdateCount(2)
+      .toBeStable([false, false, true, true]);
+
+    await act(() => {
+      jest.advanceTimersByTime(900);
+    });
+    expectHook(renderResult).toHaveUpdateCount(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+    });
+    expectHook(renderResult).toHaveUpdateCount(3);
+
+    await renderResult.waitForNextUpdate();
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([1, 2, 3], true))
+      .toHaveUpdateCount(4)
+      .toBeStable([false, true, true, true]);
+  });
+
+  it('should test stability', async () => {
+    const renderResult = testHook(useFetchState, () => Promise.resolve([1, 2, 3]), []);
+    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([1, 2, 3], true))
+      .toHaveUpdateCount(2)
+      .toBeStable([false, false, true, true]);
+
+    renderResult.rerender(() => Promise.resolve([1, 2, 4]), []);
+    expectHook(renderResult).toHaveUpdateCount(3).toBeStable([true, true, true, true]);
+
+    await renderResult.waitForNextUpdate();
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([1, 2, 4], true))
+      .toHaveUpdateCount(4)
+      .toBeStable([false, true, true, true]);
+  });
+});

--- a/frontend/src/__tests__/unit/useGroups.spec.ts
+++ b/frontend/src/__tests__/unit/useGroups.spec.ts
@@ -1,0 +1,125 @@
+import { act } from '@testing-library/react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import useGroups from '~/pages/projects/projectSharing/useGroups';
+import { GroupKind } from '~/k8sTypes';
+import { expectHook, standardUseFetchState, testHook } from './testUtils/hooks';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+const k8sListResourceMock = k8sListResource as jest.Mock;
+
+describe('useGroups', () => {
+  it('should return successful list of groups', async () => {
+    const mockList = {
+      items: [{ metadata: { name: 'item 1' } }, { metadata: { name: 'item 2' } }] as GroupKind[],
+    };
+    k8sListResourceMock.mockReturnValue(Promise.resolve(mockList));
+
+    const renderResult = testHook(useGroups);
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState(mockList.items, true))
+      .toHaveUpdateCount(2)
+      .toBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(Promise.resolve({ items: [...mockList.items] }));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expectHook(renderResult).toHaveUpdateCount(3).toBeStable([false, true, true, true]);
+  });
+
+  it('should handle 403 as an empty result', async () => {
+    const error = {
+      statusObject: {
+        code: 403,
+      },
+    };
+    k8sListResourceMock.mockReturnValue(Promise.reject(error));
+
+    const renderResult = testHook(useGroups);
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([], true))
+      .toHaveUpdateCount(2)
+      .toBeStable([false, false, true, true]);
+
+    // refresh
+    await act(() => renderResult.result.current[3]());
+    // error 403 should cache error and prevent subsequent attempts to fetch
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([], true))
+      .toHaveUpdateCount(3)
+      .toBeStable([false, true, true, true]);
+  });
+
+  it('should handle 404 as an error', async () => {
+    const error = {
+      statusObject: {
+        code: 404,
+      },
+    };
+    k8sListResourceMock.mockReturnValue(Promise.reject(error));
+
+    const renderResult = testHook(useGroups);
+
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([], false, new Error('No groups found.')))
+      .toHaveUpdateCount(2)
+      .toBeStable([true, true, false, true]);
+
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+
+    // refresh
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    // we get a new error because the k8s API is called a 2nd time
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([], false, new Error('No groups found.')))
+      .toHaveUpdateCount(3)
+      .toBeStable([true, true, false, true]);
+  });
+
+  it('should handle other errors and rethrow', async () => {
+    k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error1')));
+
+    const renderResult = testHook(useGroups);
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([], false, new Error('error1')))
+      .toHaveUpdateCount(2)
+      .toBeStable([true, true, false, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error2')));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expectHook(renderResult)
+      .toStrictEqual(standardUseFetchState([], false, new Error('error2')))
+      .toHaveUpdateCount(3)
+      .toBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/pages/TestPage.tsx.bak
+++ b/frontend/src/pages/TestPage.tsx.bak
@@ -1,0 +1,55 @@
+import { K8sModelCommon, useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { Alert, AlertVariant, Button } from '@patternfly/react-core';
+import * as React from 'react';
+import { ProjectKind } from '~/k8sTypes';
+
+const errorMessage = (e: unknown): string =>
+  (typeof e === 'object' ? e?.toString() : typeof e === 'string' ? e : '') || '';
+
+const ProjectModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'project.openshift.io',
+  kind: 'Project',
+  plural: 'projects',
+};
+const TestPage = () => {
+  new Object();
+  const [limit, setLimit] = React.useState(100);
+  const [projects, loaded, error] = useK8sWatchResource<ProjectKind[]>(
+    {
+      groupVersionKind: {
+        group: 'project.openshift.io',
+        version: 'v1',
+        kind: 'Project',
+      },
+      limit,
+      isList: true,
+    },
+    ProjectModel,
+  );
+  return (
+    <>
+      <div>
+        <Button onClick={() => setLimit((l) => l + 1)}>Update</Button>
+      </div>
+      {!loaded ? <div>Loading...</div> : null}
+      {error ? (
+        <Alert
+          title="An error occurred"
+          variant={AlertVariant.danger}
+          isInline
+          className="pf-u-mb-lg"
+        >
+          {errorMessage(error)}
+        </Alert>
+      ) : null}
+      <ol>
+        {Array.isArray(projects)
+          ? projects.map((p) => <li key={p.metadata.name}>{p.metadata.name}</li>)
+          : null}
+      </ol>
+    </>
+  );
+};
+
+export default TestPage;

--- a/frontend/src/utilities/useFetchState.ts
+++ b/frontend/src/utilities/useFetchState.ts
@@ -223,12 +223,16 @@ const useFetchState = <Type, Default extends Type = Type>(
     };
   }, [call, refreshRate]);
 
+  // Use a reference for `call` to ensure a stable reference to `refresh` is always returned
+  const callRef = React.useRef(call);
+  callRef.current = call;
+
   const refresh = React.useCallback<FetchStateRefreshPromise<Type>>(() => {
     abortCallbackRef.current();
-    const [callPromise, unload] = call();
+    const [callPromise, unload] = callRef.current();
     abortCallbackRef.current = unload;
     return callPromise;
-  }, [call]);
+  }, []);
 
   return [result, loaded, loadError, refresh];
 };


### PR DESCRIPTION
## Description

Introduces `@testing-library/react` for unit tests. While RTL does provide a means to render a hook and perform assertions using jest, such tests result in a lot of boilerplate code.

The goal of this PR is to supply testing utilities that make it easier to write tests for hooks and ensure that we test two critical areas of hooks:
- return values are stable unless their values have actually changed
- a hook doesn't unnecessary cause additional re-renders

Example of a small test asserting these two areas:
```
const useSayHello = (who: string) => `Hello ${who}!`;
```
```
it('use hook test utils', () => {
  const renderResult = testHook(useSayHello, 'world');
  expectHook(renderResult).toBe('Hello world!').toHaveUpdateCount(1);
  renderResult.rerender('world');
  expectHook(renderResult).toBe('Hello world!').toBeStable().toHaveUpdateCount(2);
});
```

The same test using RTL only:
```
it('use RTL only', () => {
  let updateCount = 0;

  const renderResult = renderHookRTL(
    ({ who }: { who: string }) => {
      updateCount++;
      return useSayHello(who);
    },
    { initialProps: { who: 'world' } },
  );
  expect(renderResult.result.current).toBe('Hello world!');
  expect(updateCount).toBe(1);

  const prevValue = renderResult.result.current;

  renderResult.rerender({
    who: 'world',
  });
  expect(renderResult.result.current).toBe('Hello world!');
  expect(renderResult.result.current).toBe(prevValue);
  expect(updateCount).toBe(2);
});
```

The example above shows the difference in testing a very simple hook. See the changes to unit test files for examples of more complex hooks.

### Code changes
- `useFetchState`: added a `useRef` to ensure the `refresh` function is always stable
- `useGroups`: return a constant for empty array