### PR TITLE
tooltip on pipeline screen impede clicking of the slider right above

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -169,22 +169,20 @@ export const RunJobStatus: RunJobUtil<{ onToggle: (value: boolean) => Promise<vo
   return (
     <Level hasGutter>
       <LevelItem>
-        <Tooltip content={isEnabled ? 'Enabled' : 'Disabled'}>
-          <Switch
-            id={`${job.id}-toggle`}
-            aria-label={`Toggle switch; ${isEnabled ? 'Enabled' : 'Disabled'}`}
-            isDisabled={isChangingFlag}
-            onChange={(checked) => {
-              setIsChangingFlag(true);
-              setError(null);
-              onToggle(checked).catch((e) => {
-                setError(e);
-                setIsChangingFlag(false);
-              });
-            }}
-            isChecked={isEnabled}
-          />
-        </Tooltip>
+        <Switch
+          id={`${job.id}-toggle`}
+          aria-label={`Toggle switch; ${isEnabled ? 'Enabled' : 'Disabled'}`}
+          isDisabled={isChangingFlag}
+          onChange={(checked) => {
+            setIsChangingFlag(true);
+            setError(null);
+            onToggle(checked).catch((e) => {
+              setError(e);
+              setIsChangingFlag(false);
+            });
+          }}
+          isChecked={isEnabled}
+        />
       </LevelItem>
       <LevelItem>
         {isChangingFlag && <Spinner size="md" />}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1586 

## Description
Removed the tooltip
 

[Screencast from 2023-09-06 19-54-12.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/961c95a9-4996-4b4a-8b09-e9a1566710b4)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
1. Create some scheduled runs
2. Go to Run page and in the Scheduled tab check for the status column

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
No test coverage
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
