### PR TITLE
Edge Model Registry - Sidebar and EmptyState

### DIFF
--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -47,6 +47,7 @@ spec:
     disableModelServing: false
     disableProjectSharing: false
     disableCustomServingRuntimes: false
+    disableEdge: false
     modelMetricsNamespace: ''
 ```
 
@@ -136,6 +137,7 @@ spec:
     disableModelServing: true
     disableProjectSharing: true
     disableCustomServingRuntimes: false
+    disableEdge: true
     modelMetricsNamespace: ''
   notebookController:
     enabled: true

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -13,6 +13,7 @@ type MockDashboardConfigType = {
   disablePipelines?: boolean;
   disableModelServing?: boolean;
   disableCustomServingRuntimes?: boolean;
+  disableEdge?: boolean;
 };
 
 export const mockDashboardConfig = ({
@@ -28,6 +29,7 @@ export const mockDashboardConfig = ({
   disableModelServing = false,
   disableCustomServingRuntimes = false,
   disablePipelines = false,
+  disableEdge = false,
 }: MockDashboardConfigType): DashboardConfigKind => ({
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',
@@ -55,6 +57,7 @@ export const mockDashboardConfig = ({
       disablePipelines,
       modelMetricsNamespace: 'test-project',
       disableProjectSharing: false,
+      disableEdge,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/__tests__/integration/pages/edge/EdgeModels.spec.ts
+++ b/frontend/src/__tests__/integration/pages/edge/EdgeModels.spec.ts
@@ -1,0 +1,9 @@
+import { test } from '@playwright/test';
+import { navigateToStory } from '~/__tests__/integration/utils';
+
+test('Empty State No models in Registry', async ({ page }) => {
+  await page.goto(navigateToStory('pages-edge-edgemodels', 'empty-state-no-models-in-registry'));
+
+  // wait for page to load
+  await page.waitForSelector('text=No models added');
+});

--- a/frontend/src/__tests__/integration/pages/edge/EdgeModels.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/edge/EdgeModels.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { StoryFn, StoryObj } from '@storybook/react';
+import EdgeModels from '~/pages/edge/EdgeModels';
+
+export default {
+  component: EdgeModels,
+};
+
+const Template: StoryFn<typeof EdgeModels> = (args) => <EdgeModels {...args} />;
+
+export const EmptyStateNoModelsInRegistry: StoryObj = {
+  render: Template,
+};

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -18,7 +18,7 @@ const ModelServingRoutes = React.lazy(() => import('../pages/modelServing/ModelS
 const NotebookController = React.lazy(
   () => import('../pages/notebookController/NotebookController'),
 );
-
+const EdgeModelsRoutes = React.lazy(() => import('../pages/edge/EdgeModelsRoutes'));
 const GlobalPipelinesRoutes = React.lazy(() => import('../pages/pipelines/GlobalPipelinesRoutes'));
 const GlobalPipelineRunsRoutes = React.lazy(
   () => import('../pages/pipelines/GlobalPipelineRunsRoutes'),
@@ -80,7 +80,7 @@ const AppRoutes: React.FC = () => {
             <Route path="/groupSettings" element={<GroupSettingsPage />} />
           </>
         )}
-
+        <Route path="/edge/*" element={<EdgeModelsRoutes />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </React.Suspense>

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -42,4 +42,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     requiredComponents: [StackComponent.WORKBENCHES],
     reliantAreas: [SupportedArea.DS_PROJECTS_VIEW],
   },
+  [SupportedArea.EDGE]: {
+    featureFlags: ['disableEdge'],
+  },
 };

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -36,6 +36,9 @@ export enum SupportedArea {
   CUSTOM_RUNTIMES = 'custom-serving-runtimes',
   K_SERVE = 'kserve',
   MODEL_MESH = 'model-mesh',
+
+  /* Edge */
+  EDGE = 'edge',
 }
 
 /** Components deployed by the Operator. Part of the DSC Status. */

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -740,6 +740,7 @@ export type DashboardCommonConfig = {
   disableCustomServingRuntimes: boolean;
   modelMetricsNamespace: string;
   disablePipelines: boolean;
+  disableEdge: boolean;
 };
 
 export type OperatorStatus = {

--- a/frontend/src/pages/edge/EdgeModels.tsx
+++ b/frontend/src/pages/edge/EdgeModels.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import EmptyEdgeModels from './EmptyEdgeModels';
+
+const EdgeModels: React.FC = () => (
+  <ApplicationsPage
+    title="Models"
+    description={''}
+    loaded={true}
+    empty={true}
+    emptyStatePage={<EmptyEdgeModels />}
+  />
+);
+
+export default EdgeModels;

--- a/frontend/src/pages/edge/EdgeModelsRoutes.tsx
+++ b/frontend/src/pages/edge/EdgeModelsRoutes.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import EdgeModels from './EdgeModels';
+
+const EdgeModelsRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/models" element={<EdgeModels />} />
+  </Routes>
+);
+
+export default EdgeModelsRoutes;

--- a/frontend/src/pages/edge/EmptyEdgeModels.tsx
+++ b/frontend/src/pages/edge/EmptyEdgeModels.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  Title,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+const EmptyEdgeModels: React.FC = () => (
+  <PageSection isFilled>
+    <EmptyState variant={EmptyStateVariant.large}>
+      <EmptyStateIcon icon={PlusCircleIcon} />
+      <Title headingLevel="h1" size="lg">
+        No models added
+      </Title>
+      <EmptyStateBody>
+        To get started, add a model. Adding a model will also initiate a pipeline that will build
+        the model and its dependencies into a container image and save that image in a container
+        image registry.
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default EmptyEdgeModels;

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -90,6 +90,15 @@ const useDSPipelinesNav = (): NavDataItem[] => {
   ];
 };
 
+const useEdgeMVPNav = (): NavDataItem[] =>
+  useAreaCheck(SupportedArea.EDGE, [
+    {
+      id: 'edgemvp',
+      group: { id: 'edge', title: 'Edge MVP' },
+      children: [{ id: 'edge-model-registry', label: 'Models', href: '/edge/models' }],
+    },
+  ]);
+
 const useModelServingNav = (): NavDataItem[] =>
   useAreaCheck(SupportedArea.MODEL_SERVING, [
     { id: 'modelServing', label: 'Model Serving', href: '/modelServing' },
@@ -162,6 +171,7 @@ export const useBuildNavData = (): NavDataItem[] => [
   ...useDSProjectsNav(),
   ...useDSPipelinesNav(),
   ...useModelServingNav(),
+  ...useEdgeMVPNav(),
   ...useResourcesNav(),
   ...useSettingsNav(),
 ];

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -53,6 +53,8 @@ spec:
                       type: string
                     disablePipelines:
                       type: boolean
+                    disableEdge:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -18,6 +18,7 @@ spec:
     disableModelServing: true
     disableProjectSharing: true
     disableCustomServingRuntimes: true
+    disableEdge: true
     modelMetricsNamespace: ''
   notebookController:
     enabled: true


### PR DESCRIPTION
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/2061

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
As part of new Edge specific initiatives, this PR introduces new section for Edge MVP and an empty state component on the new Model Registry page.

Its just the first step in Edge initiative and there will be more features introduced soon.

<img width="1500" alt="Screenshot 2023-11-22 at 5 30 01 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/40579476/4c1ca38e-07ad-42ab-b233-b2bda605264e">



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Click Edge MVP option on the sidebar and select Model Registry

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Integration Testing: Included simple test to check the title of EmptyState has rendered.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
