### PR TITLE
fix: adds service mesh annotations on ns creation

### DIFF
--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -73,13 +73,13 @@ export const applyNamespaceChange = async (
       labels = {
         'opendatahub.io/dashboard': 'true',
       };
+      annotations = {
+        'opendatahub.io/service-mesh': String(enableServiceMesh),
+      };
       break;
     case NamespaceApplicationCase.MODEL_MESH_PROMOTION:
       labels = {
         'modelmesh-enabled': 'true',
-      };
-      annotations = {
-        'opendatahub.io/service-mesh': String(enableServiceMesh),
       };
       break;
     case NamespaceApplicationCase.KSERVE_PROMOTION:


### PR DESCRIPTION
## Description
This functionality has been accidentally moved to `MODEL_MESH_PROMOTION` case, breaking service mesh support in newly created data science projects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Closes #2095 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
