### PR TITLE
Modify Accelerator support for kserve

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -909,7 +909,7 @@ export type ServingRuntime = K8sResourceCommon & {
       args: string[];
       image: string;
       name: string;
-      resources: ContainerResources;
+      resources?: ContainerResources;
       volumeMounts?: VolumeMount[];
     }[];
     supportedModelFormats: SupportedModelFormats[];

--- a/frontend/src/__mocks__/mockAcceleratork8sResource.ts
+++ b/frontend/src/__mocks__/mockAcceleratork8sResource.ts
@@ -1,0 +1,47 @@
+import { AcceleratorKind } from '~/k8sTypes';
+import { genUID } from './mockUtils';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+  displayName?: string;
+  identifier?: string;
+  enabled?: boolean;
+  tolerations?: {
+    key: string;
+    operator: string;
+    effect: string;
+  }[];
+};
+
+export const mockAcceleratork8sResource = ({
+  name = 'migrated-gpu',
+  namespace = 'test-project',
+  displayName = 'Nvidia GPU',
+  identifier = 'nvidia.com/gpu',
+  enabled = true,
+  tolerations = [
+    {
+      key: 'nvidia.com/gpu',
+      operator: 'Exists',
+      effect: 'NoSchedule',
+    },
+  ],
+}: MockResourceConfigType): AcceleratorKind => ({
+  apiVersion: 'dashboard.opendatahub.io/v1',
+  kind: 'AcceleratorProfile',
+  metadata: {
+    creationTimestamp: '2023-03-17T16:12:41Z',
+    generation: 1,
+    name,
+    namespace,
+    resourceVersion: '1309350',
+    uid: genUID('service'),
+  },
+  spec: {
+    identifier,
+    displayName,
+    enabled,
+    tolerations,
+  },
+});

--- a/frontend/src/__mocks__/mockInferenceServiceModalData.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceModalData.ts
@@ -1,0 +1,28 @@
+import {
+  CreatingInferenceServiceObject,
+  InferenceServiceStorageType,
+} from '~/pages/modelServing/screens/types';
+
+type MockResourceConfigType = Partial<CreatingInferenceServiceObject>;
+
+export const mockInferenceServiceModalData = ({
+  name = 'my-inference-service',
+  project = 'caikit-example',
+  servingRuntimeName = 'caikit',
+  storage = {
+    type: InferenceServiceStorageType.NEW_STORAGE,
+    path: '/caikit-llama',
+    dataConnection: 'aws-data-connection',
+    awsData: [],
+  },
+  format = {
+    name: 'caikit',
+    version: '1.0.0',
+  },
+}: MockResourceConfigType): CreatingInferenceServiceObject => ({
+  name,
+  project,
+  servingRuntimeName,
+  storage,
+  format,
+});

--- a/frontend/src/__mocks__/mockServingRuntimeModalData.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeModalData.ts
@@ -1,0 +1,33 @@
+import { CreatingServingRuntimeObject } from '~/pages/modelServing/screens/types';
+
+type MockResourceConfigType = Partial<CreatingServingRuntimeObject>;
+
+export const mockServingRuntimeModalData = ({
+  name = 'my-inference-service',
+  servingRuntimeTemplateName = 'caikit',
+  numReplicas = 1,
+  modelSize = {
+    name: 'small',
+    resources: {
+      requests: {
+        cpu: '1',
+        memory: '1Gi',
+      },
+      limits: {
+        cpu: '1',
+        memory: '1Gi',
+      },
+    },
+  },
+  externalRoute = false,
+  tokenAuth = false,
+  tokens = [],
+}: MockResourceConfigType): CreatingServingRuntimeObject => ({
+  name,
+  servingRuntimeTemplateName,
+  numReplicas,
+  modelSize,
+  externalRoute,
+  tokenAuth,
+  tokens,
+});

