### PR TITLE
Create pipeline version upload modal

### DIFF
--- a/frontend/src/__mocks__/mockPipelinesProxy.ts
+++ b/frontend/src/__mocks__/mockPipelinesProxy.ts
@@ -1,0 +1,230 @@
+import { PipelineKF, RelationshipKF, ResourceTypeKF } from '~/concepts/pipelines/kfTypes';
+
+/* eslint-disable camelcase */
+export const mockPipelinesProxy: { pipelines: PipelineKF[]; total_size: number } = {
+  pipelines: [
+    {
+      id: '9b6f1770-7a8a-47c3-bf55-328f7bfa98e1',
+      created_at: '2023-12-05T13:56:16Z',
+      name: 'no version pipeline',
+    },
+    {
+      id: 'f7d735ef-d47f-4d05-93b9-8a26eb6d4563',
+      created_at: '2023-11-30T22:55:17Z',
+      name: 'flip coin 2',
+      description: 'this is copy flip coin',
+      default_version: {
+        id: 'f7d735ef-d47f-4d05-93b9-8a26eb6d4563',
+        name: 'flip coin 2',
+        created_at: '2023-11-30T22:55:17Z',
+        resource_references: [
+          {
+            key: {
+              type: ResourceTypeKF.PIPELINE,
+              id: 'f7d735ef-d47f-4d05-93b9-8a26eb6d4563',
+            },
+            relationship: RelationshipKF.OWNER,
+          },
+        ],
+      },
+    },
+    {
+      id: 'dd1b49de-9d27-4431-be6f-6432b741c6d0',
+      created_at: '2023-10-03T19:14:50Z',
+      name: 'dedup-ray-pipeline',
+      parameters: [
+        {
+          name: 'content',
+          value: 'contents',
+        },
+        {
+          name: 'hash_cpu',
+          value: '.5',
+        },
+        {
+          name: 'image',
+          value: 'quay.io/ibmdpdev/dedup-exact-ray:2.5.1-py310',
+        },
+        {
+          name: 'input_path',
+          value: 'cos-optimal-llm-pile/blue-pile/0_internet/2_commoncrawl/ete=v0.2',
+        },
+        {
+          name: 'max_files',
+          value: '100',
+        },
+        {
+          name: 'n_sample',
+          value: '5',
+        },
+        {
+          name: 'name',
+          value: 'kfp-ray-dedup',
+        },
+        {
+          name: 'num_workers',
+          value: '8',
+        },
+        {
+          name: 'output_path',
+          value: 'cos-optimal-llm-pile/boris_test/',
+        },
+        {
+          name: 'print_tmout',
+          value: '1',
+        },
+        {
+          name: 'processor_cpu',
+          value: '.75',
+        },
+        {
+          name: 'template_cm',
+          value: 'ray-dedup-template',
+        },
+        {
+          name: 'wait_ready_retries',
+          value: '100',
+        },
+        {
+          name: 'wait_ready_tmout',
+          value: '1',
+        },
+        {
+          name: 'worker_cpu',
+          value: '8',
+        },
+        {
+          name: 'worker_gpu',
+          value: '0',
+        },
+        {
+          name: 'worker_memory',
+          value: '32',
+        },
+      ],
+      default_version: {
+        id: 'dd1b49de-9d27-4431-be6f-6432b741c6d0',
+        name: 'dedup-ray-pipeline',
+        created_at: '2023-10-03T19:14:50Z',
+        parameters: [
+          {
+            name: 'content',
+            value: 'contents',
+          },
+          {
+            name: 'hash_cpu',
+            value: '.5',
+          },
+          {
+            name: 'image',
+            value: 'quay.io/ibmdpdev/dedup-exact-ray:2.5.1-py310',
+          },
+          {
+            name: 'input_path',
+            value: 'cos-optimal-llm-pile/blue-pile/0_internet/2_commoncrawl/ete=v0.2',
+          },
+          {
+            name: 'max_files',
+            value: '100',
+          },
+          {
+            name: 'n_sample',
+            value: '5',
+          },
+          {
+            name: 'name',
+            value: 'kfp-ray-dedup',
+          },
+          {
+            name: 'num_workers',
+            value: '8',
+          },
+          {
+            name: 'output_path',
+            value: 'cos-optimal-llm-pile/boris_test/',
+          },
+          {
+            name: 'print_tmout',
+            value: '1',
+          },
+          {
+            name: 'processor_cpu',
+            value: '.75',
+          },
+          {
+            name: 'template_cm',
+            value: 'ray-dedup-template',
+          },
+          {
+            name: 'wait_ready_retries',
+            value: '100',
+          },
+          {
+            name: 'wait_ready_tmout',
+            value: '1',
+          },
+          {
+            name: 'worker_cpu',
+            value: '8',
+          },
+          {
+            name: 'worker_gpu',
+            value: '0',
+          },
+          {
+            name: 'worker_memory',
+            value: '32',
+          },
+        ],
+        resource_references: [
+          {
+            key: {
+              type: ResourceTypeKF.PIPELINE,
+              id: 'dd1b49de-9d27-4431-be6f-6432b741c6d0',
+            },
+            relationship: RelationshipKF.OWNER,
+          },
+        ],
+      },
+    },
+    {
+      id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+      created_at: '2023-10-03T15:37:54Z',
+      name: 'filp coin',
+      default_version: {
+        id: 'bf7c5ee8-031a-4717-804d-828adde2f7d6',
+        name: 'filp coin_version_at_2023-12-06T16:09:52.153Z',
+        created_at: '2023-12-06T16:10:01Z',
+        resource_references: [
+          {
+            key: {
+              type: ResourceTypeKF.PIPELINE,
+              id: '63a09bff-9261-43b9-a2a8-5f2158c5522e',
+            },
+            relationship: RelationshipKF.OWNER,
+          },
+        ],
+      },
+    },
+    {
+      id: 'e850325b-bc05-417b-9d47-e99c5926bc3f',
+      created_at: '2023-09-18T18:57:05Z',
+      name: 'abc',
+      default_version: {
+        id: 'e850325b-bc05-417b-9d47-e99c5926bc3f',
+        name: 'abc',
+        created_at: '2023-09-18T18:57:05Z',
+        resource_references: [
+          {
+            key: {
+              type: ResourceTypeKF.PIPELINE,
+              id: 'e850325b-bc05-417b-9d47-e99c5926bc3f',
+            },
+            relationship: RelationshipKF.OWNER,
+          },
+        ],
+      },
+    },
+  ],
+  total_size: 5,
+};

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.spec.ts
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { mockPipelineVersionsProxy } from '~/__mocks__/mockPipelineVersionsProxy';
 import { navigateToStory } from '~/__tests__/integration/utils';
 
