### PR TITLE
Log group config errors to the pod and refine logic

### DIFF
--- a/backend/src/routes/api/groups-config/groupsConfigUtil.ts
+++ b/backend/src/routes/api/groups-config/groupsConfigUtil.ts
@@ -16,19 +16,12 @@ const SYSTEM_AUTHENTICATED = 'system:authenticated';
 export const getGroupsConfig = async (fastify: KubeFastifyInstance): Promise<GroupsConfig> => {
   const customObjectsApi = fastify.kube.customObjectsApi;
 
-  try {
-    const groupsCluster = await getAllGroups(customObjectsApi);
-    const groupsData = getGroupsCR();
-    const groupsProcessed = processGroupData(groupsData);
-    const groupsConfigProcessed = processGroupConfig(groupsProcessed, groupsCluster);
-    await removeDeletedGroups(fastify, groupsData, groupsConfigProcessed.groupsCRData);
-
-    return groupsConfigProcessed.groupsConfig;
-  } catch (e) {
-    fastify.log.error(e, 'Error retrieving group configuration.');
-    const error = createError(500, 'Error retrieving group configuration');
-    throw error;
-  }
+  const groupsCluster = await getAllGroups(customObjectsApi);
+  const groupsData = getGroupsCR();
+  const groupsProcessed = processGroupData(groupsData);
+  const groupsConfigProcessed = processGroupConfig(fastify, groupsProcessed, groupsCluster);
+  await removeDeletedGroups(fastify, groupsData, groupsConfigProcessed.groupsCRData);
+  return groupsConfigProcessed.groupsConfig;
 };
 
 const transformGroupsConfig = (groupStatus: GroupStatus[]): string[] => {
@@ -38,7 +31,7 @@ const transformGroupsConfig = (groupStatus: GroupStatus[]): string[] => {
 export const updateGroupsConfig = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest<{ Body: GroupsConfig }>,
-): Promise<{ success: GroupsConfig | null; error: string | null }> => {
+): Promise<GroupsConfig> => {
   const customObjectsApi = fastify.kube.customObjectsApi;
   const { namespace } = fastify.kube;
 
@@ -58,26 +51,17 @@ export const updateGroupsConfig = async (
     const error = createError(403, 'Error, groups cannot be empty');
     throw error;
   }
-  try {
-    const dataUpdated: GroupsConfigBody = {
-      adminGroups: adminConfig.join(','),
-      allowedGroups: allowedConfig.join(','),
-    };
+  const dataUpdated: GroupsConfigBody = {
+    adminGroups: adminConfig.join(','),
+    allowedGroups: allowedConfig.join(','),
+  };
 
-    const groupsData = await updateGroupsCR(fastify, dataUpdated);
-    const groupsProcessed = processGroupData(groupsData);
-    const groupsCluster = await getAllGroups(customObjectsApi);
-    const updatedConfig = processGroupConfig(groupsProcessed, groupsCluster);
-    await removeDeletedGroups(fastify, groupsData, updatedConfig.groupsCRData);
-    return {
-      success: updatedConfig.groupsConfig,
-      error: null,
-    };
-  } catch (e) {
-    fastify.log.error(e, 'Error updating group configuration.');
-    const error = createError(500, 'Error updating group configuration');
-    throw error;
-  }
+  const groupsData = await updateGroupsCR(fastify, dataUpdated);
+  const groupsProcessed = processGroupData(groupsData);
+  const groupsCluster = await getAllGroups(customObjectsApi);
+  const updatedConfig = processGroupConfig(fastify, groupsProcessed, groupsCluster);
+  await removeDeletedGroups(fastify, groupsData, updatedConfig.groupsCRData);
+  return updatedConfig.groupsConfig;
 };
 
 const processGroupData = (groupsData: GroupsConfigBody): GroupsConfigBodyList => {
@@ -105,6 +89,7 @@ const mapListToGroupStatus =
  * @returns Processed object with the groups, removing missing groups that might be selected
  */
 const processGroupConfig = (
+  fastify: KubeFastifyInstance,
   groupsDataList: GroupsConfigBodyList,
   groups: string[],
 ): { groupsConfig: GroupsConfig; groupsCRData: GroupsConfigBody } => {
@@ -120,9 +105,14 @@ const processGroupConfig = (
   const groupsConfig: GroupsConfig = {
     adminGroups: adminGroupsConfig,
     allowedGroups: allowedGroupsConfig,
-    errorAdmin: getError(groupsDataList.adminGroups, (group) => !groups.includes(group)),
+    errorAdmin: getError(
+      fastify,
+      groupsDataList.adminGroups.filter((group) => group),
+      (group) => !groups.includes(group),
+    ),
     errorUser: getError(
-      groupsDataList.allowedGroups,
+      fastify,
+      groupsDataList.allowedGroups.filter((group) => group),
       (group) => !groups.includes(group) && group !== SYSTEM_AUTHENTICATED,
     ),
   };
@@ -137,13 +127,26 @@ const processGroupConfig = (
   return { groupsConfig, groupsCRData: updatedBody };
 };
 
-const getError = (array: string[], predicate: (group: string) => boolean): string | undefined => {
+const getError = (
+  fastify: KubeFastifyInstance,
+  array: string[],
+  predicate: (group: string) => boolean,
+): string | undefined => {
+  let error;
+  if (array.length === 0) {
+    error = 'No group is set in the group config, please set one or more group.';
+    fastify.log.error(error);
+    return error;
+  }
+
   const missingItems = array.filter(predicate);
   if (missingItems.length === 0) return undefined;
 
-  return `The group${missingItems.length === 1 ? '' : 's'} ${missingItems.join(
+  error = `The group${missingItems.length === 1 ? '' : 's'} ${missingItems.join(
     ', ',
   )} no longer exists in OpenShift and has been removed from the selected group list.`;
+  fastify.log.error(error);
+  return error;
 };
 
 /**

--- a/backend/src/routes/api/groups-config/index.ts
+++ b/backend/src/routes/api/groups-config/index.ts
@@ -6,8 +6,13 @@ import { secureAdminRoute } from '../../../utils/route-security';
 export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
     '/',
-    secureAdminRoute(fastify)(async () => {
-      return getGroupsConfig(fastify);
+    secureAdminRoute(fastify)(async (request, reply) => {
+      return getGroupsConfig(fastify).catch((e) => {
+        fastify.log.error(
+          `Error retrieving group configuration, ${e.response?.body?.message || e.message}`,
+        );
+        reply.status(500).send({ message: e.response?.body?.message || e.message });
+      });
     }),
   );
 

--- a/backend/src/utils/groupsUtils.ts
+++ b/backend/src/utils/groupsUtils.ts
@@ -16,7 +16,7 @@ export class MissingGroupError extends Error {
 }
 
 export const getGroupsCR = (): GroupsConfigBody => {
-  if (typeof getDashboardConfig().spec.groupsConfig !== 'undefined') {
+  if (getDashboardConfig().spec.groupsConfig) {
     return getDashboardConfig().spec.groupsConfig;
   }
   throw new Error(`Failed to retrieve Dashboard CR groups configuration`);

--- a/frontend/src/services/groupSettingsService.ts
+++ b/frontend/src/services/groupSettingsService.ts
@@ -11,9 +11,7 @@ export const fetchGroupsSettings = (): Promise<GroupsConfig> => {
     });
 };
 
-export const updateGroupsSettings = (
-  settings: GroupsConfig,
-): Promise<{ success: GroupsConfig | null; error: string | null }> => {
+export const updateGroupsSettings = (settings: GroupsConfig): Promise<GroupsConfig> => {
   const url = '/api/groups-config';
   return axios
     .put(url, settings)

--- a/frontend/src/utilities/__tests__/useWatchGroups.spec.ts
+++ b/frontend/src/utilities/__tests__/useWatchGroups.spec.ts
@@ -1,0 +1,34 @@
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { fetchGroupsSettings } from '~/services/groupSettingsService';
+import { useWatchGroups } from '~/utilities/useWatchGroups';
+
+jest.mock('~/services/groupSettingsService', () => ({
+  fetchGroupsSettings: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+
+const fetchGroupSettingsMock = fetchGroupsSettings as jest.Mock;
+
+describe('useWatchGroups', () => {
+  it('should fetch groups successfully', async () => {
+    const mockEmptyGroupSettings = {
+      adminGroups: [],
+      allowedGroups: [],
+    };
+    const mockGroupSettings = {
+      adminGroups: ['odh-admins'],
+      allowedGroups: [],
+    };
+    fetchGroupSettingsMock.mockReturnValue(Promise.resolve(mockGroupSettings));
+
+    const renderResult = testHook(useWatchGroups)();
+    expect(fetchGroupSettingsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult.result.current.groupSettings).toStrictEqual(mockEmptyGroupSettings);
+
+    await renderResult.waitForNextUpdate();
+    expect(renderResult.result.current.groupSettings).toStrictEqual(mockGroupSettings);
+  });
+});

--- a/frontend/src/utilities/useWatchGroups.tsx
+++ b/frontend/src/utilities/useWatchGroups.tsx
@@ -48,10 +48,10 @@ export const useWatchGroups = (): {
 
   React.useEffect(() => {
     if (errorAdmin) {
-      notification.error(`Group no longer exists`, errorAdmin);
+      notification.error(`Group error`, errorAdmin);
     }
     if (errorUser) {
-      notification.error(`Group no longer exists`, errorUser);
+      notification.error(`Group error`, errorUser);
     }
   }, [errorAdmin, errorUser, notification]);
 
@@ -59,13 +59,11 @@ export const useWatchGroups = (): {
     setIsLoading(true);
     updateGroupsSettings(group)
       .then((response) => {
-        if (response.success) {
-          setGroupSettings(response.success);
-          notification.success(
-            'Group settings changes saved',
-            'It may take up to 2 minutes for configuration changes to be applied.',
-          );
-        }
+        setGroupSettings(response);
+        notification.success(
+          'Group settings changes saved',
+          'It may take up to 2 minutes for configuration changes to be applied.',
+        );
       })
       .catch((error) => {
         setLoadError(error);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #463 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR mainly changes the error handle a little bit, to make the error more clear.
1. When the group is not set, or it's an empty string, show the error `No group is set in the group config, please set one or more group.` (May need wording)
2. When the group does not exist, show the error in the pod log (We only showed it in the dashboard notification center before)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Change the group config in the dashboard config CR, change the `adminGroups` to a non-existed group like `fake-group`
2. Wait for 2 minutes (We need to wait until the backend fetches the latest cluster data)
3. Refresh the user management settings page, you should see 2 error messages in both pod logs and dashboard UI
- The group fake-group no longer exists in OpenShift and has been removed from the selected group list.
- No group is set in the group config, please set one or more group.
4. Refresh the page again, you should only see the second message
5. Try to set or unset the groups, and make sure nothing is broken

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add tests for `useWatchGroups` hook.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
