### PR TITLE
update kustomize to remove depreciated features

### DIFF
--- a/manifests/apps/jupyter/kustomization.yaml
+++ b/manifests/apps/jupyter/kustomization.yaml
@@ -1,11 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: odh-dashboard
-  app.kubernetes.io/part-of: odh-dashboard
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: odh-dashboard
+      app.kubernetes.io/part-of: odh-dashboard
+
 resources:
-- create-jupyter-notebook-quickstart.yaml
-- deploy-python-model-quickstart.yaml
-- jupyter-app.yaml
-- jupyterhub-app.yaml
-- jupyter-docs.yaml
+  - create-jupyter-notebook-quickstart.yaml
+  - deploy-python-model-quickstart.yaml
+  - jupyter-app.yaml
+  - jupyterhub-app.yaml
+  - jupyter-docs.yaml

--- a/manifests/apps/kustomization.yaml
+++ b/manifests/apps/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: odh-dashboard
-  app.kubernetes.io/part-of: odh-dashboard
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: odh-dashboard
+      app.kubernetes.io/part-of: odh-dashboard
+
 resources:
   - ./jupyter

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,8 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: odh-dashboard
-  app.kubernetes.io/part-of: odh-dashboard
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: odh-dashboard
+      app.kubernetes.io/part-of: odh-dashboard
+
 resources:
   - ../apps
   - ../modelserving
@@ -22,10 +26,11 @@ resources:
   - model-serving-role.yaml
   - model-serving-role-binding.yaml
   - fetch-accelerators.rbac.yaml
+
 images:
-- name: odh-dashboard
-  newName: quay.io/opendatahub/odh-dashboard
-  newTag: main
-- name: oauth-proxy
-  newName: registry.redhat.io/openshift4/ose-oauth-proxy
-  digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
+  - name: odh-dashboard
+    newName: quay.io/opendatahub/odh-dashboard
+    newTag: main
+  - name: oauth-proxy
+    newName: registry.redhat.io/openshift4/ose-oauth-proxy
+    digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33

--- a/manifests/crd/kustomization.yaml
+++ b/manifests/crd/kustomization.yaml
@@ -1,11 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: odh-dashboard
-  app.kubernetes.io/part-of: odh-dashboard
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: odh-dashboard
+      app.kubernetes.io/part-of: odh-dashboard
+
 resources:
-- odhdashboardconfigs.opendatahub.io.crd.yaml
-- odhquickstarts.console.openshift.io.crd.yaml
-- odhdocuments.dashboard.opendatahub.io.crd.yaml
-- odhapplications.dashboard.opendatahub.io.crd.yaml
-- acceleratorprofiles.opendatahub.io.crd.yaml
+  - odhdashboardconfigs.opendatahub.io.crd.yaml
+  - odhquickstarts.console.openshift.io.crd.yaml
+  - odhdocuments.dashboard.opendatahub.io.crd.yaml
+  - odhapplications.dashboard.opendatahub.io.crd.yaml
+  - acceleratorprofiles.opendatahub.io.crd.yaml
+

--- a/manifests/modelserving/kustomization.yaml
+++ b/manifests/modelserving/kustomization.yaml
@@ -1,11 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: odh-dashboard
-  app.kubernetes.io/part-of: odh-dashboard
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: odh-dashboard
+      app.kubernetes.io/part-of: odh-dashboard
+
 resources:
-  -  ovms-ootb.yaml
-  -  ovms-gpu-ootb.yaml
+  - ovms-ootb.yaml
+  - ovms-gpu-ootb.yaml
+
 images:
   - name: ovms-1
     newName: quay.io/opendatahub/openvino_model_server

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../../base
   - ../../crd

--- a/manifests/overlays/dev/nvidia-dcgm-mock-exporter/kustomization.yaml
+++ b/manifests/overlays/dev/nvidia-dcgm-mock-exporter/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - deployment.yaml
   - service.yaml

--- a/manifests/overlays/incubation/kustomization.yaml
+++ b/manifests/overlays/incubation/kustomization.yaml
@@ -1,11 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+
+resources:
   - ../../base
-patchesJson6902:
+
+patches:
   - path: deployment.yaml
     target:
       group: apps
       version: v1
       kind: Deployment
       name: odh-dashboard
+

--- a/manifests/overlays/odhdashboardconfig/kustomization.yaml
+++ b/manifests/overlays/odhdashboardconfig/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../../base
   - odh-dashboard-config.yaml

--- a/manifests/overlays/performance/kustomization.yaml
+++ b/manifests/overlays/performance/kustomization.yaml
@@ -1,11 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+
+resources:
   - ../../base
-patchesJson6902:
+
+patches:
   - path: deployment.yaml
     target:
       group: apps
       version: v1
       kind: Deployment
       name: odh-dashboard
+


### PR DESCRIPTION
## Description
This update resolves several depreciation warnings for kustomize that the operator generates while applying the manifests.

## How Has This Been Tested?
Generate all of the manifests from main, then generate the manifests from the updated version.  The generated manifests should 100% match.

## Test Impact

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [n/a] Included any necessary screenshots or gifs if it was a UI change.
- [n/a] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
