### PR TITLE
pipeline yaml editor should be read only

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsYAML.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsYAML.tsx
@@ -33,6 +33,7 @@ const PipelineDetailsYAML: React.FC<PipelineDetailsYAMLProps> = ({ filename, con
       isCopyEnabled
       isLanguageLabelVisible
       language={Language.yaml}
+      isReadOnly
     />
   );
 };


### PR DESCRIPTION
Closes: #1689

## Description
It makes the yaml editor for pipeline read only
The command palette in the current editor is the same as in PatternFly's read-only code editor. https://v4-archive.patternfly.org/v4/components/code-editor

![Screenshot from 2023-08-28 11-47-08](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/a876128b-f7c9-43a2-9de4-ed255677a3ce)

## How Has This Been Tested?
1. Import pipeline
2. Move to yaml tab
3. Try editing yaml code

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
