### PR TITLE
Added pipeline run param tab

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerBottomTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerBottomTabs.tsx
@@ -4,9 +4,11 @@ import PipelineRunTabDetails from '~/concepts/pipelines/content/pipelinesDetails
 import PipelineDetailsYAML from '~/concepts/pipelines/content/pipelinesDetails/PipelineDetailsYAML';
 import { PipelineRunKind } from '~/k8sTypes';
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
+import PipelineRunTabParameters from './PipelineRunTabParameters';
 
 export enum RunDetailsTabs {
   DETAILS = 'Details',
+  PARAMETERS = 'Input parameters',
   YAML = 'Run output',
 }
 
@@ -50,6 +52,14 @@ export const PipelineRunDrawerBottomTabs: React.FC<PipelineRunBottomDrawerProps>
             workflowName={pipelineRunDetails?.kind.metadata.name}
             pipelineRunKF={pipelineRunDetails?.kf}
           />
+        </TabContent>
+        <TabContent
+          id={RunDetailsTabs.PARAMETERS}
+          eventKey={RunDetailsTabs.PARAMETERS}
+          activeKey={selection ?? ''}
+          hidden={RunDetailsTabs.PARAMETERS !== selection}
+        >
+          <PipelineRunTabParameters pipelineRunKF={pipelineRunDetails?.kf} />
         </TabContent>
         <TabContent
           id={RunDetailsTabs.YAML}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabParameters.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabParameters.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import {
+  Spinner,
+  EmptyStateVariant,
+  EmptyState,
+  Title,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
+import {
+  DetailItem,
+  renderDetailItems,
+} from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
+type PipelineRunTabParametersProps = {
+  pipelineRunKF?: PipelineRunKF;
+};
+
+const PipelineRunTabParameters: React.FC<PipelineRunTabParametersProps> = ({ pipelineRunKF }) => {
+  if (!pipelineRunKF) {
+    return (
+      <EmptyState variant={EmptyStateVariant.large} data-id="loading-empty-state">
+        <Spinner size="xl" />
+        <Title headingLevel="h4" size="lg">
+          Loading
+        </Title>
+      </EmptyState>
+    );
+  }
+
+  if (
+    !pipelineRunKF?.pipeline_spec.parameters ||
+    pipelineRunKF.pipeline_spec.parameters.length === 0
+  ) {
+    return (
+      <EmptyState variant={EmptyStateVariant.large} data-id="parameters-empty-state">
+        <Title headingLevel="h4" size="lg">
+          No parameters
+        </Title>
+        <EmptyStateBody>This pipeline run does not have any parameters defined.</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  const details: DetailItem[] = pipelineRunKF.pipeline_spec.parameters.map((param) => ({
+    key: param.name,
+    value: param.value,
+  }));
+
+  return <>{renderDetailItems(details)}</>;
+};
+
+export default PipelineRunTabParameters;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -20,7 +20,9 @@ export const renderDetailItems = (details: DetailItem[], flexKey?: boolean): Rea
     {details.map((detail) => (
       <StackItem key={detail.key}>
         <Flex flexWrap={{ default: 'wrap' }}>
-          <FlexItem style={{ width: flexKey ? undefined : 150 }}>{detail.key}</FlexItem>
+          <FlexItem style={{ width: flexKey ? undefined : 150 }}>
+            <b>{detail.key}</b>
+          </FlexItem>
           <FlexItem>{detail.value}</FlexItem>
         </Flex>
       </StackItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsPrintKeyValues.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsPrintKeyValues.tsx
@@ -9,7 +9,9 @@ const TaskDetailsPrintKeyValues: React.FC<TaskDetailsPrintKeyValuesProps> = ({ i
   <Grid hasGutter>
     {items.map((result, i) => (
       <React.Fragment key={`item-${i}`}>
-        <GridItem span={4}>{result.name}</GridItem>
+        <GridItem span={4}>
+          <b>{result.name}</b>
+        </GridItem>
         <GridItem span={8}>{result.value}</GridItem>
       </React.Fragment>
     ))}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1245

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
For a pipeline run, there is a new tab between the details and yaml that shows the global params for the pipeline
<img width="1151" alt="Screenshot 2023-08-30 at 2 01 15 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/005a73a0-b8ae-4935-bd0a-2ac5ee88bc4e">
<img width="1149" alt="Screenshot 2023-08-30 at 10 17 49 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/457c2e04-3865-451e-869d-e53d454f9e81">



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a pipeline that has global params and one that does not

_global params can be added here_
```yaml
spec:
  params:
    - name: global-param-1
      value: some-value-1
    - name: global-param-2
      value: some-value-2
```
2. Create a run for the pipeline without params
3. go to run details -> Parameters tab
4. it should show an empty state
5. create a run for the pipeline with params
6. it should show the params on the tab

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- pipeline test issue: https://github.com/opendatahub-io/odh-dashboard/issues/1297

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @yannnz 