### PR TITLE
move AcceleratorProfile crd version out of alpha

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -664,7 +664,7 @@ export const cleanupGPU = async (fastify: KubeFastifyInstance): Promise<void> =>
     const acceleratorProfilesResponse = await fastify.kube.customObjectsApi
       .listNamespacedCustomObject(
         'dashboard.opendatahub.io',
-        'v1alpha',
+        'v1',
         fastify.kube.namespace,
         'acceleratorprofiles',
       )
@@ -694,13 +694,13 @@ export const cleanupGPU = async (fastify: KubeFastifyInstance): Promise<void> =>
       if (acceleratorDetected.configured) {
         const payload: AcceleratorKind = {
           kind: 'AcceleratorProfile',
-          apiVersion: 'dashboard.opendatahub.io/v1alpha',
+          apiVersion: 'dashboard.opendatahub.io/v1',
           metadata: {
             name: 'migrated-gpu',
             namespace: fastify.kube.namespace,
           },
           spec: {
-            displayName: 'Nvidia GPU',
+            displayName: 'NVIDIA GPU',
             identifier: 'nvidia.com/gpu',
             enabled: true,
             tolerations: [
@@ -716,7 +716,7 @@ export const cleanupGPU = async (fastify: KubeFastifyInstance): Promise<void> =>
         try {
           await fastify.kube.customObjectsApi.createNamespacedCustomObject(
             'dashboard.opendatahub.io',
-            'v1alpha',
+            'v1',
             fastify.kube.namespace,
             'acceleratorprofiles',
             payload,

--- a/frontend/src/api/models/openShift.ts
+++ b/frontend/src/api/models/openShift.ts
@@ -57,7 +57,7 @@ export const TemplateModel: K8sModelCommon = {
 };
 
 export const AcceleratorModel: K8sModelCommon = {
-  apiVersion: 'v1alpha',
+  apiVersion: 'v1',
   apiGroup: 'dashboard.opendatahub.io',
   kind: 'AcceleratorProfile',
   plural: 'acceleratorprofiles',

--- a/frontend/src/utilities/useAcceleratorState.ts
+++ b/frontend/src/utilities/useAcceleratorState.ts
@@ -90,14 +90,14 @@ const useAcceleratorState = (
             } else {
               // create a fake accelerator to use
               const fakeAccelerator: AcceleratorKind = {
-                apiVersion: 'dashboard.opendatahub.io/v1alpha',
+                apiVersion: 'dashboard.opendatahub.io/v1',
                 kind: 'AcceleratorProfile',
                 metadata: {
                   name: 'migrated-gpu',
                 },
                 spec: {
                   identifier: 'nvidia.com/gpu',
-                  displayName: 'Nvidia GPU',
+                  displayName: 'NVIDIA GPU',
                   enabled: true,
                   tolerations: [
                     {

--- a/manifests/crd/acceleratorprofiles.opendatahub.io.crd.yaml
+++ b/manifests/crd/acceleratorprofiles.opendatahub.io.crd.yaml
@@ -10,7 +10,7 @@ spec:
     singular: acceleratorprofile
     kind: AcceleratorProfile
   versions:
-    - name: v1alpha
+    - name: v1
       served: true
       storage: true
       schema:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- This is a hot fix to move AcceleratorProfile crd version out of alpha.
- rename Nvidia to NVIDIA to align with proper naming conventions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. oc apply the new crd using the new version `v1`
2. make sure UI can detect accelerator profiles (check network tab for successful request)
3. make sure migration successfully fetches accelerator profiles
4. check that migrated gpu uses new name

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
n/a this is naming fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
