### PR TITLE
Filter data connections without bucket name in deploy model modal

### DIFF
--- a/frontend/src/__mocks__/mockDataConnection.ts
+++ b/frontend/src/__mocks__/mockDataConnection.ts
@@ -1,0 +1,48 @@
+import { DataConnection } from '~/pages/projects/types';
+import { genUID } from '~/__mocks__/mockUtils';
+import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
+import { KnownLabels } from '~/k8sTypes';
+
+type MockDataConnectionType = {
+  name?: string;
+  namespace?: string;
+  displayName?: string;
+  s3Bucket?: string;
+};
+
+export const mockDataConnection = ({
+  name = 'test-secret',
+  namespace = 'test-project',
+  displayName = 'Test Secret',
+  s3Bucket = 'test-bucket',
+}: MockDataConnectionType): DataConnection => ({
+  type: 0,
+  data: {
+    kind: 'Secret',
+    apiVersion: 'v1',
+    metadata: {
+      name: name,
+      namespace: namespace,
+      uid: genUID('secret'),
+      resourceVersion: '5985371',
+      creationTimestamp: '2023-03-22T16:18:56Z',
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        [KnownLabels.DATA_CONNECTION_AWS]: 'true',
+      },
+      annotations: {
+        'opendatahub.io/connection-type': 's3',
+        'openshift.io/display-name': displayName,
+      },
+    },
+    data: {
+      [AWS_KEYS.NAME]: name,
+      AWS_ACCESS_KEY_ID: 'c2RzZA==',
+      AWS_DEFAULT_REGION: 'us-east-1',
+      AWS_S3_BUCKET: s3Bucket,
+      AWS_S3_ENDPOINT: 'http://aws.com',
+      AWS_SECRET_ACCESS_KEY: 'aHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tLw==',
+    },
+    type: 'Opaque',
+  },
+});

