### PR TITLE
Add pipeline versions table, refactor pipelines table and pipelines selector

### DIFF
--- a/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
+++ b/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
@@ -1,29 +1,6 @@
 /* eslint-disable camelcase */
 import { PipelineVersionKF, RelationshipKF, ResourceTypeKF } from '~/concepts/pipelines/kfTypes';
 
-export const buildMockPipelineVersion = (
-  pipelineVersion?: Partial<PipelineVersionKF>,
-): PipelineVersionKF => ({
-  id: '8ce2d041-3eb9-41a0-828c-45209fdf1c20',
-  name: 'version-1',
-  created_at: '2023-12-07T16:08:01Z',
-  resource_references: [
-    {
-      key: { type: 'PIPELINE' as ResourceTypeKF, id: 'b2ff4cbf-f7f5-4c8a-b454-906bd9b00510' },
-      relationship: 'OWNER' as RelationshipKF,
-    },
-  ],
-  description: 'test',
-  ...pipelineVersion,
-});
-
-export const buildMockPipelineVersions = (
-  versions: PipelineVersionKF[] = mockPipelineVersionsList,
-) => ({
-  versions,
-  total_size: versions.length,
-});
-
 export const mockPipelineVersionsList: PipelineVersionKF[] = [
   {
     id: 'ad1b7153-d2fd-4e5e-ae12-30c824b19b03',
@@ -209,3 +186,47 @@ export const mockPipelineVersionsList: PipelineVersionKF[] = [
     ],
   },
 ];
+
+export const buildMockPipelineVersion = (
+  pipelineVersion?: Partial<PipelineVersionKF>,
+): PipelineVersionKF => ({
+  id: '8ce2d041-3eb9-41a0-828c-45209fdf1c20',
+  name: 'version-1',
+  created_at: '2023-12-07T16:08:01Z',
+  resource_references: [
+    {
+      key: { type: 'PIPELINE' as ResourceTypeKF, id: 'b2ff4cbf-f7f5-4c8a-b454-906bd9b00510' },
+      relationship: 'OWNER' as RelationshipKF,
+    },
+  ],
+  description: 'test',
+  ...pipelineVersion,
+});
+
+export const buildMockPipelineVersions = (
+  versions: PipelineVersionKF[] = mockPipelineVersionsList,
+  totalSize?: number,
+  nextPageToken?: string,
+) => ({
+  versions,
+  total_size: totalSize || versions.length,
+  next_page_token: nextPageToken,
+});
+
+export const mockPipelineVersionsListPage1 = buildMockPipelineVersions(
+  mockPipelineVersionsList.slice(0, 10),
+  mockPipelineVersionsList.length,
+  'next-page-token',
+);
+
+export const mockPipelineVersionsListPage2 = buildMockPipelineVersions(
+  mockPipelineVersionsList.slice(10),
+  mockPipelineVersionsList.length,
+);
+
+export const mockPipelineVersionsListSearch = (search: string) => {
+  const filteredVersions = mockPipelineVersionsList
+    .filter((version) => version.name.startsWith(search))
+    .slice(0, 10);
+  return buildMockPipelineVersions(filteredVersions, filteredVersions.length);
+};

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.spec.ts
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.spec.ts
@@ -15,13 +15,13 @@ test('Pipeline version selector - Test filter and view more', async ({ page }) =
   );
 
   // test the search
-  const search = 'flip coin_';
-  await page.getByLabel('Filter pipelines').fill(search);
+  const search = 'flip coin_version_at_2023-12-01T01:41';
+  await page.getByLabel('Filter pipeline versions').fill(search);
+  await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(4);
+
+  await page.getByLabel('Filter pipeline versions').fill('test-no-result');
+  await expect(page.getByRole('button', { name: 'Clear all filters' })).toBeVisible();
+  await page.getByRole('button', { name: 'Clear all filters' }).click();
   await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(10);
-  await page.getByText('View more').click();
-  await expect(page.locator('[data-id="pipeline-selector-table-list-row"]')).toHaveCount(
-    mockPipelineVersionsList.filter((version) => version.name.startsWith(search)).length,
-  );
-  await page.getByLabel('Filter pipelines').fill('test-no-result');
-  await expect(page.getByText('No results match the filter.')).toBeVisible();
+  await expect(page.getByText(`Showing 10/${mockPipelineVersionsList.length}`)).toBeVisible();
 });

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.stories.tsx
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineSelector.stories.tsx
@@ -1,25 +1,78 @@
 import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { userEvent, within } from '@storybook/testing-library';
