### PR TITLE
[service mesh] Fix Service Mesh flag read in Jupyter tile

### DIFF
--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -277,8 +277,8 @@ export const assembleNotebook = async (
     },
   }));
 
-  const serviceMeshEnabled = String(
-    !featureFlagEnabled(getDashboardConfig().spec?.dashboardConfig?.disableServiceMesh),
+  const serviceMeshEnabled = featureFlagEnabled(
+    getDashboardConfig().spec?.dashboardConfig?.disableServiceMesh,
   );
 
   return {
@@ -298,7 +298,7 @@ export const assembleNotebook = async (
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'notebooks.opendatahub.io/inject-oauth': String(!serviceMeshEnabled),
         'opendatahub.io/username': username,
-        'opendatahub.io/service-mesh': serviceMeshEnabled,
+        'opendatahub.io/service-mesh': String(serviceMeshEnabled),
         'kubeflow-resource-stopped': null,
         'opendatahub.io/accelerator-name': accelerator.accelerator?.metadata.name || '',
       },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes #2208

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This change fixes how the service mesh feature flag is read when creating/assembling a notebook from the jupyter tile. Previously, it was negated and set as a string, now we keep it as a boolean when checking the value, and assign it to a string when setting the needed annotation/labels.

NOTE: the two commits marked tmp: will be removed after testing and prior to PR merged. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested using image: `quay.io/maistra-dev/odh-dashboard:fix-flag-read` and will be showing Andrew changes in gmeet. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
