### PR TITLE
Revamp add server button and add tooltip

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -42,7 +42,7 @@ test('Legacy Serving Runtime', async ({ page }) => {
   );
 
   // wait for page to load
-  await page.waitForSelector('text=Add server');
+  await page.waitForSelector('text=Add model server');
 
   // Check that the legacy serving runtime is shown with the default runtime name
   expect(page.getByText('ovms')).toBeTruthy();

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeList.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeList.tsx
@@ -36,7 +36,7 @@ const ServingRuntimeList: React.FC = () => {
     getTemplateEnabled(template, templateDisablement),
   );
 
-  const emptyTemplates = templatesEnabled?.length === 0;
+  const emptyTemplates = templatesEnabled.length === 0;
   const emptyModelServer = servingRuntimes.length === 0;
 
   return (

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeListButtonAction.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeListButtonAction.tsx
@@ -11,41 +11,28 @@ const ServingRuntimeListButtonAction: React.FC<ServingRuntimeListButtonActionPro
   emptyTemplates,
   templatesLoaded,
   onClick,
-}) => {
-  if (emptyTemplates) {
-    return (
-      <Tooltip
-        removeFindDomNode
-        aria-label="Add Server Info"
-        content={
-          <Text>
-            At least one serving runtime must be enabled to add a model server. Contact your
-            administrator
-          </Text>
-        }
-      >
-        <Button
-          isLoading={!templatesLoaded}
-          isAriaDisabled={true}
-          onClick={onClick}
-          variant="secondary"
-        >
-          Add server
-        </Button>
-      </Tooltip>
-    );
-  }
-
-  return (
+}) => (
+  <Tooltip
+    removeFindDomNode
+    aria-label="Add Server Info"
+    content={
+      <Text>
+        {emptyTemplates
+          ? 'At least one serving runtime must be enabled to add a model server. Contact your administrator.'
+          : 'A model server specifies resources available for use by one or more supported models, and includes a serving runtime.'}
+      </Text>
+    }
+  >
     <Button
       isLoading={!templatesLoaded}
+      isAriaDisabled={emptyTemplates}
       isDisabled={!templatesLoaded}
       onClick={onClick}
       variant="secondary"
     >
-      Add server
+      Add model server
     </Button>
-  );
-};
+  </Tooltip>
+);
 
 export default ServingRuntimeListButtonAction;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1579 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change the name to `Add model server` and add a tooltip on hover.

<img width="607" alt="Screenshot 2023-09-29 at 12 11 15 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/29467f00-f324-4fe7-acb7-2f6ac73eaf81">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to data science project
2. Check if the button is `Add model server` now, but not `Add server`
3. Hover the button to see the tooltip

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
