### PR TITLE
Change empty global model mesh serving link text to project display name

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.spec.ts
@@ -10,7 +10,7 @@ test('Empty State No Serving Runtime', async ({ page }) => {
   await page.waitForSelector('text=No deployed models yet');
 
   // Test that the button is enabled
-  await expect(page.getByRole('button', { name: 'Go to the Projects page' })).toBeTruthy();
+  await expect(page.getByRole('button', { name: 'Go to Test Project' })).toBeTruthy();
 });
 
 test('Empty State No Inference Service', async ({ page }) => {

--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -16,6 +16,7 @@ import { getProjectModelServingPlatform } from '~/pages/modelServing/screens/pro
 import { ServingRuntimePlatform } from '~/types';
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
+import { getProjectDisplayName } from '~/pages/projects/utils';
 import ServeModelButton from './ServeModelButton';
 
 const EmptyModelServing: React.FC = () => {
@@ -47,11 +48,9 @@ const EmptyModelServing: React.FC = () => {
         <EmptyStateSecondaryActions>
           <Button
             variant="link"
-            onClick={() =>
-              navigate(project?.metadata.name ? `/projects/${project.metadata.name}` : '/projects')
-            }
+            onClick={() => navigate(project ? `/projects/${project.metadata.name}` : '/projects')}
           >
-            {project?.metadata.name ? `Go to ${project.metadata.name}` : 'Select a project'}
+            {project ? `Go to ${getProjectDisplayName(project)}` : 'Select a project'}
           </Button>
         </EmptyStateSecondaryActions>
       </EmptyState>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #2132 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change the link button text

<img width="1728" alt="Screenshot 2023-11-13 at 1 58 17 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/78742835-f88c-4d7e-8f02-5b9badd7ec09">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the global model serving page
2. Select a project, it needs to be a model mesh labelled project with no model server added yet
3. You will see the screenshot above
4. Make sure you see the project name is the display name but not the k8s name

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Change the test case a little bit to reflect the change in this PR

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
