### PR TITLE
Create pipeline and pipeline version selector and change pipeline run creation page

### DIFF
--- a/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
+++ b/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
@@ -1,0 +1,188 @@
+import { PipelineVersionKF, RelationshipKF, ResourceTypeKF } from '~/concepts/pipelines/kfTypes';
+
+/* eslint-disable camelcase */
+export const mockPipelineVersionsProxy: PipelineVersionKF[] = [
+  {
+    id: 'ad1b7153-d2fd-4e5e-ae12-30c824b19b03',
+    name: 'flip coin_version_at_2023-12-01T01:42:09.321Z',
+    created_at: '2023-12-01T01:42:15Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '1c0dd0b3-dcdf-4a5d-a4f1-9fda4e20aba6',
+    name: 'flip coin_version_at_2023-12-01T01:42:00.825Z',
+    created_at: '2023-12-01T01:42:06Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '94a67a78-be66-4b4a-88e7-1c0fdc3f2867',
+    name: 'flip coin_version_at_2023-12-01T01:41:31.560Z',
+    created_at: '2023-12-01T01:41:41Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '9c34cd40-7195-4030-b540-ef0779b30ce7',
+    name: 'flip coin_version_at_2023-12-01T01:41:23.391Z',
+    created_at: '2023-12-01T01:41:29Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: 'eaa80f52-a6f9-4ba0-9fd7-bf067f339c5f',
+    name: 'flip coin_version_at_2023-12-01T01:41:14.845Z',
+    created_at: '2023-12-01T01:41:20Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '27bbb3e2-4a29-4701-9150-ebaabff63b97',
+    name: 'flip coin_version_at_2023-12-01T01:41:06.333Z',
+    created_at: '2023-12-01T01:41:12Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '6c3f2843-de1a-408c-8bd2-d68c1073b71c',
+    name: 'flip coin_version_at_2023-12-01T01:40:56.240Z',
+    created_at: '2023-12-01T01:41:03Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: 'd2d51128-87b4-41c0-a519-d00237367b09',
+    name: 'flip coin_version_at_2023-12-01T01:40:43.847Z',
+    created_at: '2023-12-01T01:40:53Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '5a2013ef-067c-4221-925f-8cbff134189d',
+    name: 'flip coin_version_at_2023-12-01T01:40:28.425Z',
+    created_at: '2023-12-01T01:40:41Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '31222a28-9b8f-4553-b6d3-54b106a3e5f9',
+    name: 'flip coin_version_at_2023-12-01T01:36:34.957Zhdsfjkasdhflkdshfkldshfkladsfhlkadshfksdadsafadsf',
+    created_at: '2023-12-01T01:36:48Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+    description: 'dsafdsjkfsahfklsadhflkdsahfkldsfhlasdkhfksldahflkas',
+  },
+  {
+    id: '2f177ef7-6403-4933-acc0-714f556c8835',
+    name: 'flip coin_version_at_2023-12-01T00:45:29.894Zsdafjkdsalfjdsklfadlskgnakdg',
+    created_at: '2023-12-01T00:45:46Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '38fe6c54-69fd-4011-9ab4-55bcfdf1e1cd',
+    name: 'flip coin_version_at_2023-11-29T14:43:43.608Z',
+    created_at: '2023-11-29T14:44:00Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+  {
+    id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+    name: 'flip coin',
+    created_at: '2023-10-03T15:37:54Z',
+    resource_references: [
+      {
+        key: {
+          type: ResourceTypeKF.PIPELINE,
+          id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+        },
+        relationship: RelationshipKF.OWNER,
+      },
+    ],
+  },
+];

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.spec.ts
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { mockPipelineVersionsProxy } from '~/__mocks__/mockPipelineVersionsProxy';
+import { navigateToStory } from '~/__tests__/integration/utils';
+
+test('Does not show run content', async ({ page }) => {
+  await page.goto(navigateToStory('components-pipelines-pipelineselector', 'default'));
+
+  await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(10);
+
+  // check the view more button and the label
+  await expect(page.getByText(`Showing 10/${mockPipelineVersionsProxy.length}`)).toBeVisible();
+  await page.getByText('View more').click();
+  await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(
+    mockPipelineVersionsProxy.length,
+  );
+
+  // test the search
+  const search = 'flip coin_';
+  await page.getByLabel('Filter pipelines').fill(search);
+  await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(10);
+  await page.getByText('View more').click();
+  await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(
+    mockPipelineVersionsProxy.filter((version) => version.name.startsWith(search)).length,
+  );
+  await page.getByLabel('Filter pipelines').fill('test-no-result');
+  await expect(page.getByText('No results match the filter.')).toBeVisible();
+});

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.stories.tsx
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/testing-library';
+import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
+import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
+import { mockPipelineVersionsProxy } from '~/__mocks__/mockPipelineVersionsProxy';
+
+export default {
+  component: PipelineSelector,
+} as Meta<typeof PipelineSelector>;
+
+export const Default: StoryObj = {
+  render: () => (
+    <PipelineSelector
+      columns={pipelineVersionSelectorColumns}
+      data={mockPipelineVersionsProxy}
+      onSelect={() => null}
+      placeHolder="Select a pipeline version"
+      searchHelperText={`Type a name to search your ${mockPipelineVersionsProxy.length} versions.`}
+      isLoading={false}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    // load page and wait until settled
+    const canvas = within(canvasElement);
+    await canvas.findByText('Select a pipeline version', undefined, { timeout: 5000 });
+    await userEvent.click(canvas.getByText('Select a pipeline version'));
+  },
+};

