### PR TITLE
Navigate to pipelines page after pipelines operator is installed

### DIFF
--- a/frontend/src/pages/dependencies/DependencyMissingPage.tsx
+++ b/frontend/src/pages/dependencies/DependencyMissingPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import NotFound from '~/pages/NotFound';
 import PipelinesDependencyMissing from '~/pages/dependencies/PipelinesDependencyMissing';
 import { useAppContext } from '~/app/AppContext';
@@ -7,14 +7,16 @@ import { useAppContext } from '~/app/AppContext';
 const DependencyMissingPage: React.FC = () => {
   const { dashboardConfig } = useAppContext();
   const { area } = useParams();
+  const navigate = useNavigate();
 
   switch (area) {
     case 'pipelines':
       if (dashboardConfig.status.dependencyOperators.redhatOpenshiftPipelines.available) {
         // eslint-disable-next-line no-console
         console.warn(
-          'The pipelines dependency has been met, this page will not render the content.',
+          'The pipelines dependency has been met, this page will redirect to pipelines page.',
         );
+        navigate('/pipelines');
         break;
       }
       return <PipelinesDependencyMissing />;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1547 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is because after the operator is installed, we are stilling on the `/missing-dependency/pipelines` page, which will only return `<NotFound />` when it detects the operator is available. However, it should redirect to the `/pipelines` route if the operator is installed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Uninstall pipelines operator
2. Launch dashboard go to Data Science Pipelines tab
3. Install pipeline operator
4. Keep the Data Science Pipeline open
5. Check if the page redirects to the pipelines main page, which allows you to create a pipeline server in a specific project

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, it's a route issue.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
