### PR TITLE
Update pipelineServer

### DIFF
--- a/frontend/src/components/FieldList.tsx
+++ b/frontend/src/components/FieldList.tsx
@@ -24,7 +24,7 @@ type InputFieldProps = {
   value: string;
 };
 
-const FieldListField = ({ options, onChange, value }: InputFieldProps) => {
+export const FieldListField = ({ options, onChange, value }: InputFieldProps) => {
   const ComponentField = options.isPassword ? PasswordInput : TextInput;
 
   return (

--- a/frontend/src/concepts/pipelines/NoPipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/NoPipelineServer.tsx
@@ -16,11 +16,13 @@ type NoPipelineServerProps = {
 const NoPipelineServer: React.FC<NoPipelineServerProps> = ({ variant }) => (
   <EmptyState variant="sm">
     <EmptyStateHeader
-      titleText="No pipeline server"
+      titleText="Enable pipelines"
       icon={<EmptyStateIcon icon={WrenchIcon} />}
       headingLevel="h3"
     />
-    <EmptyStateBody>To import a pipeline, first create a pipeline server.</EmptyStateBody>
+    <EmptyStateBody>
+      To create and manage pipelines, first enable them by configuring a pipeline server.
+    </EmptyStateBody>
     <EmptyStateFooter>
       <CreatePipelineServerButton variant={variant} />
     </EmptyStateFooter>

--- a/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
@@ -10,19 +10,10 @@ import {
 } from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PasswordHiddenText from '~/components/PasswordHiddenText';
-import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
-import { DataConnection } from '~/pages/projects/types';
-import { useContextResourceData } from '~/utilities/useContextResourceData';
-import {
-  convertAWSSecretData,
-  getDataConnectionDisplayName,
-} from '~/pages/projects/screens/detail/data-connections/utils';
 import { dataEntryToRecord } from '~/utilities/dataEntryToRecord';
-import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
 import useNamespaceSecret from '~/concepts/projects/apiHooks/useNamespaceSecret';
 import { EXTERNAL_DATABASE_SECRET } from '~/concepts/pipelines/content/configurePipelinesServer/const';
 import { DSPipelineKind } from '~/k8sTypes';
-
 type ViewPipelineServerModalProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -35,21 +26,13 @@ const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
   pipelineNamespaceCR,
 }) => {
   const { namespace } = usePipelinesAPI();
-  const { data: dataConnections } = useContextResourceData<DataConnection>(
-    useDataConnections(namespace),
+  const [pipelineResult] = useNamespaceSecret(
+    namespace,
+    pipelineNamespaceCR?.spec.objectStorage.externalStorage?.s3CredentialsSecret.secretName ?? '',
   );
+  const pipelineSecret = dataEntryToRecord(pipelineResult?.values?.data ?? []);
   const [result] = useNamespaceSecret(namespace, EXTERNAL_DATABASE_SECRET.NAME);
   const databaseSecret = dataEntryToRecord(result?.values?.data ?? []);
-
-  const objectStorageDataConnection = dataConnections.find(
-    (dc) =>
-      dc.data.metadata.name ===
-      pipelineNamespaceCR?.spec.objectStorage?.externalStorage?.s3CredentialsSecret?.secretName,
-  );
-
-  const objectStorageRecord: Partial<Record<AWS_KEYS, string>> = objectStorageDataConnection
-    ? dataEntryToRecord(convertAWSSecretData(objectStorageDataConnection))
-    : {};
 
   return (
     <Modal
@@ -65,30 +48,22 @@ const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
     >
       {pipelineNamespaceCR && (
         <DescriptionList termWidth="20ch" isHorizontal>
-          {!!objectStorageDataConnection &&
-            !!pipelineNamespaceCR?.spec.objectStorage?.externalStorage &&
-            !!objectStorageRecord && (
+          {!!pipelineNamespaceCR.spec.objectStorage &&
+            !!pipelineNamespaceCR.spec.objectStorage.externalStorage &&
+            !!pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
+              .secretName && (
               <>
                 <Title headingLevel="h2">Object storage connection</Title>
                 <DescriptionListGroup>
-                  {/* TODO: is this the pipeline name or the secret name? */}
-                  <DescriptionListTerm>Name</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {getDataConnectionDisplayName(objectStorageDataConnection)}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
                   <DescriptionListTerm>Access key</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {objectStorageRecord?.AWS_ACCESS_KEY_ID}
+                    {pipelineSecret?.AWS_ACCESS_KEY_ID || ''}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
                   <DescriptionListTerm>Secret key</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <PasswordHiddenText
-                      password={objectStorageRecord?.AWS_SECRET_ACCESS_KEY ?? ''}
-                    />
+                    <PasswordHiddenText password={pipelineSecret?.AWS_SECRET_ACCESS_KEY ?? ''} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
@@ -105,10 +80,6 @@ const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
                   <DescriptionListDescription>
                     {pipelineNamespaceCR.spec.objectStorage.externalStorage?.bucket}
                   </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Folder path</DescriptionListTerm>
-                  <DescriptionListDescription>/pipelines</DescriptionListDescription>
                 </DescriptionListGroup>
               </>
             )}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { Alert, Button, Form, Modal, Stack, StackItem } from '@patternfly/react-core';
-import { EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
 import './ConfigurePipelinesServerModal.scss';
-import { convertAWSSecretData } from '~/pages/projects/screens/detail/data-connections/utils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { isAWSValid } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { createPipelinesCR, deleteSecret } from '~/api';
 import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
+import { EMPTY_AWS_PIPELINE_DATA } from '~/pages/projects/dataConnections/const';
 import { PipelinesDatabaseSection } from './PipelinesDatabaseSection';
 import { ObjectStorageSection } from './ObjectStorageSection';
 import {
@@ -15,7 +13,7 @@ import {
   EMPTY_DATABASE_CONNECTION,
   EXTERNAL_DATABASE_SECRET,
 } from './const';
-import { configureDSPipelineResourceSpec } from './utils';
+import { configureDSPipelineResourceSpec, objectStorageIsValid } from './utils';
 import { PipelineServerConfigType } from './types';
 
 type ConfigurePipelinesServerModalProps = {
@@ -25,7 +23,7 @@ type ConfigurePipelinesServerModalProps = {
 
 const FORM_DEFAULTS: PipelineServerConfigType = {
   database: { useDefault: true, value: EMPTY_DATABASE_CONNECTION },
-  objectStorage: { useExisting: true, existingName: '', existingValue: EMPTY_AWS_SECRET_DATA },
+  objectStorage: { newValue: EMPTY_AWS_PIPELINE_DATA },
 };
 
 export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerModalProps> = ({
@@ -33,7 +31,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
   open,
 }) => {
   const { project, namespace } = usePipelinesAPI();
-  const [dataConnections, , , refresh] = useDataConnections(namespace);
+  const [dataConnections, loaded, , refresh] = useDataConnections(namespace);
   const [fetching, setFetching] = React.useState(false);
   const [error, setError] = React.useState<Error | null>(null);
   const [config, setConfig] = React.useState<PipelineServerConfigType>(FORM_DEFAULTS);
@@ -44,23 +42,18 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
     }
   }, [open, refresh]);
 
-  const canSubmit = () => {
-    const databaseIsValid = config.database.useDefault
-      ? true
-      : config.database.value.every(({ key, value }) =>
-          DATABASE_CONNECTION_FIELDS.filter((field) => field.isRequired)
-            .map((field) => field.key)
-            .includes(key as DATABASE_CONNECTION_KEYS)
-            ? !!value
-            : true,
-        );
+  const databaseIsValid = config.database.useDefault
+    ? true
+    : config.database.value.every(({ key, value }) =>
+        DATABASE_CONNECTION_FIELDS.filter((field) => field.isRequired)
+          .map((field) => field.key)
+          .includes(key as DATABASE_CONNECTION_KEYS)
+          ? !!value
+          : true,
+      );
 
-    const objectStorageIsValid = config.objectStorage.useExisting
-      ? !!config.objectStorage.existingName
-      : isAWSValid(config.objectStorage.newValue);
-
-    return databaseIsValid && objectStorageIsValid;
-  };
+  const objectIsValid = objectStorageIsValid(config.objectStorage.newValue);
+  const canSubmit = databaseIsValid && objectIsValid;
 
   const onBeforeClose = () => {
     onClose();
@@ -70,25 +63,9 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
   };
 
   const submit = () => {
-    let objectStorage: PipelineServerConfigType['objectStorage'];
-    if (config.objectStorage.useExisting) {
-      const existingName = config.objectStorage.existingName;
-      const existingValue = dataConnections?.find((dc) => dc.data.metadata.name === existingName);
-      if (existingValue) {
-        objectStorage = {
-          existingValue: convertAWSSecretData(existingValue),
-          existingName,
-          useExisting: true,
-        };
-      } else {
-        throw new Error('Selected data connection does not exist');
-      }
-    } else {
-      objectStorage = {
-        newValue: config.objectStorage.newValue,
-        useExisting: false,
-      };
-    }
+    const objectStorage: PipelineServerConfigType['objectStorage'] = {
+      newValue: config.objectStorage.newValue,
+    };
     setFetching(true);
     setError(null);
 
@@ -121,17 +98,18 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
     <Modal
       title="Configure pipeline server"
       variant="medium"
+      description="Configuring a pipeline server enables you to create and manage pipelines."
       isOpen={open}
       onClose={onBeforeClose}
       actions={[
         <Button
           key="configure"
           variant="primary"
-          isDisabled={!canSubmit() || fetching}
+          isDisabled={!canSubmit || fetching}
           isLoading={fetching}
           onClick={submit}
         >
-          Configure
+          Configure pipeline server
         </Button>,
         <Button key="cancel" variant="link" onClick={onBeforeClose}>
           Cancel
@@ -139,6 +117,13 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
       ]}
     >
       <Stack hasGutter>
+        <StackItem>
+          <Alert
+            variant="info"
+            isInline
+            title="Pipeline server configuration cannot be edited after creation. To use a different configuration after creation, delete the pipeline server and create a new one."
+          />
+        </StackItem>
         <StackItem>
           <Form
             onSubmit={(e) => {
@@ -149,6 +134,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
             <ObjectStorageSection
               setConfig={setConfig}
               config={config}
+              loaded={loaded}
               dataConnections={dataConnections}
             />
             <PipelinesDatabaseSection setConfig={setConfig} config={config} />

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -1,39 +1,29 @@
 import {
   FormSection,
   Title,
-  Radio,
   FormGroup,
   Text,
   TextInput,
-  Stack,
-  StackItem,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
+  InputGroup,
+  Tooltip,
 } from '@patternfly/react-core';
-import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import React from 'react';
-import AWSField from '~/pages/projects/dataConnections/AWSField';
-import { getDataConnectionDisplayName } from '~/pages/projects/screens/detail/data-connections/utils';
 import { DataConnection } from '~/pages/projects/types';
-import { EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
+import { PIPELINE_AWS_FIELDS } from '~/pages/projects/dataConnections/const';
+import { FieldListField } from '~/components/FieldList';
 import { PipelineServerConfigType } from './types';
 import './ConfigurePipelinesServerModal.scss';
+import { PipelineDropdown } from './PipelineDropdown';
 
-const DISABLED_FOLDER_PATH = (
-  <FormGroup label="Folder path">
-    <TextInput isDisabled aria-label="disabled folder path field" value="/" />
-    <FormHelperText>
-      <HelperText>
-        <HelperTextItem>
-          /metadata and /artifacts folders are automatically created in the default root folder
-        </HelperTextItem>
-      </HelperText>
-    </FormHelperText>
-  </FormGroup>
-);
-
+export type FieldOptions = {
+  key: string;
+  label: string;
+  placeholder?: string;
+  isRequired?: boolean;
+  isPassword?: boolean;
+};
 type ObjectStorageSectionProps = {
+  loaded: boolean;
   setConfig: (config: PipelineServerConfigType) => void;
   config: PipelineServerConfigType;
   dataConnections: DataConnection[];
@@ -42,120 +32,64 @@ type ObjectStorageSectionProps = {
 export const ObjectStorageSection = ({
   setConfig,
   config,
+  loaded,
   dataConnections,
 }: ObjectStorageSectionProps) => {
-  const [existingDataConnectionOpen, setExistingDataConnectionOpen] = React.useState(false);
+  const onChange = (key: FieldOptions['key'], value: string) => {
+    setConfig({
+      ...config,
+      objectStorage: {
+        newValue: config.objectStorage.newValue.map((d) => (d.key === key ? { key, value } : d)),
+      },
+    });
+  };
+
   return (
     <FormSection
       title={
         <>
           <Title headingLevel="h2">Object storage connection</Title>
           <Text component="p" className="form-subtitle-text">
-            The selected S3-compatible data connection is where your pipeline artifacts are stored.
+            To store pipeline artifacts. Must be S3 compatible
           </Text>
         </>
       }
     >
-      <Radio
-        className="checkbox-radio-fix-body-width"
-        name="data-connection-type-radio"
-        id="existing-data-connection-type-radio"
-        label="Existing data connection"
-        isChecked={config.objectStorage.useExisting}
-        onChange={() =>
-          setConfig({
-            ...config,
-            objectStorage: {
-              existingName: '',
-              existingValue: EMPTY_AWS_SECRET_DATA,
-              useExisting: true,
-            },
-          })
-        }
-        body={
-          config.objectStorage.useExisting && (
-            <Stack hasGutter>
-              <StackItem>
-                <FormGroup label="Name" isRequired>
-                  <Select
-                    id="pipelines-data-connection"
-                    isOpen={existingDataConnectionOpen}
-                    placeholderText={
-                      dataConnections.length === 0
-                        ? 'No data connections available to select'
-                        : 'Select...'
-                    }
-                    isDisabled={dataConnections.length === 0}
-                    onToggle={(e, open) => setExistingDataConnectionOpen(open)}
-                    onSelect={(_, option) => {
-                      if (typeof option === 'string') {
-                        setConfig({
-                          ...config,
-                          objectStorage: {
-                            useExisting: true,
-                            existingName: option,
-                            existingValue: EMPTY_AWS_SECRET_DATA,
-                          },
-                        });
-                        setExistingDataConnectionOpen(false);
-                      }
-                    }}
-                    selections={config.objectStorage.existingName}
-                    menuAppendTo="parent"
-                  >
-                    {dataConnections.map((connection) => (
-                      <SelectOption
-                        key={connection.data.metadata.name}
-                        value={connection.data.metadata.name}
-                      >
-                        {getDataConnectionDisplayName(connection)}
-                      </SelectOption>
-                    ))}
-                  </Select>
-                </FormGroup>
-              </StackItem>
-              <StackItem>{DISABLED_FOLDER_PATH}</StackItem>
-            </Stack>
-          )
-        }
-      />
-      <Radio
-        className="checkbox-radio-fix-body-width"
-        name="data-connection-radio"
-        id="new-data-connection-radio"
-        label="Create new data connection"
-        isChecked={!config.objectStorage.useExisting}
-        onChange={() =>
-          setConfig({
-            ...config,
-            objectStorage: {
-              newValue: EMPTY_AWS_SECRET_DATA,
-              useExisting: false,
-            },
-          })
-        }
-        body={
-          !config.objectStorage.useExisting && (
-            <Stack hasGutter>
-              <StackItem>
-                <AWSField
-                  values={config.objectStorage.newValue}
-                  onUpdate={(newEnvData) =>
-                    setConfig({
-                      ...config,
-                      objectStorage: {
-                        newValue: newEnvData,
-                        useExisting: false,
-                      },
-                    })
-                  }
-                />
-              </StackItem>
-              <StackItem>{DISABLED_FOLDER_PATH}</StackItem>
-            </Stack>
-          )
-        }
-      />
+      {PIPELINE_AWS_FIELDS.map((field) =>
+        field.key === 'AWS_ACCESS_KEY_ID' ? (
+          <FormGroup key={field.key} isRequired={field.isRequired} label={field.label}>
+            <InputGroup>
+              <TextInput
+                aria-label={`Field list ${field.key}`}
+                isRequired={field.isRequired}
+                value={
+                  config.objectStorage.newValue.find((data) => data.key === field.key)?.value || ''
+                }
+                placeholder={field.placeholder}
+                onChange={(_, value) => onChange(field.key, value)}
+              />
+              {loaded && !!dataConnections.length && (
+                <Tooltip content="Populate the form with credentials from your selected data connection">
+                  <PipelineDropdown
+                    config={config}
+                    setConfig={setConfig}
+                    dataConnections={dataConnections}
+                  />
+                </Tooltip>
+              )}
+            </InputGroup>
+          </FormGroup>
+        ) : (
+          <FieldListField
+            key={field.key}
+            value={
+              config.objectStorage.newValue.find((data) => data.key === field.key)?.value || ''
+            }
+            options={field}
+            onChange={onChange}
+          />
+        ),
+      )}
     </FormSection>
   );
 };

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -1,0 +1,136 @@
+import {
+  Menu,
+  Text,
+  MenuContent,
+  MenuGroup,
+  MenuItem,
+  MenuItemAction,
+  MenuList,
+  TextContent,
+  MenuToggle,
+} from '@patternfly/react-core';
+import { Dropdown, DropdownPosition } from '@patternfly/react-core/deprecated';
+import React from 'react';
+import { EyeIcon, EyeSlashIcon, KeyIcon } from '@patternfly/react-icons';
+import styles from '@patternfly/react-styles/css/components/Menu/menu';
+import { css } from '@patternfly/react-styles';
+import { DataConnection, AWSDataEntry } from '~/pages/projects/types';
+import {
+  convertAWSSecretData,
+  getDataConnectionDisplayName,
+} from '~/pages/projects/screens/detail/data-connections/utils';
+import { PIPELINE_AWS_KEY } from '~/pages/projects/dataConnections/const';
+import { PipelineServerConfigType } from './types';
+import { getLabelName } from './utils';
+type pipelineDropdownProps = {
+  setConfig: (config: PipelineServerConfigType) => void;
+  config: PipelineServerConfigType;
+  dataConnections: DataConnection[];
+};
+export const PipelineDropdown = ({ config, setConfig, dataConnections }: pipelineDropdownProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [showPassword, setShowPassword] = React.useState<boolean[]>([]);
+
+  const existingDataConnection = (connection: DataConnection): AWSDataEntry | null =>
+    convertAWSSecretData(connection).filter((dataItem) =>
+      PIPELINE_AWS_KEY.some((filterItem) => filterItem === dataItem.key),
+    );
+
+  const onToggle = () => {
+    setShowPassword([]);
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    option?: string | number | null,
+  ) => {
+    setIsOpen(false);
+    if (typeof option === 'string') {
+      const value = dataConnections.find((d) => d.data.metadata.name === option);
+      if (!value) {
+        return;
+      }
+      const optionValue = existingDataConnection(value);
+      const updatedObjectStorageValue = config.objectStorage.newValue.map((item) => {
+        const matchingOption = optionValue?.find((optItem) => optItem.key === item.key);
+
+        return {
+          ...item,
+          value: matchingOption ? matchingOption.value : item.value,
+        };
+      });
+
+      setConfig({
+        ...config,
+        objectStorage: {
+          newValue: updatedObjectStorageValue,
+        },
+      });
+    }
+  };
+  return (
+    <Dropdown
+      menuAppendTo="parent"
+      position={DropdownPosition.right}
+      toggle={<MenuToggle onClick={onToggle} icon={<KeyIcon />}></MenuToggle>}
+      isOpen={isOpen}
+    >
+      <Menu onSelect={onSelect} isScrollable isPlain>
+        <MenuContent>
+          <MenuGroup
+            label={
+              <h1 className={css(styles.menuGroupTitle)}>
+                <KeyIcon /> Populate the form with credentials from your selected data connection
+              </h1>
+            }
+          >
+            <MenuList>
+              {dataConnections.map((dataItem, index) => (
+                <MenuItem
+                  key={dataItem.data.metadata.name}
+                  actions={
+                    <MenuItemAction
+                      icon={showPassword[index] ? <EyeSlashIcon /> : <EyeIcon />}
+                      actionId={index}
+                      // eslint-disable-next-line no-console
+                      onClick={(ev) => {
+                        ev.preventDefault();
+                        ev.stopPropagation();
+                        setShowPassword((s) => [
+                          ...s.slice(0, index),
+                          !s[index],
+                          ...s.slice(index + 1),
+                        ]);
+                      }}
+                      aria-label={dataItem.data.metadata.name}
+                    />
+                  }
+                  description={
+                    showPassword[index] ? (
+                      <TextContent className={css(styles.menuItemDescription)}>
+                        {existingDataConnection(dataItem)?.map(
+                          (field) =>
+                            field.value && (
+                              <Text key={field.key}>
+                                <b>{getLabelName(field.key)}</b> : {field.value}
+                              </Text>
+                            ),
+                        )}
+                      </TextContent>
+                    ) : (
+                      '•••••••••••••••••'
+                    )
+                  }
+                  itemId={dataItem.data.metadata.name}
+                >
+                  {getDataConnectionDisplayName(dataItem)}
+                </MenuItem>
+              ))}
+            </MenuList>
+          </MenuGroup>
+        </MenuContent>
+      </Menu>
+    </Dropdown>
+  );
+};

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
-import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
 import { PipelineServerConfigType } from '~/concepts/pipelines/content/configurePipelinesServer/types';
 import { createDSPipelineResourceSpec } from '~/concepts/pipelines/content/configurePipelinesServer/utils';
+import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
 
 describe('configure pipeline server utils', () => {
   describe('createDSPipelineResourceSpec', () => {
@@ -11,9 +11,7 @@ describe('configure pipeline server utils', () => {
           value: [],
         },
         objectStorage: {
-          useExisting: true,
-          existingName: '',
-          existingValue: [],
+          newValue: [],
         },
       } as PipelineServerConfigType);
 
@@ -22,7 +20,7 @@ describe('configure pipeline server utils', () => {
     const createSecretsResponse = (
       databaseSecret?: SecretsResponse[0],
       objectStorageSecret?: SecretsResponse[1],
-    ): SecretsResponse => [databaseSecret, objectStorageSecret ?? { secretName: '', awsData: [] }];
+    ): SecretsResponse => [databaseSecret, objectStorageSecret ?? { secretName: '' }];
 
     it('should create resource spec', () => {
       const spec = createDSPipelineResourceSpec(
@@ -47,28 +45,30 @@ describe('configure pipeline server utils', () => {
     });
 
     it('should parse S3 endpoint with scheme', () => {
+      const config = createPipelineServerConfig();
       const secretsResponse = createSecretsResponse();
-      secretsResponse[1].awsData = [
+      config.objectStorage.newValue = [
         { key: AWS_KEYS.S3_ENDPOINT, value: 'http://s3.amazonaws.com' },
       ];
-      const spec = createDSPipelineResourceSpec(createPipelineServerConfig(), secretsResponse);
+      const spec = createDSPipelineResourceSpec(config, secretsResponse);
       expect(spec.objectStorage.externalStorage?.scheme).toBe('http');
       expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
     });
 
     it('should parse S3 endpoint without scheme', () => {
       const secretsResponse = createSecretsResponse();
-
-      secretsResponse[1].awsData = [{ key: AWS_KEYS.S3_ENDPOINT, value: 's3.amazonaws.com' }];
-      const spec = createDSPipelineResourceSpec(createPipelineServerConfig(), secretsResponse);
+      const config = createPipelineServerConfig();
+      config.objectStorage.newValue = [{ key: AWS_KEYS.S3_ENDPOINT, value: 's3.amazonaws.com' }];
+      const spec = createDSPipelineResourceSpec(config, secretsResponse);
       expect(spec.objectStorage.externalStorage?.scheme).toBe('https');
       expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
     });
 
     it('should include bucket', () => {
       const secretsResponse = createSecretsResponse();
-      secretsResponse[1].awsData = [{ key: AWS_KEYS.AWS_S3_BUCKET, value: 'my-bucket' }];
-      const spec = createDSPipelineResourceSpec(createPipelineServerConfig(), secretsResponse);
+      const config = createPipelineServerConfig();
+      config.objectStorage.newValue = [{ key: AWS_KEYS.AWS_S3_BUCKET, value: 'my-bucket' }];
+      const spec = createDSPipelineResourceSpec(config, secretsResponse);
       expect(spec.objectStorage.externalStorage?.bucket).toBe('my-bucket');
     });
 

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/types.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/types.ts
@@ -1,14 +1,7 @@
-import { AWSDataEntry, EnvVariableDataEntry } from '~/pages/projects/types';
-
-export type ObjectStorageExisting = {
-  existingName: string;
-  existingValue: AWSDataEntry;
-  useExisting: true;
-};
+import { EnvVariableDataEntry } from '~/pages/projects/types';
 
 export type ObjectStorageNew = {
   newValue: EnvVariableDataEntry[];
-  useExisting: false;
 };
 
 export type PipelineServerConfigType = {
@@ -16,5 +9,5 @@ export type PipelineServerConfigType = {
     useDefault: boolean;
     value: EnvVariableDataEntry[];
   };
-  objectStorage: ObjectStorageExisting | ObjectStorageNew;
+  objectStorage: ObjectStorageNew;
 };

--- a/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
+++ b/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
@@ -167,7 +167,7 @@ export const CreatePipelineServerButton: React.FC<CreatePipelineServerButtonProp
       <Stack hasGutter>
         <StackItem>
           <Button variant={variant} onClick={() => setConfigureModalVisible(true)}>
-            Create a pipeline server
+            Configure pipeline server
           </Button>
         </StackItem>
       </Stack>

--- a/frontend/src/pages/projects/dataConnections/const.ts
+++ b/frontend/src/pages/projects/dataConnections/const.ts
@@ -9,7 +9,12 @@ export enum AWS_KEYS {
   DEFAULT_REGION = 'AWS_DEFAULT_REGION',
   AWS_S3_BUCKET = 'AWS_S3_BUCKET',
 }
-
+export const PIPELINE_AWS_KEY = [
+  AWS_KEYS.ACCESS_KEY_ID,
+  AWS_KEYS.SECRET_ACCESS_KEY,
+  AWS_KEYS.S3_ENDPOINT,
+  AWS_KEYS.AWS_S3_BUCKET,
+];
 export const AWS_FIELDS: FieldOptions[] = [
   {
     key: AWS_KEYS.NAME,
@@ -41,6 +46,29 @@ export const AWS_FIELDS: FieldOptions[] = [
     label: 'Bucket',
   },
 ];
+export const PIPELINE_AWS_FIELDS: FieldOptions[] = [
+  {
+    key: AWS_KEYS.ACCESS_KEY_ID,
+    label: 'Access key',
+    isRequired: true,
+  },
+  {
+    key: AWS_KEYS.SECRET_ACCESS_KEY,
+    label: 'Secret key',
+    isPassword: true,
+    isRequired: true,
+  },
+  {
+    key: AWS_KEYS.S3_ENDPOINT,
+    label: 'Endpoint',
+    isRequired: true,
+  },
+  {
+    key: AWS_KEYS.AWS_S3_BUCKET,
+    label: 'Bucket',
+    isRequired: true,
+  },
+];
 
 export const EMPTY_AWS_SECRET_DATA: AWSDataEntry = [
   {
@@ -65,6 +93,24 @@ export const EMPTY_AWS_SECRET_DATA: AWSDataEntry = [
   },
   {
     key: AWS_KEYS.DEFAULT_REGION,
+    value: '',
+  },
+];
+export const EMPTY_AWS_PIPELINE_DATA: AWSDataEntry = [
+  {
+    key: AWS_KEYS.ACCESS_KEY_ID,
+    value: '',
+  },
+  {
+    key: AWS_KEYS.SECRET_ACCESS_KEY,
+    value: '',
+  },
+  {
+    key: AWS_KEYS.AWS_S3_BUCKET,
+    value: '',
+  },
+  {
+    key: AWS_KEYS.S3_ENDPOINT,
     value: '',
   },
 ];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1214  

## Description
Allow for a prefill from a Data Connection for reuse of data that have already setup
separating  the relationship between the Data Connection & the DSPA.

[Screencast from 2023-09-13 18-52-30.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/f77dff33-fa49-46b2-baa4-ca803ecb5284)


3) the view pipeline server
![viewpipeline](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/4dc732c0-0015-45f9-8023-43f88bbed029)
 4) Modified the alert info in the configure pipeline modal
 
![Screenshot from 2023-10-25 13-07-24](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/90316b42-ff77-4019-910d-75d57d1befd2)
4) The dropdown with bucket whenever available

![Screenshot from 2023-11-17 11-05-15](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/cdd074ff-581c-44d7-bd67-958e751c96e5)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. create a pipeline Server
2. check for the prefill dataconnection dropdown ( note the dropdown appears only when the data connection are present) 
3. check whether the pipeline server is configured correctly
4. check the view pipeline server whether the data are correctly displayed 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
no test coverage
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
