### PR TITLE
Added accelerator column and field

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -485,6 +485,7 @@ export type BYONImage = {
   visible: boolean;
   software: BYONImagePackage[];
   packages: BYONImagePackage[];
+  recommendedAcceleratorIdentifiers: string[];
 };
 
 export type ImageTag = {

--- a/frontend/src/__mocks__/mockByon.ts
+++ b/frontend/src/__mocks__/mockByon.ts
@@ -12,6 +12,7 @@ export const mockByon = (opts?: RecursivePartial<BYONImage[]>): BYONImage[] =>
         name: 'byon-123',
         display_name: 'Testing Custom Image',
         description: 'A custom notebook image',
+        recommendedAcceleratorIdentifiers: [],
         visible: true,
         packages: [
           {

--- a/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.spec.ts
+++ b/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.spec.ts
@@ -155,3 +155,30 @@ test('Invalid id in edit page', async ({ page }) => {
     page.getByText('acceleratorprofiles.dashboard.opendatahub.io "test-accelerator" not found'),
   ).toHaveCount(1);
 });
+
+test('One preset identifier is auto filled and disabled', async ({ page }) => {
+  await page.goto(
+    navigateToStory(
+      'pages-acceleratorprofiles-manageacceleratorprofile',
+      'create-accelerator-with-one-set-identifier',
+    ),
+  );
+
+  expect(await page.getByTestId('accelerator-identifier-input').inputValue()).toBe(
+    'test-identifier',
+  );
+
+  await expect(page.getByTestId('accelerator-identifier-input')).toBeDisabled();
+});
+
+test('Multiple preset identifiers show dropdown', async ({ page }) => {
+  await page.goto(
+    navigateToStory(
+      'pages-acceleratorprofiles-manageacceleratorprofile',
+      'create-accelerator-with-multiple-set-identifiers',
+    ),
+  );
+
+  await page.getByRole('button', { name: 'Options menu' }).click();
+  await expect(page.getByRole('option', { name: 'test-identifier-3' })).toHaveCount(1);
+});

--- a/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/acceleratorProfiles/ManageAcceleratorProfile.stories.tsx
@@ -144,3 +144,54 @@ export const TolerationsModal: StoryObj = {
     await userEvent.click(canvas.getByText('Add toleration', { selector: 'button' }));
   },
 };
+
+export const CreateAcceleratorWithOneSetIdentifier: StoryObj = {
+  render: () => (
+    <RenderComponent>
+      <ManageAcceleratorProfileComponent />
+    </RenderComponent>
+  ),
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Identifier', undefined, {
+      timeout: 5000,
+    });
+  },
+  parameters: {
+    reactRouter: {
+      routePath: '/create',
+      searchParams: {
+        identifiers: ['test-identifier'],
+      },
+    },
+  },
+};
+
+export const CreateAcceleratorWithMultipleSetIdentifiers: StoryObj = {
+  render: () => (
+    <RenderComponent>
+      <ManageAcceleratorProfileComponent />
+    </RenderComponent>
+  ),
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Identifier', undefined, {
+      timeout: 5000,
+    });
+  },
+  parameters: {
+    reactRouter: {
+      routePath: '/create',
+      searchParams: {
+        identifiers: [
+          'test-identifier-1',
+          'test-identifier-2',
+          'test-identifier-3',
+          'test-identifier-3',
+        ],
+      },
+    },
+  },
+};

