### PR TITLE
apply ownerReference to ServingRuntime related resources

### DIFF
--- a/frontend/src/__mocks__/mockProjectK8sResource.ts
+++ b/frontend/src/__mocks__/mockProjectK8sResource.ts
@@ -1,3 +1,4 @@
+import { genUID } from '~/__mocks__/mockUtils';
 import { KnownLabels, ProjectKind } from '~/k8sTypes';
 
 type MockResourceConfigType = {
@@ -19,6 +20,7 @@ export const mockProjectK8sResource = ({
   apiVersion: 'project.openshift.io/v1',
   metadata: {
     name: k8sName,
+    uid: genUID('project'),
     creationTimestamp: '2023-02-14T21:43:59Z',
     labels: {
       'kubernetes.io/metadata.name': k8sName,

--- a/frontend/src/api/__tests__/apiMergeUtils.spec.ts
+++ b/frontend/src/api/__tests__/apiMergeUtils.spec.ts
@@ -1,0 +1,59 @@
+import { K8sResourceBaseOptions } from '@openshift/dynamic-plugin-sdk-utils';
+import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
+import { ConfigMapModel } from '~/api/models';
+
+describe('applyK8sAPIOptions', () => {
+  const mockBaseOptions: K8sResourceBaseOptions = { model: ConfigMapModel };
+  const defaultExpect = {
+    model: ConfigMapModel,
+    fetchOptions: { requestInit: {} },
+    queryOptions: { queryParams: {} },
+  };
+  const signal = new AbortController().signal;
+
+  it('should not apply any options', () => {
+    expect(applyK8sAPIOptions({}, mockBaseOptions)).toStrictEqual(defaultExpect);
+  });
+
+  it('should apply dryRun option to payload and query options', () => {
+    expect(
+      applyK8sAPIOptions(
+        { dryRun: true },
+        { ...mockBaseOptions, queryOptions: { name: 'test', queryParams: { foo: 'bar' } } },
+      ),
+    ).toStrictEqual({
+      ...defaultExpect,
+      payload: { dryRun: ['All'] },
+      queryOptions: { name: 'test', queryParams: { foo: 'bar', dryRun: 'All' } },
+    });
+  });
+
+  it('should apply signal to fetch options', () => {
+    expect(
+      applyK8sAPIOptions(
+        { signal: new AbortController().signal },
+        { ...mockBaseOptions, fetchOptions: { timeout: 100, requestInit: { pathPrefix: 'test' } } },
+      ),
+    ).toStrictEqual({
+      ...defaultExpect,
+      fetchOptions: { timeout: 100, requestInit: { pathPrefix: 'test', signal } },
+    });
+  });
+
+  it('should not override payload with dryRun option', () => {
+    expect(
+      applyK8sAPIOptions({ dryRun: true }, { ...mockBaseOptions, payload: 'testing' }),
+    ).toStrictEqual({
+      ...defaultExpect,
+      payload: 'testing',
+      queryOptions: { queryParams: { dryRun: 'All' } },
+    });
+  });
+
+  it('should include all API Data', () => {
+    expect(applyK8sAPIOptions({}, { ...mockBaseOptions, foo: 'bar' })).toStrictEqual({
+      ...defaultExpect,
+      foo: 'bar',
+    });
+  });
+});

--- a/frontend/src/api/__tests__/k8sUtils.spec.ts
+++ b/frontend/src/api/__tests__/k8sUtils.spec.ts
@@ -1,0 +1,57 @@
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
+import { addOwnerReference } from '~/api/k8sUtils';
+
+describe('addOwnerReference', () => {
+  it('should not add any owner reference for undefined owner', () => {
+    const resource = mockSecretK8sResource({});
+    const target = addOwnerReference(resource, undefined);
+    expect(target).toBe(resource);
+    expect(target.metadata?.ownerReferences).toBeUndefined();
+  });
+
+  it('should add owner reference only once', () => {
+    const resource = mockSecretK8sResource({});
+    const owner = mockProjectK8sResource({});
+    let target = addOwnerReference(resource, owner);
+    expect(target).not.toBe(resource);
+    expect(target).toStrictEqual({
+      ...resource,
+      metadata: {
+        ...resource.metadata,
+        ownerReferences: [
+          {
+            uid: owner.metadata.uid,
+            name: owner.metadata.name,
+            apiVersion: owner.apiVersion,
+            kind: owner.kind,
+            blockOwnerDeletion: false,
+          },
+        ],
+      },
+    });
+    target = addOwnerReference(resource, owner);
+    expect(target.metadata.ownerReferences).toHaveLength(1);
+  });
+
+  it('should override blockOwnerDeletion', () => {
+    const resource = mockSecretK8sResource({});
+    const owner = mockProjectK8sResource({});
+    const target = addOwnerReference(resource, owner, true);
+    expect(target).toStrictEqual({
+      ...resource,
+      metadata: {
+        ...resource.metadata,
+        ownerReferences: [
+          {
+            uid: owner.metadata.uid,
+            name: owner.metadata.name,
+            apiVersion: owner.apiVersion,
+            kind: owner.kind,
+            blockOwnerDeletion: true,
+          },
+        ],
+      },
+    });
+  });
+});

--- a/frontend/src/api/apiMergeUtils.ts
+++ b/frontend/src/api/apiMergeUtils.ts
@@ -1,5 +1,12 @@
-import { K8sResourceBaseOptions, QueryParams } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  K8sResourceBaseOptions,
+  K8sResourceDeleteOptions,
+  QueryParams,
+} from '@openshift/dynamic-plugin-sdk-utils';
 import { K8sAPIOptions } from '~/k8sTypes';
+
+const dryRunPayload = (dryRun?: boolean): Pick<K8sResourceDeleteOptions, 'payload'> =>
+  dryRun ? { payload: { dryRun: ['All'] } } : {};
 
 const mergeK8sQueryParams = (
   opts: K8sAPIOptions = {},
@@ -21,6 +28,7 @@ export const applyK8sAPIOptions = <T extends K8sResourceBaseOptions>(
   opts: K8sAPIOptions = {},
   apiData: T,
 ): T => ({
+  ...dryRunPayload(opts.dryRun),
   ...apiData,
   queryOptions: {
     ...apiData.queryOptions,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -32,3 +32,6 @@ export * from './errorUtils';
 
 // User access review hook
 export * from './useAccessReview';
+
+// Generic K8s utils
+export * from './k8sUtils';

--- a/frontend/src/api/k8sUtils.ts
+++ b/frontend/src/api/k8sUtils.ts
@@ -1,0 +1,32 @@
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+export const addOwnerReference = <R extends K8sResourceCommon>(
+  resource: R,
+  owner?: K8sResourceCommon,
+  blockOwnerDeletion = false,
+): R => {
+  if (!owner) {
+    return resource;
+  }
+  const ownerReferences = resource.metadata?.ownerReferences || [];
+  if (
+    owner.metadata?.uid &&
+    owner.metadata?.name &&
+    !ownerReferences.find((r) => r.uid === owner.metadata?.uid)
+  ) {
+    ownerReferences.push({
+      uid: owner.metadata.uid,
+      name: owner.metadata.name,
+      apiVersion: owner.apiVersion,
+      kind: owner.kind,
+      blockOwnerDeletion,
+    });
+  }
+  return {
+    ...resource,
+    metadata: {
+      ...resource.metadata,
+      ownerReferences,
+    },
+  };
+};

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -99,9 +99,11 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
         editInfo={{
           inferenceServiceEditInfo: editInferenceService,
           servingRuntimeEditInfo: {
-            servingRuntime: servingRuntimes.find(
-              (sr) => sr.metadata.name === editInferenceService?.spec.predictor.model.runtime,
-            ),
+            servingRuntime: editInferenceService
+              ? servingRuntimes.find(
+                  (sr) => sr.metadata.name === editInferenceService.spec.predictor.model.runtime,
+                )
+              : undefined,
             secrets: [],
           },
         }}

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
@@ -59,7 +59,6 @@ const ServingRuntimeTable: React.FC = () => {
       {allowDelete && (
         <DeleteServingRuntimeModal
           servingRuntime={deleteServingRuntime}
-          tokens={filterTokens(deleteServingRuntime?.metadata.name)}
           inferenceServices={inferenceServices}
           onClose={(deleted) => {
             if (deleted) {

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -15,6 +15,7 @@ import {
   assembleServiceAccount,
   createServiceAccount,
   getRoleBinding,
+  addOwnerReference,
 } from '~/api';
 import {
   SecretKind,
@@ -61,16 +62,19 @@ export const setUpTokenAuth = async (
   servingRuntimeName: string,
   namespace: string,
   createRolebinding: boolean,
+  owner: ServingRuntimeKind,
   existingSecrets?: SecretKind[],
   opts?: K8sAPIOptions,
 ): Promise<void> => {
   const { serviceAccountName, roleBindingName } = getTokenNames(servingRuntimeName, namespace);
 
-  const serviceAccount = assembleServiceAccount(serviceAccountName, namespace);
-  const roleBinding = generateRoleBindingServingRuntime(
-    roleBindingName,
-    serviceAccountName,
-    namespace,
+  const serviceAccount = addOwnerReference(
+    assembleServiceAccount(serviceAccountName, namespace),
+    owner,
+  );
+  const roleBinding = addOwnerReference(
+    generateRoleBindingServingRuntime(roleBindingName, serviceAccountName, namespace),
+    owner,
   );
   return Promise.all([
     ...(existingSecrets === undefined ? [createServiceAccount(serviceAccount, opts)] : []),


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/1998

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a `ServingRuntime`, adds owner references to related resources:
- `RoleBinding`
- `ServiceAccount`
- ~`Secrets`~ _secrets are already associated with the `ServiceAccount` and get removed automatically_

When deleting a `ServingRuntime`, for compatibility in existing areas, we will continue to attempt to delete the service account and role binding.

In support of kserve, when an `InferenceService` is deleted from the global model serving page, the referenced `ServingRuntime` is also deleted (manually, not by use of owner references).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a model server with all form options.
- Deploy a model to the new server.
- Inspect newly added `RoleBinding`, `ServiceAccount`, `Secrets` for `ownerReferences` pointing back to the previously created `ServingRuntime`.
- Delete the `ServingRuntime` using the UI and ensure all the related resources are removed.
- Now perform the exact same steps again using all the same name values previously entered.
- Delete the `ServingRuntime` from the CLI and ensure all related resources are removed.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added tests to utilities.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
