### PR TITLE
Provide a better experience when on the project settings tab when Bia…

### DIFF
--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -12,6 +12,7 @@ import { useAccessReview } from '~/api';
 import { isProjectSharingEnabled } from '~/pages/projects/projectSharing/utils';
 import { AccessReviewResourceAttributes } from '~/k8sTypes';
 import ProjectSettingsPage from '~/pages/projects/projectSettings/ProjectSettingsPage';
+import useBiasMetricsEnabled from '~/concepts/explainability/useBiasMetricsEnabled';
 import useCheckLogoutParams from './useCheckLogoutParams';
 import ProjectDetailsComponents from './ProjectDetailsComponents';
 
@@ -27,6 +28,7 @@ const ProjectDetails: React.FC = () => {
   const displayName = getProjectDisplayName(currentProject);
   const description = getProjectDescription(currentProject);
   const projectSharingEnabled = isProjectSharingEnabled(dashboardConfig);
+  const [biasMetricsEnabled] = useBiasMetricsEnabled();
   const { state } = useLocation();
   const [allowCreate, rbacLoaded] = useAccessReview({
     ...accessReviewResource,
@@ -54,7 +56,9 @@ const ProjectDetails: React.FC = () => {
           sections={[
             { title: 'Components', component: <ProjectDetailsComponents />, icon: <CubeIcon /> },
             { title: 'Permissions', component: <ProjectSharing />, icon: <UsersIcon /> },
-            { title: 'Settings', component: <ProjectSettingsPage />, icon: <CogIcon /> },
+            ...(biasMetricsEnabled
+              ? [{ title: 'Settings', component: <ProjectSettingsPage />, icon: <CogIcon /> }]
+              : []),
           ]}
         />
       ) : (


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes: #2024 

## Description
Hide the settings tab on the project details page when bias metrics are disabled by feature flag
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
diable the BiasMetrics feature flag and check whether the the setting tab is hidden

![Screenshot from 2023-11-01 13-59-24](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/6ae75afc-c48b-42e8-8855-3421302ed164)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
No test here are no tests as yet for this feature.
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
