### PR TITLE
#1553 Add check for stale data in session storage for selected bias charts

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/BiasTab.tsx
@@ -25,6 +25,7 @@ import DashboardExpandableSection from '~/concepts/dashboard/DashboardExpandable
 import useBiasChartsBrowserStorage from '~/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage';
 import { ModelMetricType } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import EnsureMetricsAvailable from '~/pages/modelServing/screens/metrics/EnsureMetricsAvailable';
+import { byId } from '~/pages/modelServing/screens/metrics/utils';
 
 const OPEN_WRAPPER_STORAGE_KEY_PREFIX = `odh.dashboard.xai.bias_metric_chart_wrapper_open`;
 const BiasTab: React.FC = () => {
@@ -36,6 +37,10 @@ const BiasTab: React.FC = () => {
 
   React.useEffect(() => {
     if (loaded && !loadError) {
+      // It's possible a biasMetricConfig was deleted by the user directly accessing a backend API. We need to verify
+      // that any saved state in the session storage is not stale and if it is, remove it.
+      setSelectedBiasConfigs(selectedBiasConfigs.filter((x) => biasMetricConfigs.find(byId(x))));
+
       if (firstRender.current) {
         // If the user has just navigated here AND they haven't previously selected any charts to display,
         // don't show them the "No selected" empty state, instead show them the first available chart.


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes:
* #1533 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When the bias page renders, any selected charts in the browser session storage are validated to ensure they still exist i.e. they haven't been deleted by a direct call to a backend API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pre-requisites:
* A DSProject with: 
  * TrustyAI installed
  * a demo model installed
  * some demo data sent to the model
  * at least one bias metric configured

Instructions are for Chrome, it's possible with any browser but you'll have to figure out manipulating the session storage yourself in any others:

1. Navigate to the bias metrics tab
2. From the selector, select a chart
3. Open the browser console (F12) -> Applications tab
4. From the 'storage' group on the left menu bar, expand 'Session Storage'
5. In the main tab, look for a key that will be of the format: 'odh.dashboard.xai.selected_bias_charts-$MODEL_NAME'
6. Copy the key and value into a text editor for later use.
7. Back on the dashboard, click the configure button and delete the bias metric you selected in step 2.
8. Click the "back to $MODEL_NAME" button in the top right to return to the charts section.
9. Go back to the browser console -> applications -> session storage like in steps 3 & 4
10. Re-add the key and value you pasted in steps 5 & 6
11. refresh the page.
12. Validate that the Metrics to display dropdown is both disabled and does not show any selected charts.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
This is a small bug fix and there are no tests as yet for this feature.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Use image: quay.io/acreasy/odh-dashboard:issue-1553
