### PR TITLE
first try at storageclasses get and promises

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -13,6 +13,7 @@ export * from './k8s/routes';
 export * from './k8s/secrets';
 export * from './k8s/serviceAccounts';
 export * from './k8s/servingRuntimes';
+export * from './k8s/storageClasses';
 export * from './k8s/users';
 export * from './k8s/groups';
 export * from './k8s/templates';

--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -15,6 +15,7 @@ export const assemblePvc = (
   projectName: string,
   description: string,
   pvcSize: number,
+  storageClassName?: string,
 ): PersistentVolumeClaimKind => ({
   apiVersion: 'v1',
   kind: 'PersistentVolumeClaim',
@@ -36,6 +37,7 @@ export const assemblePvc = (
         storage: `${pvcSize}Gi`,
       },
     },
+    storageClassName: storageClassName,
     volumeMode: 'Filesystem',
   },
   status: {

--- a/frontend/src/api/k8s/storageClasses.ts
+++ b/frontend/src/api/k8s/storageClasses.ts
@@ -1,0 +1,8 @@
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { StorageClassKind } from '~/k8sTypes';
+import { StorageClassModel } from '~/api/models';
+export const getStorageClasses = (): Promise<StorageClassKind[]> =>
+  k8sListResource<StorageClassKind>({
+    model: StorageClassModel,
+    queryOptions: {},
+  }).then((listResource) => listResource.items);

--- a/frontend/src/api/models/k8s.ts
+++ b/frontend/src/api/models/k8s.ts
@@ -24,6 +24,13 @@ export const PVCModel: K8sModelCommon = {
   plural: 'persistentvolumeclaims',
 };
 
+export const StorageClassModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'storage.k8s.io',
+  kind: 'StorageClass',
+  plural: 'storageclasses',
+};
+
 export const NamespaceModel: K8sModelCommon = {
   apiVersion: 'v1',
   kind: 'Namespace',

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -18,6 +18,7 @@ import { useUser } from '~/redux/selectors';
 import { DASHBOARD_MAIN_CONTAINER_SELECTOR } from '~/utilities/const';
 import useDetectUser from '~/utilities/useDetectUser';
 import ProjectsContextProvider from '~/concepts/projects/ProjectsContext';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import Header from './Header';
 import AppRoutes from './AppRoutes';
 import NavSidebar from './NavSidebar';
@@ -39,6 +40,8 @@ const App: React.FC = () => {
     loaded: configLoaded,
     loadError: fetchConfigError,
   } = useApplicationSettings();
+
+  const [storageClasses] = useStorageClasses();
 
   useDetectUser();
 
@@ -72,7 +75,6 @@ const App: React.FC = () => {
         </Page>
       );
     }
