### PR TITLE
Convert Log Viewer to PF Log Viewer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@patternfly/react-code-editor": "^5.1.1",
         "@patternfly/react-core": "^5.1.1",
         "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-log-viewer": "^5.0.0",
         "@patternfly/react-styles": "^5.1.1",
         "@patternfly/react-table": "^5.1.1",
         "@patternfly/react-topology": "^5.1.0",
@@ -4627,6 +4628,21 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz",
       "integrity": "sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-log-viewer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-log-viewer/-/react-log-viewer-5.0.0.tgz",
+      "integrity": "sha512-N4E1HAfXVlPDsvCvXhh7ycO/pu8h7nGBjQgGV7mUWQb23Q8djuzPU3aK/QODVEP6ZCnlvq2AbaKUpaLiE5z4ww==",
+      "dependencies": {
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-icons": "^5.0.0",
+        "@patternfly/react-styles": "^5.0.0",
+        "memoize-one": "^5.1.0"
+      },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
@@ -28141,6 +28157,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "@patternfly/react-code-editor": "^5.1.1",
     "@patternfly/react-core": "^5.1.1",
     "@patternfly/react-icons": "^5.1.1",
+    "@patternfly/react-log-viewer": "^5.0.0",
     "@patternfly/react-styles": "^5.1.1",
     "@patternfly/react-table": "^5.1.1",
     "@patternfly/react-topology": "^5.1.0",

