### PR TITLE
Support Truncated Model Serving Runtime Text Better

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -74,3 +74,19 @@ test('Legacy Serving Runtime', async ({ page }) => {
   await expect(firstRow).toHaveClass('pf-m-expanded');
   await expect(secondRow).not.toHaveClass('pf-m-expanded');
 });
+
+test('Add model server', async ({ page }) => {
+  await page.goto(navigateToStory('pages-modelserving-servingruntimelist', 'add-server'));
+
+  // wait for page to load
+  await page.waitForSelector('text=Add server');
+
+  // test that you can not submit on empty
+  await expect(await page.getByRole('button', { name: 'Add', exact: true })).toBeDisabled();
+
+  // test filling in minimum required fields
+  await page.getByLabel('Model server name *').fill('Test Server Name');
+  await page.locator('#serving-runtime-template-selection').click();
+  await page.getByText('New OVMS Server').click();
+  await expect(await page.getByRole('button', { name: 'Add', exact: true })).toBeEnabled();
+});

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
@@ -152,3 +152,14 @@ export const DeployModel: StoryObj = {
     await userEvent.click(canvas.getAllByText('Deploy model', { selector: 'button' })[0]);
   },
 };
+
+export const AddServer: StoryObj = {
+  render: Template,
+
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('ovms', undefined, { timeout: 5000 });
+    await userEvent.click(canvas.getByText('Add server', { selector: 'button' }));
+  },
+};

--- a/frontend/src/components/SimpleDropdownSelect.tsx
+++ b/frontend/src/components/SimpleDropdownSelect.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownToggle, Truncate } from '@patternfly/react-core';
 import './SimpleDropdownSelect.scss';
 
 export type SimpleDropdownOption = {
@@ -44,7 +44,7 @@ const SimpleDropdownSelect: React.FC<SimpleDropdownProps> = ({
           className={isFullWidth ? 'full-width' : undefined}
           onToggle={() => setOpen(!open)}
         >
-          <>{selectedLabel}</>
+          <Truncate content={selectedLabel.toString()} style={{ paddingLeft: 0 }} />
         </DropdownToggle>
       }
       dropdownItems={options

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { FormGroup, Label, Split, SplitItem, StackItem, TextInput } from '@patternfly/react-core';
+import {
+  FormGroup,
+  Label,
+  Split,
+  SplitItem,
+  StackItem,
+  TextInput,
+  Truncate,
+} from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingServingRuntimeObject } from '~/pages/modelServing/screens/types';
 import { TemplateKind } from '~/k8sTypes';
@@ -31,7 +39,9 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
     selectedLabel: getServingRuntimeDisplayNameFromTemplate(template),
     label: (
       <Split>
-        <SplitItem>{getServingRuntimeDisplayNameFromTemplate(template)}</SplitItem>
+        <SplitItem>
+          {<Truncate content={getServingRuntimeDisplayNameFromTemplate(template)} />}
+        </SplitItem>
         <SplitItem isFilled />
         <SplitItem>
           {isCompatibleWithAccelerator(

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Icon, Skeleton, Tooltip } from '@patternfly/react-core';
+import { Button, Icon, Skeleton, Tooltip, Truncate } from '@patternfly/react-core';
 import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { ServingRuntimeKind } from '~/k8sTypes';
@@ -77,7 +77,9 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
             obj.spec.builtInAdapter?.serverType ||
             'Custom Runtime'}
         </Td>
-        <Td dataLabel="Serving Runtime">{getDisplayNameFromServingRuntimeTemplate(obj)}</Td>
+        <Td dataLabel="Serving Runtime">
+          <Truncate content={getDisplayNameFromServingRuntimeTemplate(obj)} />
+        </Td>
         <Td
           dataLabel="Deployed models"
           compoundExpand={compoundExpandParams(ServingRuntimeTableTabs.DEPLOYED_MODELS, false)}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1861 

## Description
Added the <Truncate /> component within the Model Serving runtime to enhance text visibility and eliminate surplus content, ensuring a cleaner and more concise display.

<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/dcfc1f6a-7e75-4097-b445-e6ae399bc62c" width="500px"/>
<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/a67c2de8-4d7b-4793-82a4-1a0e06629fab" width="500px"/>
<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/38f91a93-aaef-4ebe-8ab8-93b40b2ac1c0" width="900px"/>


## How Has This Been Tested?
1. Open settings < serving runtimes < Add serving runtime with long display-name.
2. Open a project and scroll below to "Models & model serving section"
3. Click on "Add server"
4. In dropdown of model serving, you can see long name being truncated.
5. After adding model serving, model serving name will also be truncated.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added integration testing in model serving, related "Add server" modal and creating storybook component for it.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@vconzola 