### PR TITLE
Elevate quick starts context to the whole application layer

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -26,6 +26,7 @@ import { AppContext } from './AppContext';
 import { useApplicationSettings } from './useApplicationSettings';
 import TelemetrySetup from './TelemetrySetup';
 import { logout } from './appUtils';
+import QuickStarts from './QuickStarts';
 
 import './App.scss';
 
@@ -99,7 +100,9 @@ const App: React.FC = () => {
       >
         <ErrorBoundary>
           <ProjectsContextProvider>
-            <AppRoutes />
+            <QuickStarts>
+              <AppRoutes />
+            </QuickStarts>
           </ProjectsContextProvider>
           <ToastNotifications />
           <TelemetrySetup />

--- a/frontend/src/pages/enabledApplications/EnabledApplications.tsx
+++ b/frontend/src/pages/enabledApplications/EnabledApplications.tsx
@@ -5,7 +5,6 @@ import { useWatchComponents } from '~/utilities/useWatchComponents';
 import { OdhApplication } from '~/types';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import OdhAppCard from '~/components/OdhAppCard';
-import QuickStarts from '~/app/QuickStarts';
 import { fireTrackingEvent } from '~/utilities/segmentIOUtils';
 
 const description = `Launch your enabled applications, view documentation, or get started with quick start instructions and tasks.`;
@@ -74,13 +73,7 @@ const EnabledApplications: React.FC = () => {
   }, [components, loaded]);
 
   return (
-    <QuickStarts>
-      <EnabledApplicationsInner
-        loaded={loaded}
-        components={sortedComponents}
-        loadError={loadError}
-      />
-    </QuickStarts>
+    <EnabledApplicationsInner loaded={loaded} components={sortedComponents} loadError={loadError} />
   );
 };
 

--- a/frontend/src/pages/learningCenter/LearningCenter.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenter.tsx
@@ -9,7 +9,6 @@ import { useWatchDocs } from '~/utilities/useWatchDocs';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { useQueryParams } from '~/utilities/useQueryParams';
 import ApplicationsPage from '~/pages/ApplicationsPage';
-import QuickStarts from '~/app/QuickStarts';
 import { DOC_LINK, ODH_PRODUCT_NAME } from '~/utilities/const';
 import { combineCategoryAnnotations } from '~/utilities/utils';
 import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
@@ -230,10 +229,4 @@ export const LearningCenter: React.FC = () => {
   );
 };
 
-const LearningCenterWrapper: React.FC = () => (
-  <QuickStarts>
-    <LearningCenter />
-  </QuickStarts>
-);
-
-export default LearningCenterWrapper;
+export default LearningCenter;

--- a/frontend/src/pages/notebookController/NotebookController.tsx
+++ b/frontend/src/pages/notebookController/NotebookController.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import QuickStarts from '~/app/QuickStarts';
 import { useUser } from '~/redux/selectors';
 import NotebookServerRoutes from './screens/server/NotebookServerRoutes';
 import NotebookControllerTabs from './screens/admin/NotebookControllerTabs';
@@ -10,13 +9,11 @@ const NotebookController: React.FC = () => {
   const { isAdmin } = useUser();
 
   return (
-    <QuickStarts>
-      <NotebookControllerContextProvider>
-        <ValidateNotebookNamespace>
-          {isAdmin ? <NotebookControllerTabs /> : <NotebookServerRoutes />}
-        </ValidateNotebookNamespace>
-      </NotebookControllerContextProvider>
-    </QuickStarts>
+    <NotebookControllerContextProvider>
+      <ValidateNotebookNamespace>
+        {isAdmin ? <NotebookControllerTabs /> : <NotebookServerRoutes />}
+      </ValidateNotebookNamespace>
+    </NotebookControllerContextProvider>
   );
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes #1574 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
I found `QuickStarts` context was used across some specific pages, which is causing inconsistent user experience when switching them.
The fix is to lift up the `QuickStarts` context and use it to wrap the `App`, in this way, the whole application could share the context and when users switch between the pages, there will be no flickering any more, the quick starts will be fixed there unless closing it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the Resources page
2. Open a quick start and keep it open
3. Switch to any other pages in the dashboard (try as many pages as possible)
4. Make sure the quick start panel is always open

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, it's behavior among the whole application.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
