### PR TITLE
Update jupyter & ds projects to hide outdated images

### DIFF
--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -186,6 +186,9 @@ const getTagInfo = (imageStream: ImageStream): ImageTagInfo[] => {
     if (!checkTagExistence(tag, imageStream)) {
       return; //Skip tag
     }
+    if (tagAnnotations[IMAGE_ANNOTATIONS.OUTDATED]) {
+      return; // tag is outdated - we want to keep it around for existing notebooks, not for new ones
+    }
 
     //TODO: add build status
     const tagInfo: ImageTagInfo = {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -26,6 +26,7 @@ export const IMAGE_ANNOTATIONS = {
   DEPENDENCIES: 'opendatahub.io/notebook-python-dependencies',
   IMAGE_ORDER: 'opendatahub.io/notebook-image-order',
   RECOMMENDED: 'opendatahub.io/workbench-image-recommended',
+  OUTDATED: 'opendatahub.io/image-tag-outdated',
 };
 export const blankDashboardCR: DashboardConfig = {
   apiVersion: 'opendatahub.io/v1alpha',

--- a/frontend/src/__mocks__/mockImageStreamK8sResource.ts
+++ b/frontend/src/__mocks__/mockImageStreamK8sResource.ts
@@ -15,7 +15,7 @@ export const mockImageStreamK8sResource = ({
   displayName = 'Test Image',
   opts = {},
 }: MockResourceConfigType): ImageStreamKind =>
-  _.merge(
+  _.mergeWith(
     {
       apiVersion: 'image.openshift.io/v1',
       kind: 'ImageStream',
@@ -81,4 +81,8 @@ export const mockImageStreamK8sResource = ({
       },
     } as ImageStreamKind,
     opts,
+    // Make sure tags can be overridden
+    (defaultValue, optsValue) =>
+      // Allow for emptying the array
+      Array.isArray(optsValue) && optsValue.length === 0 ? [] : undefined,
   );

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -65,6 +65,7 @@ type ImageStreamSpecTagAnnotations = Partial<{
   'opendatahub.io/notebook-software': string;
   'opendatahub.io/workbench-image-recommended': string;
   'opendatahub.io/default-image': string;
+  'opendatahub.io/image-tag-outdated': string;
 }>;
 
 export type NotebookAnnotations = Partial<{

--- a/frontend/src/pages/projects/screens/spawner/const.ts
+++ b/frontend/src/pages/projects/screens/spawner/const.ts
@@ -15,6 +15,7 @@ export const ScrollableSelectorID = 'workbench-spawner-page';
 export const FAILED_PHASES = [BUILD_PHASE.ERROR, BUILD_PHASE.FAILED];
 export const PENDING_PHASES = [BUILD_PHASE.NEW, BUILD_PHASE.PENDING, BUILD_PHASE.CANCELLED];
 
+// TODO: Convert to enum
 export const IMAGE_ANNOTATIONS = {
   DESC: 'opendatahub.io/notebook-image-desc' as const,
   DISP_NAME: 'opendatahub.io/notebook-image-name' as const,
@@ -24,6 +25,7 @@ export const IMAGE_ANNOTATIONS = {
   DEPENDENCIES: 'opendatahub.io/notebook-python-dependencies' as const,
   IMAGE_ORDER: 'opendatahub.io/notebook-image-order' as const,
   RECOMMENDED: 'opendatahub.io/workbench-image-recommended' as const,
+  OUTDATED: 'opendatahub.io/image-tag-outdated' as const,
 };
 
 export const DEFAULT_NOTEBOOK_SIZES = [

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -199,6 +199,9 @@ export const getImageVersionSoftwareString = (imageVersion: ImageStreamSpecTagTy
   return softwareString.join(', ');
 };
 
+const isOutdated = (version: ImageStreamSpecTagType): boolean =>
+  !!version.annotations?.[IMAGE_ANNOTATIONS.OUTDATED];
+
 /**
  * Get all the `imageStream.spec.tags` and filter the ones exists in `imageStream.status.tags`
  */
@@ -206,7 +209,9 @@ export const getExistingVersionsForImageStream = (
   imageStream: ImageStreamKind,
 ): ImageStreamSpecTagType[] => {
   const allVersions = imageStream.spec.tags || [];
-  return allVersions.filter((version) => checkVersionExistence(imageStream, version));
+  return allVersions
+    .filter((version) => !isOutdated(version))
+    .filter((version) => checkVersionExistence(imageStream, version));
 };
 
 /**


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #2084

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds filters to both Jupyter tile & DS Projects for version tags that have `opendatahub.io/image-tag-outdated` annotation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add the annotation to the ImageStreamTag. If it exists on the tag it will not show up in the Jupyter Tile or DS Projects image-tag selection.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Wrote tests for modified frontend code. Backend remains untested as it is deprecated.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
