### PR TITLE
refactor hook test utils to extend jest matchers

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -30,4 +30,6 @@ module.exports = {
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   snapshotSerializers: [],
+
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/unit/jest.setup.ts'],
 };

--- a/frontend/src/__tests__/unit/jest.d.ts
+++ b/frontend/src/__tests__/unit/jest.d.ts
@@ -1,0 +1,29 @@
+declare namespace jest {
+  interface Expect {
+    isIdentityEqual<T>(expected: T): T;
+  }
+
+  interface Matchers<R, T> {
+    hookToBe(expected: unknown): R;
+    hookToStrictEqual(expected: unknown): R;
+    hookToHaveUpdateCount(expected: number): R;
+    hookToBeStable<
+      V extends T extends Pick<
+        import('~/__tests__/unit/testUtils/hooks').RenderHookResultExt<
+          infer Result,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          any
+        >,
+        'result'
+      >
+        ? import('~/__tests__/unit/testUtils/hooks').BooleanValues<Result>
+        : never,
+    >(
+      expected?: V,
+    ): R;
+  }
+
+  interface Expect {
+    isIdentityEqual(expected: unknown): AsymmetricMatcher;
+  }
+}

--- a/frontend/src/__tests__/unit/jest.setup.ts
+++ b/frontend/src/__tests__/unit/jest.setup.ts
@@ -1,0 +1,62 @@
+import { JestAssertionError } from 'expect';
+import {
+  BooleanValues,
+  RenderHookResultExt,
+  createComparativeValue,
+} from '~/__tests__/unit/testUtils/hooks';
+
+const tryExpect = (expectFn: () => void) => {
+  try {
+    expectFn();
+  } catch (e) {
+    const { matcherResult } = e as JestAssertionError;
+    if (matcherResult) {
+      return { ...matcherResult, message: () => matcherResult.message };
+    }
+    throw e;
+  }
+  return {
+    pass: true,
+    message: () => '',
+  };
+};
+
+expect.extend({
+  // custom asymmetric matchers
+
+  /**
+   * Checks that a value is what you expect.
+   * It uses Object.is to check strict equality.
+   *
+   * Usage:
+   * expect.isIdentifyEqual(...)
+   */
+  isIdentityEqual: (actual, expected) => ({
+    pass: Object.is(actual, expected),
+    message: () => `expected ${actual} to be identity equal to ${expected}`,
+  }),
+
+  // hook related custom matchers
+  hookToBe: (actual: RenderHookResultExt<unknown, unknown>, expected) =>
+    tryExpect(() => expect(actual.result.current).toBe(expected)),
+
+  hookToStrictEqual: (actual: RenderHookResultExt<unknown, unknown>, expected) =>
+    tryExpect(() => expect(actual.result.current).toStrictEqual(expected)),
+
+  hookToHaveUpdateCount: (actual: RenderHookResultExt<unknown, unknown>, expected: number) =>
+    tryExpect(() => expect(actual.getUpdateCount()).toBe(expected)),
+
+  hookToBeStable: <R>(actual: RenderHookResultExt<R, unknown>, expected?: BooleanValues<R>) => {
+    if (actual.getUpdateCount() <= 1) {
+      throw new Error('Cannot assert stability as the hook has not run at least 2 times.');
+    }
+    if (typeof expected === 'undefined') {
+      return tryExpect(() => expect(actual.result.current).toBe(actual.getPreviousResult()));
+    }
+    return tryExpect(() =>
+      expect(actual.result.current).toStrictEqual(
+        createComparativeValue(actual.getPreviousResult(), expected),
+      ),
+    );
+  },
+});

