### PR TITLE
Add empty state when no serving platform is enabled

### DIFF
--- a/frontend/src/__tests__/integration/pages/clusterSettings/ClusterSettings.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/clusterSettings/ClusterSettings.stories.tsx
@@ -4,6 +4,9 @@ import { rest } from 'msw';
 import { within } from '@storybook/testing-library';
 import { mockClusterSettings } from '~/__mocks__/mockClusterSettings';
 import ClusterSettings from '~/pages/clusterSettings/ClusterSettings';
+import { AreaContext } from '~/concepts/areas/AreaContext';
+import { mockDscStatus } from '~/__mocks__/mockDscStatus';
+import { StackComponent } from '~/concepts/areas';
 
 export default {
   component: ClusterSettings,
@@ -18,7 +21,17 @@ export default {
   },
 } as Meta<typeof ClusterSettings>;
 
-const Template: StoryFn<typeof ClusterSettings> = (args) => <ClusterSettings {...args} />;
+const Template: StoryFn<typeof ClusterSettings> = (args) => (
+  <AreaContext.Provider
+    value={{
+      dscStatus: mockDscStatus({
+        installedComponents: { [StackComponent.K_SERVE]: true, [StackComponent.MODEL_MESH]: true },
+      }),
+    }}
+  >
+    <ClusterSettings {...args} />
+  </AreaContext.Provider>
+);
 
 export const Default: StoryObj = {
   render: Template,

--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
@@ -15,6 +15,9 @@ import {
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 import ModelServingContextProvider from '~/pages/modelServing/ModelServingContext';
 import ModelServingGlobal from '~/pages/modelServing/screens/global/ModelServingGlobal';
+import { AreaContext } from '~/concepts/areas/AreaContext';
+import { mockDscStatus } from '~/__mocks__/mockDscStatus';
+import { StackComponent } from '~/concepts/areas';
 
 export default {
   component: ModelServingGlobal,
@@ -56,11 +59,19 @@ export default {
 } as Meta<typeof ModelServingGlobal>;
 
 const Template: StoryFn<typeof ModelServingGlobal> = (args) => (
-  <Routes>
-    <Route path="/" element={<ModelServingContextProvider />}>
-      <Route index element={<ModelServingGlobal {...args} />} />
-    </Route>
-  </Routes>
+  <AreaContext.Provider
+    value={{
+      dscStatus: mockDscStatus({
+        installedComponents: { [StackComponent.K_SERVE]: true, [StackComponent.MODEL_MESH]: true },
+      }),
+    }}
+  >
+    <Routes>
+      <Route path="/" element={<ModelServingContextProvider />}>
+        <Route index element={<ModelServingGlobal {...args} />} />
+      </Route>
+    </Routes>
+  </AreaContext.Provider>
 );
 
 export const EmptyStateNoServingRuntime: StoryObj = {

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -89,6 +89,17 @@ test('Deploy KServe model', async ({ page }) => {
   await expect(await page.getByRole('button', { name: 'Deploy', exact: true })).toBeEnabled();
 });
 
+test('No model serving platform available', async ({ page }) => {
+  await page.goto(
+    navigateToStory(
+      'pages-modelserving-servingruntimelist',
+      'neither-platform-enabled-and-project-not-labelled',
+    ),
+  );
+
+  expect(page.getByText('No model serving platform selected')).toBeTruthy();
+});
+
 test('ModelMesh ServingRuntime list', async ({ page }) => {
   await page.goto(
     navigateToStory('pages-modelserving-servingruntimelist', 'model-mesh-list-available-models'),

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.stories.tsx
@@ -33,6 +33,9 @@ import { AppContext } from '~/app/AppContext';
 import { useApplicationSettings } from '~/app/useApplicationSettings';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import { ServingRuntimePlatform } from '~/types';
+import { AreaContext } from '~/concepts/areas/AreaContext';
+import { mockDscStatus } from '~/__mocks__/mockDscStatus';
+import { StackComponent } from '~/concepts/areas';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -181,11 +184,22 @@ const Template: StoryFn<typeof ModelServingPlatform> = (args) => {
   const { dashboardConfig, loaded } = useApplicationSettings();
   return loaded && dashboardConfig ? (
     <AppContext.Provider value={{ buildStatuses: [], dashboardConfig }}>
-      <ProjectsRoutes>
-        <Route path="/" element={<ProjectDetailsContextProvider />}>
-          <Route index element={<ModelServingPlatform {...args} />} />
-        </Route>
-      </ProjectsRoutes>
+      <AreaContext.Provider
+        value={{
+          dscStatus: mockDscStatus({
+            installedComponents: {
+              [StackComponent.K_SERVE]: true,
+              [StackComponent.MODEL_MESH]: true,
+            },
+          }),
+        }}
+      >
+        <ProjectsRoutes>
+          <Route path="/" element={<ProjectDetailsContextProvider />}>
+            <Route index element={<ModelServingPlatform {...args} />} />
+          </Route>
+        </ProjectsRoutes>
+      </AreaContext.Provider>
     </AppContext.Provider>
   ) : (
     <Spinner />
@@ -214,6 +228,20 @@ export const OnlyEnabledModelMeshAndProjectNotLabelled: StoryObj = {
       handlers: getHandlers({
         disableModelMeshConfig: false,
         disableKServeConfig: true,
+        servingRuntimes: [],
+      }),
+    },
+  },
+};
+
+export const NeitherPlatformEnabledAndProjectNotLabelled: StoryObj = {
+  render: Template,
+
+  parameters: {
+    msw: {
+      handlers: getHandlers({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
         servingRuntimes: [],
       }),
     },

--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
@@ -5,7 +5,7 @@ test('Empty project', async ({ page }) => {
   await page.goto(navigateToStory('pages-projects-projectdetails', 'empty-details-page'));
 
   // wait for page to load
-  await page.waitForSelector('text=No model servers');
+  await page.waitForSelector('text=Models and model servers');
 
   // the dividers number should always 1 less than the section number
   const sections = await page.locator('[data-id="details-page-section"]').all();

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -128,71 +128,50 @@ describe('isAreaAvailable', () => {
     });
 
     /**
-     * These tests rely on Model Serving being in a specific configuration, we may need to replace
+     * These tests rely on Custom Serving Runtime being in a specific configuration, we may need to replace
      * these tests if these become obsolete.
      */
     describe('reliantAreas', () => {
       it('should enable area if at least one reliant area is enabled', () => {
         // Make sure this test is valid
-        expect(SupportedAreasStateMap[SupportedArea.MODEL_SERVING].reliantAreas).toEqual([
-          SupportedArea.K_SERVE,
-          SupportedArea.MODEL_MESH,
+        expect(SupportedAreasStateMap[SupportedArea.CUSTOM_RUNTIMES].reliantAreas).toEqual([
+          SupportedArea.MODEL_SERVING,
         ]);
 
         // Test both reliant areas
-        const isAvailableReliantModelMesh = isAreaAvailable(
-          SupportedArea.MODEL_SERVING,
+        const isAvailableReliantCustomRuntimes = isAreaAvailable(
+          SupportedArea.CUSTOM_RUNTIMES,
           mockDashboardConfig({ disableModelServing: false }).spec,
-          mockDscStatus({ installedComponents: { [StackComponent.MODEL_MESH]: true } }),
+          mockDscStatus({}),
         );
 
-        expect(isAvailableReliantModelMesh.status).toBe(true);
-        expect(isAvailableReliantModelMesh.featureFlags).toEqual({ ['disableModelServing']: 'on' });
-        expect(isAvailableReliantModelMesh.reliantAreas).toEqual({
-          [SupportedArea.K_SERVE]: false,
-          [SupportedArea.MODEL_MESH]: true,
+        expect(isAvailableReliantCustomRuntimes.status).toBe(true);
+        expect(isAvailableReliantCustomRuntimes.featureFlags).toEqual({
+          ['disableCustomServingRuntimes']: 'on',
         });
-        expect(isAvailableReliantModelMesh.requiredComponents).toBe(null);
-
-        const isAvailableReliantKServe = isAreaAvailable(
-          SupportedArea.MODEL_SERVING,
-          mockDashboardConfig({ disableModelServing: false }).spec,
-          mockDscStatus({ installedComponents: { [StackComponent.K_SERVE]: true } }),
-        );
-
-        expect(isAvailableReliantKServe.status).toBe(true);
-        expect(isAvailableReliantKServe.featureFlags).toEqual({ ['disableModelServing']: 'on' });
-        expect(isAvailableReliantKServe.reliantAreas).toEqual({
-          [SupportedArea.K_SERVE]: true,
-          [SupportedArea.MODEL_MESH]: false,
+        expect(isAvailableReliantCustomRuntimes.reliantAreas).toEqual({
+          [SupportedArea.MODEL_SERVING]: true,
         });
-        expect(isAvailableReliantKServe.requiredComponents).toBe(null);
+        expect(isAvailableReliantCustomRuntimes.requiredComponents).toBe(null);
       });
 
       it('should disable area if reliant areas are all disabled', () => {
         // Make sure this test is valid
-        expect(SupportedAreasStateMap[SupportedArea.MODEL_SERVING].reliantAreas).toEqual([
-          SupportedArea.K_SERVE,
-          SupportedArea.MODEL_MESH,
+        expect(SupportedAreasStateMap[SupportedArea.CUSTOM_RUNTIMES].reliantAreas).toEqual([
+          SupportedArea.MODEL_SERVING,
         ]);
 
-        // Test both areas disabled
+        // Test areas disabled
         const isAvailable = isAreaAvailable(
-          SupportedArea.MODEL_SERVING,
-          mockDashboardConfig({ disableModelServing: false }).spec,
-          mockDscStatus({
-            installedComponents: {
-              [StackComponent.K_SERVE]: false,
-              [StackComponent.MODEL_MESH]: false,
-            },
-          }),
+          SupportedArea.CUSTOM_RUNTIMES,
+          mockDashboardConfig({ disableModelServing: true }).spec,
+          mockDscStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
-        expect(isAvailable.featureFlags).toEqual({ ['disableModelServing']: 'on' });
+        expect(isAvailable.featureFlags).toEqual({ ['disableCustomServingRuntimes']: 'on' });
         expect(isAvailable.reliantAreas).toEqual({
-          [SupportedArea.K_SERVE]: false,
-          [SupportedArea.MODEL_MESH]: false,
+          [SupportedArea.MODEL_SERVING]: false,
         });
         expect(isAvailable.requiredComponents).toBe(null);
       });

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -23,16 +23,15 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.DS_PROJECTS_VIEW],
   },
   [SupportedArea.K_SERVE]: {
-    //featureFlags: ['disableKServe'], // TODO: validate KServe feature flag
+    featureFlags: ['disableKServe'],
     requiredComponents: [StackComponent.K_SERVE],
   },
   [SupportedArea.MODEL_MESH]: {
-    //featureFlags: ['disableModelMesh'], // TODO: validate ModelMesh feature flag
+    featureFlags: ['disableModelMesh'],
     requiredComponents: [StackComponent.MODEL_MESH],
   },
   [SupportedArea.MODEL_SERVING]: {
     featureFlags: ['disableModelServing'],
-    reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_MESH],
   },
   [SupportedArea.USER_MANAGEMENT]: {
     featureFlags: ['disableUserManagement'],

--- a/frontend/src/concepts/areas/index.ts
+++ b/frontend/src/concepts/areas/index.ts
@@ -6,6 +6,6 @@
   determine the state we are in.
 */
 export { default as AreaComponent, conditionalArea } from './AreaComponent';
-export { SupportedArea } from './types';
+export { SupportedArea, StackComponent } from './types';
 export { default as useIsAreaAvailable } from './useIsAreaAvailable';
 export { isAreaAvailable } from './utils';

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -17,6 +17,7 @@ import CullerSettings from '~/pages/clusterSettings/CullerSettings';
 import TelemetrySettings from '~/pages/clusterSettings/TelemetrySettings';
 import TolerationSettings from '~/pages/clusterSettings/TolerationSettings';
 import ModelServingPlatformSettings from '~/pages/clusterSettings/ModelServingPlatformSettings';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import {
   DEFAULT_CONFIG,
   DEFAULT_PVC_SIZE,
@@ -34,6 +35,7 @@ const ClusterSettings: React.FC = () => {
   const [userTrackingEnabled, setUserTrackingEnabled] = React.useState(false);
   const [cullerTimeout, setCullerTimeout] = React.useState(DEFAULT_CULLER_TIMEOUT);
   const { dashboardConfig } = useAppContext();
+  const modelServingEnabled = useIsAreaAvailable(SupportedArea.MODEL_SERVING);
   const isJupyterEnabled = useCheckJupyterEnabled();
   const [notebookTolerationSettings, setNotebookTolerationSettings] =
     React.useState<NotebookTolerationFormSettings>({
@@ -140,13 +142,15 @@ const ClusterSettings: React.FC = () => {
       provideChildrenPadding
     >
       <Stack hasGutter>
-        <StackItem>
-          <ModelServingPlatformSettings
-            initialValue={clusterSettings.modelServingPlatformEnabled}
-            enabledPlatforms={modelServingEnabledPlatforms}
-            setEnabledPlatforms={setModelServingEnabledPlatforms}
-          />
-        </StackItem>
+        {modelServingEnabled && (
+          <StackItem>
+            <ModelServingPlatformSettings
+              initialValue={clusterSettings.modelServingPlatformEnabled}
+              enabledPlatforms={modelServingEnabledPlatforms}
+              setEnabledPlatforms={setModelServingEnabledPlatforms}
+            />
+          </StackItem>
+        )}
         <StackItem>
           <PVCSizeSettings
             initialValue={clusterSettings.pvcSize}

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -3,17 +3,32 @@ import {
   Alert,
   AlertActionCloseButton,
   AlertVariant,
+  Button,
   Checkbox,
+  Flex,
+  FlexItem,
+  Popover,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import SettingSection from '~/components/SettingSection';
 import { ModelServingPlatformEnabled } from '~/types';
+import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
+import { useAccessReview } from '~/api';
+import { AccessReviewResourceAttributes } from '~/k8sTypes';
+import { useOpenShiftURL } from '~/utilities/clusterUtils';
 
 type ModelServingPlatformSettingsProps = {
   initialValue: ModelServingPlatformEnabled;
   enabledPlatforms: ModelServingPlatformEnabled;
   setEnabledPlatforms: (platforms: ModelServingPlatformEnabled) => void;
+};
+
+const accessReviewResource: AccessReviewResourceAttributes = {
+  group: 'datasciencecluster.opendatahub.io/v1',
+  resource: 'DataScienceCluster',
+  verb: 'update',
 };
 
 const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> = ({
@@ -22,9 +37,18 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
   setEnabledPlatforms,
 }) => {
   const [alert, setAlert] = React.useState<{ variant: AlertVariant; message: string }>();
+  const {
+    kServe: { installed: kServeInstalled },
+    modelMesh: { installed: modelMeshInstalled },
+  } = useServingPlatformStatuses();
+
+  const [allowUpdate] = useAccessReview(accessReviewResource);
+  const url = useOpenShiftURL();
 
   React.useEffect(() => {
-    if (!enabledPlatforms.kServe && !enabledPlatforms.modelMesh) {
+    const kServeDisabled = !enabledPlatforms.kServe || !kServeInstalled;
+    const modelMeshDisabled = !enabledPlatforms.modelMesh || !modelMeshInstalled;
+    if (kServeDisabled && modelMeshDisabled) {
       setAlert({
         variant: AlertVariant.warning,
         message:
@@ -47,18 +71,51 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
         setAlert(undefined);
       }
     }
-  }, [enabledPlatforms, initialValue]);
+  }, [enabledPlatforms, initialValue, kServeInstalled, modelMeshInstalled]);
 
   return (
     <SettingSection
       title="Model serving platforms"
-      description="Select the serving platforms that projects on this cluster can use for deploying models."
+      description={
+        <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>
+            Select the serving platforms that projects on this cluster can use for deploying models.
+          </FlexItem>
+          <Popover
+            bodyContent={
+              <>
+                To modify the availability of model serving platforms, ask your cluster admin to
+                manage the respective components in the{' '}
+                {allowUpdate && url ? (
+                  <Button
+                    isInline
+                    variant="link"
+                    onClick={() => {
+                      window.open(
+                        `${url}/k8s/cluster/datasciencecluster.opendatahub.io~v1~DataScienceCluster`,
+                      );
+                    }}
+                  >
+                    DataScienceCluster
+                  </Button>
+                ) : (
+                  'DataScienceCluster'
+                )}{' '}
+                resource.
+              </>
+            }
+          >
+            <OutlinedQuestionCircleIcon />
+          </Popover>
+        </Flex>
+      }
     >
       <Stack hasGutter>
         <StackItem>
           <Checkbox
             label="Single model serving platform"
-            isChecked={enabledPlatforms.kServe}
+            isDisabled={!kServeInstalled}
+            isChecked={kServeInstalled && enabledPlatforms.kServe}
             onChange={(enabled) => {
               const newEnabledPlatforms: ModelServingPlatformEnabled = {
                 ...enabledPlatforms,
@@ -75,7 +132,8 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
         <StackItem>
           <Checkbox
             label="Multi-model serving platform"
-            isChecked={enabledPlatforms.modelMesh}
+            isDisabled={!modelMeshInstalled}
+            isChecked={modelMeshInstalled && enabledPlatforms.modelMesh}
             onChange={(enabled) => {
               const newEnabledPlatforms: ModelServingPlatformEnabled = {
                 ...enabledPlatforms,

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels.tsx
@@ -2,27 +2,22 @@ import * as React from 'react';
 import { Button, Icon, Label, LabelGroup, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-import { useAppContext } from '~/app/AppContext';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 const CustomServingRuntimeHeaderLabels: React.FC = () => {
-  const {
-    dashboardConfig: {
-      spec: {
-        dashboardConfig: { disableKServe, disableModelMesh },
-      },
-    },
-  } = useAppContext();
+  const kServeEnabled = useIsAreaAvailable(SupportedArea.K_SERVE).status;
+  const modelMeshEnabled = useIsAreaAvailable(SupportedArea.MODEL_MESH).status;
 
-  if (disableKServe && disableModelMesh) {
+  if (!kServeEnabled && !modelMeshEnabled) {
     return null;
   }
 
   return (
     <>
       <LabelGroup>
-        {!disableKServe && <Label>Single model serving enabled</Label>}
-        {!disableModelMesh && <Label>Multi-model serving enabled</Label>}
+        {kServeEnabled && <Label>Single model serving enabled</Label>}
+        {modelMeshEnabled && <Label>Multi-model serving enabled</Label>}
       </LabelGroup>
       <Popover
         showClose

--- a/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
 import EmptyModelServing from './EmptyModelServing';
 import InferenceServiceListView from './InferenceServiceListView';
 
@@ -10,10 +11,21 @@ const ModelServingGlobal: React.FC = () => {
     inferenceServices: { data: inferenceServices },
   } = React.useContext(ModelServingContext);
 
+  const {
+    kServe: { installed: kServeInstalled },
+    modelMesh: { installed: modelMeshInstalled },
+  } = useServingPlatformStatuses();
+
+  const loadError =
+    !kServeInstalled && !modelMeshInstalled
+      ? new Error('No model serving platform installed')
+      : undefined;
+
   return (
     <ApplicationsPage
       title="Deployed models"
       description="Manage and view the health and performance of your deployed models."
+      loadError={loadError}
       loaded
       empty={servingRuntimes.length === 0 || inferenceServices.length === 0}
       emptyStatePage={<EmptyModelServing />}

--- a/frontend/src/pages/modelServing/screens/projects/EmptyModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyModelServingPlatform.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { WrenchIcon } from '@patternfly/react-icons';
+
+const EmptyModelServingPlatform: React.FC = () => (
+  <EmptyState variant="xs">
+    <EmptyStateIcon icon={WrenchIcon} />
+    <Title headingLevel="h3" size="lg">
+      No model serving platform selected
+    </Title>
+    <EmptyStateBody>
+      To enable model serving, an administrator must first select a model serving platform in the
+      cluster settings.
+    </EmptyStateBody>
+  </EmptyState>
+);
+
+export default EmptyModelServingPlatform;

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelect.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelect.tsx
@@ -10,17 +10,24 @@ import {
 import { ServingRuntimePlatform } from '~/types';
 import ModelServingPlatformCard from '~/pages/modelServing/screens/projects/ModelServingPlatformCard';
 import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import EmptyModelServingPlatform from '~/pages/modelServing/screens/projects/EmptyModelServingPlatform';
 
 type ModelServingPlatformSelectProps = {
   onSelect: (platform: ServingRuntimePlatform) => void;
   emptyTemplates: boolean;
+  emptyPlatforms: boolean;
 };
 
 const ModelServingPlatformSelect: React.FC<ModelServingPlatformSelectProps> = ({
   onSelect,
   emptyTemplates,
+  emptyPlatforms,
 }) => {
   const [alertShown, setAlertShown] = React.useState(true);
+  if (emptyPlatforms) {
+    return <EmptyModelServingPlatform />;
+  }
+
   return (
     <Stack hasGutter>
       <StackItem>

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -81,3 +81,14 @@ export type ServingRuntimeEditInfo = {
   servingRuntime?: ServingRuntimeKind;
   secrets: SecretKind[];
 };
+
+export type ServingPlatformStatuses = {
+  kServe: {
+    enabled: boolean;
+    installed: boolean;
+  };
+  modelMesh: {
+    enabled: boolean;
+    installed: boolean;
+  };
+};

--- a/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
+++ b/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
@@ -1,0 +1,24 @@
+import { StackComponent, SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
+
+const useServingPlatformStatuses = (): ServingPlatformStatuses => {
+  const kServeStatus = useIsAreaAvailable(SupportedArea.K_SERVE);
+  const modelMeshStatus = useIsAreaAvailable(SupportedArea.MODEL_MESH);
+  const kServeEnabled = kServeStatus.status;
+  const modelMeshEnabled = modelMeshStatus.status;
+  const kServeInstalled = !!kServeStatus.requiredComponents?.[StackComponent.K_SERVE];
+  const modelMeshInstalled = !!modelMeshStatus.requiredComponents?.[StackComponent.MODEL_MESH];
+
+  return {
+    kServe: {
+      enabled: kServeEnabled,
+      installed: kServeInstalled,
+    },
+    modelMesh: {
+      enabled: modelMeshEnabled,
+      installed: modelMeshInstalled,
+    },
+  };
+};
+
+export default useServingPlatformStatuses;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #1994 
Closes #1995

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There are several checks in this PR:

**When the platforms are installed:**
When we enter an unlabelled project and both `disableKServe` and `disableModelMesh` feature flags are set to `true`, you will get the empty state to tell you to ask for the administrator to enable platform selection.

<img width="1728" alt="Screenshot 2023-11-08 at 2 39 50 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/c6ac349d-0abc-4ccd-86d4-0901005bb927">

---

**When either platform is not installed:**

On the cluster settings page:

1. You will see the grey out checkbox which prevents you from enabling it if the platform is not installed on the cluster
2. If you are the cluster admin, you will see the link to bring you to the `DataScienceCluster` resource page on the OpenShift console

<img width="1407" alt="Screenshot 2023-11-09 at 4 59 06 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/7ff25aec-788a-4dca-b506-0cfd6a546a1e">

<img width="1728" alt="Screenshot 2023-11-09 at 4 59 55 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/743c3d24-5c21-4ab8-ae46-faff5bc22f05">

3. If you don't have edit access to `DataScienceCluster`, the link button will be a plain text

<img width="1407" alt="Screenshot 2023-11-09 at 4 55 04 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/8e59e1e8-9a2c-41c1-91a8-8d7883da9316">

---

On project details page:

If the project is labeled already but the serving platform in not installed at all, you will see a loading error 

<img width="1255" alt="Screenshot 2023-11-09 at 5 03 50 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/4738f8dd-0ee3-420e-b3cb-fa98bfd37ecb">

---

**When both platforms are not installed:**

You will see an error page on the global model serving page:

<img width="1728" alt="Screenshot 2023-11-09 at 5 05 27 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/77236432-d148-4ce8-85c3-3b2c2e38acf7">

Of course, the cluster settings page grey both of them out because we only hide this section when you fully disable model serving.

<img width="1401" alt="Screenshot 2023-11-09 at 5 06 02 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/133ecb85-339e-4bec-b7c4-20f035b7dcfa">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are several parts of this:
First part:
1. You need to make sure you get both model serving platforms installed on the cluster
2. Go to the cluster settings or dashboard config, disable both of the available platforms
3. Wait for 2 mins
4. Create a new project and go to the model serving section, you will see the empty state as is shown above in the description
5. The labeled projects should still be able to see the model/model server list

Second part:
1. Now you can try to remove one of the serving platforms by changing the component from `Managed` to `Removed`, making sure the status changed to `false`, which means that platform is not available anymore
2. Go to the cluster settings page, make sure the corresponding checkbox is greyed out
3. Click on the help icon on the description, make sure you could see the text and access the link the the `DataScienceCluster` resource
4. Try to impersonate a dashboard admin but not cluster admin user, you should only be able to see the plain text in the popover, but not the link
5. Try to go to a project you created before, it's better to be a project with the serving platform labeled already and you removed the platform, you should see a loading error

Third part:
1. Now you can removed the other serving platform, now none of the serving platform is available
2. Go to the global model serving page, you should error an error state and cannot see any deployed model now

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Update some feature flag related tests, and add an integration test to test the empty state.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
