### PR TITLE
logic for deprecated images

### DIFF
--- a/frontend/src/__mocks__/mockImageStreamK8sResource.ts
+++ b/frontend/src/__mocks__/mockImageStreamK8sResource.ts
@@ -1,0 +1,84 @@
+import _ from 'lodash';
+import { ImageStreamKind } from '~/k8sTypes';
+import { RecursivePartial } from '~/typeHelpers';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+  displayName?: string;
+  opts?: RecursivePartial<ImageStreamKind>;
+};
+
+export const mockImageStreamK8sResource = ({
+  name = 'test-imagestream',
+  namespace = 'test-project',
+  displayName = 'Test Image',
+  opts = {},
+}: MockResourceConfigType): ImageStreamKind =>
+  _.merge(
+    {
+      apiVersion: 'image.openshift.io/v1',
+      kind: 'ImageStream',
+      metadata: {
+        name: name,
+        namespace: namespace,
+        uid: 'd6a75af7-f215-47d1-a167-e1c1e78d465c',
+        resourceVersion: '1579802',
+        generation: 2,
+        creationTimestamp: '2023-06-30T15:07:35Z',
+        labels: {
+          'component.opendatahub.io/name': 'notebooks',
+          'opendatahub.io/component': 'true',
+          'opendatahub.io/notebook-image': 'true',
+        },
+        annotations: {
+          'kfctl.kubeflow.io/kfdef-instance': 'opendatahub.opendatahub',
+          'opendatahub.io/notebook-image-desc':
+            'Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment.',
+          'opendatahub.io/notebook-image-name': displayName,
+          'opendatahub.io/notebook-image-order': '1',
+          'opendatahub.io/notebook-image-url':
+            'https://github.com//opendatahub-io/notebooks/tree/main/jupyter/minimal',
+          'openshift.io/image.dockerRepositoryCheck': '2023-06-30T15:07:36Z',
+        },
+      },
+      spec: {
+        lookupPolicy: {
+          local: true,
+        },
+        tags: [
+          {
+            name: '1.2',
+            annotations: {
+              'opendatahub.io/notebook-python-dependencies':
+                '[{"name":"JupyterLab","version": "3.2"}, {"name": "Notebook","version": "6.4"}]',
+              'opendatahub.io/notebook-software': '[{"name":"Python","version":"v3.8"}]',
+            },
+            from: {
+              kind: 'DockerImage',
+              name: 'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+            },
+          },
+        ],
+      },
+      status: {
+        dockerImageRepository:
+          'image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-notebook',
+        tags: [
+          {
+            tag: '1.2',
+            items: [
+              {
+                created: '2023-06-30T15:07:36Z',
+                dockerImageReference:
+                  'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+                image: 'sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+                generation: 2,
+              },
+            ],
+          },
+        ],
+      },
+    } as ImageStreamKind,
+    opts,
+  );

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -1,7 +1,9 @@
+import _ from 'lodash';
 import { KnownLabels, NotebookKind } from '~/k8sTypes';
 import { DEFAULT_NOTEBOOK_SIZES } from '~/pages/projects/screens/spawner/const';
 import { ContainerResources } from '~/types';
 import { genUID } from '~/__mocks__/mockUtils';
+import { RecursivePartial } from '~/typeHelpers';
 
 type MockResourceConfigType = {
   name?: string;
@@ -10,6 +12,7 @@ type MockResourceConfigType = {
   user?: string;
   description?: string;
   resources?: ContainerResources;
+  opts?: RecursivePartial<NotebookKind>;
 };
 
 export const mockNotebookK8sResource = ({
@@ -19,276 +22,257 @@ export const mockNotebookK8sResource = ({
   user = 'test-user',
   description = '',
   resources = DEFAULT_NOTEBOOK_SIZES[0].resources,
-}: MockResourceConfigType): NotebookKind => ({
-  apiVersion: 'kubeflow.org/v1',
-  kind: 'Notebook',
-  metadata: {
-    annotations: {
-      'notebooks.kubeflow.org/last-activity': '2023-02-14T21:45:14Z',
-      'notebooks.opendatahub.io/inject-oauth': 'true',
-      'notebooks.opendatahub.io/last-image-selection': 's2i-minimal-notebook:py3.8-v1',
-      'notebooks.opendatahub.io/last-size-selection': 'Small',
-      'notebooks.opendatahub.io/oauth-logout-url':
-        'http://localhost:4010/projects/project?notebookLogout=workbench',
-      'opendatahub.io/username': user,
-      'openshift.io/description': description,
-      'openshift.io/display-name': displayName,
-    },
-    creationTimestamp: '2023-02-14T21:44:13Z',
-    generation: 4,
-    labels: {
-      app: name,
-      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
-      'opendatahub.io/odh-managed': 'true',
-      'opendatahub.io/user': user,
-    },
-    managedFields: [],
-    name: name,
-    namespace: namespace,
-    resourceVersion: '4800689',
-    uid: genUID('notebook'),
-  },
-  spec: {
-    template: {
+  opts = {},
+}: MockResourceConfigType): NotebookKind =>
+  _.merge(
+    {
+      apiVersion: 'kubeflow.org/v1',
+      kind: 'Notebook',
+      metadata: {
+        annotations: {
+          'notebooks.kubeflow.org/last-activity': '2023-02-14T21:45:14Z',
+          'notebooks.opendatahub.io/inject-oauth': 'true',
+          'notebooks.opendatahub.io/last-image-selection': 's2i-minimal-notebook:py3.8-v1',
+          'notebooks.opendatahub.io/last-size-selection': 'Small',
+          'notebooks.opendatahub.io/oauth-logout-url':
+            'http://localhost:4010/projects/project?notebookLogout=workbench',
+          'opendatahub.io/username': user,
+          'openshift.io/description': description,
+          'openshift.io/display-name': displayName,
+        },
+        creationTimestamp: '2023-02-14T21:44:13Z',
+        generation: 4,
+        labels: {
+          app: name,
+          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+          'opendatahub.io/odh-managed': 'true',
+          'opendatahub.io/user': user,
+        },
+        managedFields: [],
+        name: name,
+        namespace: namespace,
+        resourceVersion: '4800689',
+        uid: genUID('notebook'),
+      },
       spec: {
-        affinity: {
-          nodeAffinity: {
-            preferredDuringSchedulingIgnoredDuringExecution: [
-              {
-                preference: {
-                  matchExpressions: [
-                    {
-                      key: 'nvidia.com/gpu.present',
-                      operator: 'NotIn',
-                      values: ['true'],
+        template: {
+          spec: {
+            affinity: {
+              nodeAffinity: {
+                preferredDuringSchedulingIgnoredDuringExecution: [
+                  {
+                    preference: {
+                      matchExpressions: [
+                        {
+                          key: 'nvidia.com/gpu.present',
+                          operator: 'NotIn',
+                          values: ['true'],
+                        },
+                      ],
                     },
-                  ],
+                    weight: 1,
+                  },
+                ],
+              },
+            },
+            containers: [
+              {
+                env: [
+                  {
+                    name: 'NOTEBOOK_ARGS',
+                    value:
+                      '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
+                  },
+                  {
+                    name: 'JUPYTER_IMAGE',
+                    value:
+                      'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-v1',
+                  },
+                ],
+                envFrom: [
+                  {
+                    secretRef: {
+                      name: 'aws-connection-db-1',
+                    },
+                  },
+                ],
+                image:
+                  'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-v1',
+                imagePullPolicy: 'Always',
+                livenessProbe: {
+                  failureThreshold: 3,
+                  httpGet: {
+                    path: '/notebook/project/workbench/api',
+                    port: 'notebook-port',
+                    scheme: 'HTTP',
+                  },
+                  initialDelaySeconds: 10,
+                  periodSeconds: 5,
+                  successThreshold: 1,
+                  timeoutSeconds: 1,
                 },
-                weight: 1,
+                name: name,
+                ports: [
+                  {
+                    containerPort: 8888,
+                    name: 'notebook-port',
+                    protocol: 'TCP',
+                  },
+                ],
+                readinessProbe: {
+                  failureThreshold: 3,
+                  httpGet: {
+                    path: '/notebook/project/workbench/api',
+                    port: 'notebook-port',
+                    scheme: 'HTTP',
+                  },
+                  initialDelaySeconds: 10,
+                  periodSeconds: 5,
+                  successThreshold: 1,
+                  timeoutSeconds: 1,
+                },
+                resources,
+                volumeMounts: [
+                  {
+                    mountPath: '/opt/app-root/src',
+                    name: name,
+                  },
+                ],
+                workingDir: '/opt/app-root/src',
+              },
+              {
+                env: [
+                  {
+                    name: 'NAMESPACE',
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: 'metadata.namespace',
+                      },
+                    },
+                  },
+                ],
+                image:
+                  'registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46',
+                imagePullPolicy: 'Always',
+                livenessProbe: {
+                  failureThreshold: 3,
+                  httpGet: {
+                    path: '/oauth/healthz',
+                    port: 'oauth-proxy',
+                    scheme: 'HTTPS',
+                  },
+                  initialDelaySeconds: 30,
+                  periodSeconds: 5,
+                  successThreshold: 1,
+                  timeoutSeconds: 1,
+                },
+                name: 'oauth-proxy',
+                ports: [
+                  {
+                    containerPort: 8443,
+                    name: 'oauth-proxy',
+                    protocol: 'TCP',
+                  },
+                ],
+                readinessProbe: {
+                  failureThreshold: 3,
+                  httpGet: {
+                    path: '/oauth/healthz',
+                    port: 'oauth-proxy',
+                    scheme: 'HTTPS',
+                  },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 5,
+                  successThreshold: 1,
+                  timeoutSeconds: 1,
+                },
+                resources: {
+                  limits: {
+                    cpu: '100m',
+                    memory: '64Mi',
+                  },
+                  requests: {
+                    cpu: '100m',
+                    memory: '64Mi',
+                  },
+                },
+                volumeMounts: [
+                  {
+                    mountPath: '/etc/oauth/config',
+                    name: 'oauth-config',
+                  },
+                  {
+                    mountPath: '/etc/tls/private',
+                    name: 'tls-certificates',
+                  },
+                ],
+              },
+            ],
+            enableServiceLinks: false,
+            tolerations: [
+              {
+                effect: 'NoSchedule',
+                key: 'NotebooksOnlyChange',
+                operator: 'Exists',
+              },
+            ],
+            volumes: [
+              {
+                name: name,
+                persistentVolumeClaim: {
+                  claimName: name,
+                },
+              },
+              {
+                name: 'oauth-config',
+                secret: {
+                  secretName: 'workbench-oauth-config',
+                },
+              },
+              {
+                name: 'tls-certificates',
+                secret: {
+                  secretName: 'workbench-tls',
+                },
               },
             ],
           },
         },
-        containers: [
+      },
+      status: {
+        conditions: [
           {
-            env: [
-              {
-                name: 'NOTEBOOK_ARGS',
-                value:
-                  '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
-              },
-              {
-                name: 'JUPYTER_IMAGE',
-                value:
-                  'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-v1',
-              },
-            ],
-            envFrom: [
-              {
-                secretRef: {
-                  name: 'aws-connection-db-1',
-                },
-              },
-            ],
-            image:
-              'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-v1',
-            imagePullPolicy: 'Always',
-            livenessProbe: {
-              failureThreshold: 3,
-              httpGet: {
-                path: '/notebook/project/workbench/api',
-                port: 'notebook-port',
-                scheme: 'HTTP',
-              },
-              initialDelaySeconds: 10,
-              periodSeconds: 5,
-              successThreshold: 1,
-              timeoutSeconds: 1,
-            },
-            name: name,
-            ports: [
-              {
-                containerPort: 8888,
-                name: 'notebook-port',
-                protocol: 'TCP',
-              },
-            ],
-            readinessProbe: {
-              failureThreshold: 3,
-              httpGet: {
-                path: '/notebook/project/workbench/api',
-                port: 'notebook-port',
-                scheme: 'HTTP',
-              },
-              initialDelaySeconds: 10,
-              periodSeconds: 5,
-              successThreshold: 1,
-              timeoutSeconds: 1,
-            },
-            resources,
-            volumeMounts: [
-              {
-                mountPath: '/opt/app-root/src',
-                name: name,
-              },
-            ],
-            workingDir: '/opt/app-root/src',
+            lastProbeTime: '2023-02-14T22:06:54Z',
+            type: 'Running',
           },
           {
-            args: [
-              '--provider=openshift',
-              '--https-address=:8443',
-              '--http-address=',
-              '--openshift-service-account=workbench',
-              '--cookie-secret-file=/etc/oauth/config/cookie_secret',
-              '--cookie-expire=24h0m0s',
-              '--tls-cert=/etc/tls/private/tls.crt',
-              '--tls-key=/etc/tls/private/tls.key',
-              '--upstream=http://localhost:8888',
-              '--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-              '--skip-auth-regex=^(?:/notebook/$(NAMESPACE)/workbench)?/api$',
-              '--email-domain=*',
-              '--skip-provider-button',
-              '--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org","resourceName":"workbench","namespace":"$(NAMESPACE)"}',
-              '--logout-url=http://localhost:4010/projects/project?notebookLogout=workbench',
-            ],
-            env: [
-              {
-                name: 'NAMESPACE',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: 'metadata.namespace',
-                  },
-                },
-              },
-            ],
-            image:
-              'registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46',
-            imagePullPolicy: 'Always',
-            livenessProbe: {
-              failureThreshold: 3,
-              httpGet: {
-                path: '/oauth/healthz',
-                port: 'oauth-proxy',
-                scheme: 'HTTPS',
-              },
-              initialDelaySeconds: 30,
-              periodSeconds: 5,
-              successThreshold: 1,
-              timeoutSeconds: 1,
-            },
-            name: 'oauth-proxy',
-            ports: [
-              {
-                containerPort: 8443,
-                name: 'oauth-proxy',
-                protocol: 'TCP',
-              },
-            ],
-            readinessProbe: {
-              failureThreshold: 3,
-              httpGet: {
-                path: '/oauth/healthz',
-                port: 'oauth-proxy',
-                scheme: 'HTTPS',
-              },
-              initialDelaySeconds: 5,
-              periodSeconds: 5,
-              successThreshold: 1,
-              timeoutSeconds: 1,
-            },
-            resources: {
-              limits: {
-                cpu: '100m',
-                memory: '64Mi',
-              },
-              requests: {
-                cpu: '100m',
-                memory: '64Mi',
-              },
-            },
-            volumeMounts: [
-              {
-                mountPath: '/etc/oauth/config',
-                name: 'oauth-config',
-              },
-              {
-                mountPath: '/etc/tls/private',
-                name: 'tls-certificates',
-              },
-            ],
+            lastProbeTime: '2023-02-14T22:06:44Z',
+            message: 'Completed',
+            reason: 'Completed',
+            type: 'Terminated',
+          },
+          {
+            lastProbeTime: '2023-02-14T22:05:53Z',
+            type: 'Running',
+          },
+          {
+            lastProbeTime: '2023-02-14T22:05:48Z',
+            reason: 'ContainerCreating',
+            type: 'Waiting',
+          },
+          {
+            lastProbeTime: '2023-02-14T21:44:27Z',
+            type: 'Running',
+          },
+          {
+            lastProbeTime: '2023-02-14T21:44:24Z',
+            reason: 'ContainerCreating',
+            type: 'Waiting',
           },
         ],
-        enableServiceLinks: false,
-        serviceAccountName: name,
-        tolerations: [
-          {
-            effect: 'NoSchedule',
-            key: 'NotebooksOnlyChange',
-            operator: 'Exists',
-          },
-        ],
-        volumes: [
-          {
-            name: name,
-            persistentVolumeClaim: {
-              claimName: name,
-            },
-          },
-          {
-            name: 'oauth-config',
-            secret: {
-              defaultMode: 420,
-              secretName: 'workbench-oauth-config',
-            },
-          },
-          {
-            name: 'tls-certificates',
-            secret: {
-              defaultMode: 420,
-              secretName: 'workbench-tls',
-            },
-          },
-        ],
+        containerState: {},
+        readyReplicas: 1,
       },
-    },
-  },
-  status: {
-    conditions: [
-      {
-        lastProbeTime: '2023-02-14T22:06:54Z',
-        type: 'Running',
-      },
-      {
-        lastProbeTime: '2023-02-14T22:06:44Z',
-        message: 'Completed',
-        reason: 'Completed',
-        type: 'Terminated',
-      },
-      {
-        lastProbeTime: '2023-02-14T22:05:53Z',
-        type: 'Running',
-      },
-      {
-        lastProbeTime: '2023-02-14T22:05:48Z',
-        reason: 'ContainerCreating',
-        type: 'Waiting',
-      },
-      {
-        lastProbeTime: '2023-02-14T21:44:27Z',
-        type: 'Running',
-      },
-      {
-        lastProbeTime: '2023-02-14T21:44:24Z',
-        reason: 'ContainerCreating',
-        type: 'Waiting',
-      },
-    ],
-    containerState: {
-      running: {
-        startedAt: '2023-02-14T22:06:52Z',
-      },
-    },
-    readyReplicas: 1,
-  },
-});
+    } as NotebookKind,
+    opts,
+  );

--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
@@ -24,5 +24,35 @@ test('Non-empty project', async ({ page }) => {
   expect(await page.locator('[data-id="details-page-section-divider"]').all()).toHaveLength(0);
 
   // check the x-small size shown correctly
-  expect(await page.getByText('XSmall')).toBeTruthy();
+  expect(page.getByText('Small')).toBeTruthy();
+});
+
+test('Notebook with deleted image', async ({ page }) => {
+  await page.goto(navigateToStory('pages-projects-projectdetails', 'deleted-image'));
+
+  // wait for page to load
+  await page.waitForSelector('text=Test Notebook');
+
+  await expect(page.getByText('Deleted')).toHaveCount(1);
+  await expect(page.getByText('Test Image')).toHaveCount(1);
+});
+
+test('Notebook with disabled image', async ({ page }) => {
+  await page.goto(navigateToStory('pages-projects-projectdetails', 'disabled-image'));
+
+  // wait for page to load
+  await page.waitForSelector('text=Test Notebook');
+
+  await expect(page.getByText('Disabled', { exact: true })).toHaveCount(1);
+  await expect(page.getByText('Test Image')).toHaveCount(1);
+});
+
+test('Notebook with unknown image', async ({ page }) => {
+  await page.goto(navigateToStory('pages-projects-projectdetails', 'unknown-image'));
+
+  // wait for page to load
+  await page.waitForSelector('text=Test Notebook');
+
+  await expect(page.getByText('Deleted')).toHaveCount(1);
+  await expect(page.getByText('Unknown', { exact: true })).toHaveCount(1);
 });

--- a/frontend/src/api/k8s/imageStreams.ts
+++ b/frontend/src/api/k8s/imageStreams.ts
@@ -2,11 +2,16 @@ import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import { ImageStreamModel } from '~/api/models';
 import { ImageStreamKind } from '~/k8sTypes';
 
-export const getNotebookImageStreams = (namespace: string): Promise<ImageStreamKind[]> =>
+export const getNotebookImageStreams = (
+  namespace: string,
+  includeDisabled?: boolean,
+): Promise<ImageStreamKind[]> =>
   k8sListResourceItems<ImageStreamKind>({
     model: ImageStreamModel,
     queryOptions: {
       ns: namespace,
-      queryParams: { labelSelector: 'opendatahub.io/notebook-image=true' },
+      queryParams: {
+        labelSelector: includeDisabled ? undefined : 'opendatahub.io/notebook-image=true',
+      },
     },
   });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -25,6 +25,7 @@ import {
   getPipelineVolumePatch,
 } from '~/concepts/pipelines/elyra/utils';
 import { Volume, VolumeMount } from '~/types';
+import { getImageStreamDisplayName } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { assemblePodSpecOptions, getshmVolume, getshmVolumeMount } from './utils';
 
 const assembleNotebook = (
@@ -87,7 +88,7 @@ const assembleNotebook = (
     volumeMounts.push(getshmVolumeMount());
   }
 
-  return {
+  const resource: NotebookKind = {
     apiVersion: 'kubeflow.org/v1',
     kind: 'Notebook',
     metadata: {
@@ -178,6 +179,15 @@ const assembleNotebook = (
       },
     },
   };
+
+  // set image display name
+  if (image.imageStream && resource.metadata.annotations) {
+    resource.metadata.annotations['opendatahub.io/image-display-name'] = getImageStreamDisplayName(
+      image.imageStream,
+    );
+  }
+
+  return resource;
 };
 
 const getStopPatchDataString = (): string => new Date().toISOString().replace(/\.\d{3}Z/i, 'Z');

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -74,6 +74,7 @@ export type NotebookAnnotations = Partial<{
   'notebooks.opendatahub.io/last-image-selection': string; // the last image they selected
   'notebooks.opendatahub.io/last-size-selection': string; // the last notebook size they selected
   'opendatahub.io/accelerator-name': string; // the accelerator attached to the notebook
+  'opendatahub.io/image-display-name': string; // the display name of the image
 }>;
 
 export type DashboardLabels = {
@@ -259,10 +260,10 @@ export type PersistentVolumeClaimKind = K8sResourceCommon & {
 
 export type NotebookKind = K8sResourceCommon & {
   metadata: {
-    annotations: DisplayNameAnnotations & NotebookAnnotations;
+    annotations?: DisplayNameAnnotations & NotebookAnnotations;
     name: string;
     namespace: string;
-    labels: Partial<{
+    labels?: Partial<{
       'opendatahub.io/user': string; // translated username -- see translateUsername
     }>;
   };

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -17,12 +17,14 @@ type NotebookStatusToggleProps = {
   notebookState: NotebookState;
   doListen: boolean;
   enablePipelines?: boolean;
+  isDisabled?: boolean;
 };
 
 const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
   notebookState,
   doListen,
   enablePipelines,
+  isDisabled,
 }) => {
   const { notebook, isStarting, isRunning, isStopping, refresh } = notebookState;
   const [acceleratorData] = useNotebookAccelerators(notebook);
@@ -87,7 +89,7 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
         <FlexItem>
           <Switch
             aria-label={label}
-            isDisabled={inProgress || isStopping}
+            isDisabled={inProgress || isStopping || isDisabled}
             id={`${notebookName}-${notebookNamespace}`}
             isChecked={isChecked}
             onClick={() => {

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -1,0 +1,153 @@
+import {
+  Popover,
+  Spinner,
+  Flex,
+  FlexItem,
+  Label,
+  Text,
+  Alert,
+  AlertProps,
+  LabelProps,
+  TextVariants,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import React from 'react';
+import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import { NotebookImageAvailability } from './const';
+import { NotebookImage } from './types';
+
+type NotebookImageDisplayNameProps = {
+  notebookImage: NotebookImage | null;
+  loaded: boolean;
+  loadError?: Error;
+  isExpanded?: boolean;
+};
+
+export const NotebookImageDisplayName = ({
+  notebookImage,
+  loaded,
+  loadError,
+  isExpanded,
+}: NotebookImageDisplayNameProps) => {
+  // if there was an error loading the image, display unknown WITHOUT a label
+  if (loadError) {
+    return (
+      <HelperText>
+        <HelperTextItem variant="indeterminate">Unknown</HelperTextItem>
+      </HelperText>
+    );
+  }
+
+  // If the image is not loaded, display a spinner
+  if (!loaded || !notebookImage) {
+    return <Spinner size="md" />;
+  }
+
+  // helper function to get the popover variant and text
+  const getNotebookImagePopoverText = ():
+    | Record<string, never>
+    | {
+        title: string;
+        body: React.ReactNode;
+        variant: AlertProps['variant'];
+      } => {
+    if (notebookImage.imageAvailability === NotebookImageAvailability.DISABLED) {
+      return {
+        title: 'Notebook image disabled',
+        body: (
+          <p>
+            The <b>{notebookImage.imageDisplayName}</b> notebook image has been disabled. This
+            workbench can continue using the image, but disabled images are not available for
+            selection when creating new workbenches.
+          </p>
+        ),
+        variant: 'info',
+      };
+    } else if (notebookImage.imageAvailability === NotebookImageAvailability.DELETED) {
+      const unknownBody =
+        'An unknown notebook image has been deleted. To run this workbench, select a new notebook image.';
+      const knownBody = (
+        <p>
+          The <b>{notebookImage.imageDisplayName}</b> notebook image has been deleted. To run this
+          workbench, select a new notebook image.
+        </p>
+      );
+      return {
+        title: 'Notebook image deleted',
+        body: notebookImage.imageDisplayName ? knownBody : unknownBody,
+        variant: 'danger',
+      };
+    }
+
+    return {};
+  };
+
+  // helper function to get the label color
+  const getNotebookImageLabelColor = (): LabelProps['color'] => {
+    switch (notebookImage.imageAvailability) {
+      case NotebookImageAvailability.DISABLED:
+        return 'grey';
+      case NotebookImageAvailability.DELETED:
+        return 'red';
+      default:
+        return undefined;
+    }
+  };
+
+  // helper function to get the label icon
+  const getNotebookImageIcon = (): LabelProps['icon'] => {
+    switch (notebookImage.imageAvailability) {
+      case NotebookImageAvailability.DISABLED:
+        return <InfoCircleIcon />;
+      case NotebookImageAvailability.DELETED:
+        return <ExclamationCircleIcon />;
+      default:
+        return undefined;
+    }
+  };
+
+  // If the image is enabled, just display the name, no label is needed
+  if (notebookImage.imageAvailability === NotebookImageAvailability.ENABLED) {
+    return (
+      <>
+        <HelperText>
+          <HelperTextItem>{notebookImage.imageDisplayName}</HelperTextItem>
+        </HelperText>
+        {isExpanded && <Text component={TextVariants.small}>{notebookImage.tagSoftware}</Text>}
+      </>
+    );
+  }
+
+  // get the popover title, body, and variant based on the image availability
+  const { title, body, variant } = getNotebookImagePopoverText();
+
+  // otherwise, return the popover with the label as the trigger
+  return (
+    <>
+      <Flex>
+        <FlexItem>
+          <HelperText>
+            <HelperTextItem variant={notebookImage.imageDisplayName ? 'default' : 'indeterminate'}>
+              {notebookImage.imageDisplayName || 'Unknown'}
+            </HelperTextItem>
+          </HelperText>
+        </FlexItem>
+        <FlexItem>
+          <Popover
+            aria-label="Image display name popover"
+            headerContent={<Alert variant={variant} isInline isPlain title={title} />}
+            bodyContent={body}
+          >
+            <Label isCompact color={getNotebookImageLabelColor()} icon={getNotebookImageIcon()}>
+              {notebookImage.imageAvailability}
+            </Label>
+          </Popover>
+        </FlexItem>
+      </Flex>
+      {isExpanded && notebookImage.imageAvailability !== NotebookImageAvailability.DELETED && (
+        <Text component={TextVariants.small}>{notebookImage.tagSoftware}</Text>
+      )}
+    </>
+  );
+};

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionsColumn, ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
-import { Flex, FlexItem, Icon, Spinner, Text, TextVariants, Tooltip } from '@patternfly/react-core';
+import { Flex, FlexItem, Icon, Tooltip } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { NotebookState } from '~/pages/projects/notebook/types';
@@ -15,6 +15,8 @@ import useNotebookDeploymentSize from './useNotebookDeploymentSize';
 import useNotebookImage from './useNotebookImage';
 import NotebookSizeDetails from './NotebookSizeDetails';
 import NotebookStorageBars from './NotebookStorageBars';
+import { NotebookImageDisplayName } from './NotebookImageDisplayName';
+import { NotebookImageAvailability } from './const';
 
 type NotebookTableRowProps = {
   obj: NotebookState;
@@ -35,7 +37,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const navigate = useNavigate();
   const [isExpanded, setExpanded] = React.useState(false);
   const { size: notebookSize, error: sizeError } = useNotebookDeploymentSize(obj.notebook);
-  const [notebookImage, loaded] = useNotebookImage(obj.notebook);
+  const [notebookImage, loaded, loadError] = useNotebookImage(obj.notebook);
 
   return (
     <Tbody isExpanded={isExpanded}>
@@ -56,14 +58,12 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           />
         </Td>
         <Td dataLabel="Notebook image">
-          {!loaded ? (
-            <Spinner size="md" />
-          ) : (
-            <Text component="p">{notebookImage?.imageName ?? 'Unknown'}</Text>
-          )}
-          {isExpanded && notebookImage?.tagSoftware && (
-            <Text component={TextVariants.small}>{notebookImage.tagSoftware}</Text>
-          )}
+          <NotebookImageDisplayName
+            notebookImage={notebookImage}
+            loaded={loaded}
+            loadError={loadError}
+            isExpanded={isExpanded}
+          />
         </Td>
         <Td dataLabel="Container size">
           <Flex
@@ -85,6 +85,10 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             notebookState={obj}
             doListen={false}
             enablePipelines={canEnablePipelines}
+            isDisabled={
+              notebookImage?.imageAvailability === NotebookImageAvailability.DELETED &&
+              !obj.isRunning
+            }
           />
         </Td>
         <Td>
@@ -121,7 +125,8 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
         </Td>
         <Td dataLabel="Packages">
           <ExpandableRowContent>
-            {notebookImage ? (
+            {notebookImage &&
+            notebookImage.imageAvailability !== NotebookImageAvailability.DELETED ? (
               <NotebookImagePackageDetails dependencies={notebookImage.dependencies} />
             ) : (
               'Unknown package info'

--- a/frontend/src/pages/projects/screens/detail/notebooks/const.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/const.ts
@@ -1,0 +1,5 @@
+export enum NotebookImageAvailability {
+  DISABLED = 'Disabled',
+  ENABLED = 'Enabled',
+  DELETED = 'Deleted',
+}

--- a/frontend/src/pages/projects/screens/detail/notebooks/types.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/types.ts
@@ -1,0 +1,42 @@
+import { ImageVersionDependencyType } from '~/pages/projects/screens/spawner/types';
+import { ImageStreamKind, ImageStreamSpecTagType } from '~/k8sTypes';
+import { NotebookImageAvailability } from './const';
+
+export type NotebookImage =
+  | {
+      imageAvailability: Exclude<NotebookImageAvailability, NotebookImageAvailability.DELETED>;
+      imageDisplayName: string;
+      tagSoftware: string;
+      dependencies: ImageVersionDependencyType[];
+    }
+  | {
+      imageAvailability: NotebookImageAvailability.DELETED;
+      imageDisplayName?: string;
+    };
+
+export type ImageData = {
+  imageStream: ImageStreamKind;
+  imageVersion: ImageStreamSpecTagType;
+};
+
+export type NotebookImageData =
+  | [data: null, loaded: false, loadError: undefined]
+  | [data: null, loaded: false, loadError: Error]
+  | [
+      data: {
+        imageAvailability: NotebookImageAvailability.DELETED;
+        imageDisplayName?: string;
+      },
+      loaded: true,
+      loadError: undefined,
+    ]
+  | [
+      data: {
+        imageAvailability: Exclude<NotebookImageAvailability, NotebookImageAvailability.DELETED>;
+        imageDisplayName: string;
+        imageStream: ImageStreamKind;
+        imageVersion: ImageStreamSpecTagType;
+      },
+      loaded: true,
+      loadError: undefined,
+    ];

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -1,25 +1,19 @@
 import * as React from 'react';
-import { ImageStreamKind, ImageStreamSpecTagType, NotebookKind } from '~/k8sTypes';
+import { NotebookKind } from '~/k8sTypes';
 import useNamespaces from '~/pages/notebookController/useNamespaces';
 import useImageStreams from '~/pages/projects/screens/spawner/useImageStreams';
 import { NotebookContainer } from '~/types';
+import { getImageStreamDisplayName } from '~/pages/projects/screens/spawner/spawnerUtils';
+import { NotebookImageAvailability } from './const';
+import { NotebookImageData } from './types';
 
-const useNotebookImageData = (
-  notebook?: NotebookKind,
-): [
-  data: { imageStream: ImageStreamKind; imageVersion: ImageStreamSpecTagType } | null,
-  loaded: boolean,
-] => {
+const useNotebookImageData = (notebook?: NotebookKind): NotebookImageData => {
   const { dashboardNamespace } = useNamespaces();
-  const [images, loaded] = useImageStreams(dashboardNamespace);
+  const [images, loaded, loadError] = useImageStreams(dashboardNamespace, true);
 
   return React.useMemo(() => {
-    if (!notebook) {
-      return [null, false];
-    }
-
-    if (!loaded) {
-      return [null, false];
+    if (!loaded || !notebook) {
+      return [null, false, loadError];
     }
 
     const container: NotebookContainer | undefined = notebook.spec.template.spec.containers.find(
@@ -27,26 +21,68 @@ const useNotebookImageData = (
     );
     const imageTag = container?.image.split('/').at(-1)?.split(':');
 
+    // if image could not be parsed from the container, consider it deleted because the image tag is invalid
     if (!imageTag || imageTag.length < 2 || !container) {
-      return [null, true];
+      return [
+        {
+          imageAvailability: NotebookImageAvailability.DELETED,
+        },
+        true,
+        undefined,
+      ];
     }
 
     const [imageName, versionName] = imageTag;
     const imageStream = images.find((image) => image.metadata.name === imageName);
 
+    // if the image stream is not found, consider it deleted
     if (!imageStream) {
-      return [null, true];
+      // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
+      const imageDisplayName = notebook.metadata.annotations?.['opendatahub.io/image-display-name'];
+
+      return [
+        {
+          imageAvailability: NotebookImageAvailability.DELETED,
+          imageDisplayName,
+        },
+        true,
+        undefined,
+      ];
     }
 
     const versions = imageStream.spec.tags || [];
     const imageVersion = versions.find((version) => version.name === versionName);
 
+    // because the image stream was found, get its display name
+    const imageDisplayName = getImageStreamDisplayName(imageStream);
+
+    // if the image version is not found, consider the image stream deleted
     if (!imageVersion) {
-      return [null, true];
+      return [
+        {
+          imageAvailability: NotebookImageAvailability.DELETED,
+          imageDisplayName,
+        },
+        true,
+        undefined,
+      ];
     }
 
-    return [{ imageStream, imageVersion }, loaded];
-  }, [images, loaded, notebook]);
+    // if the image stream exists and the image version exists, return the image data
+    return [
+      {
+        imageStream,
+        imageVersion,
+        imageAvailability:
+          imageStream.metadata.labels?.['opendatahub.io/notebook-image'] === 'true'
+            ? NotebookImageAvailability.ENABLED
+            : NotebookImageAvailability.DISABLED,
+        imageDisplayName,
+      },
+      true,
+      undefined,
+    ];
+  }, [images, notebook, loaded, loadError]);
 };
 
 export default useNotebookImageData;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -29,6 +29,7 @@ import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksR
 import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableElyraPipelinesCheck';
 import AcceleratorSelectField from '~/pages/notebookController/screens/server/AcceleratorSelectField';
 import useNotebookAccelerator from '~/pages/projects/screens/detail/notebooks/useNotebookAccelerator';
+import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
 import { SpawnerPageSectionID } from './types';
 import { ScrollableSelectorID, SpawnerPageSectionTitles } from './const';
 import SpawnerFooter from './SpawnerFooter';
@@ -86,13 +87,15 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     }
   }, [existingNotebook, setStorageData]);
 
-  const [data, loaded] = useNotebookImageData(existingNotebook);
+  const [data, loaded, loadError] = useNotebookImageData(existingNotebook);
   React.useEffect(() => {
-    const { imageStream, imageVersion } = data || {};
-    if (loaded && imageStream && imageVersion) {
-      setSelectedImage({ imageStream, imageVersion });
+    if (loaded) {
+      if (data.imageAvailability === NotebookImageAvailability.ENABLED) {
+        const { imageStream, imageVersion } = data;
+        setSelectedImage({ imageStream, imageVersion });
+      }
     }
-  }, [data, loaded]);
+  }, [data, loaded, loadError]);
 
   const { size: notebookSize } = useNotebookDeploymentSize(existingNotebook);
   React.useEffect(() => {

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -52,40 +52,38 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
     });
   };
 
+  if (error) {
+    return (
+      <Alert title="Image loading error" variant="danger">
+        {error.message}
+      </Alert>
+    );
+  }
+
   if (!loaded) {
     return <Skeleton />;
   }
 
   return (
     <>
-      {error ? (
-        <Alert title="Image loading error" variant="danger">
-          {error.message}
-        </Alert>
-      ) : (
-        <>
-          <ImageStreamSelector
-            imageStreams={imageStreams.filter(
-              (imageStream) => !isInvalidBYONImageStream(imageStream),
-            )}
-            buildStatuses={buildStatuses}
-            onImageStreamSelect={onImageStreamSelect}
-            selectedImageStream={selectedImage.imageStream}
-            compatibleAccelerator={compatibleAccelerator}
-          />
-          <ImageVersionSelector
-            data={imageVersionData}
-            setSelectedImageVersion={(selection) =>
-              setSelectedImage((oldSelectedImage) => ({
-                ...oldSelectedImage,
-                imageVersion: selection,
-              }))
-            }
-            selectedImageVersion={selectedImage.imageVersion}
-          />
-          <ImageStreamPopover selectedImage={selectedImage} />
-        </>
-      )}
+      <ImageStreamSelector
+        imageStreams={imageStreams.filter((imageStream) => !isInvalidBYONImageStream(imageStream))}
+        buildStatuses={buildStatuses}
+        onImageStreamSelect={onImageStreamSelect}
+        selectedImageStream={selectedImage.imageStream}
+        compatibleAccelerator={compatibleAccelerator}
+      />
+      <ImageVersionSelector
+        data={imageVersionData}
+        setSelectedImageVersion={(selection) =>
+          setSelectedImage((oldSelectedImage) => ({
+            ...oldSelectedImage,
+            imageVersion: selection,
+          }))
+        }
+        selectedImageVersion={selectedImage.imageVersion}
+      />
+      <ImageStreamPopover selectedImage={selectedImage} />
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/useImageStreams.ts
+++ b/frontend/src/pages/projects/screens/spawner/useImageStreams.ts
@@ -1,29 +1,18 @@
 import * as React from 'react';
 import { ImageStreamKind } from '~/k8sTypes';
 import { getNotebookImageStreams } from '~/api';
+import useFetchState, { FetchState } from '~/utilities/useFetchState';
 
 const useImageStreams = (
-  namespace?: string,
-): [imageStreams: ImageStreamKind[], loaded: boolean, loadError: Error | undefined] => {
-  const [imageStreams, setImageStreams] = React.useState<ImageStreamKind[]>([]);
-  const [loaded, setLoaded] = React.useState(false);
-  const [loadError, setLoadError] = React.useState<Error | undefined>(undefined);
+  namespace: string,
+  includeDisabled?: boolean,
+): FetchState<ImageStreamKind[]> => {
+  const getImages = React.useCallback(
+    () => getNotebookImageStreams(namespace, includeDisabled),
+    [namespace, includeDisabled],
+  );
 
-  React.useEffect(() => {
-    if (namespace) {
-      getNotebookImageStreams(namespace)
-        .then((imageStreams) => {
-          setImageStreams(imageStreams);
-          setLoaded(true);
-        })
-        .catch((e) => {
-          setLoadError(e);
-          setLoaded(true);
-        });
-    }
-  }, [namespace]);
-
-  return [imageStreams, loaded, loadError];
+  return useFetchState<ImageStreamKind[]>(getImages, []);
 };
 
 export default useImageStreams;

--- a/frontend/src/typeHelpers.ts
+++ b/frontend/src/typeHelpers.ts
@@ -12,9 +12,11 @@ export type AnyObject = Record<string, unknown>;
  *
  * TODO: Implement the SDK & Patch logic -- this should stop being needed as things will be defined as Patches
  */
-export type RecursivePartial<T> = {
-  [P in keyof T]?: RecursivePartial<T[P]>;
-};
+export type RecursivePartial<T> = T extends object
+  ? {
+      [P in keyof T]?: RecursivePartial<T[P]>;
+    }
+  : T;
 
 /**
  * Partial only some properties.


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1370

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a new annotation to workbenches called `opendatahub.io/image-display-name` which stores the display name of the selected image. this gets used when displaying the image on the notebook table if the image itself could not be found. if it is not found it will also include the wording `(deprecated)`.

When you got to edit this workbench with a deprecated image. the image will be _unselected_ and require you to select a new one

<img width="547" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/fe28f22b-26e2-421e-a4a2-d4b15f505028">
<img width="421" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/a1c394a3-f2de-4bc0-9c2c-ebb1f63aa14c">
<img width="423" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/dbe8125d-7a8b-42b2-aad9-9e0bd453ba2d">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. create a custom notebook image
2. create a workbench with that custom image
3. delete the custom image
4. verify that deprecated wording is on the workbench table
5. verify that on edit, the image selection is required
6. remove the annotation (`opendatahub.io/image-display-name`) from the notebook resource, and notice that the image becomes `unknown` on the table row

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I added tests to check the use cases of unknown and deprecated. In doing this i felt the need to implement a few helpers for mocks. namely a `opts: RecursivePartial<k8sKindType>` and then lodash _.merge the base mock with the opts. this gives you the option for fine grained control without having to make a large amount of of options to feed in.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
