### PR TITLE
Add no-base-to-string rule to both frontend and backend

### DIFF
--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -39,7 +39,7 @@ export const passThrough = <T extends K8sResourceCommon>(
           };
         } else {
           // Likely not JSON, print the error and return the content to the client
-          fastify.log.error(`Parsing response error: ${e}, ${data}`);
+          fastify.log.error(e, `Parsing response error: ${data}`);
           throw { code: 500, response: data };
         }
       }

--- a/backend/src/routes/api/proxy/index.ts
+++ b/backend/src/routes/api/proxy/index.ts
@@ -15,7 +15,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
           host: string;
           data?: Record<string, unknown>;
           fileContents?: string;
-          queryParams?: Record<string, unknown>;
+          queryParams?: Record<string, string>;
         };
       }>,
       reply: FastifyReply,

--- a/backend/src/utils/fileUtils.ts
+++ b/backend/src/utils/fileUtils.ts
@@ -51,7 +51,7 @@ export const writeAdminLog = (fastify: KubeFastifyInstance, data: AdminLogRecord
       `${new Date().toISOString()}: ${JSON.stringify(data)}\n`,
       function (err) {
         if (err) {
-          fastify.log.error(`ERROR: Unable to write to admin log - ${err}`);
+          fastify.log.error(err, 'ERROR: Unable to write to admin log');
         }
       },
     );

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -84,6 +84,7 @@
     "object-shorthand": ["error", "always"],
     "no-console": "error",
     "no-param-reassign": "error",
+    "@typescript-eslint/no-base-to-string": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-var-requires": "off",

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsCodeBlock.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsCodeBlock.tsx
@@ -15,7 +15,7 @@ const TaskDetailsCodeBlock: React.FC<TaskDetailsCodeBlockProps> = ({ id, content
   const [copied, setCopied] = React.useState(false);
 
   const clipboardCopyFunc = (text: string) => {
-    navigator.clipboard.writeText(text.toString());
+    navigator.clipboard.writeText(text);
   };
 
   const onClick = (text: string) => {

--- a/frontend/src/utilities/allSettledPromises.ts
+++ b/frontend/src/utilities/allSettledPromises.ts
@@ -1,4 +1,4 @@
-type TypedPromiseRejectedResult<R> = PromiseRejectedResult & { reason: R };
+type TypedPromiseRejectedResult<R> = Omit<PromiseRejectedResult, 'reason'> & { reason: R };
 
 export const allSettledPromises = <T, E = undefined>(
   data: Promise<T>[],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes: [RHOAIENG-508](https://issues.redhat.com/browse/RHOAIENG-508)

## Description
This PR aims to apply no-base-to-string rule to both frontend and backend. 

## How Has This Been Tested?
Run `npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
