### PR TITLE
PF5: Follow-up UI fixes

### DIFF
--- a/frontend/src/__mocks__/mockDataSciencePipelinesApplicationK8sResource.ts
+++ b/frontend/src/__mocks__/mockDataSciencePipelinesApplicationK8sResource.ts
@@ -13,7 +13,7 @@ export const mockDataSciencePipelineApplicationK8sResource = ({
   kind: 'DataSciencePipelinesApplication',
   metadata: {
     name: 'pipelines-definition',
-    namespace: namespace,
+    namespace,
   },
   spec: {
     apiServer: {

--- a/frontend/src/__mocks__/mockPipelineKF.ts
+++ b/frontend/src/__mocks__/mockPipelineKF.ts
@@ -10,14 +10,14 @@ export const mockPipelineKF = ({
   name = 'test-pipeline',
   id = 'test-pipeline',
 }: MockResourceConfigType): PipelineKF => ({
-  id: id,
+  id,
   created_at: '2023-11-23T17:16:37Z',
-  name: name,
+  name,
   description:
     '[source code](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/flip-coin) A conditional pipeline to flip coins based on a random number generator.',
   default_version: {
-    id: id,
-    name: name,
+    id,
+    name,
     created_at: '2023-11-23T17:16:37Z',
     resource_references: [
       {

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -21,10 +21,6 @@ body,
     font-size: 13px;
   }
 
-  .pf-v5-c-app-launcher__menu-item-external-icon {
-    opacity: 1;
-    color: var(--pf-v5-global--icon--Color--light);
-  }
 
   &__brand {
     height: 36px;

--- a/frontend/src/components/OdhExploreCard.tsx
+++ b/frontend/src/components/OdhExploreCard.tsx
@@ -79,6 +79,7 @@ const OdhExploreCard: React.FC<OdhExploreCardProps> = ({
           },
           selectableActions: {
             selectableActionId: `${odhApp.metadata.name}-selectable-card-id`,
+            selectableActionAriaLabelledby: odhApp.metadata.name,
             name: `odh-explore-selectable-card`,
             variant: 'single',
             isChecked: isSelected,

--- a/frontend/src/concepts/dashboard/DashboardSearchField.tsx
+++ b/frontend/src/concepts/dashboard/DashboardSearchField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InputGroup, SearchInput } from '@patternfly/react-core';
+import { InputGroup, SearchInput, InputGroupItem } from '@patternfly/react-core';
 import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
 
 // List all the possible search fields here
@@ -33,27 +33,31 @@ const DashboardSearchField: React.FC<DashboardSearchFieldProps> = ({
   onSearchTypeChange,
 }) => (
   <InputGroup>
-    <SimpleDropdownSelect
-      aria-label="Filter type"
-      data-testid="filter-dropdown-select"
-      options={types.map((key) => ({
-        key,
-        label: key,
-      }))}
-      value={searchType}
-      onChange={(key) => {
-        onSearchTypeChange(key as SearchType);
-      }}
-    />
-    <SearchInput
-      placeholder={`Find by ${searchType.toLowerCase()}`}
-      value={searchValue}
-      onChange={(_, newSearch) => {
-        onSearchValueChange(newSearch);
-      }}
-      onClear={() => onSearchValueChange('')}
-      style={{ minWidth: '200px' }}
-    />
+    <InputGroupItem>
+      <SimpleDropdownSelect
+        aria-label="Filter type"
+        data-testid="filter-dropdown-select"
+        options={types.map((key) => ({
+          key,
+          label: key,
+        }))}
+        value={searchType}
+        onChange={(key) => {
+          onSearchTypeChange(key as SearchType);
+        }}
+      />
+    </InputGroupItem>
+    <InputGroupItem>
+      <SearchInput
+        placeholder={`Find by ${searchType.toLowerCase()}`}
+        value={searchValue}
+        onChange={(_, newSearch) => {
+          onSearchValueChange(newSearch);
+        }}
+        onClear={() => onSearchValueChange('')}
+        style={{ minWidth: '200px' }}
+      />
+    </InputGroupItem>
   </InputGroup>
 );
 

--- a/frontend/src/concepts/pipelines/NoPipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/NoPipelineServer.tsx
@@ -13,7 +13,7 @@ type NoPipelineServerProps = {
 };
 
 const NoPipelineServer: React.FC<NoPipelineServerProps> = ({ variant }) => (
-  <EmptyState variant="sm">
+  <EmptyState variant="xs">
     <EmptyStateHeader
       titleText="Enable pipelines"
       icon={<EmptyStateIcon icon={WrenchIcon} />}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -6,6 +6,7 @@ import {
   TextInput,
   InputGroup,
   Tooltip,
+  InputGroupItem,
 } from '@patternfly/react-core';
 import React from 'react';
 import { DataConnection } from '~/pages/projects/types';
@@ -59,15 +60,18 @@ export const ObjectStorageSection = ({
         field.key === 'AWS_ACCESS_KEY_ID' ? (
           <FormGroup key={field.key} isRequired={field.isRequired} label={field.label}>
             <InputGroup>
-              <TextInput
-                aria-label={`Field list ${field.key}`}
-                isRequired={field.isRequired}
-                value={
-                  config.objectStorage.newValue.find((data) => data.key === field.key)?.value || ''
-                }
-                placeholder={field.placeholder}
-                onChange={(_, value) => onChange(field.key, value)}
-              />
+              <InputGroupItem isFill>
+                <TextInput
+                  aria-label={`Field list ${field.key}`}
+                  isRequired={field.isRequired}
+                  value={
+                    config.objectStorage.newValue.find((data) => data.key === field.key)?.value ||
+                    ''
+                  }
+                  placeholder={field.placeholder}
+                  onChange={(_, value) => onChange(field.key, value)}
+                />
+              </InputGroupItem>
               {loaded && !!dataConnections.length && (
                 <Tooltip content="Populate the form with credentials from your selected data connection">
                   <PipelineDropdown

--- a/frontend/src/pages/modelServing/screens/global/ModelServingNoProjects.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ModelServingNoProjects.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Title, EmptyState, EmptyStateIcon, EmptyStateBody } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateFooter,
+} from '@patternfly/react-core';
 import WrenchIcon from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { useNavigate } from 'react-router-dom';
 import NewProjectButton from '~/pages/projects/screens/projects/NewProjectButton';
@@ -9,15 +15,18 @@ const ModelServingNoProjects: React.FC = () => {
 
   return (
     <EmptyState>
-      <EmptyStateIcon icon={WrenchIcon} />
-      <Title headingLevel="h4" size="lg">
-        No data science projects
-      </Title>
-      <EmptyStateBody>To deploy a model, first create a data science project.</EmptyStateBody>
-      <NewProjectButton
-        closeOnCreate
-        onProjectCreated={(projectName) => navigate(`/modelServing/${projectName}`)}
+      <EmptyStateHeader
+        titleText="No data science projects"
+        icon={<EmptyStateIcon icon={WrenchIcon} />}
+        headingLevel="h4"
       />
+      <EmptyStateBody>To deploy a model, first create a data science project.</EmptyStateBody>
+      <EmptyStateFooter>
+        <NewProjectButton
+          closeOnCreate
+          onProjectCreated={(projectName) => navigate(`/modelServing/${projectName}`)}
+        />
+      </EmptyStateFooter>
     </EmptyState>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/EmptyModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyModelServingPlatform.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateHeader,
+} from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 
 const EmptyModelServingPlatform: React.FC = () => (
   <EmptyState variant="xs">
-    <EmptyStateIcon icon={WrenchIcon} />
-    <Title headingLevel="h3" size="lg">
-      No model serving platform selected
-    </Title>
+    <EmptyStateHeader
+      titleText="No model serving platform selected"
+      icon={<EmptyStateIcon icon={WrenchIcon} />}
+      headingLevel="h3"
+    />
     <EmptyStateBody>
       To enable model serving, an administrator must first select a model serving platform in the
       cluster settings.

--- a/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Flex, Label, Text, TextVariants, Timestamp, Tooltip } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  Label,
+  Text,
+  TextVariants,
+  Timestamp,
+  Tooltip,
+} from '@patternfly/react-core';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { KnownLabels, ProjectKind } from '~/k8sTypes';
 import useProjectTableRowItems from '~/pages/projects/screens/projects/useProjectTableRowItems';
@@ -30,15 +38,19 @@ const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
       <Td dataLabel="Name">
         <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
           {project.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE] && (
-            <Tooltip content="Data Science">
-              <Label isCompact color="green">
-                DS
-              </Label>
-            </Tooltip>
+            <FlexItem style={{ display: 'flex' }}>
+              <Tooltip content="Data Science">
+                <Label isCompact color="green">
+                  DS
+                </Label>
+              </Tooltip>
+            </FlexItem>
           )}
-          <ResourceNameTooltip resource={project}>
-            <ProjectLink project={project} />
-          </ResourceNameTooltip>
+          <FlexItem>
+            <ResourceNameTooltip resource={project}>
+              <ProjectLink project={project} />
+            </ResourceNameTooltip>
+          </FlexItem>
         </Flex>
         {owner && <Text component={TextVariants.small}>{owner}</Text>}
       </Td>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Towards #2209 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes issue numbers 1, 2, and 4 as listed in #2209 cc @DaoDaoNoCode 

Regarding number 3:
> The filter toggle text on Notebook image settings page and global model serving page is truncated

This is part of the larger component deprecation/cleanup effort and will be addressed with the PR for https://github.com/opendatahub-io/odh-dashboard/issues/1931

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in UI

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

1)
Before:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/37624318/d99e2fb7-0a5d-49a9-a444-4a82976b51d1)

After:
<img width="350" alt="Screenshot 2023-11-29 at 8 53 12 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/382ad1ee-9844-458d-b2aa-873008a38058">

2)

 Before:
<img width="323" alt="Screenshot 2023-11-21 at 1 55 07 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/99e26469-73b1-4397-8448-8596403bdc67">

After:
<img width="323" alt="Screenshot 2023-11-29 at 9 05 26 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/c0f846b1-880e-4c63-91fb-3f1ba73580d1">
<img width="323" alt="Screenshot 2023-11-29 at 9 06 21 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/766a24d2-1b5d-4673-a963-49d5085eddcf">


4) 

Before:
<img width="1213" alt="Screenshot 2023-11-21 at 2 18 57 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/a441a6f2-9949-4ceb-afc0-6ed41b80ebe0">

After:
<img width="1213" alt="Screenshot 2023-11-29 at 9 03 17 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/4bc27f4b-16f4-4159-9e1c-d8f0f57ac0b7">

 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
