### PR TITLE
Sets HTTP requests chart color to green / red and adds patterns for a…

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -21,6 +21,7 @@ import {
   ChartLine,
   ChartStack,
   ChartThemeColor,
+  ChartThemeDefinition,
   ChartThreshold,
   ChartVoronoiContainer,
   createContainer,
@@ -54,6 +55,8 @@ type MetricsChartProps = {
   toolbar?: React.ReactElement<typeof ToolbarContent>;
   type?: MetricsChartTypes;
   isStack?: boolean;
+  theme?: ChartThemeDefinition;
+  hasPatterns?: boolean;
 };
 const MetricsChart: React.FC<MetricsChartProps> = ({
   title,
@@ -64,6 +67,8 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
   toolbar,
   type = MetricsChartTypes.AREA,
   isStack = false,
+  theme,
+  hasPatterns = false,
 }) => {
   const bodyRef = React.useRef<HTMLDivElement>(null);
   const [chartWidth, setChartWidth] = React.useState(0);
@@ -189,6 +194,8 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
               width={chartWidth}
               padding={{ left: 70, right: 50, bottom: 70, top: 50 }}
               themeColor={color ?? ChartThemeColor.multi}
+              theme={theme}
+              hasPatterns={hasPatterns}
               {...legendProps}
             >
               <ChartAxis

--- a/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
@@ -6,6 +6,7 @@ import {
   ModelServingMetricsContext,
 } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
+import { SUCCESS_FAIL_CHART_THEME } from '~/pages/modelServing/screens/metrics/const';
 import { per100 } from './utils';
 
 const ModelGraphs: React.FC = () => {
@@ -32,6 +33,7 @@ const ModelGraphs: React.FC = () => {
             },
           ]}
           title="Http requests (x100)"
+          theme={SUCCESS_FAIL_CHART_THEME}
         />
       </StackItem>
     </Stack>

--- a/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
@@ -18,14 +18,14 @@ const ModelGraphs: React.FC = () => {
         <MetricsChart
           metrics={[
             {
-              name: 'Success http requests (x100)',
+              name: 'Successful',
               metric: data[
                 ModelMetricType.REQUEST_COUNT_SUCCESS
               ] as ContextResourceData<PrometheusQueryRangeResultValue>,
               translatePoint: per100,
             },
             {
-              name: 'Failed http requests (x100)',
+              name: 'Failed',
               metric: data[
                 ModelMetricType.REQUEST_COUNT_FAILED
               ] as ContextResourceData<PrometheusQueryRangeResultValue>,

--- a/frontend/src/pages/modelServing/screens/metrics/const.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/const.ts
@@ -1,3 +1,4 @@
+import { ChartThemeColor, mergeTheme } from '@patternfly/react-charts';
 import { BiasMetricType } from '~/api';
 import { BiasChartConfigMap, MetricsChartTypes } from '~/pages/modelServing/screens/metrics/types';
 import { ModelMetricType } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
@@ -23,7 +24,7 @@ export const EMPTY_BIAS_CHART_SELECTION_TITLE = 'No bias metrics selected';
 export const EMPTY_BIAS_CHART_SELECTION_DESC =
   'To display bias metric charts, select one or more bias metrics.';
 
-export const BIAS_THRESHOLD_COLOR = 'red';
+export const BIAS_THRESHOLD_COLOR = 'var(--pf-chart-global--danger--Color--100, #c9190b)';
 export const BIAS_DOMAIN_PADDING = 0.1;
 export const DEFAULT_BIAS_THRESHOLD_DELTAS: { [key in BiasMetricType]: number } = {
   [BiasMetricType.SPD]: 0.1,
@@ -76,3 +77,17 @@ export const BIAS_CHART_CONFIGS: BiasChartConfigMap = {
     },
   },
 };
+
+const colorScale = [
+  'var(--pf-chart-color-green-300, #4cb140)',
+  'var(--pf-chart-global--danger--Color--100, #c9190b)',
+];
+
+const themeProps = {
+  bar: { colorScale },
+  chart: { colorScale },
+  group: { colorScale },
+  legend: { colorScale },
+};
+
+export const SUCCESS_FAIL_CHART_THEME = mergeTheme(ChartThemeColor.default, themeProps);

--- a/frontend/src/pages/modelServing/screens/metrics/types.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/types.ts
@@ -1,4 +1,5 @@
 import { DomainTuple, ForAxes } from 'victory-core';
+import { ChartThemeDefinitionInterface } from '@patternfly/react-charts';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
 import { BiasMetricType } from '~/api';
 import { ModelMetricType } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
@@ -9,6 +10,7 @@ export type TranslatePoint = (line: GraphMetricPoint) => GraphMetricPoint;
 type MetricChartLineBase = {
   metric: ContextResourceData<PrometheusQueryRangeResultValue>;
   translatePoint?: TranslatePoint;
+  theme?: ChartThemeDefinitionInterface;
 };
 export type NamedMetricChartLine = MetricChartLineBase & {
   name: string;


### PR DESCRIPTION
…11y (#1131)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1131 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds the following improvements to HTTP requests metrics chart: 
* Uses requested colours: green-300 for success and red-100 for failure.
* Adds patterns to follow a11y guidelines for colourblindness.

<img width="2247" alt="red_green" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/1a40a597-bcdb-4615-b603-19ad58fdef23">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Navigate to model metrics page
* View the HTTP success / failure chart.
* Verify it appears as in the screenshot

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None - small visual change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
