### PR TITLE
Use sync preferred project when switching to global model serving page

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { StoryFn, Meta, StoryObj } from '@storybook/react';
 import { rest } from 'msw';
 import { within, userEvent } from '@storybook/testing-library';
-// import { expect } from '@storybook/jest';
 import { Route, Routes } from 'react-router-dom';
 import { Spinner } from '@patternfly/react-core';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -3,10 +3,9 @@ import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import { getProjectDisplayName } from '~/pages/projects/utils';
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import useMountProjectRefresh from '~/concepts/projects/useMountProjectRefresh';
-import { ProjectKind } from '~/k8sTypes';
 
 type ProjectSelectorProps = {
-  onSelection: (project: ProjectKind) => void;
+  onSelection: (projectName: string) => void;
   namespace: string;
   invalidDropdownPlaceholder?: string;
   selectAllProjects?: boolean;
@@ -22,7 +21,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   primary,
   filterLabel,
 }) => {
-  const { projects } = React.useContext(ProjectsContext);
+  const { projects, updatePreferredProject } = React.useContext(ProjectsContext);
   useMountProjectRefresh();
   const selection = projects.find(byName(namespace));
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
@@ -54,10 +53,11 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
                 key={'all-projects'}
                 onClick={() => {
                   setDropdownOpen(false);
-                  onSelection({ metadata: { name: '' } } as ProjectKind);
+                  onSelection('');
+                  updatePreferredProject(null);
                 }}
               >
-                {'All projects'}
+                All projects
               </DropdownItem>,
             ]
           : []),
@@ -66,7 +66,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             key={project.metadata.name}
             onClick={() => {
               setDropdownOpen(false);
-              onSelection(project);
+              onSelection(project.metadata.name);
             }}
           >
             {getProjectDisplayName(project)}

--- a/frontend/src/concepts/projects/ProjectSelectorNavigator.tsx
+++ b/frontend/src/concepts/projects/ProjectSelectorNavigator.tsx
@@ -16,8 +16,8 @@ const ProjectSelectorNavigator: React.FC<ProjectSelectorProps> = ({
   return (
     <ProjectSelector
       {...projectSelectorProps}
-      onSelection={(project) => {
-        navigate(getRedirectPath(project.metadata.name));
+      onSelection={(projectName) => {
+        navigate(getRedirectPath(projectName));
       }}
       namespace={namespace ?? ''}
     />

--- a/frontend/src/concepts/projects/ProjectsContext.tsx
+++ b/frontend/src/concepts/projects/ProjectsContext.tsx
@@ -19,7 +19,7 @@ type ProjectsContext = {
    * Allows for navigation to be unimpeded by project selection
    * @see useSyncPreferredProject
    */
-  updatePreferredProject: (project: ProjectKind) => void;
+  updatePreferredProject: (project: ProjectKind | null) => void;
   refresh: (waitForName?: string) => Promise<void>;
 
   // ...the rest of the state variables

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -294,7 +294,6 @@ export type PodKind = K8sResourceCommon & {
   };
 };
 
-/** Assumed Dashboard Project -- if we need more beyond that we should break this type up */
 export type ProjectKind = K8sResourceCommon & {
   metadata: {
     annotations?: DisplayNameAnnotations &

--- a/frontend/src/pages/modelServing/ModelServingContext.tsx
+++ b/frontend/src/pages/modelServing/ModelServingContext.tsx
@@ -18,6 +18,8 @@ import { useContextResourceData } from '~/utilities/useContextResourceData';
 import { useDashboardNamespace } from '~/redux/selectors';
 import { DataConnection } from '~/pages/projects/types';
 import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
+import useSyncPreferredProject from '~/concepts/projects/useSyncPreferredProject';
+import { ProjectsContext, byName } from '~/concepts/projects/ProjectsContext';
 import useInferenceServices from './useInferenceServices';
 import useServingRuntimes from './useServingRuntimes';
 import useTemplates from './customServingRuntimes/useTemplates';
@@ -48,6 +50,9 @@ const ModelServingContextProvider: React.FC = () => {
   const { dashboardNamespace } = useDashboardNamespace();
   const navigate = useNavigate();
   const { namespace } = useParams<{ namespace: string }>();
+  const { projects } = React.useContext(ProjectsContext);
+  const project = projects.find(byName(namespace)) ?? null;
+  useSyncPreferredProject(project);
   const servingRuntimeTemplates = useContextResourceData<TemplateKind>(
     useTemplates(dashboardNamespace),
   );

--- a/frontend/src/pages/modelServing/screens/global/ModelServingProjectSelection.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ModelServingProjectSelection.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Bullseye, Split, SplitItem } from '@patternfly/react-core';
 import ProjectSelectorNavigator from '~/concepts/projects/ProjectSelectorNavigator';
-import { KnownLabels } from '~/k8sTypes';
 
 type ModelServingProjectSelectionProps = {
   getRedirectPath: (namespace: string) => string;
@@ -15,12 +14,10 @@ const ModelServingProjectSelection: React.FC<ModelServingProjectSelectionProps> 
       <Bullseye>Project</Bullseye>
     </SplitItem>
     <SplitItem>
-      {/* Maybe we want to filter the projects with no deployed models that's why I added the filterLable prop */}
       <ProjectSelectorNavigator
         getRedirectPath={getRedirectPath}
-        invalidDropdownPlaceholder={'All projects'}
+        invalidDropdownPlaceholder="All projects"
         selectAllProjects
-        filterLabel={KnownLabels.DASHBOARD_RESOURCE}
       />
     </SplitItem>
   </Split>

--- a/frontend/src/pages/projects/screens/detail/DetailsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/DetailsSection.tsx
@@ -18,8 +18,8 @@ type DetailsSectionProps = {
   title: string;
   isLoading: boolean;
   loadError?: Error;
-  isEmpty?: boolean;
-  emptyState?: React.ReactNode;
+  isEmpty: boolean;
+  emptyState: React.ReactNode;
   children: React.ReactNode;
   labels?: React.ReactNode[];
   showDivider?: boolean;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes #2137 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
1. When you switch between the navs (projects, pipelines, model serving), the preferred project is always remembered and synced up
2. When you choose `All projects` on the global model serving page, the preferred project is set to `null` (We don't have that dropdown selection on the pipelines page)
3. Remove the filter label so you could select all the available projects on the global model serving page, but not only the dashboard projects
4. Fix some nits from https://github.com/opendatahub-io/odh-dashboard/pull/2123

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the projects page
2. Get into any project
3. Click on the model serving on the side nav
4. You should be able to land on the page with the same selection as the project you just entered
5. Go to the pipelines page, you can see the selection is kept
6. Select `All projects` on the global model serving page
7. Make sure everything works

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, this needs e2e test setup IMO.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
