### PR TITLE
improve section divider rendering

### DIFF
--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
@@ -7,11 +7,20 @@ test('Empty project', async ({ page }) => {
   // wait for page to load
   await page.waitForSelector('text=Models and model servers');
 
-  // the dividers number should always 1 less than the section number
-  const sections = await page.locator('[data-id="details-page-section"]').all();
-  const dividers = await page.locator('[data-id="details-page-section-divider"]').all();
+  // all empty sections should be divided
+  const sectionsLocator = page.locator('[data-id="details-page-section"]');
+  const sections = await sectionsLocator.all();
+  const dividers = await page.locator('.odh-details-section--divide').all();
 
-  expect(dividers).toHaveLength(sections.length - 1);
+  expect(dividers).toHaveLength(sections.length);
+
+  // all but the last section should include the bottom border divider
+  const sectionsWithDivider = await sectionsLocator.evaluateAll((elements) =>
+    elements
+      .map((element) => window.getComputedStyle(element).getPropertyValue('border-bottom-style'))
+      .filter((x) => x !== 'none'),
+  );
+  expect(sectionsWithDivider).toHaveLength(sections.length - 1);
 });
 
 test('Non-empty project', async ({ page }) => {
@@ -21,7 +30,7 @@ test('Non-empty project', async ({ page }) => {
   await page.waitForSelector('text=Test Notebook');
 
   // we fill in the page with data, so there should be no dividers on the page
-  expect(await page.locator('[data-id="details-page-section-divider"]').all()).toHaveLength(0);
+  expect(await page.locator('.odh-details-section--divide').all()).toHaveLength(0);
 
   // check the x-small size shown correctly
   expect(page.getByText('Small')).toBeTruthy();

--- a/frontend/src/pages/projects/screens/detail/DetailsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/DetailsSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import {
   Alert,
   Bullseye,
@@ -21,6 +22,7 @@ type DetailsSectionProps = {
   emptyState?: React.ReactNode;
   children: React.ReactNode;
   labels?: React.ReactNode[];
+  showDivider?: boolean;
 };
 
 const DetailsSection: React.FC<DetailsSectionProps> = ({
@@ -33,6 +35,7 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({
   loadError,
   title,
   labels,
+  showDivider,
 }) => {
   const renderContent = () => {
     if (loadError) {
@@ -59,7 +62,12 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({
   };
 
   return (
-    <Stack hasGutter>
+    <Stack
+      hasGutter
+      className={classNames({
+        'odh-details-section--divide': !loadError && (isLoading || isEmpty || showDivider),
+      })}
+    >
       <StackItem>
         <Flex>
           <FlexItem>

--- a/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.scss
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.scss
@@ -1,0 +1,5 @@
+.odh-project-details-components__item:has(> .odh-details-section--divide):has(
+    + .odh-project-details-components__item
+  ) {
+  border-bottom: 1px solid var(--pf-global--BorderColor--100);
+}

--- a/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.tsx
@@ -12,6 +12,8 @@ import StorageList from './storage/StorageList';
 import { ProjectSectionTitles } from './const';
 import DataConnectionsList from './data-connections/DataConnectionsList';
 
+import './ProjectDetailsComponents.scss';
+
 type SectionType = {
   id: ProjectSectionID;
   component: React.ReactNode;
@@ -74,6 +76,7 @@ const ProjectDetailsComponents: React.FC = () => {
                 id={id}
                 aria-label={ProjectSectionTitles[id]}
                 data-id="details-page-section"
+                className="odh-project-details-components__item"
               >
                 {component}
               </StackItem>

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Divider } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import EmptyDetailsList from '~/pages/projects/screens/detail/EmptyDetailsList';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
@@ -43,7 +43,6 @@ const DataConnectionsList: React.FC = () => {
       >
         <DataConnectionsTable connections={connections} refreshData={refreshAllProjectData} />
       </DetailsSection>
-      {isDataConnectionsEmpty && <Divider data-id="details-page-section-divider" />}
       <ManageDataConnectionModal
         isOpen={open}
         onClose={(submitted) => {

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Divider } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import EmptyDetailsList from '~/pages/projects/screens/detail/EmptyDetailsList';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
@@ -53,7 +53,6 @@ const NotebookList: React.FC = () => {
       >
         <NotebookTable notebookStates={notebookStates} refresh={refresh} />
       </DetailsSection>
-      {isNotebooksEmpty && <Divider data-id="details-page-section-divider" />}
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Divider } from '@patternfly/react-core';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '~/pages/projects/screens/detail/const';
 import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
@@ -7,11 +6,11 @@ import { PipelineServerTimedOut, usePipelinesAPI } from '~/concepts/pipelines/co
 import NoPipelineServer from '~/concepts/pipelines/NoPipelineServer';
 import ImportPipelineButton from '~/concepts/pipelines/content/import/ImportPipelineButton';
 import PipelinesList from '~/pages/projects/screens/detail/pipelines/PipelinesList';
-import EnsureAPIAvailability from '~/concepts/pipelines/EnsureAPIAvailability';
 import PipelineServerActions from '~/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineServerActions';
 
 const PipelinesSection: React.FC = () => {
   const {
+    apiAvailable,
     pipelinesServer: { initializing, installed, timedOut },
   } = usePipelinesAPI();
 
@@ -34,19 +33,17 @@ const PipelinesSection: React.FC = () => {
             variant="kebab"
           />,
         ]}
-        isLoading={initializing}
+        isLoading={(!apiAvailable && installed) || initializing}
         isEmpty={!installed}
         emptyState={<NoPipelineServer variant="secondary" />}
+        showDivider={isPipelinesEmpty}
       >
         {timedOut ? (
           <PipelineServerTimedOut />
         ) : (
-          <EnsureAPIAvailability>
-            <PipelinesList setIsPipelinesEmpty={setIsPipelinesEmpty} />
-          </EnsureAPIAvailability>
+          <PipelinesList setIsPipelinesEmpty={setIsPipelinesEmpty} />
         )}
       </DetailsSection>
-      {(isPipelinesEmpty || !installed) && <Divider data-id="details-page-section-divider" />}
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Divider } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import EmptyDetailsList from '~/pages/projects/screens/detail/EmptyDetailsList';
 import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
@@ -43,7 +43,6 @@ const StorageList: React.FC = () => {
       >
         <StorageTable pvcs={pvcs} refresh={refresh} onAddPVC={() => setOpen(true)} />
       </DetailsSection>
-      {isPvcsEmpty && <Divider data-id="details-page-section-divider" />}
       <ManageStorageModal
         isOpen={isOpen}
         onClose={(submit: boolean) => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #2076
Closes: #1860

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

@andrewballantyne this solution uses custom CSS which is something we try to avoid in this project but it does make the solution simple to handle the various use cases.

There are many use cases to consider that make for a complex scenario:
- section is hidden because component is not installed
- section is hidden because section is controlled by a feature flag that is disabled
- section contains no contents and is considered 'empty' => requires divider
- section manages its own internal state and may request a divider
- section contains data => no divider
- the last section in the list => no divider
- section contains an error => no divider, displays alert box

This solution uses CSS as it requires only 2 touch points:
- Adds a class name to the stack component items (`odh-project-details-components__item`) which is used with sibling selectors to know when an item is not the last in the list
- Conditionally adds the `odh-details-section--separate` class whenever a details section wants to signal that a separator is needed. This class is automatically added if the section is empty, or overridden by the parent component.
    - `PipelinesSection` overrides this with the `showSeparator` property because it manages it's own empty state internally.

No model mesh after:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/30d3530e-85dd-4650-af96-fdfcf7e5eb57)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/dbf8230d-4484-4dfc-ba45-11f2b037b2ef)


Error state before:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/6377e302-70c7-4fd9-9850-f5501eaac3d6)

Error state after:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/353e2b06-1397-4c6a-b0a5-d83112bd6a37)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Create an empty project.
- Create a project with some data. Eg a Notebook
- Update `DataScienceCluster` to disable components.
  - Observe effect on project details view
- Update `odh-dashboard-config` to disable some features. eg `disableModelServing: true`
  - Observe effect on project details view

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated existing integration test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
