### PR TITLE
Fixes: Workbench not editable for a little while after it's stopped

### DIFF
--- a/frontend/src/pages/projects/notebook/service.ts
+++ b/frontend/src/pages/projects/notebook/service.ts
@@ -34,6 +34,8 @@ export const getNotebooksStatus = async (
           notebook: notebooks[i],
           isStarting: !isStopped && !podsReady,
           isRunning: !isStopped && podsReady,
+          isStopping: isStopped && podsReady,
+          isStopped: isStopped && !podsReady,
           runningPodUid: pods[0]?.metadata?.uid || '',
         },
       ];

--- a/frontend/src/pages/projects/notebook/types.ts
+++ b/frontend/src/pages/projects/notebook/types.ts
@@ -5,6 +5,8 @@ export type NotebookDataState = {
   notebook: NotebookKind;
   isStarting: boolean;
   isRunning: boolean;
+  isStopping: boolean;
+  isStopped: boolean;
   runningPodUid: string;
 };
 

--- a/frontend/src/pages/projects/notebook/useRefreshNotebookUntilStartOrStop.ts
+++ b/frontend/src/pages/projects/notebook/useRefreshNotebookUntilStartOrStop.ts
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { FAST_POLL_INTERVAL } from '~/utilities/const';
 import { NotebookState } from './types';
 
-const useRefreshNotebookUntilStart = (
+const useRefreshNotebookUntilStartOrStop = (
   notebookState: NotebookState,
   doListen: boolean,
-): ((listen: boolean) => void) => {
+): ((listen: boolean, stop?: boolean) => void) => {
   const [watchingForNotebook, setWatchingForNotebook] = React.useState(false);
+  const [watchingForStop, setWatchingForStop] = React.useState(false);
   const lastNotebookState = React.useRef<NotebookState>(notebookState);
   lastNotebookState.current = notebookState;
 
@@ -14,8 +15,9 @@ const useRefreshNotebookUntilStart = (
     let interval: ReturnType<typeof setInterval>;
     if (watchingForNotebook && doListen) {
       interval = setInterval(() => {
-        const { isRunning, refresh } = lastNotebookState.current;
-        if (!isRunning) {
+        const { isRunning, isStopped, refresh } = lastNotebookState.current;
+        const condition = watchingForStop ? isStopped : isRunning;
+        if (!condition) {
           refresh().catch((e) => {
             /* eslint-disable-next-line no-console */
             console.error('Error refreshing, stopping notebook refresh', e);
@@ -30,11 +32,15 @@ const useRefreshNotebookUntilStart = (
     return () => {
       clearInterval(interval);
     };
-  }, [watchingForNotebook, doListen]);
+  }, [watchingForStop, watchingForNotebook, doListen]);
 
-  return React.useCallback((listen: boolean) => {
+  /**
+   * The second parameter allows listening for the notebook to be stopped. Default is to wait until started.
+   */
+  return React.useCallback((listen: boolean, waitForStop = false) => {
+    setWatchingForStop(waitForStop);
     setWatchingForNotebook(listen);
   }, []);
 };
 
-export default useRefreshNotebookUntilStart;
+export default useRefreshNotebookUntilStartOrStop;

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -94,7 +94,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           <ActionsColumn
             items={[
               {
-                isDisabled: obj.isStarting,
+                isDisabled: obj.isStarting || obj.isStopping,
                 title: 'Edit workbench',
                 onClick: () => {
                   navigate(


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
* Closes: #1551 
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
* When stopping a workbench:  
  * the switch now waits for the pods to spin down before showing status "stopped". 
  * The edit button in the kebab is disabled until the new stopped status.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Stop a running workbench
* Wait for the edit button in the kebab to not be disabled
* Make an update to your workbench, e.g. change the notebook image.
* Ensure you do not see the error message reported in the bug.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
