### PR TITLE
Limit the use of `useTableColumnSort` hook

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -63,6 +63,14 @@
           {
             "group": ["~/api/**"],
             "message": "Read from '~/api' instead."
+          },
+          {
+            "group": ["~/components/table/**", "!~/components/table/useTableColumnSort"],
+            "message": "Read from '~/components/table' instead."
+          },
+          {
+            "group": ["~/components/table/useTableColumnSort"],
+            "message": "The data will be sorted in the table, don't use this hook outside of '~/components/table' repo. For more information, please check the props of the Table component."
           }
         ]
       }

--- a/frontend/src/components/table/Table.tsx
+++ b/frontend/src/components/table/Table.tsx
@@ -17,9 +17,10 @@ import {
   Td,
   TbodyProps,
 } from '@patternfly/react-table';
-import useTableColumnSort, { SortableData } from '~/components/table/useTableColumnSort';
-import { CHECKBOX_FIELD_ID } from '~/components/table/const';
 import { EitherNotBoth } from '~/typeHelpers';
+import useTableColumnSort from './useTableColumnSort';
+import { CHECKBOX_FIELD_ID } from './const';
+import { SortableData } from './types';
 
 type TableProps<DataType> = {
   data: DataType[];

--- a/frontend/src/components/table/const.ts
+++ b/frontend/src/components/table/const.ts
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from './types';
 
 export const CHECKBOX_FIELD_ID = 'checkbox';
 export const KEBAB_FIELD_ID = 'kebab';

--- a/frontend/src/components/table/index.ts
+++ b/frontend/src/components/table/index.ts
@@ -1,0 +1,8 @@
+export * from './types';
+export * from './const';
+
+export { default as Table } from './Table';
+export { default as useCheckboxTable } from './useCheckboxTable';
+
+export { default as TableRowTitleDescription } from './TableRowTitleDescription';
+export { default as CheckboxTd } from './CheckboxTd';

--- a/frontend/src/components/table/types.ts
+++ b/frontend/src/components/table/types.ts
@@ -1,0 +1,17 @@
+import { ThProps } from '@patternfly/react-table';
+
+export type GetColumnSort = (columnIndex: number) => ThProps['sort'];
+
+export type SortableData<T> = {
+  label: string;
+  field: string;
+  width?: ThProps['width'];
+  /**
+   * Set to false to disable sort.
+   * Set to true to handle string and number fields automatically (everything else is equal).
+   * Pass a function that will get the two results and what field needs to be matched.
+   * Assume ASC -- the result will be inverted internally if needed.
+   */
+  sortable: boolean | ((a: T, b: T, keyField: string) => number);
+  info?: ThProps['info'];
+};

--- a/frontend/src/components/table/useCheckboxTable.ts
+++ b/frontend/src/components/table/useCheckboxTable.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { xor } from 'lodash';
-import Table from '~/components/table/Table';
 import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
+import type Table from './Table';
 
 type UseCheckboxTable = {
   selections: string[];

--- a/frontend/src/components/table/useTableColumnSort.ts
+++ b/frontend/src/components/table/useTableColumnSort.ts
@@ -1,21 +1,6 @@
 import * as React from 'react';
 import { ThProps } from '@patternfly/react-table';
-
-export type GetColumnSort = (columnIndex: number) => ThProps['sort'];
-
-export type SortableData<T> = {
-  label: string;
-  field: string;
-  width?: ThProps['width'];
-  /**
-   * Set to false to disable sort.
-   * Set to true to handle string and number fields automatically (everything else is equal).
-   * Pass a function that will get the two results and what field needs to be matched.
-   * Assume ASC -- the result will be inverted internally if needed.
-   */
-  sortable: boolean | ((a: T, b: T, keyField: string) => number);
-  info?: ThProps['info'];
-};
+import { GetColumnSort, SortableData } from './types';
 
 /**
  * Using PF Composable Tables, this utility will help with handling sort logic.

--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -1,4 +1,9 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import {
+  SortableData,
+  checkboxTableColumn,
+  expandTableColumn,
+  kebabTableColumn,
+} from '~/components/table';
 import {
   PipelineKF,
   PipelineRunJobKF,
@@ -12,7 +17,6 @@ import {
   getScheduledStateWeight,
   getStatusWeight,
 } from '~/concepts/pipelines/content/tables/utils';
-import { checkboxTableColumn, expandTableColumn, kebabTableColumn } from '~/components/table/const';
 
 export const pipelineColumns: SortableData<PipelineKF>[] = [
   expandTableColumn(),

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTable.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
-import Table from '~/components/table/Table';
+import { Table } from '~/components/table';
 import PipelinesTableRow from '~/concepts/pipelines/content/tables/pipeline/PipelinesTableRow';
 import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
 import { pipelineColumns } from '~/concepts/pipelines/content/tables/columns';

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 import { relativeTime } from '~/utilities/time';
 import usePipelineRunsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineRunsForPipeline';
-import TableRowTitleDescription from '~/components/table/TableRowTitleDescription';
+import { TableRowTitleDescription } from '~/components/table';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelinesTableExpandedRow from '~/concepts/pipelines/content/tables/pipeline/PipelinesTableExpandedRow';
 import { getLastRun } from '~/concepts/pipelines/content/tables/utils';

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { TableVariant } from '@patternfly/react-table';
-import Table from '~/components/table/Table';
 import { PipelineCoreResourceKF, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import { pipelineRunColumns } from '~/concepts/pipelines/content/tables/columns';
 import PipelineRunTableRow from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow';
-import useCheckboxTable from '~/components/table/useCheckboxTable';
+import { useCheckboxTable, Table } from '~/components/table';
 import EmptyTableView from '~/concepts/pipelines/content/tables/EmptyTableView';
 import usePipelineRunFilter from '~/concepts/pipelines/content/tables/pipelineRun/usePipelineRunFilter';
 import PipelineRunTableToolbar from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar';

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -3,7 +3,7 @@ import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { Link, useNavigate } from 'react-router-dom';
 import { Skeleton } from '@patternfly/react-core';
 import { PipelineRunKF, PipelineRunStatusesKF } from '~/concepts/pipelines/kfTypes';
-import TableRowTitleDescription from '~/components/table/TableRowTitleDescription';
+import { TableRowTitleDescription, CheckboxTd } from '~/components/table';
 import {
   RunCreated,
   RunDuration,
@@ -12,7 +12,6 @@ import {
   RunStatus,
 } from '~/concepts/pipelines/content/tables/renderUtils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import CheckboxTd from '~/components/table/CheckboxTd';
 import { GetJobInformation } from '~/concepts/pipelines/content/tables/pipelineRun/useJobRelatedInformation';
 import useNotification from '~/utilities/useNotification';
 

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { TableVariant } from '@patternfly/react-table';
-import Table from '~/components/table/Table';
 import { PipelineCoreResourceKF, PipelineRunJobKF } from '~/concepts/pipelines/kfTypes';
 import { pipelineRunJobColumns } from '~/concepts/pipelines/content/tables/columns';
-import useCheckboxTable from '~/components/table/useCheckboxTable';
+import { useCheckboxTable, Table } from '~/components/table';
 import PipelineRunJobTableRow from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow';
 import PipelineRunJobTableToolbar from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar';
 import usePipelineRunJobFilter from '~/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobFilter';

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { PipelineRunJobKF } from '~/concepts/pipelines/kfTypes';
-import TableRowTitleDescription from '~/components/table/TableRowTitleDescription';
+import { TableRowTitleDescription, CheckboxTd } from '~/components/table';
 import {
   RunJobScheduled,
   RunJobStatus,
@@ -11,7 +11,6 @@ import {
   CoreResourcePipeline,
 } from '~/concepts/pipelines/content/tables/renderUtils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import CheckboxTd from '~/components/table/CheckboxTd';
 
 type PipelineRunJobTableRowProps = {
   isChecked: boolean;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView.tsx
@@ -4,7 +4,7 @@ import { Button, ToolbarItem } from '@patternfly/react-core';
 import { TemplateKind } from '~/k8sTypes';
 import { useDashboardNamespace } from '~/redux/selectors';
 import useNotification from '~/utilities/useNotification';
-import Table from '~/components/table/Table';
+import { Table } from '~/components/table';
 import useDraggableTable from '~/utilities/useDraggableTable';
 import { patchDashboardConfigTemplateOrderBackend } from '~/services/dashboardService';
 import { getServingRuntimeNameFromTemplate, getSortedTemplates } from './utils';

--- a/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { TemplateKind } from '~/k8sTypes';
 
 export const columns: SortableData<TemplateKind>[] = [

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
-import Table from '~/components/table/Table';
-
+import { Table } from '~/components/table';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import InferenceServiceTableRow from './InferenceServiceTableRow';

--- a/frontend/src/pages/modelServing/screens/global/data.ts
+++ b/frontend/src/pages/modelServing/screens/global/data.ts
@@ -1,5 +1,5 @@
 import { InferenceServiceKind, ProjectKind, SecretKind } from '~/k8sTypes';
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { getProjectDisplayName } from '~/pages/projects/utils';
 import { getInferenceServiceDisplayName, getTokenDisplayName } from './utils';
 

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Table from '~/components/table/Table';
+import { Table } from '~/components/table';
 import { AccessReviewResourceAttributes, ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { useAccessReview } from '~/api';

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTokensTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTokensTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
-import Table from '~/components/table/Table';
+import { Table } from '~/components/table';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { tokenColumns } from '~/pages/modelServing/screens/global/data';
 import { ServingRuntimeKind } from '~/k8sTypes';

--- a/frontend/src/pages/modelServing/screens/projects/data.ts
+++ b/frontend/src/pages/modelServing/screens/projects/data.ts
@@ -1,5 +1,5 @@
 import { ServingRuntimeKind } from '~/k8sTypes';
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 
 export const columns: SortableData<ServingRuntimeKind>[] = [
   {

--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -1,26 +1,20 @@
 import * as React from 'react';
 import { Alert, Stack, StackItem, Title } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
-import Table from '~/components/table/Table';
-
-import useTableColumnSort from '~/components/table/useTableColumnSort';
+import { Table } from '~/components/table';
 import ExternalLink from '~/components/ExternalLink';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import StopServerModal from '~/pages/notebookController/screens/server/StopServerModal';
 import { Notebook } from '~/types';
-import { columns } from './const';
+import { columns } from './data';
 import StopAllServersButton from './StopAllServersButton';
 import UserTableCellTransform from './UserTableCellTransform';
 import useAdminUsers from './useAdminUsers';
-import { AdminViewUserData } from './types';
 import { NotebookAdminContext } from './NotebookAdminContext';
 
 const NotebookAdminControl: React.FC = () => {
-  const [unsortedUsers, loaded, loadError] = useAdminUsers();
-  const { transformData } = useTableColumnSort<AdminViewUserData>(columns, 0);
+  const [users, loaded, loadError] = useAdminUsers();
   const { serverStatuses, setServerStatuses } = React.useContext(NotebookAdminContext);
-
-  const users = transformData(unsortedUsers);
 
   const onNotebooksStop = React.useCallback(
     (didStop: boolean) => {

--- a/frontend/src/pages/notebookController/screens/admin/data.ts
+++ b/frontend/src/pages/notebookController/screens/admin/data.ts
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { AdminViewUserData } from './types';
 
 export const columns: SortableData<AdminViewUserData>[] = [

--- a/frontend/src/pages/projects/projectSharing/ProjectSharingTable.tsx
+++ b/frontend/src/pages/projects/projectSharing/ProjectSharingTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Table from '~/components/table/Table';
+import { Table } from '~/components/table';
 import { RoleBindingKind } from '~/k8sTypes';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { deleteRoleBinding, generateRoleBindingProjectSharing, createRoleBinding } from '~/api';

--- a/frontend/src/pages/projects/projectSharing/data.ts
+++ b/frontend/src/pages/projects/projectSharing/data.ts
@@ -1,5 +1,5 @@
 import { RoleBindingKind } from '~/k8sTypes';
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { firstSubject } from './utils';
 
 export const columnsProjectSharing: SortableData<RoleBindingKind>[] = [

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import Table from '~/components/table/Table';
-
+import { Table } from '~/components/table';
 import { DataConnection } from '~/pages/projects/types';
 import { columns } from './data';
 import DataConnectionsTableRow from './DataConnectionsTableRow';

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
@@ -5,7 +5,7 @@ import ConnectedNotebookNames from '~/pages/projects/notebook/ConnectedNotebookN
 import { ConnectedNotebookContext } from '~/pages/projects/notebook/useRelatedNotebooks';
 import { DataConnection } from '~/pages/projects/types';
 import EmptyTableCellForAlignment from '~/pages/projects/components/EmptyTableCellForAlignment';
-import TableRowTitleDescription from '~/components/table/TableRowTitleDescription';
+import { TableRowTitleDescription } from '~/components/table';
 import {
   getDataConnectionDescription,
   getDataConnectionDisplayName,

--- a/frontend/src/pages/projects/screens/detail/data-connections/data.ts
+++ b/frontend/src/pages/projects/screens/detail/data-connections/data.ts
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { DataConnection } from '~/pages/projects/types';
 import { getDataConnectionDisplayName } from './utils';
 

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import Table from '~/components/table/Table';
-
+import { Table } from '~/components/table';
 import { NotebookKind } from '~/k8sTypes';
 import DeleteNotebookModal from '~/pages/projects/notebook/DeleteNotebookModal';
 import AddNotebookStorage from '~/pages/projects/pvc/AddNotebookStorage';

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -10,7 +10,7 @@ import NotebookStatusToggle from '~/pages/projects/notebook/NotebookStatusToggle
 import { NotebookKind } from '~/k8sTypes';
 import NotebookImagePackageDetails from '~/pages/projects/notebook/NotebookImagePackageDetails';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import TableRowTitleDescription from '~/components/table/TableRowTitleDescription';
+import { TableRowTitleDescription } from '~/components/table';
 import useNotebookDeploymentSize from './useNotebookDeploymentSize';
 import useNotebookImage from './useNotebookImage';
 import NotebookSizeDetails from './NotebookSizeDetails';

--- a/frontend/src/pages/projects/screens/detail/notebooks/data.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/data.ts
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { getNotebookDisplayName, getNotebookStatusPriority } from '~/pages/projects/utils';
 import { NotebookState } from '~/pages/projects/notebook/types';
 

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import Table from '~/components/table/Table';
-
+import { Table } from '~/components/table';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import DeletePVCModal from '~/pages/projects/pvc/DeletePVCModal';
 import StorageTableRow from './StorageTableRow';

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -14,7 +14,7 @@ import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import StorageSizeBar from '~/pages/projects/components/StorageSizeBars';
 import ConnectedNotebookNames from '~/pages/projects/notebook/ConnectedNotebookNames';
 import { ConnectedNotebookContext } from '~/pages/projects/notebook/useRelatedNotebooks';
-import TableRowTitleDescription from '~/components/table/TableRowTitleDescription';
+import { TableRowTitleDescription } from '~/components/table';
 import useIsRootVolume from './useIsRootVolume';
 import StorageWarningStatus from './StorageWarningStatus';
 

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { getPvcDisplayName } from '~/pages/projects/utils';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
 

--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonVariant, ToolbarItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import Table from '~/components/table/Table';
-import useTableColumnSort from '~/components/table/useTableColumnSort';
+import { Table } from '~/components/table';
 import SearchField, { SearchType } from '~/pages/projects/components/SearchField';
 import { ProjectKind } from '~/k8sTypes';
 import { getProjectDisplayName, getProjectOwner } from '~/pages/projects/utils';
@@ -25,8 +24,7 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({ allowCreate }) => {
   const navigate = useNavigate();
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
   const [search, setSearch] = React.useState('');
-  const sort = useTableColumnSort<ProjectKind>(columns, 0);
-  const filteredProjects = sort.transformData(unfilteredProjects).filter((project) => {
+  const filteredProjects = unfilteredProjects.filter((project) => {
     if (!search) {
       return true;
     }

--- a/frontend/src/pages/projects/screens/projects/tableData.tsx
+++ b/frontend/src/pages/projects/screens/projects/tableData.tsx
@@ -1,4 +1,4 @@
-import { SortableData } from '~/components/table/useTableColumnSort';
+import { SortableData } from '~/components/table';
 import { ProjectKind } from '~/k8sTypes';
 import { getProjectCreationTime, getProjectDisplayName } from '~/pages/projects/utils';
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1252 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR did the following things:
1. Get rid of all the usage of the `useTableColumnSort` hook outside of the `~/components/table` repo
2. Create an `index.ts` file and export all the hooks, components, const, types out of the `~/components/table` repo
3. Create lint rules to limit only allow to import from `~/components/table` and don't allow to import from `~/components/table/**`. Also, limit the import of `useTableColumnSort`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These are mostly infrastructure refactors which will not bring any changes to the features and functionalities. The only thing you could test is to check whether the sort is still working on the Notebook Controller admin panel table and the data science projects table

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, code refactor.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
