### PR TITLE
Handle Removed but not Disabled DS Pipelines

### DIFF
--- a/frontend/src/concepts/pipelines/context/PipelinesContextWorkaround.tsx
+++ b/frontend/src/concepts/pipelines/context/PipelinesContextWorkaround.tsx
@@ -1,0 +1,52 @@
+/**
+ * This file is immediately deprecated, this is for a small fix for the next release and will
+ * be fixed by https://github.com/opendatahub-io/odh-dashboard/issues/2010
+ */
+import * as React from 'react';
+import axios from 'axios';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { DataScienceClusterKindStatus } from '~/k8sTypes';
+import useFetchState from '~/utilities/useFetchState';
+import { PipelineContextProvider as PipelineContextProviderActual } from './PipelinesContext';
+
+/**
+ * Should only return `null` when on v1 Operator.
+ */
+const fetchDscStatus = (): Promise<DataScienceClusterKindStatus | null> => {
+  const url = '/api/dsc/status';
+  return axios
+    .get(url)
+    .then((response) => response.data)
+    .catch((e) => {
+      if (e.response.status === 404) {
+        // DSC is not available, assume v1 Operator
+        return null;
+      }
+      throw new Error(e.response.data.message);
+    });
+};
+
+const useFetchDscStatus = () => useFetchState(fetchDscStatus, null);
+
+/** @deprecated - replaced by https://github.com/opendatahub-io/odh-dashboard/issues/2010 */
+export const PipelineContextProviderWorkaround: React.FC<
+  React.ComponentProps<typeof PipelineContextProviderActual>
+> = ({ children, ...props }) => {
+  const [dscStatus, loaded] = useFetchDscStatus();
+
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (dscStatus && !dscStatus.installedComponents?.['data-science-pipelines-operator']) {
+    // eslint-disable-next-line no-console
+    console.log('Not rendering DS Pipelines Context because there is no backing component.');
+    return <>{children}</>;
+  }
+
+  return <PipelineContextProviderActual {...props}>{children}</PipelineContextProviderActual>;
+};

--- a/frontend/src/concepts/pipelines/context/index.ts
+++ b/frontend/src/concepts/pipelines/context/index.ts
@@ -6,3 +6,4 @@ export {
   ViewServerModal,
   PipelineServerTimedOut,
 } from './PipelinesContext';
+export { PipelineContextProviderWorkaround } from './PipelinesContextWorkaround';

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -783,6 +783,6 @@ type ComponentNames =
 /** We don't need or should ever get the full kind, this is the status section */
 export type DataScienceClusterKindStatus = {
   conditions: K8sCondition[];
-  installedComponents: { [key in ComponentNames]: boolean };
+  installedComponents: { [key in ComponentNames]?: boolean };
   phase?: string;
 };

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -16,7 +16,7 @@ import useInferenceServices from '~/pages/modelServing/useInferenceServices';
 import { ContextResourceData } from '~/types';
 import { useContextResourceData } from '~/utilities/useContextResourceData';
 import useServingRuntimeSecrets from '~/pages/modelServing/screens/projects/useServingRuntimeSecrets';
-import { PipelineContextProvider } from '~/concepts/pipelines/context';
+import { PipelineContextProviderWorkaround } from '~/concepts/pipelines/context';
 import { useAppContext } from '~/app/AppContext';
 import { featureFlagEnabled } from '~/utilities/utils';
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
@@ -188,9 +188,9 @@ const ProjectDetailsContextProvider: React.FC = () => {
       }}
     >
       {featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disablePipelines) ? (
-        <PipelineContextProvider namespace={project.metadata.name}>
+        <PipelineContextProviderWorkaround namespace={project.metadata.name}>
           <Outlet />
-        </PipelineContextProvider>
+        </PipelineContextProviderWorkaround>
       ) : (
         <Outlet />
       )}

--- a/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Divider } from '@patternfly/react-core';
+import { Alert, Divider } from '@patternfly/react-core';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '~/pages/projects/screens/detail/const';
 import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
