### PR TITLE
Automatically generate first token when enable route when adding modelmesh server

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -180,6 +180,8 @@ test('Add ModelMesh model server', async ({ page }) => {
   await page.locator('#alt-form-checkbox-route').check();
   await expect(page.locator('#alt-form-checkbox-auth')).toBeChecked();
   await expect(page.locator('#external-route-no-token-alert')).toBeHidden();
+  await expect(page.locator('#service-account-form-name')).toBeVisible();
+  await expect(page.locator('#service-account-form-name')).toHaveValue('default-name');
   // check external route, uncheck token, show alert
   await page.locator('#alt-form-checkbox-auth').uncheck();
   await expect(page.locator('#external-route-no-token-alert')).toBeVisible();

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Stack,
   StackItem,
+  getUniqueId,
 } from '@patternfly/react-core';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import { HelpIcon } from '@patternfly/react-icons';
@@ -138,6 +139,20 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
       });
   };
 
+  const createNewToken = React.useCallback(() => {
+    const name = 'default-name';
+    const duplicated = createData.tokens.filter((token) => token.name === name);
+    const error = duplicated.length > 0 ? 'Duplicates are invalid' : '';
+    setCreateData('tokens', [
+      ...createData.tokens,
+      {
+        name,
+        uuid: getUniqueId('ml'),
+        error,
+      },
+    ]);
+  }, [createData.tokens, setCreateData]);
+
   return (
     <Modal
       title={`${editInfo ? 'Edit' : 'Add'} model server`}
@@ -218,6 +233,9 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
                     setCreateData('externalRoute', check);
                     if (check && allowCreate) {
                       setCreateData('tokenAuth', check);
+                      if (createData.tokens.length === 0) {
+                        createNewToken();
+                      }
                     }
                   }}
                 />
@@ -229,6 +247,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
               data={createData}
               setData={setCreateData}
               allowCreate={allowCreate}
+              createNewToken={createNewToken}
             />
           </StackItem>
           {createData.externalRoute && !createData.tokenAuth && (

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
@@ -5,7 +5,6 @@ import {
   Checkbox,
   FormGroup,
   FormSection,
-  getUniqueId,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -19,87 +18,71 @@ type ServingRuntimeTokenSectionProps = {
   data: CreatingServingRuntimeObject;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
   allowCreate: boolean;
+  createNewToken: () => void;
 };
 
 const ServingRuntimeTokenSection: React.FC<ServingRuntimeTokenSectionProps> = ({
   data,
   setData,
   allowCreate,
-}) => {
-  const createNewToken = () => {
-    const name = 'default-name';
-    const duplicated = data.tokens.filter((token) => token.name === name);
-    const error = duplicated.length > 0 ? 'Duplicates are invalid' : '';
-    setData('tokens', [
-      ...data.tokens,
-      {
-        name,
-        uuid: getUniqueId('ml'),
-        error,
-      },
-    ]);
-  };
-
-  return (
-    <FormSection title="Token authorization">
-      <FormGroup>
-        <Checkbox
-          label="Require token authentication"
-          id="alt-form-checkbox-auth"
-          name="alt-form-checkbox-auth"
-          isDisabled={!allowCreate}
-          isChecked={data.tokenAuth}
-          onChange={(check) => {
-            setData('tokenAuth', check);
-            if (data.tokens.length === 0) {
-              createNewToken();
-            }
-          }}
-        />
-      </FormGroup>
-
-      {data.tokenAuth && (
-        <IndentSection>
-          <Stack hasGutter>
-            {allowCreate && (
-              <StackItem>
-                <Alert
-                  variant="info"
-                  isInline
-                  title="The actual tokens will be created and displayed when the model server is configured."
-                />
-              </StackItem>
-            )}
-
-            {data.tokens.map((token) => (
-              <StackItem key={token.uuid}>
-                <ServingRuntimeTokenInput
-                  token={token}
-                  data={data}
-                  setData={setData}
-                  disabled={!allowCreate}
-                />
-              </StackItem>
-            ))}
+  createNewToken,
+}) => (
+  <FormSection title="Token authorization">
+    <FormGroup>
+      <Checkbox
+        label="Require token authentication"
+        id="alt-form-checkbox-auth"
+        name="alt-form-checkbox-auth"
+        isDisabled={!allowCreate}
+        isChecked={data.tokenAuth}
+        onChange={(check) => {
+          setData('tokenAuth', check);
+          if (data.tokens.length === 0) {
+            createNewToken();
+          }
+        }}
+      />
+    </FormGroup>
+    {data.tokenAuth && (
+      <IndentSection>
+        <Stack hasGutter>
+          {allowCreate && (
             <StackItem>
-              <Button
-                onClick={() => {
-                  createNewToken();
-                }}
+              <Alert
+                variant="info"
                 isInline
-                iconPosition="left"
-                variant="link"
-                icon={<PlusCircleIcon />}
-                isDisabled={!allowCreate}
-              >
-                Add a service account
-              </Button>
+                title="The actual tokens will be created and displayed when the model server is configured."
+              />
             </StackItem>
-          </Stack>
-        </IndentSection>
-      )}
-    </FormSection>
-  );
-};
+          )}
+          {data.tokens.map((token) => (
+            <StackItem key={token.uuid}>
+              <ServingRuntimeTokenInput
+                token={token}
+                data={data}
+                setData={setData}
+                disabled={!allowCreate}
+              />
+            </StackItem>
+          ))}
+          <StackItem>
+            <Button
+              onClick={() => {
+                createNewToken();
+              }}
+              isInline
+              iconPosition="left"
+              variant="link"
+              icon={<PlusCircleIcon />}
+              isDisabled={!allowCreate}
+            >
+              Add a service account
+            </Button>
+          </StackItem>
+        </Stack>
+      </IndentSection>
+    )}
+  </FormSection>
+);
 
 export default ServingRuntimeTokenSection;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #2049 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In https://github.com/opendatahub-io/odh-dashboard/pull/1862, we automatically check the `token authorization` checkbox when the route is enabled. However, we didn't add the default service account in this action. This PR is to fix that issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to a model-mesh project
2. Add a model server
3. Check the Model Route section
4. Make sure the token authorization is also checked and a default service account is added

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add a check in the integration test to make sure the service account token is added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
