### PR TITLE
Improve Wording for Cluster Storage Editing

### DIFF
--- a/frontend/src/pages/projects/components/PVSizeField.tsx
+++ b/frontend/src/pages/projects/components/PVSizeField.tsx
@@ -21,7 +21,7 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({ fieldID, size, setSize, curre
       label="Persistent storage size"
       helperText={
         currentSize
-          ? "Increase the capacity of storage data. Note that capacity can't be less than the current storage size. This can be a time-consuming process."
+          ? 'Storage size can only be increased. If you do so, the workbench will restart and be unavailable for a period of time that is usually proportional to the size change.'
           : ''
       }
       helperTextIcon={<ExclamationTriangleIcon />}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1610  

## Description
This PR will change the wording (already reviewed by UX) for Cluster Storage Editing. 

![Screenshot from 2023-08-24 20-21-35](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/73e8f6d3-54ec-445a-bc33-e689a4b54150)

<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
1. Create a Workbench with a new storage
2. When the Workbench has started, edit the storage

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
