### PR TITLE
Show alert when external route is set while token is not set for model server

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -75,3 +75,36 @@ test('Legacy Serving Runtime', async ({ page }) => {
   await expect(firstRow).toHaveClass('pf-m-expanded');
   await expect(secondRow).not.toHaveClass('pf-m-expanded');
 });
+
+test('Add server', async ({ page }) => {
+  await page.goto(
+    './iframe.html?args=&id=tests-integration-pages-modelserving-servingruntimelist--list-available-models&viewMode=story',
+  );
+
+  // wait for page to load
+  await page.waitForSelector('text=Add server');
+
+  await page.getByRole('button', { name: 'Add server', exact: true }).click();
+
+  // test that you can not submit on empty
+  await expect(page.getByRole('button', { name: 'Add', exact: true })).toBeDisabled();
+
+  // test filling in minimum required fields
+  await page.getByLabel('Model server name *').fill('Test Name');
+  await page.locator('#serving-runtime-template-selection').click();
+  await page.getByRole('menuitem', { name: 'New OVMS Server' }).click();
+  await expect(page.getByRole('button', { name: 'Add', exact: true })).toBeEnabled();
+
+  // test the if the alert is visible when route is external while token is not set
+  await expect(page.locator('#external-route-no-token-alert')).toBeHidden();
+  // external route, no token, show alert
+  await page.getByLabel('Make deployed models available through an external route').click();
+  await expect(page.locator('#alt-form-checkbox-auth')).toBeChecked();
+  await expect(page.locator('#external-route-no-token-alert')).toBeHidden();
+  // external route, set token, hide alert
+  await page.getByLabel('Require token authentication').click();
+  await expect(page.locator('#external-route-no-token-alert')).toBeVisible();
+  // internal route, set token, show alert
+  await page.getByLabel('Make deployed models available through an external route').click();
+  await expect(page.locator('#external-route-no-token-alert')).toBeHidden();
+});

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
@@ -6,7 +6,6 @@ import {
   FormGroup,
   FormSection,
   getUniqueId,
-  Skeleton,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -20,14 +19,12 @@ type ServingRuntimeTokenSectionProps = {
   data: CreatingServingRuntimeObject;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
   allowCreate: boolean;
-  rbacLoaded: boolean;
 };
 
 const ServingRuntimeTokenSection: React.FC<ServingRuntimeTokenSectionProps> = ({
   data,
   setData,
   allowCreate,
-  rbacLoaded,
 }) => {
   const createNewToken = () => {
     const name = 'default-name';
@@ -42,10 +39,6 @@ const ServingRuntimeTokenSection: React.FC<ServingRuntimeTokenSectionProps> = ({
       },
     ]);
   };
-
-  if (!rbacLoaded) {
-    return <Skeleton />;
-  }
 
   return (
     <FormSection title="Token authorization">
@@ -64,14 +57,6 @@ const ServingRuntimeTokenSection: React.FC<ServingRuntimeTokenSectionProps> = ({
           }}
         />
       </FormGroup>
-
-      {!allowCreate && (
-        <Alert
-          variant="warning"
-          isInline
-          title="Administrator permissions in this namespace are required to generate tokens."
-        />
-      )}
 
       {data.tokenAuth && (
         <IndentSection>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1582 
Closes #1581 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added the alert as the description in the issue. ~One thing that needs to be noted is that the regular user with edit permission cannot enable the token, so the alert will show as soon as the user enables the external route.~
Found issue #1581 and also updated it here because they are tightly related, the user with edit permission cannot change the external route enablement anymore, and added a popover to explain that.

As the project admin:
<img width="864" alt="Screenshot 2023-09-25 at 3 55 38 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ecb6aebf-3bdc-4d6a-b9e9-bfab5f6c1170">

As the project user with edit access:
<img width="859" alt="Screenshot 2023-10-02 at 1 37 13 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/b7c912dc-24c2-45d2-bead-6719369a64dc">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the project details page, try to add a model server
2. In the adding modal, check to enable the external route
3. Make sure the alert is shown
4. Check to enable token
5. Make sure the alert is gone
6. Try to impersonate as a user with the edit permission
7. Open the add server modal to see both fields are disabled and check the popover content in the link button above

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added integration test to test all the situations where the alert is visible/hidden.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
