### PR TITLE
Update Custom Serving Runtime tooltip with Openshift resource information

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -758,3 +758,14 @@ export type AcceleratorKind = K8sResourceCommon & {
     tolerations?: PodToleration[];
   };
 };
+
+// In the SDK TResource extends from K8sResourceCommon, but both kind and apiVersion are mandatory
+export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> = {
+  apiVersion: string;
+  kind: string;
+  items: TResource[];
+  metadata: {
+    resourceVersion: string;
+    continue: string;
+  };
+};

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -35,7 +35,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
         }}
       />
       <Td dataLabel="Name" width={70} className="pf-u-text-break-word">
-        <ResourceNameTooltip resource={template.objects[0]}>
+        <ResourceNameTooltip resource={template}>
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>
         {templateOOTB && <Label>Pre-installed</Label>}

--- a/frontend/src/services/templateService.ts
+++ b/frontend/src/services/templateService.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import YAML from 'yaml';
 import { assembleServingRuntimeTemplate } from '~/api';
 import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
+import { addTypesToK8sListedResources } from '~/utilities/addTypesToK8sListedResources';
 
 export const listTemplatesBackend = async (
   namespace?: string,
@@ -10,7 +11,7 @@ export const listTemplatesBackend = async (
 ): Promise<TemplateKind[]> =>
   axios
     .get(`/api/templates/${namespace}`, { params: { labelSelector } })
-    .then((response) => response.data.items)
+    .then((response) => addTypesToK8sListedResources<TemplateKind>(response.data, 'Template').items)
     .catch((e) => Promise.reject(e));
 
 const dryRunServingRuntimeForTemplateCreationBackend = (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -289,7 +289,7 @@ type K8sMetadata = {
 /**
  * @deprecated -- use the SDK version -- see k8sTypes.ts
  * All references that use this are un-vetted data against existing types, should be converted over
- * to the new K8sResourceCommon from the SDK to keep everythung unified on one front.
+ * to the new K8sResourceCommon from the SDK to keep everything unified on one front.
  */
 export type K8sResourceCommon = {
   apiVersion?: string;

--- a/frontend/src/utilities/__tests__/addTypesToK8sListedResources.spec.ts
+++ b/frontend/src/utilities/__tests__/addTypesToK8sListedResources.spec.ts
@@ -1,0 +1,36 @@
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { addTypesToK8sListedResources } from '~/utilities/addTypesToK8sListedResources';
+
+const servingRuntimeTemplate = {
+  apiVersion: 'template.openshift.io/v1',
+  kind: 'TemplateList',
+  items: [
+    {
+      metadata: {
+        name: 'test-model',
+        annotations: {
+          'openshift.io/display-name': 'New OVMS Server',
+        },
+        labels: {
+          'opendatahub.io/dashboard': 'true',
+        },
+      },
+    },
+  ],
+  metadata: {
+    resourceVersion: '24348645',
+    continue: '',
+  },
+};
+
+describe('addTypesToK8sListedResources', () => {
+  it('should have apiVersion and kind as Template', () => {
+    const list = addTypesToK8sListedResources(servingRuntimeTemplate, 'Template');
+    expect(list).not.toBe(servingRuntimeTemplate);
+    expect(list.items).toHaveLength(servingRuntimeTemplate.items.length);
+    list.items.forEach((i: Partial<K8sResourceCommon>) => {
+      expect(i.apiVersion).toBe('template.openshift.io/v1');
+      expect(i.kind).toBe('Template');
+    });
+  });
+});

--- a/frontend/src/utilities/addTypesToK8sListedResources.ts
+++ b/frontend/src/utilities/addTypesToK8sListedResources.ts
@@ -1,0 +1,14 @@
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sResourceListResult } from '~/k8sTypes';
+
+export const addTypesToK8sListedResources = <TResource extends Partial<K8sResourceCommon>>(
+  response: K8sResourceListResult<TResource>,
+  kind: string,
+): K8sResourceListResult<TResource> => ({
+  ...response,
+  items: response.items.map((i) => ({
+    ...i,
+    apiVersion: response.apiVersion,
+    kind,
+  })),
+});


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1615

## Description
This PR aims to update the Custom Serving Runtime tooltip with the openshift resource information. Also, this PR takes care of adding "kind" to  the k8s resource. 

![Screenshot from 2023-09-11 18-02-44](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/3a5dffa1-e604-442c-a151-b3031145f9c8)



## How Has This Been Tested?
1) Log in to Dashboard with a Dashboard Admin user
2) go to Settings > Serving runtimes
3) find a Custom Serving Runtime if present, otherwise create one
4) go hover the "Question Mark" icon
5) try searching the OpenShift resource by using the information in the tooltip message

## Test Impact
Added unit test case for the utilities component.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
