### PR TITLE
Unit Test Case for useInferenceServices

### DIFF
--- a/frontend/src/pages/modelServing/__tests__/useInferenceServices.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useInferenceServices.spec.ts
@@ -1,0 +1,175 @@
+import { act } from '@testing-library/react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { InferenceServiceKind } from '~/k8sTypes';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import useModelServingEnabled from '~/pages/modelServing/useModelServingEnabled';
+import useInferenceServices from '~/pages/modelServing/useInferenceServices';
+import { useAccessReview } from '~/api';
+
+const mockInferenceServices = {
+  items: [
+    { metadata: { name: 'item 1' } },
+    { metadata: { name: 'item 2' } },
+  ] as InferenceServiceKind[],
+};
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+// Mock the API functions
+jest.mock('~/api', () => ({
+  ...jest.requireActual('~/api'),
+  useAccessReview: jest.fn(),
+}));
+
+jest.mock('~/pages/modelServing/useModelServingEnabled', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const k8sListResourceMock = k8sListResource as jest.Mock;
+const useModelServingEnabledMock = useModelServingEnabled as jest.Mock;
+const useAccessReviewMock = useAccessReview as jest.Mock;
+
+describe('useInferenceServices', () => {
+  it('should return successful list of InferenceService when model serving is enabled and access review allows', async () => {
+    // Mock the return value of useModelServingEnabled
+    useModelServingEnabledMock.mockReturnValue(true);
+    // Mock the return value of useAccessReview
+    useAccessReviewMock.mockReturnValue([true, true]);
+
+    k8sListResourceMock.mockReturnValue(Promise.resolve(mockInferenceServices));
+    const renderResult = testHook(useInferenceServices)('namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(mockInferenceServices.items, true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(
+      Promise.resolve({ items: [...mockInferenceServices.items] }),
+    );
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([...mockInferenceServices.items], true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should not call k8sListResouce when Model Serving is not enabled', async () => {
+    // Mock the return value of useModelServingEnabled
+    useModelServingEnabledMock.mockReturnValue(false);
+    // Mock the return value of useAccessReview
+    useAccessReviewMock.mockReturnValue([true, true]);
+
+    const renderResult = testHook(useInferenceServices)('namespace');
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should not call k8sListResouce when Fetch is not ready', async () => {
+    // Mock the return value of useModelServingEnabled
+    useModelServingEnabledMock.mockReturnValue(true);
+    // Mock the return value of useAccessReview
+    useAccessReviewMock.mockReturnValue([true, false]);
+
+    const renderResult = testHook(useInferenceServices)('namespace');
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('when allowCreate is false, getInferenceServiceContext is called', async () => {
+    // Mock the return value of useModelServingEnabled
+    useModelServingEnabledMock.mockReturnValue(true);
+    // Mock the return value of useAccessReview
+    useAccessReviewMock.mockReturnValue([false, true]);
+
+    k8sListResourceMock.mockReturnValue(Promise.resolve(mockInferenceServices));
+    const renderResult = testHook(useInferenceServices)('namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(mockInferenceServices.items, true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(
+      Promise.resolve({ items: [...mockInferenceServices.items] }),
+    );
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([...mockInferenceServices.items], true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('when allowCreate is true, listInferenceService is called', async () => {
+    // Mock the return value of useModelServingEnabled
+    useModelServingEnabledMock.mockReturnValue(true);
+    // Mock the return value of useAccessReview
+    useAccessReviewMock.mockReturnValue([true, true]);
+
+    k8sListResourceMock.mockReturnValue(Promise.resolve(mockInferenceServices));
+    const renderResult = testHook(useInferenceServices)('namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(mockInferenceServices.items, true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(
+      Promise.resolve({ items: [...mockInferenceServices.items] }),
+    );
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([...mockInferenceServices.items], true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+  it('should fail to fetch InferenceService', async () => {
+    useModelServingEnabledMock.mockReturnValue(true);
+    k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error')));
+    const renderResult = testHook(useInferenceServices)('namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // // Wait for the hook to handle the error
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, true, false, true]);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-1852](https://issues.redhat.com/browse/RHOAIENG-1852)

## Description
Unit test case for: frontend/src/pages/modelServing/useInferenceServices.ts

## How Has This Been Tested?
`npm run test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<img width="710" alt="Screenshot 2024-01-20 at 1 26 01 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/eaf3c724-8d5f-4ccf-a82d-b0686e21b5b5">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
