### PR TITLE
Add model serving platform settings

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -102,6 +102,10 @@ export type ClusterSettings = {
   cullerTimeout: number;
   userTrackingEnabled: boolean;
   notebookTolerationSettings: NotebookTolerationSettings | null;
+  modelServingPlatformEnabled: {
+    kServe: boolean;
+    modelMesh: boolean;
+  };
 };
 
 // Add a minimal QuickStart type here as there is no way to get types without pulling in frontend (React) modules

--- a/frontend/src/__mocks__/mockClusterSettings.ts
+++ b/frontend/src/__mocks__/mockClusterSettings.ts
@@ -9,9 +9,14 @@ export const mockClusterSettings = ({
     key: 'NotebooksOnlyChange',
     enabled: true,
   },
+  modelServingPlatformEnabled = {
+    kServe: true,
+    modelMesh: true,
+  },
 }: Partial<ClusterSettingsType>): ClusterSettingsType => ({
   userTrackingEnabled,
   cullerTimeout,
   pvcSize,
   notebookTolerationSettings,
+  modelServingPlatformEnabled,
 });

--- a/frontend/src/__tests__/integration/pages/clusterSettings/ClusterSettings.spec.ts
+++ b/frontend/src/__tests__/integration/pages/clusterSettings/ClusterSettings.spec.ts
@@ -6,6 +6,29 @@ test('Cluster settings', async ({ page }) => {
   // wait for page to load
   await page.waitForSelector('text=Save changes');
   const submitButton = page.locator('[data-id="submit-cluster-settings"]');
+
+  // check serving platform field
+  const singlePlatformCheckbox = page.locator(
+    '[data-id="single-model-serving-platform-enabled-checkbox"]',
+  );
+  const multiPlatformCheckbox = page.locator(
+    '[data-id="multi-model-serving-platform-enabled-checkbox"]',
+  );
+  const warningAlert = page.locator('[data-id="serving-platform-warning-alert"]');
+  await expect(singlePlatformCheckbox).toBeChecked();
+  await expect(multiPlatformCheckbox).toBeChecked();
+  await expect(submitButton).toBeDisabled();
+  await multiPlatformCheckbox.uncheck();
+  await expect(warningAlert).toBeVisible();
+  expect(warningAlert.getByLabel('Info Alert')).toBeTruthy();
+  await expect(submitButton).toBeEnabled();
+  await singlePlatformCheckbox.uncheck();
+  expect(warningAlert.getByLabel('Warning Alert')).toBeTruthy();
+  await singlePlatformCheckbox.check();
+  await multiPlatformCheckbox.check();
+  await expect(warningAlert).toBeHidden();
+  await expect(submitButton).toBeDisabled();
+
   // check PVC size field
   const pvcInputField = page.locator('[data-id="pvc-size-input"]');
   const pvcHint = page.locator('[data-id="pvc-size-helper-text"]');

--- a/frontend/src/components/SettingSection.tsx
+++ b/frontend/src/components/SettingSection.tsx
@@ -4,7 +4,7 @@ import { Card, CardBody, CardFooter, CardTitle, Stack, StackItem } from '@patter
 type SettingSectionProps = {
   children: React.ReactNode;
   title: string;
-  description?: string;
+  description?: React.ReactNode;
   footer?: React.ReactNode;
 };
 

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -4,7 +4,11 @@ import { Button, Stack, StackItem } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { useAppContext } from '~/app/AppContext';
 import { fetchClusterSettings, updateClusterSettings } from '~/services/clusterSettingsService';
-import { ClusterSettingsType, NotebookTolerationFormSettings } from '~/types';
+import {
+  ClusterSettingsType,
+  ModelServingPlatformEnabled,
+  NotebookTolerationFormSettings,
+} from '~/types';
 import { addNotification } from '~/redux/actions/actions';
 import { useCheckJupyterEnabled } from '~/utilities/notebookControllerUtils';
 import { useAppDispatch } from '~/redux/hooks';
@@ -12,6 +16,7 @@ import PVCSizeSettings from '~/pages/clusterSettings/PVCSizeSettings';
 import CullerSettings from '~/pages/clusterSettings/CullerSettings';
 import TelemetrySettings from '~/pages/clusterSettings/TelemetrySettings';
 import TolerationSettings from '~/pages/clusterSettings/TolerationSettings';
+import ModelServingPlatformSettings from '~/pages/clusterSettings/ModelServingPlatformSettings';
 import {
   DEFAULT_CONFIG,
   DEFAULT_PVC_SIZE,
@@ -35,12 +40,15 @@ const ClusterSettings: React.FC = () => {
       enabled: false,
       key: isJupyterEnabled ? DEFAULT_TOLERATION_VALUE : '',
     });
+  const [modelServingEnabledPlatforms, setModelServingEnabledPlatforms] =
+    React.useState<ModelServingPlatformEnabled>(clusterSettings.modelServingPlatformEnabled);
   const dispatch = useAppDispatch();
 
   React.useEffect(() => {
     fetchClusterSettings()
       .then((clusterSettings: ClusterSettingsType) => {
         setClusterSettings(clusterSettings);
+        setModelServingEnabledPlatforms(clusterSettings.modelServingPlatformEnabled);
         setLoaded(true);
         setLoadError(undefined);
       })
@@ -59,8 +67,16 @@ const ClusterSettings: React.FC = () => {
           enabled: notebookTolerationSettings.enabled,
           key: notebookTolerationSettings.key,
         },
+        modelServingPlatformEnabled: modelServingEnabledPlatforms,
       }),
-    [pvcSize, cullerTimeout, userTrackingEnabled, clusterSettings, notebookTolerationSettings],
+    [
+      pvcSize,
+      cullerTimeout,
+      userTrackingEnabled,
+      clusterSettings,
+      notebookTolerationSettings,
+      modelServingEnabledPlatforms,
+    ],
   );
 
   const handleSaveButtonClicked = () => {
@@ -72,6 +88,7 @@ const ClusterSettings: React.FC = () => {
         enabled: notebookTolerationSettings.enabled,
         key: notebookTolerationSettings.key,
       },
+      modelServingPlatformEnabled: modelServingEnabledPlatforms,
     };
     if (!_.isEqual(clusterSettings, newClusterSettings)) {
       if (
@@ -123,6 +140,13 @@ const ClusterSettings: React.FC = () => {
       provideChildrenPadding
     >
       <Stack hasGutter>
+        <StackItem>
+          <ModelServingPlatformSettings
+            initialValue={clusterSettings.modelServingPlatformEnabled}
+            enabledPlatforms={modelServingEnabledPlatforms}
+            setEnabledPlatforms={setModelServingEnabledPlatforms}
+          />
+        </StackItem>
         <StackItem>
           <PVCSizeSettings
             initialValue={clusterSettings.pvcSize}

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertVariant,
+  Checkbox,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import SettingSection from '~/components/SettingSection';
+import { ModelServingPlatformEnabled } from '~/types';
+
+type ModelServingPlatformSettingsProps = {
+  initialValue: ModelServingPlatformEnabled;
+  enabledPlatforms: ModelServingPlatformEnabled;
+  setEnabledPlatforms: (platforms: ModelServingPlatformEnabled) => void;
+};
+
+const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> = ({
+  initialValue,
+  enabledPlatforms,
+  setEnabledPlatforms,
+}) => {
+  const [alert, setAlert] = React.useState<{ variant: AlertVariant; message: string }>();
+
+  React.useEffect(() => {
+    if (!enabledPlatforms.kServe && !enabledPlatforms.modelMesh) {
+      setAlert({
+        variant: AlertVariant.warning,
+        message:
+          'Disabling both model serving platforms prevents new projects from deploying models. Models can still be deployed from existing projects that already have a serving platform.',
+      });
+    } else {
+      if (initialValue.modelMesh && !enabledPlatforms.modelMesh) {
+        setAlert({
+          variant: AlertVariant.info,
+          message:
+            'Disabling the multi-model serving platform prevents models deployed in new projects and in existing projects with no deployed models from sharing model servers. Existing projects with deployed models will continue to use multi-model serving.',
+        });
+      } else {
+        setAlert(undefined);
+      }
+    }
+  }, [enabledPlatforms, initialValue]);
+
+  return (
+    <SettingSection
+      title="Model serving platforms"
+      description="Select the serving platforms that projects on this cluster can use for deploying models."
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <Checkbox
+            label="Single model serving platform"
+            isChecked={enabledPlatforms.kServe}
+            onChange={(enabled) => {
+              const newEnabledPlatforms: ModelServingPlatformEnabled = {
+                ...enabledPlatforms,
+                kServe: enabled,
+              };
+              setEnabledPlatforms(newEnabledPlatforms);
+            }}
+            aria-label="Single model serving platform enabled checkbox"
+            id="single-model-serving-platform-enabled-checkbox"
+            data-id="single-model-serving-platform-enabled-checkbox"
+            name="singleModelServingPlatformEnabledCheckbox"
+          />
+        </StackItem>
+        <StackItem>
+          <Checkbox
+            label="Multi-model serving platform"
+            isChecked={enabledPlatforms.modelMesh}
+            onChange={(enabled) => {
+              const newEnabledPlatforms: ModelServingPlatformEnabled = {
+                ...enabledPlatforms,
+                modelMesh: enabled,
+              };
+              setEnabledPlatforms(newEnabledPlatforms);
+            }}
+            aria-label="Multi-model serving platform enabled checkbox"
+            id="multi-model-serving-platform-enabled-checkbox"
+            data-id="multi-model-serving-platform-enabled-checkbox"
+            name="multiModelServingPlatformEnabledCheckbox"
+          />
+        </StackItem>
+        {alert && (
+          <StackItem>
+            <Alert
+              data-id="serving-platform-warning-alert"
+              variant={alert.variant}
+              title={alert.message}
+              isInline
+              actionClose={<AlertActionCloseButton onClose={() => setAlert(undefined)} />}
+            />
+          </StackItem>
+        )}
+      </Stack>
+    </SettingSection>
+  );
+};
+
+export default ModelServingPlatformSettings;

--- a/frontend/src/pages/clusterSettings/const.ts
+++ b/frontend/src/pages/clusterSettings/const.ts
@@ -17,6 +17,10 @@ export const DEFAULT_CONFIG: ClusterSettingsType = {
   cullerTimeout: DEFAULT_CULLER_TIMEOUT,
   userTrackingEnabled: false,
   notebookTolerationSettings: null,
+  modelServingPlatformEnabled: {
+    kServe: true,
+    modelMesh: false,
+  },
 };
 export const DEFAULT_TOLERATION_VALUE = 'NotebooksOnly';
 export const TOLERATION_FORMAT = /^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -157,6 +157,12 @@ export type ClusterSettingsType = {
   pvcSize: number | string;
   cullerTimeout: number;
   notebookTolerationSettings: TolerationSettings | null;
+  modelServingPlatformEnabled: ModelServingPlatformEnabled;
+};
+
+export type ModelServingPlatformEnabled = {
+  kServe: boolean;
+  modelMesh: boolean;
 };
 
 /** @deprecated -- use SDK type */


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1913 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add a section in the cluster settings to control the feature flags `disableKServe` and `disableModelMesh` in the dashboard config. When both checkboxes are unchecked, show a warning alert. When the multi-model option was initially selected but unchecked, show an info alert.

<img width="1727" alt="Screenshot 2023-10-18 at 5 29 25 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/1bd6e9c6-4ba2-49cb-86f2-2d6f4f44490d">

<img width="1727" alt="Screenshot 2023-10-18 at 5 29 42 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/fde25f63-0d02-4991-83f4-b6a96bcac95d">

<img width="1728" alt="Screenshot 2023-10-19 at 11 15 36 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ab5e9e95-1768-4b8e-992a-36ab87e7bfec">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the cluster settings page
2. Try to play around with the serving platform section, change the settings, and submit
3. Go to check the dashboard config YAML on the cluster to see if the feature flags are updated
4. Try to uncheck both checkboxes to see if the alert is shown
5. Try to check both options and save the changes
6. Try to uncheck the multi-model option and see if the info alert is shown

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add some integration tests on the cluster settings page to see if the alert is properly prompted and if the disablement/enablement state of the save button is performing correctly.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
