### PR TITLE
Remove duplicated logout message when logging out from workbench

### DIFF
--- a/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.tsx
@@ -12,7 +12,6 @@ import { ProjectSectionID } from './types';
 import StorageList from './storage/StorageList';
 import { ProjectSectionTitles } from './const';
 import DataConnectionsList from './data-connections/DataConnectionsList';
-import useCheckLogoutParams from './useCheckLogoutParams';
 
 type SectionType = {
   id: ProjectSectionID;
@@ -36,7 +35,6 @@ const ProjectDetailsComponents: React.FC = () => {
   const pipelinesEnabled =
     featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disablePipelines) &&
     dashboardConfig.status.dependencyOperators.redhatOpenshiftPipelines.available;
-  useCheckLogoutParams();
 
   const sections: SectionType[] = [
     {

--- a/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
+++ b/frontend/src/pages/projects/screens/detail/useCheckLogoutParams.ts
@@ -17,7 +17,7 @@ const useCheckLogoutParams = (): void => {
   React.useEffect(() => {
     const deleteLogoutParam = () => {
       queryParams.delete('notebookLogout');
-      setQueryParams(queryParams);
+      setQueryParams(queryParams, { replace: true });
     };
     if (notebookLogout) {
       if (notebook) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Close #1567 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Easy fix, the `useCheckLogoutParams` hook is used both in the `ProjectDetails` component and the `ProjectDetailsComponents` component, so it's called twice. Removing one can fix this problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to data science project, create a workbench
2. Login to the workbench
3. In the Jupyter notebook GUI, choose `File -> Log out`
4. Check the logout success message, make sure there is only one message in the notification center

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
