### PR TITLE
fix accelerator detection logic

### DIFF
--- a/backend/src/routes/api/accelerators/acceleratorUtils.ts
+++ b/backend/src/routes/api/accelerators/acceleratorUtils.ts
@@ -49,7 +49,7 @@ export const getAcceleratorNumbers = async (
 
           // if any accelerators are available, the cluster is configured
           const configured =
-            info.configured ?? Object.values(info.available).some((value) => value > 0);
+            info.configured || Object.values(info.available).some((value) => value > 0);
 
           return {
             total: info.total,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1863

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There is a problem in gpu detection reduce function. When the detection iterates over each accelerator, it determines enablement by this logic `prevConfigured ?? checkConfigured()`. The issue was that we used `??` which would cause the configured var to always be false if it started as false because `false ?? true` is still false. This PR uses `||` instead which would give the correct result `false || true = true`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. hop on a gpu cluster with non accelerator profiles and the gpu-migration-status config map deleted.
2. start the dashboard
3. a `migrated-gpu` accelerator should be added

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no test impact -> hot fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
