### PR TITLE
Add tooltips to Model Server Modal

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -164,6 +164,38 @@ test('Add ModelMesh model server', async ({ page }) => {
   await expect(page.getByRole('menuitem', { name: 'New OVMS Server Invalid' })).toBeHidden();
   await expect(page.getByRole('button', { name: 'Add', exact: true })).toBeEnabled();
 
+  //test Add model server tooltips
+  const expectedContent = [
+    {
+      ariaLabel: 'Model server replicas info',
+      content:
+        'Consider network traffic and failover scenarios when specifying the number of model server replicas.',
+    },
+    {
+      ariaLabel: 'Model server size info',
+      content:
+        'Select a server size that will accommodate your largest model. See the product documentation for more information.',
+    },
+    {
+      ariaLabel: 'Accelerator info',
+      content:
+        'Ensure that appropriate tolerations are in place before adding an accelerator to your model server.',
+    },
+  ];
+
+  for (const item of expectedContent) {
+    const iconPopover = await page.getByRole('button', { name: item.ariaLabel, exact: true });
+    if (await iconPopover.isVisible()) {
+      await iconPopover.click();
+      const popoverContent = await page.locator('div.pf-c-popover__content').textContent();
+      expect(popoverContent).toContain(item.content);
+
+      const closeButton = await page.locator('div.pf-c-popover__content>button');
+      if (closeButton) {
+        closeButton.click();
+      }
+    }
+  }
   // test the if the alert is visible when route is external while token is not set
   await expect(page.locator('#alt-form-checkbox-route')).not.toBeChecked();
   await expect(page.locator('#alt-form-checkbox-auth')).not.toBeChecked();

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -180,7 +180,12 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
             />
           </StackItem>
           <StackItem>
-            <ServingRuntimeReplicaSection data={createData} setData={setCreateData} />
+            <ServingRuntimeReplicaSection
+              data={createData}
+              setData={setCreateData}
+              infoContent="Consider network traffic and failover scenarios when specifying the number of model
+                server replicas."
+            />
           </StackItem>
           <StackItem>
             <ServingRuntimeSizeSection
@@ -190,6 +195,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
               servingRuntimeSelected={servingRuntimeSelected}
               acceleratorState={acceleratorState}
               setAcceleratorState={setAcceleratorState}
+              infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
             />
           </StackItem>
           {!allowCreate && (

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeReplicaSection.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { FormGroup, FormSection, NumberInput } from '@patternfly/react-core';
+import { FormGroup, FormSection, NumberInput, Popover, Icon } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingServingRuntimeObject } from '~/pages/modelServing/screens/types';
 import { isHTMLInputElement, normalizeBetween } from '~/utilities/utils';
@@ -7,11 +8,13 @@ import { isHTMLInputElement, normalizeBetween } from '~/utilities/utils';
 type ServingRuntimeReplicaSectionProps = {
   data: CreatingServingRuntimeObject;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
+  infoContent?: string;
 };
 
 const ServingRuntimeReplicaSection: React.FC<ServingRuntimeReplicaSectionProps> = ({
   data,
   setData,
+  infoContent,
 }) => {
   const MIN_SIZE = 0;
 
@@ -21,7 +24,18 @@ const ServingRuntimeReplicaSection: React.FC<ServingRuntimeReplicaSectionProps> 
 
   return (
     <FormSection title="Model server replicas">
-      <FormGroup label="Number of model server replicas to deploy">
+      <FormGroup
+        label="Number of model server replicas to deploy"
+        labelIcon={
+          infoContent ? (
+            <Popover bodyContent={<div>{infoContent}</div>}>
+              <Icon aria-label="Model server replicas info" role="button">
+                <OutlinedQuestionCircleIcon />
+              </Icon>
+            </Popover>
+          ) : undefined
+        }
+      >
         <NumberInput
           inputAriaLabel="model server replicas number input"
           value={data.numReplicas}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -6,7 +6,10 @@ import {
   SelectOption,
   Stack,
   StackItem,
+  Popover,
+  Icon,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import {
   CreatingServingRuntimeObject,
@@ -26,6 +29,7 @@ type ServingRuntimeSizeSectionProps = {
   servingRuntimeSelected?: ServingRuntimeKind;
   acceleratorState: AcceleratorState;
   setAcceleratorState: UpdateObjectAtPropAndValue<AcceleratorState>;
+  infoContent?: string;
 };
 
 const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
@@ -35,6 +39,7 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
   servingRuntimeSelected,
   acceleratorState,
   setAcceleratorState,
+  infoContent,
 }) => {
   const [sizeDropdownOpen, setSizeDropdownOpen] = React.useState(false);
   const [supportedAccelerators, setSupportedAccelerators] = React.useState<string[] | undefined>();
@@ -72,7 +77,18 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
 
   return (
     <FormSection title="Compute resources per replica">
-      <FormGroup label="Model server size">
+      <FormGroup
+        label="Model server size"
+        labelIcon={
+          infoContent ? (
+            <Popover bodyContent={<div>{infoContent}</div>}>
+              <Icon aria-label="Model server size info" role="button">
+                <OutlinedQuestionCircleIcon />
+              </Icon>
+            </Popover>
+          ) : undefined
+        }
+      >
         <Stack hasGutter>
           <StackItem>
             <Select
@@ -108,6 +124,7 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
             setAcceleratorState={setAcceleratorState}
             supportedAccelerators={supportedAccelerators}
             resourceDisplayName="serving runtime"
+            infoContent="Ensure that appropriate tolerations are in place before adding an accelerator to your model server."
           />
         </FormGroup>
       )}

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorSelectField.tsx
@@ -10,7 +10,10 @@ import {
   SplitItem,
   Stack,
   StackItem,
+  Popover,
+  Icon,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { isHTMLInputElement } from '~/utilities/utils';
 import { AcceleratorKind } from '~/k8sTypes';
 import SimpleDropdownSelect, { SimpleDropdownOption } from '~/components/SimpleDropdownSelect';
@@ -23,6 +26,7 @@ type AcceleratorSelectFieldProps = {
   setAcceleratorState: UpdateObjectAtPropAndValue<AcceleratorState>;
   supportedAccelerators?: string[];
   resourceDisplayName?: string;
+  infoContent?: string;
 };
 
 const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
@@ -30,6 +34,7 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
   setAcceleratorState,
   supportedAccelerators,
   resourceDisplayName = 'image',
+  infoContent,
 }) => {
   const [detectedAcceleratorInfo] = useAcceleratorCounts();
 
@@ -149,7 +154,19 @@ const AcceleratorSelectField: React.FC<AcceleratorSelectFieldProps> = ({
   return (
     <Stack hasGutter>
       <StackItem>
-        <FormGroup label="Accelerator" fieldId="modal-notebook-accelerator">
+        <FormGroup
+          label="Accelerator"
+          fieldId="modal-notebook-accelerator"
+          labelIcon={
+            infoContent ? (
+              <Popover bodyContent={<div>{infoContent}</div>}>
+                <Icon aria-label="Accelerator info" role="button">
+                  <OutlinedQuestionCircleIcon />
+                </Icon>
+              </Popover>
+            ) : undefined
+          }
+        >
           <SimpleDropdownSelect
             isFullWidth
             options={options}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/1580
## Description
Add tooltips to Model Server Modal

<img width="871" alt="Screenshot 2023-10-23 at 2 47 39 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/8b92e358-3ba9-4693-88e2-228dda8cc4b5">


## How Has This Been Tested?

- Create DS Project
- Scroll down to **Models and model servers** section
- Click **Add model server** button
- under **Add model server** pop up check to verify the popover 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
