### PR TITLE
[WIP] Add default_url for the role of the base_url

### DIFF
--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -293,7 +293,8 @@ export const assembleNotebook = async (
                   value: `--ServerApp.port=8888
                   --ServerApp.token=''
                   --ServerApp.password=''
-                  --ServerApp.base_url=/notebook/${namespace}/${name}
+                  --ServerApp.base_url=/
+                  --ServerApp.default_url=/notebook/${namespace}/${name}
                   --ServerApp.quit_button=False
                   --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${url}","hub_prefix":"/notebookController/${translatedUsername}"}`,
                 },

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -75,7 +75,7 @@ export const mockNotebookK8sResource = ({
               {
                 name: 'NOTEBOOK_ARGS',
                 value:
-                  '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
+                  '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/\n                  --serverApp.default_url=/notebook/project/workbench\n                   --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
               },
               {
                 name: 'JUPYTER_IMAGE',

--- a/frontend/src/__mocks__/mockPodK8sResource.ts
+++ b/frontend/src/__mocks__/mockPodK8sResource.ts
@@ -143,7 +143,7 @@ export const mockPodK8sResource = ({
           {
             name: 'NOTEBOOK_ARGS',
             value:
-              '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
+              '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/\n                  --serverApp.default_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
           },
           {
             name: 'JUPYTER_IMAGE',

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -132,7 +132,8 @@ const assembleNotebook = (
                   value: `--ServerApp.port=8888
                   --ServerApp.token=''
                   --ServerApp.password=''
-                  --ServerApp.base_url=/notebook/${projectName}/${notebookId}
+                  --ServerApp.base_url=/
+                  --ServerApp.default_url=/notebook/${projectName}/${notebookId}
                   --ServerApp.quit_button=False
                   --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${origin}","hub_prefix":"/projects/${projectName}"}`,
                 },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Add `default_url` for the role of `base_url`

According to this link, https://jupyter-notebook.readthedocs.io/en/5.7.4/config.html#options seems that should be proper the `default_url` instead of `base_url` 

```
NotebookApp.base_url : Unicode

    Default: '/'

    The base URL for the notebook server.

    Leading and trailing slashes can be omitted, and will automatically be added.

```

```
NotebookApp.default_url : Unicode

    Default: '/tree'

    The default URL to redirect to from /

```

(related to the proxy issue redirection https://github.com/opendatahub-io/kubeflow/issues/150)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
