### PR TITLE
Show tooltip on disabled 'Deploy model' button when no project is selected

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
@@ -204,6 +204,22 @@ describe('Model Serving Global', () => {
     inferenceServiceModal.findSubmitButton().should('be.disabled');
   });
 
+  it('Empty State No Project Selected', () => {
+    initIntercepts({ inferenceServices: [] });
+
+    // Visit the all-projects view (no project name passed here)
+    modelServingGlobal.visit();
+
+    modelServingGlobal.shouldBeEmpty();
+
+    // Test that the button is disabled
+    modelServingGlobal.findDeployModelButton().should('have.attr', 'aria-disabled');
+
+    // Test that the tooltip appears on hover of the disabled button
+    modelServingGlobal.findDeployModelButton().trigger('mouseenter');
+    modelServingGlobal.findNoProjectSelectedTooltip().should('be.visible');
+  });
+
   it('Delete model', () => {
     initIntercepts({});
     modelServingGlobal.visit('test-project');

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -32,6 +32,10 @@ class ModelServingGlobal {
     return cy.findByRole('button', { name: 'Deploy model' });
   }
 
+  findNoProjectSelectedTooltip() {
+    return cy.findByRole('tooltip', { name: 'To deploy a model, select a project.' });
+  }
+
   findGoToProjectButton() {
     return cy.findByRole('button', { name: /^Go to / });
   }

--- a/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
@@ -46,20 +46,28 @@ const ServeModelButton: React.FC = () => {
     setPlatformSelected(undefined);
   };
 
+  const deployButton = (
+    <Button
+      variant="primary"
+      onClick={() =>
+        project &&
+        setPlatformSelected(
+          getProjectModelServingPlatform(project, servingPlatformStatuses).platform,
+        )
+      }
+      isAriaDisabled={!project || !templatesEnabled}
+    >
+      Deploy model
+    </Button>
+  );
+
   return (
     <>
-      <Button
-        variant="primary"
-        onClick={() =>
-          project &&
-          setPlatformSelected(
-            getProjectModelServingPlatform(project, servingPlatformStatuses).platform,
-          )
-        }
-        isDisabled={!project || !templatesEnabled}
-      >
-        Deploy model
-      </Button>
+      {!project ? (
+        <Tooltip content="To deploy a model, select a project.">{deployButton}</Tooltip>
+      ) : (
+        deployButton
+      )}
       {project && (
         <>
           <ManageInferenceServiceModal


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-544

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds a tooltip that appears on the 'Deploy model' button on the global Model Serving page if the button is disabled because no project is selected.

<img width="1725" alt="Screenshot 2023-12-06 at 7 54 07 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/f0f003ef-db0f-4c91-b582-c160afefb14a">

The tooltip is shown here in the empty state when there are no deployed models, but the ServeModelButton component used there is the same one used above the table in the non-empty state of the page, so the tooltip implementation affects both views.

cc @vconzola

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Viewing the Model Serving page with no project selected, and observing that the disabled button has the new tooltip. Added Cypress test, see below.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added to existing Cypress tests for the Model Serving page. The new test visits the all-projects view of the page, triggers a mouse hover event on the button and checks that the tooltip is visible.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
