### PR TITLE
add axe support to cypress for accessibility testing

### DIFF
--- a/frontend/.env.cypress.mock
+++ b/frontend/.env.cypress.mock
@@ -1,5 +1,2 @@
 # Test against prod build hosted by lightweight http server
 BASE_URL=http://localhost:9001
-
-# Test against local dev server
-# BASE_URL=http://localhost:4010

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,6 +63,7 @@
         "css-loader": "^5.2.7",
         "css-minimizer-webpack-plugin": "^4.2.2",
         "cypress": "^13.6.0",
+        "cypress-axe": "^1.5.0",
         "dotenv": "^8.2.0",
         "dotenv-expand": "^5.1.0",
         "dotenv-webpack": "^6.0.0",
@@ -13481,7 +13482,7 @@
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
       "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -16000,6 +16001,19 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.5.0.tgz",
+      "integrity": "sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10 || ^11 || ^12 || ^13"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "cypress:run:record": "RECORD=1 npm run cypress:run",
     "cypress:server:build": "ODH_DIST_DIR=./public-cypress POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 npm run build",
     "cypress:server": "serve ./public-cypress -p 9001 -s",
+    "cypress:server:dev": "POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 ODH_PORT=9001 npm run start:dev",
     "cypress:format": "prettier --write src/__tests__/**/*.snap.json"
   },
   "dependencies": {
@@ -104,6 +105,7 @@
     "css-loader": "^5.2.7",
     "css-minimizer-webpack-plugin": "^4.2.2",
     "cypress": "^13.6.0",
+    "cypress-axe": "^1.5.0",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
     "dotenv-webpack": "^6.0.0",

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -21,8 +21,7 @@ export default defineConfig({
     PASSWORD: process.env.PASSWORD,
     RECORD: !!process.env.RECORD,
   },
-  requestTimeout: process.env.MOCK ? 5000 : 10000,
-
+  defaultCommandTimeout: 10000,
   e2e: {
     baseUrl: process.env.BASE_URL,
     specPattern: process.env.MOCK
@@ -44,6 +43,21 @@ export default defineConfig({
           }
 
           return Promise.resolve({});
+        },
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+          return null;
+        },
+        error(message) {
+          // eslint-disable-next-line no-console
+          console.error(message);
+          return null;
+        },
+        table(message) {
+          // eslint-disable-next-line no-console
+          console.table(message);
+          return null;
         },
       });
 

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
@@ -201,6 +201,7 @@ describe('Model Serving Global', () => {
     modelServingGlobal.findDeployModelButton().click();
 
     // test that you can not submit on empty
+    inferenceServiceModal.shouldBeOpen();
     inferenceServiceModal.findSubmitButton().should('be.disabled');
   });
 
