### PR TITLE
Implement correct trimming for editing model deployment path

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
@@ -30,7 +30,8 @@ test('Edit model', async ({ page }) => {
   await await page.getByLabel('Model Name *').fill('');
   await await page.getByLabel('Path').fill('');
   await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeDisabled();
-
+  await await page.getByLabel('Path').fill('/');
+  await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeDisabled();
   // test that you can update the name to a different name
   await await page.getByLabel('Model Name *').fill('Updated Model Name');
   await await page.getByLabel('Path').fill('test-model/');
@@ -39,6 +40,8 @@ test('Edit model', async ({ page }) => {
   // test that user cant upload on an empty new secret
   await page.getByText('New data connection').click();
   await await page.getByLabel('Path').fill('');
+  await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeDisabled();
+  await await page.getByLabel('Path').fill('/');
   await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeDisabled();
 
   // test that adding required values validates submit
@@ -82,6 +85,8 @@ test('Create model', async ({ page }) => {
   await expect(await page.getByRole('button', { name: 'Deploy' })).toBeEnabled();
   await page.getByText('New data connection').click();
   await page.getByLabel('Path').fill('');
+  await expect(await page.getByRole('button', { name: 'Deploy' })).toBeDisabled();
+  await page.getByLabel('Path').fill('/');
   await expect(await page.getByRole('button', { name: 'Deploy' })).toBeDisabled();
   await page.getByRole('textbox', { name: 'Field list Name' }).fill('Test Name');
   await page.getByRole('textbox', { name: 'Field list AWS_ACCESS_KEY_ID' }).fill('test-key');

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -100,27 +100,12 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
       ),
     );
 
-  const cleanFormData = () => {
-    const cleanedStorageFolderPath = createData.storage.path.replace(/^\/+/, '');
-
-    return {
-      ...createData,
-      storage: {
-        ...createData.storage,
-        path: cleanedStorageFolderPath === '' ? '/' : cleanedStorageFolderPath,
-      },
-    };
-  };
-
   const createModel = (): Promise<InferenceServiceKind> => {
-    // clean data
-    const cleanedFormData = cleanFormData();
-
-    if (cleanedFormData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
-      return createInferenceService(cleanedFormData);
+    if (createData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
+      return createInferenceService(createData);
     }
     return createAWSSecret().then((secret) =>
-      createInferenceService(cleanedFormData, secret.metadata.name),
+      createInferenceService(createData, secret.metadata.name),
     );
   };
 
@@ -129,14 +114,11 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
       return Promise.reject(new Error('No model to update'));
     }
 
-    // clean data
-    const cleanedFormData = cleanFormData();
-
-    if (cleanedFormData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
-      return updateInferenceService(cleanedFormData, editInfo);
+    if (createData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
+      return updateInferenceService(createData, editInfo);
     }
     return createAWSSecret().then((secret) =>
-      updateInferenceService(cleanedFormData, editInfo, secret.metadata.name),
+      updateInferenceService(createData, editInfo, secret.metadata.name),
     );
   };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes #1173 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
#1173 
Path is correctly trimmed while editing model deployment path in "Deploy model" modal.

<img width="851" alt="Screenshot 2023-09-28 at 11 39 22 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/6ef95be1-57d1-4cad-bc57-c9e282ce4894">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Check an existing model which had a "blank" path(Go to Model serving global page and click on "Edit" on one of the table rows.)
2. Check whether you still see a `/` in the path field.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added tests for `/` path.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
