### PR TITLE
use generic object state on data connections and prevent resetting on edit

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -65,9 +65,9 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   const [storageDataWithoutDefault, setStorageData] = useStorageDataObject(existingNotebook);
   const storageData = useMergeDefaultPVCName(storageDataWithoutDefault, nameDesc.name);
   const [envVariables, setEnvVariables] = useNotebookEnvVariables(existingNotebook);
-  const [dataConnection, setDataConnection] = useNotebookDataConnection(
-    existingNotebook,
+  const [dataConnectionData, setDataConnectionData] = useNotebookDataConnection(
     dataConnections.data,
+    existingNotebook,
   );
 
   const restartNotebooks = useWillNotebooksRestart([existingNotebook?.metadata.name || '']);
@@ -205,8 +205,8 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
               aria-label={SpawnerPageSectionTitles[SpawnerPageSectionID.DATA_CONNECTIONS]}
             >
               <DataConnectionField
-                dataConnection={dataConnection}
-                setDataConnection={(connection) => setDataConnection(connection)}
+                dataConnectionData={dataConnectionData}
+                setDataConnectionData={setDataConnectionData}
               />
             </FormSection>
           </Form>
@@ -235,7 +235,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   }}
                   storageData={storageData}
                   envVariables={envVariables}
-                  dataConnection={dataConnection}
+                  dataConnection={dataConnectionData}
                   canEnablePipelines={canEnablePipelines}
                 />
               )}

--- a/frontend/src/pages/projects/screens/spawner/dataConnection/DataConnectionField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/dataConnection/DataConnectionField.tsx
@@ -4,18 +4,19 @@ import {
   DataConnectionData,
   EnvironmentVariableType,
   SecretCategory,
+  UpdateObjectAtPropAndValue,
 } from '~/pages/projects/types';
 import AWSField from '~/pages/projects/dataConnections/AWSField';
 import { EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
 import ExistingDataConnectionField from './ExistingDataConnectionField';
 
 type DataConnectionFieldProps = {
-  dataConnection: DataConnectionData;
-  setDataConnection: (dataConnection: DataConnectionData) => void;
+  dataConnectionData: DataConnectionData;
+  setDataConnectionData: UpdateObjectAtPropAndValue<DataConnectionData>;
 };
 const DataConnectionField: React.FC<DataConnectionFieldProps> = ({
-  dataConnection,
-  setDataConnection,
+  dataConnectionData,
+  setDataConnectionData,
 }) => (
   <FormGroup fieldId="cluster-storage" role="radiogroup">
     <Checkbox
@@ -23,10 +24,10 @@ const DataConnectionField: React.FC<DataConnectionFieldProps> = ({
       name="enable-data-connection-checkbox"
       id="enable-data-connection-checkbox"
       label="Use a data connection"
-      isChecked={dataConnection.enabled}
-      onChange={() => setDataConnection({ ...dataConnection, enabled: !dataConnection.enabled })}
+      isChecked={dataConnectionData.enabled}
+      onChange={() => setDataConnectionData('enabled', !dataConnectionData.enabled)}
       body={
-        dataConnection.enabled && (
+        dataConnectionData.enabled && (
           <Stack hasGutter>
             <StackItem>
               <Radio
@@ -34,19 +35,16 @@ const DataConnectionField: React.FC<DataConnectionFieldProps> = ({
                 name="new-data-connection-radio"
                 id="new-data-connection-radio"
                 label="Create new data connection"
-                isChecked={dataConnection.type === 'creating'}
-                onChange={() => setDataConnection({ ...dataConnection, type: 'creating' })}
+                isChecked={dataConnectionData.type === 'creating'}
+                onChange={() => setDataConnectionData('type', 'creating')}
                 body={
-                  dataConnection.type === 'creating' && (
+                  dataConnectionData.type === 'creating' && (
                     <AWSField
-                      values={dataConnection.creating?.values?.data ?? EMPTY_AWS_SECRET_DATA}
+                      values={dataConnectionData.creating?.values?.data ?? EMPTY_AWS_SECRET_DATA}
                       onUpdate={(newEnvData) => {
-                        setDataConnection({
-                          ...dataConnection,
-                          creating: {
-                            type: EnvironmentVariableType.SECRET,
-                            values: { category: SecretCategory.AWS, data: newEnvData },
-                          },
+                        setDataConnectionData('creating', {
+                          type: EnvironmentVariableType.SECRET,
+                          values: { category: SecretCategory.AWS, data: newEnvData },
                         });
                       }}
                     />
@@ -60,18 +58,15 @@ const DataConnectionField: React.FC<DataConnectionFieldProps> = ({
                 name="existing-data-connection-type-radio"
                 id="existing-data-connection-type-radio"
                 label="Use existing data connection"
-                isChecked={dataConnection.type === 'existing'}
-                onChange={() => setDataConnection({ ...dataConnection, type: 'existing' })}
+                isChecked={dataConnectionData.type === 'existing'}
+                onChange={() => setDataConnectionData('type', 'existing')}
                 body={
-                  dataConnection.type === 'existing' && (
+                  dataConnectionData.type === 'existing' && (
                     <ExistingDataConnectionField
                       fieldId="select-existing-data-connection"
-                      selectedDataConnection={dataConnection?.existing?.secretRef.name}
+                      selectedDataConnection={dataConnectionData?.existing?.secretRef.name}
                       setDataConnection={(name) =>
-                        setDataConnection({
-                          ...dataConnection,
-                          existing: { secretRef: { name: name ?? '' } },
-                        })
+                        setDataConnectionData('existing', { secretRef: { name: name ?? '' } })
                       }
                     />
                   )


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1487 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Refactor the data connection object to the generic state object. Also, fixed the problem mentioned in the issue. It's because we have an unstable reference that will trigger the `useEffect` hook in `useNotebookDataConnection` every time the data connections are fetched. Instead of passing the array to the `useEffect` hook, we take the value we want outside of it and pass that stable value to the hook could fix this problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a workbench with data connection
2. Stop the workbench
3. Edit the workbench
4. Go to the data connection section, change it to create a new data connection
5. Make sure the choice will not be reset back to use existing data connection

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
