### PR TITLE
[Edge] Use volumeClaimTemplate for PipelineRuns

### DIFF
--- a/frontend/src/__mocks__/mockEdgePipelineRun.ts
+++ b/frontend/src/__mocks__/mockEdgePipelineRun.ts
@@ -90,14 +90,21 @@ export const mockEdgePipelineRun = ({
     workspaces: [
       {
         name: 'buildah-cache',
-        persistentVolumeClaim: {
-          claimName: 'buildah-cache-pvc',
+        volumeClaimTemplate: {
+          spec: {
+            accessModes: ['ReadWriteOnce'],
+            resources: {
+              requests: {
+                storage: '1Gi',
+              },
+            },
+          },
         },
       },
       {
         name: 's3-secret',
         secret: {
-          secretName: 'lvl-s3-credentials-env',
+          secretName: 'credentials-s3',
         },
       },
       {

--- a/frontend/src/concepts/edge/content/models/utils.ts
+++ b/frontend/src/concepts/edge/content/models/utils.ts
@@ -124,8 +124,15 @@ export const assembleEdgePipelineRun = (
       workspaces: [
         {
           name: 'buildah-cache',
-          persistentVolumeClaim: {
-            claimName: 'buildah-cache-pvc',
+          volumeClaimTemplate: {
+            spec: {
+              accessModes: ['ReadWriteOnce'],
+              resources: {
+                requests: {
+                  storage: '1Gi',
+                },
+              },
+            },
           },
         },
         {


### PR DESCRIPTION


## Description
Changes the Edge Pipelinerun to use a volumeClaimTemplate instead of relying on a pre-existing PVC for mounting persistent storage to the Pipeline workspace

## How Has This Been Tested?
*DEMO* Dev build and deploy of the odh-dashboard container image in a cluster to verify the change

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
