### PR TITLE
Accelerator profile table filter

### DIFF
--- a/frontend/src/__tests__/integration/pages/acceleratorProfiles/AcceleratorProfiles.spec.ts
+++ b/frontend/src/__tests__/integration/pages/acceleratorProfiles/AcceleratorProfiles.spec.ts
@@ -50,4 +50,20 @@ test('List Accelerator profiles', async ({ page }) => {
     .locator('td:nth-child(2)')
     .allInnerTexts();
   await expect(firstRowIdentifier[0]).toBe('nvidia.com/gpu');
+
+  // Check create button
+  expect(page.getByRole('button', { name: 'Create accelerator profile' })).toBeTruthy();
+
+  // Check filters
+  // by name
+  expect(page.getByRole('button', { name: 'Options menu' })).toBeTruthy();
+  await page.getByLabel('Search input').fill('TensorRT');
+  expect(page.getByText('TensorRT'));
+
+  // by identifier
+  await page.getByRole('button', { name: 'Reset' }).click();
+  page.getByRole('button', { name: 'Options menu' }).click();
+  await page.getByRole('option', { name: 'Identifier' }).click();
+  await page.getByLabel('Search input').fill('tensor.com/gpu');
+  expect(page.getByText('tensor.com/gpu'));
 });

--- a/frontend/src/concepts/dashboard/DashboardSearchField.tsx
+++ b/frontend/src/concepts/dashboard/DashboardSearchField.tsx
@@ -14,6 +14,7 @@ export enum SearchType {
   OUTPUT = 'Output',
   OUTPUT_VALUE = 'Output value',
   PROVIDER = 'Provider',
+  IDENTIFIER = 'Identifier',
 }
 
 type DashboardSearchFieldProps = {

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTable.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTable.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Button, ToolbarItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
+import DashboardSearchField, { SearchType } from '~/concepts/dashboard/DashboardSearchField';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import { Table } from '~/components/table';
 import AcceleratorProfilesTableRow from '~/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow';
 import { AcceleratorKind } from '~/k8sTypes';
@@ -12,26 +14,59 @@ type AcceleratorProfilesTableProps = {
 
 const AcceleratorProfilesTable: React.FC<AcceleratorProfilesTableProps> = ({ accelerators }) => {
   const navigate = useNavigate();
+  const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
+  const [search, setSearch] = React.useState('');
+  const filteredAcceleratorProfiles = accelerators.filter((accelerator) => {
+    if (!search) {
+      return true;
+    }
+
+    switch (searchType) {
+      case SearchType.NAME:
+        return accelerator.spec.displayName.toLowerCase().includes(search.toLowerCase());
+      case SearchType.IDENTIFIER:
+        return accelerator.spec.identifier.toLowerCase().includes(search.toLowerCase());
+      default:
+        return true;
+    }
+  });
+
+  const searchTypes = React.useMemo(() => [SearchType.NAME, SearchType.IDENTIFIER], []);
 
   return (
     <Table
       id="accelerator-profile-table"
       enablePagination
-      data={accelerators}
+      data={filteredAcceleratorProfiles}
       columns={columns}
-      emptyTableView={'No projects match your filters.'}
+      emptyTableView={<DashboardEmptyTableView onClearFilters={() => setSearch('')} />}
       rowRenderer={(accelerator) => (
         <AcceleratorProfilesTableRow key={accelerator.metadata.name} accelerator={accelerator} />
       )}
       toolbarContent={
-        <ToolbarItem>
-          <Button
-            data-id="create-accelerator-profile"
-            onClick={() => navigate(`/acceleratorProfiles/create`)}
-          >
-            Create accelerator profile
-          </Button>
-        </ToolbarItem>
+        <>
+          <ToolbarItem>
+            <DashboardSearchField
+              types={searchTypes}
+              searchType={searchType}
+              searchValue={search}
+              onSearchTypeChange={(searchType) => {
+                setSearchType(searchType);
+              }}
+              onSearchValueChange={(searchValue) => {
+                setSearch(searchValue);
+              }}
+            />
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button
+              data-id="create-accelerator-profile"
+              onClick={() => navigate(`/acceleratorProfiles/create`)}
+            >
+              Create accelerator profile
+            </Button>
+          </ToolbarItem>
+        </>
       }
     />
   );


### PR DESCRIPTION
Closes: #1374

## Description
Added filter to accelerator profile table.

<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/ed888a42-c5a5-47b8-82ce-f82c4358284e" width="500px" />

![Screenshot from 2023-11-16 02-02-18](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/56a352b0-f76f-4b28-9dfb-f383c25aa099)

![Screenshot from 2023-11-16 02-01-55](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/f9d4b002-d069-4415-86ac-361158f7ebd7)

## How Has This Been Tested?
1. Add accelerator profile CR.
2. Settings < accelerator profiles
3. On accelerator profile table page, try filter some accelerators.


## Test Impact
Added some integration test within List accelerator profile tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@yannnz 