### PR TITLE
Fix microcopy issues

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/customServingRuntimes/CustomServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/customServingRuntimes/CustomServingRuntimes.cy.ts
@@ -49,4 +49,14 @@ it('Custom serving runtimes', () => {
   servingRuntimes.getRowById('template-2').shouldBeSingleModel(true).shouldBeMultiModel(false);
   servingRuntimes.getRowById('template-3').shouldBeSingleModel(false).shouldBeMultiModel(true);
   servingRuntimes.getRowById('template-4').shouldBeSingleModel(false).shouldBeMultiModel(true);
+
+  // Add a new serving runtime
+  servingRuntimes.findAddButton().click();
+
+  // Check the default values
+  servingRuntimes.shouldDisplayValues([
+    'Single-model serving platform',
+    'Multi-model serving platform',
+    'Single-model and multi-model serving platforms',
+  ]);
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
@@ -18,7 +18,7 @@ class ServingRuntimeRow {
   shouldBeSingleModel(enabled = true) {
     this.find()
       .findByRole('list', { name: 'Label group category' })
-      .findByText('Single model')
+      .findByText('Single-model')
       .should(enabled ? 'exist' : 'not.exist');
     return this;
   }
@@ -46,12 +46,22 @@ class ServingRuntimes {
   }
 
   shouldBeSingleModel(enabled = true) {
-    cy.findByText('Single model serving enabled').should(enabled ? 'exist' : 'not.exist');
+    cy.findByText('Single-model serving enabled').should(enabled ? 'exist' : 'not.exist');
     return this;
   }
 
   findAddButton() {
     return cy.findByRole('button', { name: 'Add serving runtime' });
+  }
+
+  findSelectValueButton() {
+    return cy.findByRole('button', { name: 'Select a value' });
+  }
+
+  shouldDisplayValues(values: string[]) {
+    this.findSelectValueButton().click();
+    values.forEach((value) => cy.findByRole('menuitem', { name: value }).should('exist'));
+    return this;
   }
 
   getRowById(id: string) {

--- a/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.spec.ts
+++ b/frontend/src/__tests__/integration/pages/customServingRuntimes/CustomServingRuntimes.spec.ts
@@ -7,15 +7,15 @@ test('Custom serving runtimes', async ({ page }) => {
   await page.waitForSelector('text=Serving runtimes');
 
   // check the platform setting labels in the header
-  await expect(page.getByText('Single model serving enabled')).toBeVisible();
+  await expect(page.getByText('Single-model serving enabled')).toBeVisible();
   await expect(page.getByText('Multi-model serving enabled')).toBeVisible();
 
   // check the platform labels in the table row
   await expect(page.locator('#template-1').getByLabel('Label group category')).toHaveText(
-    'Single modelMulti-model',
+    'Single-modelMulti-model',
   );
   await expect(page.locator('#template-2').getByLabel('Label group category')).toHaveText(
-    'Single model',
+    'Single-model',
   );
   await expect(page.locator('#template-3').getByLabel('Label group category')).toHaveText(
     'Multi-model',

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -65,7 +65,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
         setAlert({
           variant: AlertVariant.info,
           message:
-            'Disabling single model serving means that models in new projects or existing projects with no currently deployed models will be deployed from a shared model server. Existing projects with currently deployed models will continue to use the serving platform selected for that project.',
+            'Disabling single-model serving means that models in new projects or existing projects with no currently deployed models will be deployed from a shared model server. Existing projects with currently deployed models will continue to use the serving platform selected for that project.',
         });
       } else {
         setAlert(undefined);
@@ -79,7 +79,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
       description={
         <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
           <FlexItem>
-            Select the serving platforms that projects on this cluster can use for deploying models.
+            Select the serving platforms that can be used for deploying models on this cluster.
           </FlexItem>
           <Popover
             bodyContent={
@@ -113,7 +113,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
       <Stack hasGutter>
         <StackItem>
           <Checkbox
-            label="Single model serving platform"
+            label="Single-model serving platform"
             isDisabled={!kServeInstalled}
             isChecked={kServeInstalled && enabledPlatforms.kServe}
             onChange={(e, enabled) => {
@@ -123,7 +123,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
               };
               setEnabledPlatforms(newEnabledPlatforms);
             }}
-            aria-label="Single model serving platform enabled checkbox"
+            aria-label="Single-model serving platform enabled checkbox"
             id="single-model-serving-platform-enabled-checkbox"
             data-id="single-model-serving-platform-enabled-checkbox"
             name="singleModelServingPlatformEnabledCheckbox"

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeHeaderLabels.tsx
@@ -16,7 +16,7 @@ const CustomServingRuntimeHeaderLabels: React.FC = () => {
   return (
     <>
       <LabelGroup>
-        {kServeEnabled && <Label>Single model serving enabled</Label>}
+        {kServeEnabled && <Label>Single-model serving enabled</Label>}
         {modelMeshEnabled && <Label>Multi-model serving enabled</Label>}
       </LabelGroup>
       <Popover

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup.tsx
@@ -9,7 +9,7 @@ type CustomServingRuntimePlatformsLabelGroupProps = {
 };
 
 const ServingRuntimePlatformLabels = {
-  [ServingRuntimePlatform.SINGLE]: 'Single model',
+  [ServingRuntimePlatform.SINGLE]: 'Single-model',
   [ServingRuntimePlatform.MULTI]: 'Multi-model',
 };
 

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
@@ -10,9 +10,9 @@ type CustomServingRuntimePlatformsSelectorProps = {
 };
 
 const RuntimePlatformSelectOptionLabels = {
-  [ServingRuntimePlatform.SINGLE]: 'Single model serving platform',
+  [ServingRuntimePlatform.SINGLE]: 'Single-model serving platform',
   [ServingRuntimePlatform.MULTI]: 'Multi-model serving platform',
-  both: 'Both single and multi-model serving platforms',
+  both: 'Single-model and multi-model serving platforms',
 };
 
 const CustomServingRuntimePlatformsSelector: React.FC<

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeView.tsx
@@ -13,7 +13,7 @@ const CustomServingRuntimeView: React.FC = () => {
   return (
     <ApplicationsPage
       title="Serving runtimes"
-      description="Manage model serving runtimes"
+      description="Manage your model serving runtimes."
       loaded
       empty={servingRuntimeTemplates.length === 0}
       emptyStatePage={<EmptyCustomServingRuntime />}

--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -63,7 +63,7 @@ const EmptyModelServing: React.FC = () => {
         icon={<EmptyStateIcon icon={PlusCircleIcon} />}
         headingLevel="h2"
       />
-      <EmptyStateBody>To get started, use existing model servers to serve a model.</EmptyStateBody>
+      <EmptyStateBody>To get started, deploy a model.</EmptyStateBody>
       <EmptyStateFooter>
         <ServeModelButton />
       </EmptyStateFooter>

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceProject.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceProject.tsx
@@ -35,7 +35,7 @@ const InferenceServiceProject: React.FC<InferenceServiceProjectProps> = ({ infer
           <Label>
             {project.metadata.labels?.['modelmesh-enabled'] === 'true'
               ? 'Multi-model serving enabled'
-              : 'Single model serving enabled'}
+              : 'Single-model serving enabled'}
           </Label>
         </>
       ) : (

--- a/frontend/src/pages/modelServing/screens/global/__tests__/InferenceServiceProject.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/global/__tests__/InferenceServiceProject.spec.tsx
@@ -93,7 +93,7 @@ describe('InferenceServiceProject', () => {
     );
 
     expect(result.queryByText('My Project')).toBeInTheDocument();
-    expect(result.queryByText('Single model serving enabled')).toBeInTheDocument();
+    expect(result.queryByText('Single-model serving enabled')).toBeInTheDocument();
   });
 
   it('should render kserve project', () => {
@@ -121,7 +121,7 @@ describe('InferenceServiceProject', () => {
 
     expect(result.queryByText('My Project')).not.toBeInTheDocument();
     expect(result.queryByText('Unknown')).toBeInTheDocument();
-    expect(result.queryByText('Single model serving enabled')).not.toBeInTheDocument();
+    expect(result.queryByText('Single-model serving enabled')).not.toBeInTheDocument();
     expect(result.queryByText('Multi-model serving enabled')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -112,7 +112,7 @@ const ModelServingPlatform: React.FC = () => {
         labels={
           currentProjectServingPlatform && [
             <Label key="serving-platform-label">
-              {isProjectModelMesh ? 'Multi-model serving enabled' : 'Single model serving enabled'}
+              {isProjectModelMesh ? 'Multi-model serving enabled' : 'Single-model serving enabled'}
             </Label>,
           ]
         }

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelect.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelect.tsx
@@ -31,7 +31,7 @@ const ModelServingPlatformSelect: React.FC<ModelServingPlatformSelectProps> = ({
   return (
     <Stack hasGutter>
       <StackItem>
-        Select the type model serving platform to be used when deploying models in this project.
+        Select the type of model serving platform to be used when deploying models in this project.
       </StackItem>
       <StackItem>
         <Gallery hasGutter maxWidths={{ default: '400px' }}>
@@ -45,8 +45,8 @@ const ModelServingPlatformSelect: React.FC<ModelServingPlatformSelectProps> = ({
                   isProjectModelMesh={false}
                 />
               }
-              title="Single model serving platform"
-              description="Each model is deployed from its own model server. Choose this option only for large language models that will be deployed using the Caikit runtime."
+              title="Single-model serving platform"
+              description="Each model is deployed on its own model server. This platform works well for large models or models that need dedicated resources."
             />
           </GalleryItem>
           <GalleryItem>
@@ -60,7 +60,7 @@ const ModelServingPlatformSelect: React.FC<ModelServingPlatformSelectProps> = ({
                 />
               }
               title="Multi-model serving platform"
-              description="Multiple models can be deployed from a single model server. Choose this option when you have a large number of small models to deploy that can share server resources."
+              description="Multiple models can be deployed on a single-model server. This platform works well for sharing resources amongst deployed models"
             />
           </GalleryItem>
         </Gallery>
@@ -69,7 +69,7 @@ const ModelServingPlatformSelect: React.FC<ModelServingPlatformSelectProps> = ({
         <StackItem>
           <Alert
             variant="warning"
-            title="The model serving type can be changed until the first model is deployed from this project. After that, you will need to create a new project in order to use a different model serving type."
+            title="The model serving type can be changed until the first model is deployed on this project. After that, you will need to create a new project in order to use a different model serving type."
             isInline
             actionClose={<AlertActionCloseButton onClose={() => setAlertShown(false)} />}
           />

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -234,7 +234,7 @@ export const getProjectModelServingPlatform = (
   }
   return {
     platform: ServingRuntimePlatform.SINGLE,
-    error: kServeInstalled ? undefined : new Error('Single model platform is not installed'),
+    error: kServeInstalled ? undefined : new Error('Single-model platform is not installed'),
   };
 };
 

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -70,7 +70,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
       <Stack hasGutter>
         <StackItem>{children}</StackItem>
         <StackItem>
-          Confirm deletion by typing <strong>{deleteNameSanitized}</strong> below:
+          Type <strong>{deleteNameSanitized}</strong> to confirm deletion.
         </StackItem>
         <StackItem>
           <TextInput


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes https://issues.redhat.com/browse/RHOAIENG-543

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Replace all "Single model" references with "Single-model" for KServe

1. Go to the Custom Serving Runtimes section
2. If you have kserve enable, the tag should display "Single-model"
3. If you create a new model, you'll get "Single-model"
4. Now go to Model Serving Global View
5. All the models deployed with modelmesh should display "Single-model"

<img width="441" alt="Screenshot 2024-01-08 at 13 30 44" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/812877f1-17d4-4cdb-a40d-9be40a21d7ac">
<img width="490" alt="Screenshot 2024-01-08 at 13 30 11" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/fb9e23a5-0ffc-47dc-b91e-99359885215e">


#### Issues in Custom Serving Runtimes Dropdown in Create view

1. Go to Custom Serving Runtime
2. Create a new Serving Runtime
3. Check that the third option in the dropdown is "Single-model and multi-model serving platforms"

<img width="490" alt="Screenshot 2024-01-08 at 13 30 11" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/fb9e23a5-0ffc-47dc-b91e-99359885215e">

#### Typo in Serving Runtime platform settings

1. Go to Settings > Cluster settings
2. Check the **Model Serving platforms** section
3. It should say `Select the serving platforms that can be used for deploying models on this cluster.`

<img width="751" alt="Screenshot 2024-01-08 at 13 32 07" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/d365dc74-c2c5-44e0-8009-53dd146eeb71">


#### Typo in Custom Serving Runtimes subheader

1. Go to Custom Serving Runtimes
2. The subheader should say: `Manage your model serving runtimes`

<img width="514" alt="Screenshot 2024-01-08 at 13 32 45" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/0b1bd1d1-30d4-4f11-8900-bd2b8f5b12a9">


#### Wrong label in deletion modal for model serving

1. Create a new kserve model in either projects or global view
2. Delete it
3. The description should say: `Type <name> to confirm deletion.`

<img width="420" alt="Screenshot 2024-01-08 at 13 33 59" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/9921af5f-8de0-4874-8125-57e6cd4faddf">


#### Wrong labels in platform selection view

1. Have both Single model and multi model selected in your cluster
2. Navigate to a new project
3. Check the following:

- Model server cards descriptions (replace “from” with “on”): “Each model is deployed on…” “Multiple models can be deployed on…”
- Sentence revision: “This platform works well for large models or models that need dedicated resources.” for Single model serving platform
- Sentence revision: “This platform works well for sharing resources amongst deployed models.” For multi model serving platform

<img width="963" alt="Screenshot 2024-01-08 at 13 35 17" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/b123cda0-c00d-4fba-be96-448927ee2166">


#### Inconsistent empty state for kserve in global view

1. Enable only kserve
2. Go to Model Serving view
3. Select an empty project
4. Check that we have this message: `To get started, deploy a model`

<img width="895" alt="Screenshot 2024-01-08 at 13 36 34" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/71ac505b-5cd8-4944-bbea-3de274ba9738">

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added testing and modified existing coverage

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
