### PR TITLE
Disables model metrics screen access when project is kserve enabled (RHOAIENG-248)

### DIFF
--- a/frontend/src/concepts/trustyai/content/InstallTrustyAICheckbox.tsx
+++ b/frontend/src/concepts/trustyai/content/InstallTrustyAICheckbox.tsx
@@ -8,15 +8,21 @@ type InstallTrustyAICheckboxProps = {
   isProgressing: boolean;
   onInstall: () => Promise<unknown>;
   onDelete: () => Promise<unknown>;
+  disabled: boolean;
+  disabledReason?: string;
 };
 const InstallTrustyAICheckbox: React.FC<InstallTrustyAICheckboxProps> = ({
   isAvailable,
   isProgressing,
   onInstall,
   onDelete,
+  disabled,
+  disabledReason,
 }) => {
   const [open, setOpen] = React.useState(false);
   const [userHasChecked, setUserHasChecked] = React.useState(false);
+
+  const helperText = disabled ? disabledReason : TRUSTYAI_TOOLTIP_TEXT;
 
   return (
     <>
@@ -24,11 +30,11 @@ const InstallTrustyAICheckbox: React.FC<InstallTrustyAICheckboxProps> = ({
         label="Enable TrustyAI"
         body={
           <HelperText>
-            <HelperTextItem>{TRUSTYAI_TOOLTIP_TEXT}</HelperTextItem>
+            <HelperTextItem>{helperText}</HelperTextItem>
           </HelperText>
         }
-        isChecked={isAvailable}
-        isDisabled={userHasChecked || isProgressing}
+        isChecked={!disabled && isAvailable}
+        isDisabled={disabled || userHasChecked || isProgressing}
         onChange={(e, checked) => {
           if (checked) {
             setUserHasChecked(true);

--- a/frontend/src/concepts/trustyai/content/TrustyAIServiceControl.tsx
+++ b/frontend/src/concepts/trustyai/content/TrustyAIServiceControl.tsx
@@ -6,8 +6,14 @@ import InstallTrustyAICheckbox from './InstallTrustyAICheckbox';
 
 type TrustyAIServiceControlProps = {
   namespace: string;
+  disabled: boolean;
+  disabledReason?: string;
 };
-const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({ namespace }) => {
+const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({
+  namespace,
+  disabled,
+  disabledReason,
+}) => {
   const {
     isAvailable,
     isProgressing,
@@ -22,7 +28,7 @@ const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({ namespa
 
   const [userStartedInstall, setUserStartedInstall] = React.useState(false);
 
-  if (!isSettled) {
+  if (!disabled && !isSettled) {
     return (
       <Bullseye>
         <Spinner />
@@ -34,6 +40,8 @@ const TrustyAIServiceControl: React.FC<TrustyAIServiceControlProps> = ({ namespa
     <Stack hasGutter>
       <StackItem>
         <InstallTrustyAICheckbox
+          disabled={disabled}
+          disabledReason={disabledReason}
           isAvailable={isAvailable}
           isProgressing={isProgressing}
           onInstall={() => {

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -30,11 +30,15 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
 }) => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
 
+  const modelMetricsSupported = (inferenceService: InferenceServiceKind) =>
+    modelMetricsEnabled &&
+    inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode'] === 'ModelMesh';
+
   return (
     <>
       <Td dataLabel="Name">
         <ResourceNameTooltip resource={inferenceService}>
-          {modelMetricsEnabled ? (
+          {modelMetricsSupported(inferenceService) ? (
             <Link
               to={
                 isGlobal

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
@@ -4,7 +4,7 @@ import { Button, Icon, Skeleton, Tooltip, Truncate } from '@patternfly/react-cor
 import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
-import { ServingRuntimeKind } from '~/k8sTypes';
+import { KnownLabels, ServingRuntimeKind } from '~/k8sTypes';
 import EmptyTableCellForAlignment from '~/pages/projects/components/EmptyTableCellForAlignment';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { ServingRuntimeTableTabs } from '~/pages/modelServing/screens/types';
@@ -60,9 +60,9 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
 
   const modelInferenceServices = getInferenceServiceFromServingRuntime(inferenceServices, obj);
 
-  const performanceMetricsAreaAvailable = useIsAreaAvailable(
-    SupportedArea.PERFORMANCE_METRICS,
-  ).status;
+  const serverMetricsSupported =
+    useIsAreaAvailable(SupportedArea.PERFORMANCE_METRICS).status &&
+    currentProject.metadata.labels?.[KnownLabels.MODEL_SERVING_PROJECT] === 'true';
 
   const compoundExpandParams = (
     col: ServingRuntimeTableTabs,
@@ -154,7 +154,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
                 title: 'Edit model server',
                 onClick: () => onEditServingRuntime(obj),
               },
-              ...(performanceMetricsAreaAvailable
+              ...(serverMetricsSupported
                 ? [
                     {
                       title: 'View model server metrics',

--- a/frontend/src/pages/projects/projectSettings/ModelBiasSettingsCard.tsx
+++ b/frontend/src/pages/projects/projectSettings/ModelBiasSettingsCard.tsx
@@ -1,19 +1,33 @@
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import React from 'react';
 import TrustyAIServiceControl from '~/concepts/trustyai/content/TrustyAIServiceControl';
+import { KnownLabels, ProjectKind } from '~/k8sTypes';
+import { TRUST_AI_NOT_SUPPORTED_TEXT } from '~/pages/projects/projectSettings/const';
 
 type ModelBiasSettingsCardProps = {
-  namespace: string;
+  project: ProjectKind;
 };
-const ModelBiasSettingsCard: React.FC<ModelBiasSettingsCardProps> = ({ namespace }) => (
-  <Card isFlat>
-    <CardHeader>
-      <CardTitle>Model Bias</CardTitle>
-    </CardHeader>
-    <CardBody>
-      <TrustyAIServiceControl namespace={namespace} />
-    </CardBody>
-  </Card>
-);
+const ModelBiasSettingsCard: React.FC<ModelBiasSettingsCardProps> = ({ project }) => {
+  const namespace = project.metadata.name;
+
+  const isTrustySupported = project.metadata.labels?.[KnownLabels.MODEL_SERVING_PROJECT] === 'true';
+
+  const disabledReason = isTrustySupported ? undefined : TRUST_AI_NOT_SUPPORTED_TEXT;
+
+  return (
+    <Card isFlat>
+      <CardHeader>
+        <CardTitle>Model Bias</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <TrustyAIServiceControl
+          namespace={namespace}
+          disabled={!isTrustySupported}
+          disabledReason={disabledReason}
+        />
+      </CardBody>
+    </Card>
+  );
+};
 
 export default ModelBiasSettingsCard;

--- a/frontend/src/pages/projects/projectSettings/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/projects/projectSettings/ProjectSettingsPage.tsx
@@ -6,7 +6,6 @@ import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 const ProjectSettingsPage = () => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
-  const namespace = currentProject.metadata.name;
   const biasMetricsAreaAvailable = useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;
 
   return (
@@ -14,7 +13,7 @@ const ProjectSettingsPage = () => {
       <Stack hasGutter>
         {biasMetricsAreaAvailable && (
           <StackItem>
-            <ModelBiasSettingsCard namespace={namespace} />
+            <ModelBiasSettingsCard project={currentProject} />
           </StackItem>
         )}
       </Stack>

--- a/frontend/src/pages/projects/projectSettings/const.ts
+++ b/frontend/src/pages/projects/projectSettings/const.ts
@@ -1,2 +1,5 @@
 export const TRUSTYAI_TOOLTIP_TEXT =
   'Selecting this will install the TrustyAI service in your namespace. TrustyAI receives data from ModelMesh that is used to calculate and display various measures of model bias over time.';
+
+export const TRUST_AI_NOT_SUPPORTED_TEXT =
+  'Model bias detection is not supported for projects using single-model serving.';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-248](https://issues.redhat.com//browse/RHOAIENG-248)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Disables model metrics screen access when project is kserve enabled.
- Global modelserving table will not show links to metrics when inference service is kserve based
- 'Models and model servers' table on Project detail page will not show links to model or server metrics when project is kserve enabled.
- Model bias card on Project detail settings page will be disabled and show message (see screenshot) when project is kserve enabled.
- 
![localhost_4010_projects_model-namespace (1)](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/2667c36e-f0ae-4fe6-b3e1-450d2af917a4)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With modelmesh enabled on the project:
  - Verify all links to model serving screens work as expected.
  - Verify Install TrustyAI chackbox on settings tab works as expected

With kserve enabled on the project:
  - Verify links to model serving screens are not available
  - Verify Install TrustyAI checkbox on settings tab is disabled and displays message as shown in screenshot.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests to be added in later PR
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
