### PR TITLE
Limit storage min size onBlur instead of onChange

### DIFF
--- a/frontend/src/pages/projects/components/PVSizeField.tsx
+++ b/frontend/src/pages/projects/components/PVSizeField.tsx
@@ -40,7 +40,13 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({ fieldID, size, setSize, curre
           onChange={(event) => {
             if (isHTMLInputElement(event.target)) {
               const newSize = Number(event.target.value);
-              setSize(isNaN(newSize) ? size : Math.max(newSize, minSize));
+              setSize(isNaN(newSize) ? size : newSize);
+            }
+          }}
+          onBlur={(event) => {
+            if (isHTMLInputElement(event.target)) {
+              const blurSize = Number(event.target.value);
+              setSize(Math.max(blurSize, minSize));
             }
           }}
         />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1564 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This issue is because we check the input with the min size when the value changes, which will bring a bad user experience for the users. For example, if the minimum size is `5` and the user tries changing it to `35`, it's a valid value. However, the current `onChange` listener will prevent the user from doing that because as soon as the user inputs `3`, the listener will find this value is less than `5` and reset it back to 5. It won't wait until the user inputs the whole `35`.
The solution is to compare the minimum value and reset it in `onBlur` event instead of `onChange` event, in this way, the user could input any number value he wants, however, if the value is smaller than the min size, it will be reset when the input field loses focus.

Behavior now:

https://github.com/opendatahub-io/odh-dashboard/assets/37624318/e339b97a-98dc-4d1f-be9f-b4f6b2532dc7

Please check if the current UX is acceptable @kywalker-rh @xianli123 

**Note: This fix is only for the current UI, once we have https://github.com/opendatahub-io/odh-dashboard/pull/1714 merged to the main branch, we don't need this fix anymore since we don't do any validation when the user inputs values. There is no way to limit the size when they can change between different units. The validation will only happens when they hit submit button then.**

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the the DS projects details page
2. Try to create a workbench with a storage
3. Wait for a few seconds, make sure the storage is bound with the notebook and has a size bar
<img width="414" alt="Screenshot 2023-09-05 at 9 51 36 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/87df4bac-5438-4e10-b4e7-2ded40b3dc64">
4. Try to edit the storage
5. You will find you can input the value normally now

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
It's a UX stuff, N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
