### PR TITLE
Minor accelerator fixes

### DIFF
--- a/backend/src/plugins/kube.ts
+++ b/backend/src/plugins/kube.ts
@@ -85,7 +85,7 @@ export default fp(async (fastify: FastifyInstance) => {
   cleanupGPU(fastify).catch((e) =>
     fastify.log.error(
       `Unable to fully convert GPU to use accelerator profiles. ${
-        e.response?.body?.message || e.message
+        e.response?.body?.message || e.message || e
       }`,
     ),
   );

--- a/backend/src/routes/api/accelerators/acceleratorUtils.ts
+++ b/backend/src/routes/api/accelerators/acceleratorUtils.ts
@@ -33,23 +33,23 @@ export const getAcceleratorNumbers = async (
 
           // update the max count for each accelerator
           Object.entries(allocatable).forEach(
-            ([key, value]) => (info.available[key] = Math.max(info.available[key] || 0, value)),
+            ([key, value]) => (info.available[key] = Math.max(info.available[key] ?? 0, value)),
           );
 
           // update the total count for each accelerator
           Object.entries(capacity).forEach(
-            ([key, value]) => (info.total[key] = (info.total[key] || 0) + value),
+            ([key, value]) => (info.total[key] = (info.total[key] ?? 0) + value),
           );
 
           // update the allocated count for each accelerator
           Object.entries(capacity).forEach(
             ([key, value]) =>
-              (info.allocated[key] = (info.allocated[key] || 0) + value - (allocatable[key] || 0)),
+              (info.allocated[key] = (info.allocated[key] ?? 0) + value - (allocatable[key] ?? 0)),
           );
 
           // if any accelerators are available, the cluster is configured
           const configured =
-            info.configured || Object.values(info.available).some((value) => value > 0);
+            info.configured ?? Object.values(info.available).some((value) => value > 0);
 
           return {
             total: info.total,
@@ -63,7 +63,9 @@ export const getAcceleratorNumbers = async (
     )
     .catch((e) => {
       fastify.log.error(
-        `Exception when listing cluster nodes: ${e.response?.body?.message || e.message || e}`,
+        `A ${e.statusCode} error occurred when listing cluster nodes: ${
+          e.response?.body?.message || e.statusMessage
+        }`,
       );
       return { configured: false, available: {}, total: {}, allocated: {} };
     });

--- a/frontend/src/components/SimpleDropdownSelect.tsx
+++ b/frontend/src/components/SimpleDropdownSelect.tsx
@@ -58,7 +58,7 @@ const SimpleDropdownSelect: React.FC<SimpleDropdownProps> = ({
               setOpen(false);
             }}
           >
-            {isPlaceholder ? <i>{label}</i> : label}
+            {label}
           </DropdownItem>
         ))}
     />

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
@@ -47,13 +47,19 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj }) =>
       <DescriptionListGroup>
         <DescriptionListTerm>Accelerator</DescriptionListTerm>
         <DescriptionListDescription>
-          {accelerator.accelerator?.spec.displayName || 'unknown'}
+          {accelerator.accelerator
+            ? accelerator.accelerator.spec.displayName
+            : accelerator.useExisting
+            ? 'Unknown'
+            : 'None'}
         </DescriptionListDescription>
       </DescriptionListGroup>
-      <DescriptionListGroup>
-        <DescriptionListTerm>Number of accelerators</DescriptionListTerm>
-        <DescriptionListDescription>{accelerator.count}</DescriptionListDescription>
-      </DescriptionListGroup>
+      {!accelerator.useExisting && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Number of accelerators</DescriptionListTerm>
+          <DescriptionListDescription>{accelerator.count}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
     </DescriptionList>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -107,7 +107,7 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
             acceleratorState={acceleratorState}
             setAcceleratorState={setAcceleratorState}
             supportedAccelerators={supportedAccelerators}
-            supportedText="Compatible with serving runtime"
+            resourceDisplayName="serving runtime"
           />
         </FormGroup>
       )}

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorSelectField.tsx
@@ -22,14 +22,14 @@ type AcceleratorSelectFieldProps = {
   acceleratorState: AcceleratorState;
   setAcceleratorState: UpdateObjectAtPropAndValue<AcceleratorState>;
   supportedAccelerators?: string[];
-  supportedText?: string;
+  resourceDisplayName?: string;
 };
 
 const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
   acceleratorState,
   setAcceleratorState,
   supportedAccelerators,
