### PR TITLE
Fixes: "When enabling TrustyAI on a project, the dashboard immediately shows success notification" 

### DIFF
--- a/frontend/src/concepts/explainability/ExplainabilityContext.tsx
+++ b/frontend/src/concepts/explainability/ExplainabilityContext.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useTrustyAIAPIRoute from '~/concepts/explainability/useTrustyAIAPIRoute';
 import useTrustyAINamespaceCR, {
   taiHasServerTimedOut,
-  taiLoaded,
+  isTrustyAIAvailable,
 } from '~/concepts/explainability/useTrustyAINamespaceCR';
 import useTrustyAIAPIState, { TrustyAPIState } from '~/concepts/explainability/useTrustyAIAPIState';
 import { BiasMetricConfig } from '~/concepts/explainability/types';
@@ -60,11 +60,11 @@ export const ExplainabilityContextProvider: React.FC<ExplainabilityContextProvid
   children,
   namespace,
 }) => {
-  const state = useTrustyAINamespaceCR(namespace);
-  const [explainabilityNamespaceCR, crLoaded, crLoadError, refreshCR] = state;
-  const isCRReady = taiLoaded(state);
+  const crState = useTrustyAINamespaceCR(namespace);
+  const [explainabilityNamespaceCR, crLoaded, crLoadError, refreshCR] = crState;
+  const isCRReady = isTrustyAIAvailable(crState);
   const [disableTimeout, setDisableTimeout] = React.useState(false);
-  const serverTimedOut = !disableTimeout && taiHasServerTimedOut(state, isCRReady);
+  const serverTimedOut = !disableTimeout && taiHasServerTimedOut(crState, isCRReady);
   const ignoreTimedOut = React.useCallback(() => {
     setDisableTimeout(true);
   }, []);

--- a/frontend/src/concepts/explainability/content/DeleteTrustyAIModal.tsx
+++ b/frontend/src/concepts/explainability/content/DeleteTrustyAIModal.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
-import useManageTrustyAICR from '~/concepts/explainability/useManageTrustyAICR';
 
-type TrustyAIDeleteModalProps = {
-  namespace: string;
+type DeleteTrustyAIModalProps = {
   isOpen: boolean;
+  onDelete: () => Promise<unknown>;
   onClose: (deleted: boolean) => void;
 };
 
-const TrustyAIDeleteModal: React.FC<TrustyAIDeleteModalProps> = ({
-  namespace,
-  isOpen,
-  onClose,
-}) => {
-  const { deleteCR } = useManageTrustyAICR(namespace);
+const DeleteTrustyAIModal: React.FC<DeleteTrustyAIModalProps> = ({ isOpen, onDelete, onClose }) => {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [error, setError] = React.useState<Error>();
 
@@ -29,7 +23,7 @@ const TrustyAIDeleteModal: React.FC<TrustyAIDeleteModalProps> = ({
       deleting={isDeleting}
       onDelete={() => {
         setIsDeleting(true);
-        deleteCR()
+        onDelete()
           .then(() => onClose(true))
           .catch((e) => setError(e))
           .finally(() => setIsDeleting(false));
@@ -44,4 +38,4 @@ const TrustyAIDeleteModal: React.FC<TrustyAIDeleteModalProps> = ({
   );
 };
 
-export default TrustyAIDeleteModal;
+export default DeleteTrustyAIModal;

--- a/frontend/src/concepts/explainability/content/TrustyAIServerTimedOutError.tsx
+++ b/frontend/src/concepts/explainability/content/TrustyAIServerTimedOutError.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertActionLink,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+
+type TrustyAITimedOutErrorProps = {
+  ignoreTimedOut: () => void;
+  deleteCR: () => Promise<unknown>;
+};
+const TrustyAITimedOutError: React.FC<TrustyAITimedOutErrorProps> = ({
+  ignoreTimedOut,
+  deleteCR,
+}) => (
+  <Alert
+    variant="danger"
+    isInline
+    title="TrustyAI service failed"
+    actionClose={<AlertActionCloseButton onClose={() => ignoreTimedOut()} />}
+    actionLinks={
+      <>
+        <AlertActionLink onClick={() => deleteCR()}>Delete TrustyAI service</AlertActionLink>
+        <AlertActionLink onClick={() => ignoreTimedOut()}>Close</AlertActionLink>
+      </>
+    }
+  >
+    <Stack hasGutter>
+      <StackItem>
+        We encountered an error creating or loading your TrustyAI service. To continue, delete this
+        service and create a new one. Deleting this service will delete all of its resources,
+        including bias configurations.
+      </StackItem>
+      <StackItem>To get help contact your administrator.</StackItem>
+    </Stack>
+  </Alert>
+);
+
+export default TrustyAITimedOutError;

--- a/frontend/src/concepts/explainability/content/TrustyAIServiceControl.tsx
+++ b/frontend/src/concepts/explainability/content/TrustyAIServiceControl.tsx
@@ -8,8 +8,17 @@ type TrustyAIServiceControlProps = {
   namespace: string;
 };
 const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({ namespace }) => {
-  const { isAvailable, isProgressing, showSuccess, installCR, deleteCR, error, isSettled } =
-    useManageTrustyAICR(namespace);
+  const {
+    isAvailable,
+    isProgressing,
+    showSuccess,
+    installCR,
+    deleteCR,
+    error,
+    isSettled,
+    serverTimedOut,
+    ignoreTimedOut,
+  } = useManageTrustyAICR(namespace);
 
   const [userStartedInstall, setUserStartedInstall] = React.useState(false);
 
@@ -40,6 +49,9 @@ const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({ namespa
           showSuccess={showSuccess}
           isAvailable={isAvailable}
           error={error}
+          timedOut={serverTimedOut}
+          ignoreTimedOut={ignoreTimedOut}
+          deleteCR={deleteCR}
         />
       </StackItem>
     </Stack>

--- a/frontend/src/concepts/explainability/content/TrustyAIServiceControl.tsx
+++ b/frontend/src/concepts/explainability/content/TrustyAIServiceControl.tsx
@@ -1,0 +1,49 @@
+import { Bullseye, Spinner, Stack, StackItem } from '@patternfly/react-core';
+import React from 'react';
+import useManageTrustyAICR from '~/concepts/explainability/useManageTrustyAICR';
+import TrustyAIServiceNotification from '~/concepts/explainability/content/TrustyAIServiceNotification';
+import InstallTrustyAICheckbox from './InstallTrustyAICheckbox';
+
+type TrustyAIServiceControlProps = {
+  namespace: string;
+};
+const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({ namespace }) => {
+  const { isAvailable, isProgressing, showSuccess, installCR, deleteCR, error, isSettled } =
+    useManageTrustyAICR(namespace);
+
+  const [userStartedInstall, setUserStartedInstall] = React.useState(false);
+
+  if (!isSettled) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <InstallTrustyAICheckbox
+          isAvailable={isAvailable}
+          isProgressing={isProgressing}
+          onInstall={() => {
+            setUserStartedInstall(true);
+            return installCR().finally(() => setUserStartedInstall(false));
+          }}
+          onDelete={deleteCR}
+        />
+      </StackItem>
+      <StackItem>
+        <TrustyAIServiceNotification
+          loading={userStartedInstall || isProgressing}
+          showSuccess={showSuccess}
+          isAvailable={isAvailable}
+          error={error}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default TrustyAIServiceControl;

--- a/frontend/src/concepts/explainability/content/TrustyAIServiceNotification.tsx
+++ b/frontend/src/concepts/explainability/content/TrustyAIServiceNotification.tsx
@@ -1,0 +1,55 @@
+import { Alert, AlertActionCloseButton, Bullseye, Spinner } from '@patternfly/react-core';
+import React from 'react';
+
+type TrustyAIServiceNotificationProps = {
+  error?: Error;
+  isAvailable: boolean;
+  showSuccess: boolean;
+  loading: boolean;
+};
+
+const TrustyAIServiceNotification: React.FC<TrustyAIServiceNotificationProps> = ({
+  error,
+  isAvailable,
+  showSuccess,
+  loading,
+}) => {
+  const [dismissSuccess, setDismissSuccess] = React.useState(false);
+
+  if (loading) {
+    if (dismissSuccess) {
+      setDismissSuccess(false);
+    }
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (!dismissSuccess && showSuccess && isAvailable) {
+    return (
+      <Alert
+        variant="success"
+        title="TrustyAI installed"
+        actionClose={<AlertActionCloseButton onClose={() => setDismissSuccess(true)} />}
+        isLiveRegion
+        isInline
+      >
+        The TrustyAI service was successfully installed
+      </Alert>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="danger" title="TrustyAI service error" isLiveRegion isInline>
+        {error?.message}
+      </Alert>
+    );
+  }
+
+  return null;
+};
+
+export default TrustyAIServiceNotification;

--- a/frontend/src/concepts/explainability/content/TrustyAIServiceNotification.tsx
+++ b/frontend/src/concepts/explainability/content/TrustyAIServiceNotification.tsx
@@ -1,11 +1,15 @@
 import { Alert, AlertActionCloseButton, Bullseye, Spinner } from '@patternfly/react-core';
 import React from 'react';
+import TrustyAITimedOutError from '~/concepts/explainability/content/TrustyAIServerTimedOutError';
 
 type TrustyAIServiceNotificationProps = {
   error?: Error;
   isAvailable: boolean;
   showSuccess: boolean;
   loading: boolean;
+  timedOut: boolean;
+  ignoreTimedOut: () => void;
+  deleteCR: () => Promise<unknown>;
 };
 
 const TrustyAIServiceNotification: React.FC<TrustyAIServiceNotificationProps> = ({
@@ -13,13 +17,23 @@ const TrustyAIServiceNotification: React.FC<TrustyAIServiceNotificationProps> = 
   isAvailable,
   showSuccess,
   loading,
+  timedOut,
+  ignoreTimedOut,
+  deleteCR,
 }) => {
   const [dismissSuccess, setDismissSuccess] = React.useState(false);
 
-  if (loading) {
-    if (dismissSuccess) {
+  React.useEffect(() => {
+    if (loading) {
       setDismissSuccess(false);
     }
+  }, [loading]);
+
+  if (timedOut) {
+    return <TrustyAITimedOutError ignoreTimedOut={ignoreTimedOut} deleteCR={deleteCR} />;
+  }
+
+  if (loading) {
     return (
       <Bullseye>
         <Spinner />

--- a/frontend/src/concepts/explainability/useManageTrustyAICR.ts
+++ b/frontend/src/concepts/explainability/useManageTrustyAICR.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import useTrustyAINamespaceCR, {
   isTrustyAIAvailable,
+  taiHasServerTimedOut,
 } from '~/concepts/explainability/useTrustyAINamespaceCR';
 import { createTrustyAICR, deleteTrustyAICR } from '~/api';
 
@@ -9,12 +10,18 @@ const useManageTrustyAICR = (namespace: string) => {
   const [cr, loaded, serviceError, refresh] = state;
 
   const [installReqError, setInstallReqError] = React.useState<Error | undefined>();
-  const showSuccess = React.useRef(false);
 
   const isAvailable = isTrustyAIAvailable(state);
   const isProgressing = loaded && !!cr && !isAvailable;
   const error = installReqError || serviceError;
 
+  const [disableTimeout, setDisableTimeout] = React.useState(false);
+  const serverTimedOut = !disableTimeout && taiHasServerTimedOut(state, isAvailable);
+  const ignoreTimedOut = React.useCallback(() => {
+    setDisableTimeout(true);
+  }, []);
+
+  const showSuccess = React.useRef(false);
   if (isProgressing) {
     showSuccess.current = true;
   }
@@ -38,6 +45,8 @@ const useManageTrustyAICR = (namespace: string) => {
     isAvailable,
     showSuccess: showSuccess.current,
     isSettled: loaded,
+    serverTimedOut,
+    ignoreTimedOut,
     installCR,
     deleteCR,
   };

--- a/frontend/src/concepts/explainability/useTrustyAIAPIRoute.ts
+++ b/frontend/src/concepts/explainability/useTrustyAIAPIRoute.ts
@@ -35,7 +35,6 @@ const useTrustyAIAPIRoute = (hasCR: boolean, namespace: string): FetchState<Stat
     [hasCR, namespace, trustyAIAreaAvailable],
   );
 
-  // TODO: add duplicate functionality to useFetchState.
   const state = useFetchState<State>(callback, null, {
     initialPromisePurity: true,
   });

--- a/frontend/src/concepts/explainability/useTrustyAINamespaceCR.ts
+++ b/frontend/src/concepts/explainability/useTrustyAINamespaceCR.ts
@@ -67,11 +67,6 @@ const useTrustyAINamespaceCR = (namespace: string): FetchState<State> => {
   }, [hasStatus, resourceLoaded]);
 
   return state;
-  // return {
-  //   isAvailable: hasStatus,
-  //   isProgressing: resourceLoaded && !hasStatus,
-  //   crState: state,
-  // };
 };
 
 export default useTrustyAINamespaceCR;

--- a/frontend/src/concepts/explainability/useTrustyAINamespaceCR.ts
+++ b/frontend/src/concepts/explainability/useTrustyAINamespaceCR.ts
@@ -6,13 +6,16 @@ import useFetchState, {
 } from '~/utilities/useFetchState';
 import { TrustyAIKind } from '~/k8sTypes';
 import { getTrustyAICR } from '~/api';
-import { FAST_POLL_INTERVAL } from '~/utilities/const';
+import { FAST_POLL_INTERVAL, SERVER_TIMEOUT } from '~/utilities/const';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 type State = TrustyAIKind | null;
 
-export const taiLoaded = ([state, loaded]: FetchState<State>): boolean =>
-  loaded && !!state && state.status?.ready === 'True';
+export const isTrustyCRStatusAvailable = (cr: TrustyAIKind): boolean =>
+  !!cr.status?.conditions?.find((c) => c.type === 'Available' && c.status === 'True');
+
+export const isTrustyAIAvailable = ([state, loaded]: FetchState<State>): boolean =>
+  loaded && !!state && isTrustyCRStatusAvailable(state);
 
 export const taiHasServerTimedOut = (
   [state, loaded]: FetchState<State>,
@@ -27,26 +30,25 @@ export const taiHasServerTimedOut = (
     return false;
   }
   // If we are here, and 5 mins have past, we are having issues
-  return Date.now() - new Date(createTime).getTime() > 60 * 5 * 1000;
+  return Date.now() - new Date(createTime).getTime() > SERVER_TIMEOUT;
 };
 
 const useTrustyAINamespaceCR = (namespace: string): FetchState<State> => {
   const trustyAIAreaAvailable = useIsAreaAvailable(SupportedArea.TRUSTY_AI).status;
+
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
     (opts) => {
       if (!trustyAIAreaAvailable) {
         return Promise.reject(new NotReadyError('Bias metrics is not enabled'));
       }
 
-      return getTrustyAICR(namespace, opts)
-        .then((r) => r)
-        .catch((e) => {
-          if (e.statusObject?.code === 404) {
-            // Not finding is okay, not an error
-            return null;
-          }
-          throw e;
-        });
+      return getTrustyAICR(namespace, opts).catch((e) => {
+        if (e.statusObject?.code === 404) {
+          // Not finding is okay, not an error
+          return null;
+        }
+        throw e;
+      });
     },
     [namespace, trustyAIAreaAvailable],
   );
@@ -59,12 +61,17 @@ const useTrustyAINamespaceCR = (namespace: string): FetchState<State> => {
   });
 
   const resourceLoaded = state[1] && !!state[0];
-  const hasStatus = taiLoaded(state);
+  const hasStatus = isTrustyAIAvailable(state);
   React.useEffect(() => {
-    setIsStarting(!resourceLoaded && !hasStatus);
+    setIsStarting(resourceLoaded && !hasStatus);
   }, [hasStatus, resourceLoaded]);
 
   return state;
+  // return {
+  //   isAvailable: hasStatus,
+  //   isProgressing: resourceLoaded && !hasStatus,
+  //   crState: state,
+  // };
 };
 
 export default useTrustyAINamespaceCR;

--- a/frontend/src/concepts/pipelines/context/usePipelineNamespaceCR.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelineNamespaceCR.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DSPipelineKind } from '~/k8sTypes';
 import { getPipelinesCR } from '~/api';
 import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
-import { FAST_POLL_INTERVAL } from '~/utilities/const';
+import { FAST_POLL_INTERVAL, SERVER_TIMEOUT } from '~/utilities/const';
 
 type State = DSPipelineKind | null;
 
@@ -25,7 +25,7 @@ export const hasServerTimedOut = (
   }
 
   // If we are here, and 5 mins have past, we are having issues
-  return Date.now() - new Date(createTime).getTime() > 60 * 5 * 1000;
+  return Date.now() - new Date(createTime).getTime() > SERVER_TIMEOUT;
 };
 
 const usePipelineNamespaceCR = (namespace: string): FetchState<State> => {

--- a/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
+++ b/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
@@ -38,7 +38,6 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({ activeKey, 
           activeKey={activeTabKey}
           onSelect={(event, tabIndex) => setActiveTabKey(tabIndex)}
           aria-label="Horizontal bar"
-          mountOnEnter
         >
           {sections.map((section) => (
             <Tab
@@ -61,17 +60,18 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({ activeKey, 
         aria-label="horizontal-bar-content-section"
         padding={{ default: 'noPadding' }}
       >
-        {sections.map((section) => (
-          <TabContent
-            id={section.title}
-            activeKey={activeTabKey}
-            eventKey={section.title}
-            key={section.title}
-            hidden={section.title !== activeTabKey}
-          >
-            <TabContentBody>{section.component}</TabContentBody>
-          </TabContent>
-        ))}
+        {sections
+          .filter((section) => section.title === activeTabKey)
+          .map((section) => (
+            <TabContent
+              id={section.title}
+              activeKey={activeTabKey}
+              eventKey={section.title}
+              key={section.title}
+            >
+              <TabContentBody>{section.component}</TabContentBody>
+            </TabContent>
+          ))}
       </PageSection>
     </>
   );

--- a/frontend/src/pages/projects/projectSettings/ModelBiasSettingsCard.tsx
+++ b/frontend/src/pages/projects/projectSettings/ModelBiasSettingsCard.tsx
@@ -1,119 +1,19 @@
-import {
-  Alert,
-  AlertActionCloseButton,
-  Card,
-  CardBody,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import React from 'react';
-import InstallTrustyAICheckbox, {
-  TrustyAICRActions,
-} from '~/concepts/explainability/content/InstallTrustyAICheckbox';
+import TrustyAIServiceControl from '~/concepts/explainability/content/TrustyAIServiceControl';
 
 type ModelBiasSettingsCardProps = {
   namespace: string;
 };
-const ModelBiasSettingsCard: React.FC<ModelBiasSettingsCardProps> = ({ namespace }) => {
-  const [notifyAction, setNotifyAction] = React.useState<TrustyAICRActions | undefined>(undefined);
-  const [success, setSuccess] = React.useState(false);
-  const [error, setError] = React.useState<Error | undefined>(undefined);
-  const clearNotification = React.useCallback(() => {
-    setNotifyAction(undefined);
-    setSuccess(false);
-    setError(undefined);
-  }, []);
-
-  const renderNotification = () => {
-    if (success && notifyAction === TrustyAICRActions.CREATE) {
-      return (
-        <Alert
-          variant="success"
-          title="TrustyAI installed"
-          actionClose={<AlertActionCloseButton onClose={clearNotification} />}
-          isLiveRegion
-          isInline
-        >
-          The TrustyAI service was successfully installed
-        </Alert>
-      );
-    }
-
-    if (!success && notifyAction === TrustyAICRActions.CREATE) {
-      return (
-        <Alert
-          variant="danger"
-          title="TrustyAI installation error"
-          actionClose={<AlertActionCloseButton onClose={clearNotification} />}
-          isLiveRegion
-          isInline
-        >
-          {/* This is a temporary fix, this should be updated to incorporate work from
-          https://github.com/opendatahub-io/odh-dashboard/pull/2032 in the future to provide a
-          better experience.*/}
-          {error?.message.includes('404')
-            ? 'The TrustyAI operator is not installed on this cluster.'
-            : error?.message}
-        </Alert>
-      );
-    }
-
-    if (success && notifyAction === TrustyAICRActions.DELETE) {
-      return (
-        <Alert
-          variant="success"
-          title="TrustyAI uninstalled"
-          actionClose={<AlertActionCloseButton onClose={clearNotification} />}
-          isLiveRegion
-          isInline
-        >
-          The TrustyAI service was successfully uninstalled
-        </Alert>
-      );
-    }
-
-    if (!success && notifyAction === TrustyAICRActions.DELETE) {
-      return (
-        <Alert
-          variant="danger"
-          title="TrustyAI uninstallation error"
-          actionClose={<AlertActionCloseButton onClose={clearNotification} />}
-          isLiveRegion
-          isInline
-        >
-          {error?.message}
-        </Alert>
-      );
-    }
-
-    return null;
-  };
-
-  return (
-    <Card isFlat>
-      <CardHeader>
-        <CardTitle>Model Bias</CardTitle>
-      </CardHeader>
-      <CardBody>
-        <Stack>
-          <StackItem>
-            <InstallTrustyAICheckbox
-              namespace={namespace}
-              onAction={(action, success, error) => {
-                setNotifyAction(action);
-                setSuccess(success);
-                setError(error);
-              }}
-            />
-          </StackItem>
-        </Stack>
-      </CardBody>
-      <CardFooter>{renderNotification()}</CardFooter>
-    </Card>
-  );
-};
+const ModelBiasSettingsCard: React.FC<ModelBiasSettingsCardProps> = ({ namespace }) => (
+  <Card isFlat>
+    <CardHeader>
+      <CardTitle>Model Bias</CardTitle>
+    </CardHeader>
+    <CardBody>
+      <TrustyAIServiceControl namespace={namespace} />
+    </CardBody>
+  </Card>
+);
 
 export default ModelBiasSettingsCard;

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -6,6 +6,7 @@ const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTE
 const FAST_POLL_INTERVAL = process.env.FAST_POLL_INTERVAL
   ? parseInt(process.env.FAST_POLL_INTERVAL)
   : 3000;
+const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // 5 minutes
 const DOC_LINK = process.env.DOC_LINK;
 const COMMUNITY_LINK = process.env.COMMUNITY_LINK;
 const SUPPORT_LINK = process.env.SUPPORT_LINK;
@@ -19,6 +20,7 @@ export {
   API_PORT,
   POLL_INTERVAL,
   FAST_POLL_INTERVAL,
+  SERVER_TIMEOUT,
   DOC_LINK,
   COMMUNITY_LINK,
   SUPPORT_LINK,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #1531
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This fixes the UX around installing and uninstalling Trusty AI, this includes:
- Updating the condition by which the dashboard decides Trusty is installed, in order to utilise the fixes provided by the Trusty team.
- General rework of the logic to ensure users receive notifications of success / error robustly at the correct time.
- Adds a spinner whilst the service is installing.
- An update to how the `Project Settings` page tabs are loaded to fix an issue where all tabs are mounted immediately regardless of `mountOnEnter` logic.

### Screenshots
**NOTE:** It takes about 90 seconds on average for TrustyAI to install, rather than post a monster GIF, the first shows the transition when the checkbox is clicked, the second shows the transition from the spinner to a success notification.

![install_trusty_1](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/f18f0729-a2f6-4832-834d-c39b7c915247)
![install_trusty_2](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/5b355b05-618d-434b-a36f-0c78a0568a47)
![install_trusty_3](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/476e877b-8420-45fa-9b5a-d424c02d9263)


**NB: [Animated GIF to follow shortly, will tag UX once I've recorded it and attached]**

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Environment setup:
- The `biasMetricsDisabled` feature flag MUST be `false`.
- You need to have the latest version of TrustyAI running on your cluster, this has only been tested with v2 operator. 
- Use the following DSC modification to install this version:
```
    trustyai:
      devFlags:
        manifests:
          - contextDir: config
            uri: https://github.com/trustyai-explainability/trustyai-service-operator/tarball/main/
      managementState: Managed
```

Test Steps:

Happy Path:
It's best to test this with two browser windows side by side. One showing the dashboard, the other showing your OpenShift console.
- Create a new project
- Navigate to the settings tab of the project detail page for your new project
- Observe the `Bias Metrics` card
- In your OpenShift console window, navigate to the Workloads section for the project you created above
- When you have both side by side - check the `Install TrustyAI` checkbox.
- You will need to verify a few things:
  - The checkbox immediately is disabled and a spinner is shown
  - Watch your OpenShift console - you're looking to verify that the `TrustyAIService` appears and starts to spin up.
  - Verify that a "success" notification does NOT appear until the service has spun up.
  - Watch and ensure there is no other "weirdness" or anything that makes for a poor experience.
  - Once it is installed, verify uninstalling TrustyAI works.

Sad path:
This is pretty difficult to test, you'll need to modify the `TrustyAIServiceControl` and assign a made up error to the "error" const. This will be more reliably tested by automated tests in the future.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Test have not been added in this PR in order to avoid holdup to incubation, however tests will be written and follow shortly in a subsequent PR.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
quay.io/acreasy/odh-dashboard:issue-1531