### PR TITLE
Convert nightly over to the right image

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard
-  newTag: main
+  newTag: nightly
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
   digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33


### PR DESCRIPTION
Updates the tag to point at the nightly.

Hopefully this doesn't cause conflicts 🤞 (with each feature branch that merges into `incubation`)

The Why...  talking with @VaishnaviHire this will be needed for our transition to component manifests. The Operator will by default for ODH point at our `incubation` branch (the branch we take to ODH Manifests in the past) — however the current image it pulls will be that of `main`. This is a problem because it seems when we build off the branch the code will be of `main` but the manifests will be that of `incubation`. So let us point everything at the latest of `incubation` by this change.