-
     // Assume we are still waiting on the API to finish
     return (
       <Bullseye>
@@ -86,6 +88,7 @@ const App: React.FC = () => {
       value={{
         buildStatuses,
         dashboardConfig,
+        storageClasses,
       }}
     >
       <Page

--- a/frontend/src/app/AppContext.ts
+++ b/frontend/src/app/AppContext.ts
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import { BuildStatus, DashboardConfig } from '~/types';
+import { StorageClassKind } from '~/k8sTypes';
 
 type AppContextProps = {
   buildStatuses: BuildStatus[];
   dashboardConfig: DashboardConfig;
+  storageClasses: StorageClassKind[];
 };
 
 const defaultAppContext: AppContextProps = {
   buildStatuses: [],
   // At runtime dashboardConfig is never null -- DO NOT DO THIS usually
   dashboardConfig: null as unknown as DashboardConfig,
+  storageClasses: [] as StorageClassKind[],
 };
 
 export const AppContext = React.createContext(defaultAppContext);

--- a/frontend/src/concepts/k8s/useStorageClasses.ts
+++ b/frontend/src/concepts/k8s/useStorageClasses.ts
@@ -1,0 +1,6 @@
+import useFetchState from '~/utilities/useFetchState';
+import { getStorageClasses } from '~/api';
+
+const useStorageClasses = () => useFetchState(getStorageClasses, []);
+
+export default useStorageClasses;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -41,6 +41,14 @@ type DisplayNameAnnotations = Partial<{
   'openshift.io/display-name': string; // the name provided by the user
 }>;
 
+type StorageClassAnnotations = Partial<{
+  // if true, enables any persistent volume claim (PVC) that does not specify a specific storage class to automatically be provisioned.
+  // Only one, if any, StorageClass per cluster can be set as default.
+  'storageclass.kubernetes.io/is-default-class': 'true' | 'false';
+  // the description provided by the cluster admin or Container Storage Interface (CSI) provider
+  'kubernetes.io/description': string;
+}>;
+
 export type K8sDSGResource = K8sResourceCommon & {
   metadata: {
     annotations?: DisplayNameAnnotations;
@@ -248,6 +256,18 @@ export type PersistentVolumeClaimKind = K8sResourceCommon & {
       storage: string;
     };
   } & Record<string, unknown>;
+};
+
+export type StorageClassKind = K8sResourceCommon & {
+  metadata: {
+    annotations?: StorageClassAnnotations;
+    name: string;
+  };
+  provisioner: string;
+  parameters?: string;
+  reclaimPolicy: string;
+  volumeBindingMode: string;
+  allowVolumeExpansion?: boolean;
 };
 
 export type NotebookKind = K8sResourceCommon & {
@@ -721,6 +741,7 @@ export type DashboardConfigKind = K8sResourceCommon & {
     notebookController?: {
       enabled: boolean;
       pvcSize?: string;
+      storageClassName?: string;
       notebookNamespace?: string;
       gpuSetting?: GpuSettingString;
       notebookTolerationSettings?: TolerationSettings;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -19,6 +19,7 @@ import { useUser } from '~/redux/selectors';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { AppContext } from '~/app/AppContext';
 import { fireTrackingEvent } from '~/utilities/segmentIOUtils';
+import usePreferredStorageClass from '~/pages/projects/screens/spawner/storage/usePreferredStorageClass';
 import {
   createPvcDataForNotebook,
   createConfigMapsAndSecretsForNotebook,
@@ -44,12 +45,14 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   canEnablePipelines,
 }) => {
   const [errorMessage, setErrorMessage] = React.useState('');
+
   const {
     dashboardConfig: {
       spec: { notebookController },
     },
   } = React.useContext(AppContext);
   const tolerationSettings = notebookController?.notebookTolerationSettings;
+  const storageClass = usePreferredStorageClass();
   const {
     notebooks: { data },
     dataConnections: { data: existingDataConnections },
@@ -187,7 +190,11 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
         ? [dataConnection.existing]
         : [];
 
-    const pvcDetails = await createPvcDataForNotebook(projectName, storageData).catch(handleError);
+    const pvcDetails = await createPvcDataForNotebook(
+      projectName,
+      storageData,
+      storageClass?.metadata.name,
+    ).catch(handleError);
     const envFrom = await createConfigMapsAndSecretsForNotebook(projectName, [
       ...envVariables,
       ...newDataConnection,

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -30,6 +30,7 @@ import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnv
 export const createPvcDataForNotebook = async (
   projectName: string,
   storageData: StorageData,
+  storageClassName?: string,
 ): Promise<{ volumes: Volume[]; volumeMounts: VolumeMount[] }> => {
   const {
     storageType,
@@ -42,7 +43,7 @@ export const createPvcDataForNotebook = async (
   const { volumes, volumeMounts } = getVolumesByStorageData(storageData);
 
   if (storageType === StorageType.NEW_PVC) {
-    const pvcData = assemblePvc(pvcName, projectName, pvcDescription, size);
+    const pvcData = assemblePvc(pvcName, projectName, pvcDescription, size, storageClassName);
     const pvc = await createPvc(pvcData);
     const newPvcName = pvc.metadata.name;
     volumes.push({ name: newPvcName, persistentVolumeClaim: { claimName: newPvcName } });

--- a/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { AppContext } from '~/app/AppContext';
+import { StorageClassKind } from '~/k8sTypes';
+
+const usePreferredStorageClass = (): StorageClassKind | undefined => {
+  const {
+    dashboardConfig: {
+      spec: { notebookController },
+    },
+    storageClasses,
+  } = React.useContext(AppContext);
+
+  const defaultClusterStorageClasses = storageClasses.filter((storageclass) =>
+    storageclass.metadata.annotations?.['storageclass.kubernetes.io/is-default-class']?.includes(
+      'true',
+    ),
+  );
+
+  const configStorageClassName = notebookController?.storageClassName ?? '';
+
+  if (defaultClusterStorageClasses.length != 0) {
+    return undefined;
+  }
+
+  if (configStorageClassName == '') {
+    return undefined;
+  }
+
+  const storageClassDashBoardConfigVsCluster = storageClasses.filter((storageclass) =>
+    storageclass.metadata.name.includes(configStorageClassName),
+  );
+
+  if (storageClassDashBoardConfigVsCluster.length === 0) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'no cluster default storageclass set and notebooks.storageClassName entry is not in list of cluster StorageClasses',
+    );
+
+    return undefined;
+  }
+
+  return storageClassDashBoardConfigVsCluster[0];
+};
+
+export default usePreferredStorageClass;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -59,6 +59,7 @@ export type DashboardConfig = K8sResourceCommon & {
     notebookController?: {
       enabled: boolean;
       pvcSize?: string;
+      storageClassName?: string;
       notebookNamespace?: string;
       gpuSetting?: GpuSettingString;
       notebookTolerationSettings?: TolerationSettings;


### PR DESCRIPTION
first try at storageclasses get and promises
early stage ... runs and build without errors

related to https://github.com/opendatahub-io/odh-dashboard/issues/1701

## Description
trying to get all storageclasses via api call, working nicely.

never mind any 404 on /notebooks routes in screenshots, for local tests together with remote AWS Rosa cluster, I did not bother to install kubeflow and odh notebook controller, which create the routes from kind: Notebook as well as the CRD for Notebook, as part of ODH on my test Rosa cluster. PVC creation by ODH dashboard can be checked with that setup, too.

Q: @andrewballantyne since storage classes of the cluster are not namespace-specific, would it make sense to put the cluster storage classes into the React JS appContext instead of the ProjectDetailsContext? I don't think we need to watch the cluster storage classes for changes, it is enough to load them at application startup or on hard browser refreshs

I did just that in this PR.

## How Has This Been Tested?

npm run-script dev


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