--- a/frontend/src/concepts/dashboard/DashboardLogViewer.tsx
+++ b/frontend/src/concepts/dashboard/DashboardLogViewer.tsx
@@ -1,0 +1,22 @@
+import { LogViewer } from '@patternfly/react-log-viewer';
+import React from 'react';
+
+const DashboardLogViewer: React.FC<{
+  data: string;
+  logViewerRef: React.MutableRefObject<{ scrollToBottom: () => void } | undefined>;
+  toolbar: JSX.Element;
+  footer: JSX.Element | false;
+  onScroll: React.ComponentProps<typeof LogViewer>['onScroll'];
+}> = ({ data, logViewerRef, toolbar, footer, onScroll }) => (
+  <LogViewer
+    hasLineNumbers={false}
+    data={data}
+    innerRef={logViewerRef}
+    height="100%"
+    toolbar={toolbar}
+    footer={footer}
+    onScroll={onScroll}
+  />
+);
+
+export default DashboardLogViewer;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawer.scss
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawer.scss
@@ -1,0 +1,8 @@
+// temp fix for the PF issue https://github.com/patternfly/patternfly-react/issues/8541
+// can be removed after the issue is solved
+.pipeline-run {
+    &__drawer-panel-body {
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent.tsx
@@ -11,6 +11,7 @@ import {
 import PipelineRunDrawerRightTabs from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs';
 import { TaskReferenceMap, PipelineRunTaskDetails } from '~/concepts/pipelines/content/types';
 import { PipelineRunTaskParam } from '~/k8sTypes';
+import './PipelineRunDrawer.scss';
 
 type PipelineRunDrawerRightContentProps = {
   task?: PipelineRunTaskDetails;
@@ -31,9 +32,13 @@ const PipelineRunDrawerRightContent: React.FC<PipelineRunDrawerRightContentProps
 
   return (
     <DrawerPanelContent
+      // This forces a re-render to solve resize of the Log viewer inside Drawer.
+      onResize={() => {
+        window.dispatchEvent(new Event('resize'));
+      }}
       isResizable
       widths={{ default: 'width_33', lg: 'width_50' }}
-      minSize="400px"
+      minSize="500px"
       data-testid="pipeline-run-drawer-right-content"
     >
       <DrawerHead>
@@ -46,7 +51,10 @@ const PipelineRunDrawerRightContent: React.FC<PipelineRunDrawerRightContentProps
           <DrawerCloseButton onClick={onClose} />
         </DrawerActions>
       </DrawerHead>
-      <DrawerPanelBody style={{ display: 'flex', flexDirection: 'column' }}>
+      <DrawerPanelBody
+        className="pipeline-run__drawer-panel-body pf-v5-u-pr-sm"
+        // pf-v5-u-pr-sm
+      >
         <PipelineRunDrawerRightTabs
           taskReferences={taskReferences}
           task={task}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -6,6 +6,7 @@ import SelectedNodeInputOutputTab from '~/concepts/pipelines/content/pipelinesDe
 import SelectedNodeVolumeMountsTab from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeVolumeMountsTab';
 import { PipelineRunTaskParam } from '~/k8sTypes';
 import LogsTab from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab';
+import './PipelineRunDrawer.scss';
 
 enum PipelineRunNodeTabs {
   INPUT_OUTPUT = 'Input / Output',
@@ -31,13 +32,22 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
 }) => {
   const [selection, setSelection] = React.useState(PipelineRunNodeTabs.INPUT_OUTPUT);
 
-  const tabContentProps = (tab: PipelineRunNodeTabs): React.ComponentProps<typeof TabContent> => ({
-    id: tab,
-    eventKey: tab,
-    activeKey: selection ?? '',
-    hidden: tab !== selection,
-    style: { flex: '1 1 auto' },
-  });
+  const tabContents: Record<PipelineRunNodeTabs, React.ReactNode> = {
+    [PipelineRunNodeTabs.INPUT_OUTPUT]: (
+      <SelectedNodeInputOutputTab
+        taskReferences={taskReferences}
+        task={task}
+        parameters={parameters}
+      />
+    ),
+    // [PipelineRunNodeTabs.VISUALIZATIONS]: <>TBD 2</>,
+    [PipelineRunNodeTabs.DETAILS]: <SelectedNodeDetailsTab task={task} />,
+    [PipelineRunNodeTabs.VOLUMES]: <SelectedNodeVolumeMountsTab task={task} />,
+    [PipelineRunNodeTabs.LOGS]: <LogsTab task={task} />,
+    // [PipelineRunNodeTabs.POD]: <>TBD 6</>,
+    // [PipelineRunNodeTabs.EVENTS]: <>TBD 7</>,
+    // [PipelineRunNodeTabs.ML_METADATA]: <>TBD 8</>,
+  };
 
   return (
     <>
@@ -53,27 +63,15 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
         ))}
       </Tabs>
       {selection && (
-        <DrawerPanelBody style={{ display: 'flex', flexDirection: 'column' }}>
-          <TabContent {...tabContentProps(PipelineRunNodeTabs.INPUT_OUTPUT)}>
-            <SelectedNodeInputOutputTab
-              taskReferences={taskReferences}
-              task={task}
-              parameters={parameters}
-            />
+        <DrawerPanelBody className="pipeline-run__drawer-panel-body pf-v5-u-px-sm">
+          <TabContent
+            id={selection}
+            eventKey={selection}
+            activeKey={selection ?? ''}
+            style={{ flex: '1 1 auto' }}
+          >
+            {tabContents[selection]}
           </TabContent>
-          {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.VISUALIZATIONS)}>TBD 2</TabContent>*/}
-          <TabContent {...tabContentProps(PipelineRunNodeTabs.DETAILS)}>
-            <SelectedNodeDetailsTab task={task} />
-          </TabContent>
-          <TabContent {...tabContentProps(PipelineRunNodeTabs.VOLUMES)}>
-            <SelectedNodeVolumeMountsTab task={task} />
-          </TabContent>
-          <TabContent {...tabContentProps(PipelineRunNodeTabs.LOGS)}>
-            <LogsTab task={task} />
-          </TabContent>
-          {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.POD)}>TBD 6</TabContent>*/}
-          {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.EVENTS)}>TBD 7</TabContent>*/}
-          {/*<TabContent {...tabContentProps(PipelineRunNodeTabs.ML_METADATA)}>TBD 8</TabContent>*/}
         </DrawerPanelBody>
       )}
     </>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
@@ -1,53 +1,32 @@
 import React from 'react';
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownToggle,
-  KebabToggle,
-} from '@patternfly/react-core/deprecated';
-import { Truncate } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
+import { DownloadIcon } from '@patternfly/react-icons';
 
 type DownloadDropdownProps = {
   onDownload: () => void;
   onDownloadAll: () => void;
-  isSmallScreen: boolean;
   isSingleStepLogsEmpty: boolean;
 };
 
 const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
   onDownload,
   onDownloadAll,
