### PR TITLE
run pull_request jobs for all branches

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,6 @@
 name: Pull request
 on:
   pull_request:
-    branches: [ main, f/** ]
-
 jobs:
   Tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes the restriction on running PR jobs only against `main` and `f/**` branches so that all branches are included.
