### PR TITLE
Adapt custom serving runtimes to KServe

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,27 +1,29 @@
 import { TemplateKind } from '~/k8sTypes';
+import { ServingRuntimePlatform } from '~/types';
 
 type MockResourceConfigType = {
   name?: string;
   namespace?: string;
+  displayName?: string;
+  platforms?: ServingRuntimePlatform[];
 };
 
-export const mockTemplateK8sResource = ({
-  name = 'test-model',
+export const mockServingRuntimeTemplateK8sResource = ({
+  name = 'template-1',
   namespace = 'opendatahub',
+  displayName = 'New OVMS Server',
+  platforms,
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
-    name: 'template-ar2pcc',
+    name,
     namespace,
-    uid: '31277020-b60a-40c9-91bc-5ee3e2bb25ec',
-    resourceVersion: '164740435',
-    creationTimestamp: '2023-05-03T21:58:17Z',
     labels: {
       'opendatahub.io/dashboard': 'true',
     },
     annotations: {
-      tags: 'new-one,servingruntime',
+      'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
     },
   },
   objects: [
@@ -31,7 +33,7 @@ export const mockTemplateK8sResource = ({
       metadata: {
         name,
         annotations: {
-          'openshift.io/display-name': 'New OVMS Server',
+          'openshift.io/display-name': displayName,
         },
         labels: {
           'opendatahub.io/dashboard': 'true',

--- a/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.spec.ts
+++ b/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Custom serving runtimes', async ({ page }) => {
+  await page.goto(
+    './iframe.html?args=&id=tests-integration-pages-customservingruntimes-customservingruntimes--default&viewMode=story',
+  );
+  // wait for page to load
+  await page.waitForSelector('text=Serving runtimes');
+
+  // check the platform setting labels in the header
+  await expect(page.getByText('Single model serving enabled')).toBeVisible();
+  await expect(page.getByText('Multi-model serving enabled')).toBeHidden();
+
+  // check the platform labels in the table row
+  await expect(page.locator('#template-1').getByLabel('Label group category')).toHaveText(
+    'Single modelMulti-model',
+  );
+  await expect(page.locator('#template-2').getByLabel('Label group category')).toHaveText(
+    'Multi-model',
+  );
+  await expect(page.locator('#template-3').getByLabel('Label group category')).toHaveText(
+    'Single modelMulti-model',
+  );
+});

--- a/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { StoryFn, Meta, StoryObj } from '@storybook/react';
+import { rest } from 'msw';
+import { within } from '@storybook/testing-library';
+import { Route, Routes } from 'react-router-dom';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import CustomServingRuntimeView from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimeView';
+import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
+import CustomServingRuntimeContextProvider from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimeContext';
+import { mockStatus } from '~/__mocks__/mockStatus';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import useDetectUser from '~/utilities/useDetectUser';
+import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
+import { ServingRuntimePlatform } from '~/types';
+
+export default {
+  component: CustomServingRuntimeView,
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get('/api/status', (req, res, ctx) => res(ctx.json(mockStatus()))),
+        rest.get('/api/templates/opendatahub', (req, res, ctx) =>
+          res(
+            ctx.json(
+              mockK8sResourceList([
+                mockServingRuntimeTemplateK8sResource({
+                  platforms: [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI],
+                }),
+                mockServingRuntimeTemplateK8sResource({
+                  name: 'template-2',
+                  displayName: 'Multi-model Serving Runtime',
+                  platforms: [ServingRuntimePlatform.MULTI],
+                }),
+                mockServingRuntimeTemplateK8sResource({
+                  name: 'template-3',
+                  displayName: 'Serving Runtime with No Annotations',
+                }),
+              ]),
+            ),
+          ),
+        ),
+        rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
+          res(ctx.json(mockK8sResourceList([mockProjectK8sResource({})]))),
+        ),
+        rest.get('/api/dashboardConfig/opendatahub/odh-dashboard-config', (req, res, ctx) =>
+          res(ctx.json(mockDashboardConfig({}))),
+        ),
+      ],
+    },
+  },
+} as Meta<typeof CustomServingRuntimeView>;
+
+const Template: StoryFn<typeof CustomServingRuntimeView> = (args) => {
+  useDetectUser();
+  return (
+    <Routes>
+      <Route path="/" element={<CustomServingRuntimeContextProvider />}>
+        <Route index element={<CustomServingRuntimeView {...args} />} />
+      </Route>
+    </Routes>
+  );
+};
+
+export const Default: StoryObj = {
+  render: Template,
+
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Serving runtimes', undefined, { timeout: 5000 });
+  },
+};

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
@@ -22,7 +22,7 @@ import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import ProjectsRoutes from '~/concepts/projects/ProjectsRoutes';
 import {
   mockInvalidTemplateK8sResource,
-  mockTemplateK8sResource,
+  mockServingRuntimeTemplateK8sResource,
 } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
 import { mockStatus } from '~/__mocks__/mockStatus';
@@ -114,7 +114,7 @@ export default {
             res(
               ctx.json(
                 mockK8sResourceList([
-                  mockTemplateK8sResource({}),
+                  mockServingRuntimeTemplateK8sResource({}),
                   mockInvalidTemplateK8sResource({}),
                 ]),
               ),

--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.stories.tsx
@@ -22,7 +22,7 @@ import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import useDetectUser from '~/utilities/useDetectUser';
 import ProjectsRoutes from '~/concepts/projects/ProjectsRoutes';
 import { mockStatus } from '~/__mocks__/mockStatus';
-import { mockTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
+import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
 import ProjectDetails from '~/pages/projects/screens/detail/ProjectDetails';
 
@@ -119,7 +119,8 @@ const handlers = (isEmpty: boolean): RestHandler<MockedRequest<DefaultBodyType>>
   ),
   rest.get(
     '/api/k8s/apis/template.openshift.io/v1/namespaces/opendatahub/templates',
-    (req, res, ctx) => res(ctx.json(mockK8sResourceList([mockTemplateK8sResource({})]))),
+    (req, res, ctx) =>
+      res(ctx.json(mockK8sResourceList([mockServingRuntimeTemplateK8sResource({})]))),
   ),
   rest.get(
     '/api/k8s/apis/opendatahub.io/v1alpha/namespaces/opendatahub/odhdashboardconfigs/odh-dashboard-config',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -705,6 +705,7 @@ export type TemplateKind = K8sResourceCommon & {
       tags: string;
       iconClass?: string;
       'opendatahub.io/template-enabled': string;
+      'opendatahub.io/modelServingSupport': string;
     }>;
     name: string;
     namespace: string;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Button, Icon, Label, LabelGroup, Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+import { useAppContext } from '~/app/AppContext';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+
+const CustomServingRuntimeHeaderLabels: React.FC = () => {
+  const {
+    dashboardConfig: {
+      spec: {
+        dashboardConfig: { disableKServe, disableModelMesh },
+      },
+    },
+  } = useAppContext();
+
+  if (disableKServe && disableModelMesh) {
+    return null;
+  }
+
+  return (
+    <>
+      <LabelGroup>
+        {!disableKServe && <Label>Single model serving enabled</Label>}
+        {!disableModelMesh && <Label>Multi-model serving enabled</Label>}
+      </LabelGroup>
+      <Popover
+        showClose
+        bodyContent={
+          <>
+            You can change which model serving platforms are enabled in the{' '}
+            <Button isSmall isInline variant="link">
+              <Link to="/clusterSettings">Cluster settings</Link>
+            </Button>
+            .
+          </>
+        }
+      >
+        <Icon>
+          <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+        </Icon>
+      </Popover>
+    </>
+  );
+};
+
+export default CustomServingRuntimeHeaderLabels;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView.tsx
@@ -24,6 +24,7 @@ const CustomServingRuntimeListView: React.FC = () => {
   const navigate = useNavigate();
 
   const [deleteTemplate, setDeleteTemplate] = React.useState<TemplateKind>();
+
   const sortedTemplates = React.useMemo(
     () => getSortedTemplates(unsortedTemplates, templateOrder),
     [unsortedTemplates, templateOrder],

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup.tsx
@@ -1,0 +1,34 @@
+import { Label, LabelGroup } from '@patternfly/react-core';
+import * as React from 'react';
+import { TemplateKind } from '~/k8sTypes';
+import { getEnabledPlatformsFromTemplate } from '~/pages/modelServing/customServingRuntimes/utils';
+import { ServingRuntimePlatform } from '~/types';
+
+type CustomServingRuntimePlatformsLabelGroupProps = {
+  template: TemplateKind;
+};
+
+const ServingRuntimePlatformLabels = {
+  [ServingRuntimePlatform.SINGLE]: 'Single model',
+  [ServingRuntimePlatform.MULTI]: 'Multi-model',
+};
+
+const CustomServingRuntimePlatformsLabelGroup: React.FC<
+  CustomServingRuntimePlatformsLabelGroupProps
+> = ({ template }) => {
+  const platforms = getEnabledPlatformsFromTemplate(template);
+
+  if (platforms.length === 0) {
+    return null;
+  }
+
+  return (
+    <LabelGroup>
+      {platforms.map((platform, i) => (
+        <Label key={i}>{ServingRuntimePlatformLabels[platform]}</Label>
+      ))}
+    </LabelGroup>
+  );
+};
+
+export default CustomServingRuntimePlatformsLabelGroup;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { FormGroup } from '@patternfly/react-core';
+import { ServingRuntimePlatform } from '~/types';
+import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
+
+type CustomServingRuntimePlatformsSelectorProps = {
+  isSinglePlatformEnabled: boolean;
+  isMultiPlatformEnabled: boolean;
+  setSelectedPlatforms: (platforms: ServingRuntimePlatform[]) => void;
+};
+
+const RuntimePlatformSelectOptionLabels = {
+  [ServingRuntimePlatform.SINGLE]: 'Single model serving platform',
+  [ServingRuntimePlatform.MULTI]: 'Multi-model serving platform',
+  both: 'Both single and multi-model serving platforms',
+};
+
+const CustomServingRuntimePlatformsSelector: React.FC<
+  CustomServingRuntimePlatformsSelectorProps
+> = ({ isSinglePlatformEnabled, isMultiPlatformEnabled, setSelectedPlatforms }) => {
+  const options = [
+    {
+      key: ServingRuntimePlatform.SINGLE,
+      label: RuntimePlatformSelectOptionLabels[ServingRuntimePlatform.SINGLE],
+    },
+    {
+      key: ServingRuntimePlatform.MULTI,
+      label: RuntimePlatformSelectOptionLabels[ServingRuntimePlatform.MULTI],
+    },
+    {
+      key: 'both',
+      label: RuntimePlatformSelectOptionLabels['both'],
+    },
+  ];
+
+  const selection =
+    isSinglePlatformEnabled && isMultiPlatformEnabled
+      ? 'both'
+      : isSinglePlatformEnabled
+      ? ServingRuntimePlatform.SINGLE
+      : isMultiPlatformEnabled
+      ? ServingRuntimePlatform.MULTI
+      : '';
+  return (
+    <FormGroup
+      label="Select the model serving platforms this runtime supports"
+      fieldId="custom-serving-runtime-selection"
+      isRequired
+    >
+      <SimpleDropdownSelect
+        id="custom-serving-runtime-selection"
+        aria-label="Select a model serving runtime platform"
+        placeholder="Select a value"
+        options={options}
+        value={selection}
+        onChange={(key) => {
+          if (key === 'both') {
+            setSelectedPlatforms([ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI]);
+          } else if (
+            key === ServingRuntimePlatform.SINGLE ||
+            key === ServingRuntimePlatform.MULTI
+          ) {
+            setSelectedPlatforms([key]);
+          }
+        }}
+      />
+    </FormGroup>
+  );
+};
+
+export default CustomServingRuntimePlatformsSelector;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Label } from '@patternfly/react-core';
 import { TemplateKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
+import CustomServingRuntimePlatformsLabelGroup from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup';
 import CustomServingRuntimeEnabledToggle from './CustomServingRuntimeEnabledToggle';
 import {
   getServingRuntimeDisplayNameFromTemplate,
@@ -34,7 +35,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
           id: `draggable-row-${servingRuntimeName}`,
         }}
       />
-      <Td dataLabel="Name" width={70} className="pf-u-text-break-word">
+      <Td dataLabel="Name" className="pf-u-text-break-word">
         <ResourceNameTooltip resource={template}>
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>
@@ -42,6 +43,9 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
       </Td>
       <Td dataLabel="Enabled">
         <CustomServingRuntimeEnabledToggle template={template} />
+      </Td>
+      <Td dataLabel="Serving platforms supported">
+        <CustomServingRuntimePlatformsLabelGroup template={template} />
       </Td>
       <Td isActionCell>
         <ActionsColumn

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import CustomServingRuntimeListView from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView';
+import CustomServingRuntimeHeaderLabels from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels';
 import EmptyCustomServingRuntime from './EmptyCustomServingRuntime';
 import { CustomServingRuntimeContext } from './CustomServingRuntimeContext';
 
@@ -17,6 +18,7 @@ const CustomServingRuntimeView: React.FC = () => {
       empty={servingRuntimeTemplates.length === 0}
       emptyStatePage={<EmptyCustomServingRuntime />}
       provideChildrenPadding
+      headerContent={<CustomServingRuntimeHeaderLabels />}
     >
       <CustomServingRuntimeListView />
     </ApplicationsPage>

--- a/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
@@ -24,6 +24,11 @@ export const columns: SortableData<TemplateKind>[] = [
     },
   },
   {
+    field: 'platforms',
+    label: 'Serving platforms supported',
+    sortable: false,
+  },
+  {
     field: 'kebab',
     label: '',
     sortable: false,

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -1,6 +1,7 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource } from '~/pages/projects/utils';
+import { ServingRuntimePlatform } from '~/types';
 
 export const getTemplateEnabled = (template: TemplateKind, templateDisablement: string[]) =>
   !templateDisablement.includes(getServingRuntimeNameFromTemplate(template));
@@ -92,4 +93,18 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
     resource.spec.builtInAdapter?.serverType === 'ovms' ? 'OpenVINO Model Server' : undefined;
 
   return templateName || legacyTemplateName || 'Unknown Serving Runtime';
+};
+
+export const getEnabledPlatformsFromTemplate = (
+  template: TemplateKind,
+): ServingRuntimePlatform[] => {
+  if (!template.metadata.annotations?.['opendatahub.io/modelServingSupport']) {
+    return [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI];
+  }
+
+  try {
+    return JSON.parse(template.metadata.annotations?.['opendatahub.io/modelServingSupport']);
+  } catch (e) {
+    return [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI];
+  }
 };

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -10,7 +10,9 @@ export const getDashboardConfigBackend = (namespace: string): Promise<DashboardC
     .catch((e) => Promise.reject(e));
 
 export const getDashboardConfigTemplateOrderBackend = (ns: string): Promise<string[]> =>
-  getDashboardConfigBackend(ns).then((dashboardConfig) => dashboardConfig.spec.templateOrder || []);
+  getDashboardConfigBackend(ns).then(
+    (dashboardConfig) => dashboardConfig.spec?.templateOrder || [],
+  );
 
 export const getDashboardConfigTemplateDisablementBackend = (ns: string): Promise<string[]> =>
   getDashboardConfigBackend(ns).then(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -749,3 +749,8 @@ export type AcceleratorInfo = {
   total: { [key: string]: number };
   allocated: { [key: string]: number };
 };
+
+export enum ServingRuntimePlatform {
+  SINGLE = 'single',
+  MULTI = 'multi',
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1912 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The PR did the following things:
1. Add a required select dropdown when adding/editing custom serving runtimes, you can not click submit without selecting a value

<img width="1727" alt="Screenshot 2023-10-16 at 3 28 19 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/55387dc6-d3e3-4006-9c1b-e562cb3cc8ec">

2. Add a column to show the supported platform of the custom serving runtimes, and in the header show the available platforms based on the dashboard config

<img width="1727" alt="Screenshot 2023-10-18 at 5 19 04 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ef6f7cd9-b2e6-4bdf-91f6-2aa18b4a5370">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test the custom serving runtime template labels:
1. Go to the custom serving runtimes page
2. Make sure the OOTB serving runtimes have both labels shown because they don't have the `opendatahub.io/modelServingSupport` annotation
3. Try to duplicate one of the serving runtimes, make sure you cannot submit without selecting a platform
4. Select a platform and create one
5. Make sure the label is correct
6. Try to edit the serving runtime again, choose a different option, and submit
7. Make sure the label is changed too

To test the header labels of the available platforms:
1. Check the dashboard config, and try to change the `disableKServe` flag and `disableModelMesh` flag
2. Every time you make the change, wait for 2 minutes until the frontend fetches the latest data
3. If you set `disableKServe` to `true`, you shouldn't see the `Single model serving enabled` label. If you set `disableModelMesh` to `true`, you shouldn't see the `Multi-model serving enabled` label. On the other hand, setting these values to `false` should make the labels visible

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add the storybook test for the custom serving runtimes page and check the labels, more tests to be added along with the feature development.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