--- a/frontend/src/api/pipelines/custom.ts
+++ b/frontend/src/api/pipelines/custom.ts
@@ -28,7 +28,7 @@ import {
 } from './callTypes';
 import { handlePipelineFailures } from './errorUtils';
 
-const pipelineParamsToQuery = (params?: PipelineParams) => ({
+const commonPipelineQueryParams = (params?: PipelineParams) => ({
   // eslint-disable-next-line camelcase
   sort_by: params?.sortField
     ? `${params.sortField} ${params.sortDirection || 'asc'}`
@@ -40,6 +40,10 @@ const pipelineParamsToQuery = (params?: PipelineParams) => ({
   filter: params?.filter?.predicates
     ? JSON.stringify({ predicates: params.filter.predicates })
     : undefined,
+});
+
+const pipelineParamsToQuery = (params?: PipelineParams) => ({
+  ...commonPipelineQueryParams(params),
   'resource_reference_key.type': params?.filter?.resourceReference?.type,
   'resource_reference_key.id': params?.filter?.resourceReference?.id,
 });
@@ -137,9 +141,9 @@ export const listPipelineVersionsByPipeline: ListPipelineVersionsByPipelineAPI =
         hostPath,
         `/apis/v1beta1/pipeline_versions`,
         {
-          ...pipelineParamsToQuery(params),
-          'resource_reference_key.id': pipelineId,
-          'resource_reference_key.type': ResourceTypeKF.PIPELINE,
+          ...commonPipelineQueryParams(params),
+          'resource_key.id': pipelineId,
+          'resource_key.type': ResourceTypeKF.PIPELINE,
         },
         opts,
       ),

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelineQuery.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelineQuery.ts
@@ -14,9 +14,10 @@ const usePipelineQuery = <T extends PipelineCoreResourceKF>(
     params?: PipelineParams,
   ) => PipelineKFCallCommon<unknown> & { items?: T[] },
   options?: PipelineOptions,
+  refreshRate = POLL_INTERVAL,
 ): FetchState<PipelineListPaged<T>> => {
   const [totalSize, setTotalSize] = React.useState(0);
-  const { sortField, sortDirection, page = 1, pageSize = 2, filter } = options ?? {};
+  const { sortField, sortDirection, page = 1, pageSize, filter } = options ?? {};
   const pageTokensRef = React.useRef<(string | undefined)[]>([]);
 
   React.useEffect(() => {
@@ -29,16 +30,13 @@ const usePipelineQuery = <T extends PipelineCoreResourceKF>(
       if (page > 1 && !pageTokensRef.current[page - 1]) {
         throw new Error(`No token available for page ${page}.`);
       }
-      const result =
-        pageSize > 0
-          ? await apiFetch(opts, {
-              pageSize: pageSize,
-              pageToken: pageTokensRef.current[page - 1],
-              sortField,
-              sortDirection,
-              filter,
-            })
-          : undefined;
+      const result = await apiFetch(opts, {
+        pageSize,
+        pageToken: pageTokensRef.current[page - 1],
+        sortField,
+        sortDirection,
+        filter,
+      });
 
       return {
         items: result?.items || [],
@@ -54,7 +52,7 @@ const usePipelineQuery = <T extends PipelineCoreResourceKF>(
     { totalSize: 0, items: [] },
     {
       initialPromisePurity: true,
-      refreshRate: POLL_INTERVAL,
+      refreshRate,
     },
   );
 

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline.ts
@@ -3,19 +3,29 @@ import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import usePipelineQuery from '~/concepts/pipelines/apiHooks/usePipelineQuery';
 import { PipelineOptions } from '~/concepts/pipelines/types';
+import { NotReadyError } from '~/utilities/useFetchState';
 
-const usePipelineVersionsForPipeline = (pipelineId: string, options?: PipelineOptions) => {
+const usePipelineVersionsForPipeline = (
+  pipelineId?: string,
+  options?: PipelineOptions,
+  refreshRate?: number,
+) => {
   const { api } = usePipelinesAPI();
 
   return usePipelineQuery<PipelineVersionKF>(
     React.useCallback(
-      (opts, params) =>
-        api
+      (opts, params) => {
+        if (!pipelineId) {
+          return Promise.reject(new NotReadyError('No pipeline id'));
+        }
+        return api
           .listPipelineVersionsByPipeline(opts, pipelineId, params)
-          .then((result) => ({ ...result, items: result.versions })),
+          .then((result) => ({ ...result, items: result.versions }));
+      },
       [api, pipelineId],
     ),
     options,
+    refreshRate,
   );
 };
 

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelines.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelines.ts
@@ -4,7 +4,7 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import usePipelineQuery from '~/concepts/pipelines/apiHooks/usePipelineQuery';
 import { PipelineOptions } from '~/concepts/pipelines/types';
 
-const usePipelines = (options?: PipelineOptions) => {
+const usePipelines = (options?: PipelineOptions, refreshRate?: number) => {
   const { api } = usePipelinesAPI();
   return usePipelineQuery<PipelineKF>(
     React.useCallback(
@@ -13,6 +13,7 @@ const usePipelines = (options?: PipelineOptions) => {
       [api],
     ),
     options,
+    refreshRate,
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -6,6 +6,7 @@ import { ValueOf } from '~/typeHelpers';
 import RunTypeSection from '~/concepts/pipelines/content/createRun/contentSections/RunTypeSection';
 import ParamsSection from '~/concepts/pipelines/content/createRun/contentSections/ParamsSection';
 import { getProjectDisplayName } from '~/pages/projects/utils';
+import PipelineVersionSection from '~/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection';
 import PipelineSection from './contentSections/PipelineSection';
 import { CreateRunPageSections, runPageSectionTitles } from './const';
 
@@ -44,9 +45,30 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange }) => (
       value={data.pipeline}
       onChange={(pipeline) => {
         onValueChange('pipeline', pipeline);
+        onValueChange('version', pipeline.default_version);
         onValueChange(
           'params',
-          (pipeline.parameters || []).map((p) => ({ label: p.name, value: p.value ?? '' })),
+          (pipeline.default_version?.parameters || pipeline.parameters || []).map((p) => ({
+            label: p.name,
+            value: p.value ?? '',
+          })),
+        );
+      }}
+    />
+    <PipelineVersionSection
+      onLoaded={(loaded) => {
+        onValueChange('pipelineVersionsLoaded', loaded);
+      }}
+      pipelineId={data.pipeline?.id}
+      value={data.version}
+      onChange={(version) => {
+        onValueChange('version', version);
+        onValueChange(
+          'params',
+          (version.parameters || []).map((p) => ({
+            label: p.name,
+            value: p.value ?? '',
+          })),
         );
       }}
     />

--- a/frontend/src/concepts/pipelines/content/createRun/const.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/const.ts
@@ -8,6 +8,7 @@ export const DEFAULT_TIME = '12:00 AM';
 export enum CreateRunPageSections {
   NAME_DESC = 'run-section-name-desc',
   PIPELINE = 'run-section-pipeline',
+  PIPELINE_VERSION = 'run-section-pipeline-version',
   // EXPERIMENT = 'run-section-experiment',
   RUN_TYPE = 'run-section-run-type',
   PARAMS = 'run-section-params',
@@ -16,6 +17,7 @@ export enum CreateRunPageSections {
 export const runPageSectionTitles: Record<CreateRunPageSections, string> = {
   [CreateRunPageSections.NAME_DESC]: 'Name and description',
   [CreateRunPageSections.PIPELINE]: 'Pipeline',
+  [CreateRunPageSections.PIPELINE_VERSION]: 'Pipeline version',
   // [CreateRunPageSections.EXPERIMENT]: 'Experiment',
   [CreateRunPageSections.RUN_TYPE]: 'Run type',
   [CreateRunPageSections.PARAMS]: 'Pipeline input parameters',

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { FormSection, Skeleton, Stack, StackItem } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { FormSection } from '@patternfly/react-core';
 import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
 import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
-import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
-import ImportPipelineButton from '~/concepts/pipelines/content/import/ImportPipelineButton';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
+import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
+import { pipelineSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
 
 type PipelineSectionProps = {
   onLoaded: (loaded: boolean) => void;
@@ -17,44 +16,33 @@ type PipelineSectionProps = {
 };
 
 const PipelineSection: React.FC<PipelineSectionProps> = ({ onLoaded, value, onChange }) => {
-  const [{ items: pipelines }, loaded] = usePipelines();
+  const [{ items: pipelines }, loaded] = usePipelines({}, 0);
+
   React.useEffect(() => {
     onLoaded(loaded);
     // only run when `loaded` changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded]);
-  if (!loaded) {
-    return <Skeleton />;
-  }
+
   return (
     <FormSection
       id={CreateRunPageSections.PIPELINE}
       title={runPageSectionTitles[CreateRunPageSections.PIPELINE]}
     >
-      <Stack hasGutter>
-        <StackItem>
-          <SimpleDropdownSelect
-            placeholder="Select a pipeline"
-            options={pipelines.map((p) => ({ key: p.id, label: p.name }))}
-            value={value?.id ?? ''}
-            onChange={(id) => {
-              const pipeline = pipelines.find((p) => p.id === id);
-              if (pipeline) {
-                onChange(pipeline);
-              }
-            }}
-          />
-        </StackItem>
-        <StackItem>
-          <ImportPipelineButton
-            variant="link"
-            icon={<PlusCircleIcon />}
-            onCreate={(pipeline) => onChange(pipeline)}
-          >
-            Import pipeline
-          </ImportPipelineButton>
-        </StackItem>
-      </Stack>
+      <PipelineSelector
+        name={value?.name}
+        data={pipelines}
+        columns={pipelineSelectorColumns}
+        onSelect={(id) => {
+          const pipeline = pipelines.find((p) => p.id === id);
+          if (pipeline) {
+            onChange(pipeline);
+          }
+        }}
+        isLoading={!loaded}
+        placeHolder={pipelines.length === 0 ? 'No pipelines available' : 'Select a pipeline'}
+        searchHelperText={`Type a name to search your ${pipelines.length} pipelines.`}
+      />
     </FormSection>
   );
 };

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { FormSection } from '@patternfly/react-core';
+import {
+  CreateRunPageSections,
+  runPageSectionTitles,
+} from '~/concepts/pipelines/content/createRun/const';
+import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import usePipelineVersionsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline';
+import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
+import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
+
+type PipelineVersionSectionProps = {
+  onLoaded: (loaded: boolean) => void;
+  pipelineId?: string;
+  value: PipelineVersionKF | null;
+  onChange: (version: PipelineVersionKF) => void;
+};
+
+const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
+  onLoaded,
+  pipelineId,
+  value,
+  onChange,
+}) => {
+  const [{ items: versions }, loaded] = usePipelineVersionsForPipeline(pipelineId, {}, 0);
+
+  React.useEffect(() => {
+    onLoaded(loaded);
+    // only run when `loaded` changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  return (
+    <FormSection
+      id={CreateRunPageSections.PIPELINE_VERSION}
+      title={runPageSectionTitles[CreateRunPageSections.PIPELINE_VERSION]}
+    >
+      <PipelineSelector
+        name={value?.name}
+        data={versions}
+        columns={pipelineVersionSelectorColumns}
+        onSelect={(id) => {
+          const version = versions.find((v) => v.id === id);
+          if (version) {
+            onChange(version);
+          }
+        }}
+        isDisabled={!pipelineId}
+        isLoading={!!pipelineId && !loaded}
+        placeHolder={
+          pipelineId && versions.length === 0
+            ? 'No versions available'
+            : 'Select a pipeline version'
+        }
+        searchHelperText={`Type a name to search your ${versions.length} versions.`}
+      />
+    </FormSection>
+  );
+};
+
+export default PipelineVersionSection;

--- a/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
@@ -20,10 +20,10 @@ import { isFilledRunFormData } from '~/concepts/pipelines/content/createRun/util
 const getResourceReferences = (formData: SafeRunFormData): ResourceReferenceKF[] => {
   const refs: ResourceReferenceKF[] = [];
 
-  if (formData.pipeline) {
+  if (formData.version) {
     refs.push({
       key: {
-        id: formData.pipeline.id,
+        id: formData.version.id,
         type: ResourceTypeKF.PIPELINE_VERSION,
       },
       relationship: RelationshipKF.CREATOR,

--- a/frontend/src/concepts/pipelines/content/createRun/types.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/types.ts
@@ -1,5 +1,5 @@
 import { ProjectKind } from '~/k8sTypes';
-import { PipelineKF } from '~/concepts/pipelines/kfTypes';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 
 export enum RunTypeOption {
   ONE_TRIGGER = 'run',
@@ -44,7 +44,9 @@ export type RunFormData = {
   project: ProjectKind;
   nameDesc: { name: string; description: string };
   pipelinesLoaded: boolean;
+  pipelineVersionsLoaded: boolean;
   pipeline: PipelineKF | null;
+  version: PipelineVersionKF | null;
   // experiment: ExperimentKF | null;
   runType: RunType;
   params?: RunParam[];

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -17,6 +17,7 @@ import {
   PipelineKF,
   PipelineRunJobKF,
   PipelineRunKF,
+  PipelineVersionKF,
   ResourceReferenceKF,
 } from '~/concepts/pipelines/kfTypes';
 
@@ -205,6 +206,7 @@ const getParams = (pipeline?: PipelineKF): RunParam[] | undefined =>
 const useRunFormData = (
   initialData?: PipelineRunKF | PipelineRunJobKF,
   lastPipeline?: PipelineKF,
+  lastVersion?: PipelineVersionKF,
 ) => {
   const { project } = usePipelinesAPI();
 
@@ -215,7 +217,9 @@ const useRunFormData = (
       description: initialData?.description ?? '',
     },
     pipelinesLoaded: false,
+    pipelineVersionsLoaded: false,
     pipeline: lastPipeline ?? null,
+    version: lastVersion ?? lastPipeline?.default_version ?? null,
     // experiment: null,
     runType: { type: RunTypeOption.ONE_TRIGGER },
     params: getParams(lastPipeline),

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -40,7 +40,9 @@ const runTypeSafeDates = (runType: RunFormData['runType']): boolean =>
 export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData =>
   !!formData.nameDesc.name &&
   formData.pipelinesLoaded &&
+  formData.pipelineVersionsLoaded &&
   !!formData.pipeline &&
+  !!formData.version &&
   !!formData.params &&
   runTypeSafeData(formData.runType) &&
   runTypeSafeDates(formData.runType);

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelector.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import {
+  Badge,
+  Bullseye,
+  HelperText,
+  HelperTextItem,
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuSearch,
+  MenuSearchInput,
+  MenuToggle,
+  SearchInput,
+  Skeleton,
+} from '@patternfly/react-core';
+import useDebounceCallback from '~/utilities/useDebounceCallback';
+import PipelineSelectorTableRow from '~/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow';
+import { SortableData, Table } from '~/components/table';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+
+type PipelineSelectorProps<DataType> = {
+  name?: string;
+  columns: SortableData<DataType>[];
+  data: DataType[];
+  placeHolder: string;
+  searchHelperText: string;
+  onSelect: (id: string) => void;
+  isLoading: boolean;
+  isDisabled?: boolean;
+};
+
+const PipelineSelector = <T extends PipelineKF | PipelineVersionKF>({
+  name,
+  columns,
+  data,
+  onSelect,
+  isLoading,
+  isDisabled,
+  placeHolder,
+  searchHelperText,
+}: PipelineSelectorProps<T>) => {
+  const [isOpen, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [filteredData, setFilteredData] = React.useState(data);
+  const [visibleLength, setVisibleLength] = React.useState(10);
+
+  const toggleRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+
+  const doSetSearchDebounced = useDebounceCallback(setSearch);
+
+  React.useEffect(() => {
+    if (search) {
+      setFilteredData(
+        data.filter((option) => option.name.toLowerCase().includes(search.toLowerCase())),
+      );
+    } else {
+      setFilteredData(data);
+    }
+    setVisibleLength(10);
+  }, [search, data]);
+
+  if (isLoading) {
+    return <Skeleton />;
+  }
+
+  const menu = (
+    <Menu data-id="pipeline-selector-menu" ref={menuRef} isScrollable>
+      <MenuContent>
+        <MenuSearch>
+          <MenuSearchInput>
+            <SearchInput
+              value={search}
+              aria-label="Filter pipelines"
+              onChange={(_event, value) => doSetSearchDebounced(value)}
+            />
+          </MenuSearchInput>
+          <HelperText>
+            <HelperTextItem variant="indeterminate">{searchHelperText}</HelperTextItem>
+          </HelperText>
+        </MenuSearch>
+        <MenuList>
+          <div role="menuitem">
+            <Table
+              data-id="pipeline-selector-table-list"
+              emptyTableView={<Bullseye>No results match the filter.</Bullseye>}
+              borders={false}
+              variant="compact"
+              columns={columns}
+              data={filteredData}
+              truncateRenderingAt={visibleLength}
+              rowRenderer={(row, index) => (
+                <PipelineSelectorTableRow
+                  key={index}
+                  obj={row}
+                  onClick={() => {
+                    onSelect(row.id);
+                    setOpen(false);
+                  }}
+                />
+              )}
+            />
+          </div>
+          {visibleLength < filteredData.length && (
+            <MenuItem
+              isLoadButton
+              onClick={(e) => {
+                // sometimes it will trigger onOpenChange function
+                // because it misjudges the outside of the menu
+                // use stopPropagation to prevent menu from closing
+                e.stopPropagation();
+                setVisibleLength((length) => length + 10);
+              }}
+            >
+              <>
+                View more <Badge isRead>{`Showing ${visibleLength}/${filteredData.length}`}</Badge>
+              </>
+            </MenuItem>
+          )}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      toggleRef={toggleRef}
+      toggle={
+        <MenuToggle
+          style={{ maxWidth: '500px' }}
+          ref={toggleRef}
+          onClick={() => setOpen(!isOpen)}
+          isExpanded={isOpen}
+          isDisabled={isDisabled || data.length === 0}
+          isFullWidth
+        >
+          {name || placeHolder}
+        </MenuToggle>
+      }
+      menu={menu}
+      menuRef={menuRef}
+      popperProps={{ maxWidth: 'trigger' }}
+      onOpenChange={(open) => setOpen(open)}
+    />
+  );
+};
+
+export default PipelineSelector;

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import { Td, Tr } from '@patternfly/react-table';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { relativeTime } from '~/utilities/time';
+
+type PipelineSelectorTableRowProps = {
+  obj: PipelineKF | PipelineVersionKF;
+  onClick: () => void;
+};
+
+const PipelineSelectorTableRow: React.FC<PipelineSelectorTableRowProps> = ({ obj, onClick }) => {
+  const tooltipRef = React.useRef(null);
+
+  return (
+    <>
+      {obj.description && (
+        <Tooltip
+          position="right"
+          content={
+            <>
+              Description:
+              <br />
+              {obj.description}
+            </>
+          }
+          triggerRef={tooltipRef}
+        />
+      )}
+      <Tr
+        ref={tooltipRef}
+        onRowClick={onClick}
+        isClickable
+        data-id="pipeline-selector-table-list-row"
+      >
+        <Td width={70} modifier="truncate" dataLabel="Name">
+          {obj.name}
+        </Td>
+        <Td width={30} dataLabel="Updated">
+          {relativeTime(Date.now(), new Date(obj.created_at).getTime())}
+        </Td>
+      </Tr>
+    </>
+  );
+};
+
+export default PipelineSelectorTableRow;

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/columns.ts
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/columns.ts
@@ -1,0 +1,32 @@
+import { SortableData } from '~/components/table';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+
+export const pipelineSelectorColumns: SortableData<PipelineKF>[] = [
+  {
+    label: 'Pipeline name',
+    field: 'name',
+    sortable: false,
+    width: 70,
+  },
+  {
+    label: 'Updated',
+    field: 'updated',
+    sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    width: 30,
+  },
+];
+
+export const pipelineVersionSelectorColumns: SortableData<PipelineVersionKF>[] = [
+  {
+    label: 'Pipeline version',
+    field: 'version',
+    sortable: false,
+    width: 70,
+  },
+  {
+    label: 'Updated',
+    field: 'updated',
+    sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    width: 30,
+  },
+];

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -176,7 +176,7 @@ export type PipelineKF = PipelineCoreResourceKF & {
   parameters?: ParameterKF[];
   url?: UrlKF;
   error?: string;
-  default_version: PipelineVersionKF;
+  default_version?: PipelineVersionKF;
 };
 
 export type PipelineRunKF = PipelineCoreResourceKF & {


### PR DESCRIPTION
 <!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA:
[RHOAIENG-266](https://issues.redhat.com/browse/RHOAIENG-266)
[RHOAIENG-268](https://issues.redhat.com/browse/RHOAIENG-268)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR creates a selector for both pipeline and pipeline versions that could be used in many places. Here in this PR, we add this selector to the pipeline runs creation form.

When no pipeline is selected, the version selector is disabled

<img width="1726" alt="Screenshot 2023-12-04 at 4 59 23 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/5b3fd5bb-7108-4ab7-a6cd-e62cb89eef1e">

Now you could select the pipeline, if the number is less than 10, we will not show the `View more` button

<img width="1726" alt="Screenshot 2023-12-04 at 5 00 18 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/fa3ca1f1-6877-4c01-9975-a88d4ac5e3e2">

After the pipeline is selected, the default version will be automatically selected

<img width="1726" alt="Screenshot 2023-12-04 at 5 01 27 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/eee7eba5-4896-4370-ab7c-7da61826399f">

If the number is more than 10, it will show the badge of the visible options and the total size

<img width="1726" alt="Screenshot 2023-12-04 at 5 01 46 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/f06f85ac-6ce4-4a63-bc6a-fb9328b63ae5">

Clicking on it will load more options

<img width="1726" alt="Screenshot 2023-12-04 at 5 03 17 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/429dc1c9-8834-4131-a49b-6cabccdd837d">

If the name is truncated, the tooltip will show up. If the version has a description, another tooltip will show on the side

<img width="1726" alt="Screenshot 2023-12-04 at 5 04 08 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/164eee4c-8526-4618-87f4-ce394b015caf">

The `Updated` column is sortable, the sort is based on *ALL* options, but not only the visible options

<img width="1726" alt="Screenshot 2023-12-04 at 5 05 02 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ae4f7788-20da-44db-baa7-25f162e45b41">

The search input could be used to filter the pipelines or pipeline versions

<img width="1726" alt="Screenshot 2023-12-04 at 5 06 56 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/ab054a1c-961c-495d-9e5b-26d920abb2e2">

<img width="1726" alt="Screenshot 2023-12-04 at 5 07 06 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/0bc948b2-9ca6-473f-90c0-da9d697a36a6">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Upload several versions to one pipeline (better to be more than 10 to test the `View more` function). If you don't know how to upload, you could enable the kubeflow pipeline UI following the instructions here https://github.com/opendatahub-io/data-science-pipelines-operator#ml-pipelines-ui. Then you could upload a version to a specific pipeline. A version is the same YAML file as the pipeline you uploaded before.
2. Go to the create run page, and test the dropdowns for both pipeline and pipeline version

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Created a unit test to test the selector to see whether it could show the correct number and badge and search.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
