### PR TITLE
display StatefulSet errors when notebook pod fails to create

### DIFF
--- a/backend/src/routes/api/nb-events/eventUtils.ts
+++ b/backend/src/routes/api/nb-events/eventUtils.ts
@@ -4,7 +4,8 @@ import { KubeFastifyInstance } from '../../../types';
 export const getNotebookEvents = async (
   fastify: KubeFastifyInstance,
   namespace: string,
-  podUID: string,
+  notebookName: string,
+  podUID: string | undefined,
 ): Promise<V1Event[]> => {
   return fastify.kube.coreV1Api
     .listNamespacedEvent(
@@ -12,7 +13,9 @@ export const getNotebookEvents = async (
       undefined,
       undefined,
       undefined,
-      `involvedObject.kind=Pod,involvedObject.uid=${podUID}`,
+      podUID
+        ? `involvedObject.kind=Pod,involvedObject.uid=${podUID}`
+        : `involvedObject.kind=StatefulSet,involvedObject.name=${notebookName}`,
     )
     .then((res) => {
       const body = res.body as V1EventList;

--- a/backend/src/routes/api/nb-events/index.ts
+++ b/backend/src/routes/api/nb-events/index.ts
@@ -3,24 +3,21 @@ import { getNotebookEvents } from './eventUtils';
 import { secureRoute } from '../../../utils/route-security';
 
 export default async (fastify: FastifyInstance): Promise<void> => {
-  fastify.get(
-    '/:namespace/:podUID',
-    secureRoute(fastify)(
-      async (
-        request: FastifyRequest<{
-          Params: {
-            namespace: string;
-            podUID: string;
-          };
-          Querystring: {
-            // TODO: Support server side filtering
-            from?: string;
-          };
-        }>,
-      ) => {
-        const { namespace, podUID } = request.params;
-        return getNotebookEvents(fastify, namespace, podUID);
-      },
-    ),
+  const routeHandler = secureRoute(fastify)(
+    async (
+      request: FastifyRequest<{
+        Params: {
+          namespace: string;
+          notebookName: string;
+          podUID: string | undefined;
+        };
+      }>,
+    ) => {
+      const { namespace, notebookName, podUID } = request.params;
+      return getNotebookEvents(fastify, namespace, notebookName, podUID);
+    },
   );
+
+  fastify.get('/:namespace/:notebookName', routeHandler);
+  fastify.get('/:namespace/:notebookName/:podUID', routeHandler);
 };

--- a/frontend/src/api/k8s/events.ts
+++ b/frontend/src/api/k8s/events.ts
@@ -1,17 +1,20 @@
-import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import { EventKind } from '~/k8sTypes';
 import { EventModel } from '~/api/models';
 
-export const getNotebookEvents = async (namespace: string, podUid: string): Promise<EventKind[]> =>
-  k8sListResource<EventKind>({
+export const getNotebookEvents = async (
+  namespace: string,
+  notebookName: string,
+  podUid: string | undefined,
+): Promise<EventKind[]> =>
+  k8sListResourceItems<EventKind>({
     model: EventModel,
     queryOptions: {
       ns: namespace,
       queryParams: {
-        fieldSelector: `involvedObject.kind=Pod,involvedObject.uid=${podUid}`,
+        fieldSelector: podUid
+          ? `involvedObject.kind=Pod,involvedObject.uid=${podUid}`
+          : `involvedObject.kind=StatefulSet,involvedObject.name=${notebookName}`,
       },
     },
-  }).then(
-    // Filter the events by pods that have the same name as the notebook
-    (r) => r.items,
-  );
+  });

--- a/frontend/src/api/models/k8s.ts
+++ b/frontend/src/api/models/k8s.ts
@@ -18,6 +18,13 @@ export const PodModel: K8sModelCommon = {
   plural: 'pods',
 };
 
+export const StatefulSetModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'apps',
+  kind: 'StatefulSet',
+  plural: 'statefulsets',
+};
+
 export const PVCModel: K8sModelCommon = {
   apiVersion: 'v1',
   kind: 'PersistentVolumeClaim',

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -217,11 +217,14 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
       isIndented
     >
       <List isPlain isBordered tabIndex={0}>
-        {events.reverse().map((event, index) => (
-          <ListItem key={`notebook-event-${event.metadata.uid ?? index}`}>
-            {`${getEventTimestamp(event)} [${event.type}] ${event.message}`}
-          </ListItem>
-        ))}
+        {events
+          .slice()
+          .reverse()
+          .map((event, index) => (
+            <ListItem key={`notebook-event-${event.metadata.uid ?? index}`}>
+              {`${getEventTimestamp(event)} [${event.type}] ${event.message}`}
+            </ListItem>
+          ))}
         <ListItem>Server requested</ListItem>
       </List>
     </ExpandableSection>

--- a/frontend/src/pages/projects/notebook/StartNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/StartNotebookModal.tsx
@@ -162,11 +162,14 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
         <Panel isScrollable>
           <PanelMain maxHeight="250px">
             <List isPlain isBordered data-id="event-logs">
-              {events.reverse().map((event, index) => (
-                <ListItem key={`notebook-event-${event.metadata.uid ?? index}`}>
-                  {getEventFullMessage(event)}
-                </ListItem>
-              ))}
+              {events
+                .slice()
+                .reverse()
+                .map((event, index) => (
+                  <ListItem key={`notebook-event-${event.metadata.uid ?? index}`}>
+                    {getEventFullMessage(event)}
+                  </ListItem>
+                ))}
               <ListItem>Server requested</ListItem>
             </List>
           </PanelMain>

--- a/frontend/src/pages/projects/notebook/utils.ts
+++ b/frontend/src/pages/projects/notebook/utils.ts
@@ -70,9 +70,9 @@ const filterEvents = (
   allEvents: EventKind[],
   lastActivity: Date,
 ): [filterEvents: EventKind[], thisInstanceEvents: EventKind[], gracePeriod: boolean] => {
-  const thisInstanceEvents = allEvents.filter(
-    (event) => new Date(getEventTimestamp(event)) >= lastActivity,
-  );
+  const thisInstanceEvents = allEvents
+    .filter((event) => new Date(getEventTimestamp(event)) >= lastActivity)
+    .sort((a, b) => getEventTimestamp(a).localeCompare(getEventTimestamp(b)));
   if (thisInstanceEvents.length === 0) {
     // Filtered out all of the events, exit early
     return [[], [], false];
@@ -121,7 +121,7 @@ export const useNotebookStatus = (
   podUid: string,
   spawnInProgress: boolean,
 ): [status: NotebookStatus | null, events: EventKind[]] => {
-  const events = useWatchNotebookEvents(notebook.metadata.namespace, podUid, spawnInProgress);
+  const events = useWatchNotebookEvents(notebook, podUid, spawnInProgress);
 
   const annotationTime = notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
   const lastActivity = annotationTime
@@ -228,6 +228,11 @@ export const useNotebookStatus = (
       case 'TriggeredScaleUp': {
         currentEvent = 'Pod triggered scale-up';
         status = EventStatus.INFO;
+        break;
+      }
+      case 'FailedCreate': {
+        currentEvent = 'Failed to create pod';
+        status = EventStatus.ERROR;
         break;
       }
       default: {

--- a/frontend/src/services/notebookEventsService.ts
+++ b/frontend/src/services/notebookEventsService.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import { K8sEvent } from '~/types';
 
-export const getNotebookEvents = (projectName: string, podUID: string): Promise<K8sEvent[]> => {
-  const url = `/api/nb-events/${projectName}/${podUID}`;
+export const getNotebookEvents = (
+  projectName: string,
+  notebookName: string,
+  podUID?: string,
+): Promise<K8sEvent[]> => {
+  const url = `/api/nb-events/${projectName}/${notebookName}${podUID ? `/${podUID}` : ''}`;
   return axios.get(url).then((response) => response.data);
 };

--- a/frontend/src/utilities/useWatchNotebookEvents.tsx
+++ b/frontend/src/utilities/useWatchNotebookEvents.tsx
@@ -1,49 +1,64 @@
 import * as React from 'react';
 import { getNotebookEvents } from '~/services/notebookEventsService';
-import { K8sEvent } from '~/types';
+import { K8sEvent, Notebook } from '~/types';
 import useNotification from './useNotification';
 import { FAST_POLL_INTERVAL } from './const';
 
 export const useWatchNotebookEvents = (
-  projectName: string,
-  podUID: string,
+  notebook: Notebook | null,
+  podUid: string,
   activeFetch: boolean,
 ): K8sEvent[] => {
-  const [notebookEvents, setNoteBookEvents] = React.useState<K8sEvent[]>([]);
+  const notebookName = notebook?.metadata.name;
+  const namespace = notebook?.metadata.namespace;
+  const [notebookEvents, setNotebookEvents] = React.useState<K8sEvent[]>([]);
   const notification = useNotification();
+
+  // Cached events are returned when activeFetch is false.
+  // This allows us to reset notebookEvents state when activeFetch becomes
+  // false to prevent UI blips when activeFetch goes true again.
+  const notebookEventsCache = React.useRef<K8sEvent[]>(notebookEvents);
+
+  // when activeFetch switches to false, reset events state
+  React.useEffect(() => {
+    if (!activeFetch) {
+      setNotebookEvents([]);
+    }
+  }, [activeFetch]);
 
   React.useEffect(() => {
     let watchHandle: ReturnType<typeof setTimeout>;
     let cancelled = false;
 
-    const clear = () => {
+    if (activeFetch && namespace && notebookName) {
+      const watchNotebookEvents = () => {
+        getNotebookEvents(namespace, notebookName, podUid)
+          .then((data: K8sEvent[]) => {
+            if (!cancelled) {
+              notebookEventsCache.current = data;
+              setNotebookEvents(data);
+            }
+          })
+          .catch((e) => {
+            notification.error('Error fetching notebook events', e.response.data.message);
+            /* eslint-disable-next-line no-console */
+            console.error('Error fetching notebook events', e);
+          });
+        watchHandle = setTimeout(watchNotebookEvents, FAST_POLL_INTERVAL);
+      };
+
+      if (!podUid) {
+        // delay the initial fetch to avoid older StatefulSet event errors from blipping on screen during notebook startup
+        watchHandle = setTimeout(watchNotebookEvents, Math.max(FAST_POLL_INTERVAL, 3000));
+      } else {
+        watchNotebookEvents();
+      }
+    }
+    return () => {
       cancelled = true;
       clearTimeout(watchHandle);
     };
+  }, [namespace, notebookName, podUid, activeFetch, notification]);
 
-    if (activeFetch) {
-      const watchNotebookEvents = () => {
-        if (projectName && podUID) {
-          getNotebookEvents(projectName, podUID)
-            .then((data: K8sEvent[]) => {
-              if (cancelled) {
-                return;
-              }
-              setNoteBookEvents(data);
-            })
-            .catch((e) => {
-              notification.error('Error fetching notebook events', e.response.data.message);
-              clear();
-            })
-            .finally(() => {
-              watchHandle = setTimeout(watchNotebookEvents, FAST_POLL_INTERVAL);
-            });
-        }
-      };
-      watchNotebookEvents();
-    }
-    return clear;
-  }, [projectName, podUID, notification, activeFetch]);
-
-  return notebookEvents;
+  return activeFetch ? notebookEvents : notebookEventsCache.current;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes: #793

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When `LimitRange` prevents the creation of notebook server pods, no errors are displayed in the UI. The error occurs on the `StatefulSet`. This change reads events from the `StatefulSet` when no pod is present. Once a pod is present, we go back to reading the pod events as was done previously.

Added a new error message `Failed to create pod` to represent this state (see screen shots below).
cc @kywalker-rh

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<details>
  <summary>Limit Range YAML</summary>

```yaml
kind: LimitRange
apiVersion: v1
metadata:
  name: limit-range
  namespace: <namespace>
spec:
  limits:
    - type: Container
      max:
        cpu: 50m
        memory: 50Mi
      default:
        cpu: 50m
        memory: 50Mi
      defaultRequest:
        cpu: 50m
        memory: 50Mi
    - type: Pod
      max:
        cpu: 100m
        memory: 50Mi
```

</details>


Workbench:
- Create a data science project
- Create a `LimitRange` in the newly created project / namespace
- Create a workbench whose container size will be limited by the `LimitRange`
- Click on the `Starting...` text in the workbench status column to open the status popup
- Click `Event log`
- Wait for an error state to appear describing resource limits with the overall error message of `Failed to create pod`
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/644e1184-f6b3-4c83-b277-b1048ac3255e)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/011b5033-9686-43c3-8e20-32160c609bdd)
- Close the modal
- Toggle the status to off to stop the notebook
- Toggle the status to on to start the notebook and observe the same error state
- Toggle the status to off
- Delete the `LimitRange` resource
- Toggle the status to on
- Observe the notebook starts successfully. Viewing the event log during this process shows pod events accordingly.


Jupyter notebook:
- Create a `LimitRange` in default ODH namespace. eg. `opendatahub`
- Click on `Applications` => `Enabled` in the left nav
- on the Jupyter card, click `Launch application`
- Start a notebook server whose container size will be limited by the `LimitRange`
- Wait for an error state to appear describing resource limits with the overall error message of `Failed to create pod`
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/9a349014-ad5b-4c04-9717-ec119e6ce927)
- Click `Cancel`
- Delete the `LimitRange` resource
- Click `Start server`
- Observe the notebook starts successfully. Viewing the event log during this process shows pod events accordingly.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no new tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