-test('Does not show run content', async ({ page }) => {
+test('Pipeline version selector - Test filter and view more', async ({ page }) => {
   await page.goto(navigateToStory('components-pipelines-pipelineselector', 'default'));
 
   await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(10);

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.stories.tsx
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.stories.tsx
@@ -12,6 +12,7 @@ export default {
 export const Default: StoryObj = {
   render: () => (
     <PipelineSelector
+      maxWidth="500px"
       columns={pipelineVersionSelectorColumns}
       data={mockPipelineVersionsProxy}
       onSelect={() => null}

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineVersionImportModal.spec.ts
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineVersionImportModal.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { mockPipelinesProxy } from '~/__mocks__/mockPipelinesProxy';
+import { navigateToStory } from '~/__tests__/integration/utils';
+
+test('Pipeline version import modal - Update pipeline selector should generate meaningful version name', async ({
+  page,
+}) => {
+  await page.goto(navigateToStory('components-pipelines-pipelineversionimportmodal', 'default'));
+
+  await page.locator('#pipeline-selection').click();
+  await page.getByText(mockPipelinesProxy.pipelines[0].name).click();
+  await expect(await page.locator('#pipeline-version-name').getAttribute('value')).toMatch(
+    new RegExp(`${mockPipelinesProxy.pipelines[0].name}_version_at_.*`),
+  );
+
+  await page.locator('#pipeline-selection').click();
+  await page.getByText(mockPipelinesProxy.pipelines[1].name).click();
+  await expect(await page.locator('#pipeline-version-name').getAttribute('value')).toMatch(
+    new RegExp(`${mockPipelinesProxy.pipelines[1].name}_version_at_.*`),
+  );
+});

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineVersionImportModal.stories.tsx
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineVersionImportModal.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { rest } from 'msw';
+import PipelineVersionImportModal from '~/concepts/pipelines/content/import/PipelineVersionImportModal';
+import { PipelineContextProvider } from '~/concepts/pipelines/context';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import { mockDataSciencePipelineApplicationK8sResource } from '~/__mocks__/mockDataSciencePipelinesApplicationK8sResource';
+import { mockRouteK8sResource } from '~/__mocks__/mockRouteK8sResource';
+import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { mockPipelinesProxy } from '~/__mocks__/mockPipelinesProxy';
+
+export default {
+  component: PipelineVersionImportModal,
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
+          res(ctx.json(mockK8sResourceList([mockProjectK8sResource({})]))),
+        ),
+        rest.get(
+          '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/pipelines-definition',
+          (req, res, ctx) => res(ctx.json(mockDataSciencePipelineApplicationK8sResource({}))),
+        ),
+        rest.get(
+          '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-pipelines-definition',
+          (req, res, ctx) =>
+            res(
+              ctx.json(mockRouteK8sResource({ notebookName: 'ds-pipeline-pipelines-definition' })),
+            ),
+        ),
+        rest.get(
+          '/api/k8s/api/v1/namespaces/test-project/secrets/ds-pipeline-config',
+          (req, res, ctx) => res(ctx.json(mockSecretK8sResource({ name: 'ds-pipeline-config' }))),
+        ),
+        rest.get(
+          '/api/k8s/api/v1/namespaces/test-project/secrets/aws-connection-testdb',
+          (req, res, ctx) =>
+            res(ctx.json(mockSecretK8sResource({ name: 'aws-connection-testdb' }))),
+        ),
+        rest.post('/api/proxy/apis/v1beta1/pipelines', (req, res, ctx) =>
+          res(ctx.json(mockPipelinesProxy)),
+        ),
+      ],
+    },
+  },
+} as Meta<typeof PipelineVersionImportModal>;
+
+export const Default: StoryObj = {
+  render: () => (
+    <PipelineContextProvider namespace="test-project">
+      <PipelineVersionImportModal isOpen onClose={() => null} />;
+    </PipelineContextProvider>
+  ),
+};

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -3,7 +3,8 @@ import { isCommonStateError } from '~/utilities/useFetchState';
 type ErrorKF = {
   error: string;
   code: number;
-  details: Record<string, unknown>;
+  message: string;
+  details?: Record<string, unknown>;
 };
 type ResultErrorKF = {
   /** Has stack trace */
@@ -13,7 +14,7 @@ type ResultErrorKF = {
 };
 
 const isErrorKF = (e: unknown): e is ErrorKF =>
-  ['error', 'code', 'details'].every((key) => key in (e as ErrorKF));
+  ['error', 'code', 'message'].every((key) => key in (e as ErrorKF));
 
 const isErrorDetailsKF = (result: unknown): result is ResultErrorKF =>
   ['error_details', 'error_message'].every((key) => key in (result as ResultErrorKF));
@@ -28,6 +29,7 @@ export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
         const errorKF: ErrorKF = {
           error: result.error_message,
           code: 400, // assume it's our fault
+          message: result.error_message,
           details: { trace: result.error_details },
         };
         throw errorKF;

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -59,7 +59,7 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange }) => (
       onLoaded={(loaded) => {
         onValueChange('pipelineVersionsLoaded', loaded);
       }}
-      pipelineId={data.pipeline?.id}
+      pipeline={data.pipeline}
       value={data.version}
       onChange={(version) => {
         onValueChange('version', version);

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { FormSection } from '@patternfly/react-core';
+import { FormSection, Stack, StackItem } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   CreateRunPageSections,
   runPageSectionTitles,
@@ -8,6 +9,7 @@ import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
 import { pipelineSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
+import ImportPipelineButton from '~/concepts/pipelines/content/import/ImportPipelineButton';
 
 type PipelineSectionProps = {
   onLoaded: (loaded: boolean) => void;
@@ -29,20 +31,34 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({ onLoaded, value, onCh
       id={CreateRunPageSections.PIPELINE}
       title={runPageSectionTitles[CreateRunPageSections.PIPELINE]}
     >
-      <PipelineSelector
-        name={value?.name}
-        data={pipelines}
-        columns={pipelineSelectorColumns}
-        onSelect={(id) => {
-          const pipeline = pipelines.find((p) => p.id === id);
-          if (pipeline) {
-            onChange(pipeline);
-          }
-        }}
-        isLoading={!loaded}
-        placeHolder={pipelines.length === 0 ? 'No pipelines available' : 'Select a pipeline'}
-        searchHelperText={`Type a name to search your ${pipelines.length} pipelines.`}
-      />
+      <Stack hasGutter>
+        <StackItem>
+          <PipelineSelector
+            maxWidth="500px"
+            name={value?.name}
+            data={pipelines}
+            columns={pipelineSelectorColumns}
+            onSelect={(id) => {
+              const pipeline = pipelines.find((p) => p.id === id);
+              if (pipeline) {
+                onChange(pipeline);
+              }
+            }}
+            isLoading={!loaded}
+            placeHolder={pipelines.length === 0 ? 'No pipelines available' : 'Select a pipeline'}
+            searchHelperText={`Type a name to search your ${pipelines.length} pipelines.`}
+          />
+        </StackItem>
+        <StackItem>
+          <ImportPipelineButton
+            variant="link"
+            icon={<PlusCircleIcon />}
+            onCreate={(pipeline) => onChange(pipeline)}
+          >
+            Create new pipeline
+          </ImportPipelineButton>
+        </StackItem>
+      </Stack>
     </FormSection>
   );
 };

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
@@ -1,27 +1,30 @@
 import * as React from 'react';
-import { FormSection } from '@patternfly/react-core';
+import { FormSection, Stack, StackItem } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
-import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import usePipelineVersionsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
 import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
+import ImportPipelineVersionButton from '~/concepts/pipelines/content/import/ImportPipelineVersionButton';
 
 type PipelineVersionSectionProps = {
   onLoaded: (loaded: boolean) => void;
-  pipelineId?: string;
+  pipeline: PipelineKF | null;
   value: PipelineVersionKF | null;
   onChange: (version: PipelineVersionKF) => void;
 };
 
 const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
   onLoaded,
-  pipelineId,
+  pipeline,
   value,
   onChange,
 }) => {
+  const pipelineId = pipeline?.id;
   const [{ items: versions }, loaded] = usePipelineVersionsForPipeline(pipelineId, {}, 0);
 
   React.useEffect(() => {
@@ -35,25 +38,38 @@ const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
       id={CreateRunPageSections.PIPELINE_VERSION}
       title={runPageSectionTitles[CreateRunPageSections.PIPELINE_VERSION]}
     >
-      <PipelineSelector
-        name={value?.name}
-        data={versions}
-        columns={pipelineVersionSelectorColumns}
-        onSelect={(id) => {
-          const version = versions.find((v) => v.id === id);
-          if (version) {
-            onChange(version);
-          }
-        }}
-        isDisabled={!pipelineId}
-        isLoading={!!pipelineId && !loaded}
-        placeHolder={
-          pipelineId && versions.length === 0
-            ? 'No versions available'
-            : 'Select a pipeline version'
-        }
-        searchHelperText={`Type a name to search your ${versions.length} versions.`}
-      />
+      <Stack hasGutter>
+        <StackItem>
+          <PipelineSelector
+            maxWidth="500px"
+            name={value?.name}
+            data={versions}
+            columns={pipelineVersionSelectorColumns}
+            onSelect={(id) => {
+              const version = versions.find((v) => v.id === id);
+              if (version) {
+                onChange(version);
+              }
+            }}
+            isDisabled={!pipelineId}
+            isLoading={!!pipelineId && !loaded}
+            placeHolder={
+              pipelineId && versions.length === 0
+                ? 'No versions available'
+                : 'Select a pipeline version'
+            }
+            searchHelperText={`Type a name to search your ${versions.length} versions.`}
+          />
+        </StackItem>
+        <StackItem>
+          <ImportPipelineVersionButton
+            pipeline={pipeline}
+            variant="link"
+            icon={<PlusCircleIcon />}
+            onCreate={(pipelineVersion) => onChange(pipelineVersion)}
+          />
+        </StackItem>
+      </Stack>
     </FormSection>
   );
 };

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineButton.tsx
@@ -23,7 +23,7 @@ const ImportPipelineButton: React.FC<ImportPipelineButtonProps> = ({
         isDisabled={!apiAvailable || buttonProps.isDisabled}
         onClick={() => setOpen(true)}
       >
-        {children || <>Import pipeline</>}
+        {children || 'Import pipeline'}
       </Button>
       <PipelineImportModal
         isOpen={open}

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineSplitButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineSplitButton.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleAction,
+} from '@patternfly/react-core';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import PipelineImportModal from '~/concepts/pipelines/content/import/PipelineImportModal';
+import PipelineVersionImportModal from '~/concepts/pipelines/content/import/PipelineVersionImportModal';
+
+type ImportPipelineSplitButtonProps = {
+  onImportPipeline?: (pipeline: PipelineKF) => void;
+  onImportPipelineVersion?: (pipelineVersion: PipelineVersionKF) => void;
+};
+
+const ImportPipelineSplitButton: React.FC<ImportPipelineSplitButtonProps> = ({
+  onImportPipeline,
+  onImportPipelineVersion,
+}) => {
+  const { apiAvailable, refreshAllAPI } = usePipelinesAPI();
+  const [isDropdownOpen, setDropdownOpen] = React.useState(false);
+  const [isPipelineModalOpen, setPipelineModalOpen] = React.useState(false);
+  const [isPipelineVersionModalOpen, setPipelineVersionModalOpen] = React.useState(false);
+
+  return (
+    <>
+      <Dropdown
+        isOpen={isDropdownOpen}
+        onSelect={() => setDropdownOpen(false)}
+        onOpenChange={(isOpen) => setDropdownOpen(isOpen)}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            isFullWidth
+            variant="primary"
+            ref={toggleRef}
+            onClick={() => setDropdownOpen(!isDropdownOpen)}
+            isExpanded={isDropdownOpen}
+            splitButtonOptions={{
+              variant: 'action',
+              items: [
+                <MenuToggleAction
+                  id="import-pipeline-button"
+                  key="import-pipeline-button"
+                  aria-label="Import pipeline"
+                  onClick={() => setPipelineModalOpen(true)}
+                  isDisabled={!apiAvailable}
+                >
+                  Import pipeline
+                </MenuToggleAction>,
+              ],
+            }}
+            aria-label="Import pipeline and pipeline version button"
+          />
+        )}
+      >
+        <DropdownList>
+          <DropdownItem
+            id="import-pipeline-version-button"
+            key="import-pipeline-version-button"
+            onClick={() => setPipelineVersionModalOpen(true)}
+          >
+            Upload new version
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+      <PipelineImportModal
+        isOpen={isPipelineModalOpen}
+        onClose={(pipeline) => {
+          setPipelineModalOpen(false);
+          if (pipeline) {
+            onImportPipeline && onImportPipeline(pipeline);
+            refreshAllAPI();
+          }
+        }}
+      />
+      <PipelineVersionImportModal
+        isOpen={isPipelineVersionModalOpen}
+        onClose={(pipelineVersion) => {
+          setPipelineVersionModalOpen(false);
+          if (pipelineVersion) {
+            onImportPipelineVersion && onImportPipelineVersion(pipelineVersion);
+            refreshAllAPI();
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default ImportPipelineSplitButton;

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import PipelineVersionImportModal from '~/concepts/pipelines/content/import/PipelineVersionImportModal';
+
+type ImportPipelineVersionButtonProps = {
+  pipeline: PipelineKF | null;
+  onCreate?: (pipelineVersion: PipelineVersionKF) => void;
+} & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
+
+const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = ({
+  pipeline,
+  onCreate,
+  children,
+  ...buttonProps
+}) => {
+  const { apiAvailable, refreshAllAPI } = usePipelinesAPI();
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <Button
+        {...buttonProps}
+        isDisabled={!apiAvailable || buttonProps.isDisabled}
+        onClick={() => setOpen(true)}
+      >
+        {children || 'Upload new version'}
+      </Button>
+      <PipelineVersionImportModal
+        existingPipeline={pipeline}
+        isOpen={open}
+        onClose={(pipelineVersion) => {
+          setOpen(false);
+          if (pipelineVersion) {
+            onCreate && onCreate(pipelineVersion);
+            refreshAllAPI();
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default ImportPipelineVersionButton;

--- a/frontend/src/concepts/pipelines/content/import/PipelineFileUpload.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineFileUpload.tsx
@@ -28,6 +28,9 @@ const PipelineFileUpload: React.FC<PipelineFileUploadProps> = ({ fileContents, o
         setFilename('');
         onUpload('');
       }}
+      dropzoneProps={{
+        accept: { 'application/x-yaml': ['.yml', '.yaml'] },
+      }}
       isLoading={isLoading}
       isRequired
       allowEditingUploadedText={false}

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import useImportModalData from '~/concepts/pipelines/content/import/useImportModalData';
+import { usePipelineImportModalData } from '~/concepts/pipelines/content/import/useImportModalData';
 import { getProjectDisplayName } from '~/pages/projects/utils';
 import PipelineFileUpload from '~/concepts/pipelines/content/import/PipelineFileUpload';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
@@ -24,9 +24,9 @@ const PipelineImportModal: React.FC<PipelineImportModalProps> = ({ isOpen, onClo
   const { project, api, apiAvailable } = usePipelinesAPI();
   const [importing, setImporting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
-  const [{ name, description, fileContents }, setData, resetData] = useImportModalData();
+  const [{ name, description, fileContents }, setData, resetData] = usePipelineImportModalData();
 
-  const haveEnoughData = !!name && !!fileContents;
+  const isImportButtonDisabled = !apiAvailable || importing || !name || !fileContents;
 
   const onBeforeClose = (pipeline?: PipelineKF) => {
     onClose(pipeline);
@@ -44,7 +44,8 @@ const PipelineImportModal: React.FC<PipelineImportModalProps> = ({ isOpen, onClo
         <Button
           key="import-button"
           variant="primary"
-          isDisabled={!apiAvailable || importing || !haveEnoughData}
+          isDisabled={isImportButtonDisabled}
+          isLoading={importing}
           onClick={() => {
             setImporting(true);
             setError(undefined);

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  Stack,
+  StackItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { usePipelineVersionImportModalData } from '~/concepts/pipelines/content/import/useImportModalData';
+import { getProjectDisplayName } from '~/pages/projects/utils';
+import PipelineFileUpload from '~/concepts/pipelines/content/import/PipelineFileUpload';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
+import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
+import { pipelineSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
+import { generatePipelineVersionName } from '~/concepts/pipelines/content/import/utils';
+
+type PipelineVersionImportModalProps = {
+  existingPipeline?: PipelineKF | null;
+  isOpen: boolean;
+  onClose: (pipelineVersion?: PipelineVersionKF) => void;
+};
+
+const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
+  existingPipeline,
+  isOpen,
+  onClose,
+}) => {
+  const { project, api, apiAvailable } = usePipelinesAPI();
+  const [{ items: pipelines }, loaded] = usePipelines({}, 0);
+  const [importing, setImporting] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+  const [{ name, description, pipelineId, pipelineName, fileContents }, setData, resetData] =
+    usePipelineVersionImportModalData(existingPipeline);
+
+  const isImportButtonDisabled =
+    !apiAvailable || importing || !name || !fileContents || !pipelineId;
+
+  const onBeforeClose = (pipelineVersion?: PipelineVersionKF) => {
+    onClose(pipelineVersion);
+    setImporting(false);
+    setError(undefined);
+    resetData();
+  };
+
+  return (
+    <Modal
+      title="Upload new version"
+      isOpen={isOpen}
+      onClose={() => onBeforeClose()}
+      actions={[
+        <Button
+          key="import-button"
+          variant="primary"
+          isDisabled={isImportButtonDisabled}
+          isLoading={importing}
+          onClick={() => {
+            setImporting(true);
+            setError(undefined);
+            api
+              .uploadPipelineVersion({}, name, description, fileContents, pipelineId)
+              .then((pipelineVersion) => onBeforeClose(pipelineVersion))
+              .catch((e) => {
+                setImporting(false);
+                setError(e);
+              });
+          }}
+        >
+          Upload
+        </Button>,
+        <Button key="cancel-button" variant="secondary" onClick={() => onBeforeClose()}>
+          Cancel
+        </Button>,
+      ]}
+      variant="medium"
+    >
+      <Form>
+        <Stack hasGutter>
+          <StackItem>
+            <FormGroup label="Project">{getProjectDisplayName(project)}</FormGroup>
+          </StackItem>
+          <StackItem>
+            <FormGroup label="Pipeline" isRequired fieldId="pipeline-selection">
+              <PipelineSelector
+                toggleId="pipeline-selection"
+                name={pipelineName}
+                data={pipelines}
+                columns={pipelineSelectorColumns}
+                onSelect={(id) => {
+                  const pipeline = pipelines.find((p) => p.id === id);
+                  if (pipeline) {
+                    setData('pipelineId', pipeline.id);
+                    setData('pipelineName', pipeline.name);
+                    setData('name', generatePipelineVersionName(pipeline));
+                  }
+                }}
+                isLoading={!loaded}
+                placeHolder={
+                  pipelines.length === 0 ? 'No pipelines available' : 'Select a pipeline'
+                }
+                searchHelperText={`Type a name to search your ${pipelines.length} pipelines.`}
+              />
+            </FormGroup>
+          </StackItem>
+          <StackItem>
+            <FormGroup label="Pipeline version name" isRequired fieldId="pipeline-version-name">
+              <TextInput
+                isRequired
+                type="text"
+                id="pipeline-version-name"
+                name="pipeline-version-name"
+                value={name}
+                onChange={(e, value) => setData('name', value)}
+              />
+            </FormGroup>
+          </StackItem>
+          <StackItem>
+            <FormGroup label="Pipeline version description" fieldId="pipeline-version-description">
+              <TextInput
+                isRequired
+                type="text"
+                id="pipeline-version-description"
+                name="pipeline-version-description"
+                value={description}
+                onChange={(e, value) => setData('description', value)}
+              />
+            </FormGroup>
+          </StackItem>
+          <StackItem>
+            <PipelineFileUpload
+              fileContents={fileContents}
+              onUpload={(data) => setData('fileContents', data)}
+            />
+          </StackItem>
+          {error && (
+            <StackItem>
+              <Alert title="Error uploading pipeline version" isInline variant="danger">
+                {error.message}
+              </Alert>
+            </StackItem>
+          )}
+        </Stack>
+      </Form>
+    </Modal>
+  );
+};
+
+export default PipelineVersionImportModal;

--- a/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
+++ b/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import { generatePipelineVersionName } from '~/concepts/pipelines/content/import/utils';
+import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
 
 type PipelineModalData = {
@@ -6,11 +9,39 @@ type PipelineModalData = {
   fileContents: string;
 };
 
-const useImportModalData = () =>
+export const usePipelineImportModalData = () =>
   useGenericObjectState<PipelineModalData>({
     name: '',
     description: '',
     fileContents: '',
   });
 
-export default useImportModalData;
+type PipelineVersionModalData = {
+  name: string;
+  description: string;
+  pipelineId: string;
+  pipelineName: string;
+  fileContents: string;
+};
+
+export const usePipelineVersionImportModalData = (pipeline?: PipelineKF | null) => {
+  const createDataState = useGenericObjectState<PipelineVersionModalData>({
+    name: generatePipelineVersionName(pipeline),
+    description: '',
+    pipelineId: pipeline?.id ?? '',
+    pipelineName: pipeline?.name ?? '',
+    fileContents: '',
+  });
+
+  const [, setData] = createDataState;
+
+  React.useEffect(() => {
+    if (pipeline) {
+      setData('pipelineId', pipeline.id);
+      setData('pipelineName', pipeline.name);
+      setData('name', generatePipelineVersionName(pipeline));
+    }
+  }, [pipeline, setData]);
+
+  return createDataState;
+};

--- a/frontend/src/concepts/pipelines/content/import/utils.ts
+++ b/frontend/src/concepts/pipelines/content/import/utils.ts
@@ -1,0 +1,4 @@
+import { PipelineKF } from '~/concepts/pipelines/kfTypes';
+
+export const generatePipelineVersionName = (pipeline?: PipelineKF | null) =>
+  pipeline ? `${pipeline.name}_version_at_${new Date().toISOString()}` : '';

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelector.tsx
@@ -22,6 +22,7 @@ import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 
 type PipelineSelectorProps<DataType> = {
   name?: string;
+  toggleId?: string;
   columns: SortableData<DataType>[];
   data: DataType[];
   placeHolder: string;
@@ -29,9 +30,11 @@ type PipelineSelectorProps<DataType> = {
   onSelect: (id: string) => void;
   isLoading: boolean;
   isDisabled?: boolean;
+  maxWidth?: string | number;
 };
 
 const PipelineSelector = <T extends PipelineKF | PipelineVersionKF>({
+  toggleId,
   name,
   columns,
   data,
@@ -40,6 +43,7 @@ const PipelineSelector = <T extends PipelineKF | PipelineVersionKF>({
   isDisabled,
   placeHolder,
   searchHelperText,
+  maxWidth,
 }: PipelineSelectorProps<T>) => {
   const [isOpen, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
@@ -130,7 +134,8 @@ const PipelineSelector = <T extends PipelineKF | PipelineVersionKF>({
       toggleRef={toggleRef}
       toggle={
         <MenuToggle
-          style={{ maxWidth: '500px' }}
+          id={toggleId}
+          style={{ maxWidth }}
           ref={toggleRef}
           onClick={() => setOpen(!isOpen)}
           isExpanded={isOpen}

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTable.tsx
@@ -72,6 +72,7 @@ const PipelinesTable: React.FC<PipelinesTableProps> = ({
             rowIndex={rowIndex}
             pipelineDetailsPath={pipelineDetailsPath}
             onDeletePipeline={() => setDeleteTarget(pipeline)}
+            refreshPipelines={refreshPipelines}
           />
         )}
         disableRowRenderSupport

--- a/frontend/src/pages/pipelines/global/pipelines/GlobalPipelinesTableToolbar.tsx
+++ b/frontend/src/pages/pipelines/global/pipelines/GlobalPipelinesTableToolbar.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { TextInput, ToolbarItem } from '@patternfly/react-core';
-import ImportPipelineButton from '~/concepts/pipelines/content/import/ImportPipelineButton';
 import PipelineFilterBar from '~/concepts/pipelines/content/tables/PipelineFilterBar';
 import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 import DashboardDatePicker from '~/components/DashboardDatePicker';
+import ImportPipelineSplitButton from '~/concepts/pipelines/content/import/ImportPipelineSplitButton';
 
 const options = {
   [FilterOptions.NAME]: 'Pipeline name',
@@ -49,7 +49,7 @@ const GlobalPipelinesTableToolbar: React.FC<GlobalPipelinesTableToolbarProps> = 
     onClearFilters={onClearFilters}
   >
     <ToolbarItem>
-      <ImportPipelineButton />
+      <ImportPipelineSplitButton />
     </ToolbarItem>
   </PipelineFilterBar>
 );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: [RHOAIENG-269](https://issues.redhat.com/browse/RHOAIENG-269)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Create a modal which allows user to upload a version for a specific pipeline

Implementation:

<img width="1725" alt="Screenshot 2023-12-06 at 3 26 18 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/94769b3e-7dc2-4603-8280-cc520ef0ac65">

When the pipeline is selected, it will automatically generate the name for the version, user can edit it, too

<img width="1725" alt="Screenshot 2023-12-06 at 3 27 09 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/b3e7dc2f-93bc-480b-aa3d-5947a2e6c2d5">

Added a split button on the global pipelines page, which supports both uploading the pipelines and uploading the pipeline versions

<img width="1725" alt="Screenshot 2023-12-06 at 3 27 27 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/0004732c-43ac-49b5-853e-0dbcc60b649e">

Add a dropdown item in the pipeline row action menu, which allows the user to upload new version to a specific

<img width="1725" alt="Screenshot 2023-12-06 at 3 28 26 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/d3b6a581-d114-4cae-bddc-2cd57001011b">

On create run page, add 2 link buttons to support uploading pipelines and pipeline versions on this page

<img width="1725" alt="Screenshot 2023-12-06 at 3 31 29 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/22940f2c-103e-4293-9c56-fddca6c37cfe">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the global pipelines page
2. Try to upload a version or upload a pipeline
3. You could verify where the version is successfully uploaded in the create run page, if you successfully upload it, you should be able to select it when you create a run
4. Try to upload a version in the create run page, it will be auto-selected after you create it
5. Try the upload new version button in the pipeline table row action, it will auto-fill the pipeline selection in the modal

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a storybook test for the modal, mainly test whether it could generate the version name based on the change of the pipeline selection.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
