### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ or
 npm run make:build
 ```
 
-in the root of this repository. By default, we use [podman](https://podman.io/) as the default container tool, but you can change it by setting the `CONTAINER_TOOL` environment variable to `docker`.
+in the root of this repository. By default, we use [podman](https://podman.io/) as the default container tool, but you can change it by setting the `CONTAINER_BUILDER` environment variable to `docker`.
 
 After building the image, you need to push it to a container registry accessible by your cluster. You can do that by running
 


### PR DESCRIPTION
Fixes an error in our contribution guide. The environment variable used by our Makefile to change the container engine used to build is `CONTAINER_BUILDER` not `CONTAINER_TOOL` as the doc currently says.

NB: This is a documentation only change.
