### PR TITLE
support workbench-image-recommended annotation being set to false

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
@@ -2,6 +2,7 @@ import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
 import {
   getExistingVersionsForImageStream,
   isAWSValid,
+  checkVersionRecommended, // Added import for the new function
 } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { EnvVariableDataEntry } from '~/pages/projects/types';
 import { mockImageStreamK8sResource } from '~/__mocks__/mockImageStreamK8sResource';
@@ -133,5 +134,44 @@ describe('getExistingVersionsForImageStream', () => {
     const result = getExistingVersionsForImageStream(imageStream);
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({ name: 'should-be-included' });
+  });
+});
+
+describe('checkVersionRecommended', () => {
+  it('should return true if the image version is recommended', () => {
+    const imageVersion = {
+      name: 'test-image',
+      annotations: {
+        [IMAGE_ANNOTATIONS.RECOMMENDED]: 'true',
+      },
+    };
+    expect(checkVersionRecommended(imageVersion)).toBe(true);
+  });
+
+  it('should return false if the image version is not recommended', () => {
+    const imageVersion = {
+      name: 'test-image',
+      annotations: {
+        [IMAGE_ANNOTATIONS.RECOMMENDED]: 'false',
+      },
+    };
+    expect(checkVersionRecommended(imageVersion)).toBe(false);
+  });
+
+  it('should return false if the image version does not have the recommended annotation', () => {
+    const imageVersion = {
+      name: 'test-image',
+    };
+    expect(checkVersionRecommended(imageVersion)).toBe(false);
+  });
+
+  it('should return false if the image version is invalid JSON', () => {
+    const imageVersion = {
+      name: 'test-image',
+      annotations: {
+        [IMAGE_ANNOTATIONS.RECOMMENDED]: 'invalid-json',
+      },
+    };
+    expect(checkVersionRecommended(imageVersion)).toBe(false);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -107,9 +107,9 @@ export const compareTagVersions = (
   b: ImageStreamSpecTagType,
 ): number => {
   // Recommended tags should be first
-  if (a.annotations?.[IMAGE_ANNOTATIONS.RECOMMENDED]) {
+  if (checkVersionRecommended(a)) {
     return -1;
-  } else if (b.annotations?.[IMAGE_ANNOTATIONS.RECOMMENDED]) {
+  } else if (checkVersionRecommended(b)) {
     return 1;
   }
   if (compareVersions.validate(a.name) && compareVersions.validate(b.name)) {
@@ -322,7 +322,7 @@ export const checkVersionExistence = (
 };
 
 export const checkVersionRecommended = (imageVersion: ImageStreamSpecTagType): boolean =>
-  !!imageVersion.annotations?.[IMAGE_ANNOTATIONS.RECOMMENDED];
+  imageVersion.annotations?.[IMAGE_ANNOTATIONS.RECOMMENDED] === 'true';
 
 export const isValidGenericKey = (key: string): boolean => !!key;
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-937

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
check that `opendatahub.io/workbench-image-recommended: 'false'` does not show the recommended label.

_Note: the jupyter tile already does this in the backend, so no need to do anything there._ 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. edit any imagestream tag's annotation for `opendatahub.io/workbench-image-recommended: 'false'` and verify that in the UI the recommended label is not shown. You can see this when going to the workbench spawner and selecting a version for the image you changed.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added util test to test how different annotation values are handled

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