--- a/frontend/src/__tests__/integration/pages/notebookImageSettings/NotebookImageSettings.spec.ts
+++ b/frontend/src/__tests__/integration/pages/notebookImageSettings/NotebookImageSettings.spec.ts
@@ -18,6 +18,12 @@ test('Table filtering, sorting, searching', async ({ page }) => {
   await page.getByRole('button', { name: 'Provider' }).click();
   expect(page.getByText('image-0'));
 
+  // by accelerator
+  await page.getByRole('button', { name: 'Recommended accelerators' }).click();
+  expect(page.getByText('test-accelerator')).toHaveCount(0);
+  await page.getByRole('button', { name: 'Recommended accelerators' }).click();
+  expect(page.getByText('test-accelerator'));
+
   // by enabled
   await page.getByRole('button', { name: 'Enable', exact: true }).click();
   expect(page.getByText('image-14'));
@@ -114,6 +120,30 @@ test('Import form fields', async ({ page }) => {
   await page.getByLabel('Name *').fill('image');
   await expect(page.getByRole('button', { name: 'Import' })).toBeEnabled();
 
+  // test accelerator select field
+  // select accelerator from api call
+  await page.getByPlaceholder('Example, nvidia.com/gpu').click();
+  await page.getByRole('option', { name: 'nvidia.com/gpu' }).click();
+
+  // create new and select
+  await page.getByPlaceholder('Example, nvidia.com/gpu').click();
+  await page.getByPlaceholder('Example, nvidia.com/gpu').fill('test.com/gpu');
+  await page.getByRole('option', { name: 'Create "test.com/gpu"' }).click();
+  await page.getByRole('button', { name: 'Options menu' }).click();
+  expect(page.getByText('test.com/gpu'));
+
+  // remove custom
+  await page.getByRole('button', { name: 'Remove test.com/gpu' }).click();
+  await page.getByRole('button', { name: 'Options menu' }).click();
+  await expect(page.getByText('test.com/gpu')).toHaveCount(0);
+
+  // reselect custom
+  await page
+    .getByRole('dialog', { name: 'Import notebook image' })
+    .getByRole('button', { name: 'Options menu' })
+    .click();
+  await page.getByRole('option', { name: 'test.com/gpu' }).click();
+
   // test form is disabled after entering software add form
   await page.getByTestId('add-software-button').click();
   await expect(page.getByRole('button', { name: 'Import' })).toBeDisabled();
@@ -204,7 +234,7 @@ test('Edit form fields match', async ({ page }) => {
   expect(await page.getByLabel('Image Location *').inputValue()).toBe('test-image:latest');
   expect(await page.getByLabel('Name *').inputValue()).toBe('Testing Custom Image');
   expect(await page.getByLabel('Description').inputValue()).toBe('A custom notebook image');
-
+  expect(page.getByText('nvidia.com/gpu'));
   // test software and packages have correct values
   expect(page.getByRole('gridcell', { name: 'test-software' }));
   expect(page.getByRole('gridcell', { name: '2.0' }));

--- a/frontend/src/__tests__/integration/pages/notebookImageSettings/NotebookImageSettings.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/notebookImageSettings/NotebookImageSettings.stories.tsx
@@ -5,24 +5,48 @@ import { rest } from 'msw';
 import { userEvent, within } from '@storybook/testing-library';
 import BYONImages from '~/pages/BYONImages/BYONImages';
 import { mockByon } from '~/__mocks__/mockByon';
+import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import { mockStatus } from '~/__mocks__/mockStatus';
+import useDetectUser from '~/utilities/useDetectUser';
 
 export default {
   component: BYONImages,
+  parameters: {
+    msw: {
+      handlers: {
+        status: [
+          rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
+            res(ctx.json(mockK8sResourceList([mockProjectK8sResource({})]))),
+          ),
+          rest.get('/api/status', (req, res, ctx) => res(ctx.json(mockStatus()))),
+        ],
+        accelerators: rest.get(
+          '/api/k8s/apis/dashboard.opendatahub.io/v1/namespaces/opendatahub/acceleratorprofiles',
+          (req, res, ctx) => res(ctx.json(mockK8sResourceList([mockAcceleratorProfile()]))),
+        ),
+        images: rest.get('/api/images/byon', (req, res, ctx) =>
+          res(
+            ctx.json(
+              mockByon([
+                { url: 'test-image:latest', recommendedAcceleratorIdentifiers: ['nvidia.com/gpu'] },
+              ]),
+            ),
+          ),
+        ),
+      },
+    },
+  },
 } as Meta<typeof BYONImages>;
 
-const Template: StoryFn<typeof BYONImages> = (args) => <BYONImages {...args} />;
+const Template: StoryFn<typeof BYONImages> = (args) => {
+  useDetectUser();
+  return <BYONImages {...args} />;
+};
 
 export const Default: StoryObj = {
   render: Template,
-  parameters: {
-    msw: {
-      handlers: [
-        rest.get('/api/images/byon', (req, res, ctx) =>
-          res(ctx.json(mockByon([{ url: 'test-image:latest' }]))),
-        ),
-      ],
-    },
-  },
   play: async ({ canvasElement }) => {
     // load page and wait until settled
     const canvas = within(canvasElement);
@@ -34,7 +58,7 @@ export const Empty: StoryObj = {
   render: Template,
   parameters: {
     msw: {
-      handlers: [rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json([])))],
+      handlers: { images: rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json([]))) },
     },
   },
   play: async ({ canvasElement }) => {
@@ -48,7 +72,7 @@ export const LoadingError: StoryObj = {
   render: Template,
   parameters: {
     msw: {
-      handlers: [rest.get('/api/images/byon', (req, res, ctx) => res(ctx.status(404)))],
+      handlers: { images: rest.get('/api/images/byon', (req, res, ctx) => res(ctx.status(404))) },
     },
   },
   play: async ({ canvasElement }) => {
@@ -62,8 +86,8 @@ export const LargeList: StoryObj = {
   render: Template,
   parameters: {
     msw: {
-      handlers: [
-        rest.get('/api/images/byon', (req, res, ctx) =>
+      handlers: {
+        images: rest.get('/api/images/byon', (req, res, ctx) =>
           res(
             ctx.json(
               Array.from(
@@ -77,13 +101,14 @@ export const LargeList: StoryObj = {
                       description: `description-${i}`,
                       provider: `provider-${i}`,
                       visible: i % 3 === 0,
+                      recommendedAcceleratorIdentifiers: i % 3 ? ['nvidia.com/gpu'] : [],
                     },
                   ])[0],
               ),
             ),
           ),
         ),
-      ],
+      },
     },
   },
   play: async ({ canvasElement }) => {
@@ -97,39 +122,41 @@ export const ImageError: StoryObj = {
   render: Template,
   parameters: {
     msw: {
-      handlers: [
-        rest.post('/api/images', (req, res, ctx) =>
-          res(
-            ctx.json({
-              success: false,
-              error: 'Testing create error message',
-            }),
-          ),
-        ),
-        rest.put('/api/images/byon-1', (req, res, ctx) =>
-          res(
-            ctx.json({
-              success: false,
-              error: 'Testing edit error message',
-            }),
-          ),
-        ),
-        rest.delete('/api/images/byon-1', (req, res, ctx) =>
-          res(ctx.status(404, 'Testing delete error message')),
-        ),
-        rest.get('/api/images/byon', (req, res, ctx) =>
-          res(
-            ctx.json(
-              mockByon([
-                {
-                  name: 'byon-1',
-                  error: 'Testing error message',
-                },
-              ]),
+      handlers: {
+        images: [
+          rest.post('/api/images', (req, res, ctx) =>
+            res(
+              ctx.json({
+                success: false,
+                error: 'Testing create error message',
+              }),
             ),
           ),
-        ),
-      ],
+          rest.put('/api/images/byon-1', (req, res, ctx) =>
+            res(
+              ctx.json({
+                success: false,
+                error: 'Testing edit error message',
+              }),
+            ),
+          ),
+          rest.delete('/api/images/byon-1', (req, res, ctx) =>
+            res(ctx.status(404, 'Testing delete error message')),
+          ),
+          rest.get('/api/images/byon', (req, res, ctx) =>
+            res(
+              ctx.json(
+                mockByon([
+                  {
+                    name: 'byon-1',
+                    error: 'Testing error message',
+                  },
+                ]),
+              ),
+            ),
+          ),
+        ],
+      },
     },
   },
   play: async ({ canvasElement }) => {
@@ -148,7 +175,9 @@ export const EditModal: StoryObj = {
       element: '.pf-c-backdrop',
     },
     msw: {
-      handlers: [rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json(mockByon())))],
+      handlers: {
+        images: rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json(mockByon()))),
+      },
     },
   },
   play: async ({ canvasElement }) => {
@@ -169,7 +198,9 @@ export const DeleteModal: StoryObj = {
       element: '.pf-c-backdrop',
     },
     msw: {
-      handlers: [rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json(mockByon())))],
+      handlers: {
+        images: rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json(mockByon()))),
+      },
     },
   },
   play: async ({ canvasElement }) => {
@@ -190,7 +221,9 @@ export const ImportModal: StoryObj = {
       element: '.pf-c-backdrop',
     },
     msw: {
-      handlers: [rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json(mockByon())))],
+      handlers: {
+        images: rest.get('/api/images/byon', (req, res, ctx) => res(ctx.json(mockByon()))),
+      },
     },
   },
   play: async ({ canvasElement }) => {

--- a/frontend/src/pages/BYONImages/BYONImageAccelerators.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageAccelerators.tsx
@@ -1,0 +1,97 @@
+import {
+  Spinner,
+  LabelGroup,
+  Label,
+  StackItem,
+  Stack,
+  Tooltip,
+  Button,
+} from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { BYONImage } from '~/types';
+import { AcceleratorKind } from '~/k8sTypes';
+import { FetchState } from '~/utilities/useFetchState';
+
+type BYONImageAcceleratorsProps = {
+  image: BYONImage;
+  acceleratorProfiles: FetchState<AcceleratorKind[]>;
+};
+
+export const BYONImageAccelerators: React.FC<BYONImageAcceleratorsProps> = ({
+  image,
+  acceleratorProfiles,
+}) => {
+  const [data, loaded, loadError] = acceleratorProfiles;
+
+  const recommendedAcceleratorProfiles = data.filter((accelerator) =>
+    image.recommendedAcceleratorIdentifiers?.includes(accelerator.spec.identifier),
+  );
+  if (loadError) {
+    return <>{'-'}</>;
+  }
+
+  if (!loaded) {
+    return <Spinner size="sm" />;
+  }
+
+  return (
+    <Stack>
+      {recommendedAcceleratorProfiles.length > 0 && (
+        <StackItem>
+          <LabelGroup isCompact>
+            {recommendedAcceleratorProfiles.map((cr) => (
+              <Label key={cr.metadata.name} color="blue" variant="filled" isTruncated isCompact>
+                {cr.spec.displayName}
+              </Label>
+            ))}
+          </LabelGroup>
+        </StackItem>
+      )}
+      <StackItem>
+        {image.recommendedAcceleratorIdentifiers?.length > 0 ? (
+          <Tooltip
+            content={`This image is compatible with accelerators with the identifier ${image.recommendedAcceleratorIdentifiers.join(
+              ', ',
+            )}.`}
+          >
+            <Label
+              color="blue"
+              variant="outline"
+              render={({ className, content }) => (
+                <Link
+                  to={
+                    '/acceleratorProfiles/create?' +
+                    new URLSearchParams({
+                      identifiers: image.recommendedAcceleratorIdentifiers.join(','),
+                    }).toString()
+                  }
+                  className={className}
+                >
+                  {content}
+                </Link>
+              )}
+              isCompact
+              icon={<PlusIcon />}
+            >
+              Create profile
+            </Label>
+          </Tooltip>
+        ) : (
+          <Tooltip content="To create an accelerator profile for this image, edit it to include an accelerator identifier.">
+            <Button
+              isAriaDisabled
+              variant="link"
+              className="pf-u-font-size-xs"
+              isInline
+              icon={<PlusIcon />}
+            >
+              Create profile
+            </Button>
+          </Tooltip>
+        )}
+      </StackItem>
+    </Stack>
+  );
+};

--- a/frontend/src/pages/BYONImages/BYONImageModal/AcceleratorIdentifierMultiselect.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageModal/AcceleratorIdentifierMultiselect.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import useAccelerators from '~/pages/notebookController/screens/server/useAccelerators';
+import { useDashboardNamespace } from '~/redux/selectors';
+
+type AcceleratorIdentifierMultiselectProps = {
+  data: string[];
+  setData: (data: string[]) => void;
+};
+
+export const AcceleratorIdentifierMultiselect: React.FC<AcceleratorIdentifierMultiselectProps> = ({
+  data,
+  setData,
+}) => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [accelerators, loaded, loadError] = useAccelerators(dashboardNamespace);
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [newOptions, setNewOptions] = useState<string[]>([]);
+
+  const options = React.useMemo(() => {
+    if (loaded && !loadError) {
+      const uniqueIdentifiers = new Set<string>();
+      accelerators.forEach((accelerator) => {
+        uniqueIdentifiers.add(accelerator.spec.identifier);
+      });
+
+      data.forEach((identifier) => {
+        uniqueIdentifiers.add(identifier);
+      });
+
+      newOptions.forEach((option) => {
+        uniqueIdentifiers.add(option);
+      });
+      return Array.from(uniqueIdentifiers);
+    }
+    return [];
+  }, [accelerators, loaded, loadError, data, newOptions]);
+
+  const clearSelection = () => {
+    setData([]);
+    setIsOpen(false);
+  };
+
+  return (
+    <Select
+      variant={SelectVariant.typeaheadMulti}
+      typeAheadAriaLabel="Example, nvidia.com/gpu"
+      onToggle={() => setIsOpen(!isOpen)}
+      onSelect={(_, selection) => {
+        if (data.includes(selection.toString())) {
+          setData(data.filter((item) => item !== selection));
+        } else {
+          setData([...data, selection.toString()]);
+        }
+      }}
+      {...(!loaded && !loadError && { loadingVariant: 'spinner' })}
+      onClear={clearSelection}
+      selections={data}
+      isOpen={isOpen}
+      placeholderText="Example, nvidia.com/gpu"
+      isCreatable
+      onCreateOption={(value) => {
+        setNewOptions([...options, value]);
+      }}
+    >
+      {options.map((option, i) => (
+        <SelectOption key={option + i} value={option} />
+      ))}
+    </Select>
+  );
+};

--- a/frontend/src/pages/BYONImages/BYONImageModal/ManageBYONImageModal.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageModal/ManageBYONImageModal.tsx
@@ -8,12 +8,16 @@ import {
   Tabs,
   Tab,
   TabTitleText,
+  Popover,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { importBYONImage, updateBYONImage } from '~/services/imagesService';
 import { ResponseStatus, BYONImagePackage, BYONImage } from '~/types';
 import { useAppSelector } from '~/redux/hooks';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { filterBlankPackages } from '~/pages/BYONImages/utils';
+import { AcceleratorIdentifierMultiselect } from '~/pages/BYONImages/BYONImageModal/AcceleratorIdentifierMultiselect';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import ImageLocationField from './ImageLocationField';
 import DisplayedContentTabContent from './DisplayedContentTabContent';
 
@@ -40,6 +44,9 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
   const [repository, setRepository] = React.useState('');
   const [displayName, setDisplayName] = React.useState('');
   const [description, setDescription] = React.useState('');
+  const [recommendedAcceleratorIdentifiers, setRecommendedAcceleratorIdentifiers] = React.useState<
+    string[]
+  >([]);
   const [software, setSoftware] = React.useState<BYONImagePackage[]>([]);
   const [packages, setPackages] = React.useState<BYONImagePackage[]>([]);
   const [tempSoftware, setTempSoftware] = React.useState<BYONImagePackage[]>([]);
@@ -59,6 +66,7 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
       setSoftware(existingImage.software);
       setTempPackages(existingImage.packages);
       setTempSoftware(existingImage.software);
+      setRecommendedAcceleratorIdentifiers(existingImage.recommendedAcceleratorIdentifiers);
     }
   }, [existingImage]);
 
