### PR TITLE
Differentiate between model-server metrics and model metrics

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -148,7 +148,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
               ...(performanceMetricsEnabled
                 ? [
                     {
-                      title: 'View metrics',
+                      title: 'View model server metrics',
                       onClick: () =>
                         navigate(
                           `/projects/${currentProject.metadata.name}/metrics/server/${obj.metadata.name}`,


### PR DESCRIPTION
Closes #1524

## Description
Changed the wording in action menu item of "Model and model servers" table. From `View metrics` to `View model server metrics`

![Screenshot from 2023-08-29 12-40-07](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/2301ba0d-1ec0-40f6-9e79-c46b6d688ae3)


## How Has This Been Tested?
1. Open dashboard in `incubation` branch.
2. Open/Create any data science project.
3. Scroll down below to view "Model and Model server" section.
4. You should have a model added, click on action button and you can see list of action items.
5. `View metrics` should be changed to `View model server metrics`.

## Test Impact
No test require as this is small wording change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
