### PR TITLE
Truncate long display name in serving runtimes

### DIFF
--- a/frontend/src/components/table/Table.tsx
+++ b/frontend/src/components/table/Table.tsx
@@ -111,7 +111,7 @@ const Table = <T,>({
       )}
       <TableComposable {...props}>
         {caption && <Caption>{caption}</Caption>}
-        <Thead>
+        <Thead noWrap>
           <Tr>
             {columns.map((col, i) => {
               if (col.field === CHECKBOX_FIELD_ID && selectAll) {

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -34,7 +34,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
           id: `draggable-row-${servingRuntimeName}`,
         }}
       />
-      <Td dataLabel="Name">
+      <Td dataLabel="Name" width={70} className="pf-u-text-break-word">
         <ResourceNameTooltip resource={template.objects[0]}>
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1394

## Description
This PR will truncate the long display name in "serving runtimes" and table will not expand as large as name.

![Screenshot from 2023-08-30 13-41-29](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/fe7d6e6d-4e40-4133-9d28-6015c1de1dd5)


## How Has This Been Tested?
1. Go to serving runtimes page
2. Create a new serving runtime with a long display name
3. After creation of new serving runtime, the long display name will be truncated and table will not expand as before.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
