### PR TITLE
Minor UX fixes for custom notebook images

### DIFF
--- a/frontend/src/pages/BYONImages/BYONImageModal/ImageLocationField.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageModal/ImageLocationField.tsx
@@ -5,9 +5,14 @@ import { HelpIcon } from '@patternfly/react-icons';
 type ImageLocationFieldProps = {
   location: string;
   setLocation: (location: string) => void;
+  isDisabled: boolean;
 };
 
-const ImageLocationField: React.FC<ImageLocationFieldProps> = ({ location, setLocation }) => (
+const ImageLocationField: React.FC<ImageLocationFieldProps> = ({
+  location,
+  setLocation,
+  isDisabled,
+}) => (
   <FormGroup
     label="Image location"
     isRequired
@@ -45,6 +50,7 @@ const ImageLocationField: React.FC<ImageLocationFieldProps> = ({ location, setLo
       onChange={(value) => {
         setLocation(value);
       }}
+      isDisabled={isDisabled}
     />
   </FormGroup>
 );

--- a/frontend/src/pages/BYONImages/BYONImageModal/ManageBYONImageModal.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageModal/ManageBYONImageModal.tsx
@@ -13,6 +13,7 @@ import { importBYONImage, updateBYONImage } from '~/services/imagesService';
 import { ResponseStatus, BYONImagePackage, BYONImage } from '~/types';
 import { useAppSelector } from '~/redux/hooks';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import { filterBlankPackages } from '~/pages/BYONImages/utils';
 import ImageLocationField from './ImageLocationField';
 import DisplayedContentTabContent from './DisplayedContentTabContent';
 
@@ -90,8 +91,8 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
         // eslint-disable-next-line camelcase
         display_name: displayName,
         description: description,
-        packages: packages,
-        software: software,
+        packages: filterBlankPackages(packages),
+        software: filterBlankPackages(software),
       }).then(handleResponse);
     } else {
       importBYONImage({
@@ -100,8 +101,8 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
         url: repository,
         description: description,
         provider: userName,
-        software: software,
-        packages: packages,
+        packages: filterBlankPackages(packages),
+        software: filterBlankPackages(software),
       }).then(handleResponse);
     }
   };
@@ -132,7 +133,13 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
           submit();
         }}
       >
-        {!existingImage && <ImageLocationField location={repository} setLocation={setRepository} />}
+        {
+          <ImageLocationField
+            isDisabled={!!existingImage}
+            location={repository}
+            setLocation={setRepository}
+          />
+        }
         <FormGroup label="Name" isRequired fieldId="byon-image-name-input">
           <TextInput
             id="byon-image-name-input"

--- a/frontend/src/pages/BYONImages/BYONImagesTableRow.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTableRow.tsx
@@ -47,7 +47,7 @@ const BYONImagesTableRow: React.FC<BYONImagesTableRowProps> = ({
             onToggle: () => setExpanded(!isExpanded),
           }}
         />
-        <Td dataLabel="Name">
+        <Td dataLabel="Name" modifier="nowrap">
           <Flex
             spaceItems={{ default: 'spaceItemsSm' }}
             alignItems={{ default: 'alignItemsCenter' }}
@@ -62,8 +62,10 @@ const BYONImagesTableRow: React.FC<BYONImagesTableRowProps> = ({
             </FlexItem>
           </Flex>
         </Td>
-        <Td dataLabel="Description">{obj.description}</Td>
-        <Td dataLabel="Enable">
+        <Td dataLabel="Description" modifier="breakWord">
+          {obj.description}
+        </Td>
+        <Td dataLabel="Enable" modifier="nowrap">
           <BYONImageStatusToggle image={obj} />
         </Td>
         <Td dataLabel="Provider">{obj.provider}</Td>

--- a/frontend/src/pages/BYONImages/utils.ts
+++ b/frontend/src/pages/BYONImages/utils.ts
@@ -1,5 +1,5 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { BYONImage } from '~/types';
+import { BYONImage, BYONImagePackage } from '~/types';
 
 export const convertBYONImageToK8sResource = (image: BYONImage): K8sResourceCommon => ({
   kind: 'ImageStream',
@@ -24,3 +24,6 @@ export const getEnabledStatus = (image: BYONImage): number =>
     : image.error
     ? ImageEnabledStatus.ERROR
     : ImageEnabledStatus.DISABLED;
+
+export const filterBlankPackages = (packages: BYONImagePackage[]) =>
+  packages.filter((p) => p.name.trim() || p.version.trim());


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1769 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes the issues mentioned above.

For the first issue, add some modifiers to the table column:

https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ec6f3185-a8b1-4a1f-8918-131be6d6a50d

For the second issue, filter the blank entry of the packages/software out when users import/update the image.

For the third issue, add the disabled input field for the image location when user edit the image:

<img width="1727" alt="Screenshot 2023-09-13 at 2 04 51 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/8d4b0ffc-f9a6-4586-bd99-0ce4d03f6598">

cc @vconzola Please check the updates when you get a chance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Try to shrink the window size, and make sure the `Enabled` field is not wrapped
2. Try to create/update a notebook image, give it some blank entries (no name and no version) in the packages/software, and submit. Edit the image, and make sure those empty entries are removed
3. Edit a notebook image, you should be able to see the image location now but with a disabled status because it cannot be edited after creation

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
