### PR TITLE
Fix pipeline runs Scheduled & Triggered Table width issue

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -26,7 +26,9 @@ module.exports = {
   testEnvironment: 'jest-environment-jsdom',
 
   // include projects from node_modules as required
-  transformIgnorePatterns: ['node_modules/(?!yaml|@openshift|lodash-es|uuid)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!yaml|@openshift|lodash-es|uuid|@patternfly/react-icons|d3|delaunator|robust-predicates|internmap)',
+  ],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   snapshotSerializers: [],

--- a/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable camelcase*/
+import {
+  BanIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  NotStartedIcon,
+  QuestionCircleIcon,
+  SyncAltIcon,
+} from '@patternfly/react-icons';
+import React from 'react';
+import {
+  PipelineRunKF,
+  PipelineRunStatusesKF,
+  RunStorageStateKF,
+} from '~/concepts/pipelines/kfTypes';
+import { computeRunStatus } from '~/concepts/pipelines/content/utils';
+
+const run: PipelineRunKF = {
+  created_at: '2023-09-05T16:23:25Z',
+  storage_state: RunStorageStateKF.AVAILABLE,
+  pipeline_spec: {
+    runtime_config: {
+      parameters: {},
+      pipeline_root: '',
+    },
+  },
+  finished_at: '2023-09-05T16:24:34Z',
+  id: 'dc66a214-4df2-4d4d-a302-0d02d8bba0e7',
+  name: 'flip-coin',
+  scheduled_at: '1970-01-01T00:00:00Z',
+  service_account: 'pipeline-runner-pipelines-definition',
+  status: '',
+  error: '',
+  metrics: [],
+};
+
+const createRun = (status: string): PipelineRunKF => ({
+  ...run,
+  status,
+});
+
+describe('computeRunStatus', () => {
+  it('should check for run status when run status is undefined', () => {
+    const UNKNOWN_ICON = <QuestionCircleIcon />;
+    const UNKNOWN_STATUS = 'warning';
+    const UNKNOWN_LABEL = '-';
+    const runStatus = computeRunStatus(createRun('-'));
+    expect(runStatus.label).toBe(UNKNOWN_LABEL);
+    expect(runStatus.icon).toStrictEqual(UNKNOWN_ICON);
+    expect(runStatus.status).toBe(UNKNOWN_STATUS);
+  });
+
+  it('should check for Started run status', () => {
+    const runStatus = computeRunStatus(createRun('Started'));
+    expect(runStatus.label).toBe(PipelineRunStatusesKF.STARTED);
+    expect(runStatus.icon).toStrictEqual(<NotStartedIcon />);
+  });
+
+  it('should check for Running run status', () => {
+    const runStatus = computeRunStatus(createRun('Running'));
+    expect(runStatus.label).toBe(PipelineRunStatusesKF.RUNNING);
+    expect(runStatus.icon).toStrictEqual(<SyncAltIcon />);
+  });
+
+  it('should check for Completed run status', () => {
+    const runStatus = computeRunStatus(createRun('Completed'));
+    expect(runStatus.label).toBe(PipelineRunStatusesKF.COMPLETED);
+    expect(runStatus.icon).toStrictEqual(<CheckCircleIcon />);
+    expect(runStatus.status).toBe('success');
+  });
+
+  it('should check for Failed run status', () => {
+    const runStatus = computeRunStatus(createRun('Failed'));
+    expect(runStatus.label).toBe(PipelineRunStatusesKF.FAILED);
+    expect(runStatus.icon).toStrictEqual(<ExclamationCircleIcon />);
+    expect(runStatus.status).toBe('danger');
+    expect(runStatus.details).toBe(run.error);
+  });
+
+  it('should check for Cancelled run status', () => {
+    const runStatus = computeRunStatus(createRun('Cancelled'));
+    expect(runStatus.label).toBe(PipelineRunStatusesKF.CANCELLED);
+    expect(runStatus.icon).toStrictEqual(<BanIcon />);
+  });
+
+  it('should check for default run status', () => {
+    const UNKNOWN_ICON = <QuestionCircleIcon />;
+    const UNKNOWN_STATUS = 'warning';
+    const runStatus = computeRunStatus(createRun('warning'));
+    expect(runStatus.status).toBe(UNKNOWN_STATUS);
+    expect(runStatus.icon).toStrictEqual(UNKNOWN_ICON);
+  });
+});

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -10,6 +10,7 @@ import {
   TabContent,
   Tabs,
   TabTitleText,
+  Truncate,
 } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import usePipelineTemplate from '~/concepts/pipelines/apiHooks/usePipelineTemplate';
@@ -73,10 +74,12 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
               breadcrumb={
                 <Breadcrumb>
                   {breadcrumbPath}
-                  <BreadcrumbItem isActive>{pipeline?.name || 'Loading...'}</BreadcrumbItem>
+                  <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
+                    <Truncate content={pipeline?.name || 'Loading...'} />
+                  </BreadcrumbItem>
                 </Breadcrumb>
               }
-              title={pipeline?.name || 'Loading...'}
+              title={<Truncate content={pipeline?.name || 'Loading...'} />}
               description={
                 pipeline ? <MarkdownView conciseDisplay markdown={pipeline.description} /> : ''
               }

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -11,6 +11,7 @@ import {
   EmptyStateBody,
   Bullseye,
   Spinner,
+  Truncate,
   EmptyStateHeader,
 } from '@patternfly/react-core';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -122,8 +123,8 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
                   breadcrumb={
                     <Breadcrumb>
                       {breadcrumbPath}
-                      <BreadcrumbItem isActive>
-                        {error ? 'Run details' : run?.name ?? 'Loading...'}
+                      <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
+                        <Truncate content={error ? 'Run details' : run?.name ?? 'Loading...'} />
                       </BreadcrumbItem>
                     </Breadcrumb>
                   }

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Spinner, EmptyStateVariant, EmptyState, EmptyStateHeader } from '@patternfly/react-core';
+import {
+  Spinner,
+  EmptyStateVariant,
+  EmptyState,
+  EmptyStateHeader,
+  Truncate,
+} from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import {
@@ -15,6 +21,8 @@ import {
   isEmptyDateKF,
   renderDetailItems,
 } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
+import { NoRunContent } from '~/concepts/pipelines/content/tables/renderUtils';
+
 type PipelineRunTabDetailsProps = {
   pipelineRunKF?: PipelineRunKF;
   workflowName?: string;
@@ -40,17 +48,19 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({
         {
           key: 'Pipeline',
           // TODO: get the relative parent namespaced link
-          value: (
+          value: pipelineReference.name ? (
             <Link to={`/pipelines/${namespace}/pipeline/view/${pipelineReference.key.id}`}>
-              {pipelineReference.name}
+              <Truncate content={pipelineReference.name} />
             </Link>
+          ) : (
+            <NoRunContent />
           ),
         },
       ]
     : [];
 
   const details: DetailItem[] = [
-    { key: 'Name', value: pipelineRunKF.name },
+    { key: 'Name', value: <Truncate content={pipelineRunKF.name} /> },
     ...pipelineRef,
     {
       key: 'Project',

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { Label, Split, SplitItem, Truncate } from '@patternfly/react-core';
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import { computeRunStatus } from '~/concepts/pipelines/content/utils';
 
@@ -16,7 +16,9 @@ const PipelineRunTitle: React.FC<PipelineRunTitleProps> = ({ run }) => {
 
   return (
     <Split hasGutter>
-      <SplitItem>{run.name}</SplitItem>
+      <SplitItem>
+        <Truncate content={run.name} />
+      </SplitItem>
       <SplitItem>
         <Label icon={icon}>{label}</Label>
       </SplitItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -24,7 +24,7 @@ export const renderDetailItems = (details: DetailItem[], flexKey?: boolean): Rea
           <FlexItem style={{ width: flexKey ? undefined : 150 }}>
             <b>{detail.key}</b>
           </FlexItem>
-          <FlexItem>{detail.value}</FlexItem>
+          <FlexItem flex={{ default: 'flex_1' }}>{detail.value}</FlexItem>
         </Flex>
       </StackItem>
     ))}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, TableText, Td, Tr } from '@patternfly/react-table';
 import { Link, useNavigate } from 'react-router-dom';
 import { Skeleton } from '@patternfly/react-core';
 import { PipelineRunKF, PipelineRunStatusesKF } from '~/concepts/pipelines/kfTypes';
@@ -47,7 +47,9 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
           <TableRowTitleDescription
             title={
               <Link to={`/pipelineRuns/${namespace}/pipelineRun/view/${run.id}`}>
-                {data ? `Run of ${data.name}` : run.name}
+                <TableText wrapModifier="truncate">
+                  {data ? `Run of ${data.name}` : run.name}
+                </TableText>
               </Link>
             }
             description={
@@ -62,7 +64,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
       <Td>
         <CoreResourceExperiment resource={run} />
       </Td>
-      <Td>
+      <Td modifier="truncate">
         {loading ? (
           loadingState
         ) : (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, TableText, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { PipelineRunJobKF } from '~/concepts/pipelines/kfTypes';
 import { TableRowTitleDescription, CheckboxTd } from '~/components/table';
@@ -32,12 +32,14 @@ const PipelineRunJobTableRow: React.FC<PipelineRunJobTableRowProps> = ({
     <Tr>
       <CheckboxTd id={job.id} isChecked={isChecked} onToggle={onToggleCheck} />
       <Td>
-        <TableRowTitleDescription title={job.name} description={job.description} />
+        <TableText wrapModifier="truncate">
+          <TableRowTitleDescription title={job.name} description={job.description} />
+        </TableText>
       </Td>
       <Td>
         <CoreResourceExperiment resource={job} />
       </Td>
-      <Td>
+      <Td modifier="truncate">
         <CoreResourcePipeline resource={job} namespace={namespace} />
       </Td>
       <Td>

--- a/frontend/src/concepts/pipelines/topology/__tests__/pipelineUtils.spec.ts
+++ b/frontend/src/concepts/pipelines/topology/__tests__/pipelineUtils.spec.ts
@@ -1,0 +1,217 @@
+import { RunStatus } from '@patternfly/react-topology';
+import {
+  getNameAndPathFromTaskRef,
+  getNameFromTaskRef,
+  getRunStatus,
+  getValue,
+  paramAsRunAfter,
+  whenAsRunAfter,
+} from '~/concepts/pipelines/topology/pipelineUtils';
+import {
+  PipelineRunTaskParam,
+  PipelineRunTaskRunStatusProperties,
+  PipelineRunTaskWhen,
+} from '~/k8sTypes';
+import { PipelineRunTaskDetails } from '~/concepts/pipelines/content/types';
+
+const taskRef = '$(tasks.random-num.results.Output)';
+
+const param: PipelineRunTaskParam = {
+  name: 'operator',
+  value: '5',
+};
+
+const when: PipelineRunTaskWhen = {
+  input: '',
+  operator: 'in',
+  values: ['true'],
+};
+
+const status: PipelineRunTaskRunStatusProperties = {
+  conditions: [
+    {
+      type: 'Succeeded',
+      status: 'True',
+      lastTransitionTime: '2023-10-20T07:32:06Z',
+      reason: 'Succeeded',
+      message: 'All Steps have completed executing',
+    },
+  ],
+  podName: 'conditional-execution-pipeline-5fe97-condition-2-pod',
+  startTime: '2023-10-20T07:32:00Z',
+};
+
+const task: PipelineRunTaskDetails = {
+  name: 'flip-coin',
+  runDetails: {
+    pipelineTaskName: 'flip-coin',
+    runID: 'conditional-execution-pipeline-6a55f-flip-coin',
+    status: {
+      conditions: [
+        {
+          type: 'Succeeded',
+          status: 'True',
+          lastTransitionTime: '2023-10-21T22:11:11Z',
+          reason: 'Succeeded',
+          message: 'All Steps have completed executing',
+        },
+      ],
+      podName: 'conditional-execution-pipeline-6a55f-flip-coin-pod',
+      startTime: '2023-10-21T22:11:02Z',
+      taskSpec: {
+        results: [
+          {
+            name: 'Output',
+            type: 'string',
+          },
+        ],
+        steps: [{}],
+      },
+      taskResults: [
+        {
+          name: 'Output',
+          type: 'string',
+          value: 'heads',
+        },
+      ],
+    },
+  },
+  skipped: true,
+  taskSpec: {
+    steps: [
+      {
+        name: 'main',
+        image: 'python:alpine3.6',
+        command: [
+          'sh',
+          '-ec',
+          'program_path=$(mktemp)\nprintf "%s" "$0" > "$program_path"\npython3 -u "$program_path" "$@"\n',
+        ],
+      },
+    ],
+    results: [
+      {
+        name: 'Output',
+        type: 'string',
+      },
+    ],
+  },
+};
+
+describe('getNameAndPathFromTaskRef', () => {
+  it("should return null when name and task from path ref doesn't match", () => {
+    const taskRef = 'random-string';
+    const nameandTaskfromPath = getNameAndPathFromTaskRef(taskRef);
+    expect(nameandTaskfromPath).toBe(null);
+  });
+
+  it('should check for name and task from path ref', () => {
+    const nameandTaskfromPath = getNameAndPathFromTaskRef(taskRef);
+    expect(nameandTaskfromPath?.[0]).toBe('random-num');
+    expect(nameandTaskfromPath?.[1]).toBe('results.Output');
+  });
+});
+
+describe('getNameFromTaskRef', () => {
+  it('should get null from task ref', () => {
+    const taskRef = 'random-string';
+    const nameFromTaskRef = getNameFromTaskRef(taskRef);
+    expect(nameFromTaskRef).toBe(null);
+  });
+
+  it('should get name from task ref', () => {
+    const nameFromTaskRef = getNameFromTaskRef(taskRef);
+    expect(nameFromTaskRef).toBe('random-num');
+  });
+});
+
+describe('paramAsRunAfter', () => {
+  it('should return null for param as run after', () => {
+    const paramasRunAfter = paramAsRunAfter(param);
+    expect(paramasRunAfter).toBe(null);
+  });
+
+  it('should return name for param as run after', () => {
+    param.value = '$(tasks.random-num.results.Output)';
+    const paramasRunAfter = paramAsRunAfter(param);
+    expect(paramasRunAfter).toBe('random-num');
+  });
+});
+
+describe('whenAsRunAfter', () => {
+  it('should return null for when as run after', () => {
+    const whenasRunAfter = whenAsRunAfter(when);
+    expect(whenasRunAfter).toBe(null);
+  });
+
+  it('should return name for when as run after', () => {
+    when.input = '$(tasks.condition-1.results.outcome)';
+    const whenasRunAfter = whenAsRunAfter(when);
+    expect(whenasRunAfter).toBe('condition-1');
+  });
+});
+
+describe('getRunStatus', () => {
+  it('should get run status as Succeeded', () => {
+    const getrunStatus = getRunStatus(status);
+    expect(getrunStatus).toBe(RunStatus.Succeeded);
+  });
+
+  it('should get run status as failed', () => {
+    status.conditions[0].status = 'False';
+    const getrunStatus = getRunStatus(status);
+    expect(getrunStatus).toBe(RunStatus.Failed);
+  });
+
+  it('should get run status as running', () => {
+    status.conditions[0].status = 'Unkonown';
+    const getrunStatus = getRunStatus(status);
+    expect(getrunStatus).toBe(RunStatus.Running);
+  });
+
+  it('should get run status as idle', () => {
+    status.conditions[0].type = 'Failed';
+    const getrunStatus = getRunStatus(status);
+    expect(getrunStatus).toBe(RunStatus.Idle);
+  });
+});
+
+describe('getValue', () => {
+  it('should get value as null when runDetails is undefined', () => {
+    const task: PipelineRunTaskDetails = {
+      name: 'flip-coin',
+      runDetails: undefined,
+      skipped: true,
+      taskSpec: {
+        steps: [
+          {
+            name: 'main',
+            image: 'python:alpine3.6',
+            command: ['sh', '-ec'],
+          },
+        ],
+        results: [
+          {
+            name: 'Output',
+            type: 'string',
+          },
+        ],
+      },
+    };
+    const path = 'results.Output';
+    const getvalue = getValue(task, path);
+    expect(getvalue).toBe(null);
+  });
+
+  it('should get value as heads', () => {
+    const path = 'results.Output';
+    const getvalue = getValue(task, path);
+    expect(getvalue).toBe('heads');
+  });
+
+  it("should get value as null when path doesn't match", () => {
+    const path = 'random.string';
+    const getvalue = getValue(task, path);
+    expect(getvalue).toBe(null);
+  });
+});

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -55,7 +55,7 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
     <PageSection variant={PageSectionVariants.light}>
       <Stack hasGutter>
         <StackItem>
-          <Split>
+          <Split hasGutter>
             <SplitItem isFilled>
               <TextContent>
                 <Text component="h1">{title}</Text>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1182  

## Description
This PR will truncate the long pipeline name and solve the pipeline runs scheduled and Triggered table width issue. Also solves the breaking of pipelinerun details page and pipeline details page because of the long name. 
 
![Screenshot from 2023-12-01 20-23-37](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/fc2e9781-a489-427d-b68e-0f1c09da3476)

![Screenshot from 2023-09-27 16-09-55](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/ce83524d-3a3d-4b35-9f05-9e6c51904e0d)

![Screenshot from 2023-09-27 16-10-32](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/d264cd10-5659-4df7-b653-28a6f2506121)

![Screenshot from 2023-12-01 20-25-18](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/f2a9c6de-8ecc-4953-876d-47ebb7192249)


## How Has This Been Tested?
1) Have a project
2) Create a Pipeline with long name, like long pipeline nameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
3) Create a Run that is scheduled or Triggered
4) View the Global Pipeline Runs page
5) Also check the pipelinerun details page (details tab, title with label, breadcrumb)

## Test Impact
Added unit test case.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
