### PR TITLE
RHOAIENG-267: Improve pipeline runs table

### DIFF
--- a/frontend/src/__tests__/integration/pages/pipelines/PipelineDetails.spec.ts
+++ b/frontend/src/__tests__/integration/pages/pipelines/PipelineDetails.spec.ts
@@ -8,7 +8,7 @@ test('page details are updated when a new pipeline version is selected', async (
   const toggleButtonInput = await page.getByTestId('pipeline-version-toggle-button');
 
   // Verify default version is selected and visible by default
-  await expect(toggleButtonInput).toHaveText('Pipeline version: version-1');
+  await expect(toggleButtonInput).toHaveText('version-1');
 
   await toggleButtonInput.click();
   await page
@@ -16,7 +16,7 @@ test('page details are updated when a new pipeline version is selected', async (
     .click();
 
   // Verify new version is selected and visible after selection
-  await expect(toggleButtonInput).toHaveText('Pipeline version: version-2');
+  await expect(toggleButtonInput).toHaveText('version-2');
 });
 
 test('page details are updated after uploading a new version', async ({ page }) => {
@@ -28,7 +28,7 @@ test('page details are updated after uploading a new version', async ({ page }) 
   const toggleButtonInput = await page.getByTestId('pipeline-version-toggle-button');
 
   // Verify default version is selected and visible by default
-  await expect(toggleButtonInput).toHaveText('Pipeline version: version-1');
+  await expect(toggleButtonInput).toHaveText('version-1');
 
   await page.getByRole('button', { name: 'Actions' }).click();
   await page.getByRole('menuitem', { name: 'Upload new version' }).click();
@@ -48,7 +48,7 @@ test('page details are updated after uploading a new version', async ({ page }) 
   await page.waitForSelector('[data-testid="upload-version-modal"]', { state: 'hidden' });
 
   // Verify new version is selected and visible after selection
-  await expect(toggleButtonInput).toHaveText(`Pipeline version: ${newVersionName}`);
+  await expect(toggleButtonInput).toHaveText(newVersionName);
 });
 
 test('Test topology renders', async ({ page }) => {

--- a/frontend/src/concepts/pipelines/apiHooks/useAllPipelineVersions.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/useAllPipelineVersions.ts
@@ -1,0 +1,50 @@
+import React from 'react';
+import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import usePipelineQuery from '~/concepts/pipelines/apiHooks/usePipelineQuery';
+import { PipelineListPaged, PipelineOptions } from '~/concepts/pipelines/types';
+import { FetchState, NotReadyError } from '~/utilities/useFetchState';
+import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
+import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
+
+/**
+ * Fetch all pipelines, then use those pipeline IDs to accumulate a list of pipeline versions.
+ */
+export const useAllPipelineVersions = (
+  options: PipelineOptions = {},
+  refreshRate = 0,
+): FetchState<PipelineListPaged<PipelineVersionKF>> => {
+  const { api } = usePipelinesAPI();
+  const [{ items: pipelines }] = usePipelines();
+  const pipelineIds = useDeepCompareMemoize(pipelines?.map((pipeline) => pipeline.id) || []);
+
+  return usePipelineQuery<PipelineVersionKF>(
+    React.useCallback(
+      async (opts, params) => {
+        if (pipelineIds.length === 0) {
+          return Promise.reject(new NotReadyError('No pipeline id'));
+        }
+
+        const pipelineVersionRequests = pipelineIds.map((pipelineId) =>
+          api.listPipelineVersionsByPipeline(opts, pipelineId, params),
+        );
+        const results = await Promise.all(pipelineVersionRequests);
+
+        return results.reduce(
+          (acc: { total_size: number; items: PipelineVersionKF[] }, result) => {
+            // eslint-disable-next-line camelcase
+            acc.total_size += result.total_size || 0;
+            acc.items = acc.items?.concat(result?.versions || []);
+
+            return acc;
+          },
+          // eslint-disable-next-line camelcase
+          { total_size: 0, items: [] },
+        );
+      },
+      [api, pipelineIds],
+    ),
+    options,
+    refreshRate,
+  );
+};

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineVersionSelect.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineVersionSelect.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import {
+  Badge,
+  EmptyStateVariant,
+  HelperText,
+  HelperTextItem,
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuSearch,
+  MenuSearchInput,
+  MenuToggle,
+  SearchInput,
+} from '@patternfly/react-core';
+import useDebounceCallback from '~/utilities/useDebounceCallback';
+import PipelineSelectorTableRow from '~/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow';
+import { Table } from '~/components/table';
+import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { pipelineVersionSelectorColumns } from '~/concepts/pipelines/content/pipelineSelector/columns';
+import EmptyTableView from '~/concepts/pipelines/content/tables/EmptyTableView';
+
+type CustomPipelineVersionSelectProps = {
+  versions: PipelineVersionKF[];
+  selection: string | undefined;
+  onSelect: (version: PipelineVersionKF) => void;
+};
+
+const CustomPipelineVersionSelect: React.FC<CustomPipelineVersionSelectProps> = ({
+  versions,
+  selection,
+  onSelect,
+}) => {
+  const [isOpen, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [filteredVersions, setFilteredVersions] = React.useState<PipelineVersionKF[]>(versions);
+  const [visibleLength, setVisibleLength] = React.useState(10);
+  const placeholder =
+    versions?.length === 0 ? 'No versions available' : 'Select a pipeline version';
+
+  const toggleRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+
+  const doSetSearchDebounced = useDebounceCallback(setSearch);
+
+  React.useEffect(() => {
+    if (search) {
+      setFilteredVersions(
+        versions.filter((option) => option.name.toLowerCase().includes(search.toLowerCase())),
+      );
+    } else {
+      setFilteredVersions(versions);
+    }
+    setVisibleLength(10);
+  }, [search, versions]);
+
+  const menu = (
+    <Menu data-id="pipeline-version-selector-menu" ref={menuRef} isScrollable>
+      <MenuContent>
+        <MenuSearch>
+          <MenuSearchInput>
+            <SearchInput
+              value={search}
+              aria-label="Filter pipeline versions"
+              onChange={(_event, value) => doSetSearchDebounced(value)}
+            />
+          </MenuSearchInput>
+          <HelperText>
+            <HelperTextItem variant="indeterminate">{`Type a name to search your ${versions.length} versions.`}</HelperTextItem>
+          </HelperText>
+        </MenuSearch>
+        <MenuList>
+          <div role="menuitem">
+            <Table
+              data-id="pipeline-selector-table-list"
+              emptyTableView={
+                <EmptyTableView
+                  hasIcon={false}
+                  onClearFilters={() => setSearch('')}
+                  variant={EmptyStateVariant.xs}
+                />
+              }
+              borders={false}
+              variant="compact"
+              columns={pipelineVersionSelectorColumns}
+              data={filteredVersions}
+              truncateRenderingAt={visibleLength}
+              rowRenderer={(row, index) => (
+                <PipelineSelectorTableRow
+                  key={index}
+                  obj={row}
+                  onClick={() => {
+                    onSelect(row);
+                    setOpen(false);
+                  }}
+                />
+              )}
+            />
+          </div>
+          {visibleLength < filteredVersions.length && (
+            <MenuItem
+              isLoadButton
+              onClick={(e) => {
+                e.stopPropagation();
+                setVisibleLength((length) => length + 10);
+              }}
+            >
+              <>
+                View more
+                <Badge isRead>{`Showing ${visibleLength}/${filteredVersions.length}`}</Badge>
+              </>
+            </MenuItem>
+          )}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      toggleRef={toggleRef}
+      toggle={
+        <MenuToggle
+          id="pipeline-version-selector"
+          ref={toggleRef}
+          style={{ minWidth: '300px' }}
+          onClick={() => setOpen(!isOpen)}
+          isExpanded={isOpen}
+          isDisabled={!versions?.length}
+          isFullWidth
+          data-testid="pipeline-version-toggle-button"
+        >
+          {selection || placeholder}
+        </MenuToggle>
+      }
+      menu={menu}
+      menuRef={menuRef}
+      popperProps={{ maxWidth: 'trigger' }}
+      onOpenChange={(open) => setOpen(open)}
+    />
+  );
+};
+
+export default CustomPipelineVersionSelect;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -51,13 +51,14 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
   const pipelineId = getPipelineIdByPipelineVersion(pipelineVersion);
 
   const [pipeline, isPipelineLoaded, pipelineLoadError] = usePipelineById(pipelineId);
+  const pipelineName = pipeline?.name;
   const [pipelineVersionRun, isPipelineVersionTemplateLoaded, templateLoadError] =
     usePipelineVersionTemplate(pipelineVersionId);
   const { taskMap, nodes } = usePipelineTaskTopology(pipelineVersionRun);
   const isLoaded = isPipelineVersionLoaded && isPipelineLoaded && isPipelineVersionTemplateLoaded;
 
-  if (pipelineVersionLoadError || pipelineLoadError || !pipeline) {
-    const title = isLoaded ? 'Pipeline version not found' : 'Loading...';
+  if (pipelineVersionLoadError || pipelineLoadError) {
+    const title = 'Pipeline version not found';
 
     return (
       <ApplicationsPage
@@ -69,7 +70,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
         }
         title={title}
         empty={false}
-        loaded={isLoaded}
+        loaded
       >
         <PipelineNotFound />
       </ApplicationsPage>
@@ -92,7 +93,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
               breadcrumb={
                 <Breadcrumb>
                   {breadcrumbPath}
-                  <BreadcrumbItem>{pipeline?.name || 'Loading...'}</BreadcrumbItem>
+                  <BreadcrumbItem>{pipelineName || 'Loading...'}</BreadcrumbItem>
                   <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
                     <Truncate content={pipelineVersion?.name || 'Loading...'} />
                   </BreadcrumbItem>
@@ -120,7 +121,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
                     <FlexItem style={{ width: '300px' }}>
                       <PipelineVersionSelector
                         pipelineId={pipeline?.id}
-                        selection={`Pipeline version: ${pipelineVersion?.name}`}
+                        selection={pipelineVersion?.name}
                         onSelect={(version) =>
                           navigate(`/pipelines/${namespace}/pipeline/view/${version.id}`)
                         }
@@ -205,18 +206,21 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
           </DrawerContentBody>
         </DrawerContent>
       </Drawer>
-      <DeletePipelinesModal
-        isOpen={isDeletionOpen}
-        toDeletePipelineVersions={
-          pipelineVersion ? [{ pipelineName: pipeline?.name, version: pipelineVersion }] : []
-        }
-        onClose={(deleted) => {
-          setDeletionOpen(false);
-          if (deleted) {
-            navigate(`/pipelines/${namespace}`);
+
+      {pipelineName && (
+        <DeletePipelinesModal
+          isOpen={isDeletionOpen}
+          toDeletePipelineVersions={
+            pipelineVersion ? [{ pipelineName, version: pipelineVersion }] : []
           }
-        }}
-      />
+          onClose={(deleted) => {
+            setDeletionOpen(false);
+            if (deleted) {
+              navigate(`/pipelines/${namespace}`);
+            }
+          }}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
@@ -11,6 +11,7 @@ import {
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelineVersionImportModal from '~/concepts/pipelines/content/import/PipelineVersionImportModal';
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+import { PipelineRunType } from '~/pages/pipelines/global/runs/GlobalPipelineRunsTabs';
 
 type PipelineDetailsActionsProps = {
   onDelete: () => void;
@@ -54,7 +55,20 @@ const PipelineDetailsActions: React.FC<PipelineDetailsActionsProps> = ({
           >
             Create run
           </DropdownItem>,
-          <DropdownItem key="view-runs" onClick={() => navigate(`/pipelineRuns/${namespace}`)}>
+          <DropdownItem
+            key="view-runs"
+            onClick={() =>
+              navigate(
+                {
+                  pathname: `/pipelineRuns/${namespace}`,
+                  search: `?runType=${PipelineRunType.Triggered}`,
+                },
+                {
+                  state: { lastVersion: pipelineVersion },
+                },
+              )
+            }
+          >
             View runs
           </DropdownItem>,
           <DropdownSeparator key="separator-2" />,

--- a/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.ts
+++ b/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.ts
@@ -12,6 +12,8 @@ describe('usePipelineFilter', () => {
       [FilterOptions.NAME]: '',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
+      [FilterOptions.EXPERIMENT]: undefined,
+      [FilterOptions.PIPELINE_VERSION]: '',
     });
 
     act(() => {
@@ -21,6 +23,8 @@ describe('usePipelineFilter', () => {
       [FilterOptions.NAME]: 'test',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
+      [FilterOptions.EXPERIMENT]: undefined,
+      [FilterOptions.PIPELINE_VERSION]: '',
     });
 
     act(() => {
@@ -30,6 +34,8 @@ describe('usePipelineFilter', () => {
       [FilterOptions.NAME]: '',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
+      [FilterOptions.EXPERIMENT]: undefined,
+      [FilterOptions.PIPELINE_VERSION]: '',
     });
   });
 

--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -79,8 +79,8 @@ const sharedRunLikeColumns: SortableData<PipelineCoreResourceKF>[] = [
     width: 10,
   },
   {
-    label: 'Pipeline',
-    field: 'pipeline',
+    label: 'Pipeline version',
+    field: 'pipeline_version',
     sortable: false,
     width: 15,
   },

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar.tsx
@@ -9,10 +9,13 @@ import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFi
 import ExperimentSearchInput from '~/concepts/pipelines/content/tables/ExperimentSearchInput';
 import { PipelineRunStatusesKF } from '~/concepts/pipelines/kfTypes';
 import DashboardDatePicker from '~/components/DashboardDatePicker';
+import { useAllPipelineVersions } from '~/concepts/pipelines/apiHooks/useAllPipelineVersions';
+import PipelineVersionSelect from '~/concepts/pipelines/content/pipelineSelector/CustomPipelineVersionSelect';
 
 const options = {
   [FilterOptions.NAME]: 'Name',
   [FilterOptions.EXPERIMENT]: 'Experiment',
+  [FilterOptions.PIPELINE_VERSION]: 'Pipeline version',
   [FilterOptions.CREATED_AT]: 'Started',
   [FilterOptions.STATUS]: 'Status',
 };
@@ -32,6 +35,7 @@ const PipelineRunTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
 }) => {
   const navigate = useNavigate();
   const { namespace } = usePipelinesAPI();
+  const [{ items: pipelineVersions }] = useAllPipelineVersions();
 
   return (
     <PipelineFilterBar<keyof typeof options>
@@ -43,13 +47,20 @@ const PipelineRunTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
             {...props}
             aria-label="Search for a triggered run name"
             placeholder="Triggered run name"
-            onChange={(event, value) => onChange(value)}
+            onChange={(_event, value) => onChange(value)}
           />
         ),
         [FilterOptions.EXPERIMENT]: ({ onChange, value, label }) => (
           <ExperimentSearchInput
             onChange={(data) => onChange(data?.value, data?.label)}
             selected={value && label ? { value, label } : undefined}
+          />
+        ),
+        [FilterOptions.PIPELINE_VERSION]: ({ onChange, label }) => (
+          <PipelineVersionSelect
+            versions={pipelineVersions}
+            selection={label}
+            onSelect={(version) => onChange(version.id, version.name)}
           />
         ),
         [FilterOptions.CREATED_AT]: ({ onChange, ...props }) => (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable.tsx
@@ -15,7 +15,6 @@ import usePipelineFilter from '~/concepts/pipelines/content/tables/usePipelineFi
 
 type PipelineRunTableProps = {
   jobs: PipelineRunJobKF[];
-
   loading?: boolean;
   totalSize: number;
   page: number;

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
@@ -6,10 +6,13 @@ import RunTableToolbarActions from '~/concepts/pipelines/content/tables/RunTable
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 import ExperimentSearchInput from '~/concepts/pipelines/content/tables/ExperimentSearchInput';
+import { useAllPipelineVersions } from '~/concepts/pipelines/apiHooks/useAllPipelineVersions';
+import PipelineVersionSelect from '~/concepts/pipelines/content/pipelineSelector/CustomPipelineVersionSelect';
 
 const options = {
   [FilterOptions.NAME]: 'Name',
   [FilterOptions.EXPERIMENT]: 'Experiment',
+  [FilterOptions.PIPELINE_VERSION]: 'Pipeline version',
 };
 
 export type FilterProps = Pick<
@@ -27,6 +30,7 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
 }) => {
   const navigate = useNavigate();
   const { namespace } = usePipelinesAPI();
+  const [{ items: pipelineVersions }] = useAllPipelineVersions();
 
   return (
     <PipelineFilterBar<keyof typeof options>
@@ -45,6 +49,13 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
           <ExperimentSearchInput
             onChange={(data) => onChange(data?.value, data?.label)}
             selected={value && label ? { value, label } : undefined}
+          />
+        ),
+        [FilterOptions.PIPELINE_VERSION]: ({ onChange, label }) => (
+          <PipelineVersionSelect
+            versions={pipelineVersions}
+            selection={label}
+            onSelect={(version) => onChange(version.id, version.name)}
           />
         ),
       }}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Td, Tr } from '@patternfly/react-table';
 import { Button } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd, TableRowTitleDescription } from '~/components/table';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
+import { PipelineRunType } from '~/pages/pipelines/global/runs/GlobalPipelineRunsTabs';
 
 type PipelineVersionTableRowProps = {
   isChecked: boolean;
@@ -22,6 +23,7 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
   version,
   isDisabled,
 }) => {
+  const navigate = useNavigate();
   const { namespace } = usePipelinesAPI();
   const createdDate = new Date(version.created_at);
 
@@ -44,8 +46,21 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
         <PipelinesTableRowTime date={createdDate} />
       </Td>
       <Td>
-        {/* TODO: add navigation link, show be done with the pipeline runs page refactor */}
-        <Button variant="link" isInline>
+        <Button
+          variant="link"
+          isInline
+          onClick={() =>
+            navigate(
+              {
+                pathname: `/pipelineRuns/${namespace}`,
+                search: `?runType=${PipelineRunType.Triggered}`,
+              },
+              {
+                state: { lastVersion: version },
+              },
+            )
+          }
+        >
           View runs
         </Button>
       </Td>

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -16,6 +16,7 @@ export enum FilterOptions {
   CREATED_AT = 'create_at',
   STATUS = 'status',
   EXPERIMENT = 'experiment',
+  PIPELINE_VERSION = 'pipeline_version',
 }
 
 const statusMap = {
@@ -44,6 +45,7 @@ const defaultValue: FilterProps['filterData'] = {
   [FilterOptions.CREATED_AT]: '',
   [FilterOptions.STATUS]: '',
   [FilterOptions.EXPERIMENT]: undefined,
+  [FilterOptions.PIPELINE_VERSION]: '',
 };
 
 const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): FilterProps => {
@@ -67,6 +69,7 @@ const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): Filte
       const startedValue = getDataValue(data[FilterOptions.CREATED_AT]);
       const statusValue = getDataValue(data[FilterOptions.STATUS]);
       const experimentValue = getDataValue(data[FilterOptions.EXPERIMENT]);
+      const pipelineVersionValue = getDataValue(data[FilterOptions.PIPELINE_VERSION]);
 
       if (runValue) {
         predicates.push({
@@ -107,8 +110,12 @@ const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): Filte
         resourceReference = { type: ResourceTypeKF.EXPERIMENT, id: experimentValue };
       }
 
+      if (pipelineVersionValue) {
+        resourceReference = { type: ResourceTypeKF.PIPELINE_VERSION, id: pipelineVersionValue };
+      }
+
       setFilter(
-        predicates.length > 0
+        predicates.length > 0 || !!resourceReference
           ? {
               resourceReference,
               predicates,
@@ -120,6 +127,11 @@ const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): Filte
   );
 
   const doSetFilterDebounced = useDebounceCallback(doSetFilter);
+  const {
+    [FilterOptions.CREATED_AT]: createdAtFilter,
+    [FilterOptions.STATUS]: statusFilter,
+    [FilterOptions.PIPELINE_VERSION]: pipelineVersionFilter,
+  } = filterData;
 
   React.useEffect(() => {
     doSetFilterDebounced(filterData);
@@ -132,7 +144,7 @@ const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): Filte
     doSetFilter(filterData);
     // perform filter change immediately
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterData[FilterOptions.CREATED_AT], filterData[FilterOptions.STATUS], doSetFilter]);
+  }, [createdAtFilter, statusFilter, pipelineVersionFilter, doSetFilter]);
 
   return toolbarProps;
 };

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineRunsTabs.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineRunsTabs.tsx
@@ -1,31 +1,35 @@
 import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import ScheduledRuns from '~/pages/pipelines/global/runs/ScheduledRuns';
 import TriggeredRuns from '~/pages/pipelines/global/runs/TriggeredRuns';
 import './GlobalPipelineRunsTabs.scss';
 
-enum PipelineRunsTabs {
-  SCHEDULED,
-  TRIGGERED,
+export enum PipelineRunType {
+  Scheduled = 'scheduled',
+  Triggered = 'triggered',
 }
 
 const GlobalPipelineRunsTab: React.FC = () => {
-  const [tab, setTab] = React.useState<PipelineRunsTabs>(PipelineRunsTabs.SCHEDULED);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const runTypeSearchParam = searchParams.get('runType') as PipelineRunType;
+  const [tab, setTab] = React.useState<PipelineRunType>(
+    runTypeSearchParam || PipelineRunType.Scheduled,
+  );
 
   return (
     <Tabs
       activeKey={tab}
-      onSelect={(_, tabId) => {
-        if (PipelineRunsTabs[tabId as keyof typeof PipelineRunsTabs]) {
-          setTab(tabId as PipelineRunsTabs);
-        }
+      onSelect={(_event, tabId) => {
+        setTab(tabId as PipelineRunType);
+        runTypeSearchParam && setSearchParams({});
       }}
       aria-label="Pipeline run page tabs"
       role="region"
       className="odh-tabs-fix"
     >
       <Tab
-        eventKey={PipelineRunsTabs.SCHEDULED}
+        eventKey={PipelineRunType.Scheduled}
         title={<TabTitleText>Scheduled</TabTitleText>}
         aria-label="Scheduled tab"
         className="odh-tabcontent-fix"
@@ -35,7 +39,7 @@ const GlobalPipelineRunsTab: React.FC = () => {
         </PageSection>
       </Tab>
       <Tab
-        eventKey={PipelineRunsTabs.TRIGGERED}
+        eventKey={PipelineRunType.Triggered}
         title={<TabTitleText>Triggered</TabTitleText>}
         aria-label="Triggered runs tab"
         className="odh-tabcontent-fix"


### PR DESCRIPTION
Closes: [RHOAIENG-267](https://issues.redhat.com/browse/RHOAIENG-267)

## Description
- If the page is navigated from the "View run" button on the pipeline details page or pipeline version table action dropdown, then preset the filter to the pipeline version name and filter the runs
- Change the column Pipeline to Pipeline version
- Add the Pipeline version to the filter dropdown

<img width="1725" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/1c5b3dd1-9260-4e1b-b973-fe77a91dc3c3">
<img width="1725" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/5e7ebaf2-5b62-4703-8d03-aa8367570f19">
<img width="1725" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/5afda30f-2bab-48ff-9c8a-767c07065377">
<img width="1725" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/abc478aa-3332-4d24-b6e3-6f8edcd8cb20">


## How Has This Been Tested?
Only manual tests for now.

## Test Impact
When this approach is approved, we can proceed with integration tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
