### PR TITLE
fix test fails on project details page and serving runtimes

### DIFF
--- a/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
+++ b/frontend/src/__tests__/integration/pages/modelServing/ModelServingGlobal.stories.tsx
@@ -313,7 +313,7 @@ export const DeployModelModelKServe: StoryObj = {
   parameters: {
     a11y: {
       // need to select modal as root
-      element: '.pf-c-backdrop',
+      element: '.pf-v5-c-backdrop',
     },
     msw: {
       handlers: getHandlers({

--- a/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
+++ b/frontend/src/__tests__/integration/pages/modelServing/ServingRuntimeList.spec.ts
@@ -202,18 +202,19 @@ test('Add ModelMesh model server', async ({ page }) => {
     },
   ];
 
-  for (const item of expectedContent) {
+  for await (const item of expectedContent) {
     const iconPopover = await page.getByRole('button', { name: item.ariaLabel, exact: true });
     if (await iconPopover.isVisible()) {
       await iconPopover.click();
-      const popoverContent = await page.locator('div.pf-c-popover__content').textContent();
+      const popoverContent = await page.locator('div.pf-v5-c-popover__content').textContent();
       expect(popoverContent).toContain(item.content);
 
-      const closeButton = await page.locator('div.pf-c-popover__content>button');
+      const closeButton = await page.locator('div.pf-v5-c-popover__close');
       if (closeButton) {
-        closeButton.click();
+        await closeButton.click();
       }
     }
+    await page.waitForTimeout(300);
   }
   // test the if the alert is visible when route is external while token is not set
   await expect(page.locator('#alt-form-checkbox-route')).not.toBeChecked();
@@ -246,7 +247,7 @@ test('Edit ModelMesh model server', async ({ page }) => {
   await page
     .getByRole('rowgroup')
     .filter({ has: page.getByRole('button', { name: 'ovms', exact: true }) })
-    .getByLabel('Actions')
+    .getByLabel('Kebab toggle')
     .click();
   await page.getByText('Edit model server').click();
 

--- a/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.scss
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetailsComponents.scss
@@ -1,5 +1,5 @@
 .odh-project-details-components__item:has(> .odh-details-section--divide):has(
     + .odh-project-details-components__item
   ) {
-  border-bottom: 1px solid var(--pf-global--BorderColor--100);
+  border-bottom: 1px solid var(--pf-v5-global--BorderColor--100);
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
contributes to https://github.com/opendatahub-io/odh-dashboard/pull/2041

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
this fixes the tests to pass in adding or editing model mesh servers tests and project details empty page tests without regressions in other tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
check tests logs that all test pass for ServingRuntimeList.spec.ts and ProjectDetails.spec.ts

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updates selectors and some pf4 styles

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`