### PR TITLE
fix proxy call content-length header for encoded characters in payload

### DIFF
--- a/backend/src/utils/httpUtils.ts
+++ b/backend/src/utils/httpUtils.ts
@@ -55,7 +55,7 @@ export const proxyCall = (
           requestOptions.headers = {
             ...requestOptions.headers,
             'Content-Type': contentType,
-            'Content-Length': requestData.length,
+            'Content-Length': Buffer.byteLength(requestData, 'utf8'),
           };
         }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/1968

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The backend passthrough proxy used string length for the `content-length` header which does not match the byte length of a payload which contains encoded characters. Therefore the payload was cut short when received by the api server resulting in malformed JSON being received.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Any request that uses our pass through proxy can be used for testing.
Easiest to test with projects.
Create a new project named `testł`. 
Expect the project to be created successfully.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No backend tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
