### PR TITLE
Added accelerator edit page

### DIFF
--- a/backend/src/routes/api/accelerator-profiles/acceleratorProfilesUtils.ts
+++ b/backend/src/routes/api/accelerator-profiles/acceleratorProfilesUtils.ts
@@ -1,0 +1,150 @@
+import { KubeFastifyInstance, AcceleratorKind } from '../../../types';
+import { FastifyRequest } from 'fastify';
+import createError from 'http-errors';
+import { translateDisplayNameForK8s } from '../../../utils/resourceUtils';
+
+export const postAcceleratorProfile = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ success: boolean; error: string }> => {
+  const customObjectsApi = fastify.kube.customObjectsApi;
+  const namespace = fastify.kube.namespace;
+  const body = request.body as AcceleratorKind['spec'];
+
+  const payload: AcceleratorKind = {
+    apiVersion: 'dashboard.opendatahub.io/v1',
+    kind: 'AcceleratorProfile',
+    metadata: {
+      name: translateDisplayNameForK8s(body.displayName),
+      namespace: namespace,
+      annotations: {
+        'opendatahub.io/modified-date': new Date().toISOString(),
+      },
+    },
+    spec: body,
+  };
+
+  try {
+    await customObjectsApi
+      .createNamespacedCustomObject(
+        'dashboard.opendatahub.io',
+        'v1',
+        namespace,
+        'acceleratorprofiles',
+        payload,
+      )
+      .catch((e) => {
+        throw createError(e.statusCode, e?.body?.message);
+      });
+    return { success: true, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error(e, 'Unable to add accelerator profile.');
+      return { success: false, error: 'Unable to add accelerator profile: ' + e.message };
+    }
+    throw e;
+  }
+};
+
+export const deleteAcceleratorProfile = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ success: boolean; error: string }> => {
+  const customObjectsApi = fastify.kube.customObjectsApi;
+  const namespace = fastify.kube.namespace;
+  const params = request.params as { acceleratorProfileName: string };
+
+  try {
+    await customObjectsApi
+      .deleteNamespacedCustomObject(
+        'dashboard.opendatahub.io',
+        'v1',
+        namespace,
+        'acceleratorprofiles',
+        params.acceleratorProfileName,
+      )
+      .catch((e) => {
+        throw createError(e.statusCode, e?.body?.message);
+      });
+    return { success: true, error: null };
+  } catch (e) {
+    if (e.response?.statusCode === 404) {
+      fastify.log.error(e, 'Unable to delete accelerator profile.');
+      return { success: false, error: 'Unable to delete accelerator profile: ' + e.message };
+    }
+    throw e;
+  }
+};
+
+export const updateAcceleratorProfile = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ success: boolean; error: string }> => {
+  const customObjectsApi = fastify.kube.customObjectsApi;
+  const namespace = fastify.kube.namespace;
+  const params = request.params as { acceleratorProfileName: string };
+  const body = request.body as Partial<AcceleratorKind['spec']>;
+
+  try {
+    const currentProfile = await customObjectsApi
+      .getNamespacedCustomObject(
+        'dashboard.opendatahub.io',
+        'v1',
+        namespace,
+        'acceleratorprofiles',
+        params.acceleratorProfileName,
+      )
+      .then((r) => r.body as AcceleratorKind)
+      .catch((e) => {
+        throw createError(e.statusCode, e?.body?.message);
+      });
+
+    if (body.displayName !== undefined) {
+      currentProfile.spec.displayName = body.displayName;
+    }
+    if (body.enabled !== undefined) {
+      currentProfile.spec.enabled = body.enabled;
+    }
+    if (body.identifier !== undefined) {
+      currentProfile.spec.identifier = body.identifier;
+    }
+    if (body.description !== undefined) {
+      currentProfile.spec.description = body.description;
+    }
+    if (body.tolerations !== undefined) {
+      currentProfile.spec.tolerations = body.tolerations;
+    }
+
+    // Update the modified date annotation
+    if (!currentProfile.metadata.annotations) {
+      currentProfile.metadata.annotations = {};
+    }
+    currentProfile.metadata.annotations['opendatahub.io/modified-date'] = new Date().toISOString();
+
+    await customObjectsApi
+      .patchNamespacedCustomObject(
+        'dashboard.opendatahub.io',
+        'v1',
+        namespace,
+        'acceleratorprofiles',
+        params.acceleratorProfileName,
+        currentProfile,
+        undefined,
+        undefined,
+        undefined,
+        {
+          headers: { 'Content-Type': 'application/merge-patch+json' },
+        },
+      )
+      .catch((e) => {
+        throw createError(e.statusCode, e?.body?.message);
+      });
+    return { success: true, error: null };
+  } catch (e) {
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error(e, 'Unable to update accelerator profile.');
+      return { success: false, error: 'Unable to update accelerator profile: ' + e.message };
+    }
+    throw e;
+  }
+};

--- a/backend/src/routes/api/accelerator-profiles/index.ts
+++ b/backend/src/routes/api/accelerator-profiles/index.ts
@@ -1,0 +1,48 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { secureAdminRoute } from '../../../utils/route-security';
+import {
+  deleteAcceleratorProfile,
+  postAcceleratorProfile,
+  updateAcceleratorProfile,
+} from './acceleratorProfilesUtils';
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  fastify.delete(
+    '/:acceleratorProfileName',
+    secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
+      return deleteAcceleratorProfile(fastify, request)
+        .then((res) => {
+          return res;
+        })
+        .catch((res) => {
+          reply.send(res);
+        });
+    }),
+  );
+
+  fastify.put(
+    '/:acceleratorProfileName',
+    secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
+      return updateAcceleratorProfile(fastify, request)
+        .then((res) => {
+          return res;
+        })
+        .catch((res) => {
+          reply.send(res);
+        });
+    }),
+  );
+
+  fastify.post(
+    '/',
+    secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
+      return postAcceleratorProfile(fastify, request)
+        .then((res) => {
+          return res;
+        })
+        .catch((res) => {
+          reply.send(res);
+        });
+    }),
+  );
+};

--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -1,5 +1,6 @@
 import { IMAGE_ANNOTATIONS } from '../../../utils/constants';
 import { convertLabelsToString } from '../../../utils/componentUtils';
