### PR TITLE
Enable modelmesh on cluster creation

### DIFF
--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -55,7 +55,7 @@ export const blankDashboardCR: DashboardConfig = {
       modelMetricsNamespace: '',
       disablePipelines: false,
       disableKServe: false,
-      disableModelMesh: true,
+      disableModelMesh: false,
     },
     notebookController: {
       enabled: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -25,7 +25,7 @@ The following are a list of features that are supported, along with there defaul
 | disableProjectSharing        | false   | Disables Project Sharing from Data Science Projects.                                                 |
 | disableCustomServingRuntimes | false   | Disables Custom Serving Runtimes from the Admin Panel.                                               |
 | disableKServe                | false   | Disables the ability to select KServe as a Serving Platform.                                         |
-| disableModelMesh             | true    | Disables the ability to select ModelMesh as a Serving Platform.                                      |
+| disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | modelMetricsNamespace        | false   | Enables the namespace in which the Model Serving Metrics' Prometheus Operator is installed.          |
 
 ## Defaults

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -31,7 +31,7 @@ export const mockDashboardConfig = ({
   disableCustomServingRuntimes = false,
   disablePipelines = false,
   disableKServe = false,
-  disableModelMesh = true,
+  disableModelMesh = false,
 }: MockDashboardConfigType): DashboardConfigKind => ({
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',

--- a/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.spec.ts
+++ b/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.spec.ts
@@ -8,7 +8,7 @@ test('Custom serving runtimes', async ({ page }) => {
 
   // check the platform setting labels in the header
   await expect(page.getByText('Single model serving enabled')).toBeVisible();
-  await expect(page.getByText('Multi-model serving enabled')).toBeHidden();
+  await expect(page.getByText('Multi-model serving enabled')).toBeVisible();
 
   // check the platform labels in the table row
   await expect(page.locator('#template-1').getByLabel('Label group category')).toHaveText(

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelect.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelect.tsx
@@ -46,7 +46,7 @@ const ModelServingPlatformSelect: React.FC<ModelServingPlatformSelectProps> = ({
                 />
               }
               title="Single model serving platform"
-              description="Each model is deployed from its own model server. Choose this option when you have a small number of large models to deploy."
+              description="Each model is deployed from its own model server. Choose this option only for large language models that will be deployed using the Caikit runtime."
             />
           </GalleryItem>
           <GalleryItem>

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -20,7 +20,7 @@ spec:
     disableCustomServingRuntimes: true
     modelMetricsNamespace: ''
     disableKServe: false
-    disableModelMesh: true
+    disableModelMesh: false
   notebookController:
     enabled: true
   notebookSizes:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes #2238 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Delete the dashboard deployment in DSC
2. Configure DSC with the configuration bellow
3. Check that modelmesh is enabled by default
4. Check that KServe selection has the right wording.

```yaml
    dashboard:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/lucferbux/odh-dashboard/tarball/issue-2238'
      managementState: Managed
```


<img width="2086" alt="Screenshot 2023-11-28 at 18 36 40" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/f3a595c0-1923-441d-858b-3203a62fe9a3">

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No further testing added, working on the kserve migration coverage on https://github.com/opendatahub-io/odh-dashboard/issues/1980



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
