### PR TITLE
Fix linter error & add doc help

### DIFF
--- a/docs/release-steps.md
+++ b/docs/release-steps.md
@@ -1,4 +1,5 @@
 [base/kustomization.yaml]: ../manifests/base/kustomization.yaml
+[SMEs]: ./smes.md
 [quay repo]: https://quay.io/repository/opendatahub/odh-dashboard?tab=tags
 [drafting a new release]: https://github.com/opendatahub-io/odh-dashboard/releases/new
 [semver]: https://semver.org/
@@ -36,6 +37,8 @@ There are two types of releases in the Dashboard, and they usually happen togeth
 
 * First make sure [main is released](#main-release)
 * Merge the `main` release content into `incubation`
+    * Conflict resolution may be needed; reach out to the [SMEs] if you're unsure about a given resolution
+    * Before officially pushing the merge, run all tests to make sure no linter, TypeScript, or tests fail
 * Wait for the `nightly` build to re-trigger
 
 ### Day 2

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionsColumn, ExpandableRowContent, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, ExpandableRowContent, Td } from '@patternfly/react-table';
 import { Link, useNavigate } from 'react-router-dom';
 import { Skeleton } from '@patternfly/react-core';
 import { PipelineRunKF, PipelineRunStatusesKF } from '~/concepts/pipelines/kfTypes';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1963

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
I didn't run the linter when I merged main... this should fix that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None, but docs were added.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
