### PR TITLE
Add new issues to tracking boards

### DIFF
--- a/.github/workflows/auto_add_to_project.yaml
+++ b/.github/workflows/auto_add_to_project.yaml
@@ -1,0 +1,18 @@
+name: Add Issues to Tracking boards
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to projects
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/opendatahub-io/projects/40
+          github-token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/opendatahub-io/projects/45
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Adds new issues to the tracking boards. Planning conversation happening [on the internal slack](https://redhat-internal.slack.com/archives/C05SRUPUUUV).