### PR TITLE
fix bug when filtering cluster storageclasses and now doing correct s…

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
@@ -18,16 +18,16 @@ const usePreferredStorageClass = (): StorageClassKind | undefined => {
 
   const configStorageClassName = notebookController?.storageClassName ?? '';
 
-  if (defaultClusterStorageClasses.length != 0) {
+  if (defaultClusterStorageClasses.length !== 0) {
     return undefined;
   }
 
-  if (configStorageClassName == '') {
+  if (configStorageClassName === '') {
     return undefined;
   }
 
-  const storageClassDashBoardConfigVsCluster = storageClasses.filter((storageclass) =>
-    storageclass.metadata.name.includes(configStorageClassName),
+  const storageClassDashBoardConfigVsCluster = storageClasses.filter(
+    (storageclass) => storageclass.metadata.name === configStorageClassName,
   );
 
   if (storageClassDashBoardConfigVsCluster.length === 0) {


### PR DESCRIPTION
fixes #1921

## Description
doing correct full-string compare on storageclass metadata.name string by using === between two strings instead of .includes

## How Has This Been Tested?


## Test Impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
