### PR TITLE
Prevent download of empty files in Pipeline Logs

### DIFF
--- a/frontend/src/__tests__/integration/pages/pipelines/PipelineRunJobDetails.spec.ts
+++ b/frontend/src/__tests__/integration/pages/pipelines/PipelineRunJobDetails.spec.ts
@@ -28,4 +28,10 @@ test('Does not show run content', async ({ page }) => {
   // expect nodes dont open drawer on click
   await page.getByText('flip-coin').click();
   await expect(page.getByTestId('pipeline-run-drawer-right-content')).toHaveCount(1);
+
+  //expect drawer to open on clicking node
+  await expect(page.getByText('Input / Output')).toHaveCount(1);
+  await expect(page.getByText('Details')).toHaveCount(2);
+  await expect(page.getByText('Volumes')).toHaveCount(1);
+  await expect(page.getByText('Logs')).toHaveCount(1);
 });

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
+import { Truncate } from '@patternfly/react-core';
+
+type DownloadDropdownProps = {
+  onDownload: () => void;
+  onDownloadAll: () => void;
+  isSmallScreen: boolean;
+  isSingleStepLogsEmpty: boolean;
+};
+
+const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
+  onDownload,
+  onDownloadAll,
+  isSmallScreen,
+  isSingleStepLogsEmpty,
+}) => {
+  const [isDownloadDropdownOpen, setIsDownloadDropdownOpen] = React.useState(false);
+
+  return isSmallScreen ? (
+    <Dropdown
+      toggle={<KebabToggle onToggle={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)} />}
+      isOpen={isDownloadDropdownOpen}
+      isPlain
+      dropdownItems={[
+        <DropdownItem
+          isDisabled={isSingleStepLogsEmpty}
+          key="current-container-logs"
+          onClick={onDownload}
+        >
+          <Truncate content="Download current step log" />
+        </DropdownItem>,
+        <DropdownItem key="all-container-logs" onClick={onDownloadAll}>
+          <Truncate content="Download all step logs" />
+        </DropdownItem>,
+      ]}
+    />
+  ) : (
+    <Dropdown
+      toggle={
+        <DropdownToggle
+          id="download-steps-logs-toggle"
+          onToggle={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)}
+        >
+          Download
+        </DropdownToggle>
+      }
+      isOpen={isDownloadDropdownOpen}
+      dropdownItems={[
+        <DropdownItem
+          isDisabled={isSingleStepLogsEmpty}
+          key="current-container-logs"
+          onClick={onDownload}
+        >
+          <Truncate content="Current step log" />
+        </DropdownItem>,
+        <DropdownItem key="all-container-logs" onClick={onDownloadAll}>
+          <Truncate content="All step logs" />
+        </DropdownItem>,
+      ]}
+    />
+  );
+};
+export default DownloadDropdown;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
@@ -7,12 +7,19 @@ import {
 
 type LogsTabStatusProps = {
   error?: Error;
+  isLogsAvailable?: boolean;
   loaded: boolean;
   refresh: () => void;
   onDownload: () => void;
 };
 
-const LogsTabStatus: React.FC<LogsTabStatusProps> = ({ error, loaded, refresh, onDownload }) => {
+const LogsTabStatus: React.FC<LogsTabStatusProps> = ({
+  error,
+  isLogsAvailable,
+  loaded,
+  refresh,
+  onDownload,
+}) => {
   if (error) {
     return (
       <Alert
@@ -38,10 +45,9 @@ const LogsTabStatus: React.FC<LogsTabStatusProps> = ({ error, loaded, refresh, o
         latest {LOG_TAIL_LINES} lines. Exceptionally long lines are abridged. To view the full log
         for this task, you can{' '}
         <Button
-          isDisabled={!onDownload}
+          isDisabled={!onDownload || !isLogsAvailable}
           variant="link"
           isInline
-          component="span"
           onClick={onDownload}
         >
           download all step logs

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/useWindowResize.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/useWindowResize.ts
@@ -16,6 +16,6 @@ export function useWindowResize() {
     return () => window.removeEventListener('resize', handleResize);
   }, [handleResize]);
 
-  const isSmallScreen = () => width < 576;
-  return { isSmallScreen };
+  const isSmallScreen = width < 576;
+  return isSmallScreen;
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: [RHOAIENG-259](https://issues.redhat.com/browse/RHOAIENG-259)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR : 
- Prevents downloading empty log files
- Some changes to align with mocks
- Handles small screen "Download" button for pods with a single step 
- Add functionality to view raw logs (part of https://github.com/opendatahub-io/odh-dashboard/issues/1814)
- Code refactor
![Screenshot from 2023-11-24 20-36-16](https://github.com/opendatahub-io/odh-dashboard/assets/22885912/cf30f422-4db5-44b4-989a-78062822bf6e)

GIF for raw logs:

https://github.com/opendatahub-io/odh-dashboard/assets/22885912/3bc7459a-b192-4c8a-9185-7064833f3634

Screenshots for view raw logs and disabled and enabled states of both Raw logs and Download button:

Enabled state: 

<img width="660" alt="Screenshot 2023-11-30 at 7 36 07 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/25734410-f015-46b3-833e-a4e903de83fb">

Disabled: 
<img width="570" alt="Screenshot 2023-11-30 at 7 50 23 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/4dbfca87-20f2-488f-9fcd-4c72b4f40bbd">

Small screen:
<img width="390" alt="Screenshot 2023-11-30 at 8 06 31 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/3e886888-5608-472f-bd73-9dd30c2c26aa">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run any pipeline
2. Go to the Logs tab
3. Go to any node that has completed execution but has no logs
4. Check that you see "No logs available" and the "Download" button is disabled

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added tests to check whether the drawer opens on clicking the node of a pipeline run

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
