### PR TITLE
fixed ux on label text for image in workbench table

### DIFF
--- a/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
+++ b/frontend/src/__tests__/integration/pages/projects/ProjectDetails.spec.ts
@@ -54,5 +54,5 @@ test('Notebook with unknown image', async ({ page }) => {
   await page.waitForSelector('text=Test Notebook');
 
   await expect(page.getByText('Deleted')).toHaveCount(1);
-  await expect(page.getByText('Unknown', { exact: true })).toHaveCount(1);
+  await expect(page.getByText('unknown', { exact: true })).toHaveCount(1);
 });

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -65,8 +65,12 @@ export const NotebookImageDisplayName = ({
         variant: 'info',
       };
     } else if (notebookImage.imageAvailability === NotebookImageAvailability.DELETED) {
-      const unknownBody =
-        'An unknown notebook image has been deleted. To run this workbench, select a new notebook image.';
+      const unknownBody = (
+        <p>
+          An <b>unknown</b> notebook image has been deleted. To run this workbench, select a new
+          notebook image.
+        </p>
+      );
       const knownBody = (
         <p>
           The <b>{notebookImage.imageDisplayName}</b> notebook image has been deleted. To run this
@@ -129,7 +133,7 @@ export const NotebookImageDisplayName = ({
         <FlexItem>
           <HelperText>
             <HelperTextItem variant={notebookImage.imageDisplayName ? 'default' : 'indeterminate'}>
-              {notebookImage.imageDisplayName || 'Unknown'}
+              {notebookImage.imageDisplayName || 'unknown'}
             </HelperTextItem>
           </HelperText>
         </FlexItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

closes: https://github.com/opendatahub-io/odh-dashboard/issues/1370

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updated text to lowercase and bolded text in popover

<img width="425" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/90994c10-dc42-4e39-b598-dd5e83ee9112">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run storybook and navigate to the unknown story to view what a image looks like when a workbench references an image that does not exists and does not have a past name

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated test to reflect `Unknown` to `unknown`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

@xianli123 This is just a fix from the past mocks

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
