### PR TITLE
Add shm to ServingRuntime volumes and volumeMounts

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -901,8 +901,10 @@ export type ServingRuntime = K8sResourceCommon & {
       image: string;
       name: string;
       resources: ContainerResources;
+      volumeMounts?: VolumeMount[];
     }[];
     supportedModelFormats: SupportedModelFormats[];
     replicas: number;
+    volumes?: Volume[];
   };
 };

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -26,17 +26,7 @@ import {
 } from '~/concepts/pipelines/elyra/utils';
 import { createRoleBinding } from '~/api';
 import { Volume, VolumeMount } from '~/types';
-import { assemblePodSpecOptions } from './utils';
-
-const getshmVolumeMount = (): VolumeMount => ({
-  name: 'shm',
-  mountPath: '/dev/shm',
-});
-
-const getshmVolume = (): Volume => ({
-  name: 'shm',
-  emptyDir: { medium: 'Memory' },
-});
+import { assemblePodSpecOptions, getshmVolume, getshmVolumeMount } from './utils';
 
 const assembleNotebook = (
   data: StartNotebookData,

--- a/frontend/src/api/k8s/utils.ts
+++ b/frontend/src/api/k8s/utils.ts
@@ -4,6 +4,8 @@ import {
   PodToleration,
   TolerationSettings,
   ContainerResourceAttributes,
+  VolumeMount,
+  Volume,
 } from '~/types';
 import { determineTolerations } from '~/utilities/tolerations';
 
@@ -54,3 +56,13 @@ export const assemblePodSpecOptions = (
   const tolerations = determineTolerations(gpus > 0, tolerationSettings);
   return { affinity, tolerations, resources };
 };
+
+export const getshmVolumeMount = (): VolumeMount => ({
+  name: 'shm',
+  mountPath: '/dev/shm',
+});
+
+export const getshmVolume = (sizeLimit?: string): Volume => ({
+  name: 'shm',
+  emptyDir: { medium: 'Memory', ...(sizeLimit && { sizeLimit }) },
+});

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -12,6 +12,7 @@ import {
   TolerationSettings,
   ImageStreamStatusTagItem,
   ImageStreamStatusTagCondition,
+  VolumeMount,
 } from './types';
 import { ServingRuntimeSize } from './pages/modelServing/screens/types';
 
@@ -327,9 +328,11 @@ export type ServingRuntimeKind = K8sResourceCommon & {
       image: string;
       name: string;
       resources: ContainerResources;
+      volumeMounts?: VolumeMount[];
     }[];
     supportedModelFormats: SupportedModelFormats[];
     replicas: number;
+    volumes?: Volume[];
   };
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1685 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Apply shm `volumes` and `volumeMounts` when creating or updating (this is for backward compatibility, let me know if we want only to apply this to the future created serving runtimes @lucferbux ) the serving runtime.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a model server
2. Check the YAML object of the model server (ServingRuntime), make sure you can see the following in the container
```
volumeMounts:
  - mountPath: /dev/shm
  name: shm
```
and the following in the spec:
```
volumes:
  - emptyDir:
    medium: Memory
    sizeLimit: 2Gi
  name: shm
```

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
