### PR TITLE
Pipeline run pod logs

### DIFF
--- a/frontend/src/components/SimpleDropdownSelect.tsx
+++ b/frontend/src/components/SimpleDropdownSelect.tsx
@@ -2,28 +2,33 @@ import * as React from 'react';
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 
 type SimpleDropdownProps = {
+  isDisabled?: boolean;
   options: { key: string; label: React.ReactNode }[];
   value: string;
   placeholder?: string;
   onChange: (key: string) => void;
+  width?: number;
 } & Omit<React.ComponentProps<typeof Dropdown>, 'isOpen' | 'toggle' | 'dropdownItems' | 'onChange'>;
 
 const SimpleDropdownSelect: React.FC<SimpleDropdownProps> = ({
+  isDisabled,
   onChange,
   options,
   placeholder = 'Select...',
   value,
+  width,
   ...props
 }) => {
   const [open, setOpen] = React.useState(false);
+  const displayValue = options.find(({ key }) => key === value)?.label ?? placeholder;
 
   return (
     <Dropdown
       {...props}
       isOpen={open}
       toggle={
-        <DropdownToggle onToggle={() => setOpen(!open)}>
-          <>{options.find(({ key }) => key === value)?.label ?? placeholder}</>
+        <DropdownToggle isDisabled={isDisabled} onToggle={() => setOpen(!open)} style={{ width }}>
+          {displayValue}
         </DropdownToggle>
       }
       dropdownItems={options.map(({ key, label }) => (

--- a/frontend/src/concepts/dashboard/codeEditor/useCodeEditorAsLogs.tsx
+++ b/frontend/src/concepts/dashboard/codeEditor/useCodeEditorAsLogs.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import * as monacoEditor from 'monaco-editor';
+import { EditorDidMount } from 'react-monaco-editor';
+import { LOG_TAIL_LINES } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/const';
+
+type UseCodeEditorAsLogs = {
+  editorOptions: monacoEditor.editor.IStandaloneEditorConstructionOptions;
+  onMount: EditorDidMount;
+  scrollToBottom: () => void;
+};
+
+type EditorData = {
+  editor: monacoEditor.editor.IStandaloneCodeEditor;
+  monaco: typeof monacoEditor;
+};
+
+const useCodeEditorAsLogs = (): UseCodeEditorAsLogs => {
+  const [editorData, setEditorData] = React.useState<EditorData | null>(null);
+
+  const scrollToBottom = React.useCallback<UseCodeEditorAsLogs['scrollToBottom']>(() => {
+    if (!editorData) {
+      return;
+    }
+
+    // Move the cursor back to the start / unselect everything
+    editorData.editor.setSelection(new editorData.monaco.Selection(0, 0, 0, 0));
+
+    // Scroll to the bottom
+    editorData.editor.revealLine(editorData.editor.getModel()?.getLineCount() ?? LOG_TAIL_LINES);
+  }, [editorData]);
+
+  const onMount = React.useCallback<UseCodeEditorAsLogs['onMount']>((editor, monaco) => {
+    setEditorData({ editor, monaco });
+  }, []);
+
+  return {
+    editorOptions: {
+      // Always wrap
+      wordWrap: 'on',
+      // Cursor on item highlights repeats -- not needed
+      occurrencesHighlight: false,
+      // Disable the selection highlight
+      selectionHighlight: true,
+      // Stop it at the last line; logs editors don't usually go past that
+      scrollBeyondLastLine: false,
+    },
+    scrollToBottom,
+    onMount,
+  };
+};
+
+export default useCodeEditorAsLogs;

--- a/frontend/src/concepts/k8s/pods/useFetchLogs.ts
+++ b/frontend/src/concepts/k8s/pods/useFetchLogs.ts
@@ -2,8 +2,14 @@ import * as React from 'react';
 import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { getPodContainerLogText } from '~/api';
+import { LOG_REFRESH_RATE } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/const';
 
-const useFetchLogs = (podName: string, containerName: string, tail = 500): FetchState<string> => {
+const useFetchLogs = (
+  podName: string,
+  containerName: string,
+  activelyRefresh?: boolean,
+  tail?: number,
+): FetchState<string> => {
   const { namespace } = usePipelinesAPI();
 
   const callback = React.useCallback(() => {
@@ -14,7 +20,10 @@ const useFetchLogs = (podName: string, containerName: string, tail = 500): Fetch
     return getPodContainerLogText(namespace, podName, containerName, tail);
   }, [podName, containerName, namespace, tail]);
 
-  return useFetchState(callback, '');
+  return useFetchState(callback, '', {
+    refreshRate: activelyRefresh ? LOG_REFRESH_RATE : 0,
+    initialPromisePurity: true,
+  });
 };
 
 export default useFetchLogs;

--- a/frontend/src/concepts/k8s/pods/usePod.ts
+++ b/frontend/src/concepts/k8s/pods/usePod.ts
@@ -17,7 +17,7 @@ const usePod = (namespace: string, podName: string): FetchState<PodState> => {
     return getPod(namespace, podName);
   }, [namespace, podName]);
 
-  return useFetchState(callback, null);
+  return useFetchState(callback, null, { initialPromisePurity: true });
 };
 
 export default usePod;

--- a/frontend/src/concepts/k8s/pods/utils.ts
+++ b/frontend/src/concepts/k8s/pods/utils.ts
@@ -1,0 +1,20 @@
+import { PodKind } from '~/k8sTypes';
+import { PodContainer } from '~/types';
+import { getPodContainerLogText } from '~/api';
+import { downloadString } from '~/utilities/string';
+
+export const getPodContainers = (
+  pod: PodKind | null,
+): { containers: PodContainer[]; initContainers: PodContainer[] } => ({
+  containers: pod?.spec.containers ?? [],
+  initContainers: pod?.spec.initContainers ?? [],
+});
+
+export const downloadFullPodLog = async (
+  namespace: string,
+  podName: string,
+  containerName: string,
+) =>
+  getPodContainerLogText(namespace, podName, containerName).then((content) =>
+    downloadString(`${podName}-${containerName}.log`, content),
+  );

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent.tsx
@@ -33,7 +33,7 @@ const PipelineRunDrawerRightContent: React.FC<PipelineRunDrawerRightContentProps
     <DrawerPanelContent
       isResizable
       widths={{ default: 'width_33', lg: 'width_50' }}
-      minSize="300px"
+      minSize="400px"
     >
       <DrawerHead>
         <Title headingLevel="h2" size="xl">
@@ -45,7 +45,7 @@ const PipelineRunDrawerRightContent: React.FC<PipelineRunDrawerRightContentProps
           <DrawerCloseButton onClick={onClose} />
         </DrawerActions>
       </DrawerHead>
-      <DrawerPanelBody>
+      <DrawerPanelBody style={{ display: 'flex', flexDirection: 'column' }}>
         <PipelineRunDrawerRightTabs
           taskReferences={taskReferences}
           task={task}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -5,13 +5,14 @@ import { PipelineRunTaskDetails, TaskReferenceMap } from '~/concepts/pipelines/c
 import SelectedNodeInputOutputTab from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeInputOutputTab';
 import SelectedNodeVolumeMountsTab from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeVolumeMountsTab';
 import { PipelineRunTaskParam } from '~/k8sTypes';
+import LogsTab from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab';
 
 enum PipelineRunNodeTabs {
   INPUT_OUTPUT = 'Input / Output',
   // VISUALIZATIONS = 'Visualizations',
   DETAILS = 'Details',
   VOLUMES = 'Volumes',
-  // LOGS = 'Logs',
+  LOGS = 'Logs',
   // POD = 'Pod',
   // EVENTS = 'Events',
   // ML_METADATA = 'ML Metadata',
@@ -35,11 +36,12 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
     eventKey: tab,
     activeKey: selection ?? '',
     hidden: tab !== selection,
+    style: { flex: '1 1 auto' },
   });
 
   return (
     <>
-      <Tabs activeKey={selection ?? undefined}>
+      <Tabs activeKey={selection ?? undefined} mountOnEnter>
         {Object.values(PipelineRunNodeTabs).map((tab) => (
           <Tab
             key={tab}
@@ -51,7 +53,7 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
         ))}
       </Tabs>
       {selection && (
-        <DrawerPanelBody>
+        <DrawerPanelBody style={{ display: 'flex', flexDirection: 'column' }}>
           <TabContent {...tabContentProps(PipelineRunNodeTabs.INPUT_OUTPUT)}>
             <SelectedNodeInputOutputTab
               taskReferences={taskReferences}
@@ -66,7 +68,9 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
           <TabContent {...tabContentProps(PipelineRunNodeTabs.VOLUMES)}>
             <SelectedNodeVolumeMountsTab task={task} />
           </TabContent>
-          {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.LOGS)}>TBD 5</TabContent>*/}
+          <TabContent {...tabContentProps(PipelineRunNodeTabs.LOGS)}>
+            <LogsTab task={task} />
+          </TabContent>
           {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.POD)}>TBD 6</TabContent>*/}
           {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.EVENTS)}>TBD 7</TabContent>*/}
           {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.ML_METADATA)}>TBD 8</TabContent>*/}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import {
+  Button,
+  Tooltip,
+  TextListItem,
+  TextListItemVariants,
+  TextContent,
+  Spinner,
+  Stack,
+  StackItem,
+  Split,
+  SplitItem,
+  Bullseye,
+} from '@patternfly/react-core';
+import OutlinedPlayCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-play-circle-icon';
+import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
+import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import { PipelineRunTaskDetails } from '~/concepts/pipelines/content/types';
+import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
+import useFetchLogs from '~/concepts/k8s/pods/useFetchLogs';
+import usePodContainerLogState from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/usePodContainerLogState';
+import LogsTabStatus from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus';
+import { LOG_TAIL_LINES } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/const';
+import DashboardCodeEditor from '~/concepts/dashboard/codeEditor/DashboardCodeEditor';
+import useCodeEditorAsLogs from '~/concepts/dashboard/codeEditor/useCodeEditorAsLogs';
+import { downloadFullPodLog } from '~/concepts/k8s/pods/utils';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+
+// TODO: If this gets large enough we should look to make this its own component file
+const LogsTab: React.FC<{ task: PipelineRunTaskDetails }> = ({ task }) => {
+  const podName = task.runDetails?.status.podName;
+
+  if (!podName) {
+    return <>No content</>;
+  }
+
+  return <LogsTabForPodName podName={podName} />;
+};
+
+/** Must be a non-empty podName -- use LogsTabForTask for safer usage */
+const LogsTabForPodName: React.FC<{ podName: string }> = ({ podName }) => {
+  const { namespace } = usePipelinesAPI();
+  const { podLoaded, podError, podContainers, selectedContainer, setSelectedContainer } =
+    usePodContainerLogState(podName);
+  const [isPaused, setIsPaused] = React.useState(false);
+  const [logs, logsLoaded, logsError, refreshLogs] = useFetchLogs(
+    podName,
+    selectedContainer?.name ?? '',
+    !isPaused,
+    LOG_TAIL_LINES,
+  );
+  const [downloading, setDownloading] = React.useState(false);
+  const [downloadError, setDownloadError] = React.useState<Error | undefined>();
+  const { scrollToBottom, onMount, editorOptions } = useCodeEditorAsLogs();
+
+  React.useEffect(() => {
+    if (!isPaused && logs) {
+      scrollToBottom();
+    }
+  }, [isPaused, logs, scrollToBottom]);
+
+  const canDownload = !!selectedContainer && !!podName && !downloading;
+  const onDownload = () => {
+    if (!canDownload) {
+      return;
+    }
+    setDownloadError(undefined);
+    setDownloading(true);
+    downloadFullPodLog(namespace, podName, selectedContainer.name)
+      .catch((e) => setDownloadError(e))
+      .finally(() => setDownloading(false));
+  };
+
+  const error = podError || logsError || downloadError;
+  const loaded = podLoaded && logsLoaded;
+
+  let data: string;
+  if (error) {
+    data = '';
+  } else if (!logsLoaded) {
+    data = 'Loading...';
+  } else if (logs) {
+    data = logs;
+  } else {
+    data = 'No content';
+  }
+
+  return (
+    <Stack hasGutter style={{ minHeight: 400 }}>
+      <StackItem>
+        <LogsTabStatus
+          loaded={loaded}
+          error={error}
+          refresh={refreshLogs}
+          onDownload={onDownload}
+        />
+      </StackItem>
+      <StackItem>
+        <Split hasGutter isWrappable>
+          <SplitItem>
+            <Split hasGutter>
+              <SplitItem>
+                <Bullseye>
+                  <TextContent>
+                    <TextListItem component={TextListItemVariants.dt}>Container</TextListItem>
+                  </TextContent>
+                </Bullseye>
+              </SplitItem>
+              <SplitItem>
+                <SimpleDropdownSelect
+                  isDisabled={podContainers.length === 0}
+                  options={podContainers.map((container) => ({
+                    key: container.name,
+                    label: container.name,
+                  }))}
+                  value={selectedContainer?.name ?? ''}
+                  placeholder="Select container..."
+                  onChange={(v) => {
+                    setSelectedContainer(podContainers.find((c) => c.name === v) ?? null);
+                  }}
+                  width={200}
+                />
+              </SplitItem>
+            </Split>
+          </SplitItem>
+          <SplitItem>
+            <Button
+              variant={!logsLoaded ? 'plain' : isPaused ? 'plain' : 'link'}
+              onClick={() => setIsPaused(!isPaused)}
+              isDisabled={!!error}
+            >
+              {error ? (
+                'Error loading logs'
+              ) : !logsLoaded ? (
+                <>
+                  <Spinner size="sm" /> Loading log
+                </>
+              ) : isPaused ? (
+                <>
+                  <PlayIcon /> Resume refreshing
+                </>
+              ) : (
+                <>
+                  <PauseIcon /> Pause refreshing
+                </>
+              )}
+            </Button>
+          </SplitItem>
+          <SplitItem isFilled style={{ textAlign: 'right' }}>
+            <Tooltip position="top" content={<div>Download currently selected container</div>}>
+              <Button
+                onClick={onDownload}
+                variant="link"
+                aria-label="Download current logs"
+                icon={<DownloadIcon />}
+                isDisabled={!canDownload}
+              >
+                Download
+              </Button>
+            </Tooltip>
+          </SplitItem>
+        </Split>
+      </StackItem>
+      <StackItem isFilled>
+        <DashboardCodeEditor
+          onEditorDidMount={onMount}
+          code={data}
+          isReadOnly
+          options={editorOptions}
+        />
+        {isPaused && (
+          <Button onClick={() => setIsPaused(false)} isBlock icon={<OutlinedPlayCircleIcon />}>
+            Resume refreshing log
+          </Button>
+        )}
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default LogsTab;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Alert, AlertActionLink, Button, Skeleton } from '@patternfly/react-core';
+import {
+  LOG_REFRESH_RATE,
+  LOG_TAIL_LINES,
+} from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/const';
+
+type LogsTabStatusProps = {
+  error?: Error;
+  loaded: boolean;
+  refresh: () => void;
+  onDownload?: () => void;
+};
+
+const LogsTabStatus: React.FC<LogsTabStatusProps> = ({ error, loaded, refresh, onDownload }) => {
+  if (error) {
+    return (
+      <Alert
+        isInline
+        variant="danger"
+        title="An error occurred while retrieving the requested logs"
+        actionLinks={<AlertActionLink onClick={refresh}>Retry</AlertActionLink>}
+      >
+        <p>{error.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!loaded) {
+    // Size of the expandable alert about logs (see below)
+    return <Skeleton height="55px" width="100%" />;
+  }
+
+  return (
+    <Alert isExpandable isInline variant="warning" title="The log window displays partial content">
+      <p>
+        The log refreshes every {Math.floor(LOG_REFRESH_RATE / 1000)} seconds and displays the
+        latest {LOG_TAIL_LINES} lines. Exceptionally long lines are abridged. To view the full log
+        for this task, you can{' '}
+        <Button
+          isDisabled={!!onDownload}
+          variant="link"
+          isInline
+          component="span"
+          onClick={onDownload}
+        >
+          download the selected container logs
+        </Button>{' '}
+        associated with it.
+      </p>
+    </Alert>
+  );
+};
+
+export default LogsTabStatus;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/const.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/const.ts
@@ -1,0 +1,2 @@
+export const LOG_REFRESH_RATE = 3000;
+export const LOG_TAIL_LINES = 500;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/usePodContainerLogState.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/usePodContainerLogState.ts
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { PodContainer } from '~/types';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import usePod from '~/concepts/k8s/pods/usePod';
+import { getPodContainers } from '~/concepts/k8s/pods/utils';
+import { PodKind } from '~/k8sTypes';
+
+const usePodContainerLogState = (
+  podName: string,
+): {
+  pod: PodKind | null;
+  podLoaded: boolean;
+  podError: Error | undefined;
+  podContainers: PodContainer[];
+  selectedContainer: PodContainer | null;
+  setSelectedContainer: (podContainer: PodContainer | null) => void;
+} => {
+  const { namespace } = usePipelinesAPI();
+  const [pod, podLoaded, podError] = usePod(namespace, podName);
+  const { containers: podContainers } = getPodContainers(pod);
+  const [selectedContainer, setSelectedContainer] = React.useState<PodContainer | null>(null);
+
+  React.useEffect(() => {
+    // Pod name changed value -- our selected container isn't part of this pod
+    setSelectedContainer(null);
+  }, [podName]);
+
+  const firstPodContainer = podContainers[0];
+  React.useEffect(() => {
+    if (!selectedContainer && firstPodContainer) {
+      setSelectedContainer(firstPodContainer);
+    }
+  }, [firstPodContainer, selectedContainer]);
+
+  return { pod, podLoaded, podError, podContainers, selectedContainer, setSelectedContainer };
+};
+
+export default usePodContainerLogState;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -254,6 +254,7 @@ export type PodSpec = {
   affinity?: PodAffinity;
   enableServiceLinks?: boolean;
   containers: PodContainer[];
+  initContainers?: PodContainer[];
   volumes?: Volume[];
   tolerations?: PodToleration[];
 };

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -3,3 +3,13 @@ export const genRandomChars = (len = 6): string =>
     .toString(36)
     .replace(/[^a-z0-9]+/g, '')
     .substr(1, len);
+
+export const downloadString = (filename: string, data: string): void => {
+  const element = document.createElement('a');
+  const file = new Blob([data], { type: 'text/plain' });
+  element.href = URL.createObjectURL(file);
+  element.download = filename;
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1247

Collaborated with @manaswinidas to complete this feature.

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a Logs tab to the selected node sidebar.

Couple high level notes:
* Issue (A): We could not use the Log Viewer -- it does not handle itself well in the Sidebar. We may be able to hack something together but that won't be first pass. We use the code editor in read only mode
* Issue (B): We can't properly capture scroll with the code editor -- but you can manually pause the refresh, it just won't trigger on scroll up
* List of known issues will be after the screenshots -- these are to be handled in a future PR
* For dev purposes, log tab was selected first, some gifs show this -- this is not the case in the PR

> Note: Issues (A) & (B) will be listed below as well.

### Screenshots

> Note: There will be some documented gaps. This should get the functionality down and we can swing back and improve the rest in smaller bitesized PRs.

Look at a loaded log with very little content:
![Screenshot 2023-08-30 at 6 59 05 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/c46c51fa-5170-41b3-910e-afb9a0f37691)

Showing the dropdown of containers:
> Note: Issue (C): `Init` containers get a prefix and not proper sections

![Screenshot 2023-08-30 at 6 59 13 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/5b7851a7-57e4-4ec2-8e0b-9fbe2a8f1147)

Expanded warning for the state of the logs:
![Screenshot 2023-08-30 at 6 59 18 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/a439c85f-bccd-46a5-b6a1-cefe1e574044)

Paused state, comes with button (space is currently reserved and log view does not move):
![Screenshot 2023-08-30 at 6 59 22 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/37aacfa9-5fdb-4bcb-89d1-56123a18665d)

Full 500 line content:
![Screenshot 2023-08-30 at 6 59 38 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/da6461f1-0c79-4d97-9aa7-de5d87b1b859)

Error state when OpenShift Console cleans up the pod and we can't fetch anything:
![Screenshot 2023-08-30 at 6 59 58 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/b88f16c4-3fab-4f73-8b69-70b6d5e0a7f8)

While paused, it does not scroll a container when flipped to it:
<img width="714" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/8126518/472de869-a188-4b46-a7a5-4449928b0ca3">

### Gifs

First node: Showcasing skipped node; does not have a pod NAME -- never was assigned one, can't ever have logs

> Note: Issue (D): Do we want an error here? Is there better UX?

Second node: Showcasing a completed node; does not have a pod
![NoPods_ShowingSkippedTask](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/5de273cd-9140-471f-8927-a223b20087ad)

Loading up a run, showing a large log (capped at 500 lines), pausing log, flipping between containers

> Note: Issue (B) shown here

![LoadingPLR_ShowingLargeLog_ContainerFlipping](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/b77e3016-5759-4c4d-9257-e7b1cae0ea18)

### Notes & Issues

- (A): Code Editor needs to be converted to Log Viewer
- (B): Code Editor does not have scroll abilities
- (C): `init` containers are not properly handled in the dropdown -- needs a new issue, low priority
- (D): Pipeline Tasks that never execute don't have a Pod Name -- we treat it slightly different than deleted pods, but it could probably use a different treatment

cc @yih-wang 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Upload a Pipeline & create runs
* Select a node & go to the logs tab
* View logs for containers

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No additions -- lack Pipeline Tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