@@ -69,6 +77,7 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
     setRepository('');
     setDisplayName('');
     setDescription('');
+    setRecommendedAcceleratorIdentifiers([]);
     setSoftware([]);
     setPackages([]);
     setTempSoftware([]);
@@ -91,6 +100,7 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
         // eslint-disable-next-line camelcase
         display_name: displayName,
         description: description,
+        recommendedAcceleratorIdentifiers: recommendedAcceleratorIdentifiers,
         packages: filterBlankPackages(packages),
         software: filterBlankPackages(software),
       }).then(handleResponse);
@@ -100,6 +110,7 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
         display_name: displayName,
         url: repository,
         description: description,
+        recommendedAcceleratorIdentifiers: recommendedAcceleratorIdentifiers,
         provider: userName,
         packages: filterBlankPackages(packages),
         software: filterBlankPackages(software),
@@ -165,6 +176,22 @@ export const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({
             onChange={(value) => {
               setDescription(value);
             }}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Accelerator identifier"
+          labelIcon={
+            <Popover bodyContent="Add recommended accelerator identifiers for this image.">
+              <DashboardPopupIconButton
+                icon={<OutlinedQuestionCircleIcon />}
+                aria-label="More info for identifier field"
+              />
+            </Popover>
+          }
+        >
+          <AcceleratorIdentifierMultiselect
+            setData={(identifiers) => setRecommendedAcceleratorIdentifiers(identifiers)}
+            data={recommendedAcceleratorIdentifiers}
           />
         </FormGroup>
         <FormGroup label="Displayed contents" fieldId="byon-image-software-packages">

--- a/frontend/src/pages/BYONImages/BYONImagesTable.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTable.tsx
@@ -4,6 +4,8 @@ import { BYONImage } from '~/types';
 import { Table } from '~/components/table';
 import DashboardSearchField, { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
+import { useDashboardNamespace } from '~/redux/selectors';
+import useAccelerators from '~/pages/notebookController/screens/server/useAccelerators';
 import ManageBYONImageModal from './BYONImageModal/ManageBYONImageModal';
 import DeleteBYONImageModal from './BYONImageModal/DeleteBYONImageModal';
 import { columns } from './tableData';
@@ -47,6 +49,9 @@ export const BYONImagesTable: React.FC<BYONImagesTableProps> = ({ images, refres
   const [editImage, setEditImage] = React.useState<BYONImage>();
   const [deleteImage, setDeleteImage] = React.useState<BYONImage>();
 
+  const { dashboardNamespace } = useDashboardNamespace();
+  const acceleratorProfiles = useAccelerators(dashboardNamespace);
+
   return (
     <>
       <Table
@@ -64,6 +69,7 @@ export const BYONImagesTable: React.FC<BYONImagesTableProps> = ({ images, refres
             obj={image}
             onEditImage={(i) => setEditImage(i)}
             onDeleteImage={(i) => setDeleteImage(i)}
+            acceleratorProfiles={acceleratorProfiles}
           />
         )}
         toolbarContent={

--- a/frontend/src/pages/BYONImages/BYONImagesTableRow.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTableRow.tsx
@@ -10,14 +10,18 @@ import {
 import { BYONImage } from '~/types';
 import { relativeTime } from '~/utilities/time';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
+import { AcceleratorKind } from '~/k8sTypes';
+import { FetchState } from '~/utilities/useFetchState';
 import ImageErrorStatus from './ImageErrorStatus';
 import BYONImageStatusToggle from './BYONImageStatusToggle';
 import { convertBYONImageToK8sResource } from './utils';
 import BYONImageDependenciesList from './BYONImageDependenciesList';
+import { BYONImageAccelerators } from './BYONImageAccelerators';
 
 type BYONImagesTableRowProps = {
   obj: BYONImage;
   rowIndex: number;
+  acceleratorProfiles: FetchState<AcceleratorKind[]>;
   onEditImage: (obj: BYONImage) => void;
   onDeleteImage: (obj: BYONImage) => void;
 };
@@ -25,6 +29,7 @@ type BYONImagesTableRowProps = {
 const BYONImagesTableRow: React.FC<BYONImagesTableRowProps> = ({
   obj,
   rowIndex,
+  acceleratorProfiles,
   onEditImage,
   onDeleteImage,
 }) => {
@@ -67,6 +72,9 @@ const BYONImagesTableRow: React.FC<BYONImagesTableRowProps> = ({
         </Td>
         <Td dataLabel="Enable" modifier="nowrap">
           <BYONImageStatusToggle image={obj} />
+        </Td>
+        <Td dataLabel="Accelerators">
+          <BYONImageAccelerators image={obj} acceleratorProfiles={acceleratorProfiles} />
         </Td>
         <Td dataLabel="Provider">{obj.provider}</Td>
         <Td dataLabel="Imported">

--- a/frontend/src/pages/BYONImages/tableData.tsx
+++ b/frontend/src/pages/BYONImages/tableData.tsx
@@ -23,7 +23,16 @@ export const columns: SortableData<BYONImage>[] = [
     label: 'Enable',
     sortable: (a, b) => getEnabledStatus(a) - getEnabledStatus(b),
     info: {
-      tooltip: 'Enabled images are selectable when creating workbenches.',
+      popover: 'Enabled images are selectable when creating workbenches.',
+    },
+  },
+  {
+    field: 'recommendedAccelerators',
+    label: 'Recommended accelerators',
+    sortable: (a, b) =>
+      a.recommendedAcceleratorIdentifiers.length - b.recommendedAcceleratorIdentifiers.length,
+    info: {
+      popover: 'Accelerators are used to speed up the execution of workbenches.',
     },
   },
   {

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/IdentifierSelectField.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/IdentifierSelectField.tsx
@@ -1,0 +1,68 @@
+import { Select, SelectOption, TextInput } from '@patternfly/react-core';
+import React, { useEffect, useMemo } from 'react';
+
+type IdentifierSelectFieldProps = {
+  value: string;
+  onChange: (identifier: string) => void;
+  identifierOptions: string[];
+};
+
+export const IdentifierSelectField = ({
+  value,
+  onChange,
+  identifierOptions = [],
+}: IdentifierSelectFieldProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  // remove possible duplicates
+  const options = useMemo(() => Array.from(new Set(identifierOptions)), [identifierOptions]);
+
+  // auto-select if there is only one option
+  useEffect(() => {
+    if (options.length === 1) {
+      onChange(options[0]);
+    }
+    // Do not include onChange callback as dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options]);
+
+  if (options.length > 1) {
+    return (
+      <Select
+        removeFindDomNode
+        id="accelerator-identifier-select"
+        data-testid="accelerator-identifier-select"
+        isOpen={isOpen}
+        placeholderText="Select an identifier"
+        onToggle={(open) => setIsOpen(open)}
+        onSelect={(_, option) => {
+          if (typeof option === 'string') {
+            onChange(option);
+            setIsOpen(false);
+          }
+        }}
+        selections={value}
+      >
+        {options.map((option) => (
+          <SelectOption key={option} value={option}>
+            {option}
+          </SelectOption>
+        ))}
+      </Select>
+    );
+  }
+
+  return (
+    <TextInput
+      isRequired
+      value={value}
+      id="accelerator-identifier"
+      name="accelerator-identifier"
+      isDisabled={options.length === 1}
+      onChange={(identifier) => onChange(identifier)}
+      placeholder="Example, nvidia.com/gpu"
+      aria-label="Identifier"
+      data-testid="accelerator-identifier-input"
+    />
+  );
+};

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
@@ -9,12 +9,14 @@ import {
   Popover,
 } from '@patternfly/react-core';
 import React from 'react';
-import { HelpIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { useSearchParams } from 'react-router-dom';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { AcceleratorKind } from '~/k8sTypes';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import { ManageAcceleratorSectionTitles } from './const';
 import { ManageAcceleratorSectionID } from './types';
+import { IdentifierSelectField } from './IdentifierSelectField';
 
 type ManageAcceleratorProfileDetailsSectionProps = {
   state: AcceleratorKind['spec'];
@@ -24,77 +26,81 @@ type ManageAcceleratorProfileDetailsSectionProps = {
 export const ManageAcceleratorProfileDetailsSection = ({
   state,
   setState,
-}: ManageAcceleratorProfileDetailsSectionProps) => (
-  <FormSection
-    id={ManageAcceleratorSectionID.DETAILS}
-    aria-label={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.DETAILS]}
-    title={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.DETAILS]}
-  >
-    <Stack hasGutter>
-      <StackItem>
-        <FormGroup label="Name" isRequired>
-          <TextInput
+}: ManageAcceleratorProfileDetailsSectionProps) => {
+  const [searchParams] = useSearchParams();
+
+  const acceleratorIdentifiers = React.useMemo(
+    () => searchParams.get('identifiers')?.split(',') ?? [],
+    [searchParams],
+  );
+
+  return (
+    <FormSection
+      id={ManageAcceleratorSectionID.DETAILS}
+      aria-label={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.DETAILS]}
+      title={ManageAcceleratorSectionTitles[ManageAcceleratorSectionID.DETAILS]}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <FormGroup label="Name" isRequired>
+            <TextInput
+              isRequired
+              value={state.displayName}
+              id="accelerator-name"
+              name="accelerator-name"
+              onChange={(name) => setState('displayName', name)}
+              aria-label="Name"
+              data-testid="accelerator-name-input"
+            />
+          </FormGroup>
+        </StackItem>
+        <StackItem>
+          <FormGroup
+            label="Identifier"
             isRequired
-            value={state.displayName}
-            id="accelerator-name"
-            name="accelerator-name"
-            onChange={(name) => setState('displayName', name)}
-            aria-label="accelerator-name"
-            data-testid="accelerator-name-input"
-          />
-        </FormGroup>
-      </StackItem>
-      <StackItem>
-        <FormGroup
-          label="Identifier"
-          isRequired
-          labelIcon={
-            <Popover
-              removeFindDomNode
-              bodyContent="An identifier is a unique string that names a specific hardware accelerator resource."
-            >
-              <DashboardPopupIconButton
-                icon={<HelpIcon />}
-                aria-label="More info for identifier field"
-              />
-            </Popover>
-          }
-        >
-          <TextInput
-            isRequired
-            value={state.identifier}
-            id="accelerator-identifier"
-            name="accelerator-identifier"
-            onChange={(identifier) => setState('identifier', identifier)}
-            placeholder="Example, nvidia.com/gpu"
-            aria-label="accelerator-identifier"
-            data-testid="accelerator-identifier-input"
-          />
-        </FormGroup>
-      </StackItem>
-      <StackItem>
-        <FormGroup label="Description">
-          <TextArea
-            resizeOrientation="vertical"
-            id="accelerator-description"
-            name="accelerator-description"
-            value={state.description}
-            onChange={(description) => setState('description', description)}
-            aria-label="accelerator-description"
-            data-testid="accelerator-description-input"
-          />
-        </FormGroup>
-      </StackItem>
-      <StackItem>
-        <FormGroup label="Enabled">
-          <Switch
-            id="accelerator-enabled"
-            isChecked={state.enabled}
-            onChange={(enabled) => setState('enabled', enabled)}
-            aria-label="accelerator-enabled"
-          />
-        </FormGroup>
-      </StackItem>
-    </Stack>
-  </FormSection>
-);
+            labelIcon={
+              <Popover
+                removeFindDomNode
+                bodyContent="An identifier is a unique string that names a specific hardware accelerator resource."
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info for identifier field"
+                />
+              </Popover>
+            }
+          >
+            <IdentifierSelectField
+              value={state.identifier}
+              onChange={(identifier) => setState('identifier', identifier)}
+              identifierOptions={acceleratorIdentifiers}
+            />
+          </FormGroup>
+        </StackItem>
+        <StackItem>
+          <FormGroup label="Description">
+            <TextArea
+              resizeOrientation="vertical"
+              id="accelerator-description"
+              name="accelerator-description"
+              value={state.description}
+              onChange={(description) => setState('description', description)}
+              aria-label="Description"
+              data-testid="accelerator-description-input"
+            />
+          </FormGroup>
+        </StackItem>
+        <StackItem>
+          <FormGroup label="Enabled">
+            <Switch
+              id="accelerator-enabled"
+              isChecked={state.enabled}
+              onChange={(enabled) => setState('enabled', enabled)}
+              aria-label="Enabled"
+            />
+          </FormGroup>
+        </StackItem>
+      </Stack>
+    </FormSection>
+  );
+};

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
@@ -12,7 +12,7 @@ import {
   InputGroupText,
   Popover,
 } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { PodToleration, TolerationEffect, TolerationOperator } from '~/types';
 import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
 import NumberInputWrapper from '~/components/NumberInputWrapper';
@@ -97,7 +97,7 @@ export const TolerationFields: React.FC<TolerationFieldsProps> = ({ toleration, 
             bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted."
           >
             <DashboardPopupIconButton
-              icon={<HelpIcon />}
+              icon={<OutlinedQuestionCircleIcon />}
               aria-label="More info for toleration seconds field"
             />
           </Popover>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -464,6 +464,7 @@ export type BYONImage = {
   visible: boolean;
   software: BYONImagePackage[];
   packages: BYONImagePackage[];
+  recommendedAcceleratorIdentifiers: string[];
 };
 
 export type BYONImagePackage = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://github.com/opendatahub-io/odh-dashboard/issues/1439
closes: https://github.com/opendatahub-io/odh-dashboard/issues/2056

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- Added accelerators column to image admin page
   - each row matches to what accelerator profiles exist in the cluster
   - pending [UX issue](https://github.com/opendatahub-io/odh-dashboard/issues/2056) for when an image does not have the "recommended accelerators" annotation
   - a button that navigates with state of identifier to the create accelerator profile page
- multi select input value for accelerator identifiers
   - this uses the identifiers from all accelerator profiles found to populate the dropdown
- navigate to create page when clicking "Create accelerator"
<img width="849" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/32e573cf-5af3-448c-970d-bf9f04399288">
<img width="603" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/2d7afdfa-8a4e-43cf-aaf5-b982322c1755">
<img width="1214" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/5719dc54-ac05-4adb-aeeb-a37a9edcf4c1">
<img width="490" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/09b20e8c-1bd2-43e7-962c-cc4a8ee63dea">

![Screenshot 2023-11-06 at 4 56 29 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/80dfdef9-fbb8-4295-88e7-6c07fd7cd722)
![Screenshot 2023-11-06 at 4 56 39 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/c6cbaa0b-4845-46c6-9cc7-8efae445213c)
![Screenshot 2023-11-06 at 4 57 30 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/cab624db-69c9-41a7-b0d0-fec577a338af)
![Screenshot 2023-11-06 at 4 57 41 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/c1a1a550-9613-4526-9b24-9161f5803423)
![Screenshot 2023-11-06 at 4 58 41 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/9db4cc9b-bcd4-4f97-8c42-451b1865be4d)
![Screenshot 2023-11-06 at 4 58 59 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/cf4688e5-5a78-4326-b42b-747fd7c0b6fb)
![Screenshot 2023-11-06 at 4 59 14 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/f0dff1fc-dd51-471f-80b4-52deb711ddc2)

**When clicking on "Create profile"**
_multiple identifiers_
![image](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/656800ca-4de0-439d-bd95-eb972ab0eaa2)
_one identifier_
![image](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/1ae6181a-555c-49a5-99ad-8a4cdec41c97)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a accelerator profile CR
2. open BYON import modal
3. fill in required fields
4. open dropdown for accelerators
5. The accelerator profile identifier you just added should be there. select it
6. start typing a new identifier
7. select create
8. save form
9. edit new image just created
10. see that identifiers are there
11. remove and add a new identifier
12. repeat steps 9 and 10

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests are added to the existing image admin page test suite. Specifically testing
- ability to see accelerator profile display names when there is a match in the table
- able to sort accelerator column
-  import modal's accelerator identifier multi select can select, create, and remove from the input
- edit modal has identifier info when present in the image annotations

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
