### PR TITLE
Make notebook controller access button to link behavior

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
@@ -34,6 +34,8 @@ export const NotebookServer: React.FC = () => {
     [requestNotebookRefresh, navigate],
   );
 
+  const link = notebook?.metadata.annotations?.['opendatahub.io/link'] || '#';
+
   return (
     <>
       <ImpersonateAlert />
@@ -54,10 +56,9 @@ export const NotebookServer: React.FC = () => {
               />
               <ActionList>
                 <ActionListItem
-                  onClick={() => {
-                    if (notebook.metadata.annotations?.['opendatahub.io/link']) {
-                      window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
-                    } else {
+                  onClick={(e) => {
+                    if (link === '#') {
+                      e.preventDefault();
                       notification.error(
                         'Error accessing notebook server',
                         'Failed to redirect page due to missing notebook URL, please try to refresh the page and try it again.',
@@ -65,7 +66,7 @@ export const NotebookServer: React.FC = () => {
                     }
                   }}
                 >
-                  <Button data-id="return-nb-button" variant="primary">
+                  <Button component="a" href={link} data-id="return-nb-button">
                     Access notebook server
                   </Button>
                 </ActionListItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1591 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Didn't make any visual changes here, only updated the button's behavior to make it a link.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to notebook controller page (Jupyter card on Enabled page), spawner a notebook
2. After spawning, don't get into the notebook, you will see the control panel
3. Click on the `Access notebook server` button, you will be navigated to the notebook in the same tab
4. `Cmd/Ctrl` + Click on the button, you will be able to access the notebook in a new tab
5. Right click the button, you will see some link options like `Copy link address` or `Open link in new tab`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, just behavior change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
