### PR TITLE
[Service Mesh]: handle istio proxy events

### DIFF
--- a/frontend/src/pages/projects/notebook/utils.ts
+++ b/frontend/src/pages/projects/notebook/utils.ts
@@ -145,40 +145,56 @@ export const useNotebookStatus = (
   let status: EventStatus = EventStatus.IN_PROGRESS;
   const lastItem = filteredEvents[filteredEvents.length - 1];
   let currentEvent = '';
-  if (lastItem.message.includes('oauth-proxy')) {
-    switch (lastItem.reason) {
-      case 'Pulling': {
-        currentEvent = 'Pulling oauth proxy';
-        percentile = 72;
-        break;
-      }
-      case 'Pulled': {
-        currentEvent = 'Oauth proxy pulled';
-        percentile = 80;
-        break;
-      }
-      case 'Created': {
-        currentEvent = 'Oauth proxy container created';
-        percentile = 88;
-        break;
-      }
-      case 'Started': {
-        currentEvent = 'Oauth proxy container started';
-        percentile = 96;
-        break;
-      }
-      case 'Killing': {
-        currentEvent = 'Stopping container oauth-proxy';
-        status = EventStatus.WARNING;
-        break;
-      }
-      default: {
-        if (lastItem.type === 'Warning') {
-          currentEvent = 'Issue creating oauth proxy container';
-          status = EventStatus.WARNING;
+
+  function handleProxyEvent(proxyType: 'istio' | 'oauth', event: EventKind) {
+    switch (event.reason) {
+      case 'Pulling':
+        return {
+          event: `Pulling ${proxyType} proxy`,
+          percentile: 72,
+        };
+      case 'Pulled':
+        return {
+          event: `${capitalizeFirstLetter(proxyType)} proxy pulled`,
+          percentile: 80,
+        };
+      case 'Created':
+        return {
+          event: `${capitalizeFirstLetter(proxyType)} proxy container created`,
+          percentile: 88,
+        };
+      case 'Started':
+        return {
+          event: `${capitalizeFirstLetter(proxyType)} proxy container started`,
+          percentile: 96,
+        };
+      case 'Killing':
+        return {
+          event: `Stopping container ${proxyType}-proxy`,
+          percentile: null,
+          status: EventStatus.WARNING,
+        };
+      default:
+        if (event.type === 'Warning') {
+          return {
+            event: `Issue creating ${proxyType} proxy container`,
+            status: EventStatus.WARNING,
+          };
         }
-      }
+        return {};
     }
+  }
+
+  if (lastItem.message.includes('oauth-proxy')) {
+    const result = handleProxyEvent('oauth', lastItem);
+    currentEvent = result.event ?? currentEvent;
+    percentile = result.percentile ?? percentile;
+    status = result.status ?? status;
+  } else if (lastItem.message.includes('istio-proxy')) {
+    const result = handleProxyEvent('istio', lastItem);
+    currentEvent = result.event ?? currentEvent;
+    percentile = result.percentile ?? percentile;
+    status = result.status ?? status;
   } else {
     switch (lastItem.reason) {
       case 'SuccessfulCreate': {
@@ -258,6 +274,10 @@ export const useNotebookStatus = (
     thisInstanceEvents,
   ];
 };
+
+function capitalizeFirstLetter(string: string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
 
 export const getEventFullMessage = (event: EventKind): string =>
   `${getEventTimestamp(event)} [${event.type}] ${event.message}`;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes: #1935 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR adds displaying the various event states when pulling the istio-proxy container.  Before this PR, the percentage is not updated for the different stages of pulling the istio-proxy container as it was for the oauth-proxy container.

This is implemented by adding a function wrapping around the switch statement previously used for oauth-proxy, and now can be used for either `oauth` or `istio` proxy depending on which is being pulled/started. The helper function `capitalizeFirstLetter` is used to maintain the same messages as before (in terms of capitalizing Oauth vs oauth). 

Note: the 'pulling istio proxy' message *should* not appear - this proxy sidecar will be pulled for the dashboard's sidecars as well so.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by installing operator v2 with service mesh: see https://github.com/opendatahub-io/opendatahub-operator/pull/605. Then, tested creating notebooks from the jupyter tile and from a data science project to ensure that the "Istio proxy container started" message is shown last. Also, tested with `ODHDashboardConfig.disableServiceMesh=true` in both cases to see that Oauth related event messages are still shown.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I am not sure where to add tests for this kind of a change - please point me in the right direction if testing would be needed for this PR!

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
