### PR TITLE
Assert edit permissions on appropriate mutations in namespaceUtils, fix promise logic when deploying a model or adding a model server, show inner error messages from the backend when present

### DIFF
--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -1,29 +1,24 @@
-import { PatchUtils, V1SelfSubjectAccessReview } from '@kubernetes/client-node';
+import {
+  PatchUtils,
+  V1ResourceAttributes,
+  V1SelfSubjectAccessReview,
+} from '@kubernetes/client-node';
 import { NamespaceApplicationCase } from './const';
 import { K8sStatus, KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { createCustomError } from '../../../utils/requestUtils';
 import { isK8sStatus, passThrough } from '../k8s/pass-through';
 
-const checkNamespacePermission = (
+const createSelfSubjectAccessReview = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
-  name: string,
+  resourceAttributes: V1ResourceAttributes,
 ): Promise<V1SelfSubjectAccessReview | K8sStatus> => {
   const kc = fastify.kube.config;
   const cluster = kc.getCurrentCluster();
   const selfSubjectAccessReviewObject: V1SelfSubjectAccessReview = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SelfSubjectAccessReview',
-    spec: {
-      resourceAttributes: {
-        group: 'project.openshift.io',
-        resource: 'projects',
-        subresource: '',
-        verb: 'update',
-        name,
-        namespace: name,
-      },
-    },
+    spec: { resourceAttributes },
   };
   return passThrough<V1SelfSubjectAccessReview>(fastify, request, {
     url: `${cluster.server}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`,
@@ -31,6 +26,34 @@ const checkNamespacePermission = (
     requestData: JSON.stringify(selfSubjectAccessReviewObject),
   });
 };
+
+const checkAdminNamespacePermission = (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  name: string,
+): Promise<V1SelfSubjectAccessReview | K8sStatus> =>
+  createSelfSubjectAccessReview(fastify, request, {
+    group: 'project.openshift.io',
+    resource: 'projects',
+    subresource: '',
+    verb: 'update',
+    name,
+    namespace: name,
+  });
+
+const checkEditNamespacePermission = (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  name: string,
+): Promise<V1SelfSubjectAccessReview | K8sStatus> =>
+  createSelfSubjectAccessReview(fastify, request, {
+    group: 'serving.kserve.io',
+    resource: 'ServingRuntimes',
+    subresource: '',
+    verb: 'create',
+    name,
+    namespace: name,
+  });
 
 export const applyNamespaceChange = async (
   fastify: KubeFastifyInstance,
@@ -47,7 +70,39 @@ export const applyNamespaceChange = async (
     );
   }
 
-  const selfSubjectAccessReview = await checkNamespacePermission(fastify, request, name);
+  let labels = {};
+  let checkPermissionsFn = null;
+  switch (context) {
+    case NamespaceApplicationCase.DSG_CREATION:
+      {
+        labels = { 'opendatahub.io/dashboard': 'true' };
+        checkPermissionsFn = checkAdminNamespacePermission;
+      }
+      break;
+    case NamespaceApplicationCase.MODEL_MESH_PROMOTION:
+      {
+        labels = { 'modelmesh-enabled': 'true' };
+        checkPermissionsFn = checkEditNamespacePermission;
+      }
+      break;
+    case NamespaceApplicationCase.KSERVE_PROMOTION:
+      {
+        labels = { 'modelmesh-enabled': 'false' };
+        checkPermissionsFn = checkEditNamespacePermission;
+      }
+      break;
+    default:
+      throw createCustomError('Unknown configuration', 'Cannot apply namespace change', 400);
+  }
+
+  if (checkPermissionsFn === null) {
+    throw createCustomError(
+      'Invalid backend state -- dev broken workflow',
+      'checkPermissionsFn is null -- appropriate permissions must be checked for all actions',
+      500,
+    );
+  }
+  const selfSubjectAccessReview = await checkPermissionsFn(fastify, request, name);
   if (isK8sStatus(selfSubjectAccessReview)) {
     throw createCustomError(
       selfSubjectAccessReview.reason,
@@ -57,28 +112,11 @@ export const applyNamespaceChange = async (
   }
   if (!selfSubjectAccessReview.status.allowed) {
     fastify.log.error(`Unable to access the namespace, ${selfSubjectAccessReview.status.reason}`);
-    throw createCustomError('Forbidden', "You don't have the access to update the namespace", 403);
-  }
-
-  let labels = {};
-  switch (context) {
-    case NamespaceApplicationCase.DSG_CREATION:
-      labels = {
-        'opendatahub.io/dashboard': 'true',
-      };
-      break;
-    case NamespaceApplicationCase.MODEL_MESH_PROMOTION:
-      labels = {
-        'modelmesh-enabled': 'true',
-      };
-      break;
-    case NamespaceApplicationCase.KSERVE_PROMOTION:
-      labels = {
-        'modelmesh-enabled': 'false',
-      };
-      break;
-    default:
-      throw createCustomError('Unknown configuration', 'Cannot apply namespace change', 400);
+    throw createCustomError(
+      'Forbidden',
+      "You don't have permission to update serving platform labels on the current project.",
+      403,
+    );
   }
 
   return fastify.kube.coreV1Api

--- a/frontend/src/__mocks__/mockServiceAccountK8sResource.ts
+++ b/frontend/src/__mocks__/mockServiceAccountK8sResource.ts
@@ -1,0 +1,21 @@
+import { genUID } from '~/__mocks__/mockUtils';
+import { ServiceAccountKind } from '~/k8sTypes';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+};
+
+export const mockServiceAccountK8sResource = ({
+  name = 'test-model-sa',
+  namespace = 'test-project',
+}: MockResourceConfigType): ServiceAccountKind => ({
+  kind: 'ServiceAccount',
+  apiVersion: 'v1',
+  metadata: {
+    name,
+    namespace,
+    uid: genUID('serviceaccount'),
+    creationTimestamp: '2023-02-14T21:43:59Z',
+  },
+});

--- a/frontend/src/api/errorUtils.ts
+++ b/frontend/src/api/errorUtils.ts
@@ -1,4 +1,5 @@
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+import { AxiosError } from 'axios';
 
 export const isK8sStatus = (data: unknown): data is K8sStatus =>
   (data as K8sStatus).kind === 'Status';
@@ -12,3 +13,17 @@ export class K8sStatusError extends Error {
     this.statusObject = statusObject;
   }
 }
+
+const isAxiosErrorWithResponseMessage = (
+  error?: Error | AxiosError,
+): error is AxiosError<{ message: string }> =>
+  Boolean(
+    error && typeof (error as AxiosError<{ message: string }>).response?.data?.message === 'string',
+  );
+
+export const throwErrorFromAxios = (error: Error | AxiosError): never => {
+  if (isAxiosErrorWithResponseMessage(error)) {
+    throw new Error(error.response?.data.message);
+  }
+  throw error;
+};

--- a/frontend/src/api/k8s/projects.ts
+++ b/frontend/src/api/k8s/projects.ts
@@ -10,6 +10,7 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { ProjectKind } from '~/k8sTypes';
 import { ProjectModel } from '~/api/models';
+import { throwErrorFromAxios } from '~/api/errorUtils';
 import { translateDisplayNameForK8s } from '~/pages/projects/utils';
 import { ODH_PRODUCT_NAME } from '~/utilities/const';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE, LABEL_SELECTOR_MODEL_SERVING_PROJECT } from '~/const';
