### PR TITLE
Remove default designator when selecting a notebook

### DIFF
--- a/frontend/src/utilities/imageUtils.ts
+++ b/frontend/src/utilities/imageUtils.ts
@@ -139,7 +139,7 @@ export const getImageTagVersion = (
   if (image?.tags.length > 1) {
     const defaultTag = getDefaultTag(buildStatuses, image);
     if (image.name === selectedImage && selectedTag) {
-      return `${selectedTag} ${selectedTag === defaultTag?.name ? ' (default)' : ''}`;
+      return selectedTag;
     }
     return defaultTag?.name ?? image.tags[0].name;
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1690

## Description
Removing the `default` designator from notebook image name, when starting a notebook server.
@xianli123 tagging you here.

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/aed3c9c2-5870-4c24-94be-8c245055f4c5)


## How Has This Been Tested?
1. Launch a Jupyter notebook
2. On "Start a notebook server page" click on any notebook image which has more than 1 tags.
3. `(default)` should not be there.

## Test Impact
Tests are not required for this.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
