### PR TITLE
Add info alert to kserve on settings page

### DIFF
--- a/frontend/src/__tests__/integration/pages/clusterSettings/ClusterSettings.spec.ts
+++ b/frontend/src/__tests__/integration/pages/clusterSettings/ClusterSettings.spec.ts
@@ -24,8 +24,10 @@ test('Cluster settings', async ({ page }) => {
   await expect(submitButton).toBeEnabled();
   await singlePlatformCheckbox.uncheck();
   expect(warningAlert.getByLabel('Warning Alert')).toBeTruthy();
-  await singlePlatformCheckbox.check();
   await multiPlatformCheckbox.check();
+  await expect(warningAlert).toBeVisible();
+  expect(warningAlert.getByLabel('Info Alert')).toBeTruthy();
+  await singlePlatformCheckbox.check();
   await expect(warningAlert).toBeHidden();
   await expect(submitButton).toBeDisabled();
 

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -35,7 +35,13 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
         setAlert({
           variant: AlertVariant.info,
           message:
-            'Disabling the multi-model serving platform prevents models deployed in new projects and in existing projects with no deployed models from sharing model servers. Existing projects with deployed models will continue to use multi-model serving.',
+            'Disabling multi-model serving means that models in new projects or existing projects with no currently deployed models will be deployed from their own model server. Existing projects with currently deployed models will continue to use the serving platform selected for that project.',
+        });
+      } else if (initialValue.kServe && !enabledPlatforms.kServe) {
+        setAlert({
+          variant: AlertVariant.info,
+          message:
+            'Disabling single model serving means that models in new projects or existing projects with no currently deployed models will be deployed from a shared model server. Existing projects with currently deployed models will continue to use the serving platform selected for that project.',
         });
       } else {
         setAlert(undefined);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #2047 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Previously, we only showed this alert when `Multi-model serving platform` was checked but unchecked later. In this PR, we apply the same behavior to `Single model serving platform` as well. No matter which checkbox was checked before but unchecked later, we show this info alert with the following text.

<img width="1409" alt="Screenshot 2023-11-07 at 10 46 24 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/923b76a6-6536-4613-b2e0-7c606a4c6057">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable both single and multi model serving platforms
2. Uncheck either of them, but not both, see if the alert is showing

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add an integration test check to see if this alert also shows when single model serving platform was checked but unchecked later.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