@@ -84,6 +85,7 @@ export const createProject = (
 
             resolve(projectName);
           })
+          .catch(throwErrorFromAxios)
           .catch(reject);
       })
       .catch(reject);
@@ -113,15 +115,17 @@ export const addSupportServingPlatformProject = (
   name: string,
   servingPlatform: NamespaceApplicationCase,
 ): Promise<string> =>
-  axios(`/api/namespaces/${name}/${servingPlatform}`).then((response) => {
-    const applied = response.data?.applied ?? false;
-    if (!applied) {
-      throw new Error(
-        `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
-      );
-    }
-    return name;
-  });
+  axios(`/api/namespaces/${name}/${servingPlatform}`)
+    .then((response) => {
+      const applied = response.data?.applied ?? false;
+      if (!applied) {
+        throw new Error(
+          `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
+        );
+      }
+      return name;
+    })
+    .catch(throwErrorFromAxios);
 
 export const updateProject = (
   editProjectData: ProjectKind,

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -145,28 +145,28 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       editInfo?.inferenceServiceEditInfo?.spec.predictor.model.runtime ||
       translateDisplayNameForK8s(createDataInferenceService.name);
 
-    Promise.all([
-      submitServingRuntimeResources(
-        servingRuntimeSelected,
-        createDataServingRuntime,
-        customServingRuntimesEnabled,
-        namespace,
-        editInfo?.servingRuntimeEditInfo,
-        true,
-        acceleratorProfileState,
-        NamespaceApplicationCase.KSERVE_PROMOTION,
-        projectContext?.currentProject,
-        servingRuntimeName,
-        false,
-      ),
-      submitInferenceServiceResource(
-        createDataInferenceService,
-        editInfo?.inferenceServiceEditInfo,
-        servingRuntimeName,
-        false,
-        acceleratorProfileState,
-      ),
-    ])
+    submitServingRuntimeResources(
+      servingRuntimeSelected,
+      createDataServingRuntime,
+      customServingRuntimesEnabled,
+      namespace,
+      editInfo?.servingRuntimeEditInfo,
+      true,
+      acceleratorProfileState,
+      NamespaceApplicationCase.KSERVE_PROMOTION,
+      projectContext?.currentProject,
+      servingRuntimeName,
+      false,
+    )
+      .then(() =>
+        submitInferenceServiceResource(
+          createDataInferenceService,
+          editInfo?.inferenceServiceEditInfo,
+          servingRuntimeName,
+          false,
+          acceleratorProfileState,
+        ),
+      )
       .then(() => onSuccess())
       .catch((e) => {
         setErrorModal(e);


### PR DESCRIPTION
Resolves [RHOAIENG-548](https://issues.redhat.com/browse/RHOAIENG-548) and [RHOAIENG-556](https://issues.redhat.com/browse/RHOAIENG-556).

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When a user has "edit" permission on a data science project they don't own, they don't have permission to update that namespace. When adding the first model or model server to a project, the namespace needs to be updated by `addSupportServingPlatformProject` to add labels that describe which serving platform the project is using, which fails with a 403 error for users in this position (as expected). Currently, even though this namespace update fails, the ServingRuntime gets created anyway. It does not become visible in the UI because it still shows the platform-selection view (choosing single- or multi-model serving), but it is visible in the cluster.

The `submitServingRuntimeResources` function that is called to make these updates and create the ServingRuntime currently operates like this:
* Execute a dry-run of the operations concurrently with a `Promise.all`.
* If no error in the dry-run, execute the same operations with another `Promise.all`, but this time include the namespace update (because the namespace update performed by `addSupportServingPlatformProject` has no dry-run option).

This means that if `addSupportServingPlatformProject` fails, the other requests will run anyway. The fix is to add a step in between the dry-run and the actual run of these requests where we perform the namespace update before proceeding, which means if it fails the ServingRuntime will not be created. As part of the fix, we convert the `submitServingRuntimeResources` to an async function so we can use `await` for readability.

There are also a few other notable changes:
* Removes the `allowCreate` condition on updating the namespace, which was a relic of an earlier workaround that is no longer needed (@lucferbux can provide more context on this -- thanks for your help Lucas!).
* Changes the `applyNamespaceChange` function on the backend to perform a more accurate `selfSubjectAccessReview`: users with "edit" permission should still be able to create ServingRuntimes when the namespace update is not needed (a serving platform has already been chosen for the project), so we check for that permission only for the `MODEL_MESH_PROMOTION` and `KSERVE_PROMOTION` cases.
* When deploying a Kserve model, there was another `Promise.all` for concurrently calling `submitServingRuntimeResources` and `submitInferenceServiceResource`, which means if the error described above happens here the InferenceService will also still be created. Changing this to be a sequential `.then` also fixes that problem. (Edit: I hadn't realized this was the separate issue [RHOAIENG-556](https://issues.redhat.com/browse/RHOAIENG-556), so this PR fixes that now too :))
* Adds a new `throwErrorFromAxios` utility and uses it in `addSupportServingPlatformProject` (and in `createProject`, the only other place we're directly calling `axios()`). This will ensure that if an error thrown by the `axios()` call has a response object containing a message from the backend, that message will be used instead of the top-level `message` property from Axios ("Request failed with status code X"). If the error being displayed does not contain an inner error message in this expected structure, the current behavior is retained and the top-level `error.message` is used.

Considering that last point above, the error message that used to look like this:

![Screenshot 2024-01-15 at 5 44 47 PM](https://github.com/opendatahub-io/odh-dashboard/assets/811963/29235ed7-ead9-408b-abc5-b1ad3ef4ebb5)

now looks like this:

![Screenshot 2024-01-16 at 3 07 39 PM](https://github.com/opendatahub-io/odh-dashboard/assets/811963/8f6e23e3-d7c1-4752-b63a-7632497efb9b)

@vconzola, does that error text look good to you?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With @lucferbux's help, I reproduced the error in a cluster and verified the fix by using the PR image in that cluster. Testing locally gave us trouble because apparently an impersonated regular user cannot list templates in a namespace they don't own (which does not seem to match the behavior in production), so we can't get the "Models and model servers" section of the data science project page to render when trying to reproduce the bug this way.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

New Cypress tests have been added to submit the "deploy model" and "add model server" modals and intercept their requests, ensuring that the request to create ServingRuntimes and InferenceServices are not made when there is an error updating the namespace.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
