### PR TITLE
Expose the DSC status for the client

### DIFF
--- a/backend/src/routes/api/dsc/index.ts
+++ b/backend/src/routes/api/dsc/index.ts
@@ -1,0 +1,12 @@
+import { KubeFastifyInstance } from '../../../types';
+import { secureRoute } from '../../../utils/route-security';
+import { getClusterStatus } from '../../../utils/dsc';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.get(
+    '/status',
+    secureRoute(fastify)(async () => {
+      return getClusterStatus(fastify);
+    }),
+  );
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -254,7 +254,6 @@ export type KubeDecorator = KubeStatus & {
   customObjectsApi: k8s.CustomObjectsApi;
   rbac: k8s.RbacAuthorizationV1Api;
   currentToken: string;
-
 };
 
 export type KubeFastifyInstance = FastifyInstance & {
@@ -759,10 +758,10 @@ export type GPUInfo = {
 
 export type AcceleratorInfo = {
   configured: boolean;
-  available: {[key: string]: number};
-  total: {[key: string]: number};
-  allocated: {[key: string]: number};
-}
+  available: { [key: string]: number };
+  total: { [key: string]: number };
+  allocated: { [key: string]: number };
+};
 
 export type EnvironmentVariable = EitherNotBoth<
   { value: string | number },
@@ -882,7 +881,6 @@ export type SupportedModelFormats = {
   autoSelect?: boolean;
 };
 
-
 export enum ContainerResourceAttributes {
   CPU = 'cpu',
   MEMORY = 'memory',
@@ -947,3 +945,29 @@ export enum KnownLabels {
   MODEL_SERVING_PROJECT = 'modelmesh-enabled',
   DATA_CONNECTION_AWS = 'opendatahub.io/managed',
 }
+
+type ComponentNames =
+  | 'codeflare'
+  | 'data-science-pipelines-operator'
+  | 'kserve'
+  | 'model-mesh'
+  // Bug: https://github.com/opendatahub-io/opendatahub-operator/issues/641
+  | 'odh-dashboard'
+  | 'ray'
+  | 'workbenches';
+
+export type DataScienceClusterKindStatus = {
+  conditions: [];
+  installedComponents: { [key in ComponentNames]: boolean };
+  phase?: string;
+};
+
+export type DataScienceClusterKind = K8sResourceCommon & {
+  spec: unknown; // we should never need to look into this
+  status: DataScienceClusterKindStatus;
+};
+
+export type DataScienceClusterList = {
+  kind: 'DataScienceClusterList';
+  items: DataScienceClusterKind[];
+};

--- a/backend/src/utils/dsc.ts
+++ b/backend/src/utils/dsc.ts
@@ -1,0 +1,26 @@
+import {
+  DataScienceClusterKind,
+  DataScienceClusterKindStatus,
+  DataScienceClusterList,
+  KubeFastifyInstance,
+} from '../types';
+import { createCustomError } from './requestUtils';
+
+export const getClusterStatus = async (
+  fastify: KubeFastifyInstance,
+): Promise<DataScienceClusterKindStatus> => {
+  const result: DataScienceClusterKind | null = await fastify.kube.customObjectsApi
+    .listClusterCustomObject('datasciencecluster.opendatahub.io', 'v1', 'datascienceclusters')
+    .then((res) => (res.body as DataScienceClusterList).items[0])
+    .catch((e) => {
+      fastify.log.error(`Failure to fetch dsc: ${e.response.body}`);
+      return null;
+    });
+
+  if (!result) {
+    // May not be using v2 Operator
+    throw createCustomError('DSC Unavailable', 'Unable to get status', 404);
+  }
+
+  return result.status;
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -769,3 +769,20 @@ export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> 
     continue: string;
   };
 };
+
+type ComponentNames =
+  | 'codeflare'
+  | 'data-science-pipelines-operator'
+  | 'kserve'
+  | 'model-mesh'
+  // Bug: https://github.com/opendatahub-io/opendatahub-operator/issues/641
+  | 'odh-dashboard'
+  | 'ray'
+  | 'workbenches';
+
+/** We don't need or should ever get the full kind, this is the status section */
+export type DataScienceClusterKindStatus = {
+  conditions: K8sCondition[];
+  installedComponents: { [key in ComponentNames]: boolean };
+  phase?: string;
+};

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -164,3 +164,11 @@ rules:
       - delete
     resources:
       - notebooks
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    verbs:
+      - list
+      - watch
+      - get
+    resources:
+      - datascienceclusters


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1979 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Implements a shim layer to get the DSC Status state. A proxy effort until we have https://github.com/opendatahub-io/opendatahub-operator/issues/588 and we can switch to the pass-through k8s API.

Odd concern here is how we can determine the name of the DSC, so we can get just the status. This solution fetches the list, and gets the first item's `.status`. This won't be able to be done by the k8s pass-through.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Calling `GET <host>/api/dsc/status`.

```
{"conditions":[...statuses],"installedComponents":{"codeflare":false,"data-science-pipelines-operator":false,"kserve":false,"model-mesh":false,"odh-dashboard":true,"ray":false,"workbenches":false},"phase":"Ready"}
```
I imagine most will stick to `installedComponents` on first usage. `phase` of `"Ready"` may be needed to make sure it gets the proper details after it has finalized the first install.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None -- not sure if this can be really tested without an e2e test. We also don't have scaffolding for API tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
