### PR TITLE
Fixed isCpuLimitEqual and isMemoryLimitEqual wrongly comparing null/undefined values.

### DIFF
--- a/frontend/src/utilities/__tests__/valueUnits.spec.ts
+++ b/frontend/src/utilities/__tests__/valueUnits.spec.ts
@@ -1,0 +1,27 @@
+import { isCpuLimitEqual, isMemoryLimitEqual } from '~/utilities/valueUnits';
+
+describe('isCpuLimitEqual', () => {
+  test('correctly compares non-undefined values', () => {
+    expect(isCpuLimitEqual('1', '1')).toBe(true);
+    expect(isCpuLimitEqual('1000m', '1')).toBe(true);
+    expect(isCpuLimitEqual('1001m', '1')).toBe(false);
+  });
+  test('correctly compares undefined values', () => {
+    expect(isCpuLimitEqual('1000m', undefined)).toBe(false);
+    expect(isCpuLimitEqual('1', undefined)).toBe(false);
+    expect(isCpuLimitEqual(undefined, undefined)).toBe(true);
+  });
+});
+
+describe('isMemoryLimitEqual', () => {
+  test('correctly compares non-undefined values', () => {
+    expect(isMemoryLimitEqual('1Gi', '1Gi')).toBe(true);
+    expect(isMemoryLimitEqual('1Gi', '1024Mi')).toBe(true);
+    expect(isMemoryLimitEqual('1Gi', '1025Mi')).toBe(false);
+  });
+  test('correctly compares undefined values', () => {
+    expect(isMemoryLimitEqual('1Gi', undefined)).toBe(false);
+    expect(isMemoryLimitEqual('1024Mi', undefined)).toBe(false);
+    expect(isMemoryLimitEqual(undefined, undefined)).toBe(true);
+  });
+});

--- a/frontend/src/utilities/valueUnits.ts
+++ b/frontend/src/utilities/valueUnits.ts
@@ -52,6 +52,10 @@ export const isEqual = (
 ): boolean => calculateDelta(value1, value2, units) === 0;
 
 export const isCpuLimitEqual = (cpu1?: ValueUnitString, cpu2?: ValueUnitString): boolean => {
+  if (!cpu1 && !cpu2) {
+    return true;
+  }
+
   if (!cpu1 || !cpu2) {
     return false;
   }
@@ -63,6 +67,10 @@ export const isMemoryLimitEqual = (
   memory1?: ValueUnitString,
   memory2?: ValueUnitString,
 ): boolean => {
+  if (!memory1 && !memory2) {
+    return true;
+  }
+
   if (!memory1 || !memory2) {
     return false;
   }


### PR DESCRIPTION
Fixes #1730

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
Fixes an issue when notebook sizes contain a size with either CPU or memory limit not set. When viewing such noetbook in project details page, size was not recognized.

Before:
![obraz](https://github.com/opendatahub-io/odh-dashboard/assets/3638714/e25c0a70-170a-4634-a9f5-bc4286efb8ff)

After:
![obraz](https://github.com/opendatahub-io/odh-dashboard/assets/3638714/a3aeec78-5308-4bf1-a629-18ea21df7463)


## How Has This Been Tested?
1. Add noetbook size with no limits to ODH dashboard configuration
2. Create new DS project
3. Create workbench with new size
4. Go back to project details

Also added unit tests for good measure

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

@kywalker-rh @xianli123 (for dashboard change) and @Gkrumbach07 (for tests)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
