### PR TITLE
Removes x100 scale from HTTP request charts

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -40,6 +40,7 @@ import {
 import {
   convertTimestamp,
   createGraphMetricLine,
+  defaultDomainCalculator,
   formatToShow,
   getThresholdData,
   useStableMetrics,
@@ -62,7 +63,7 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
   color,
   metrics: unstableMetrics,
   thresholds = [],
-  domain,
+  domain = defaultDomainCalculator,
   toolbar,
   type = MetricsChartTypes.AREA,
   isStack = false,
@@ -188,7 +189,7 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
             <Chart
               ariaTitle={title}
               containerComponent={containerComponent}
-              domain={domain ? domain(maxYValue, minYValue) : undefined}
+              domain={domain(maxYValue, minYValue)}
               height={400}
               width={chartWidth}
               padding={{ left: 70, right: 50, bottom: 70, top: 50 }}

--- a/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
@@ -21,18 +21,16 @@ const ModelGraphs: React.FC = () => {
               metric: data[
                 ModelMetricType.REQUEST_COUNT_SUCCESS
               ] as ContextResourceData<PrometheusQueryRangeResultValue>,
-              translatePoint: per100,
             },
             {
               name: 'Failed',
               metric: data[
                 ModelMetricType.REQUEST_COUNT_FAILED
               ] as ContextResourceData<PrometheusQueryRangeResultValue>,
-              translatePoint: per100,
             },
           ]}
           color="blue"
-          title="Http requests (x100)"
+          title="HTTP requests"
           isStack
         />
       </StackItem>

--- a/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelGraphs.tsx
@@ -6,7 +6,6 @@ import {
   ModelServingMetricsContext,
 } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
-import { per100 } from './utils';
 
 const ModelGraphs: React.FC = () => {
   const { data } = React.useContext(ModelServingMetricsContext);

--- a/frontend/src/pages/modelServing/screens/metrics/ServerGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ServerGraphs.tsx
@@ -7,7 +7,6 @@ import {
 } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import {
   convertPrometheusNaNToZero,
-  per100,
   toPercentage,
 } from '~/pages/modelServing/screens/metrics/utils';
 import {

--- a/frontend/src/pages/modelServing/screens/metrics/ServerGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ServerGraphs.tsx
@@ -28,10 +28,9 @@ const ServerGraphs: React.FC = () => {
             metric: data[
               ServerMetricType.REQUEST_COUNT
             ] as ContextResourceData<PrometheusQueryRangeResultValue>,
-            translatePoint: per100,
           }}
           color="blue"
-          title="Http requests (x100)"
+          title="HTTP requests"
           isStack
         />
       </StackItem>

--- a/frontend/src/pages/modelServing/screens/metrics/types.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/types.ts
@@ -42,7 +42,10 @@ export type MetricChartThreshold = {
   label?: string;
 };
 
-export type DomainCalculator = (maxYValue: number, minYValue: number) => ForAxes<DomainTuple>;
+export type DomainCalculator = (
+  maxYValue: number,
+  minYValue: number,
+) => ForAxes<DomainTuple> | undefined;
 
 export enum MetricsChartTypes {
   AREA,

--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -14,6 +14,7 @@ import {
 import { QueryTimeframeStep } from '~/pages/modelServing/screens/const';
 import {
   BiasSelectOption,
+  DomainCalculator,
   GraphMetricLine,
   GraphMetricPoint,
   MetricChartLine,
@@ -321,3 +322,6 @@ export const convertPrometheusNaNToZero = (
   data: PrometheusQueryRangeResultValue[],
 ): PrometheusQueryRangeResultValue[] =>
   data.map((value) => [value[0], isNaN(Number(value[1])) ? '0' : value[1]]);
+
+export const defaultDomainCalculator: DomainCalculator = (maxYValue, minYValue) =>
+  maxYValue === 0 && minYValue === 0 ? { y: [0, 10] } : undefined;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #2091 
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
* Removes x100 scale from HTTP requests charts on model and server metrics screens.

Model metrics:
<img width="2253" alt="Screenshot 2023-11-10 at 13 42 52" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/8f9c5d03-2ed0-4c75-b4da-e9a5ebdb9464">
Server metrics:
<img width="2232" alt="Screenshot 2023-11-10 at 13 44 43" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/65301fa6-4184-4f21-82d1-b115fbab7849">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Open metrics pages and verify there is no scale applied to the graph data

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
