### PR TITLE
added dry run to workbench update

### DIFF
--- a/frontend/src/api/k8s/configMaps.ts
+++ b/frontend/src/api/k8s/configMaps.ts
@@ -5,9 +5,10 @@ import {
   k8sUpdateResource,
   K8sStatus,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import { ConfigMapKind, KnownLabels } from '~/k8sTypes';
+import { ConfigMapKind, K8sAPIOptions, KnownLabels } from '~/k8sTypes';
 import { ConfigMapModel } from '~/api/models';
 import { genRandomChars } from '~/utilities/string';
+import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 
 export const assembleConfigMap = (
   projectName: string,
@@ -32,14 +33,30 @@ export const getConfigMap = (projectName: string, configMapName: string): Promis
     queryOptions: { name: configMapName, ns: projectName },
   });
 
-export const createConfigMap = (data: ConfigMapKind): Promise<ConfigMapKind> =>
-  k8sCreateResource<ConfigMapKind>({ model: ConfigMapModel, resource: data });
+export const createConfigMap = (
+  data: ConfigMapKind,
+  opts?: K8sAPIOptions,
+): Promise<ConfigMapKind> =>
+  k8sCreateResource<ConfigMapKind>(
+    applyK8sAPIOptions(opts, { model: ConfigMapModel, resource: data }),
+  );
 
-export const replaceConfigMap = (data: ConfigMapKind): Promise<ConfigMapKind> =>
-  k8sUpdateResource<ConfigMapKind>({ model: ConfigMapModel, resource: data });
+export const replaceConfigMap = (
+  data: ConfigMapKind,
+  opts?: K8sAPIOptions,
+): Promise<ConfigMapKind> =>
+  k8sUpdateResource<ConfigMapKind>(
+    applyK8sAPIOptions(opts, { model: ConfigMapModel, resource: data }),
+  );
 
