### PR TITLE
Fix If workbench name is just numbers, it never starts

### DIFF
--- a/frontend/src/__tests__/integration/pages/projects/ProjectView.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectView.stories.tsx
@@ -56,7 +56,6 @@ export const Default: StoryObj = {
 export const EditProject: StoryObj = {
   parameters: {
     a11y: {
-      // need to select modal as root
       element: '.pf-v5-c-backdrop',
     },
   },

--- a/frontend/src/concepts/k8s/K8sNameField.tsx
+++ b/frontend/src/concepts/k8s/K8sNameField.tsx
@@ -1,0 +1,146 @@
+import React, { FormEvent } from 'react';
+import {
+  TextInput,
+  FormGroup,
+  Popover,
+  Icon,
+  HelperText,
+  HelperTextItem,
+  ValidatedOptions,
+  HelperTextItemProps,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { NameDescType, K8sNameValidationState, IndeterminateOption } from '~/pages/projects/types';
+import { isK8sNameValid } from '~/pages/projects/utils';
+
+type K8sNameFieldProps = {
+  data: NameDescType;
+  setData: (data: NameDescType) => void;
+  nameFieldId: string;
+  disableK8sName?: boolean;
+  validateK8sName: K8sNameValidationState;
+  setValidateK8sName: React.Dispatch<React.SetStateAction<K8sNameValidationState>>;
+};
+const combinedValidationStatus = {
+  ...ValidatedOptions,
+  ...IndeterminateOption,
+};
+const K8sNameField: React.FC<K8sNameFieldProps> = ({
+  nameFieldId,
+  disableK8sName,
+  data,
+  setData,
+  validateK8sName,
+  setValidateK8sName,
+}) => {
+  const { ruleLength, ruleCharacterTypes } = validateK8sName;
+
+  const handlek8sNameChange = (event: FormEvent<HTMLInputElement>, k8sName: string) => {
+    const isK8sNameLengthExceeded = k8sName.length >= 30;
+    const isK8sNameValidated = isK8sNameValid(k8sName);
+    const isK8sNameEmpty = data.k8sName?.value?.length === 0;
+
+    if (isK8sNameLengthExceeded) {
+      setValidateK8sName({
+        ruleCharacterTypes: isK8sNameValidated
+          ? combinedValidationStatus.success
+          : combinedValidationStatus.error,
+        ruleLength: combinedValidationStatus.warning,
+      });
+
+      setData({
+        ...data,
+        k8sName: {
+          value: k8sName.slice(0, 30),
+          isTruncated: true,
+          isUserInputK8sName: true,
+        },
+      });
+    } else {
+      setData({
+        ...data,
+        k8sName: {
+          value: k8sName,
+          isTruncated: false,
+          isUserInputK8sName: true,
+        },
+      });
+
+      if (isK8sNameEmpty) {
+        setValidateK8sName({
+          ruleCharacterTypes: combinedValidationStatus.indeterminate,
+          ruleLength: combinedValidationStatus.indeterminate,
+        });
+      } else {
+        setValidateK8sName({
+          ruleCharacterTypes: isK8sNameValidated
+            ? combinedValidationStatus.success
+            : combinedValidationStatus.error,
+          ruleLength: combinedValidationStatus.success,
+        });
+      }
+    }
+  };
+
+  return (
+    <FormGroup
+      label="Resource name"
+      labelIcon={
+        <Popover
+          aria-label="Resource name"
+          headerContent={<div>Resource name</div>}
+          bodyContent={
+            <div>
+              The resource name is used to identify your resource in OpenShift, and is not editable
+              after creation.
+            </div>
+          }
+        >
+          <Icon aria-label="Resource name info" role="button">
+            <OutlinedQuestionCircleIcon />
+          </Icon>
+        </Popover>
+      }
+      isRequired
+      fieldId={`resource-${nameFieldId}`}
+    >
+      <TextInput
+        isRequired
+        isDisabled={disableK8sName}
+        id={`resource-${nameFieldId}`}
+        name={`resource-${nameFieldId}`}
+        value={data.k8sName?.value}
+        onChange={handlek8sNameChange}
+        validated={
+          ruleCharacterTypes === 'error'
+            ? ValidatedOptions.error
+            : ruleLength === 'warning'
+            ? ValidatedOptions.warning
+            : ValidatedOptions.default
+        }
+      />
+      {!disableK8sName && (
+        <HelperText component="ul">
+          <HelperTextItem
+            component="li"
+            id="ruleLength"
+            isDynamic
+            variant={ruleLength as HelperTextItemProps['variant']}
+          >
+            {`Cannot exceed 30 characters. Otherwise, the excess will be truncated.`}
+          </HelperTextItem>
+          <HelperTextItem
+            component="li"
+            id="ruleCharacterTypes"
+            isDynamic
+            variant={ruleCharacterTypes as HelperTextItemProps['variant']}
+          >
+            {`Must consist of lower case alphanumeric characters or '-', and must start and end
+        with an alphanumeric character.`}
+          </HelperTextItem>
+        </HelperText>
+      )}
+    </FormGroup>
+  );
+};
+export default K8sNameField;

--- a/frontend/src/concepts/k8s/ToggleResourceName.tsx
+++ b/frontend/src/concepts/k8s/ToggleResourceName.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Checkbox, Popover, Icon, Split, SplitItem } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+type ToggleResourceNameProps = {
+  showHiddenResourceName: boolean | undefined;
+  setShowHiddenResourceName: (checked: boolean) => void;
+};
+const ToggleResourceName: React.FC<ToggleResourceNameProps> = ({
+  showHiddenResourceName,
+  setShowHiddenResourceName,
+}) => (
+  <Split hasGutter>
+    <SplitItem>
+      <Checkbox
+        label="Show advanced settings"
+        isChecked={showHiddenResourceName}
+        id="toggleResourceName"
+        name="toggleResourceName"
+        onChange={() => setShowHiddenResourceName(!showHiddenResourceName)}
+        aria-label="Show advanced settings"
+        role="checkbox"
+      />
+    </SplitItem>
+    <SplitItem>
+      <Popover
+        aria-label="Show advanced settings"
+        headerContent={<div>Show advanced settings</div>}
+        bodyContent={
+          <div>
+            It contains some advanced settings that operate less frequently and are related to
+            names.
+          </div>
+        }
+      >
+        <Icon aria-label="Show advanced settings info" role="button">
+          <OutlinedQuestionCircleIcon />
+        </Icon>
+      </Popover>
+    </SplitItem>
+  </Split>
+);
+
+export default ToggleResourceName;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -34,6 +34,7 @@ type SpawnerFooterProps = {
   envVariables: EnvVariable[];
   dataConnection: DataConnectionData;
   canEnablePipelines: boolean;
+  isK8sResourceNameValid: boolean;
 };
 
 const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
@@ -42,6 +43,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   envVariables,
   dataConnection,
   canEnablePipelines,
+  isK8sResourceNameValid,
 }) => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const {
@@ -65,6 +67,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   const [createInProgress, setCreateInProgress] = React.useState(false);
   const isButtonDisabled =
     createInProgress ||
+    !isK8sResourceNameValid ||
     !checkRequiredFieldsForNotebookStart(
       startNotebookData,
       storageData,

--- a/frontend/src/pages/projects/screens/spawner/useK8sCommonResource.ts
+++ b/frontend/src/pages/projects/screens/spawner/useK8sCommonResource.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import { NameDescType } from '~/pages/projects/types';
+
+export const useK8sCommonResource = (initialResource?: NameDescType) => {
+  const [nameDesc, setNameDesc] = useState<NameDescType>({
+    name: initialResource?.name ?? '',
+    k8sName: {
+      value: initialResource?.k8sName?.value ?? '',
+      isUserInputK8sName: initialResource?.k8sName?.isUserInputK8sName ?? false,
+      isTruncated: initialResource?.k8sName?.isTruncated ?? false,
+    },
+    description: initialResource?.description ?? '',
+  });
+
+  return { nameDesc, setNameDesc };
+};

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -1,4 +1,5 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { ValidatedOptions } from '@patternfly/react-core';
 import {
   ContainerResources,
   ImageStreamAndVersion,
@@ -17,8 +18,23 @@ export type UpdateObjectAtPropAndValue<T> = (propKey: keyof T, propValue: ValueO
 
 export type NameDescType = {
   name: string;
-  k8sName?: string;
+  k8sName?: {
+    value?: string;
+    isTruncated?: boolean;
+    isUserInputK8sName?: boolean;
+  };
   description: string;
+};
+
+export enum IndeterminateOption {
+  indeterminate = 'indeterminate',
+}
+
+export type K8sNameValidatedOptions = ValidatedOptions | IndeterminateOption;
+
+export type K8sNameValidationState = {
+  ruleLength: K8sNameValidatedOptions;
+  ruleCharacterTypes: K8sNameValidatedOptions;
 };
 
 export type CreatingStorageObject = {

--- a/frontend/src/pages/projects/utils.ts
+++ b/frontend/src/pages/projects/utils.ts
@@ -18,8 +18,13 @@ export const translateDisplayNameForK8s = (name: string): string =>
     .toLowerCase()
     .replace(/\s/g, '-')
     .replace(/[^A-Za-z0-9-]/g, '');
-export const isValidK8sName = (name?: string): boolean =>
-  name === undefined || (name.length > 0 && /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(name));
+
+export const isK8sNameValid = (name?: string): boolean =>
+  name === undefined ||
+  (name.length > 0 && /^(?![0-9]+$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(name));
+
+export const isValidK8sNameLength = (k8sName?: string): boolean =>
+  k8sName !== undefined && k8sName.length <= 30;
 
 export const getProjectDisplayName = (project: ProjectKind): string =>
   getDisplayNameFromK8sResource(project);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1589
Closes: #1741
Closes: #1627
Closes: #1741
## Description
It fixes the issue when you enter a workbench name only numbers like `1234`. This workbench never fully starts.


https://github.com/opendatahub-io/odh-dashboard/assets/2117670/364b8994-817b-41d4-a765-32a0f425909e


## How Has This Been Tested?

1. Create DS Project
2. Select DS project
3. Create Workbench - Workbench name regex handle the following

- It should not consist only of numbers.
- It starts with an uppercase letter, lowercase letter, or digit.
- It may have a hyphen, lowercase letters, digits, or spaces in the middle (but not multiple hyphens in a row).
- It ends with a lowercase letter or digit.
- The entire hyphen, lowercase/digit, or space sequence in the middle is optional.



## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