-  isSmallScreen,
   isSingleStepLogsEmpty,
 }) => {
   const [isDownloadDropdownOpen, setIsDownloadDropdownOpen] = React.useState(false);
 
-  return isSmallScreen ? (
+  return (
     <Dropdown
-      toggle={<KebabToggle onToggle={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)} />}
-      isOpen={isDownloadDropdownOpen}
       isPlain
-      dropdownItems={[
-        <DropdownItem
-          isDisabled={isSingleStepLogsEmpty}
-          key="current-container-logs"
-          onClick={onDownload}
-        >
-          <Truncate content="Download current step log" />
-        </DropdownItem>,
-        <DropdownItem key="all-container-logs" onClick={onDownloadAll}>
-          <Truncate content="Download all step logs" />
-        </DropdownItem>,
-      ]}
-    />
-  ) : (
-    <Dropdown
+      position="right"
       toggle={
         <DropdownToggle
+          className="pf-v5-u-px-sm"
+          style={{ width: '60px' }}
           id="download-steps-logs-toggle"
           onToggle={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)}
         >
-          Download
+          <DownloadIcon />
         </DropdownToggle>
       }
       isOpen={isDownloadDropdownOpen}
@@ -57,10 +36,10 @@ const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
           key="current-container-logs"
           onClick={onDownload}
         >
-          <Truncate content="Current step log" />
+          Download current step log
         </DropdownItem>,
         <DropdownItem key="all-container-logs" onClick={onDownloadAll}>
-          <Truncate content="All step logs" />
+          Download all step logs
         </DropdownItem>,
       ]}
     />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-258](https://issues.redhat.com/browse/RHOAIENG-258)  and [RHOAIENG-1095](https://issues.redhat.com/browse/RHOAIENG-1095) 

## Description
This PR aims to change the existing Log viewer to PF Log viewer. Also this PR includes 
1) scroll up to pause feature.
2) Find/search feature in the log viewer toolbar.
3) Support for a full-screen log viewer (expand functionality).

UX Design: https://www.figma.com/proto/rJjOtl3nxpW6BAcl0MZr4y/Pipeline-log-viewer?page-id=62%3A1895&type=design&node-id=1075-5045&viewport=1226%2C-14994%2C0.33&t=BbsTwCedaJMiJaRo-1&scaling=min-zoom&starting-point-node-id=1075%3A5045&show-proto-sidebar=1&mode=design

**Gifs:**

[Screencast from 2024-01-16 22-27-04.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/e91b4805-4c86-4475-be74-85d038658043)

[Screencast from 2024-01-16 22-28-20.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/c09e50e5-0c57-4758-a53d-48567cd863a0)


[Screencast from 2024-01-16 16-31-09.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/737cc680-8fb0-47cf-a8b2-501653b2741f)

**Screenshots:**

When the drawer is at its default width.

![Screenshot from 2024-01-16 22-29-38](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/4aeb9ac9-58ea-4199-af3a-47ed66ea0a87)

Log viewer when Drawer is at minSize.

![Screenshot from 2024-01-16 22-29-46](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/0623b7b9-9f86-4c9a-8767-2d4135958573)

When search bar is expanded

![Screenshot from 2024-01-16 22-37-12](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/b30111bb-92be-4dac-8f3b-3eb143e10821)

![Screenshot from 2024-01-16 22-29-51](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/207859f4-d1dc-495e-9a13-f04e8d8c9447)

Log viewer when "No logs available"

![Screenshot from 2024-01-16 22-30-15](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/e53dc6f4-9ae3-433f-90a1-c3892a557d22)

![Screenshot from 2024-01-16 22-30-25](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/519c2af1-5167-4e4e-b415-1bf601e31b05)


## How Has This Been Tested?
- Upload a Pipeline & create runs
- Select a node & go to the logs tab
- View logs for containers

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
