### PR TITLE
Missing Duplicate Run from Triggered Action Menu

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsActions.tsx
@@ -39,13 +39,13 @@ const PipelineRunDetailsActions: React.FC<PipelineDetailsActionsProps> = ({ onDe
                     .catch((e) => notification.error('Unable to stop pipeline run', e.message))
                 }
               >
-                Stop run
+                Stop
               </DropdownItem>,
               <DropdownItem
                 key="clone-run"
                 onClick={() => navigate(`/pipelineRuns/${namespace}/pipelineRun/clone/${run.id}`)}
               >
-                Duplicate run
+                Duplicate
               </DropdownItem>,
               <DropdownSeparator key="separator" />,
               <DropdownItem key="delete-run" onClick={() => onDelete()}>


### PR DESCRIPTION
Closes #1568
Closes #1282

## Description
Action menu of Runs triggered page updated with "Stop run" & "Duplicate run" which is same as in Pipeline Run detail page.

@kywalker-rh tagging you for UX review

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/a5cb12e6-48c0-4ba6-959a-59e7926b9bd5)

## How Has This Been Tested?
1. Create workbench and upload a pipeline.
2. Create run with Run type: Run once immediately after creation
3. Move back to Runs page, on Triggered tab.
4. Click on action menu on any row.
5. New actions added "Stop run", "Duplicate run".
6. "Stop run" is disabled when pipeline not running.
7. Click on both actions to run them.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