--- a/frontend/src/__mocks__/mockSecretK8sResource.ts
+++ b/frontend/src/__mocks__/mockSecretK8sResource.ts
@@ -5,12 +5,14 @@ type MockResourceConfigType = {
   name?: string;
   namespace?: string;
   displayName?: string;
+  s3Bucket?: string;
 };
 
 export const mockSecretK8sResource = ({
   name = 'test-secret',
   namespace = 'test-project',
   displayName = 'Test Secret',
+  s3Bucket = 'test-bucket',
 }: MockResourceConfigType): SecretKind => ({
   kind: 'Secret',
   apiVersion: 'route.openshift.io/v1',
@@ -32,7 +34,7 @@ export const mockSecretK8sResource = ({
   data: {
     AWS_ACCESS_KEY_ID: 'c2RzZA==',
     AWS_DEFAULT_REGION: 'dXMtZWFzdC0x',
-    AWS_S3_BUCKET: '',
+    AWS_S3_BUCKET: s3Bucket,
     AWS_S3_ENDPOINT: 'aHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tLw==',
     AWS_SECRET_ACCESS_KEY: 'c2RzZA==',
   },

--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
@@ -12,7 +12,6 @@ import {
   mockInferenceServiceK8sResource,
   mockInferenceServicek8sError,
 } from '~/__mocks__/mockInferenceServiceK8sResource';
-import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 import ModelServingGlobal from '~/pages/modelServing/screens/global/ModelServingGlobal';
 import { AreaContext } from '~/concepts/areas/AreaContext';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';
@@ -30,6 +29,7 @@ import { useApplicationSettings } from '~/app/useApplicationSettings';
 import { AppContext } from '~/app/AppContext';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import GlobalModelServingCoreLoader from '~/pages/modelServing/screens/global/GlobalModelServingCoreLoader';
+import { mockDataConnection } from '~/__mocks__/mockDataConnection';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -66,7 +66,7 @@ const getHandlers = ({
     (req, res, ctx) => res(ctx.json(mockK8sResourceList(inferenceServices))),
   ),
   rest.get('/api/k8s/api/v1/namespaces/test-project/secrets', (req, res, ctx) =>
-    res(ctx.json(mockK8sResourceList([mockSecretK8sResource({})]))),
+    res(ctx.json(mockK8sResourceList([mockDataConnection({}).data]))),
   ),
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/modelServing/servingruntimes',
@@ -77,7 +77,7 @@ const getHandlers = ({
     (req, res, ctx) => res(ctx.json(mockK8sResourceList(inferenceServices))),
   ),
   rest.get('/api/k8s/api/v1/namespaces/modelServing/secrets', (req, res, ctx) =>
-    res(ctx.json(mockK8sResourceList([mockSecretK8sResource({})]))),
+    res(ctx.json(mockK8sResourceList([mockDataConnection({}).data]))),
   ),
   rest.get(
     '/api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes/test-model',

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
@@ -12,7 +12,6 @@ import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockNotebookK8sResource } from '~/__mocks__/mockNotebookK8sResource';
 import ProjectDetailsContextProvider from '~/pages/projects/ProjectDetailsContext';
-import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 import {
   mockServingRuntimeK8sResource,
   mockServingRuntimeK8sResourceLegacy,
@@ -36,6 +35,7 @@ import { ServingRuntimePlatform } from '~/types';
 import { AreaContext } from '~/concepts/areas/AreaContext';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import { StackComponent } from '~/concepts/areas';
+import { mockDataConnection } from '~/__mocks__/mockDataConnection';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -112,7 +112,7 @@ const getHandlers = ({
     (req, res, ctx) => res(ctx.json(mockK8sResourceList(inferenceServices))),
   ),
   rest.get('/api/k8s/api/v1/namespaces/test-project/secrets', (req, res, ctx) =>
-    res(ctx.json(mockK8sResourceList([mockSecretK8sResource({})]))),
+    res(ctx.json(mockK8sResourceList([mockDataConnection({}).data]))),
   ),
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes',

--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.stories.tsx
@@ -12,7 +12,7 @@ import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockNotebookK8sResource } from '~/__mocks__/mockNotebookK8sResource';
 import ProjectDetailsContextProvider from '~/pages/projects/ProjectDetailsContext';
 import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
-import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
+import { mockDataConnection } from '~/__mocks__/mockDataConnection';
 import {
   mockServingRuntimeK8sResource,
   mockServingRuntimeK8sResourceLegacy,
@@ -126,7 +126,7 @@ const handlers = (isEmpty: boolean): RestHandler<MockedRequest<DefaultBodyType>>
       ),
   ),
   rest.get('/api/k8s/api/v1/namespaces/test-project/secrets', (req, res, ctx) =>
-    res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockSecretK8sResource({})]))),
+    res(ctx.json(mockK8sResourceList(isEmpty ? [] : [mockDataConnection({}).data]))),
   ),
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes',

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionExistingField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionExistingField.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { FormGroup, Stack, StackItem } from '@patternfly/react-core';
+import { Button, FormGroup, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { DataConnection, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
+import { filterOutConnectionsWithoutBucket } from '~/pages/modelServing/screens/projects/utils';
 import { getDataConnectionDisplayName } from '~/pages/projects/screens/detail/data-connections/utils';
 import './DataConnectionExistingField.scss';
 import DataConnectionFolderPathField from './DataConnectionFolderPathField';
@@ -19,17 +21,37 @@ const DataConnectionExistingField: React.FC<DataConnectionExistingFieldType> = (
   dataConnections,
 }) => {
   const [isOpen, setOpen] = React.useState(false);
+  const connectionsWithoutBucket = filterOutConnectionsWithoutBucket(dataConnections);
+  const isDataConnectionsEmpty = connectionsWithoutBucket.length === 0;
+
   return (
     <Stack hasGutter>
       <StackItem>
+        {dataConnections.length !== 0 && (
+          <Popover
+            aria-label="No bucket popover"
+            bodyContent={
+              'Only data connections that include a bucket, which is required for model serving, are included in this list.'
+            }
+          >
+            <Button
+              style={{ paddingLeft: 0 }}
+              variant="link"
+              icon={<OutlinedQuestionCircleIcon />}
+              iconPosition="left"
+            >
+              {"Not seeing what you're looking for?"}
+            </Button>
+          </Popover>
+        )}
         <FormGroup label="Name" isRequired>
           <Select
             id="inference-service-data-connection"
             isOpen={isOpen}
             placeholderText={
-              dataConnections.length === 0 ? 'No data connections available to select' : 'Select...'
+              isDataConnectionsEmpty ? 'No data connections available to select' : 'Select...'
             }
-            isDisabled={dataConnections.length === 0}
+            isDisabled={isDataConnectionsEmpty}
             onToggle={(e, open) => setOpen(open)}
             onSelect={(_, option) => {
               if (typeof option === 'string') {
@@ -43,7 +65,7 @@ const DataConnectionExistingField: React.FC<DataConnectionExistingFieldType> = (
             selections={data.storage.dataConnection}
             menuAppendTo="parent"
           >
-            {dataConnections.map((connection) => (
+            {connectionsWithoutBucket.map((connection) => (
               <SelectOption
                 key={connection.data.metadata.name}
                 value={connection.data.metadata.name}

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -1,0 +1,26 @@
+import { mockDataConnection } from '~/__mocks__/mockDataConnection';
+import { filterOutConnectionsWithoutBucket } from '~/pages/modelServing/screens/projects/utils';
+import { DataConnection } from '~/pages/projects/types';
+
+describe('filterOutConnectionsWithoutBucket', () => {
+  it('should return an empty array if input connections array is empty', () => {
+    const inputConnections: DataConnection[] = [];
+    const result = filterOutConnectionsWithoutBucket(inputConnections);
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out connections without an AWS_S3_BUCKET property', () => {
+    const dataConnections = [
+      mockDataConnection({ name: 'name1', s3Bucket: 'bucket1' }),
+      mockDataConnection({ name: 'name2', s3Bucket: '' }),
+      mockDataConnection({ name: 'name3', s3Bucket: 'bucket2' }),
+    ];
+
+    const result = filterOutConnectionsWithoutBucket(dataConnections);
+
+    expect(result).toMatchObject([
+      { data: { data: { Name: 'name1' } } },
+      { data: { data: { Name: 'name3' } } },
+    ]);
+  });
+});

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -7,7 +7,11 @@ import {
   SecretKind,
   ServingRuntimeKind,
 } from '~/k8sTypes';
-import { NamespaceApplicationCase, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import {
+  DataConnection,
+  NamespaceApplicationCase,
+  UpdateObjectAtPropAndValue,
+} from '~/pages/projects/types';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
 import {
   CreatingInferenceServiceObject,
@@ -384,3 +388,7 @@ export const submitServingRuntimeResources = (
 export const getUrlFromKserveInferenceService = (
   inferenceService: InferenceServiceKind,
 ): string | undefined => inferenceService.status?.url;
+
+export const filterOutConnectionsWithoutBucket = (
+  connections: DataConnection[],
+): DataConnection[] => connections.filter((obj) => obj.data.data['AWS_S3_BUCKET'].trim() !== '');


### PR DESCRIPTION
Closes: #1604

## Description
This PR filters out data connection without bucket name in the Deploy model Modal

<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/6444eaa4-34ed-49ea-9ce2-ff5cbb0e7141" height="350px" />
<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/1b7e95d4-6a5e-497e-bc8f-d730f269a3f2" height="350px" />

## How Has This Been Tested?
1. Create and open project.
2. Create a data connection without bucket name.
3. Create model server.
4. Click on "Deploy model"
5. In the Deploy model modal you can see list of Data connections.
6. Above that you can see the tooltip. 
7. In the dropdown without bucket connection is removed.

## Test Impact
Added unit test to test `filterOutConnectionsWithoutBucket` utility function

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@vconzola 