### PR TITLE
Fix model server expand issue on the project details page

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -45,17 +45,33 @@ test('Legacy Serving Runtime', async ({ page }) => {
   await page.waitForSelector('text=Add server');
 
   // Check that the legacy serving runtime is shown with the default runtime name
-  expect(await page.getByText('ovms')).toBeTruthy();
+  expect(page.getByText('ovms')).toBeTruthy();
 
   // Check that the legacy serving runtime displays the correct Serving Runtime
-  expect(await page.getByText('OpenVINO Model Server')).toBeTruthy();
+  expect(page.getByText('OpenVINO Model Server')).toBeTruthy();
 
   // Check that the legacy serving runtime has tokens disabled
-  expect(await page.getByText('Tokens disabled')).toBeTruthy();
+  expect(page.getByText('Tokens disabled')).toBeTruthy();
 
   // Check that the serving runtime is shown with the default runtime name
-  expect(await page.getByText('OVMS Model Serving')).toBeTruthy();
+  expect(page.getByText('OVMS Model Serving')).toBeTruthy();
 
   // Check that the serving runtime displays the correct Serving Runtime
-  expect(await page.getByText('OpenVINO Serving Runtime (Supports GPUs)')).toBeTruthy();
+  expect(page.getByText('OpenVINO Serving Runtime (Supports GPUs)')).toBeTruthy();
+
+  // Get the first and second row
+  const firstButton = page.getByRole('button', { name: 'ovms', exact: true });
+  const secondButton = page.getByRole('button', { name: 'OVMS Model Serving', exact: true });
+  const firstRow = page.getByRole('rowgroup').filter({ has: firstButton });
+  const secondRow = page.getByRole('rowgroup').filter({ has: secondButton });
+
+  // Check that both of the rows are not expanded
+  await expect(firstRow).not.toHaveClass('pf-m-expanded');
+  await expect(secondRow).not.toHaveClass('pf-m-expanded');
+
+  await firstButton.click();
+
+  // Check that the first row is expanded while the second is not
+  await expect(firstRow).toHaveClass('pf-m-expanded');
+  await expect(secondRow).not.toHaveClass('pf-m-expanded');
 });

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTable.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import Table from '~/components/table/Table';
 import { AccessReviewResourceAttributes, ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { ServingRuntimeTableTabs } from '~/pages/modelServing/screens/types';
 import { useAccessReview } from '~/api';
 import { columns } from './data';
 import ServingRuntimeTableRow from './ServingRuntimeTableRow';
@@ -20,7 +19,7 @@ const ServingRuntimeTable: React.FC = () => {
   const [deployServingRuntime, setDeployServingRuntime] = React.useState<ServingRuntimeKind>();
   const [deleteServingRuntime, setDeleteServingRuntime] = React.useState<ServingRuntimeKind>();
   const [editServingRuntime, setEditServingRuntime] = React.useState<ServingRuntimeKind>();
-  const [expandedColumn, setExpandedColumn] = React.useState<ServingRuntimeTableTabs>();
+  const [expandedServingRuntimeName, setExpandedServingRuntimeName] = React.useState<string>();
 
   const {
     servingRuntimes: { data: modelServers, refresh: refreshServingRuntime },
@@ -52,8 +51,7 @@ const ServingRuntimeTable: React.FC = () => {
             onDeleteServingRuntime={(obj) => setDeleteServingRuntime(obj)}
             onEditServingRuntime={(obj) => setEditServingRuntime(obj)}
             onDeployModel={(obj) => setDeployServingRuntime(obj)}
-            expandedColumn={expandedColumn}
-            setExpandedColumn={setExpandedColumn}
+            expandedServingRuntimeName={expandedServingRuntimeName}
             allowDelete={allowDelete}
           />
         )}
@@ -95,7 +93,7 @@ const ServingRuntimeTable: React.FC = () => {
             if (submit) {
               refreshInferenceServices();
               refreshDataConnections();
-              setExpandedColumn(ServingRuntimeTableTabs.DEPLOYED_MODELS);
+              setExpandedServingRuntimeName(deployServingRuntime.metadata.name);
             }
           }}
           projectContext={{

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -16,8 +16,7 @@ type ServingRuntimeTableRowProps = {
   onDeleteServingRuntime: (obj: ServingRuntimeKind) => void;
   onEditServingRuntime: (obj: ServingRuntimeKind) => void;
   onDeployModel: (obj: ServingRuntimeKind) => void;
-  expandedColumn?: ServingRuntimeTableTabs;
-  setExpandedColumn: (column?: ServingRuntimeTableTabs) => void;
+  expandedServingRuntimeName?: string;
   allowDelete: boolean;
 };
 
@@ -26,8 +25,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
   onDeleteServingRuntime,
   onEditServingRuntime,
   onDeployModel,
-  expandedColumn,
-  setExpandedColumn,
+  expandedServingRuntimeName,
   allowDelete,
 }) => {
   const {
@@ -39,6 +37,14 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
     serverSecrets: { loaded: secretsLoaded, error: secretsLoadError },
     filterTokens,
   } = React.useContext(ProjectDetailsContext);
+
+  const [expandedColumn, setExpandedColumn] = React.useState<ServingRuntimeTableTabs>();
+
+  React.useEffect(() => {
+    if (expandedServingRuntimeName === obj.metadata.name) {
+      setExpandedColumn(ServingRuntimeTableTabs.DEPLOYED_MODELS);
+    }
+  }, [expandedServingRuntimeName, obj.metadata.name]);
 
   const tokens = filterTokens(obj.metadata.name);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1756 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Bring the expanded column state back to each row, and make the row manage its own state. When creating a new model, it will trigger a hook in the row to compare and expand the column in that row.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create more than 2 model servers
2. Deploy a new model, it should expand the `Deployed model` tab on that model server
3. Try to expand and collapse the tab on every model server, make sure the original issue not happen

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add some unit tests to make sure the click on one model server will not expand all the rows.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