@@ -12,10 +12,27 @@ import PipelineServerActions from '~/concepts/pipelines/content/pipelinesDetails
 
 const PipelinesSection: React.FC = () => {
   const {
+    project,
     pipelinesServer: { initializing, installed, timedOut },
   } = usePipelinesAPI();
 
   const [isPipelinesEmpty, setIsPipelinesEmpty] = React.useState(false);
+
+  if (!project) {
+    // Only possible today because of not having the API installed
+    // TODO: Fix in https://github.com/opendatahub-io/odh-dashboard/issues/2010
+    return (
+      <DetailsSection
+        id={ProjectSectionID.PIPELINES}
+        title={ProjectSectionTitles[ProjectSectionID.PIPELINES]}
+        isLoading={false}
+        isEmpty={false}
+        emptyState={null}
+      >
+        <Alert isInline variant="danger" title="Pipelines not installed" />
+      </DetailsSection>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1870

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When DSP is disabled in v2 Operator, the context fails and blocks the rendering of DS Projects details view.

## Screenshots / Flow

Two users:
1. Cluster Admin - The cluster admin can read 404 normally when an API is not available (404 error)
2. Regular user (eg. admin with no special permissions) - The regular user cannot read API from one that does not exist (403 error)
    * This will be done through impersonate, same difference on cluster (the screenshot has a white button in the header)

> Note: There are a lot of screenshots to show each state, so I added collapsible sections. Expand each one to see the screenshots. Two sets will be provided in each section. One for the cluster-admin and one for the "regular user".

#### DS Projects - No Operator installed & No DS Pipelines Component

<details>
  <summary>Screenshots</summary>

![Screenshot 2023-10-26 at 10 56 50 AM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/2ebdf1bd-9b54-4310-b094-75edc7f057c7)
![Screenshot 2023-10-26 at 10 57 15 AM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/24739d6a-4108-4bd1-9aa0-8ae89735f0f2)

</details>

---

#### DS Projects - Operator installed & No DS Pipelines Component

<details>
  <summary>Screenshots</summary>

![Screenshot 2023-10-26 at 12 39 56 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/1cadb42d-1176-4350-8ca6-3c46d4352f49)
![Screenshot 2023-10-26 at 12 40 34 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/386609e6-ca0c-4555-b5ec-d6c1a5f86e5f)
</details>

#### Global Screens (Pipeline & Run) - Operator installed & No DS Pipelines Component 

<details>
  <summary>Screenshots</summary>

![Screenshot 2023-10-26 at 11 01 22 AM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/8802866d-7cf7-4e73-86e6-54c675965b70)
![Screenshot 2023-10-26 at 11 01 11 AM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/d4e238a5-6b26-4eae-9da9-51011981bd4f)

![Screenshot 2023-10-26 at 11 00 29 AM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/9ef7f098-4866-443f-8901-d7c4c55c3611)
![Screenshot 2023-10-26 at 11 00 42 AM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/3560f961-9b45-4974-b4ea-0133fb23cef1)
</details>

---

#### DS Projects - Everything installed

<details>
  <summary>Screenshots</summary>

![Screenshot 2023-10-26 at 12 56 28 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/4110898c-e5ce-4718-9701-5f63d384b2ee)
![Screenshot 2023-10-26 at 12 57 38 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/da1d3814-58ef-4dd5-82c4-bf8484d17169)
</details>

### Global Screens (Pipeline & Run) - Everything installed

<details>
  <summary>Screenshots</summary>

![Screenshot 2023-10-26 at 12 56 48 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/823c4b70-1750-4420-8416-00f3cc02a3a9)
![Screenshot 2023-10-26 at 12 57 04 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/d0a45a96-ce1d-4c8e-bd30-24380f5573b1)
![Screenshot 2023-10-26 at 12 57 49 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/864d108d-f41b-4d5a-91e2-86090e1af99b)
![Screenshot 2023-10-26 at 12 57 58 PM](https://github.com/opendatahub-io/odh-dashboard/assets/8126518/6e6d5ac6-fe59-4b82-9874-c7ba01b078ba)
</details>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Three layers of testing here

* First layer is nothing installed, no operator & no component << Was the bug, installing the operator got a different error
* Second layer is just operator, no component << Once the first layer is removed, the error changes
* Third layer is both operator & component << Once the second layer is removed, we successfully render

Normal flows continue after this.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Deferring tests to https://github.com/opendatahub-io/odh-dashboard/issues/2010. This is a temporary fix to still show errors in the UI -- but nicer. To properly support components against our feature flags we need 2010, where tests should be included.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
