### PR TITLE
Performance metric chart needs area charts to be in a stack

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -40,7 +40,6 @@ import {
 import {
   convertTimestamp,
   createGraphMetricLine,
-  defaultDomainCalculator,
   formatToShow,
   getThresholdData,
   useStableMetrics,
@@ -63,7 +62,7 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
   color,
   metrics: unstableMetrics,
   thresholds = [],
-  domain = defaultDomainCalculator,
+  domain,
   toolbar,
   type = MetricsChartTypes.AREA,
   isStack = false,
@@ -189,7 +188,7 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
             <Chart
               ariaTitle={title}
               containerComponent={containerComponent}
-              domain={domain(maxYValue, minYValue)}
+              domain={domain ? domain(maxYValue, minYValue) : undefined}
               height={400}
               width={chartWidth}
               padding={{ left: 70, right: 50, bottom: 70, top: 50 }}

--- a/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
@@ -34,6 +34,7 @@ const ModelGraphs: React.FC = () => {
           ]}
           title="Http requests (x100)"
           theme={SUCCESS_FAIL_CHART_THEME}
+          isStack
         />
       </StackItem>
     </Stack>

--- a/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
@@ -6,7 +6,6 @@ import {
   ModelServingMetricsContext,
 } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
-import { SUCCESS_FAIL_CHART_THEME } from '~/pages/modelServing/screens/metrics/const';
 import { per100 } from './utils';
 
 const ModelGraphs: React.FC = () => {
@@ -32,8 +31,8 @@ const ModelGraphs: React.FC = () => {
               translatePoint: per100,
             },
           ]}
+          color="blue"
           title="Http requests (x100)"
-          theme={SUCCESS_FAIL_CHART_THEME}
           isStack
         />
       </StackItem>

--- a/frontend/src/pages/modelServing/screens/metrics/ServerGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ServerGraphs.tsx
@@ -32,6 +32,7 @@ const ServerGraphs: React.FC = () => {
           }}
           color="blue"
           title="Http requests (x100)"
+          isStack
         />
       </StackItem>
       <StackItem>

--- a/frontend/src/pages/modelServing/screens/metrics/const.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/const.ts
@@ -88,6 +88,7 @@ const themeProps = {
   chart: { colorScale },
   group: { colorScale },
   legend: { colorScale },
+  stack: { colorScale },
 };
 
 export const SUCCESS_FAIL_CHART_THEME = mergeTheme(ChartThemeColor.default, themeProps);

--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -14,7 +14,6 @@ import {
 import { QueryTimeframeStep } from '~/pages/modelServing/screens/const';
 import {
   BiasSelectOption,
-  DomainCalculator,
   GraphMetricLine,
   GraphMetricPoint,
   MetricChartLine,
@@ -169,10 +168,6 @@ export const useStableMetrics = (
   }
   return metricsRef.current;
 };
-
-export const defaultDomainCalculator: DomainCalculator = (maxYValue) => ({
-  y: maxYValue === 0 ? [0, 1] : [0, maxYValue],
-});
 
 export const getBreadcrumbItemComponents = (breadcrumbItems: BreadcrumbItemType[]) =>
   breadcrumbItems.map((item) => (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #2090 
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Makes the following changes:
* Model metrics and server metrics HTTP requests charts are now stacks
* Fixes a bug with stack charts where the domain is truncated
* Changes the colour scheme away from red / green to avoid a11y issues

<img width="2273" alt="issue-2090" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/b8d5dab5-adc2-4610-99d8-6340455e8b72">
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Check the HTTP charts for server and model metrics ensuring they are now a stack (i.e. successful and failed requests add up to a total value, so if there are 5 failed requests and 5 successful requests at the same time, the total on the graph should be 10 at that point).

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Area is not yet tested so no impact.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
