### PR TITLE
OSSM: Add service mesh manifests overlay

### DIFF
--- a/manifests/base/_mesh_overlay-delete-oauth-config-patch.yaml
+++ b/manifests/base/_mesh_overlay-delete-oauth-config-patch.yaml
@@ -1,0 +1,6 @@
+# DO NOT DELETE. Check kustomization.yaml comments in overlays/service-mesh
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-config

--- a/manifests/base/_mesh_overlay_delete-oauth-client-patch.yaml
+++ b/manifests/base/_mesh_overlay_delete-oauth-client-patch.yaml
@@ -1,0 +1,6 @@
+# DO NOT DELETE. Check kustomization.yaml comments in overlays/service-mesh
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-client

--- a/manifests/overlays/minimal/README.md
+++ b/manifests/overlays/minimal/README.md
@@ -1,0 +1,4 @@
+## Dashboard Minimal overlay
+
+This overlay is specifically used to trim deployment options such as replica count and probes times. 
+Might be useful for resource-constrained environments such as [Openshift Local](https://developers.redhat.com/products/openshift-local/overview) (aka `crc`).

--- a/manifests/overlays/minimal/deployment-resources-patch.yaml
+++ b/manifests/overlays/minimal/deployment-resources-patch.yaml
@@ -1,0 +1,12 @@
+# these three replaces are for testing on less powerful clusters (crc)
+- op: replace
+  path: /spec/replicas
+  value: 1
+
+- op: replace
+  path: /spec/template/spec/containers/0/livenessProbe/periodSeconds
+  value: 300
+
+- op: replace
+  path: /spec/template/spec/containers/0/readinessProbe/periodSeconds
+  value: 300

--- a/manifests/overlays/minimal/kustomization.yaml
+++ b/manifests/overlays/minimal/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+
+patchesJson6902:
+- path: deployment-resources-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: odh-dashboard

--- a/manifests/overlays/service-mesh/OWNERS
+++ b/manifests/overlays/service-mesh/OWNERS
@@ -1,0 +1,10 @@
+# Each list is sorted alphabetically, additions should maintain that order
+approvers:
+- aslakknutsen
+- bartoszmajsak
+- cam-garrison
+
+reviewers:
+- aslakknutsen
+- bartoszmajsak
+- cam-garrison

--- a/manifests/overlays/service-mesh/kustomization.yaml
+++ b/manifests/overlays/service-mesh/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+
+## FIXME: Temporary until odh-dashboard PR is merged upstream
+images:
+# this needs to match newName from base, not the name used in the deployment
+- name: quay.io/opendatahub/odh-dashboard
+  newName: quay.io/maistra-dev/odh-dashboard
+  newTag: service-mesh-integration
+
+patchesStrategicMerge:
+# when using bases:
+# - ../../base
+# the entire directory is truncated and the lookup is performed in base/
+# for this reason the files must be there as well. with the same content, as they will be in fact used
+- patches/_mesh_overlay_delete-oauth-client-patch.yaml
+- patches/_mesh_overlay-delete-oauth-config-patch.yaml
+
+# # needs to be patchesJson6902, patches seems to be ignored
+# # also: inline patches do not work, operator complains about overlays/service-mesh being 
+# # a directory and not a kustomization.yaml file 
+patchesJson6902:
+- path: patches/route-patch.yaml
+  target:
+    group: route.openshift.io
+    version: v1
+    kind: Route
+    name: odh-dashboard
+- path: patches/service-patch.yaml
+  target:
+    version: v1
+    kind: Service
+    name: odh-dashboard
+- path: patches/service-account-patch.yaml
+  target:
+    version: v1
+    kind: ServiceAccount
+    name: odh-dashboard
+- path: patches/deployment-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: odh-dashboard

--- a/manifests/overlays/service-mesh/patches/_mesh_overlay-delete-oauth-config-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/_mesh_overlay-delete-oauth-config-patch.yaml
@@ -1,0 +1,6 @@
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-config
+

--- a/manifests/overlays/service-mesh/patches/_mesh_overlay_delete-oauth-client-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/_mesh_overlay_delete-oauth-client-patch.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-client

--- a/manifests/overlays/service-mesh/patches/deployment-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/deployment-patch.yaml
@@ -1,0 +1,13 @@
+# remove the oauth proxy container. NOTE: this will break if another container is added above.
+- op: remove
+  path: /spec/template/spec/containers/1
+
+# remove the volumes, no longer needed and secrets that are mounted are no longer created.
+- op: remove
+  path: /spec/template/spec/volumes
+
+# add istio inject label
+- op: add
+  path: /spec/template/metadata/annotations
+  value:
+    sidecar.istio.io/inject: "true"

--- a/manifests/overlays/service-mesh/patches/oauth-client-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/oauth-client-patch.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-client

--- a/manifests/overlays/service-mesh/patches/oauth-config-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/oauth-config-patch.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-config

--- a/manifests/overlays/service-mesh/patches/route-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/route-patch.yaml
@@ -1,0 +1,9 @@
+- op: remove
+  path: /metadata/annotations
+
+- op: replace
+  path: /spec/port/targetPort
+  value: 8080
+
+- op: remove
+  path: /spec/tls

--- a/manifests/overlays/service-mesh/patches/service-account-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/service-account-patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /metadata/annotations

--- a/manifests/overlays/service-mesh/patches/service-patch.yaml
+++ b/manifests/overlays/service-mesh/patches/service-patch.yaml
@@ -1,0 +1,9 @@
+- op: remove
+  path: /metadata/annotations
+
+- op: replace
+  path: /spec/ports/0
+  value:
+    protocol: TCP
+    targetPort: 8080
+    port: 80


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
This PR adds the service mesh overlay to the manifests directory which make changes to odh-dashboard resources enabling service-mesh, as well as a `minimal` overlay that can be useful when developing/testing on a cluster with low resource limits (ie: CRC). 

This is needed for using the new version of the operator, as the v2 operator pulls manifests from the main branch of odh-dashboard rather than from the odh-manifests repo as before. 

Unfortunately, due to restrictions with kustomize and patching, two patches have to be added to the base directory - please see comments in said files and `overlays/service-mesh/kustomization.yaml` for reasoning on this. Patches that are not immediately obvious are commented with reasoning. 

These changes should be completely unobtrusive to users not using service-mesh, as the overlays are only enabled when specified - or in our case, when service-mesh is enabled in the v2 operator, the overlay is applied by operator. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested in several ways: 

- manually running `kustomize build manifests/overlays/service-mesh` to ensure that the manifests build correctly using this overlay.
- Using a modified v2 operator (just merged [here](https://github.com/opendatahub-io/opendatahub-operator/commit/0214bb38b33f12635d5d6ceedfc8b4830c7a9fe3)) to pull in the changes and ensured that the overlays are applied correctly. 
- to test above, try adding these args when building v2 operator `--build-arg OVERWRITE_MANIFESTS='--odh-dashboard="maistra:odh-dashboard:add-sm-overlay:manifests:odh-dashboard"'"`
- In addition, these same overlays have been used in testing for months in the odh-manifests/service-mesh-integration branch. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I do not believe that tests can be created to ensure this overlay - please let me know if there is some way to add tests for this.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