-export const deleteConfigMap = (projectName: string, configMapName: string): Promise<K8sStatus> =>
-  k8sDeleteResource<ConfigMapKind, K8sStatus>({
-    model: ConfigMapModel,
-    queryOptions: { name: configMapName, ns: projectName },
-  });
+export const deleteConfigMap = (
+  projectName: string,
+  configMapName: string,
+  opts?: K8sAPIOptions,
+): Promise<K8sStatus> =>
+  k8sDeleteResource<ConfigMapKind, K8sStatus>(
+    applyK8sAPIOptions(opts, {
+      model: ConfigMapModel,
+      queryOptions: { name: configMapName, ns: projectName },
+    }),
+  );

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -273,6 +273,7 @@ export const updateNotebook = (
   existingNotebook: NotebookKind,
   data: StartNotebookData,
   username: string,
+  opts?: K8sAPIOptions,
 ): Promise<NotebookKind> => {
   data.notebookId = existingNotebook.metadata.name;
   const notebook = assembleNotebook(data, username);
@@ -287,10 +288,12 @@ export const updateNotebook = (
   oldNotebook.spec.template.spec.affinity = {};
   container.resources = {};
 
-  return k8sUpdateResource<NotebookKind>({
-    model: NotebookModel,
-    resource: _.merge({}, oldNotebook, notebook),
-  });
+  return k8sUpdateResource<NotebookKind>(
+    applyK8sAPIOptions(opts, {
+      model: NotebookModel,
+      resource: _.merge({}, oldNotebook, notebook),
+    }),
+  );
 };
 
 export const createNotebookWithoutStarting = (

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -130,32 +130,48 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     handleStart();
     if (editNotebook) {
-      const pvcDetails = await replaceRootVolumesForNotebook(
-        projectName,
-        editNotebook,
-        storageData,
-      ).catch(handleError);
-      const envFrom = await updateConfigMapsAndSecretsForNotebook(
-        projectName,
-        editNotebook,
-        envVariables,
-        dataConnection,
-        existingNotebookDataConnection,
-      ).catch(handleError);
+      const updateNotebookPromise = async (dryRun: boolean) => {
+        const pvcDetails = await replaceRootVolumesForNotebook(
+          projectName,
+          editNotebook,
+          storageData,
+          dryRun,
+        ).catch(handleError);
 
-      if (!pvcDetails || !envFrom) {
-        return;
-      }
-      const { volumes, volumeMounts } = pvcDetails;
-      const newStartNotebookData = {
-        ...startNotebookData,
-        volumes,
-        volumeMounts,
-        envFrom,
-        tolerationSettings,
+        const envFrom = await updateConfigMapsAndSecretsForNotebook(
+          projectName,
+          editNotebook,
+          envVariables,
+          dataConnection,
+          existingNotebookDataConnection,
+          dryRun,
+        ).catch(handleError);
+
+        if (!pvcDetails || !envFrom) {
+          return;
+        }
+
+        const { volumes, volumeMounts } = pvcDetails;
+        const newStartNotebookData = {
+          ...startNotebookData,
+          volumes,
+          volumeMounts,
+          envFrom,
+          tolerationSettings,
+        };
+        return updateNotebook(editNotebook, newStartNotebookData, username, { dryRun });
       };
-      updateNotebook(editNotebook, newStartNotebookData, username)
-        .then((notebook) => afterStart(notebook.metadata.name, 'updated'))
+
+      updateNotebookPromise(true)
+        .then(() =>
+          updateNotebookPromise(false)
+            .then((notebook) => {
+              if (notebook) {
+                afterStart(notebook.metadata.name, 'updated');
+              }
+            })
+            .catch(handleError),
+        )
         .catch(handleError);
     }
   };

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -48,6 +48,7 @@ export const replaceRootVolumesForNotebook = async (
   projectName: string,
   notebook: NotebookKind,
   storageData: StorageData,
+  dryRun?: boolean,
 ): Promise<{ volumes: Volume[]; volumeMounts: VolumeMount[] }> => {
   const {
     storageType,
@@ -67,7 +68,7 @@ export const replaceRootVolumesForNotebook = async (
     };
     replacedVolumeMount = { name: existingName, mountPath: ROOT_MOUNT_PATH };
   } else {
-    const pvc = await createPvc(storageData.creating, projectName);
+    const pvc = await createPvc(storageData.creating, projectName, { dryRun });
     const newPvcName = pvc.metadata.name;
     replacedVolume = { name: newPvcName, persistentVolumeClaim: { claimName: newPvcName } };
     replacedVolumeMount = { mountPath: ROOT_MOUNT_PATH, name: newPvcName };
@@ -99,6 +100,7 @@ const getPromisesForConfigMapsAndSecrets = (
   projectName: string,
   envVariables: EnvVariable[],
   type: 'create' | 'update',
+  dryRun = false,
 ): Promise<SecretKind | ConfigMapKind>[] =>
   envVariables
     .map<Promise<SecretKind | ConfigMapKind> | null>((envVar) => {
@@ -115,19 +117,24 @@ const getPromisesForConfigMapsAndSecrets = (
         case SecretCategory.GENERIC:
         case SecretCategory.UPLOAD:
           return type === 'create'
-            ? createSecret(assembleSecret(projectName, dataAsRecord))
+            ? createSecret(assembleSecret(projectName, dataAsRecord), { dryRun })
             : replaceSecret(
                 assembleSecret(projectName, dataAsRecord, 'generic', envVar.existingName),
+                { dryRun },
               );
         case SecretCategory.AWS:
           return type === 'create'
-            ? createSecret(assembleSecret(projectName, dataAsRecord, 'aws'))
-            : replaceSecret(assembleSecret(projectName, dataAsRecord, 'aws', envVar.existingName));
+            ? createSecret(assembleSecret(projectName, dataAsRecord, 'aws'), { dryRun })
+            : replaceSecret(assembleSecret(projectName, dataAsRecord, 'aws', envVar.existingName), {
+                dryRun,
+              });
         case ConfigMapCategory.GENERIC:
         case ConfigMapCategory.UPLOAD:
           return type === 'create'
-            ? createConfigMap(assembleConfigMap(projectName, dataAsRecord))
-            : replaceConfigMap(assembleConfigMap(projectName, dataAsRecord, envVar.existingName));
+            ? createConfigMap(assembleConfigMap(projectName, dataAsRecord), { dryRun })
+            : replaceConfigMap(assembleConfigMap(projectName, dataAsRecord, envVar.existingName), {
+                dryRun,
+              });
         default:
           return null;
       }
@@ -179,6 +186,7 @@ export const updateConfigMapsAndSecretsForNotebook = async (
   envVariables: EnvVariable[],
   dataConnection?: DataConnectionData,
   existingDataConnection?: DataConnection,
+  dryRun = false,
 ): Promise<EnvironmentFromVariable[]> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
   const newDataConnection =
@@ -223,9 +231,9 @@ export const updateConfigMapsAndSecretsForNotebook = async (
       }
       switch (envVar.values?.category) {
         case SecretCategory.GENERIC:
-          return deleteSecret(projectName, envVar.existingName);
+          return deleteSecret(projectName, envVar.existingName, { dryRun });
         case ConfigMapCategory.GENERIC:
-          return deleteConfigMap(projectName, envVar.existingName);
+          return deleteConfigMap(projectName, envVar.existingName, { dryRun });
         default:
           return null;
       }
@@ -235,12 +243,14 @@ export const updateConfigMapsAndSecretsForNotebook = async (
     projectName,
     [...newResources, ...typeChangeResources, ...(newDataConnection ? [newDataConnection] : [])],
     'create',
+    dryRun,
   );
 
   const updatingPromises = getPromisesForConfigMapsAndSecrets(
     projectName,
     updateResources,
     'update',
+    dryRun,
   );
 
   const [created] = await Promise.all([


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-577

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added dry runs to the secrets, configmaps, pvc, and notebook update. We dry run all of them first and if successful, then we return.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
_copied from issue_

1. Start to create a Workbench
2. Add two secrets or configmaps (test both)
3. Submit the Workbench
4. Stop the Workbench (just reduces variables, this is not needed)
5. Edit the Workbench
6. Open a new tab and go to the OpenShift Console & locate the Notebook resource
7. Notice that there are two envFrom entires – these are your configmaps/secrets
8. Edit the resource's template spec... modifying one of the resources values seems to work
9. Save the yaml in OpenShift Console
10. Return to the Dashboard UI still mid-edit of that Workbench
11. Remove one of the configmap/secrets
12. Update the workbench
13. In the network tab, you should see that we did a dry run for the delete, which would have passed, and we did a dry run for the update which failed.
14. Check to see if resource was not deleted
15. then you can submit again because the spawner should have grabbed the latest
16. should still dry run but now it should also run the actual calls

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
this is a e2e type test, will be added later

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
