### PR TITLE
Fix error creating pipeline server when data connection endpoint omits scheme

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   testEnvironment: 'jest-environment-jsdom',
 
   // include projects from node_modules as required
-  transformIgnorePatterns: ['node_modules/(?!yaml)'],
+  transformIgnorePatterns: ['node_modules/(?!yaml|@openshift|lodash-es|uuid)'],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   snapshotSerializers: [],

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
@@ -1,0 +1,130 @@
+import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
+import { PipelineServerConfigType } from '~/concepts/pipelines/content/configurePipelinesServer/types';
+import { createDSPipelineResourceSpec } from '~/concepts/pipelines/content/configurePipelinesServer/utils';
+
+describe('configure pipeline server utils', () => {
+  describe('createDSPipelineResourceSpec', () => {
+    const createPipelineServerConfig = () =>
+      ({
+        database: {
+          useDefault: true,
+          value: [],
+        },
+        objectStorage: {
+          useExisting: true,
+          existingName: '',
+          existingValue: [],
+        },
+      } as PipelineServerConfigType);
+
+    type SecretsResponse = Parameters<typeof createDSPipelineResourceSpec>[1];
+
+    const createSecretsResponse = (
+      databaseSecret?: SecretsResponse[0],
+      objectStorageSecret?: SecretsResponse[1],
+    ): SecretsResponse => [databaseSecret, objectStorageSecret ?? { secretName: '', awsData: [] }];
+
+    it('should create resource spec', () => {
+      const spec = createDSPipelineResourceSpec(
+        createPipelineServerConfig(),
+        createSecretsResponse(),
+      );
+      expect(spec).toEqual({
+        database: undefined,
+        objectStorage: {
+          externalStorage: {
+            bucket: '',
+            host: '',
+            s3CredentialsSecret: {
+              accessKey: 'AWS_ACCESS_KEY_ID',
+              secretKey: 'AWS_SECRET_ACCESS_KEY',
+              secretName: '',
+            },
+            scheme: 'https',
+          },
+        },
+      });
+    });
+
+    it('should parse S3 endpoint with scheme', () => {
+      const secretsResponse = createSecretsResponse();
+      secretsResponse[1].awsData = [
+        { key: AWS_KEYS.S3_ENDPOINT, value: 'http://s3.amazonaws.com' },
+      ];
+      const spec = createDSPipelineResourceSpec(createPipelineServerConfig(), secretsResponse);
+      expect(spec.objectStorage.externalStorage?.scheme).toBe('http');
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
+    });
+
+    it('should parse S3 endpoint without scheme', () => {
+      const secretsResponse = createSecretsResponse();
+
+      secretsResponse[1].awsData = [{ key: AWS_KEYS.S3_ENDPOINT, value: 's3.amazonaws.com' }];
+      const spec = createDSPipelineResourceSpec(createPipelineServerConfig(), secretsResponse);
+      expect(spec.objectStorage.externalStorage?.scheme).toBe('https');
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
+    });
+
+    it('should include bucket', () => {
+      const secretsResponse = createSecretsResponse();
+      secretsResponse[1].awsData = [{ key: AWS_KEYS.AWS_S3_BUCKET, value: 'my-bucket' }];
+      const spec = createDSPipelineResourceSpec(createPipelineServerConfig(), secretsResponse);
+      expect(spec.objectStorage.externalStorage?.bucket).toBe('my-bucket');
+    });
+
+    it('should create spec with database object', () => {
+      const config = createPipelineServerConfig();
+      config.database.value = [
+        {
+          key: 'Username',
+          value: 'test-user',
+        },
+        {
+          key: 'Port',
+          value: '8080',
+        },
+        {
+          key: 'Host',
+          value: 'test.host.com',
+        },
+        {
+          key: 'Database',
+          value: 'db-name',
+        },
+      ];
+      const spec = createDSPipelineResourceSpec(
+        config,
+        createSecretsResponse({
+          key: 'password-key',
+          name: 'password-name',
+        }),
+      );
+      expect(spec).toEqual({
+        objectStorage: {
+          externalStorage: {
+            bucket: '',
+            host: '',
+            s3CredentialsSecret: {
+              accessKey: 'AWS_ACCESS_KEY_ID',
+              secretKey: 'AWS_SECRET_ACCESS_KEY',
+              secretName: '',
+            },
+            scheme: 'https',
+          },
+        },
+        database: {
+          externalDB: {
+            host: 'test.host.com',
+            passwordSecret: {
+              key: 'password-key',
+              name: 'password-name',
+            },
+            pipelineDBName: 'db-name',
+            port: '8080',
+            username: 'test-user',
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1350

Depends on https://github.com/opendatahub-io/odh-dashboard/pull/1773 for unit tests.

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a data connect whose endpoint does not include a scheme in the URL, creating of a pipeline server will fail with a javascript error attempting to access a property of an undefined value. This is because the regex used to parse the data connection endpoint URL assumed a scheme would always be present.

This change does not affect the UI / UX.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a data connection
2. set the endpoint to `s3.amazonaws.com`
3. Create a pipeline server
4. Select pre-existing data connection
5. Click `Configure` button

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
