### PR TITLE
Model status will never update if the runtime pod is unschedulable

### DIFF
--- a/frontend/src/__mocks__/mockPodK8sResource.ts
+++ b/frontend/src/__mocks__/mockPodK8sResource.ts
@@ -5,12 +5,14 @@ type MockResourceConfigType = {
   user?: string;
   name?: string;
   namespace?: string;
+  isPending?: boolean;
 };
 
 export const mockPodK8sResource = ({
   user = 'test-user',
   name = 'test-pod',
   namespace = 'test-project',
+  isPending = false,
 }: MockResourceConfigType): PodKind => ({
   kind: 'Pod',
   apiVersion: 'project.openshift.io/v1',
@@ -382,33 +384,45 @@ export const mockPodK8sResource = ({
     preemptionPolicy: 'PreemptLowerPriority',
   },
   status: {
-    phase: 'Running',
-    conditions: [
-      {
-        type: 'Initialized',
-        status: 'True',
-        lastProbeTime: null,
-        lastTransitionTime: '2023-02-14T22:06:45Z',
-      },
-      {
-        type: 'Ready',
-        status: 'True',
-        lastProbeTime: null,
-        lastTransitionTime: '2023-02-14T22:07:05Z',
-      },
-      {
-        type: 'ContainersReady',
-        status: 'True',
-        lastProbeTime: null,
-        lastTransitionTime: '2023-02-14T22:07:05Z',
-      },
-      {
-        type: 'PodScheduled',
-        status: 'True',
-        lastProbeTime: null,
-        lastTransitionTime: '2023-02-14T22:06:45Z',
-      },
-    ],
+    phase: isPending ? 'Pending' : 'Running',
+    conditions: !isPending
+      ? [
+          {
+            type: 'Initialized',
+            status: 'True',
+            lastTransitionTime: '2023-02-14T22:06:45Z',
+            lastProbeTime: null,
+          },
+          {
+            type: 'Ready',
+            status: 'True',
+            lastTransitionTime: '2023-02-14T22:07:05Z',
+            lastProbeTime: null,
+          },
+          {
+            type: 'ContainersReady',
+            status: 'True',
+            lastTransitionTime: '2023-02-14T22:07:05Z',
+            lastProbeTime: null,
+          },
+          {
+            type: 'PodScheduled',
+            status: 'True',
+            lastTransitionTime: '2023-02-14T22:06:45Z',
+            lastProbeTime: null,
+          },
+        ]
+      : [
+          {
+            type: 'PodScheduled',
+            status: 'False',
+            lastProbeTime: null,
+            lastTransitionTime: '2023-11-30T21:24:21Z',
+            reason: 'Unschedulable',
+            message:
+              ' 0/7 nodes are available: 2 Insufficient memory, 3 node(s) had untolerated taint {node-role.kubernetes.io/master: }, 4 Insufficient cpu, 4 Insufficient nvidia.com/gpu. preemption: 0/7 nodes are available:3 Preemption is not helpful for scheduling, 4 No preemption victims found for incoming pod..',
+          },
+        ],
     hostIP: '192.168.0.217',
     podIP: '10.131.1.182',
     podIPs: [

--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
@@ -137,6 +137,15 @@ test('Create model', async ({ page }) => {
   await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeEnabled();
 });
 
+test('Insufficient resources due to failed Pod scheduling', async ({ page }) => {
+  await page.goto(
+    navigateToStory('pages-modelserving-modelservingglobal', 'insufficient-resources-error'),
+  );
+  // hover over the icon
+  await page.getByLabel('error icon').hover();
+  await expect(page.getByText('Insufficient resources')).toBeVisible();
+});
+
 test('Create model error', async ({ page }) => {
   await page.goto(
     navigateToStory('pages-modelserving-modelservingglobal', 'deploy-model-model-mesh'),

--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
@@ -27,9 +27,10 @@ import { mockStatus } from '~/__mocks__/mockStatus';
 import useDetectUser from '~/utilities/useDetectUser';
 import { useApplicationSettings } from '~/app/useApplicationSettings';
 import { AppContext } from '~/app/AppContext';
-import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, PodKind, ServingRuntimeKind } from '~/k8sTypes';
 import GlobalModelServingCoreLoader from '~/pages/modelServing/screens/global/GlobalModelServingCoreLoader';
 import { mockDataConnection } from '~/__mocks__/mockDataConnection';
+import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -37,6 +38,7 @@ type HandlersProps = {
   projectEnableModelMesh?: boolean;
   servingRuntimes?: ServingRuntimeKind[];
   inferenceServices?: InferenceServiceKind[];
+  pod?: PodKind;
 };
 
 const getHandlers = ({
@@ -45,6 +47,7 @@ const getHandlers = ({
   projectEnableModelMesh,
   servingRuntimes = [mockServingRuntimeK8sResource({})],
   inferenceServices = [mockInferenceServiceK8sResource({})],
+  pod = mockPodK8sResource({}),
 }: HandlersProps) => [
   rest.get('/api/status', (req, res, ctx) => res(ctx.json(mockStatus()))),
   rest.get('/api/config', (req, res, ctx) =>
@@ -60,6 +63,9 @@ const getHandlers = ({
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/servingruntimes',
     (req, res, ctx) => res(ctx.json(mockK8sResourceList(servingRuntimes))),
+  ),
+  rest.get('/api/k8s/api/v1/namespaces/test-project/pods', (req, res, ctx) =>
+    res(ctx.json(mockK8sResourceList([pod]))),
   ),
   rest.get(
     'api/k8s/apis/serving.kserve.io/v1beta1/namespaces/test-project/inferenceservices',
@@ -204,6 +210,16 @@ export const EmptyStateNoServingRuntime: StoryObj = {
         servingRuntimes: [],
         inferenceServices: [],
       }),
+    },
+  },
+};
+
+export const InsufficientResourcesError: StoryObj = {
+  render: Template({}),
+
+  parameters: {
+    msw: {
+      handlers: getHandlers({ pod: mockPodK8sResource({ isPending: true }) }),
     },
   },
 };

--- a/frontend/src/api/k8s/pods.ts
+++ b/frontend/src/api/k8s/pods.ts
@@ -10,3 +10,21 @@ export const getPodsForNotebook = (namespace: string, notebookName: string): Pro
       queryParams: { labelSelector: `notebook-name=${notebookName}` },
     },
   }).then((r) => r.items);
+
+export const getPodsForModelMesh = (namespace: string, modelName: string): Promise<PodKind[]> =>
+  k8sListResource<PodKind>({
+    model: PodModel,
+    queryOptions: {
+      ns: namespace,
+      queryParams: { labelSelector: `name=modelmesh-serving-${modelName}` },
+    },
+  }).then((r) => r.items);
+
+export const getPodsForKserve = (namespace: string, modelName: string): Promise<PodKind[]> =>
+  k8sListResource<PodKind>({
+    model: PodModel,
+    queryOptions: {
+      ns: namespace,
+      queryParams: { labelSelector: `serving.kserve.io/inferenceservice=${modelName}` },
+    },
+  }).then((r) => r.items);

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -92,6 +92,7 @@ export type K8sCondition = {
   status: string;
   reason?: string;
   message?: string;
+  lastProbeTime?: string | null;
   lastTransitionTime?: string;
   lastHeartbeatTime?: string;
 };
@@ -281,6 +282,8 @@ export type NotebookKind = K8sResourceCommon & {
 
 export type PodKind = K8sResourceCommon & {
   status: {
+    phase: string;
+    conditions: K8sCondition[];
     containerStatuses: { ready: boolean; state?: { running?: boolean } }[];
   };
 };

--- a/frontend/src/pages/modelServing/__tests__/modelPod.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/modelPod.spec.ts
@@ -1,0 +1,18 @@
+import { checkModelStatus } from '~/pages/modelServing/screens/global/utils';
+import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
+
+const mockModelStatus = (status: boolean) => ({
+  failedToSchedule: status,
+});
+
+describe('checkModelStatus', () => {
+  it('Should return true  when pod fails to schedule due to insufficient resources.', async () => {
+    expect(checkModelStatus(mockPodK8sResource({ isPending: true }))).toEqual(
+      mockModelStatus(true),
+    );
+  });
+
+  it('Should return false when pod is scheduled.', async () => {
+    expect(checkModelStatus(mockPodK8sResource({}))).toEqual(mockModelStatus(false));
+  });
+});

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -68,7 +68,10 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
         />
       </Td>
       <Td dataLabel="Status">
-        <InferenceServiceStatus inferenceService={inferenceService} />
+        <InferenceServiceStatus
+          inferenceService={inferenceService}
+          isKserve={!isModelMesh(inferenceService)}
+        />
       </Td>
       <Td isActionCell>
         <ResourceActionsColumn

--- a/frontend/src/pages/modelServing/screens/global/useModelStatus.ts
+++ b/frontend/src/pages/modelServing/screens/global/useModelStatus.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { getPodsForKserve, getPodsForModelMesh } from '~/api';
+import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import { ModelStatus } from '~/pages/modelServing/screens/types';
+import { checkModelStatus } from './utils';
+
+export const useModelStatus = (
+  namespace: string,
+  name: string,
+  isKserve: boolean,
+): FetchState<ModelStatus | null> => {
+  const fetchSecret = React.useCallback<() => Promise<ModelStatus | null>>(() => {
+    const fetchFunction = isKserve ? getPodsForKserve : getPodsForModelMesh;
+    return fetchFunction(namespace, name)
+      .then((model) => checkModelStatus(model[0]))
+      .catch((e) => {
+        if (e.statusObject?.code === 404) {
+          throw new Error(`Pod ${name} not found`);
+        }
+        throw e;
+      });
+  }, [namespace, name, isKserve]);
+  return useFetchState<ModelStatus | null>(fetchSecret, null);
+};

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -1,6 +1,8 @@
 import { InferenceServiceKind, ProjectKind, SecretKind } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource, getProjectDisplayName } from '~/pages/projects/utils';
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
+import { PodKind } from '~/k8sTypes';
+import { ModelStatus } from '~/pages/modelServing/screens/types';
 
 export const getInferenceServiceDisplayName = (is: InferenceServiceKind): string =>
   getDisplayNameFromK8sResource(is);
@@ -26,4 +28,11 @@ export const getInferenceServiceProjectDisplayName = (
 ): string => {
   const project = projects.find(({ metadata: { name } }) => name === is.metadata.namespace);
   return project ? getProjectDisplayName(project) : 'Unknown';
+};
+
+export const checkModelStatus = (model: PodKind): ModelStatus => {
+  const modelStatus = model.status.conditions.some((model) => model?.reason === 'Unschedulable');
+  return {
+    failedToSchedule: model.status.phase === 'Pending' && modelStatus,
+  };
 };

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -30,6 +30,10 @@ export enum InferenceServiceModelState {
   UNKNOWN = 'Unknown',
 }
 
+export type ModelStatus = {
+  failedToSchedule: boolean;
+};
+
 export type CreatingServingRuntimeObject = {
   name: string;
   servingRuntimeTemplateName: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1548  

## Description
The status displays an error with  "insufficient resources" messages instead of just loading infinitely

![Screenshot from 2023-11-06 12-05-24](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/8a8ba478-f881-46d6-92b4-3af84402ed87)

Even displays in the global model serving

![Screenshot from 2023-11-06 12-09-24](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/e1ee8ea0-7ca6-44e9-9e1c-c573cbf819da)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Deploy a model via model serving using more resources than currently available
2. Wait for its status in the list of deployed models to become either pass or fail


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
