### PR TITLE
RHOAIENG-1748: Duplicating runs doesn't auto-fill the pipeline and version selector

### DIFF
--- a/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Label, Tooltip } from '@patternfly/react-core';
 import {
   PipelineRunLabels,
-  getPipelineCoreResourceJobReference,
-  getPipelineVersionRunReference,
+  getJobResourceRef,
+  getPipelineVersionResourceRef,
 } from '~/concepts/pipelines/content/tables/utils';
 import { PipelineCoreResourceKF } from '~/concepts/pipelines/kfTypes';
 
@@ -12,8 +12,8 @@ type PipelineRunTypeLabelProps = {
   isCompact?: boolean;
 };
 const PipelineRunTypeLabel: React.FC<PipelineRunTypeLabelProps> = ({ resource, isCompact }) => {
-  const jobReference = getPipelineCoreResourceJobReference(resource);
-  const pipelineVersionRef = getPipelineVersionRunReference(resource);
+  const jobReference = getJobResourceRef(resource);
+  const pipelineVersionRef = getPipelineVersionResourceRef(resource);
 
   return (
     <>

--- a/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
@@ -1,6 +1,8 @@
-import * as React from 'react';
-import { PageSection } from '@patternfly/react-core';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
+
+import { PageSection } from '@patternfly/react-core';
+
 import { PipelineRunJobKF, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import GenericSidebar from '~/components/GenericSidebar';
 import {
@@ -11,6 +13,12 @@ import RunForm from '~/concepts/pipelines/content/createRun/RunForm';
 import useRunFormData from '~/concepts/pipelines/content/createRun/useRunFormData';
 import RunPageFooter from '~/concepts/pipelines/content/createRun/RunPageFooter';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import usePipelineVersionById from '~/concepts/pipelines/apiHooks/usePipelineVersionById';
+import usePipelineById from '~/concepts/pipelines/apiHooks/usePipelineById';
+import {
+  getPipelineResourceRef,
+  getPipelineVersionResourceRef,
+} from '~/concepts/pipelines/content/tables/utils';
 
 type RunPageProps = {
   cloneRun?: PipelineRunKF | PipelineRunJobKF;
@@ -21,10 +29,16 @@ const RunPage: React.FC<RunPageProps> = ({ cloneRun, contextPath }) => {
   const { namespace } = usePipelinesAPI();
   const location = useLocation();
 
+  const cloneRunVersionId = getPipelineVersionResourceRef(cloneRun)?.key.id;
+  const [cloneRunPipelineVersion] = usePipelineVersionById(cloneRunVersionId) || null;
+
+  const cloneRunPipelineId = getPipelineResourceRef(cloneRunPipelineVersion)?.key.id;
+  const [cloneRunPipeline] = usePipelineById(cloneRunPipelineId);
+
   const [formData, setFormDataValue] = useRunFormData(
     cloneRun,
-    location.state?.lastPipeline,
-    location.state?.lastVersion,
+    location.state?.lastPipeline || cloneRunPipeline,
+    location.state?.lastVersion || cloneRunPipelineVersion,
   );
 
   return (

--- a/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
+++ b/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { generatePipelineVersionName } from '~/concepts/pipelines/content/import/utils';
 import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
@@ -27,7 +28,7 @@ export const usePipelineVersionImportModalData = (
   pipeline?: PipelineKF | null,
 ): GenericObjectState<PipelineVersionModalData> => {
   const createDataState = useGenericObjectState<PipelineVersionModalData>({
-    name: generatePipelineVersionName(pipeline),
+    name: React.useMemo(() => generatePipelineVersionName(pipeline), [pipeline]),
     description: '',
     pipelineId: pipeline?.id ?? '',
     pipelineName: pipeline?.name ?? '',

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
@@ -9,7 +9,7 @@ import {
 import { Link } from 'react-router-dom';
 import { PipelineRunJobKF, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import {
-  getPipelineVersionRunReference,
+  getPipelineVersionResourceRef,
   getRunDuration,
 } from '~/concepts/pipelines/content/tables/utils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
@@ -34,7 +34,7 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({
   workflowName,
 }) => {
   const { namespace, project } = usePipelinesAPI();
-  const pipelineVersionRef = getPipelineVersionRunReference(pipelineRunKF);
+  const pipelineVersionRef = getPipelineVersionResourceRef(pipelineRunKF);
 
   if (!pipelineRunKF || !workflowName) {
     return (

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -21,10 +21,10 @@ import {
 } from '~/concepts/pipelines/kfTypes';
 import {
   getRunDuration,
-  getPipelineCoreResourceExperimentName,
+  getExperimentResourceRef,
   getPipelineRunJobScheduledState,
   ScheduledState,
-  getPipelineVersionRunReference,
+  getPipelineVersionResourceRef,
 } from '~/concepts/pipelines/content/tables/utils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { computeRunStatus } from '~/concepts/pipelines/content/utils';
@@ -88,13 +88,13 @@ export const RunCreated: RunUtil = ({ run }) => {
 };
 
 export const CoreResourceExperiment: CoreResourceUtil = ({ resource }) => (
-  <>{getPipelineCoreResourceExperimentName(resource)}</>
+  <>{getExperimentResourceRef(resource)?.name || 'Default'}</>
 );
 
 export const CoreResourcePipelineVersion: CoreResourceUtil<{
   isLoading?: boolean;
 }> = ({ resource, isLoading }) => {
-  const resourceRef = getPipelineVersionRunReference(resource);
+  const resourceRef = getPipelineVersionResourceRef(resource);
 
   if (isLoading) {
     return <Skeleton />;

--- a/frontend/src/concepts/pipelines/content/tables/utils.ts
+++ b/frontend/src/concepts/pipelines/content/tables/utils.ts
@@ -5,6 +5,7 @@ import {
   PipelineRunStatusesKF,
   ResourceReferenceKF,
   ResourceTypeKF,
+  PipelineVersionKF,
 } from '~/concepts/pipelines/kfTypes';
 import { DateRangeString, splitDateRange } from '~/components/dateRange/utils';
 
@@ -33,27 +34,27 @@ export const getStatusWeight = (run: PipelineRunKF): number => {
   return weights[run.status as PipelineRunStatusesKF] ?? Infinity;
 };
 
-export const getRunResourceReference = (
-  resource?: PipelineCoreResourceKF,
-  type?: ResourceTypeKF,
+export const getResourceRef = (
+  resource: PipelineCoreResourceKF | null | undefined,
+  type: ResourceTypeKF,
 ): ResourceReferenceKF | undefined =>
   resource?.resource_references?.find((ref) => ref.key.type === type);
 
-export const getPipelineCoreResourceJobReference = (
-  resource?: PipelineCoreResourceKF,
-): ResourceReferenceKF | undefined => getRunResourceReference(resource, ResourceTypeKF.JOB);
+export const getJobResourceRef = (
+  resource: Parameters<typeof getResourceRef>[0],
+): ResourceReferenceKF | undefined => getResourceRef(resource, ResourceTypeKF.JOB);
 
-export const getPipelineVersionRunReference = (
-  resource?: PipelineCoreResourceKF,
-): ResourceReferenceKF | undefined =>
-  getRunResourceReference(resource, ResourceTypeKF.PIPELINE_VERSION);
+export const getPipelineVersionResourceRef = (
+  resource: PipelineCoreResourceKF | PipelineRunKF | PipelineRunJobKF | null | undefined,
+): ResourceReferenceKF | undefined => getResourceRef(resource, ResourceTypeKF.PIPELINE_VERSION);
 
-export const getPipelineCoreResourceExperimentReference = (
-  resource?: PipelineCoreResourceKF,
-): ResourceReferenceKF | undefined => getRunResourceReference(resource, ResourceTypeKF.EXPERIMENT);
+export const getPipelineResourceRef = (
+  resource: PipelineCoreResourceKF | PipelineVersionKF | null,
+): ResourceReferenceKF | undefined => getResourceRef(resource, ResourceTypeKF.PIPELINE);
 
-export const getPipelineCoreResourceExperimentName = (resource?: PipelineCoreResourceKF): string =>
-  getPipelineCoreResourceExperimentReference(resource)?.name || 'Default';
+export const getExperimentResourceRef = (
+  resource: Parameters<typeof getResourceRef>[0],
+): ResourceReferenceKF | undefined => getResourceRef(resource, ResourceTypeKF.EXPERIMENT);
 
 export const getPipelineRunJobStartTime = (job: PipelineRunJobKF): Date | null => {
   const startTime =

--- a/frontend/src/concepts/pipelines/context/useJobRelatedInformation.ts
+++ b/frontend/src/concepts/pipelines/context/useJobRelatedInformation.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PipelineCoreResourceKF, PipelineRunJobKF } from '~/concepts/pipelines/kfTypes';
-import { getPipelineCoreResourceJobReference } from '~/concepts/pipelines/content/tables/utils';
+import { getJobResourceRef } from '~/concepts/pipelines/content/tables/utils';
 import { APIState } from '~/concepts/pipelines/context/useAPIState';
 
 type JobStatus = {
@@ -20,7 +20,7 @@ const useJobRelatedInformation = (apiState: APIState): { getJobInformation: GetJ
         if (!apiState.apiAvailable) {
           return { loading: false, data: null };
         }
-        const jobReference = getPipelineCoreResourceJobReference(resource);
+        const jobReference = getJobResourceRef(resource);
         if (!jobReference) {
           return { loading: false, data: null };
         }


### PR DESCRIPTION
Closes: [RHOAIENG-1748](https://issues.redhat.com/browse/RHOAIENG-1748)

## Description
Clicking "Duplicate" was not populating any pre-existing run/job details, specifically pertaining to the pipeline, its input params, and pipeline version.

## How Has This Been Tested?
Tested by navigating to the pipeline `Runs` page, for any given row with an active pipeline version, click the row actions kebab, then "Duplicate" to navigate to what should now be a pre-populated "create run" form.

https://github.com/opendatahub-io/odh-dashboard/assets/96431149/362b11cb-6d84-4c1a-9297-d67fa4701ddd

## Test Impact
Only regression tested for now.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
