### PR TITLE
Removed Started at date

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
@@ -12,6 +12,7 @@ import { relativeDuration } from '~/utilities/time';
 import {
   asTimestamp,
   DetailItem,
+  isEmptyDateKF,
   renderDetailItems,
 } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
 type PipelineRunTabDetailsProps = {
@@ -24,7 +25,6 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({
   workflowName,
 }) => {
   const { namespace, project } = usePipelinesAPI();
-
   if (!pipelineRunKF || !workflowName) {
     return (
       <EmptyState variant={EmptyStateVariant.large} data-id="loading-empty-state">
@@ -62,10 +62,11 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({
     { key: 'Workflow name', value: workflowName },
     { key: 'Created at', value: asTimestamp(new Date(pipelineRunKF.created_at)) },
     {
-      key: 'Started at',
-      value: asTimestamp(new Date(pipelineRunKF.scheduled_at || pipelineRunKF.created_at)),
+      key: 'Finished at',
+      value: isEmptyDateKF(pipelineRunKF.finished_at)
+        ? 'N/A'
+        : asTimestamp(new Date(pipelineRunKF.finished_at)),
     },
-    { key: 'Finished at', value: asTimestamp(new Date(pipelineRunKF.finished_at)) },
     { key: 'Duration', value: relativeDuration(getRunDuration(pipelineRunKF)) },
   ];
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -9,6 +9,7 @@ import {
   TimestampFormat,
 } from '@patternfly/react-core';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
+import { DateTimeKF } from '~/concepts/pipelines/kfTypes';
 
 export type DetailItem = {
   key: string;
@@ -43,3 +44,8 @@ export const asTimestamp = (date: Date): React.ReactNode => (
     </FlexItem>
   </Flex>
 );
+
+export const isEmptyDateKF = (date: DateTimeKF): boolean => {
+  const INVALID_TIMESTAMP = '1970-01-01T00:00:00Z';
+  return date === INVALID_TIMESTAMP ? true : false;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1543 

## Description
Removed the `Started at` date from Details tab of pipelineRun
![Screenshot from 2023-09-21 16-13-33](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/2c23ee6c-cf85-4fae-a7b9-763558cf3132)
When pipelineRuns are immediately triggerred the `finished at` first has N/A value later after completion of runs it gets it exact value

[Screencast from 2023-09-21 17-12-08.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/093cbcbf-2f4f-46e2-95ef-083a0046975d)
 
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Check whether the Started at date is not present in the detail tab of pipelineRun
2. When creating a new piplineRun the `finished at` displays N/A instead of epoch value and later on gets the exact value

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
