### PR TITLE
Display error message on enabling TrustyAI via UI

### DIFF
--- a/frontend/src/pages/projects/projectSettings/ModelBiasSettingsCard.tsx
+++ b/frontend/src/pages/projects/projectSettings/ModelBiasSettingsCard.tsx
@@ -21,7 +21,6 @@ const ModelBiasSettingsCard: React.FC<ModelBiasSettingsCardProps> = ({ namespace
   const [notifyAction, setNotifyAction] = React.useState<TrustyAICRActions | undefined>(undefined);
   const [success, setSuccess] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>(undefined);
-
   const clearNotification = React.useCallback(() => {
     setNotifyAction(undefined);
     setSuccess(false);
@@ -52,7 +51,12 @@ const ModelBiasSettingsCard: React.FC<ModelBiasSettingsCardProps> = ({ namespace
           isLiveRegion
           isInline
         >
-          {error?.message}
+          {/* This is a temporary fix, this should be updated to incorporate work from
+          https://github.com/opendatahub-io/odh-dashboard/pull/2032 in the future to provide a
+          better experience.*/}
+          {error?.message.includes('404')
+            ? 'The TrustyAI operator is not installed on this cluster.'
+            : error?.message}
         </Alert>
       );
     }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #1996 

## Description
This PR aims to display error message on enabling TrustyAI via UI.

![Screenshot from 2023-10-31 19-21-23](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/9c71ded3-7ada-4bbe-8680-d3d0e01e2e64)

## How Has This Been Tested?
1) Create a Data Science Project
2) Navigate to DSP page
3) Click Settings
4) Check the Enable TrustyAI checkbox, you will show the error (only if  TrustyAIService CRD not installed on your cluster)

## Test Impact
NA

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