-  supportedText,
+  resourceDisplayName = 'image',
 }) => {
   const [detectedAcceleratorInfo] = useAcceleratorCounts();
 
@@ -83,7 +83,7 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
           <SplitItem isFilled />
           <SplitItem>
             {isAcceleratorSupported(ac) && (
-              <Label color="blue">{supportedText ?? 'Compatible with image'}</Label>
+              <Label color="blue">{`Compatible with ${resourceDisplayName}`}</Label>
             )}
           </SplitItem>
         </Split>
@@ -109,13 +109,12 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
   if (accelerator && supportedAccelerators !== undefined) {
     if (supportedAccelerators?.length === 0) {
       acceleratorAlertMessage = {
-        title:
-          "The image you have selected doesn't support the selected accelerator. It is recommended to use a compatible image for optimal performance.",
+        title: `The ${resourceDisplayName} you have selected doesn't support the selected accelerator. It is recommended to use a compatible ${resourceDisplayName} for optimal performance.`,
         variant: AlertVariant.info,
       };
     } else if (!isAcceleratorSupported(accelerator)) {
       acceleratorAlertMessage = {
-        title: 'The image you have selected is not compatible with the selected accelerator',
+        title: `The ${resourceDisplayName} you have selected is not compatible with the selected accelerator`,
         variant: AlertVariant.warning,
       };
     }
@@ -139,7 +138,7 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
   }
 
   const onStep = (step: number) => {
-    setAcceleratorState('count', Math.max(acceleratorCount + step, 0));
+    setAcceleratorState('count', Math.max(acceleratorCount + step, 1));
   };
 
   // if there is more than a none option, show the dropdown
@@ -168,6 +167,7 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
                 setAcceleratorState('count', 0);
               } else {
                 // normal flow
+                setAcceleratorState('count', 1);
                 setAcceleratorState('useExisting', false);
                 setAcceleratorState(
                   'accelerator',
@@ -198,13 +198,13 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
                 name="number-of-accelerators"
                 value={acceleratorCount}
                 validated={acceleratorCountWarning ? 'warning' : 'default'}
-                min={0}
+                min={1}
                 onPlus={() => onStep(1)}
                 onMinus={() => onStep(-1)}
                 onChange={(event) => {
                   if (isHTMLInputElement(event.target)) {
                     const newSize = Number(event.target.value);
-                    setAcceleratorState('count', newSize);
+                    setAcceleratorState('count', Math.max(newSize, 1));
                   }
                 }}
               />

--- a/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
@@ -108,13 +108,19 @@ const NotebookServerDetails: React.FC = () => {
         <DescriptionListGroup>
           <DescriptionListTerm>Accelerator</DescriptionListTerm>
           <DescriptionListDescription>
-            {accelerator.accelerator?.spec.displayName || 'unknown'}
+            {accelerator.accelerator
+              ? accelerator.accelerator.spec.displayName
+              : accelerator.useExisting
+              ? 'Unknown'
+              : 'None'}
           </DescriptionListDescription>
         </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Number of accelerators</DescriptionListTerm>
-          <DescriptionListDescription>{accelerator.count}</DescriptionListDescription>
-        </DescriptionListGroup>
+        {!accelerator.useExisting && (
+          <DescriptionListGroup>
+            <DescriptionListTerm>Number of accelerators</DescriptionListTerm>
+            <DescriptionListDescription>{accelerator.count}</DescriptionListDescription>
+          </DescriptionListGroup>
+        )}
       </DescriptionList>
     </ExpandableSection>
   );

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -232,8 +232,12 @@ const SpawnerPage: React.FC = () => {
 
   const fireStartServerEvent = () => {
     fireTrackingEvent('Notebook Server Started', {
-      accelerator: accelerator.accelerator ? JSON.stringify(accelerator.accelerator) : 'unknown',
-      acceleratorCount: accelerator.count,
+      accelerator: accelerator.accelerator
+        ? `${accelerator.accelerator.spec.displayName} (${accelerator.accelerator.metadata.name}): ${accelerator.accelerator.spec.identifier}`
+        : accelerator.useExisting
+        ? 'Unknown'
+        : 'None',
+      acceleratorCount: accelerator.useExisting ? undefined : accelerator.count,
       lastSelectedSize: selectedSize.name,
       lastSelectedImage: `${selectedImageTag.image?.name}:${selectedImageTag.tag?.name}`,
     });

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -51,10 +51,12 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
   const fireNotebookTrackingEvent = React.useCallback(
     (action: 'started' | 'stopped') => {
       fireTrackingEvent(`Workbench ${action}`, {
-        acceleratorCount: acceleratorData.count,
+        acceleratorCount: acceleratorData.useExisting ? undefined : acceleratorData.count,
         accelerator: acceleratorData.accelerator
-          ? JSON.stringify(acceleratorData.accelerator)
-          : 'unknown',
+          ? `${acceleratorData.accelerator.spec.displayName} (${acceleratorData.accelerator.metadata.name}): ${acceleratorData.accelerator.spec.identifier}`
+          : acceleratorData.useExisting
+          ? 'Unknown'
+          : 'None',
         lastSelectedSize:
           size?.name ||
           notebook.metadata.annotations?.['notebooks.opendatahub.io/last-size-selection'],

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -80,8 +80,12 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   const afterStart = (name: string, type: 'created' | 'updated') => {
     const { accelerator, notebookSize, image } = startNotebookData;
     fireTrackingEvent(`Workbench ${type}`, {
-      acceleratorCount: accelerator.count,
-      accelerator: accelerator ? JSON.stringify(accelerator.accelerator) : 'unknown',
+      acceleratorCount: accelerator.useExisting ? undefined : accelerator.count,
+      accelerator: accelerator.accelerator
+        ? `${accelerator.accelerator.spec.displayName} (${accelerator.accelerator.metadata.name}): ${accelerator.accelerator.spec.identifier}`
+        : accelerator.useExisting
+        ? 'Unknown'
+        : 'None',
       lastSelectedSize: notebookSize.name,
       lastSelectedImage: image.imageVersion?.from
         ? `${image.imageVersion.from.name}`


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1765

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Minor UX and bug fixes found by testers
- making naming in the error states of the dropdown dynamic so they can use image or servingruntime
- improved backend logging to be more verbose and not miss any exit points
- remove double array usage in accelerator state hook
- remove usage of unknown when we know that there is not an accelerator for description fields and logging - replaced with None when there is no accelerator, and unknown when we use existing settings
- prevent count from going to 0 -> same logic as other number inputs. The default and limit are now 1.
- removed italics from dropdown None option

<img width="645" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/b522fd27-0486-4f7f-9018-ab4f2b34e01b">
<img width="640" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/47cb8c6c-7a3c-48a2-8a5e-ea303bebbba8">
<img width="721" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/d29e1b28-0b15-4dad-a11b-de979c71694a">
<img width="695" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/aa64ffec-9f17-47eb-8d98-7b8758974407">
<img width="718" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/ceb80b54-10ab-415b-8cd0-d756034b0ef5">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Migration should always give a logging on error, success, or skipping
2. test that errors display correctly in migration (try removing crd for acceleratorprofiles so it throws a 404 error on migration)
3. serving runtime dropdown errors should not reference an image
4. count should always default to 1 and should not be able to go to 0

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no tests are made for this feature yet. These will be created once the feature has gone through development

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

There are UI changes, but they are not changes in the UX, just small bugs. I will still tag UX, however there is not much action needed.
@yannnz 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