+import { translateDisplayNameForK8s } from '../../../utils/resourceUtils';
 import {
   ImageStreamTag,
   ImageTagInfo,
@@ -12,13 +13,6 @@ import {
 } from '../../../types';
 import { FastifyRequest } from 'fastify';
 import createError from 'http-errors';
-
-const translateDisplayNameForK8s = (name: string): string =>
-  name
-    .trim()
-    .toLowerCase()
-    .replace(/\s/g, '-')
-    .replace(/[^A-Za-z0-9-]/g, '');
 
 /**
  * This function uses a regex to match the image location string

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -952,3 +952,10 @@ export const migrateTemplateDisablement = async (
 
 export const getServingRuntimeNameFromTemplate = (template: Template): string =>
   template.objects[0].metadata.name;
+
+export const translateDisplayNameForK8s = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/\s/g, '-')
+    .replace(/[^A-Za-z0-9-]/g, '');

--- a/frontend/src/__mocks__/mockAcceleratorProfile.ts
+++ b/frontend/src/__mocks__/mockAcceleratorProfile.ts
@@ -1,22 +1,34 @@
+import _ from 'lodash';
 import { AcceleratorKind } from '~/k8sTypes';
+import { RecursivePartial } from '~/typeHelpers';
+import { TolerationEffect, TolerationOperator } from '~/types';
 
-export const mockAcceleratorProfile = (): AcceleratorKind => ({
-  apiVersion: 'dashboard.opendatahub.io/v1',
-  kind: 'AcceleratorProfile',
-  metadata: {
-    name: 'test-accelerator',
-  },
-  spec: {
-    displayName: 'test-accelerator',
-    enabled: true,
-    identifier: 'nvidia.com/gpu',
-    description: 'Test description',
-    tolerations: [
-      {
-        key: 'nvidia.com/gpu',
-        operator: 'Exists',
-        effect: 'NoSchedule',
+export const mockAcceleratorProfile = (
+  data: RecursivePartial<AcceleratorKind> = {},
+): AcceleratorKind =>
+  _.merge(
+    {
+      apiVersion: 'dashboard.opendatahub.io/v1',
+      kind: 'AcceleratorProfile',
+      metadata: {
+        name: 'test-accelerator',
+        annotations: {
+          'opendatahub.io/modified-date': '2023-10-31T21:16:11.721Z',
+        },
       },
-    ],
-  },
-});
+      spec: {
+        displayName: 'Test Accelerator',
+        enabled: true,
+        identifier: 'nvidia.com/gpu',
+        description: 'Test description',
+        tolerations: [
+          {
+            key: 'nvidia.com/gpu',
+            operator: TolerationOperator.EXISTS,
+            effect: TolerationEffect.NO_SCHEDULE,
+          },
+        ],
+      },
+    } as AcceleratorKind,
+    data,
+  );

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -1,6 +1,6 @@
 import { KnownLabels, NotebookKind } from '~/k8sTypes';
 import { DEFAULT_NOTEBOOK_SIZES } from '~/pages/projects/screens/spawner/const';
-import { ContainerResources } from '~/types';
+import { ContainerResources, TolerationEffect, TolerationOperator } from '~/types';
 import { genUID } from '~/__mocks__/mockUtils';
 
 type MockResourceConfigType = {
@@ -135,23 +135,6 @@ export const mockNotebookK8sResource = ({
             workingDir: '/opt/app-root/src',
           },
           {
-            args: [
-              '--provider=openshift',
-              '--https-address=:8443',
-              '--http-address=',
-              '--openshift-service-account=workbench',
-              '--cookie-secret-file=/etc/oauth/config/cookie_secret',
-              '--cookie-expire=24h0m0s',
-              '--tls-cert=/etc/tls/private/tls.crt',
-              '--tls-key=/etc/tls/private/tls.key',
-              '--upstream=http://localhost:8888',
-              '--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-              '--skip-auth-regex=^(?:/notebook/$(NAMESPACE)/workbench)?/api$',
-              '--email-domain=*',
-              '--skip-provider-button',
-              '--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org","resourceName":"workbench","namespace":"$(NAMESPACE)"}',
-              '--logout-url=http://localhost:4010/projects/project?notebookLogout=workbench',
-            ],
             env: [
               {
                 name: 'NAMESPACE',
@@ -220,12 +203,11 @@ export const mockNotebookK8sResource = ({
           },
         ],
         enableServiceLinks: false,
-        serviceAccountName: name,
         tolerations: [
           {
-            effect: 'NoSchedule',
+            effect: TolerationEffect.NO_SCHEDULE,
             key: 'NotebooksOnlyChange',
-            operator: 'Exists',
+            operator: TolerationOperator.EXISTS,
           },
         ],
         volumes: [
@@ -238,14 +220,12 @@ export const mockNotebookK8sResource = ({
           {
             name: 'oauth-config',
             secret: {
-              defaultMode: 420,
               secretName: 'workbench-oauth-config',
             },
           },
           {
             name: 'tls-certificates',
             secret: {
-              defaultMode: 420,
               secretName: 'workbench-tls',
             },
           },
@@ -284,11 +264,7 @@ export const mockNotebookK8sResource = ({
         type: 'Waiting',
       },
     ],
-    containerState: {
-      running: {
-        startedAt: '2023-02-14T22:06:52Z',
-      },
-    },
+    containerState: {},
     readyReplicas: 1,
   },
 });

--- a/frontend/src/__tests__/integration/pages/acceleratorProfiles/AcceleratorProfiles.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/acceleratorProfiles/AcceleratorProfiles.stories.tsx
@@ -7,7 +7,7 @@ import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import useDetectUser from '~/utilities/useDetectUser';
 import { mockStatus } from '~/__mocks__/mockStatus';
 
-import AcceleratorProfiles from '~/pages/acceleratorProfiles/AcceleratorProfiles';
+import AcceleratorProfiles from '~/pages/acceleratorProfiles/screens/list/AcceleratorProfiles';
 
 export default {
   component: AcceleratorProfiles,

--- a/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.spec.ts
+++ b/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '@playwright/test';
+import { navigateToStory } from '~/__tests__/integration/utils';
+
+test('Create accelerator profile', async ({ page }) => {
+  await page.goto(
+    navigateToStory(
+      'pages-acceleratorprofiles-manageacceleratorprofile',
+      'new-accelerator-profile',
+    ),
+  );
+
+  // wait for page to load
+  await page.waitForSelector('text=Details');
+
+  // test required fields
+  await expect(page.getByTestId('accelerator-profile-create-button')).toBeDisabled();
+  await page.getByTestId('accelerator-name-input').fill('Test Name');
+  await expect(page.getByTestId('accelerator-profile-create-button')).toBeDisabled();
+  await page.getByTestId('accelerator-identifier-input').fill('test.com/gpu');
+  await expect(page.getByTestId('accelerator-profile-create-button')).toBeEnabled();
+
+  // test tolerations
+  await expect(page.getByTestId('tolerations-modal-empty-state')).toBeTruthy();
+
+  // open modal
+  await page.getByTestId('add-toleration-button').click();
+
+  // fill in form required fields
+  await expect(page.getByTestId('modal-submit-button')).toBeDisabled();
+  await page.getByTestId('toleration-key-input').fill('test-key');
+  await expect(page.getByTestId('modal-submit-button')).toBeEnabled();
+
+  // test value info warning when operator is Exists
+  await page.getByTestId('toleration-value-input').fill('test-value');
+  await expect(page.getByTestId('toleration-value-alert')).toBeTruthy();
+  await page.getByRole('button', { name: 'Equal' }).click();
+  await page
+    .getByRole('menuitem', {
+      name: 'Equal A toleration "matches" a taint if the keys are the same, the effects are the same, and the values are equal.',
+    })
+    .click();
+  await expect(page.getByTestId('toleration-value-alert')).toHaveCount(0);
+
+  // test toleration seconds warning when effect is not NoExecute
+  await page.getByTestId('toleration-seconds-radio-custom').check();
+  await expect(page.getByTestId('toleration-seconds-alert')).toHaveCount(1);
+  await page.getByRole('button', { name: 'None' }).click();
+  await page
+    .getByRole('menuitem', {
+      name: 'NoExecute Pods will be evicted from the node if they do not tolerate the taint.',
+    })
+    .click();
+  await expect(page.getByTestId('toleration-seconds-alert')).toHaveCount(0);
+  await page.getByRole('button', { name: 'Plus' }).click();
+
+  // test adding toleration
+  await page.getByTestId('modal-submit-button').click();
+
+  // test that values were added correctly
+  await expect(page.getByRole('gridcell', { name: 'Equal' })).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: 'test-key' })).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: 'test-value' })).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: 'NoExecute' })).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: '1 seconds(s)' })).toBeTruthy();
+
+  // test bare minimum fields
+  await page.getByTestId('add-toleration-button').click();
+  await page.getByTestId('toleration-key-input').click();
+  await page.getByTestId('toleration-key-input').fill('new-key');
+  await page.getByTestId('modal-submit-button').click();
+  await expect(page.getByRole('gridcell', { name: 'Exists' })).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: 'new-key' })).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: '-', exact: true }).first()).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: '-', exact: true }).nth(1)).toBeTruthy();
+  await expect(page.getByRole('gridcell', { name: '-', exact: true }).nth(2)).toBeTruthy();
+
+  // test edit toleration
+  await page
+    .getByRole('row', { name: 'Equal new-key - - - Actions' })
+    .getByRole('button', { name: 'Actions' })
+    .click();
+  await page.getByRole('menuitem', { name: 'Edit' }).click();
+  await page.getByTestId('toleration-key-input').click();
+  await page.getByTestId('toleration-key-input').fill('new-key-update');
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.getByRole('gridcell', { name: 'new-key' })).toHaveCount(1);
+  await page
+    .getByRole('row', { name: 'Equal new-key - - - Actions' })
+    .getByRole('button', { name: 'Actions' })
+    .click();
+  await page.getByRole('menuitem', { name: 'Edit' }).click();
+  await page.getByTestId('toleration-key-input').click();
+  await page.getByTestId('toleration-key-input').fill('updated-key');
+  await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByRole('gridcell', { name: 'updated-key' })).toHaveCount(1);
+
+  // test cancel clears fields
+  await page
+    .getByRole('row', { name: 'Equal test-key test-value NoExecute 1 seconds(s) Actions' })
+    .getByRole('button', { name: 'Actions' })
+    .click();
+  await page.getByRole('menuitem', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await page.getByTestId('add-toleration-button').click();
+  await expect(page.getByTestId('modal-submit-button')).toBeDisabled();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  // test delete
+  await page
+    .getByRole('row', { name: 'Equal test-key test-value NoExecute 1 seconds(s) Actions' })
+    .getByRole('button', { name: 'Actions' })
+    .click();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: 'Actions' }).click();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await expect(page.getByRole('heading', { name: 'No tolerations' })).toHaveCount(1);
+});
+
+test('Edit page has expected values', async ({ page }) => {
+  await page.goto(
+    navigateToStory(
+      'pages-acceleratorprofiles-manageacceleratorprofile',
+      'edit-accelerator-profile',
+    ),
+  );
+
+  // wait for page to load
+  await page.waitForSelector('text=Details');
+
+  // test values
+  expect(await page.getByTestId('accelerator-name-input').inputValue()).toBe('Test Accelerator');
+  expect(await page.getByTestId('accelerator-identifier-input').inputValue()).toBe(
+    'nvidia.com/gpu',
+  );
+  expect(await page.getByTestId('accelerator-description-input').inputValue()).toBe(
+    'Test description',
+  );
+  await expect(page.getByRole('gridcell', { name: 'Exists' })).toHaveCount(1);
+  await expect(page.getByRole('gridcell', { name: 'nvidia.com/gpu' })).toHaveCount(1);
+  await expect(page.getByRole('gridcell', { name: '-' }).first()).toHaveCount(1);
+  await expect(page.getByRole('gridcell', { name: 'NoSchedule' })).toHaveCount(1);
+  await expect(page.getByRole('gridcell', { name: '-' }).nth(1)).toHaveCount(1);
+});
+
+test('Invalid id in edit page', async ({ page }) => {
+  await page.goto(
+    navigateToStory(
+      'pages-acceleratorprofiles-manageacceleratorprofile',
+      'invalid-accelerator-profile',
+    ),
+  );
+
+  // test for error message
+  await expect(
+    page.getByText('acceleratorprofiles.dashboard.opendatahub.io "test-accelerator" not found'),
+  ).toHaveCount(1);
+});

--- a/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.stories.tsx
@@ -1,0 +1,146 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { rest } from 'msw';
+import { userEvent, within } from '@storybook/testing-library';
+import React from 'react';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import { mockStatus } from '~/__mocks__/mockStatus';
+import EditAcceleratorProfileComponent from '~/pages/acceleratorProfiles/screens/manage/EditAcceleratorProfile';
+import useDetectUser from '~/utilities/useDetectUser';
+import ManageAcceleratorProfileComponent from '~/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfile';
+
+export default {
+  component: ManageAcceleratorProfileComponent,
+  parameters: {
+    msw: {
+      handlers: {
+        status: [
+          rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
+            res(ctx.json(mockK8sResourceList([mockProjectK8sResource({})]))),
+          ),
+          rest.get('/api/status', (req, res, ctx) => res(ctx.json(mockStatus()))),
+        ],
+      },
+    },
+  },
+} as Meta<typeof ManageAcceleratorProfileComponent>;
+
+const RenderComponent = ({ children }: { children: React.ReactElement }) => {
+  useDetectUser();
+  return children;
+};
+export const NewAcceleratorProfile: StoryObj = {
+  render: () => (
+    <RenderComponent>
+      <ManageAcceleratorProfileComponent />
+    </RenderComponent>
+  ),
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Identifier', undefined, {
+      timeout: 5000,
+    });
+  },
+};
+
+export const EditAcceleratorProfile: StoryObj = {
+  render: () => (
+    <RenderComponent>
+      <EditAcceleratorProfileComponent />
+    </RenderComponent>
+  ),
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Identifier', undefined, {
+      timeout: 5000,
+    });
+  },
+  parameters: {
+    reactRouter: {
+      routePath: '/edit/:acceleratorProfileName',
+      routeParams: { acceleratorProfileName: 'test-accelerator' },
+    },
+    msw: {
+      handlers: {
+        accelerator: rest.get(
+          '/api/k8s/apis/dashboard.opendatahub.io/v1/namespaces/opendatahub/acceleratorprofiles/test-accelerator',
+          (req, res, ctx) =>
+            res(ctx.json(mockAcceleratorProfile({ metadata: { name: 'test-accelerator' } }))),
+        ),
+      },
+    },
+  },
+};
+
+export const InvalidAcceleratorProfile: StoryObj = {
+  render: () => (
+    <RenderComponent>
+      <EditAcceleratorProfileComponent />
+    </RenderComponent>
+  ),
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Problem loading accelerator profile', undefined, {
+      timeout: 5000,
+    });
+  },
+  parameters: {
+    reactRouter: {
+      routePath: '/edit/:acceleratorProfileName',
+      routeParams: { acceleratorProfileName: 'test-accelerator' },
+    },
+    msw: {
+      handlers: {
+        accelerator: rest.get(
+          '/api/k8s/apis/dashboard.opendatahub.io/v1/namespaces/opendatahub/acceleratorprofiles/test-accelerator',
+          (req, res, ctx) =>
+            res(
+              ctx.status(404),
+              ctx.json({
+                kind: 'Status',
+                apiVersion: 'v1',
+                metadata: {},
+                status: 'Failure',
+                message:
+                  'acceleratorprofiles.dashboard.opendatahub.io "test-accelerator" not found',
+                reason: 'NotFound',
+                details: {
+                  name: 'test-gpud',
+                  group: 'dashboard.opendatahub.io',
+                  kind: 'acceleratorprofiles',
+                },
+                code: 404,
+              }),
+            ),
+        ),
+      },
+    },
+  },
+};
+
+export const TolerationsModal: StoryObj = {
+  render: () => (
+    <RenderComponent>
+      <ManageAcceleratorProfileComponent />
+    </RenderComponent>
+  ),
+  parameters: {
+    a11y: {
+      element: '.pf-c-backdrop',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Identifier', undefined, {
+      timeout: 5000,
+    });
+
+    // user flow for deleting a project
+    await userEvent.click(canvas.getByText('Add toleration', { selector: 'button' }));
+  },
+};

--- a/frontend/src/api/k8s/accelerators.ts
+++ b/frontend/src/api/k8s/accelerators.ts
@@ -1,4 +1,4 @@
-import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sGetResource, k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { AcceleratorKind } from '~/k8sTypes';
 import { AcceleratorModel } from '~/api/models';
 
@@ -9,3 +9,9 @@ export const listAccelerators = async (namespace: string): Promise<AcceleratorKi
       ns: namespace,
     },
   }).then((listResource) => listResource.items);
+
+export const getAccelerator = (name: string, namespace: string): Promise<AcceleratorKind> =>
+  k8sGetResource<AcceleratorKind>({
+    model: AcceleratorModel,
+    queryOptions: { name, ns: namespace },
+  });

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -37,8 +37,8 @@ const DependencyMissingPage = React.lazy(
   () => import('../pages/dependencies/DependencyMissingPage'),
 );
 
-const AcceleratorProfiles = React.lazy(
-  () => import('../pages/acceleratorProfiles/AcceleratorProfiles'),
+const AcceleratorProfileRoutes = React.lazy(
+  () => import('../pages/acceleratorProfiles/AcceleratorProfilesRoutes'),
 );
 
 const AppRoutes: React.FC = () => {
@@ -80,7 +80,7 @@ const AppRoutes: React.FC = () => {
           <>
             <Route path="/notebookImages" element={<BYONImagesPage />} />
             <Route path="/clusterSettings" element={<ClusterSettingsPage />} />
-            <Route path="/acceleratorProfiles" element={<AcceleratorProfiles />} />
+            <Route path="/acceleratorProfiles/*" element={<AcceleratorProfileRoutes />} />
             <Route path="/servingRuntimes/*" element={<CustomServingRuntimeRoutes />} />
             <Route path="/groupSettings" element={<GroupSettingsPage />} />
           </>

--- a/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
+++ b/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
@@ -39,7 +39,13 @@ const DashboardModalFooter: React.FC<DashboardModalFooterProps> = ({
     <StackItem>
       <ActionList>
         <ActionListItem>
-          <Button key="submit" variant="primary" isDisabled={isSubmitDisabled} onClick={onSubmit}>
+          <Button
+            key="submit"
+            variant="primary"
+            isDisabled={isSubmitDisabled}
+            onClick={onSubmit}
+            data-testid="modal-submit-button"
+          >
             {submitLabel}
           </Button>
         </ActionListItem>

--- a/frontend/src/pages/acceleratorProfiles/AcceleratorProfilesRoutes.tsx
+++ b/frontend/src/pages/acceleratorProfiles/AcceleratorProfilesRoutes.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import EditAcceleratorProfile from './screens/manage/EditAcceleratorProfile';
+import AcceleratorProfiles from './screens/list/AcceleratorProfiles';
+import ManageAcceleratorProfile from './screens/manage/ManageAcceleratorProfile';
+
+const AcceleratorProfilesRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<AcceleratorProfiles />} />
+    <Route path="/create" element={<ManageAcceleratorProfile />} />
+    <Route path="/edit/:acceleratorProfileName" element={<EditAcceleratorProfile />} />
+    <Route path="*" element={<Navigate to="." />} />
+  </Routes>
+);
+
+export default AcceleratorProfilesRoutes;

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfiles.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfiles.tsx
@@ -13,6 +13,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import useAccelerators from '~/pages/notebookController/screens/server/useAccelerators';
 import { useDashboardNamespace } from '~/redux/selectors';
@@ -22,6 +23,8 @@ const description = `Manage accelerator profile settings for users in your organ
 const AcceleratorProfiles: React.FC = () => {
   const { dashboardNamespace } = useDashboardNamespace();
   const [accelerators, loaded, loadError] = useAccelerators(dashboardNamespace);
+
+  const navigate = useNavigate();
 
   const isEmpty = !accelerators || accelerators.length === 0;
 
@@ -40,7 +43,7 @@ const AcceleratorProfiles: React.FC = () => {
         <Button
           data-id="display-accelerator-modal-button"
           variant={ButtonVariant.primary}
-          onClick={() => undefined}
+          onClick={() => navigate('/acceleratorProfiles/create')}
         >
           Add new accelerator profile
         </Button>

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/EditAcceleratorProfile.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/EditAcceleratorProfile.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { useParams } from 'react-router';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+import { useDashboardNamespace } from '~/redux/selectors';
+import useAcceleratorProfile from './useAcceleratorProfile';
+import ManageAcceleratorProfile from './ManageAcceleratorProfile';
+
+const EditAcceleratorProfile: React.FC = () => {
+  const navigate = useNavigate();
+  const { acceleratorProfileName } = useParams();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [data, , error] = useAcceleratorProfile(dashboardNamespace, acceleratorProfileName);
+
+  if (error) {
+    return (
+      <Bullseye>
+        <EmptyState>
+          <EmptyStateIcon icon={ExclamationCircleIcon} />
+          <Title headingLevel="h4" size="lg">
+            Problem loading accelerator profile
+          </Title>
+          <EmptyStateBody>{error.message}</EmptyStateBody>
+          <Button variant="primary" onClick={() => navigate('/acceleratorProfiles')}>
+            View all accelerator profiles
+          </Button>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return <ManageAcceleratorProfile existingAccelerator={data} />;
+};
+
+export default EditAcceleratorProfile;

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfile.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfile.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Breadcrumb, BreadcrumbItem, Form, PageSection } from '@patternfly/react-core';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
+import GenericSidebar from '~/components/GenericSidebar';
+
+import { AcceleratorKind } from '~/k8sTypes';
+import { ManageAcceleratorProfileFooter } from './ManageAcceleratorProfileFooter';
+import { ManageAcceleratorProfileTolerationsSection } from './ManageAcceleratorProfileTolerationsSection';
+import { ManageAcceleratorSectionID } from './types';
+import { ManageAcceleratorSectionTitles, ScrollableSelectorID } from './const';
+import { ManageAcceleratorProfileDetailsSection } from './ManageAcceleratorProfileDetailsSection';
+
+type ManageAcceleratorProfileProps = {
+  existingAccelerator?: AcceleratorKind;
+};
+
+const ManageAcceleratorProfile: React.FC<ManageAcceleratorProfileProps> = ({
+  existingAccelerator,
+}) => {
+  const [state, setState] = useGenericObjectState<AcceleratorKind['spec']>({
+    displayName: '',
+    identifier: '',
+    enabled: true,
+    tolerations: [],
+  });
+
+  React.useEffect(() => {
+    if (existingAccelerator) {
+      setState('displayName', existingAccelerator.spec.displayName);
+      setState('identifier', existingAccelerator.spec.identifier);
+      setState('description', existingAccelerator.spec.description);
+      setState('enabled', existingAccelerator.spec.enabled);
+      setState('tolerations', existingAccelerator.spec.tolerations);
+    }
+  }, [existingAccelerator, setState]);
+
+  const sectionIDs = Object.values(ManageAcceleratorSectionID);
+
+  return (
+    <ApplicationsPage
+      title={
+        existingAccelerator
+          ? `Edit ${existingAccelerator.spec.displayName}`
+          : 'Create accelerator profile'
+      }
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem
+            render={() => <Link to="/acceleratorProfiles">Accelerator profiles</Link>}
+          />
+          <BreadcrumbItem>
+            {existingAccelerator ? 'Edit' : 'Create'} accelerator profile
+          </BreadcrumbItem>
+        </Breadcrumb>
+      }
+      loaded
+      empty={false}
+    >
+      <PageSection
+        isFilled
+        id={ScrollableSelectorID}
+        aria-label="manage-accelerator-spawner-section"
+        variant="light"
+      >
+        <GenericSidebar sections={sectionIDs} titles={ManageAcceleratorSectionTitles}>
+          <Form style={{ maxWidth: 600 }}>
+            <ManageAcceleratorProfileDetailsSection state={state} setState={setState} />
+            <ManageAcceleratorProfileTolerationsSection
+              tolerations={state.tolerations ?? []}
+              setTolerations={(tolerations) => setState('tolerations', tolerations)}
+            />
+          </Form>
+        </GenericSidebar>
+      </PageSection>
+      <PageSection stickyOnBreakpoint={{ default: 'bottom' }} variant="light">
+        <ManageAcceleratorProfileFooter state={state} existingAccelerator={existingAccelerator} />
+      </PageSection>
+    </ApplicationsPage>
+  );
+};
+
+export default ManageAcceleratorProfile;

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
@@ -1,0 +1,100 @@
+import {
+  FormSection,
+  Stack,
+  StackItem,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Switch,
+  Popover,
+} from '@patternfly/react-core';
+import React from 'react';
+import { HelpIcon } from '@patternfly/react-icons';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import { AcceleratorKind } from '~/k8sTypes';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import { ManageAcceleratorSectionTitles } from './const';
+import { ManageAcceleratorSectionID } from './types';
+
+type ManageAcceleratorProfileDetailsSectionProps = {
+  state: AcceleratorKind['spec'];
+  setState: UpdateObjectAtPropAndValue<AcceleratorKind['spec']>;
+};
+
+export const ManageAcceleratorProfileDetailsSection = ({
+  state,
+  setState,
+}: ManageAcceleratorProfileDetailsSectionProps) => (
+  <FormSection
+    id={ManageAcceleratorSectionID.DETAILS}
+    aria-label={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.DETAILS]}
+    title={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.DETAILS]}
+  >
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup label="Name" isRequired>
+          <TextInput
+            isRequired
+            value={state.displayName}
+            id="accelerator-name"
+            name="accelerator-name"
+            onChange={(name) => setState('displayName', name)}
+            aria-label="accelerator-name"
+            data-testid="accelerator-name-input"
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup
+          label="Identifier"
+          isRequired
+          labelIcon={
+            <Popover
+              removeFindDomNode
+              bodyContent="An identifier is a unique string that names a specific hardware accelerator resource."
+            >
+              <DashboardPopupIconButton
+                icon={<HelpIcon />}
+                aria-label="More info for identifier field"
+              />
+            </Popover>
+          }
+        >
+          <TextInput
+            isRequired
+            value={state.identifier}
+            id="accelerator-identifier"
+            name="accelerator-identifier"
+            onChange={(identifier) => setState('identifier', identifier)}
+            placeholder="Example, nvidia.com/gpu"
+            aria-label="accelerator-identifier"
+            data-testid="accelerator-identifier-input"
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Description">
+          <TextArea
+            resizeOrientation="vertical"
+            id="accelerator-description"
+            name="accelerator-description"
+            value={state.description}
+            onChange={(description) => setState('description', description)}
+            aria-label="accelerator-description"
+            data-testid="accelerator-description-input"
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Enabled">
+          <Switch
+            id="accelerator-enabled"
+            isChecked={state.enabled}
+            onChange={(enabled) => setState('enabled', enabled)}
+            aria-label="accelerator-enabled"
+          />
+        </FormGroup>
+      </StackItem>
+    </Stack>
+  </FormSection>
+);

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
@@ -1,0 +1,113 @@
+import {
+  Stack,
+  StackItem,
+  Alert,
+  ActionList,
+  ActionListItem,
+  Button,
+} from '@patternfly/react-core';
+import React from 'react';
+import { useNavigate } from 'react-router';
+import { AcceleratorKind } from '~/k8sTypes';
+import {
+  createAcceleratorProfile,
+  updateAcceleratorProfile,
+} from '~/services/acceleratorProfileService';
+
+type ManageAcceleratorProfileFooterProps = {
+  state: AcceleratorKind['spec'];
+  existingAccelerator?: AcceleratorKind;
+};
+
+export const ManageAcceleratorProfileFooter = ({
+  state,
+  existingAccelerator,
+}: ManageAcceleratorProfileFooterProps) => {
+  const [errorMessage, setErrorMessage] = React.useState<string>('');
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const navigate = useNavigate();
+
+  const isButtonDisabled = !state.displayName || !state.identifier;
+
+  const onCreateAcceleratorProfile = async () => {
+    setIsLoading(true);
+    createAcceleratorProfile(state)
+      .then((res) => {
+        if (res.success) {
+          navigate(`/acceleratorProfiles`);
+        } else {
+          setErrorMessage(res.error || 'Could not create accelerator profile');
+        }
+      })
+      .catch((err) => {
+        setErrorMessage(err.message);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  const onUpdateAcceleratorProfile = async () => {
+    if (existingAccelerator) {
+      setIsLoading(true);
+      updateAcceleratorProfile(existingAccelerator.metadata.name, state)
+        .then((res) => {
+          if (res.success) {
+            navigate(`/acceleratorProfiles`);
+          } else {
+            setErrorMessage(res.error || 'Could not update accelerator profile');
+          }
+        })
+        .catch((err) => {
+          setErrorMessage(err.message);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  };
+
+  return (
+    <Stack hasGutter>
+      {errorMessage && (
+        <StackItem>
+          <Alert
+            isInline
+            variant="danger"
+            title={`Error ${existingAccelerator ? 'updating' : 'creating'} accelerator profile`}
+          >
+            {errorMessage}
+          </Alert>
+        </StackItem>
+      )}
+      <StackItem>
+        <ActionList>
+          <ActionListItem>
+            <Button
+              isDisabled={isButtonDisabled || isLoading}
+              isLoading={isLoading}
+              variant="primary"
+              id="create-button"
+              onClick={
+                existingAccelerator ? onUpdateAcceleratorProfile : onCreateAcceleratorProfile
+              }
+              data-testid="accelerator-profile-create-button"
+            >
+              {existingAccelerator ? 'Update' : 'Create'} accelerator profile
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button
+              variant="link"
+              id="cancel-button"
+              onClick={() => navigate(`/acceleratorProfiles`)}
+              isDisabled={isLoading}
+            >
+              Cancel
+            </Button>
+          </ActionListItem>
+        </ActionList>
+      </StackItem>
+    </Stack>
+  );
+};

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileTolerationsSection.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileTolerationsSection.tsx
@@ -1,0 +1,53 @@
+import { FormSection, Flex, FlexItem, Button } from '@patternfly/react-core';
+import React from 'react';
+import { PodToleration } from '~/types';
+import { ManageAcceleratorSectionTitles } from './const';
+import ManageTolerationModal from './tolerations/ManageTolerationModal';
+import { TolerationsTable } from './tolerations/TolerationsTable';
+import { ManageAcceleratorSectionID } from './types';
+
+type ManageAcceleratorProfileTolerationsSectionProps = {
+  tolerations: PodToleration[];
+  setTolerations: (tolerations: PodToleration[]) => void;
+};
+
+export const ManageAcceleratorProfileTolerationsSection = ({
+  tolerations,
+  setTolerations,
+}: ManageAcceleratorProfileTolerationsSectionProps) => {
+  const [manageTolerationModalOpen, setManageTolerationModalOpen] = React.useState<boolean>(false);
+  return (
+    <>
+      <FormSection
+        id={ManageAcceleratorSectionID.TOLERATIONS}
+        aria-label={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.TOLERATIONS]}
+        title={
+          <Flex>
+            <FlexItem>
+              {ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.TOLERATIONS]}
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="secondary"
+                onClick={() => setManageTolerationModalOpen(true)}
+                data-testid="add-toleration-button"
+              >
+                Add toleration
+              </Button>
+            </FlexItem>
+          </Flex>
+        }
+      >
+        <TolerationsTable
+          tolerations={tolerations}
+          onUpdate={(tolerations) => setTolerations(tolerations)}
+        />
+      </FormSection>
+      <ManageTolerationModal
+        isOpen={manageTolerationModalOpen}
+        onClose={() => setManageTolerationModalOpen(false)}
+        onSave={(toleration) => setTolerations([...tolerations, toleration])}
+      />
+    </>
+  );
+};

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/const.ts
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/const.ts
@@ -1,0 +1,8 @@
+import { ManageAcceleratorSectionID, ManageAcceleratorSectionTitlesType } from './types';
+
+export const ManageAcceleratorSectionTitles: ManageAcceleratorSectionTitlesType = {
+  [ManageAcceleratorSectionID.DETAILS]: 'Details',
+  [ManageAcceleratorSectionID.TOLERATIONS]: 'Tolerations',
+};
+
+export const ScrollableSelectorID = 'workbench-spawner-page';

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/ManageTolerationModal.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/ManageTolerationModal.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Form } from '@patternfly/react-core';
+import { PodToleration } from '~/types';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import TolerationFields from './TolerationFields';
+import { EMPTY_TOLERATION } from './const';
+
+type ManageTolerationModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  initialToleration?: PodToleration;
+  onSave: (toleration: PodToleration) => void;
+};
+
+const ManageTolerationModal: React.FC<ManageTolerationModalProps> = ({
+  isOpen,
+  onClose,
+  initialToleration,
+  onSave,
+}) => {
+  const [toleration, setToleration] = useState<PodToleration>(EMPTY_TOLERATION);
+
+  const isButtonDisabled = !toleration.key;
+
+  useEffect(() => {
+    if (initialToleration) {
+      setToleration(initialToleration);
+    }
+  }, [initialToleration]);
+
+  const handleUpdate = (updatedToleration: PodToleration) => {
+    setToleration(updatedToleration);
+  };
+
+  const onBeforeClose = () => {
+    setToleration(EMPTY_TOLERATION);
+    onClose();
+  };
+
+  return (
+    <Modal
+      title={initialToleration ? 'Edit toleration' : 'Add toleration'}
+      variant="medium"
+      isOpen={isOpen}
+      onClose={() => {
+        onBeforeClose();
+      }}
+      footer={
+        <DashboardModalFooter
+          submitLabel={initialToleration ? 'Update' : 'Add'}
+          onSubmit={() => {
+            onSave(toleration);
+            onBeforeClose();
+          }}
+          onCancel={() => onBeforeClose()}
+          isSubmitDisabled={isButtonDisabled}
+          alertTitle="Error saving toleration"
+        />
+      }
+    >
+      <Form>
+        <TolerationFields toleration={toleration} onUpdate={handleUpdate} />
+      </Form>
+    </Modal>
+  );
+};
+
+export default ManageTolerationModal;

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import {
+  Radio,
+  TextInput,
+  FormGroup,
+  Alert,
+  Flex,
+  FlexItem,
+  StackItem,
+  Stack,
+  InputGroup,
+  InputGroupText,
+  Popover,
+} from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import { PodToleration, TolerationEffect, TolerationOperator } from '~/types';
+import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
+import NumberInputWrapper from '~/components/NumberInputWrapper';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import { effectDropdownOptions, operatorDropdownOptions } from './const';
+
+type TolerationFieldsProps = {
+  toleration: PodToleration;
+  onUpdate: (data: PodToleration) => void;
+};
+
+export const TolerationFields: React.FC<TolerationFieldsProps> = ({ toleration, onUpdate }) => {
+  const handleFieldUpdate = (field: keyof PodToleration, value: unknown) => {
+    onUpdate({ ...toleration, [field]: value });
+  };
+
+  const showAlertForValue = toleration.operator === TolerationOperator.EXISTS && toleration.value;
+  const showAlertForTolerationSeconds =
+    toleration.effect !== TolerationEffect.NO_EXECUTE && toleration.tolerationSeconds !== undefined;
+
+  return (
+    <>
+      <FormGroup label="Operator" fieldId="operator-select">
+        <SimpleDropdownSelect
+          isFullWidth
+          options={operatorDropdownOptions}
+          value={toleration.operator || ''}
+          onChange={(key) => handleFieldUpdate('operator', key)}
+          data-testid="toleration-operator-select"
+        />
+      </FormGroup>
+
+      <FormGroup label="Effect" fieldId="effect-select">
+        <SimpleDropdownSelect
+          isFullWidth
+          options={effectDropdownOptions}
+          value={toleration.effect || ''}
+          onChange={(key) => handleFieldUpdate('effect', key)}
+        />
+      </FormGroup>
+
+      <FormGroup label="Key" isRequired fieldId="toleration-key">
+        <TextInput
+          id="toleration-key"
+          value={toleration.key || ''}
+          onChange={(value) => handleFieldUpdate('key', value)}
+          aria-label="Toleration key field"
+          data-testid="toleration-key-input"
+        />
+      </FormGroup>
+      <FormGroup label="Value" fieldId="toleration-value">
+        <Stack hasGutter>
+          <StackItem>
+            <TextInput
+              id="toleration-value"
+              value={toleration.value || ''}
+              onChange={(value) => handleFieldUpdate('value', value)}
+              aria-label="Toleration value field"
+              data-testid="toleration-value-input"
+            />
+          </StackItem>
+          {showAlertForValue && (
+            <StackItem>
+              <Alert
+                variant="info"
+                isPlain
+                isInline
+                title="Value should be empty when operator is Exists."
+                data-testid="toleration-value-alert"
+              />
+            </StackItem>
+          )}
+        </Stack>
+      </FormGroup>
+
+      <FormGroup
+        label="Toleration Seconds"
+        fieldId="toleration-seconds"
+        labelIcon={
+          <Popover
+            removeFindDomNode
+            bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted."
+          >
+            <DashboardPopupIconButton
+              icon={<HelpIcon />}
+              aria-label="More info for toleration seconds field"
+            />
+          </Popover>
+        }
+      >
+        <Stack hasGutter>
+          <StackItem>
+            <Flex>
+              <FlexItem>
+                <Radio
+                  id="forever"
+                  name="tolerationSeconds"
+                  label="Forever"
+                  isChecked={toleration.tolerationSeconds === undefined}
+                  onChange={() => handleFieldUpdate('tolerationSeconds', undefined)}
+                />
+              </FlexItem>
+              <FlexItem>
+                <Radio
+                  id="custom-value"
+                  name="tolerationSeconds"
+                  label="Custom value"
+                  isChecked={toleration.tolerationSeconds !== undefined}
+                  onChange={() => {
+                    handleFieldUpdate('tolerationSeconds', 0);
+                  }}
+                  data-testid="toleration-seconds-radio-custom"
+                />
+              </FlexItem>
+            </Flex>
+          </StackItem>
+          {toleration.tolerationSeconds !== undefined && (
+            <StackItem>
+              <InputGroup>
+                <NumberInputWrapper
+                  min={0}
+                  value={toleration.tolerationSeconds}
+                  onChange={(value) => {
+                    handleFieldUpdate('tolerationSeconds', value || 0);
+                  }}
+                />
+                <InputGroupText variant="plain">{'second(s)'}</InputGroupText>
+              </InputGroup>
+            </StackItem>
+          )}
+          {showAlertForTolerationSeconds && (
+            <StackItem>
+              <Alert
+                variant="info"
+                isInline
+                isPlain
+                title="Toleration seconds are ignored unless effect is NoExecute"
+                data-testid="toleration-seconds-alert"
+              />
+            </StackItem>
+          )}
+        </Stack>
+      </FormGroup>
+    </>
+  );
+};
+
+export default TolerationFields;

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationRow.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationRow.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { DropdownDirection } from '@patternfly/react-core';
+import { PodToleration } from '~/types';
+
+type TolerationRowProps = {
+  toleration: PodToleration;
+  onDelete: (toleration: PodToleration) => void;
+  onEdit: (toleration: PodToleration) => void;
+};
+
+export const TolerationRow: React.FC<TolerationRowProps> = ({ toleration, onEdit, onDelete }) => {
+  const formatValue = (value: string | undefined) => value || '-';
+  const formatSeconds = (seconds: number | undefined) =>
+    seconds !== undefined ? `${seconds} seconds(s)` : '-';
+
+  return (
+    <Tr>
+      <Td dataLabel="Operator">{formatValue(toleration.operator)}</Td>
+      <Td dataLabel="Key">{formatValue(toleration.key)}</Td>
+      <Td dataLabel="Value">{formatValue(toleration.value)}</Td>
+      <Td dataLabel="Effect">{formatValue(toleration.effect)}</Td>
+      <Td dataLabel="Toleration Seconds">{formatSeconds(toleration.tolerationSeconds)}</Td>
+      <Td isActionCell>
+        <ActionsColumn
+          dropdownDirection={DropdownDirection.up}
+          items={[
+            {
+              title: 'Edit',
+              onClick: () => onEdit(toleration),
+            },
+            {
+              title: 'Delete',
+              onClick: () => onDelete(toleration),
+            },
+          ]}
+        />
+      </Td>
+    </Tr>
+  );
+};
+
+export default TolerationRow;

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationsTable.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationsTable.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Table } from '~/components/table';
+import { PodToleration } from '~/types';
+import { columns } from './const';
+import TolerationRow from './TolerationRow';
+import ManageTolerationModal from './ManageTolerationModal';
+
+type TolerationTableProps = {
+  tolerations: PodToleration[];
+  onUpdate: (tolerations: PodToleration[]) => void;
+};
+
+export const TolerationsTable: React.FC<TolerationTableProps> = ({ tolerations, onUpdate }) => {
+  const [editToleration, setEditToleration] = React.useState<PodToleration | undefined>();
+  const [currentIndex, setCurrentIndex] = React.useState<number | undefined>();
+
+  if (tolerations.length === 0) {
+    return (
+      <EmptyState variant="xs" data-testid="tolerations-modal-empty-state">
+        <EmptyStateIcon icon={PlusCircleIcon} />
+        <Title headingLevel="h2" size="lg">
+          No tolerations
+        </Title>
+        <EmptyStateBody>
+          Tolerations are applied to pods and allow the scheduler to schedule pods with matching
+          taints.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <>
+      <Table
+        data={tolerations}
+        columns={columns}
+        rowRenderer={(toleration, rowIndex) => (
+          <TolerationRow
+            key={toleration.key + rowIndex}
+            toleration={toleration}
+            onEdit={(toleration) => {
+              setEditToleration(toleration);
+              setCurrentIndex(rowIndex);
+            }}
+            onDelete={() => {
+              const updatedTolerations = [...tolerations];
+              updatedTolerations.splice(rowIndex, 1);
+              onUpdate(updatedTolerations);
+            }}
+          />
+        )}
+      />
+      <ManageTolerationModal
+        isOpen={!!editToleration}
+        initialToleration={editToleration}
+        onClose={() => {
+          setEditToleration(undefined);
+          setCurrentIndex(undefined);
+        }}
+        onSave={(toleration) => {
+          if (currentIndex !== undefined) {
+            const updatedTolerations = [...tolerations];
+            updatedTolerations[currentIndex] = toleration;
+            onUpdate(updatedTolerations);
+          }
+        }}
+      />
+    </>
+  );
+};

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/const.ts
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/const.ts
@@ -1,0 +1,82 @@
+import { SimpleDropdownOption } from '~/components/SimpleDropdownSelect';
+import { SortableData } from '~/components/table';
+import { PodToleration, TolerationOperator, TolerationEffect } from '~/types';
+
+export const columns: SortableData<PodToleration>[] = [
+  {
+    field: 'operator',
+    label: 'Operator',
+    sortable: false,
+  },
+  {
+    field: 'key',
+    label: 'Key',
+    sortable: false,
+  },
+  {
+    field: 'value',
+    label: 'Value',
+    sortable: false,
+  },
+  {
+    field: 'effect',
+    label: 'Effect',
+    sortable: false,
+  },
+  {
+    field: 'tolerationSeconds',
+    label: 'Toleration Seconds',
+    sortable: false,
+  },
+  {
+    field: 'kebab',
+    label: '',
+    sortable: false,
+  },
+];
+
+export const EMPTY_TOLERATION: PodToleration = {
+  operator: TolerationOperator.EQUAL,
+  key: '',
+  value: undefined,
+  effect: undefined,
+  tolerationSeconds: undefined,
+};
+
+export const operatorDropdownOptions: SimpleDropdownOption[] = [
+  {
+    key: TolerationOperator.EQUAL,
+    label: TolerationOperator.EQUAL,
+    description:
+      'A toleration "matches" a taint if the keys are the same, the effects are the same, and the values are equal.',
+  },
+  {
+    key: TolerationOperator.EXISTS,
+    label: TolerationOperator.EXISTS,
+    description:
+      'A toleration "matches" a taint if the keys are the same and the effects are the same. No value should be specified.',
+  },
+];
+
+export const effectDropdownOptions: SimpleDropdownOption[] = [
+  {
+    key: '',
+    label: 'None',
+    isPlaceholder: true,
+  },
+  {
+    key: TolerationEffect.NO_SCHEDULE,
+    label: TolerationEffect.NO_SCHEDULE,
+    description: 'Prevents scheduling of new pods on the node with the matching taint.',
+  },
+  {
+    key: TolerationEffect.PREFER_NO_SCHEDULE,
+    label: TolerationEffect.PREFER_NO_SCHEDULE,
+    description: 'Scheduler will try to avoid placing a pod on the node but it is not guaranteed.',
+  },
+  {
+    key: TolerationEffect.NO_EXECUTE,
+    label: TolerationEffect.NO_EXECUTE,
+    description: 'Pods will be evicted from the node if they do not tolerate the taint.',
+  },
+];

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/types.ts
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/types.ts
@@ -1,0 +1,8 @@
+export enum ManageAcceleratorSectionID {
+  DETAILS = 'details',
+  TOLERATIONS = 'tolerations',
+}
+
+export type ManageAcceleratorSectionTitlesType = {
+  [key in ManageAcceleratorSectionID]: string;
+};

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/useAcceleratorProfile.ts
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/useAcceleratorProfile.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import useFetchState, { FetchStateCallbackPromise, NotReadyError } from '~/utilities/useFetchState';
+import { AcceleratorKind } from '~/k8sTypes';
+import { getAccelerator } from '~/api';
+
+const useAcceleratorProfile = (namespace: string, name?: string) => {
+  const callback = React.useCallback<FetchStateCallbackPromise<AcceleratorKind | null>>(() => {
+    if (!name) {
+      return Promise.reject(new NotReadyError('Accelerator profile name is missing'));
+    }
+    return getAccelerator(name, namespace);
+  }, [name, namespace]);
+
+  return useFetchState(callback, null);
+};
+
+export default useAcceleratorProfile;

--- a/frontend/src/services/acceleratorProfileService.ts
+++ b/frontend/src/services/acceleratorProfileService.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { AcceleratorKind } from '~/k8sTypes';
+import { ResponseStatus } from '~/types';
+
+export const createAcceleratorProfile = (
+  acceleratorProfile: AcceleratorKind['spec'],
+): Promise<ResponseStatus> => {
+  const url = '/api/accelerator-profiles';
+  return axios
+    .post(url, acceleratorProfile)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};
+
+export const deleteAcceleratorProfile = (name: string): Promise<ResponseStatus> => {
+  const url = `/api/accelerator-profiles/${name}`;
+  return axios
+    .delete(url)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};
+
+export const updateAcceleratorProfile = (
+  name: string,
+  spec: Partial<AcceleratorKind['spec']>,
+): Promise<ResponseStatus> => {
+  const url = `/api/accelerator-profiles/${name}`;
+  return axios
+    .put(url, spec)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -344,11 +344,22 @@ export type NotebookPort = {
   protocol: string;
 };
 
+export enum TolerationOperator {
+  EXISTS = 'Exists',
+  EQUAL = 'Equal',
+}
+
+export enum TolerationEffect {
+  NO_SCHEDULE = 'NoSchedule',
+  PREFER_NO_SCHEDULE = 'PreferNoSchedule',
+  NO_EXECUTE = 'NoExecute',
+}
+
 export type PodToleration = {
   key: string;
-  operator?: string;
+  operator?: TolerationOperator;
   value?: string;
-  effect?: string;
+  effect?: TolerationEffect;
   tolerationSeconds?: number;
 };
 

--- a/frontend/src/utilities/tolerations.ts
+++ b/frontend/src/utilities/tolerations.ts
@@ -1,6 +1,12 @@
 import { Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import _ from 'lodash';
-import { DashboardConfig, PodToleration, TolerationSettings } from '~/types';
+import {
+  DashboardConfig,
+  PodToleration,
+  TolerationEffect,
+  TolerationOperator,
+  TolerationSettings,
+} from '~/types';
 import { NotebookKind } from '~/k8sTypes';
 import { AcceleratorState } from './useAcceleratorState';
 
@@ -40,9 +46,9 @@ export const determineTolerations = (
     )
   ) {
     tolerations.push({
-      effect: 'NoSchedule',
+      effect: TolerationEffect.NO_SCHEDULE,
       key: tolerationSettings.key,
-      operator: 'Exists',
+      operator: TolerationOperator.EXISTS,
     });
   }
 

--- a/frontend/src/utilities/useAcceleratorState.ts
+++ b/frontend/src/utilities/useAcceleratorState.ts
@@ -2,7 +2,13 @@ import React from 'react';
 import { AcceleratorKind } from '~/k8sTypes';
 import useAccelerators from '~/pages/notebookController/screens/server/useAccelerators';
 import { useDashboardNamespace } from '~/redux/selectors';
-import { ContainerResourceAttributes, ContainerResources, PodToleration } from '~/types';
+import {
+  ContainerResourceAttributes,
+  ContainerResources,
+  PodToleration,
+  TolerationEffect,
+  TolerationOperator,
+} from '~/types';
 import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
 
 export type AcceleratorState = {
@@ -102,8 +108,8 @@ const useAcceleratorState = (
                   tolerations: [
                     {
                       key: 'nvidia.com/gpu',
-                      operator: 'Exists',
-                      effect: 'NoSchedule',
+                      operator: TolerationOperator.EXISTS,
+                      effect: TolerationEffect.NO_SCHEDULE,
                     },
                   ],
                 },

--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -7,6 +7,9 @@ rules:
       - create
       - get
       - list
+      - update
+      - patch
+      - delete
     apiGroups:
       - dashboard.opendatahub.io
     resources:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1375

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- created a accelerator routing component to cover all the pages
- broke manage accelerator into a edit component and the core component
- edit fetches the existing profile and handles any errors there
- core manage page is a basic form with
   - name, identifier, description, enabled, and tolerations
   - tolerations is a table
       - adding new/editing tolerations opens a modal with toleration fields. some are drop downs, some are text, key is required, and seconds is a radio that can be set to forever or a number
       - toleration modal does not make network calls
       - toleration modal has non blocking info alerts when invalid combo of inputs is detected
- new k8s api functions for update, get, and post
- new function for generating k8s yaml

**Error**
<img width="1290" alt="Screenshot 2023-11-01 at 2 49 19 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/436575f8-6c9d-4b5c-8ae3-70f3af19e732">

**Accelerator Page**
![Screenshot 2023-11-03 at 1 52 39 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/b95f2d41-b306-4a3d-a9df-7b396696d41c)

**Helper texts on accelerator page**
![Screenshot 2023-11-03 at 1 52 49 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/28b44dcb-ca45-40c4-9c04-592b9ca512b6)
<img width="647" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/7450220a-adfd-4a3e-ba51-c502d63294e4">


**Toleration Modal**
![Screenshot 2023-11-03 at 1 53 03 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/32381855-ffaa-480d-ba5f-93c93f7f11d8)
![Screenshot 2023-11-03 at 1 53 11 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/cc808087-5caf-49ac-8486-9298925ec5ba)
![Screenshot 2023-11-03 at 1 53 18 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/4d8302d0-3761-4cfd-bf3b-91b2a77607bb)
![Screenshot 2023-11-03 at 1 53 30 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/f2582410-c2c1-43c9-83f5-7a53fa4889bd)
![Screenshot 2023-11-03 at 1 54 46 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/8c9beb11-3660-467c-aeaf-c310d3b3ecc0)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Go to /acceleratorProfiles/manage to open the create page
- play around with the form
   - add and remove tolerations from the table
   - make sure toleration form is reflected in the core form
   - submit when satisfied with form
- edit the accelerator by going to /acceleratorProfiles/manage/{resource-id}
   - edit the name to something else
   - remove tolerations
   - edit other fields
   - submit and edit it again. make sure all is reflected
- edit a profile that does not exist, see error page
- go to routes such as /acceleratorProfiles/wrong or /acceleratorProfiles/manage/id/not/a/route and make sure you are redirected to /acceleratorProfiles

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
tests exist for the page in all three states (create, edit, error)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
