### PR TITLE
Remove misplaced divider in Global Pipelines Page

### DIFF
--- a/frontend/src/pages/pipelines/global/pipelines/GlobalPipelines.tsx
+++ b/frontend/src/pages/pipelines/global/pipelines/GlobalPipelines.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Divider } from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import {
   pipelinesPageDescription,
@@ -20,7 +19,6 @@ const GlobalPipelines: React.FC = () => {
       headerAction={pipelinesAPi.pipelinesServer.installed && <PipelinesPageHeaderActions />}
       getRedirectPath={(namespace) => `/pipelines/${namespace}`}
     >
-      <Divider />
       <EnsureAPIAvailability>
         <PipelinesView />
       </EnsureAPIAvailability>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes #1606 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is how the Global Pipelines page look like now.
<img width="1228" alt="Screenshot 2023-08-04 at 2 54 15 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/8bf69afc-cf38-4532-aa04-d8f2f92f95a0">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the `Pipelines` page using the left Navbar
2. Check whether you can see the divider between the table and the header

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Visual changes.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
