### PR TITLE
Update kustomization.yaml

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard
-  newTag: main
+  newTag: nightly
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
   digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33


### PR DESCRIPTION
Correct for `tmp-incubation` switch to `incubation` (matching the former implementation for incubation; you can see on [branch `incubation-old`](https://github.com/opendatahub-io/odh-dashboard/blob/incubation-old/manifests/base/kustomization.yaml#L28))