### PR TITLE
update branch docs to include merge pr branch naming pattern

### DIFF
--- a/docs/process-definition/branches.md
+++ b/docs/process-definition/branches.md
@@ -17,7 +17,7 @@ There are really two types of branches.
   - Core branches (like `main` and `incubation`)
   - [Bot branches](#bot-branches)
 
-Every _new_ commit needs to come from a fork through a PR. We don't allow for pushing new content directly through our flows. New docs file, new code change, and even fixing a typo needs a PR from your fork to get into our repository.
+Every _new_ commit needs to come from a fork through a PR. We don't allow for pushing new content directly through our flows. New docs file, new code change, and even fixing a typo needs a PR from your fork to get into our repository. This ensures automated tests pass before the change is merged.
 
 With that said, there are really 3 types of flows that utilize both fork branches and Upstream branches.
 
@@ -32,6 +32,10 @@ Notes:
 There is only ever 1 `main` and 1 `incubation` branch. Feature branches start with `f/`, and can be as many as needed.
 
 Read more on git tags & releases in our [release documentation].
+
+Understanding the commit history on a branch is important. Therefore when merging a branch into another, your PR branch must follow the pattern `merge-<source branch nam>`.
+
+For example when merging `f/some-feature` into `incubation`, name your branch `merge-f/some-feature`. This will result in a commit message on the `incubation` branch of `Merge pull request # from <username>/merge-f/some-feature` when the PR is merged.
 
 ## Main
 


### PR DESCRIPTION
Doc update to support the [existing requirement](https://github.com/opendatahub-io/odh-dashboard/blob/main/docs/process-definition/branches.md#branches) that all commits need to come from a fork through a PR and ensure that the commit history shows an understandable commit message when merging a feature branch into incubation.

Adhere to pattern `merge-<source branch name>` when creating a PR for the sole purpose of merging one branch into another. eg. merging a feature branch into incubation