### PR TITLE
Add project name to the session storage key for the selected metrics …

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/useBiasChartsBrowserStorage.ts
@@ -9,10 +9,10 @@ const useBiasChartsBrowserStorage = (): [
   BiasMetricConfig[],
   SetBrowserStorageHook<BiasMetricConfig[]>,
 ] => {
-  const { inferenceService } = useParams();
+  const { project, namespace, inferenceService } = useParams();
 
   const [selectedBiasConfigs, setSelectedBiasConfigs] = useBrowserStorage<BiasMetricConfig[]>(
-    `${SELECTED_CHARTS_STORAGE_KEY_PREFIX}-${inferenceService}`,
+    `${SELECTED_CHARTS_STORAGE_KEY_PREFIX}-${project ?? namespace}-${inferenceService}`,
     [],
     true,
     true,


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #2022 

## Description
The key for the session variable that holds the user's chart selections can be found here[1]. The project name should form part of the key name as well as the inference service name.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Navigate to the bias metrics tab
From the selector, select a chart
Open the browser console (F12) -> Applications tab
From the 'storage' group on the left menu bar, expand 'Session Storage'
In the main tab, look for a key that will be of the format: 'odh.dashboard.xai.selected_bias_charts-$PROJECT_NAME-$MODEL_NAME'
It should contain a project name 
![Screenshot from 2023-11-06 18-51-13](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/f04e4e96-af58-45f0-9ca8-df2f230dfc77)


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
No test cases

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
