### PR TITLE
Remove automatically scrolling into view functionality

### DIFF
--- a/frontend/src/components/ScrollViewOnMount.tsx
+++ b/frontend/src/components/ScrollViewOnMount.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react';
 
-const ScrollViewOnMount: React.FC = () => (
-  <div
-    ref={(elm) => {
-      if (elm) {
-        elm.scrollIntoView();
-      }
-    }}
-  />
-);
+type ScrollViewOnMountProps = {
+  shouldScroll: boolean;
+};
+
+const ScrollViewOnMount: React.FC<ScrollViewOnMountProps> = ({ shouldScroll }) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (shouldScroll && ref.current) {
+      ref.current?.scrollIntoView();
+    }
+  }, [shouldScroll]);
+
+  return <div ref={ref} />;
+};
 
 export default ScrollViewOnMount;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTable.tsx
@@ -3,6 +3,7 @@ import Table from '~/components/table/Table';
 import useTableColumnSort from '~/components/table/useTableColumnSort';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { ServingRuntimeTableTabs } from '~/pages/modelServing/screens/types';
 import { columns } from './data';
 import ServingRuntimeTableRow from './ServingRuntimeTableRow';
 import DeleteServingRuntimeModal from './DeleteServingRuntimeModal';
@@ -25,6 +26,7 @@ const ServingRuntimeTable: React.FC<ServingRuntimeTableProps> = ({
   const [deployServingRuntime, setDeployServingRuntime] = React.useState<ServingRuntimeKind>();
   const [deleteServingRuntime, setDeleteServingRuntime] = React.useState<ServingRuntimeKind>();
   const [editServingRuntime, setEditServingRuntime] = React.useState<ServingRuntimeKind>();
+  const [expandedColumn, setExpandedColumn] = React.useState<ServingRuntimeTableTabs>();
 
   const {
     dataConnections: { data: dataConnections },
@@ -48,7 +50,9 @@ const ServingRuntimeTable: React.FC<ServingRuntimeTableProps> = ({
             obj={modelServer}
             onDeleteServingRuntime={(obj) => setDeleteServingRuntime(obj)}
             onEditServingRuntime={(obj) => setEditServingRuntime(obj)}
-            onDeployModal={(obj) => setDeployServingRuntime(obj)}
+            onDeployModel={(obj) => setDeployServingRuntime(obj)}
+            expandedColumn={expandedColumn}
+            setExpandedColumn={setExpandedColumn}
           />
         )}
       />
@@ -86,6 +90,7 @@ const ServingRuntimeTable: React.FC<ServingRuntimeTableProps> = ({
             setDeployServingRuntime(undefined);
             if (submit) {
               refreshInferenceServices();
+              setExpandedColumn(ServingRuntimeTableTabs.DEPLOYED_MODELS);
             }
           }}
           projectContext={{

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableExpandedSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableExpandedSection.tsx
@@ -59,7 +59,9 @@ const ServingRuntimeTableExpandedSection: React.FC<ServingRuntimeTableExpandedSe
           ) : (
             <EmptyInferenceServicesCell onDeployModel={onDeployModel} />
           )}
-          <ScrollViewOnMount />
+          <ScrollViewOnMount
+            shouldScroll={activeColumn === ServingRuntimeTableTabs.DEPLOYED_MODELS}
+          />
         </ExpandableRowContent>
       </Td>
     );

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -15,17 +15,19 @@ type ServingRuntimeTableRowProps = {
   obj: ServingRuntimeKind;
   onDeleteServingRuntime: (obj: ServingRuntimeKind) => void;
   onEditServingRuntime: (obj: ServingRuntimeKind) => void;
-  onDeployModal: (obj: ServingRuntimeKind) => void;
+  onDeployModel: (obj: ServingRuntimeKind) => void;
+  expandedColumn?: ServingRuntimeTableTabs;
+  setExpandedColumn: (column?: ServingRuntimeTableTabs) => void;
 };
 
 const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
   obj,
   onDeleteServingRuntime,
   onEditServingRuntime,
-  onDeployModal,
+  onDeployModel,
+  expandedColumn,
+  setExpandedColumn,
 }) => {
-  const [expandedColumn, setExpandedColumn] = React.useState<ServingRuntimeTableTabs | undefined>();
-
   const {
     inferenceServices: {
       data: inferenceServices,
@@ -119,7 +121,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
         </Td>
         <Td style={{ textAlign: 'end' }}>
           <Button
-            onClick={() => onDeployModal(obj)}
+            onClick={() => onDeployModel(obj)}
             key={`action-${ProjectSectionID.CLUSTER_STORAGES}`}
             variant="secondary"
           >
@@ -146,7 +148,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
           activeColumn={expandedColumn}
           obj={obj}
           onClose={() => setExpandedColumn(undefined)}
-          onDeployModel={() => onDeployModal(obj)}
+          onDeployModel={() => onDeployModel(obj)}
         />
       </Tr>
     </Tbody>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1545 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The div will automatically scroll into view because we added that feature somehow. But I think it's not needed because users can always scroll the screen by themselves, auto-scroll will only destroy some of the layouts and behaviors and cause unexpected results.

@kywalker-rh Could you confirm this?
The context: When you click on `Deployed models` on project details page, it will expand the models table, and the page will scroll to show the whole table. However, this auto scroll could cause problems. So I removed it, no when clicking on `Deployed models`, the page will not auto scroll anymore. Is that acceptable?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Follow the same instructions in the issues, you will find the issue disappeared.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, layout issue.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
