### PR TITLE
[Service Mesh] include SM notebook patches in one function

### DIFF
--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -197,23 +197,25 @@ const getStopPatch = (): Patch => ({
   value: getStopPatchDataString(),
 });
 
-const getInjectOAuthPatch = (enableServiceMesh: boolean): Patch => ({
-  op: 'add',
-  path: '/metadata/annotations/notebooks.opendatahub.io~1inject-oauth',
-  value: String(!enableServiceMesh),
-});
-
-const getProxyInjectPatch = (enableServiceMesh: boolean): Patch => ({
-  op: 'add',
-  path: '/metadata/labels/sidecar.istio.io~1inject',
-  value: String(enableServiceMesh),
-});
-
-const getServiceMeshPatch = (enableServiceMesh: boolean): Patch => ({
-  op: 'add',
-  path: '/metadata/annotations/opendatahub.io~1service-mesh',
-  value: String(enableServiceMesh),
-});
+export const getServiceMeshPatches = (enableServiceMesh: boolean): Patch[] => {
+  return [
+    {
+      op: 'add',
+      path: '/metadata/annotations/notebooks.opendatahub.io~1inject-oauth',
+      value: String(!enableServiceMesh),
+    },
+    {
+      op: 'add',
+      path: '/metadata/labels/sidecar.istio.io~1inject',
+      value: String(enableServiceMesh),
+    },
+    {
+      op: 'add',
+      path: '/metadata/annotations/opendatahub.io~1service-mesh',
+      value: String(enableServiceMesh),
+    },
+  ];
+};
 
 export const getNotebooks = (namespace: string): Promise<NotebookKind[]> =>
   k8sListResource<NotebookKind>({
@@ -246,9 +248,7 @@ export const startNotebook = async (
 
   const patches: Patch[] = [
     startPatch,
-    getInjectOAuthPatch(enableServiceMesh),
-    getServiceMeshPatch(enableServiceMesh),
-    getProxyInjectPatch(enableServiceMesh),
+    ...getServiceMeshPatches(enableServiceMesh),
   ];
 
   const tolerationPatch = getTolerationPatch(tolerationChanges);

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -197,25 +197,23 @@ const getStopPatch = (): Patch => ({
   value: getStopPatchDataString(),
 });
 
-export const getServiceMeshPatches = (enableServiceMesh: boolean): Patch[] => {
-  return [
-    {
-      op: 'add',
-      path: '/metadata/annotations/notebooks.opendatahub.io~1inject-oauth',
-      value: String(!enableServiceMesh),
-    },
-    {
-      op: 'add',
-      path: '/metadata/labels/sidecar.istio.io~1inject',
-      value: String(enableServiceMesh),
-    },
-    {
-      op: 'add',
-      path: '/metadata/annotations/opendatahub.io~1service-mesh',
-      value: String(enableServiceMesh),
-    },
-  ];
-};
+export const getServiceMeshPatches = (enableServiceMesh: boolean): Patch[] => [
+  {
+    op: 'add',
+    path: '/metadata/annotations/notebooks.opendatahub.io~1inject-oauth',
+    value: String(!enableServiceMesh),
+  },
+  {
+    op: 'add',
+    path: '/metadata/labels/sidecar.istio.io~1inject',
+    value: String(enableServiceMesh),
+  },
+  {
+    op: 'add',
+    path: '/metadata/annotations/opendatahub.io~1service-mesh',
+    value: String(enableServiceMesh),
+  },
+];
 
 export const getNotebooks = (namespace: string): Promise<NotebookKind[]> =>
   k8sListResource<NotebookKind>({
@@ -246,10 +244,7 @@ export const startNotebook = async (
     dashboardConfig.spec.dashboardConfig.disableServiceMesh,
   );
 
-  const patches: Patch[] = [
-    startPatch,
-    ...getServiceMeshPatches(enableServiceMesh),
-  ];
+  const patches: Patch[] = [startPatch, ...getServiceMeshPatches(enableServiceMesh)];
 
   const tolerationPatch = getTolerationPatch(tolerationChanges);
   if (tolerationPatch) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes #1954 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

During review of #1088, it was left as an open comment to consolidate the three notebook annotation/label patch functions into one for code cleanness and to ensure future development doesn't "disable" one of the patches. 

This PR implements this by wrapping the three patches into one function, and calling it the same as before but now flattening the returned array of patches.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by installing operator v2 with service mesh: see https://github.com/opendatahub-io/opendatahub-operator/pull/605. Then, tested creating notebooks from the jupyter tile and from a data science project to ensure that the correct annotations and label are still added to the notebook object when using Service Mesh. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I would be happy to add tests, but would need some directions on how to add testing for this type of PR (patching of NB resource). 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