--- a/frontend/src/api/__tests__/servingRuntimes.spec.ts
+++ b/frontend/src/api/__tests__/servingRuntimes.spec.ts
@@ -1,23 +1,20 @@
+import { mockAcceleratork8sResource } from '~/__mocks__/mockAcceleratork8sResource';
 import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
+import { mockServingRuntimeModalData } from '~/__mocks__/mockServingRuntimeModalData';
 import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { assembleServingRuntime } from '~/api/k8s/servingRuntimes';
 import { ServingRuntimeKind } from '~/k8sTypes';
+import { AcceleratorState } from '~/utilities/useAcceleratorState';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
 
 describe('assembleServingRuntime', () => {
   it('should omit enable-xxxx annotations when creating', async () => {
     const servingRuntime = assembleServingRuntime(
-      {
-        name: 'my-serving-runtime',
-        servingRuntimeTemplateName: 'ovms',
-        numReplicas: 2,
-        modelSize: { name: 'Small', resources: {} },
-        tokens: [],
-        // test false values
+      mockServingRuntimeModalData({
         externalRoute: false,
         tokenAuth: false,
-      },
+      }),
       'test',
       mockServingRuntimeTemplateK8sResource({}).objects[0] as ServingRuntimeKind,
       false,
@@ -31,16 +28,10 @@ describe('assembleServingRuntime', () => {
 
   it('should remove enable-xxxx annotations when editing', async () => {
     const servingRuntime = assembleServingRuntime(
-      {
-        name: 'my-serving-runtime',
-        servingRuntimeTemplateName: 'ovms',
-        numReplicas: 2,
-        modelSize: { name: 'Small', resources: {} },
-        tokens: [],
-        // test false values
+      mockServingRuntimeModalData({
         externalRoute: false,
         tokenAuth: false,
-      },
+      }),
       'test',
       mockServingRuntimeK8sResource({ auth: true, route: true }),
       false,
@@ -54,16 +45,10 @@ describe('assembleServingRuntime', () => {
 
   it('should add enable-xxxx annotations when creating', async () => {
     const servingRuntime = assembleServingRuntime(
-      {
-        name: 'my-serving-runtime',
-        servingRuntimeTemplateName: 'ovms',
-        numReplicas: 2,
-        modelSize: { name: 'Small', resources: {} },
-        tokens: [],
-        // test true values
+      mockServingRuntimeModalData({
         externalRoute: true,
         tokenAuth: true,
-      },
+      }),
       'test',
       mockServingRuntimeTemplateK8sResource({}).objects[0] as ServingRuntimeKind,
       false,
@@ -77,16 +62,10 @@ describe('assembleServingRuntime', () => {
 
   it('should add enable-xxxx annotations when editing', async () => {
     const servingRuntime = assembleServingRuntime(
-      {
-        name: 'my-serving-runtime',
-        servingRuntimeTemplateName: 'ovms',
-        numReplicas: 2,
-        modelSize: { name: 'Small', resources: {} },
-        tokens: [],
-        // test true values
+      mockServingRuntimeModalData({
         externalRoute: true,
         tokenAuth: true,
-      },
+      }),
       'test',
       mockServingRuntimeK8sResource({ auth: false, route: false }),
       false,
@@ -96,5 +75,63 @@ describe('assembleServingRuntime', () => {
     expect(servingRuntime.metadata.annotations).toBeDefined();
     expect(servingRuntime.metadata.annotations?.['enable-auth']).toBe('true');
     expect(servingRuntime.metadata.annotations?.['enable-route']).toBe('true');
+  });
+
+  it('should add tolerations and gpu on modelmesh', async () => {
+    const acceleratorState: AcceleratorState = {
+      accelerator: mockAcceleratork8sResource({}),
+      accelerators: [mockAcceleratork8sResource({})],
+      initialAccelerator: mockAcceleratork8sResource({}),
+      count: 1,
+      additionalOptions: {},
+      useExisting: false,
+    };
+
+    const servingRuntime = assembleServingRuntime(
+      mockServingRuntimeModalData({
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      'test',
+      mockServingRuntimeK8sResource({ auth: false, route: false }),
+      true,
+      false,
+      acceleratorState,
+      true,
+    );
+
+    expect(servingRuntime.spec.tolerations).toBeDefined();
+    expect(servingRuntime.spec.containers[0].resources?.limits?.['nvidia.com/gpu']).toBe(1);
+    expect(servingRuntime.spec.containers[0].resources?.requests?.['nvidia.com/gpu']).toBe(1);
+  });
+
+  it('should not add tolerations and gpu on kserve', async () => {
+    const acceleratorState: AcceleratorState = {
+      accelerator: mockAcceleratork8sResource({}),
+      accelerators: [mockAcceleratork8sResource({})],
+      initialAccelerator: mockAcceleratork8sResource({}),
+      count: 1,
+      additionalOptions: {},
+      useExisting: false,
+    };
+
+    const servingRuntime = assembleServingRuntime(
+      mockServingRuntimeModalData({
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      'test',
+      mockServingRuntimeK8sResource({ auth: false, route: false }),
+      true,
+      false,
+      acceleratorState,
+      false,
+    );
+
+    expect(servingRuntime.spec.tolerations).toBeUndefined();
+    expect(servingRuntime.spec.containers[0].resources?.limits?.['nvidia.com/gpu']).toBeUndefined();
+    expect(
+      servingRuntime.spec.containers[0].resources?.requests?.['nvidia.com/gpu'],
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -329,7 +329,7 @@ export type ServingContainer = {
   image: string;
   name: string;
   affinity?: PodAffinity;
-  resources: ContainerResources;
+  resources?: ContainerResources;
   volumeMounts?: VolumeMount[];
 };
 
@@ -378,11 +378,13 @@ export type InferenceServiceKind = K8sResourceCommon & {
   };
   spec: {
     predictor: {
+      tolerations?: PodToleration[];
       model: {
         modelFormat: {
           name: string;
           version?: string;
         };
+        resources?: ContainerResources;
         runtime?: string;
         storageUri?: string;
         storage?: {

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
@@ -96,7 +96,7 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
               </StackItem>
               {servingRuntime && (
                 <StackItem>
-                  <ServingRuntimeDetails obj={servingRuntime} />
+                  <ServingRuntimeDetails obj={servingRuntime} isvc={obj} />
                 </StackItem>
               )}
             </Stack>

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -9,17 +9,18 @@ import {
   ListItem,
 } from '@patternfly/react-core';
 import { AppContext } from '~/app/AppContext';
-import { ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { getServingRuntimeSizes } from '~/pages/modelServing/screens/projects/utils';
 import useServingAccelerator from '~/pages/modelServing/screens/projects/useServingAccelerator';
 
 type ServingRuntimeDetailsProps = {
   obj: ServingRuntimeKind;
+  isvc?: InferenceServiceKind;
 };
 
-const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj }) => {
+const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc }) => {
   const { dashboardConfig } = React.useContext(AppContext);
-  const [accelerator] = useServingAccelerator(obj);
+  const [accelerator] = useServingAccelerator(obj, isvc);
   const container = obj.spec.containers[0]; // can we assume the first container?
   const sizes = getServingRuntimeSizes(dashboardConfig);
   const size = sizes.find((size) => _.isEqual(size.resources, container.resources));
@@ -30,20 +31,22 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj }) =>
         <DescriptionListTerm>Model server replicas</DescriptionListTerm>
         <DescriptionListDescription>{obj.spec.replicas}</DescriptionListDescription>
       </DescriptionListGroup>
-      <DescriptionListGroup>
-        <DescriptionListTerm>Model server size</DescriptionListTerm>
-        <DescriptionListDescription>
-          <List isPlain>
-            <ListItem>{size?.name || 'Custom'}</ListItem>
-            <ListItem>
-              {`${container.resources.requests?.cpu} CPUs, ${container.resources.requests?.memory} Memory requested`}
-            </ListItem>
-            <ListItem>
-              {`${container.resources.limits?.cpu} CPUs, ${container.resources.limits?.memory} Memory limit`}
-            </ListItem>
-          </List>
-        </DescriptionListDescription>
-      </DescriptionListGroup>
+      {container.resources && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Model server size</DescriptionListTerm>
+          <DescriptionListDescription>
+            <List isPlain>
+              <ListItem>{size?.name || 'Custom'}</ListItem>
+              <ListItem>
+                {`${container.resources.requests?.cpu} CPUs, ${container.resources.requests?.memory} Memory requested`}
+              </ListItem>
+              <ListItem>
+                {`${container.resources.limits?.cpu} CPUs, ${container.resources.limits?.memory} Memory limit`}
+              </ListItem>
+            </List>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
       <DescriptionListGroup>
         <DescriptionListTerm>Accelerator</DescriptionListTerm>
         <DescriptionListDescription>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -132,6 +132,8 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
       acceleratorState,
       NamespaceApplicationCase.MODEL_MESH_PROMOTION,
       currentProject,
+      undefined,
+      true,
     )
       .then(() => onSuccess())
       .catch((e) => {

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -61,6 +61,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     useCreateInferenceServiceObject(editInfo?.inferenceServiceEditInfo);
   const [acceleratorState, setAcceleratorState, resetAcceleratorData] = useServingAccelerator(
     editInfo?.servingRuntimeEditInfo?.servingRuntime,
+    editInfo?.inferenceServiceEditInfo,
   );
 
   const [actionInProgress, setActionInProgress] = React.useState(false);
@@ -152,12 +153,14 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         NamespaceApplicationCase.KSERVE_PROMOTION,
         projectContext?.currentProject,
         servingRuntimeName,
+        false,
       ),
       submitInferenceServiceResource(
         createDataInferenceService,
         editInfo?.inferenceServiceEditInfo,
         servingRuntimeName,
         false,
+        acceleratorState,
       ),
     ])
       .then(() => onSuccess())

--- a/frontend/src/pages/modelServing/screens/projects/useServingAccelerator.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAccelerator.ts
@@ -1,13 +1,17 @@
-import { ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import useAcceleratorState, { AcceleratorState } from '~/utilities/useAcceleratorState';
 import { GenericObjectState } from '~/utilities/useGenericObjectState';
 
 const useServingAccelerator = (
   servingRuntime?: ServingRuntimeKind | null,
+  inferenceService?: InferenceServiceKind | null,
 ): GenericObjectState<AcceleratorState> => {
   const acceleratorName = servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-name'];
-  const resources = servingRuntime?.spec.containers[0].resources;
-  const tolerations = servingRuntime?.spec.tolerations;
+  const resources =
+    inferenceService?.spec.predictor.model.resources ||
+    servingRuntime?.spec.containers[0].resources;
+  const tolerations =
+    inferenceService?.spec.predictor.tolerations || servingRuntime?.spec.tolerations;
 
   return useAcceleratorState(resources, tolerations, acceleratorName);
 };

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -255,17 +255,35 @@ const createInferenceServiceAndDataConnection = (
   existingStorage: boolean,
   editInfo?: InferenceServiceKind,
   isModelMesh?: boolean,
+  acceleratorState?: AcceleratorState,
 ) => {
   if (!existingStorage) {
     return createAWSSecret(inferenceServiceData).then((secret) =>
       editInfo
-        ? updateInferenceService(inferenceServiceData, editInfo, secret.metadata.name, isModelMesh)
-        : createInferenceService(inferenceServiceData, secret.metadata.name, isModelMesh),
+        ? updateInferenceService(
+            inferenceServiceData,
+            editInfo,
+            secret.metadata.name,
+            isModelMesh,
+            acceleratorState,
+          )
+        : createInferenceService(
+            inferenceServiceData,
+            secret.metadata.name,
+            isModelMesh,
+            acceleratorState,
+          ),
     );
   }
   return editInfo !== undefined
-    ? updateInferenceService(inferenceServiceData, editInfo, undefined, isModelMesh)
-    : createInferenceService(inferenceServiceData, undefined, isModelMesh);
+    ? updateInferenceService(
+        inferenceServiceData,
+        editInfo,
+        undefined,
+        isModelMesh,
+        acceleratorState,
+      )
+    : createInferenceService(inferenceServiceData, undefined, isModelMesh, acceleratorState);
 };
 
 export const submitInferenceServiceResource = (
@@ -273,6 +291,7 @@ export const submitInferenceServiceResource = (
   editInfo?: InferenceServiceKind,
   servingRuntimeName?: string,
   isModelMesh?: boolean,
+  acceleratorState?: AcceleratorState,
 ): Promise<InferenceServiceKind> => {
   const inferenceServiceData = {
     ...createData,
@@ -289,6 +308,7 @@ export const submitInferenceServiceResource = (
     existingStorage,
     editInfo,
     isModelMesh,
+    acceleratorState,
   );
 };
 
@@ -303,6 +323,7 @@ export const submitServingRuntimeResources = (
   servingPlatformEnablement: NamespaceApplicationCase,
   currentProject?: ProjectKind,
   name?: string,
+  isModelMesh?: boolean,
 ): Promise<void | (string | void | ServingRuntimeKind)[]> => {
   if (!servingRuntimeSelected) {
     return Promise.reject(
@@ -341,6 +362,7 @@ export const submitServingRuntimeResources = (
               dryRun,
             },
             acceleratorState: accelerator,
+            isModelMesh,
           }),
           setUpTokenAuth(
             servingRuntimeData,
@@ -364,6 +386,7 @@ export const submitServingRuntimeResources = (
               dryRun,
             },
             acceleratorState: accelerator,
+            isModelMesh,
           }).then((servingRuntime) =>
             setUpTokenAuth(
               servingRuntimeData,

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -190,7 +190,7 @@ const isAcceleratorChanged = (
   return (
     accelerator.metadata.name !== initialAccelerator.metadata.name ||
     acceleratorState.count !==
-      getAcceleratorGpuCount(initialAccelerator, servingRuntime.spec.containers[0].resources)
+      getAcceleratorGpuCount(initialAccelerator, servingRuntime.spec.containers[0].resources || {})
   );
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes #2244 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Prerequisites
Enable accelerator support in your cluster, you can add this accelerator into your cluster:

```yaml
apiVersion: dashboard.opendatahub.io/v1
kind: AcceleratorProfile
metadata:
  name: migrated-gpu
  namespace: redhat-ods-applications
spec:
  displayName: Nvidia GPU
  enabled: true
  identifier: nvidia.com/gpu
  tolerations:
    - effect: NoSchedule
      key: nvidia.com/gpu
      operator: Exists
```

### KServe Resource Creation

1. Deploy a new KServe model selecting the accelerator and a number of nodes
2. Check the `ServingRuntime` spec. **It shouldn't contain** tolerations, neither the gpu requests/limits `nvidia.com/gpu`
3. Check the `InferenceService` spec. **It should contain** tolerations under `spec.predictor.tolerations` and the gpu request/limits under `spec.predictor.model.resources`

### KServe Resource Editing

1. Edit the model deployed and remove the accelerator
2. Check the `ServingRuntime` spec. **It shouldn't be the same, just removing the opendatahub.io/accelerator-name label**
3. Check the `InferenceService` spec. **It shouldn't contain** tolerations under `spec.predictor.tolerations` neither the gpu request/limits under `spec.predictor.model.resources`


### Modelmesh Resrouce Creation

1. Create a new modelmesh server and select accelerator
2. Check the `ServingRuntime` spec. **It should contain tolerations and gpu resources**
3. Deploy a model
4. Check the `InferenceService` spec. **It shouldn't contain any gpu resource**


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Covered all paths with unit testing

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

**I haven't tested this changes with a proper gpu cluster, we should do that asap**