### PR TITLE
Add owner references to Elyra role binding when creating notebooks

### DIFF
--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -17,14 +17,13 @@ import { translateDisplayNameForK8s } from '~/pages/projects/utils';
 import { getTolerationPatch, TolerationChanges } from '~/utilities/tolerations';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import {
+  createElyraServiceAccountRoleBinding,
   ELYRA_VOLUME_NAME,
-  generateElyraServiceAccountRoleBinding,
   getElyraVolume,
   getElyraVolumeMount,
   getPipelineVolumeMountPatch,
   getPipelineVolumePatch,
 } from '~/concepts/pipelines/elyra/utils';
-import { createRoleBinding } from '~/api';
 import { Volume, VolumeMount } from '~/types';
 import { assemblePodSpecOptions, getshmVolume, getshmVolumeMount } from './utils';
 
@@ -207,8 +206,7 @@ export const stopNotebook = (name: string, namespace: string): Promise<NotebookK
   });
 
 export const startNotebook = async (
-  name: string,
-  namespace: string,
+  notebook: NotebookKind,
   tolerationChanges: TolerationChanges,
   enablePipelines?: boolean,
 ): Promise<NotebookKind> => {
@@ -223,18 +221,12 @@ export const startNotebook = async (
   if (enablePipelines) {
     patches.push(getPipelineVolumePatch());
     patches.push(getPipelineVolumeMountPatch());
-    await createRoleBinding(generateElyraServiceAccountRoleBinding(name, namespace)).catch((e) => {
-      // This is not ideal, but it shouldn't impact the starting of the notebook. Let us log it, and mute the error
-      // eslint-disable-next-line no-console
-      console.error(
-        `Could not patch rolebinding to service account for notebook, ${name}; Reason ${e.message}`,
-      );
-    });
+    await createElyraServiceAccountRoleBinding(notebook);
   }
 
   return k8sPatchResource<NotebookKind>({
     model: NotebookModel,
-    queryOptions: { name, ns: namespace },
+    queryOptions: { name: notebook.metadata.name, ns: notebook.metadata.namespace },
     patches,
   });
 };
@@ -252,9 +244,9 @@ export const createNotebook = (
   });
 
   if (canEnablePipelines) {
-    return createRoleBinding(
-      generateElyraServiceAccountRoleBinding(notebook.metadata.name, notebook.metadata.namespace),
-    ).then(() => notebookPromise);
+    return notebookPromise.then((notebook) =>
+      createElyraServiceAccountRoleBinding(notebook).then(() => notebook),
+    );
   }
 
   return notebookPromise;

--- a/frontend/src/api/k8s/roleBindings.ts
+++ b/frontend/src/api/k8s/roleBindings.ts
@@ -1,4 +1,5 @@
 import {
+  OwnerReference,
   k8sCreateResource,
   k8sDeleteResource,
   k8sGetResource,
@@ -159,6 +160,23 @@ export const patchRoleBindingName = (
         op: 'replace',
         path: '/roleRef/name',
         value: rbRoleRefType,
+      },
+    ],
+  });
+
+export const patchRoleBindingOwnerRef = (
+  rbName: string,
+  namespace: string,
+  ownerReferences: OwnerReference[],
+): Promise<RoleBindingKind> =>
+  k8sPatchResource<RoleBindingKind>({
+    model: RoleBindingModel,
+    queryOptions: { name: rbName, ns: namespace },
+    patches: [
+      {
+        op: 'replace',
+        path: '/metadata/ownerReferences',
+        value: ownerReferences,
       },
     ],
   });

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -99,8 +99,7 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
                   notebookState.notebook,
                 );
                 startNotebook(
-                  notebookName,
-                  notebookNamespace,
+                  notebook,
                   tolerationSettings,
                   enablePipelines && !currentlyHasPipelines(notebook),
                 ).then(() => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1721 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Check the Elyra service account role binding every time we create/restart a notebook with the enabled pipelines feature. If the role binding is there, check the `ownerReferences` field to see if the notebook is the owner, if not, patch it. If the role binding is not there, create a new one with the `ownerReferences` field and set the notebook as the owner. In this way, every time the user deletes the notebook, it will also delete the role binding.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable pipelines
2. Create a workbench
3. Check the role binding named `elyra-pipelines-${workbenchName}` is created and has the `ownerReferences` field
4. Try to delete the workbench, make sure the role binding is also deleted along with the deletion of the workbench
5. Create a workbench again, then remove the `ownerReferences` field in the role binding
6. Delete the workbench, you will find the role binding is not deleted
7. Then create a workbench with the same name in step 5
8. Check the role binding and you will find it's patched with the `ownerReferences` field again with the new workbench uid
9. Delete the workbench, and make sure the role binding is deleted too
10. Repeat step 5
11. Stop the workbench, then restart it
12. You will find the `ownerReferences` field is added
13. Toggle the status, make sure the role binding is not affected and no error out

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, it's about a field in role binding,

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