@@ -215,7 +216,7 @@ describe('Model Serving Global', () => {
       .click();
 
     // Test that can submit on valid form
-    deleteModal.find().should('exist');
+    deleteModal.shouldBeOpen();
     deleteModal.findSubmitButton().should('be.disabled');
 
     deleteModal.findInput().type('Test Inference Service');
@@ -234,6 +235,7 @@ describe('Model Serving Global', () => {
     modelServingGlobal.findModelRow('Test Inference Service').findKebabAction('Edit').click();
 
     // test that you can not submit on empty
+    inferenceServiceModal.shouldBeOpen();
     inferenceServiceModal.findModelNameInput().clear();
     inferenceServiceModal.findLocationPathInput().clear();
     inferenceServiceModal.findSubmitButton().should('be.disabled');
@@ -270,6 +272,7 @@ describe('Model Serving Global', () => {
     modelServingGlobal.findDeployModelButton().click();
 
     // test that you can not submit on empty
+    inferenceServiceModal.shouldBeOpen();
     inferenceServiceModal.findSubmitButton().should('be.disabled');
 
     // test filling in minimum required fields
@@ -303,6 +306,7 @@ describe('Model Serving Global', () => {
     modelServingGlobal.findDeployModelButton().click();
 
     // test that you can not submit on empty
+    inferenceServiceModal.shouldBeOpen();
     inferenceServiceModal.findSubmitButton().should('be.disabled');
 
     // test filling in minimum required fields

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
@@ -203,7 +203,8 @@ describe('Serving Runtime List', () => {
 
     modelServingSection.getModelMeshRow('ovms').findDeployModelButton().click();
 
-    // TODO this is duplicate code that can be simplied into a single form filling function
+    inferenceServiceModal.shouldBeOpen();
+
     // test that you can not submit on empty
     inferenceServiceModal.findSubmitButton().should('be.disabled');
 
@@ -236,6 +237,8 @@ describe('Serving Runtime List', () => {
     projectDetails.visit('test-project');
 
     modelServingSection.findDeployModelButton().click();
+
+    kserveModal.shouldBeOpen();
 
     // test that you can not submit on empty
     kserveModal.findSubmitButton().should('be.disabled');
@@ -309,7 +312,6 @@ describe('Serving Runtime List', () => {
       .getModelMeshRow('OVMS Model Serving')
       .shouldHaveServingRuntime('OpenVINO Serving Runtime (Supports GPUs)');
 
-    // TODO not ideal
     modelServingSection.getModelMeshRow('ovms').findExpansion().should(be.collapsed);
     modelServingSection.getModelMeshRow('ovms').findExpandButton().click();
     modelServingSection.getModelMeshRow('ovms').findExpansion().should(be.expanded);
@@ -356,6 +358,8 @@ describe('Serving Runtime List', () => {
     projectDetails.visit('test-project');
 
     modelServingSection.findAddModelServerButton().click();
+
+    createServingRuntimeModal.shouldBeOpen();
 
     // test that you can not submit on empty
     createServingRuntimeModal.findSubmitButton().should('be.disabled');
@@ -411,6 +415,8 @@ describe('Serving Runtime List', () => {
 
     // click on the toggle button and open edit model server
     modelServingSection.getModelMeshRow('ovms').find().findKebabAction('Edit model server').click();
+
+    editServingRuntimeModal.shouldBeOpen();
 
     // test name field
     editServingRuntimeModal.findSubmitButton().should('be.disabled');

--- a/frontend/src/__tests__/cypress/cypress/e2e/projects/project-list.scy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/projects/project-list.scy.ts
@@ -30,11 +30,11 @@ describe('Data Science Projects', { testIsolation: false }, () => {
 
   it('should open a modal to create a project', () => {
     projectListPage.findCreateProjectButton().click();
-    createProjectModal.find().should('exist');
+    createProjectModal.shouldBeOpen();
     createProjectModal.findCancelButton().click();
-    createProjectModal.find().should('not.exist');
+    createProjectModal.shouldBeOpen(false);
     projectListPage.findCreateProjectButton().click();
-    createProjectModal.find().should('exist');
+    createProjectModal.shouldBeOpen();
     createProjectModal.findSubmitButton().should('be.disabled');
   });
 
@@ -88,19 +88,18 @@ describe('Data Science Projects', { testIsolation: false }, () => {
     cy.waitSnapshot('@projects-1');
     projectListPage.shouldHaveProjects();
     projectListPage.findProjectRow('My Test Project').should('exist');
+
+    cy.testA11y();
   });
 
   it('should delete project', () => {
     projectListPage.findProjectRow('My Test Project').findKebabAction('Delete project').click();
 
-    deleteModal.find().should('exist');
-
+    deleteModal.shouldBeOpen();
     deleteModal.findSubmitButton().should('be.disabled');
     deleteModal.findCancelButton().should('be.enabled').click();
 
     projectListPage.findProjectRow('My Test Project').findKebabAction('Delete project').click();
-
-    deleteModal.find().should('exist');
 
     deleteModal.findInput().type('My Test Project');
 

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
@@ -12,7 +12,8 @@ class ClusterSettings {
   }
 
   private wait() {
-    cy.get('[data-id="submit-cluster-settings"]', { timeout: 10000 });
+    this.findSubmitButton();
+    cy.testA11y();
   }
 
   findSubmitButton() {

--- a/frontend/src/__tests__/cypress/cypress/pages/components/Modal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/Modal.ts
@@ -3,6 +3,14 @@ import { ByRoleOptions } from '@testing-library/react';
 export class Modal {
   constructor(private title: ByRoleOptions['name']) {}
 
+  shouldBeOpen(open = true) {
+    if (open) {
+      this.find().testA11y();
+    } else {
+      this.find().should('not.exist');
+    }
+  }
+
   find() {
     return cy.findByRole('dialog', { name: this.title });
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -14,7 +14,8 @@ class ProjectListPage {
   }
 
   private wait() {
-    cy.findByText('View your existing projects or create new projects.', { timeout: 10000 });
+    cy.findByText('View your existing projects or create new projects.');
+    cy.testA11y();
   }
 
   shouldHaveProjects() {
@@ -65,10 +66,12 @@ class CreateEditProjectModal extends Modal {
 class ProjectDetails {
   visit(project: string) {
     cy.visit(`/projects/${project}`);
+    this.wait();
   }
 
-  wait() {
-    cy.findByRole('tab', { name: 'Components', timeout: 10000 });
+  private wait() {
+    cy.findByRole('tab', { name: 'Components' });
+    cy.testA11y();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
@@ -36,7 +36,8 @@ class ServingRuntimes {
   }
 
   private wait() {
-    cy.findByRole('button', { name: 'Add serving runtime', timeout: 10000 });
+    this.findAddButton();
+    cy.testA11y();
   }
 
   shouldBeMultiModel(enabled = true) {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/axe.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/axe.ts
@@ -1,0 +1,69 @@
+import 'cypress-axe';
+
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      testA11y(context?: Parameters<cy['checkA11y']>[0]): void;
+    }
+  }
+}
+
+Cypress.Commands.overwrite('visit', (orig, url) => {
+  orig(url);
+  cy.injectAxe();
+  cy.configureAxe();
+});
+
+Cypress.Commands.add('testA11y', { prevSubject: 'optional' }, (subject, context) => {
+  // FIXME need to injectAxe again right before checkking to solve undefined error
+  // https://github.com/component-driven/cypress-axe/issues/164
+  cy.injectAxe();
+  const test = (c: Parameters<typeof cy.checkA11y>[0]) => {
+    cy.checkA11y(
+      c,
+      {
+        includedImpacts: ['serious', 'critical'],
+      },
+      (violations) => {
+        cy.task(
+          'error',
+          `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${
+            violations.length === 1 ? 'was' : 'were'
+          } detected`,
+        );
+        // pluck specific keys to keep the table readable
+        const violationData = violations.map(({ id, impact, description, nodes }) => ({
+          id,
+          impact,
+          description,
+          nodes: nodes.length,
+        }));
+
+        cy.task('table', violationData);
+
+        cy.task(
+          'log',
+          violations
+            .map(
+              ({ nodes }, i) =>
+                `${i}. Affected elements:\n${nodes.map(
+                  ({ target, failureSummary, ancestry }) =>
+                    `\t${failureSummary} - ${target
+                      .map((node) => `"${node}"\n${ancestry}`)
+                      .join(', ')}`,
+                )}`,
+            )
+            .join('\n'),
+        );
+      },
+    );
+  };
+  if (!context && subject) {
+    cy.wrap(subject).each(($el) => {
+      test($el[0]);
+    });
+  } else {
+    test(context);
+  }
+});

--- a/frontend/src/__tests__/cypress/cypress/support/commands/index.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/index.ts
@@ -1,3 +1,4 @@
 import '@testing-library/cypress/add-commands';
 import './application';
+import './axe';
 import './intercept-snapshots';

--- a/frontend/src/__tests__/cypress/tsconfig.json
+++ b/frontend/src/__tests__/cypress/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["../../**/*.ts"],
   "exclude": ["node_modules", "public"],
   "compilerOptions": {
-    "types": ["node", "cypress", "@testing-library/cypress"]
+    "types": ["node", "cypress", "@testing-library/cypress", "cypress-axe"]
   }
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://github.com/opendatahub-io/odh-dashboard/issues/2252

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds `cypress-axe` to cypress integration.

Currently configured to fail on `serious` and `critical` issues. There are `moderate` issues currently in the app. We can revisit this configuration in the future.

Added a new custom command `testA11y` to help with reporting axe related violations.

There isn't a silver bullet to continuously test accessibility violations. It's up to individual tests to make an assertion at various points. But I have update existing tests to make accessibility checks on page load and on modal open.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
