### PR TITLE
Fix issue displaying error in Inference Service

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -9,6 +9,28 @@ type MockResourceConfigType = {
   secretName?: string;
 };
 
+export const mockInferenceServicek8sError = () => ({
+  kind: 'Status',
+  apiVersion: 'v1',
+  metadata: {},
+  status: 'Failure',
+  message:
+    'InferenceService.serving.kserve.io "trigger-error" is invalid: [metadata.name: Invalid value: "trigger-error": is invalid, metadata.labels: Invalid value: "trigger-error": must have proper format]',
+  reason: 'Invalid',
+  details: {
+    name: 'trigger-error',
+    group: 'serving.kserve.io',
+    kind: 'InferenceService',
+    causes: [
+      {
+        reason: 'FieldValueInvalid',
+        message: 'Invalid value: "trigger-error": must have proper format',
+        field: 'metadata.name',
+      },
+    ],
+  },
+});
+
 export const mockInferenceServiceK8sResource = ({
   name = 'test-inference-service',
   namespace = 'test-project',

--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
@@ -8,7 +8,10 @@ import { Route, Routes } from 'react-router-dom';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
-import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
+import {
+  mockInferenceServiceK8sResource,
+  mockInferenceServicek8sError,
+} from '~/__mocks__/mockInferenceServiceK8sResource';
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 import ModelServingContextProvider from '~/pages/modelServing/ModelServingContext';
 import ModelServingGlobal from '~/pages/modelServing/screens/global/ModelServingGlobal';
@@ -37,6 +40,15 @@ export default {
         ),
         rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
           res(ctx.json(mockK8sResourceList([mockProjectK8sResource({})]))),
+        ),
+        rest.post(
+          'api/k8s/apis/serving.kserve.io/v1beta1/namespaces/test-project/inferenceservices/test',
+          (req, res, ctx) => res(ctx.json(mockInferenceServiceK8sResource({}))),
+        ),
+        rest.post(
+          'api/k8s/apis/serving.kserve.io/v1beta1/namespaces/test-project/inferenceservices/trigger-error',
+          (req, res, ctx) =>
+            res(ctx.status(422, 'Unprocessable Entity'), ctx.json(mockInferenceServicek8sError())),
         ),
       ],
     },

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -78,6 +78,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
 
   const onBeforeClose = (submitted: boolean) => {
     onClose(submitted);
+    setError(undefined);
     setActionInProgress(false);
     resetData();
   };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes #1785 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to Global Serving Runtimes view
2. Try to deploy a new model with a really large name to trigger an error
3. Close the modal
4. Open again the modal to deploy a new model

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Covered this flow in integration

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