+import { rest } from 'msw';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
-import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
-import { mockPipelineVersionsList } from '~/__mocks__/mockPipelineVersionsProxy';
+import {
+  mockPipelineVersionsListPage1,
+  mockPipelineVersionsListPage2,
+  mockPipelineVersionsListSearch,
+} from '~/__mocks__/mockPipelineVersionsProxy';
+import PipelineVersionSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineVersionSelector';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { PipelineContextProvider } from '~/concepts/pipelines/context';
+import { mockDataSciencePipelineApplicationK8sResource } from '~/__mocks__/mockDataSciencePipelinesApplicationK8sResource';
+import { mockRouteK8sResource } from '~/__mocks__/mockRouteK8sResource';
+import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 
 export default {
   component: PipelineSelector,
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get('/api/k8s/apis/project.openshift.io/v1/projects', (req, res, ctx) =>
+          res(ctx.json(mockK8sResourceList([mockProjectK8sResource({})]))),
+        ),
+        rest.get(
+          '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/pipelines-definition',
+          (req, res, ctx) => res(ctx.json(mockDataSciencePipelineApplicationK8sResource({}))),
+        ),
+        rest.get(
+          '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-pipelines-definition',
+          (req, res, ctx) =>
+            res(
+              ctx.json(mockRouteK8sResource({ notebookName: 'ds-pipeline-pipelines-definition' })),
+            ),
+        ),
+        rest.get(
+          '/api/k8s/api/v1/namespaces/test-project/secrets/ds-pipeline-config',
+          (req, res, ctx) => res(ctx.json(mockSecretK8sResource({ name: 'ds-pipeline-config' }))),
+        ),
+        rest.get(
+          '/api/k8s/api/v1/namespaces/test-project/secrets/aws-connection-testdb',
+          (req, res, ctx) =>
+            res(ctx.json(mockSecretK8sResource({ name: 'aws-connection-testdb' }))),
+        ),
+        rest.post('/api/proxy/apis/v1beta1/pipeline_versions', async (req, res, ctx) => {
+          const reqBody = await req.json();
+          if (reqBody.queryParams['filter']) {
+            return res(
+              ctx.json(
+                mockPipelineVersionsListSearch(
+                  JSON.parse(reqBody.queryParams['filter'])['predicates'][0]['string_value'],
+                ),
+              ),
+            );
+          }
+          if (reqBody.queryParams['page_token'] === 'next-page-token') {
+            return res(ctx.json(mockPipelineVersionsListPage2));
+          }
+          return res(ctx.json(mockPipelineVersionsListPage1));
+        }),
+      ],
+    },
+  },
 } as Meta<typeof PipelineSelector>;
 
 export const Default: StoryObj = {
   render: () => (
-    <PipelineSelector
-      maxWidth="500px"
-      columns={pipelineVersionSelectorColumns}
-      data={mockPipelineVersionsList}
-      onSelect={() => null}
-      placeHolder="Select a pipeline version"
-      searchHelperText={`Type a name to search your ${mockPipelineVersionsList.length} versions.`}
-      isLoading={false}
-    />
+    <PipelineContextProvider namespace="test-project">
+      <PipelineVersionSelector
+        pipelineId="63a09bff-9261-43b9-a2a8-5f2158c5522e"
+        onSelect={() => null}
+      />
+    </PipelineContextProvider>
   ),
   play: async ({ canvasElement }) => {
     // load page and wait until settled

--- a/frontend/src/__tests__/integration/components/pipelines/PipelineVersionImportModal.spec.ts
+++ b/frontend/src/__tests__/integration/components/pipelines/PipelineVersionImportModal.spec.ts
@@ -7,13 +7,13 @@ test('Pipeline version import modal - Update pipeline selector should generate m
 }) => {
   await page.goto(navigateToStory('components-pipelines-pipelineversionimportmodal', 'default'));
 
-  await page.locator('#pipeline-selection').click();
+  await page.locator('#pipeline-selector').click();
   await page.getByText(mockPipelinesProxy.pipelines[0].name).click();
   await expect(await page.locator('#pipeline-version-name').getAttribute('value')).toMatch(
     new RegExp(`${mockPipelinesProxy.pipelines[0].name}_version_at_.*`),
   );
 
-  await page.locator('#pipeline-selection').click();
+  await page.locator('#pipeline-selector').click();
   await page.getByText(mockPipelinesProxy.pipelines[1].name).click();
   await expect(await page.locator('#pipeline-version-name').getAttribute('value')).toMatch(
     new RegExp(`${mockPipelinesProxy.pipelines[1].name}_version_at_.*`),

--- a/frontend/src/components/table/TableBase.tsx
+++ b/frontend/src/components/table/TableBase.tsx
@@ -179,7 +179,7 @@ const TableBase = <T,>({
             {columns.map((col, i) => {
               if (col.field === CHECKBOX_FIELD_ID && selectAll) {
                 return (
-                  <>
+                  <React.Fragment key={`checkbox-${i}`}>
                     <Tooltip
                       key="select-all-checkbox"
                       content="Select all page items"
@@ -194,7 +194,7 @@ const TableBase = <T,>({
                       // TODO: Log PF bug -- when there are no rows this gets truncated
                       style={{ minWidth: '45px' }}
                     />
-                  </>
+                  </React.Fragment>
                 );
               }
 

--- a/frontend/src/components/table/index.ts
+++ b/frontend/src/components/table/index.ts
@@ -7,3 +7,5 @@ export { default as useCheckboxTable } from './useCheckboxTable';
 
 export { default as TableRowTitleDescription } from './TableRowTitleDescription';
 export { default as CheckboxTd } from './CheckboxTd';
+
+export { getTableColumnSort } from './useTableColumnSort';

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -39,9 +39,6 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange }) => (
       />
     </FormSection>
     <PipelineSection
-      onLoaded={(loaded) => {
-        onValueChange('pipelinesLoaded', loaded);
-      }}
       value={data.pipeline}
       onChange={(pipeline) => {
         onValueChange('pipeline', pipeline);
@@ -56,9 +53,6 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange }) => (
       }}
     />
     <PipelineVersionSection
-      onLoaded={(loaded) => {
-        onValueChange('pipelineVersionsLoaded', loaded);
-      }}
       pipeline={data.pipeline}
       value={data.version}
       onChange={(version) => {

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -1,53 +1,31 @@
 import * as React from 'react';
-import { FormSection, Stack, StackItem } from '@patternfly/react-core';
+import { FormGroup, FormSection, Stack, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
-import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
-import { pipelineSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
 import ImportPipelineButton from '~/concepts/pipelines/content/import/ImportPipelineButton';
 
 type PipelineSectionProps = {
-  onLoaded: (loaded: boolean) => void;
   value: PipelineKF | null;
   onChange: (pipeline: PipelineKF) => void;
 };
 
-const PipelineSection: React.FC<PipelineSectionProps> = ({ onLoaded, value, onChange }) => {
-  const [{ items: pipelines }, loaded] = usePipelines({}, 0);
-
-  React.useEffect(() => {
-    onLoaded(loaded);
-    // only run when `loaded` changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded]);
-
-  return (
-    <FormSection
-      id={CreateRunPageSections.PIPELINE}
-      title={runPageSectionTitles[CreateRunPageSections.PIPELINE]}
-    >
+const PipelineSection: React.FC<PipelineSectionProps> = ({ value, onChange }) => (
+  <FormSection
+    id={CreateRunPageSections.PIPELINE}
+    title={runPageSectionTitles[CreateRunPageSections.PIPELINE]}
+  >
+    {/* `minWidth` a temp fix for PF issue https://github.com/patternfly/patternfly/issues/6062
+      We can remove this after bumping to PF v5.2.0
+    */}
+    <FormGroup style={{ minWidth: 0 }}>
       <Stack hasGutter>
         <StackItem>
-          <PipelineSelector
-            maxWidth="500px"
-            name={value?.name}
-            data={pipelines}
-            columns={pipelineSelectorColumns}
-            onSelect={(id) => {
-              const pipeline = pipelines.find((p) => p.id === id);
-              if (pipeline) {
-                onChange(pipeline);
-              }
-            }}
-            isLoading={!loaded}
-            placeHolder={pipelines.length === 0 ? 'No pipelines available' : 'Select a pipeline'}
-            searchHelperText={`Type a name to search your ${pipelines.length} pipelines.`}
-          />
+          <PipelineSelector selection={value?.name} onSelect={(pipeline) => onChange(pipeline)} />
         </StackItem>
         <StackItem>
           <ImportPipelineButton
@@ -59,8 +37,8 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({ onLoaded, value, onCh
           </ImportPipelineButton>
         </StackItem>
       </Stack>
-    </FormSection>
-  );
-};
+    </FormGroup>
+  </FormSection>
+);
 
 export default PipelineSection;

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
@@ -1,64 +1,41 @@
 import * as React from 'react';
-import { FormSection, Stack, StackItem } from '@patternfly/react-core';
+import { FormGroup, FormSection, Stack, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
-import usePipelineVersionsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline';
-import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
-import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
 import ImportPipelineVersionButton from '~/concepts/pipelines/content/import/ImportPipelineVersionButton';
+import PipelineVersionSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineVersionSelector';
 
 type PipelineVersionSectionProps = {
-  onLoaded: (loaded: boolean) => void;
   pipeline: PipelineKF | null;
   value: PipelineVersionKF | null;
   onChange: (version: PipelineVersionKF) => void;
 };
 
 const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
-  onLoaded,
   pipeline,
   value,
   onChange,
-}) => {
-  const pipelineId = pipeline?.id;
-  const [{ items: versions }, loaded] = usePipelineVersionsForPipeline(pipelineId);
-
-  React.useEffect(() => {
-    onLoaded(loaded);
-    // only run when `loaded` changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded]);
-
-  return (
-    <FormSection
-      id={CreateRunPageSections.PIPELINE_VERSION}
-      title={runPageSectionTitles[CreateRunPageSections.PIPELINE_VERSION]}
-    >
+}) => (
+  <FormSection
+    id={CreateRunPageSections.PIPELINE_VERSION}
+    title={runPageSectionTitles[CreateRunPageSections.PIPELINE_VERSION]}
+  >
+    {/* `minWidth` a temp fix for PF issue https://github.com/patternfly/patternfly/issues/6062
+      We can remove this after bumping to PF v5.2.0
+    */}
+    <FormGroup style={{ minWidth: 0 }}>
       <Stack hasGutter>
         <StackItem>
-          <PipelineSelector
-            maxWidth="500px"
-            name={value?.name}
-            data={versions}
-            columns={pipelineVersionSelectorColumns}
-            onSelect={(id) => {
-              const version = versions.find((v) => v.id === id);
-              if (version) {
-                onChange(version);
-              }
+          <PipelineVersionSelector
+            selection={value?.name}
+            pipelineId={pipeline?.id}
+            onSelect={(version) => {
+              onChange(version);
             }}
-            isDisabled={!pipelineId}
-            isLoading={!!pipelineId && !loaded}
-            placeHolder={
-              pipelineId && versions.length === 0
-                ? 'No versions available'
-                : 'Select a pipeline version'
-            }
-            searchHelperText={`Type a name to search your ${versions.length} versions.`}
           />
         </StackItem>
         <StackItem>
@@ -70,8 +47,8 @@ const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
           />
         </StackItem>
       </Stack>
-    </FormSection>
-  );
-};
+    </FormGroup>
+  </FormSection>
+);
 
 export default PipelineVersionSection;

--- a/frontend/src/concepts/pipelines/content/createRun/types.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/types.ts
@@ -43,8 +43,6 @@ export type RunParam = {
 export type RunFormData = {
   project: ProjectKind;
   nameDesc: { name: string; description: string };
-  pipelinesLoaded: boolean;
-  pipelineVersionsLoaded: boolean;
   pipeline: PipelineKF | null;
   version: PipelineVersionKF | null;
   // experiment: ExperimentKF | null;

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -216,8 +216,6 @@ const useRunFormData = (
       name: initialData?.name ? `Duplicate of ${initialData.name}` : '',
       description: initialData?.description ?? '',
     },
-    pipelinesLoaded: false,
-    pipelineVersionsLoaded: false,
     pipeline: lastPipeline ?? null,
     version: lastVersion ?? lastPipeline?.default_version ?? null,
     // experiment: null,

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -39,8 +39,6 @@ const runTypeSafeDates = (runType: RunFormData['runType']): boolean =>
 
 export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData =>
   !!formData.nameDesc.name &&
-  formData.pipelinesLoaded &&
-  formData.pipelineVersionsLoaded &&
   !!formData.pipeline &&
   !!formData.version &&
   !!formData.params &&

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -15,8 +15,6 @@ import { getProjectDisplayName } from '~/pages/projects/utils';
 import PipelineFileUpload from '~/concepts/pipelines/content/import/PipelineFileUpload';
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
-import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
-import { pipelineSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
 import { generatePipelineVersionName } from '~/concepts/pipelines/content/import/utils';
 
 type PipelineVersionImportModalProps = {
@@ -31,7 +29,6 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
   onClose,
 }) => {
   const { project, api, apiAvailable } = usePipelinesAPI();
-  const [{ items: pipelines }, loaded] = usePipelines({}, 0);
   const [importing, setImporting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
   const [{ name, description, pipelineId, pipelineName, fileContents }, setData, resetData] =
@@ -88,23 +85,12 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
           <StackItem>
             <FormGroup label="Pipeline" isRequired fieldId="pipeline-selection">
               <PipelineSelector
-                toggleId="pipeline-selection"
-                name={pipelineName}
-                data={pipelines}
-                columns={pipelineSelectorColumns}
-                onSelect={(id) => {
-                  const pipeline = pipelines.find((p) => p.id === id);
-                  if (pipeline) {
-                    setData('pipelineId', pipeline.id);
-                    setData('pipelineName', pipeline.name);
-                    setData('name', generatePipelineVersionName(pipeline));
-                  }
+                selection={pipelineName}
+                onSelect={(pipeline) => {
+                  setData('pipelineId', pipeline.id);
+                  setData('pipelineName', pipeline.name);
+                  setData('name', generatePipelineVersionName(pipeline));
                 }}
-                isLoading={!loaded}
-                placeHolder={
-                  pipelines.length === 0 ? 'No pipelines available' : 'Select a pipeline'
-                }
-                searchHelperText={`Type a name to search your ${pipelines.length} pipelines.`}
               />
             </FormGroup>
           </StackItem>
@@ -151,4 +137,8 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
   );
 };
 
-export default PipelineVersionImportModal;
+const PipelineVersionImportModalWrapper = (props: PipelineVersionImportModalProps) => (
+  <PipelineVersionImportModal key={props.existingPipeline?.id} {...props} />
+);
+
+export default PipelineVersionImportModalWrapper;

--- a/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
+++ b/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { generatePipelineVersionName } from '~/concepts/pipelines/content/import/utils';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
@@ -32,16 +31,6 @@ export const usePipelineVersionImportModalData = (pipeline?: PipelineKF | null) 
     pipelineName: pipeline?.name ?? '',
     fileContents: '',
   });
-
-  const [, setData] = createDataState;
-
-  React.useEffect(() => {
-    if (pipeline) {
-      setData('pipelineId', pipeline.id);
-      setData('pipelineName', pipeline.name);
-      setData('name', generatePipelineVersionName(pipeline));
-    }
-  }, [pipeline, setData]);
 
   return createDataState;
 };

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow.tsx
@@ -33,12 +33,10 @@ const PipelineSelectorTableRow: React.FC<PipelineSelectorTableRowProps> = ({ obj
         isClickable
         data-id="pipeline-selector-table-list-row"
       >
-        <Td width={70} modifier="truncate" dataLabel="Name">
+        <Td width={70} modifier="truncate">
           {obj.name}
         </Td>
-        <Td width={30} dataLabel="Updated">
-          {relativeTime(Date.now(), new Date(obj.created_at).getTime())}
-        </Td>
+        <Td width={30}>{relativeTime(Date.now(), new Date(obj.created_at).getTime())}</Td>
       </Tr>
     </>
   );

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/columns.ts
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/columns.ts
@@ -5,12 +5,12 @@ export const pipelineSelectorColumns: SortableData<PipelineKF>[] = [
   {
     label: 'Pipeline name',
     field: 'name',
-    sortable: false,
+    sortable: (a, b) => a.name.localeCompare(b.name),
     width: 70,
   },
   {
     label: 'Updated',
-    field: 'updated',
+    field: 'created_at',
     sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     width: 30,
   },
@@ -19,13 +19,13 @@ export const pipelineSelectorColumns: SortableData<PipelineKF>[] = [
 export const pipelineVersionSelectorColumns: SortableData<PipelineVersionKF>[] = [
   {
     label: 'Pipeline version',
-    field: 'version',
-    sortable: false,
+    field: 'name',
+    sortable: (a, b) => a.name.localeCompare(b.name),
     width: 70,
   },
   {
     label: 'Updated',
-    field: 'updated',
+    field: 'created_at',
     sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     width: 30,
   },

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/utils.ts
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/utils.ts
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { SearchInputProps } from '@patternfly/react-core';
+import usePipelineFilter, {
+  FilterOptions,
+  getDataValue,
+} from '~/concepts/pipelines/content/tables/usePipelineFilter';
+import { PipelinesFilter } from '~/concepts/pipelines/types';
+
+type SelectorSearchProps = {
+  setFilter: (filter?: PipelinesFilter) => void;
+  fetchedSize: number;
+  loaded: boolean;
+};
+
+export const useSelectorSearch = ({
+  setFilter,
+  fetchedSize,
+  loaded,
+}: SelectorSearchProps): Required<Pick<SearchInputProps, 'onChange' | 'onClear'>> & {
+  value?: string;
+  totalSize: number;
+} => {
+  const totalSizeRef = React.useRef(0);
+  const { onFilterUpdate, filterData, onClearFilters } = usePipelineFilter(setFilter);
+
+  const search = getDataValue(filterData[FilterOptions.NAME]);
+
+  const totalSize = React.useMemo(() => {
+    if (loaded && !search) {
+      totalSizeRef.current = fetchedSize;
+      return fetchedSize;
+    }
+    return totalSizeRef.current;
+    // The kubeflow API will only return the total size after the search filter
+    // We need to use the ref to record the real total size and only update it when `loaded` changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  const setSearch = React.useCallback(
+    (value: string) => {
+      onFilterUpdate(FilterOptions.NAME, value);
+    },
+    [onFilterUpdate],
+  );
+
+  return {
+    value: search,
+    onChange: (_event, value) => setSearch(value),
+    onClear: (e) => {
+      e.stopPropagation();
+      onClearFilters();
+    },
+    totalSize,
+  };
+};

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -22,12 +22,10 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelineTopologyEmpty from '~/concepts/pipelines/content/pipelinesDetails/PipelineTopologyEmpty';
 import { PipelineCoreDetailsPageComponent } from '~/concepts/pipelines/content/types';
 import DeletePipelineCoreResourceModal from '~/concepts/pipelines/content/DeletePipelineCoreResourceModal';
-import usePipelineVersionsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline';
-import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
-import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
 import usePipelineVersionById from '~/concepts/pipelines/apiHooks/usePipelineVersionById';
 import usePipelineById from '~/concepts/pipelines/apiHooks/usePipelineById';
 import { RelationshipKF, ResourceTypeKF } from '~/concepts/pipelines/kfTypes';
+import PipelineVersionSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineVersionSelector';
 import PipelineDetailsActions from './PipelineDetailsActions';
 import SelectedTaskDrawerContent from './SelectedTaskDrawerContent';
 import PipelineNotFound from './PipelineNotFound';
@@ -54,7 +52,6 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
   )?.key.id;
 
   const [pipeline, isPipelineLoaded, pipelineLoadError] = usePipelineById(pipelineId);
-  const [{ items: versions }, versionsLoaded] = usePipelineVersionsForPipeline(pipelineId);
   const [pipelineVersionRun, isPipelineVersionTemplateLoaded, templateLoadError] =
     usePipelineTemplate(pipelineVersionId);
   const { taskMap, nodes } = usePipelineTaskTopology(pipelineVersionRun);
@@ -115,24 +112,15 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
                     spaceItems={{ default: 'spaceItemsMd' }}
                     alignItems={{ default: 'alignItemsFlexStart' }}
                   >
-                    <FlexItem>
-                      <PipelineSelector
-                        maxWidth={300}
-                        name={`Pipeline version: ${pipelineVersion?.name}`}
-                        data={versions}
-                        columns={pipelineVersionSelectorColumns}
-                        onSelect={(id) => navigate(`/pipelines/${namespace}/pipeline/view/${id}`)}
-                        isDisabled={!pipelineId}
-                        isLoading={!!pipelineId && !versionsLoaded}
-                        placeHolder={
-                          pipelineId && versions.length === 0
-                            ? 'No versions available'
-                            : 'Select a pipeline version'
+                    <FlexItem style={{ width: '300px' }}>
+                      <PipelineVersionSelector
+                        pipelineId={pipeline?.id}
+                        selection={`Pipeline version: ${pipelineVersion?.name}`}
+                        onSelect={(version) =>
+                          navigate(`/pipelines/${namespace}/pipeline/view/${version.id}`)
                         }
-                        searchHelperText={`Type a name to search your ${versions.length} versions.`}
                       />
                     </FlexItem>
-
                     <FlexItem>
                       {isLoaded && (
                         <PipelineDetailsActions

--- a/frontend/src/concepts/pipelines/content/tables/EmptyTableView.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/EmptyTableView.tsx
@@ -8,27 +8,34 @@ import {
   EmptyStateActions,
   EmptyStateHeader,
   EmptyStateFooter,
+  EmptyStateVariant,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
 type EmptyTableViewProps = {
-  onClearFilters: () => void;
+  hasIcon?: boolean;
+  onClearFilters: (event: React.SyntheticEvent<HTMLButtonElement, Event>) => void;
+  variant?: EmptyStateVariant;
 };
 
-const EmptyTableView: React.FC<EmptyTableViewProps> = ({ onClearFilters }) => (
+const EmptyTableView: React.FC<EmptyTableViewProps> = ({
+  onClearFilters,
+  hasIcon = true,
+  variant,
+}) => (
   <Bullseye>
-    <EmptyState>
+    <EmptyState variant={variant}>
       <EmptyStateHeader
         titleText="No results found"
-        icon={<EmptyStateIcon icon={SearchIcon} />}
         headingLevel="h2"
+        {...(hasIcon && { icon: <EmptyStateIcon icon={SearchIcon} /> })}
       />
       <EmptyStateBody>
         No results match the filter criteria. Clear all filters and try again.
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
-          <Button variant="link" onClick={() => onClearFilters()}>
+          <Button variant="link" onClick={onClearFilters}>
             Clear all filters
           </Button>
         </EmptyStateActions>

--- a/frontend/src/concepts/pipelines/content/tables/PipelineViewMoreFooterRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/PipelineViewMoreFooterRow.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Badge, Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Tbody, Td, Tr } from '@patternfly/react-table';
+import useNotification from '~/utilities/useNotification';
+
+type PipelineViewMoreFooterRowProps = {
+  visibleLength: number;
+  totalSize: number;
+  onClick: () => Promise<void>;
+  errorTitle: string;
+  isIndented?: boolean;
+  colSpan: number;
+};
+
+const PipelineViewMoreFooterRow: React.FC<PipelineViewMoreFooterRowProps> = ({
+  visibleLength,
+  totalSize,
+  onClick,
+  errorTitle,
+  isIndented,
+  colSpan,
+}) => {
+  const [isLoading, setLoading] = React.useState(false);
+  const notification = useNotification();
+
+  if (visibleLength === totalSize) {
+    return null;
+  }
+
+  return (
+    <Tbody>
+      <Tr>
+        {isIndented && <Td />}
+        <Td colSpan={colSpan}>
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <FlexItem>
+              <Button
+                isLoading={isLoading}
+                isInline
+                variant="link"
+                onClick={() => {
+                  setLoading(true);
+                  onClick()
+                    .catch((e) => notification.error(errorTitle, e.message))
+                    .finally(() => setLoading(false));
+                }}
+              >
+                View more
+              </Button>
+            </FlexItem>
+            {!isLoading && (
+              <FlexItem>
+                <Badge isRead>{`Showing ${visibleLength}/${totalSize}`}</Badge>
+              </FlexItem>
+            )}
+          </Flex>
+        </Td>
+      </Tr>
+    </Tbody>
+  );
+};
+
+export default PipelineViewMoreFooterRow;

--- a/frontend/src/concepts/pipelines/content/tables/PipelinesTableRowTime.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/PipelinesTableRowTime.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Timestamp, TimestampTooltipVariant } from '@patternfly/react-core';
+import { relativeTime } from '~/utilities/time';
+
+type PipelinesTableRowTimeProps = {
+  date: Date;
+};
+
+const PipelinesTableRowTime: React.FC<PipelinesTableRowTimeProps> = ({ date }) => (
+  <span style={{ whiteSpace: 'nowrap' }}>
+    <Timestamp
+      date={date}
+      tooltip={{
+        variant: TimestampTooltipVariant.default,
+      }}
+    >
+      {relativeTime(Date.now(), date.getTime())}
+    </Timestamp>
+  </span>
+);
+
+export default PipelinesTableRowTime;

--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -9,37 +9,59 @@ import {
   PipelineRunJobKF,
   PipelineRunKF,
   PipelineCoreResourceKF,
+  PipelineVersionKF,
 } from '~/concepts/pipelines/kfTypes';
 
 export const pipelineColumns: SortableData<PipelineKF>[] = [
   expandTableColumn(),
+  checkboxTableColumn(),
   {
     label: 'Pipeline name',
     field: 'name',
     sortable: (a, b) => a.name.localeCompare(b.name),
-    width: 25,
+    width: 40,
   },
   {
-    label: 'Last run',
-    field: 'lastRun',
+    label: 'Versions',
+    field: 'versions',
     sortable: false,
-  },
-  {
-    label: 'Last run status',
-    field: 'lastRunStatus',
-    sortable: false,
-  },
-  {
-    label: 'Last run time',
-    field: 'lastRunTime',
-    sortable: false,
+    width: 20,
   },
   {
     label: 'Created',
     field: 'created_at',
     sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    width: 20,
+  },
+  {
+    label: 'Updated',
+    field: 'updated',
+    sortable: false,
+    width: 20,
   },
   kebabTableColumn(),
+];
+
+export const pipelineVersionColumns: SortableData<PipelineVersionKF>[] = [
+  checkboxTableColumn(),
+  {
+    label: 'Pipeline version',
+    field: 'name',
+    sortable: (a, b) => a.name.localeCompare(b.name),
+    width: 60,
+  },
+  {
+    label: 'Created',
+    field: 'created_at',
+    sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    width: 20,
+  },
+  {
+    label: '',
+    field: 'Action',
+    sortable: false,
+    width: 20,
+  },
 ];
 
 const sharedRunLikeColumns: SortableData<PipelineCoreResourceKF>[] = [

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableExpandedRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableExpandedRow.tsx
@@ -1,126 +1,85 @@
 import * as React from 'react';
-import { Td, Tbody, Tr, ExpandableRowContent } from '@patternfly/react-table';
+import { Td, Tr, ExpandableRowContent } from '@patternfly/react-table';
 import {
-  Button,
   EmptyState,
   EmptyStateVariant,
   Spinner,
-  Title,
   EmptyStateActions,
   EmptyStateHeader,
   EmptyStateFooter,
+  Bullseye,
 } from '@patternfly/react-core';
-import { Link, useNavigate } from 'react-router-dom';
-import { PipelineKF, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
-import IndentSection from '~/pages/projects/components/IndentSection';
-import { FetchState } from '~/utilities/useFetchState';
-import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { TABLE_CONTENT_LIMIT } from '~/concepts/pipelines/const';
-import { RenderContentList, combineRunsByColumn } from './expandedRowRenderUtils';
+import { PipelineKF } from '~/concepts/pipelines/kfTypes';
+import ImportPipelineVersionButton from '~/concepts/pipelines/content/import/ImportPipelineVersionButton';
+import PipelineVersionTable from '~/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTable';
+import usePipelineVersionsTable from '~/concepts/pipelines/content/tables/pipelineVersion/usePipelineVersionsTable';
 
 type PipelinesTableExpandedRowProps = {
-  isExpanded: boolean;
-  runsFetchState: FetchState<PipelineRunKF[]>;
   pipeline: PipelineKF;
+  pipelineDetailsPath: (namespace: string, id: string) => string;
 };
 
 const PipelinesTableExpandedRow: React.FC<PipelinesTableExpandedRowProps> = ({
-  isExpanded,
-  runsFetchState,
   pipeline,
+  pipelineDetailsPath,
 }) => {
-  const navigate = useNavigate();
-  const { namespace } = usePipelinesAPI();
-  const [runs, loaded] = runsFetchState;
+  const [
+    [{ items: initialVersions, totalSize, nextPageToken }, loaded],
+    { initialLoaded, ...tableProps },
+  ] = usePipelineVersionsTable(pipeline.id)();
 
-  if (!loaded) {
+  if (!loaded && !initialLoaded) {
     return (
-      <Tbody>
-        <Tr isExpanded={isExpanded}>
-          <Td colSpan={6}>
-            <ExpandableRowContent>
-              <Spinner size="sm" /> Loading runs...
-            </ExpandableRowContent>
-          </Td>
-        </Tr>
-      </Tbody>
+      <Tr isExpanded>
+        <Td />
+        <Td colSpan={6}>
+          <ExpandableRowContent>
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          </ExpandableRowContent>
+        </Td>
+      </Tr>
     );
   }
 
-  if (runs.length === 0) {
+  if (loaded && initialVersions.length === 0) {
     return (
-      <Tbody>
-        <Tr isExpanded={isExpanded}>
-          <Td />
-          <Td colSpan={6}>
-            <ExpandableRowContent>
-              <EmptyState variant={EmptyStateVariant.xs}>
-                <EmptyStateHeader titleText="No pipeline runs" headingLevel="h3" />
-                <EmptyStateFooter>
-                  <EmptyStateActions>
-                    <Button
-                      variant="link"
-                      onClick={() =>
-                        navigate(`/pipelines/${namespace}/pipelineRun/create`, {
-                          state: { lastPipeline: pipeline },
-                        })
-                      }
-                    >
-                      Create run
-                    </Button>
-                  </EmptyStateActions>
-                </EmptyStateFooter>
-              </EmptyState>
-            </ExpandableRowContent>
-          </Td>
-        </Tr>
-      </Tbody>
+      <Tr isExpanded>
+        <Td />
+        <Td colSpan={6}>
+          <ExpandableRowContent>
+            <EmptyState variant={EmptyStateVariant.xs}>
+              <EmptyStateHeader titleText="No pipeline versions" headingLevel="h3" />
+              <EmptyStateFooter>
+                <EmptyStateActions>
+                  <ImportPipelineVersionButton pipeline={pipeline} variant="link" />
+                </EmptyStateActions>
+              </EmptyStateFooter>
+            </EmptyState>
+          </ExpandableRowContent>
+        </Td>
+      </Tr>
     );
   }
-
-  const renderContentByColumn = combineRunsByColumn(runs, TABLE_CONTENT_LIMIT);
 
   return (
-    <Tbody isExpanded={isExpanded}>
-      <Tr isExpanded={isExpanded}>
-        <Td />
-        <Td colSpan={2}>
-          <ExpandableRowContent>
-            <IndentSection>
-              <RenderContentList
-                firstItem={
-                  <Title headingLevel="h3" size="md">
-                    Runs
-                  </Title>
-                }
-                items={[
-                  ...renderContentByColumn.names,
-                  runs.length > TABLE_CONTENT_LIMIT && (
-                    <Link to={`/pipelineRuns/${namespace}`}>View all runs</Link>
-                  ),
-                ]}
-              />
-            </IndentSection>
-          </ExpandableRowContent>
-        </Td>
-        <Td>
-          <ExpandableRowContent>
-            <RenderContentList items={renderContentByColumn.statuses} />
-          </ExpandableRowContent>
-        </Td>
-        <Td>
-          <ExpandableRowContent>
-            <RenderContentList items={renderContentByColumn.durations} />
-          </ExpandableRowContent>
-        </Td>
-        <Td>
-          <ExpandableRowContent>
-            <RenderContentList items={renderContentByColumn.createDates} />
-          </ExpandableRowContent>
-        </Td>
-        <Td isActionCell />
-      </Tr>
-    </Tbody>
+    <Tr isExpanded>
+      <Td />
+      <Td colSpan={6}>
+        <ExpandableRowContent>
+          <PipelineVersionTable
+            {...tableProps}
+            initialVersions={initialVersions}
+            loading={!loaded}
+            totalSize={totalSize}
+            pipelineDetailsPath={pipelineDetailsPath}
+            nextPageToken={nextPageToken}
+            pipelineId={pipeline.id}
+          />
+        </ExpandableRowContent>
+      </Td>
+    </Tr>
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/usePipelineTableRowData.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/usePipelineTableRowData.ts
@@ -1,0 +1,16 @@
+import usePipelineVersionsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline';
+import { PipelineKF } from '~/concepts/pipelines/kfTypes';
+
+const usePipelineTableRowData = (pipeline: PipelineKF) => {
+  const [{ items, totalSize }, isLoaded, , refresh] = usePipelineVersionsForPipeline(pipeline.id, {
+    pageSize: 1,
+    sortField: 'created_at',
+    sortDirection: 'desc',
+  });
+
+  const updatedDate = new Date(items[0]?.created_at || pipeline.created_at);
+
+  return { updatedDate, totalSize, loading: !isLoaded, refresh };
+};
+
+export default usePipelineTableRowData;

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TableVariant } from '@patternfly/react-table';
-import { TableBase } from '~/components/table';
+import { TableBase, getTableColumnSort } from '~/components/table';
 import { PipelineCoreResourceKF, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import { pipelineRunColumns } from '~/concepts/pipelines/content/tables/columns';
 import PipelineRunTableRow from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow';
@@ -36,23 +36,24 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
   pageSize,
   setPage,
   setPageSize,
-  sortField,
-  sortDirection,
-  setSortField,
-  setSortDirection,
   setFilter,
+  ...tableProps
 }) => {
   const { refreshAllAPI, getJobInformation } = usePipelinesAPI();
   const filterToolbarProps = usePipelineFilter(setFilter);
-  const { selections, tableProps, toggleSelection, isSelected } = useCheckboxTable(
-    runs.map(({ id }) => id),
-  );
+  const {
+    selections,
+    tableProps: checkboxTableProps,
+    toggleSelection,
+    isSelected,
+  } = useCheckboxTable(runs.map(({ id }) => id));
   const [deleteResources, setDeleteResources] = React.useState<PipelineCoreResourceKF[]>([]);
 
   return (
     <>
       <TableBase
         {...tableProps}
+        {...checkboxTableProps}
         loading={loading}
         page={page}
         perPage={pageSize}
@@ -93,22 +94,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
           />
         )}
         variant={TableVariant.compact}
-        getColumnSort={(columnIndex) =>
-          pipelineRunColumns[columnIndex].sortable
-            ? {
-                sortBy: {
-                  index: pipelineRunColumns.findIndex((c) => c.field === sortField),
-                  direction: sortDirection,
-                  defaultDirection: 'asc',
-                },
-                onSort: (_event, index, direction) => {
-                  setSortField(String(pipelineRunColumns[index].field));
-                  setSortDirection(direction);
-                },
-                columnIndex,
-              }
-            : undefined
-        }
+        getColumnSort={getTableColumnSort({ columns: pipelineRunColumns, ...tableProps })}
       />
       <DeletePipelineCoreResourceModal
         toDeleteResources={deleteResources}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { PipelineCoreResourceKF, PipelineRunJobKF } from '~/concepts/pipelines/kfTypes';
 import { pipelineRunJobColumns } from '~/concepts/pipelines/content/tables/columns';
-import { useCheckboxTable } from '~/components/table';
+import { getTableColumnSort, useCheckboxTable } from '~/components/table';
 import PipelineRunJobTableRow from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow';
 import PipelineRunJobTableToolbar from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar';
 import EmptyTableView from '~/concepts/pipelines/content/tables/EmptyTableView';
@@ -37,23 +37,24 @@ const PipelineRunJobTable: React.FC<PipelineRunTableProps> = ({
   pageSize,
   setPage,
   setPageSize,
-  sortField,
-  sortDirection,
-  setSortField,
-  setSortDirection,
   setFilter,
+  ...tableProps
 }) => {
   const { refreshAllAPI } = usePipelinesAPI();
   const filterToolbarProps = usePipelineFilter(setFilter);
-  const { selections, tableProps, toggleSelection, isSelected } = useCheckboxTable(
-    jobs.map(({ id }) => id),
-  );
+  const {
+    selections,
+    tableProps: checkboxTableProps,
+    toggleSelection,
+    isSelected,
+  } = useCheckboxTable(jobs.map(({ id }) => id));
   const [deleteResources, setDeleteResources] = React.useState<PipelineCoreResourceKF[]>([]);
 
   return (
     <>
       <TableBase
         {...tableProps}
+        {...checkboxTableProps}
         loading={loading}
         page={page}
         perPage={pageSize}
@@ -93,22 +94,7 @@ const PipelineRunJobTable: React.FC<PipelineRunTableProps> = ({
           />
         )}
         variant={TableVariant.compact}
-        getColumnSort={(columnIndex) =>
-          pipelineRunJobColumns[columnIndex].sortable
-            ? {
-                sortBy: {
-                  index: pipelineRunJobColumns.findIndex((c) => c.field === sortField),
-                  direction: sortDirection,
-                  defaultDirection: 'asc',
-                },
-                onSort: (_event, index, direction) => {
-                  setSortField(String(pipelineRunJobColumns[index].field));
-                  setSortDirection(direction);
-                },
-                columnIndex,
-              }
-            : undefined
-        }
+        getColumnSort={getTableColumnSort({ columns: pipelineRunJobColumns, ...tableProps })}
       />
       <DeletePipelineCoreResourceModal
         toDeleteResources={deleteResources}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTable.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { TableVariant } from '@patternfly/react-table';
+import { TableBase, getTableColumnSort } from '~/components/table';
+import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { pipelineVersionColumns } from '~/concepts/pipelines/content/tables/columns';
+import { useCheckboxTable } from '~/components/table';
+import PipelineVersionTableRow from '~/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow';
+import { usePipelineVersionLoadMore } from '~/concepts/pipelines/content/tables/usePipelineLoadMore';
+import PipelineViewMoreFooterRow from '~/concepts/pipelines/content/tables/PipelineViewMoreFooterRow';
+
+type PipelineVersionTableProps = {
+  pipelineId: string;
+  initialVersions: PipelineVersionKF[];
+  nextPageToken?: string;
+  loading?: boolean;
+  totalSize: number;
+  sortField?: string;
+  sortDirection?: 'asc' | 'desc';
+  setSortField: (field: string) => void;
+  setSortDirection: (dir: 'asc' | 'desc') => void;
+  pipelineDetailsPath: (namespace: string, id: string) => string;
+};
+
+const PipelineVersionTable: React.FC<PipelineVersionTableProps> = ({
+  pipelineId,
+  initialVersions,
+  nextPageToken,
+  loading,
+  totalSize,
+  sortField,
+  sortDirection,
+  pipelineDetailsPath,
+  ...tableProps
+}) => {
+  const { data: versions, onLoadMore } = usePipelineVersionLoadMore({
+    pipelineId,
+    initialData: initialVersions,
+    initialPageToken: nextPageToken,
+    sortDirection,
+    sortField,
+    loaded: !loading,
+  });
+  const {
+    tableProps: checkboxTableProps,
+    toggleSelection,
+    isSelected,
+  } = useCheckboxTable(versions.map(({ id }) => id));
+
+  return (
+    <TableBase
+      {...tableProps}
+      {...checkboxTableProps}
+      loading={loading}
+      itemCount={totalSize}
+      data={versions}
+      columns={pipelineVersionColumns}
+      rowRenderer={(version) => (
+        <PipelineVersionTableRow
+          key={version.id}
+          isChecked={isSelected(version.id)}
+          onToggleCheck={() => toggleSelection(version.id)}
+          version={version}
+          pipelineVersionDetailsPath={pipelineDetailsPath}
+        />
+      )}
+      variant={TableVariant.compact}
+      borders={false}
+      getColumnSort={getTableColumnSort({
+        columns: pipelineVersionColumns,
+        sortField,
+        sortDirection,
+        ...tableProps,
+      })}
+      footerRow={() =>
+        !loading ? (
+          <PipelineViewMoreFooterRow
+            visibleLength={versions.length}
+            totalSize={totalSize}
+            errorTitle="Error loading more pipeline versions"
+            onClick={onLoadMore}
+            isIndented
+            colSpan={5}
+          />
+        ) : null
+      }
+    />
+  );
+};
+
+export default PipelineVersionTable;

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Td, Tr } from '@patternfly/react-table';
+import { Button } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { CheckboxTd, TableRowTitleDescription } from '~/components/table';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
+
+type PipelineVersionTableRowProps = {
+  isChecked: boolean;
+  onToggleCheck: () => void;
+  pipelineVersionDetailsPath: (namespace: string, id: string) => string;
+  version: PipelineVersionKF;
+};
+
+const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
+  isChecked,
+  onToggleCheck,
+  pipelineVersionDetailsPath,
+  version,
+}) => {
+  const { namespace } = usePipelinesAPI();
+  const createdDate = new Date(version.created_at);
+
+  return (
+    <Tr>
+      <CheckboxTd id={version.id} isChecked={isChecked} onToggle={onToggleCheck} />
+      <Td>
+        <TableRowTitleDescription
+          title={<Link to={pipelineVersionDetailsPath(namespace, version.id)}>{version.name}</Link>}
+          description={version.description}
+          descriptionAsMarkdown
+        />
+      </Td>
+      <Td>
+        <PipelinesTableRowTime date={createdDate} />
+      </Td>
+      <Td>
+        {/* TODO: add navigation link, show be done with the pipeline runs page refactor */}
+        <Button variant="link" isInline>
+          View runs
+        </Button>
+      </Td>
+    </Tr>
+  );
+};
+
+export default PipelineVersionTableRow;

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/usePipelineVersionsTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/usePipelineVersionsTable.ts
@@ -1,0 +1,8 @@
+import usePipelineVersionsForPipeline from '~/concepts/pipelines/apiHooks/usePipelineVersionsForPipeline';
+import createUsePipelineTable from '~/concepts/pipelines/content/tables/usePipelineTable';
+import { PipelineOptions } from '~/concepts/pipelines/types';
+
+export default (pipelineId?: string) =>
+  createUsePipelineTable((options: PipelineOptions) =>
+    usePipelineVersionsForPipeline(pipelineId, options),
+  );

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -27,6 +27,7 @@ import {
 } from '~/concepts/pipelines/content/tables/utils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { computeRunStatus } from '~/concepts/pipelines/content/utils';
+import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
 
 export const NoRunContent = () => <>-</>;
 
@@ -81,13 +82,7 @@ export const RunDuration: RunUtil = ({ run }) => {
 
 export const RunCreated: RunUtil = ({ run }) => {
   const createdDate = new Date(run.created_at);
-  return (
-    <span style={{ whiteSpace: 'nowrap' }}>
-      <Timestamp date={createdDate} tooltip={{ variant: TimestampTooltipVariant.default }}>
-        {relativeTime(Date.now(), createdDate.getTime())}
-      </Timestamp>
-    </span>
-  );
+  return <PipelinesTableRowTime date={createdDate} />;
 };
 
 export const CoreResourceExperiment: CoreResourceUtil = ({ resource }) => (

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -30,7 +30,7 @@ const statusMap = {
   [PipelineRunStatusesKF.CANCELLED]: PipelineRunStatusesKF.CANCELLED,
 };
 
-const getDataValue = <T extends FilterProps['filterData'], R = T[keyof T]>(
+export const getDataValue = <T extends FilterProps['filterData'], R = T[keyof T]>(
   data: R,
 ): string | undefined => {
   if (typeof data === 'string') {

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineLoadMore.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineLoadMore.ts
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { PipelinesFilter } from '~/concepts/pipelines/types';
+import { NotReadyError } from '~/utilities/useFetchState';
+
+type LoadMoreProps = {
+  initialPageToken?: string;
+  sortField?: string;
+  sortDirection?: 'asc' | 'desc';
+  loaded?: boolean;
+  filter?: PipelinesFilter;
+};
+
+type PipelineLoadMoreProps = {
+  initialData: PipelineKF[];
+} & LoadMoreProps;
+
+type PipelineVersionLoadMoreProps = {
+  pipelineId?: string;
+  initialData: PipelineVersionKF[];
+} & LoadMoreProps;
+
+export const usePipelineLoadMore = ({
+  initialData,
+  initialPageToken,
+  sortDirection,
+  sortField,
+  loaded,
+  filter,
+}: PipelineLoadMoreProps) => {
+  const { api } = usePipelinesAPI();
+  const [, showMoreData] = React.useState(false);
+  const dataRef = React.useRef<PipelineKF[]>([]);
+  const pageTokenRef = React.useRef<string>();
+
+  React.useMemo(() => {
+    if (loaded) {
+      dataRef.current = [...initialData];
+      pageTokenRef.current = initialPageToken;
+    }
+    // Only change the data and page token when loaded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  const onLoadMore = React.useCallback(async () => {
+    if (!pageTokenRef.current) {
+      return;
+    }
+    const result = await api.listPipelines(
+      {},
+      {
+        pageToken: pageTokenRef.current,
+        pageSize: 10,
+        sortField,
+        sortDirection,
+        filter,
+      },
+    );
+    showMoreData((flag) => !flag);
+    dataRef.current = [...dataRef.current, ...(result.pipelines || [])];
+    pageTokenRef.current = result.next_page_token;
+  }, [api, sortDirection, sortField, filter]);
+
+  return { data: dataRef.current, onLoadMore };
+};
+
+export const usePipelineVersionLoadMore = ({
+  initialData,
+  initialPageToken,
+  pipelineId,
+  sortDirection,
+  sortField,
+  filter,
+  loaded,
+}: PipelineVersionLoadMoreProps) => {
+  const { api } = usePipelinesAPI();
+  const [, showMoreData] = React.useState<boolean>(false);
+  const dataRef = React.useRef<PipelineVersionKF[]>([]);
+  const pageTokenRef = React.useRef<string>();
+
+  React.useMemo(() => {
+    if (loaded) {
+      dataRef.current = [...initialData];
+      pageTokenRef.current = initialPageToken;
+    }
+    // Only change the data and page token when loaded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  const onLoadMore = React.useCallback(async () => {
+    if (!pageTokenRef.current) {
+      return;
+    }
+    if (!pipelineId) {
+      throw new NotReadyError('No pipeline id');
+    }
+    const result = await api.listPipelineVersionsByPipeline({}, pipelineId, {
+      pageToken: pageTokenRef.current,
+      pageSize: 10,
+      sortField,
+      sortDirection,
+      filter,
+    });
+    showMoreData((flag) => !flag);
+    dataRef.current = [...dataRef.current, ...(result.versions || [])];
+    pageTokenRef.current = result.next_page_token;
+  }, [api, pipelineId, sortField, sortDirection, filter]);
+
+  return { data: dataRef.current, onLoadMore };
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA:
https://issues.redhat.com/browse/RHOAIENG-263
https://issues.redhat.com/browse/RHOAIENG-264

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The PR did the following things:
1. Refactor the global pipelines table, and change it to bulk selection, change the columns to get the versions number and updated date (the latest version date)

<img width="1724" alt="Screenshot 2023-12-14 at 4 39 55 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/d7235502-a6ff-4761-9e59-736c1a0ee535">

2. Add the pipeline versions table to the expandable section in the row of the pipeline, when it's more than 10 versions, you can click on the View More button to load more versions, you can also sort the versions by name and create time.

**NOTE: The view run Button link is not implemented yet, needs to be addressed when refactoring the pipeline runs page.**

<img width="1724" alt="Screenshot 2023-12-14 at 4 42 16 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/dd588160-0fa8-4ea8-8812-930fa320cdf3">

3. Refactor the pipeline and pipeline version selector to make it also use the server-side filtering and sorting to keep the behavior aligned with what we have now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the global pipelines page
2. Try to expand the pipelines to see the pipeline versions
3. Click on the version should be able to navigate you to the version details page
4. Try to upload new versions to the pipelines
5. Try to create more than 10 pipeline versions under a pipeline to test the view more function
6. Try to sort the pipelines table and the pipeline versions table
7. Try to delete all the versions in one pipeline to check this state
<img width="1724" alt="Screenshot 2023-12-14 at 4 47 30 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/677ca02d-3d3e-4ab5-bc75-a030eb749351">
8. Play around with the pipeline selectors, it should have better filtering and sorting now

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Update the test cases for the pipeline selector. Didn't create new tests, because it makes more sense to use e2e tests for this.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