--- a/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
+++ b/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expectHook, renderHook, standardUseFetchState, testHook } from './hooks';
+import { createComparativeValue, renderHook, standardUseFetchState, testHook } from './hooks';
 
 const useSayHello = (who: string, showCount = false) => {
   const countRef = React.useRef(0);
@@ -18,34 +18,33 @@ const useSayHelloDelayed = (who: string, delay = 0) => {
 
 describe('hook test utils', () => {
   it('simple testHook', () => {
-    const renderResult = testHook((who: string) => `Hello ${who}!`, 'world');
-    expectHook(renderResult).toBe('Hello world!').toHaveUpdateCount(1);
+    const renderResult = testHook((who: string) => `Hello ${who}!`)('world');
+    expect(renderResult).hookToBe('Hello world!');
+    expect(renderResult).hookToHaveUpdateCount(1);
     renderResult.rerender('world');
-    expectHook(renderResult).toBe('Hello world!').toBeStable().toHaveUpdateCount(2);
+    expect(renderResult).hookToBe('Hello world!');
+    expect(renderResult).hookToBeStable();
+    expect(renderResult).hookToHaveUpdateCount(2);
   });
 
   it('use testHook for rendering', () => {
-    const renderResult = testHook(useSayHello, 'world');
-    expectHook(renderResult)
-      .toHaveUpdateCount(1)
-      .toBe('Hello world!')
-      .toStrictEqual('Hello world!');
+    const renderResult = testHook(useSayHello)('world');
+    expect(renderResult).hookToHaveUpdateCount(1);
+    expect(renderResult).hookToBe('Hello world!');
+    expect(renderResult).hookToStrictEqual('Hello world!');
 
     renderResult.rerender('world', false);
 
-    expectHook(renderResult)
-      .toHaveUpdateCount(2)
-      .toBe('Hello world!')
-      .toStrictEqual('Hello world!')
-      .toBeStable();
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBe('Hello world!');
+    expect(renderResult).hookToStrictEqual('Hello world!');
+    expect(renderResult).hookToBeStable();
 
     renderResult.rerender('world', true);
 
-    expectHook(renderResult)
-      .toHaveUpdateCount(3)
-      .toBe('Hello world! x3')
-      .toStrictEqual('Hello world! x3')
-      .toBeStable(false);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBe('Hello world! x3');
+    expect(renderResult).hookToStrictEqual('Hello world! x3');
   });
 
   it('use renderHook for rendering', () => {
@@ -59,50 +58,47 @@ describe('hook test utils', () => {
       },
     });
 
-    expectHook(renderResult)
-      .toHaveUpdateCount(1)
-      .toBe('Hello world!')
-      .toStrictEqual('Hello world!');
+    expect(renderResult).hookToHaveUpdateCount(1);
+    expect(renderResult).hookToBe('Hello world!');
+    expect(renderResult).hookToStrictEqual('Hello world!');
 
     renderResult.rerender({
       who: 'world',
     });
 
-    expectHook(renderResult)
-      .toHaveUpdateCount(2)
-      .toBe('Hello world!')
-      .toStrictEqual('Hello world!')
-      .toBeStable();
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBe('Hello world!');
+    expect(renderResult).hookToStrictEqual('Hello world!');
 
     renderResult.rerender({ who: 'world', showCount: true });
 
-    expectHook(renderResult)
-      .toHaveUpdateCount(3)
-      .toBe('Hello world! x3')
-      .toStrictEqual('Hello world! x3')
-      .toBeStable(false);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBe('Hello world! x3');
+    expect(renderResult).hookToStrictEqual('Hello world! x3');
   });
 
   it('should use waitForNextUpdate for async update testing', async () => {
-    const renderResult = testHook(useSayHelloDelayed, 'world');
-    expectHook(renderResult).toHaveUpdateCount(1).toBe('');
+    const renderResult = testHook(useSayHelloDelayed)('world');
+    expect(renderResult).hookToHaveUpdateCount(1);
+    expect(renderResult).hookToBe('');
 
     await renderResult.waitForNextUpdate();
-    expectHook(renderResult).toHaveUpdateCount(2).toBe('Hello world!');
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBe('Hello world!');
   });
 
   it('should throw error if waitForNextUpdate times out', async () => {
     const renderResult = renderHook(() => useSayHelloDelayed('', 20));
 
     await expect(renderResult.waitForNextUpdate({ timeout: 10, interval: 5 })).rejects.toThrow();
-    expectHook(renderResult).toHaveUpdateCount(1);
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     // unmount to test waiting for an update that will never happen
     renderResult.unmount();
 
     await expect(renderResult.waitForNextUpdate({ timeout: 50, interval: 10 })).rejects.toThrow();
 
-    expectHook(renderResult).toHaveUpdateCount(1);
+    expect(renderResult).hookToHaveUpdateCount(1);
   });
 
   it('should not throw if waitForNextUpdate timeout is sufficient', async () => {
@@ -112,43 +108,47 @@ describe('hook test utils', () => {
       renderResult.waitForNextUpdate({ timeout: 50, interval: 10 }),
     ).resolves.not.toThrow();
 
-    expectHook(renderResult).toHaveUpdateCount(2);
+    expect(renderResult).hookToHaveUpdateCount(2);
   });
 
   it('should assert stability of results using isStable', () => {
     let testValue = 'test';
     const renderResult = renderHook(() => testValue);
-    expectHook(renderResult).toHaveUpdateCount(1);
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     renderResult.rerender();
-    expectHook(renderResult).toHaveUpdateCount(2).toBeStable(true);
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable();
 
     testValue = 'new';
     renderResult.rerender();
-    expectHook(renderResult).toHaveUpdateCount(3).toBeStable(false);
+    expect(renderResult).hookToHaveUpdateCount(3);
 
     renderResult.rerender();
-    expectHook(renderResult).toHaveUpdateCount(4).toBeStable(true);
+    expect(renderResult).hookToHaveUpdateCount(4);
+    expect(renderResult).hookToBeStable();
   });
 
-  it('should assert stability of results using isStableArray', () => {
-    let testValue = 'test';
+  it(`should assert stability of result using isStable 'array'`, () => {
+    let testValue = ['test'];
     // explicitly returns a new array each render to show the difference between `isStable` and `isStableArray`
-    const renderResult = renderHook(() => [testValue]);
-    expectHook(renderResult).toHaveUpdateCount(1);
+    const renderResult = renderHook(() => testValue);
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     renderResult.rerender();
-    expectHook(renderResult).toHaveUpdateCount(2).toBeStable(false);
-    expectHook(renderResult).toHaveUpdateCount(2).toBeStable([true]);
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable();
+    expect(renderResult).hookToBeStable([true]);
 
-    testValue = 'new';
+    testValue = ['new'];
     renderResult.rerender();
-    expectHook(renderResult).toHaveUpdateCount(3).toBeStable(false);
-    expectHook(renderResult).toHaveUpdateCount(3).toBeStable([false]);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false]);
 
     renderResult.rerender();
-    expectHook(renderResult).toHaveUpdateCount(4).toBeStable(false);
-    expectHook(renderResult).toHaveUpdateCount(4).toBeStable([true]);
+    expect(renderResult).hookToHaveUpdateCount(4);
+    expect(renderResult).hookToBeStable();
+    expect(renderResult).hookToBeStable([true]);
   });
 
   it('standardUseFetchState should return an array matching the state of useFetchState', () => {
@@ -159,5 +159,103 @@ describe('hook test utils', () => {
     expect(['test', false, new Error('error'), () => null]).toStrictEqual(
       standardUseFetchState('test', false, new Error('error')),
     );
+  });
+
+  describe('createComparativeValue', () => {
+    it('should extract array values according to the boolean object', () => {
+      expect([1, 2, 3]).toStrictEqual(createComparativeValue([1, 2, 3], [true, true, true]));
+      expect([1, 2, 3]).toStrictEqual(createComparativeValue([1, 2, 3], [true, true, false]));
+      expect([1, 2, 3]).toStrictEqual(createComparativeValue([1, 2, 4], [true, true, false]));
+      expect([1, 2, 3]).toStrictEqual(createComparativeValue([1, 2, 4], [true, true]));
+      expect([1, 2, 3]).not.toStrictEqual(createComparativeValue([1, 4, 3], [true, true, true]));
+    });
+
+    it('should extract object values according to the boolean object', () => {
+      expect({ a: 1, b: 2, c: 3 }).toStrictEqual(
+        createComparativeValue({ a: 1, b: 2, c: 3 }, { a: true, b: true, c: true }),
+      );
+      expect({ a: 1, b: 2, c: 3 }).toStrictEqual(
+        createComparativeValue({ a: 1, b: 2, c: 3 }, { a: true, b: true, c: true }),
+      );
+      expect({ a: 1, b: 2, c: 3 }).toStrictEqual(
+        createComparativeValue({ a: 1, b: 2, c: 4 }, { a: true, b: true, c: false }),
+      );
+      expect({ a: 1, b: 2, c: 3 }).toStrictEqual(
+        createComparativeValue({ a: 1, b: 2, c: 4 }, { a: true, b: true }),
+      );
+      expect({ a: 1, b: 2, c: 3 }).not.toStrictEqual(
+        createComparativeValue({ a: 1, b: 4, c: 3 }, { a: true, b: true, c: true }),
+      );
+    });
+
+    it('should extract nested values', () => {
+      const testValue = {
+        a: 1,
+        b: {
+          c: 2,
+          d: [{ e: 3 }, 'f', {}],
+        },
+      };
+      expect(testValue).toStrictEqual(
+        createComparativeValue(
+          { a: 10, b: { c: 2, d: [null, 'f'] } },
+          {
+            b: {
+              c: true,
+              d: [false, true],
+            },
+          },
+        ),
+      );
+    });
+
+    it('should extract objects for identity comparisons', () => {
+      const obj = {};
+      const array: string[] = [];
+      const testValue = {
+        a: obj,
+        b: array,
+        c: {
+          d: obj,
+          e: array,
+        },
+      };
+
+      expect(testValue).not.toStrictEqual(
+        createComparativeValue(
+          {
+            a: {},
+            b: [],
+            c: {
+              d: {},
+              e: [],
+            },
+          },
+          {
+            a: true,
+            b: true,
+            c: { d: true, e: true },
+          },
+        ),
+      );
+
+      expect(testValue).toStrictEqual(
+        createComparativeValue(
+          {
+            a: obj,
+            b: array,
+            c: {
+              d: obj,
+              e: array,
+            },
+          },
+          {
+            a: true,
+            b: true,
+            c: { d: true, e: true },
+          },
+        ),
+      );
+    });
   });
 });

--- a/frontend/src/pages/projects/projectSharing/__tests__/useGroups.spec.ts
+++ b/frontend/src/pages/projects/projectSharing/__tests__/useGroups.spec.ts
@@ -2,7 +2,7 @@ import { act } from '@testing-library/react';
 import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import useGroups from '~/pages/projects/projectSharing/useGroups';
 import { GroupKind } from '~/k8sTypes';
-import { expectHook, standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResource: jest.fn(),
@@ -17,23 +17,24 @@ describe('useGroups', () => {
     };
     k8sListResourceMock.mockReturnValue(Promise.resolve(mockList));
 
-    const renderResult = testHook(useGroups);
+    const renderResult = testHook(useGroups)();
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     // wait for update
     await renderResult.waitForNextUpdate();
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState(mockList.items, true))
-      .toHaveUpdateCount(2)
-      .toBeStable([false, false, true, true]);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(mockList.items, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
 
     // refresh
     k8sListResourceMock.mockReturnValue(Promise.resolve({ items: [...mockList.items] }));
     await act(() => renderResult.result.current[3]());
     expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
-    expectHook(renderResult).toHaveUpdateCount(3).toBeStable([false, true, true, true]);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
   });
 
   it('should handle 403 as an empty result', async () => {
@@ -44,26 +45,25 @@ describe('useGroups', () => {
     };
     k8sListResourceMock.mockReturnValue(Promise.reject(error));
 
-    const renderResult = testHook(useGroups);
+    const renderResult = testHook(useGroups)();
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     // wait for update
     await renderResult.waitForNextUpdate();
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState([], true))
-      .toHaveUpdateCount(2)
-      .toBeStable([false, false, true, true]);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
 
     // refresh
     await act(() => renderResult.result.current[3]());
     // error 403 should cache error and prevent subsequent attempts to fetch
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState([], true))
-      .toHaveUpdateCount(3)
-      .toBeStable([false, true, true, true]);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], true));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
   });
 
   it('should handle 404 as an error', async () => {
@@ -74,17 +74,19 @@ describe('useGroups', () => {
     };
     k8sListResourceMock.mockReturnValue(Promise.reject(error));
 
-    const renderResult = testHook(useGroups);
+    const renderResult = testHook(useGroups)();
 
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     // wait for update
     await renderResult.waitForNextUpdate();
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState([], false, new Error('No groups found.')))
-      .toHaveUpdateCount(2)
-      .toBeStable([true, true, false, true]);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([], false, new Error('No groups found.')),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
 
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
 
@@ -92,34 +94,34 @@ describe('useGroups', () => {
     await act(() => renderResult.result.current[3]());
     expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
     // we get a new error because the k8s API is called a 2nd time
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState([], false, new Error('No groups found.')))
-      .toHaveUpdateCount(3)
-      .toBeStable([true, true, false, true]);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([], false, new Error('No groups found.')),
+    );
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
   });
 
   it('should handle other errors and rethrow', async () => {
     k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error1')));
 
-    const renderResult = testHook(useGroups);
+    const renderResult = testHook(useGroups)();
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult).toStrictEqual(standardUseFetchState([])).toHaveUpdateCount(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
 
     // wait for update
     await renderResult.waitForNextUpdate();
     expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState([], false, new Error('error1')))
-      .toHaveUpdateCount(2)
-      .toBeStable([true, true, false, true]);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
 
     // refresh
     k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error2')));
     await act(() => renderResult.result.current[3]());
     expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
-    expectHook(renderResult)
-      .toStrictEqual(standardUseFetchState([], false, new Error('error2')))
-      .toHaveUpdateCount(3)
-      .toBeStable([true, true, false, true]);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Test hook utils were previously introduced to help developers test hook state updates and stability.
This PR updates those hook utils to extend jest instead of having standalone utilities.

The old API:
```
const renderResult = testHook(useSayHello, 'world');
expectHook(renderResult)
  .toBe(...)
  .toStrictEqual(...)
  .toHaveUpdateCount(...)
  .toBeStable(...)
```
Becomes:
```
const renderResult = testHook(useSayHello)('world');
expect(renderResult).hookToBe(...)
expect(renderResult).hookToStrictEqual(...)
expect(renderResult).hookToHaveUpdateCount(...)
expect(renderResult).hookToBeStable(...)
```

While this change looks to be more verbose, it aligns with how assertions are done with jest. It also allows for the use of `expect.not`.
eg. `expect(renderResult).not.hookToBe(...)`

Another useful change comes with way stability checks work. Now the API allows for asserting whether specific paths of deeply nested state is stable.
eg.
`[{ items: ... }, { onChange, onToggle }, somethingElse...]`
To assert only the stability of `onChange` and `onToggle` we can do the following:
`expect(renderResult).hookToBeStable([false, { onChange: true, onToggle: true }])`

Lastly, there is an improvement to `useFetchState` which ensures that the return value immediately reflects the current state when `useFetchState` is initialized with `initialPromisePurity = true` and the promise callback changes. Previously, the return value was delayed a full update cycle because the resetting of state occurs in a `useEffect`. While the state reset still occurs inside a `useEffect`, this change captures that a reset is pending and stores it in a ref and allows the hook to return the default state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
