### PR TITLE
[Service Mesh] General Improvements

### DIFF
--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -35,10 +35,11 @@ export const getNotebookStatus = async (
     let host: string;
     if (enableServiceMesh) {
       host = await getServiceMeshGwHost(fastify, namespace).catch((e) => {
-        fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
+        fastify.log.warn(`Failed getting service mesh route ${notebookName}: ${e.message}`);
         return undefined;
       });
-    } else {
+    }
+    if (!host) {
       const route = await getRoute(fastify, namespace, notebookName).catch((e) => {
         fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
         return undefined;

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -592,6 +592,10 @@ export const getDashboardConfig = (): DashboardConfig => {
   return dashboardConfigWatcher.getResources()?.[0];
 };
 
+/**
+ * Feature flags are required in the config -- but upgrades can be mixed and omission of the property
+ * usually ends up being enabled. This will prevent that as a general utility.
+ */
 export const featureFlagEnabled = (disabledSettingState?: boolean): boolean =>
   disabledSettingState === false;
 

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -27,7 +27,7 @@ const useRouteForNotebook = (
       if (notebookName && projectName) {
         // if not using service mesh fetch openshift route, otherwise get Istio Ingress Gateway route
         const getRoutePromise = !enableServiceMesh
-          ? getRoute(notebookName, projectName).then((route) => route?.spec.host)
+          ? getRoute(notebookName, projectName).then((route) => route.spec.host)
           : getServiceMeshGwHost(projectName);
 
         getRoutePromise


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes #1958 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and used image `quay.io/maistra-dev/odh-dashboard:gen-improve` for testing.

Changes here are pretty minimal, just tested that when a notebook is created/started from the jupyter tile + from a DS project with `ODHDashboardConfig.spec.disableServiceMesh=false`, the user is routed to the notebook correctly through the mesh. 

Verified the same when ODHDashboardConfig.spec.disableServiceMesh=true`, that the user is routed to the old route using oauth-proxy.

Credited @christianvogt as a co-author on the commit as these 3 changes came directly from Christian's review + suggestions on #1088 so I didn't want that to be lost to the sands of time. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
