### PR TITLE
Unit Test Case for imageUtils

### DIFF
--- a/frontend/src/utilities/__tests__/imageUtils.spec.ts
+++ b/frontend/src/utilities/__tests__/imageUtils.spec.ts
@@ -1,0 +1,421 @@
+import {
+  compareTagVersions,
+  isImageBuildInProgress,
+  isImageTagBuildValid,
+  checkOrder,
+  getVersion,
+  getNameVersionString,
+  getDefaultTag,
+  getTagForImage,
+  getImageTagVersion,
+  getDescriptionForTag,
+  getImageTagByContainer,
+} from '~/utilities/imageUtils';
+import {
+  ImageTagInfo,
+  ImageInfo,
+  BuildStatus,
+  BUILD_PHASE,
+  NameVersionPair,
+  NotebookContainer,
+  ImageSoftwareType,
+  ImageTag,
+} from '~/types';
+
+describe('Compare tag versions', () => {
+  it('should sort recommended tags first', () => {
+    const recemendedTagVersion = {
+      tag: [
+        { name: 'v1', recommended: false },
+        { name: 'v2', recommended: true },
+        { name: 'v3', recommended: false },
+      ] as ImageTagInfo[],
+    };
+    expect(recemendedTagVersion.tag.sort(compareTagVersions)).toEqual([
+      { name: 'v2', recommended: true },
+      { name: 'v3', recommended: false },
+      { name: 'v1', recommended: false },
+    ]);
+  });
+});
+describe('isImageBuildInProgress', () => {
+  it('should return true if image build is in progress', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'image:tag1',
+        status: BUILD_PHASE.new,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'image',
+      tags: [{ name: 'tag1' }] as ImageTagInfo[],
+    } as ImageInfo;
+    expect(isImageBuildInProgress(buildStatuses, image)).toBe(true);
+  });
+  it('should return false if image build is not in progress', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'imageName',
+      tags: [{ name: 'tag1' }, { name: 'tag2' }] as ImageTagInfo[],
+    } as ImageInfo;
+
+    expect(isImageBuildInProgress(buildStatuses, image)).toBe(false);
+  });
+});
+describe('isImageTagBuildValid', () => {
+  it('should return true if image tag build is valid', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'image:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'image',
+      tags: [{ name: 'tag1' }] as ImageTagInfo[],
+    } as ImageInfo;
+    const tag = { name: 'tag1' } as ImageTagInfo;
+    expect(isImageTagBuildValid(buildStatuses, image, tag)).toBe(true);
+  });
+  it('should return false if image tag build is invalid', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'image:tag1',
+        status: BUILD_PHASE.failed,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'image',
+      tags: [{ name: 'tag1' }] as ImageTagInfo[],
+    } as ImageInfo;
+    const tag = { name: 'tag1' } as ImageTagInfo;
+    expect(isImageTagBuildValid(buildStatuses, image, tag)).toBe(false);
+  });
+});
+describe('checkOrder', () => {
+  it('should return 1 if a.order is greater than b.order', () => {
+    const a = { order: 2 } as ImageInfo;
+    const b = { order: 1 } as ImageInfo;
+    expect(checkOrder(a, b)).toBe(1);
+  });
+  it('should return -1 if a.order is less than b.order', () => {
+    const a = { order: 1 } as ImageInfo;
+    const b = { order: 2 } as ImageInfo;
+    expect(checkOrder(a, b)).toBe(-1);
+  });
+  it('should return 0 if a.order is equal to b.order', () => {
+    const a = { order: 1 } as ImageInfo;
+    const b = { order: 1 } as ImageInfo;
+    expect(checkOrder(a, b)).toBe(0);
+  });
+});
+describe('getVersion', () => {
+  it('should return version if version is defined', () => {
+    expect(getVersion('version1', 'v')).toBe('version1');
+  });
+  it('should return empty if version is undefined', () => {
+    expect(getVersion(undefined, '')).toBe('');
+  });
+});
+describe('getNameVersionString', () => {
+  it('should return name and version string', () => {
+    const software = { name: 'name', version: 'v1' };
+    expect(getNameVersionString(software)).toBe('name v1');
+  });
+});
+describe('getDefaultTag', () => {
+  it('should return first tag if image has only one tag', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'image:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'image',
+      tags: [{ name: 'tag1' }] as ImageTagInfo[],
+    } as ImageInfo;
+    expect(getDefaultTag(buildStatuses, image)).toEqual({ name: 'tag1' });
+  });
+});
+describe('getTagForImage', () => {
+  it('should return the selected tag if image has multiple tags and a selected tag is provided', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'imageName',
+      tags: [{ name: 'tag1' }, { name: 'tag2' }] as ImageTagInfo[],
+    } as ImageInfo;
+
+    const selectedImage = 'imageName';
+    const selectedTag = 'tag2';
+
+    const result = getTagForImage(buildStatuses, image, selectedImage, selectedTag);
+
+    expect(result).toEqual({ name: 'tag2' });
+  });
+  it('should return the default tag if image has multiple tags and no selected tag is provided', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      default: true,
+      name: 'imageName',
+      tags: [
+        { name: 'tag1', default: true },
+        { name: 'tag2', default: false },
+      ] as ImageTagInfo[],
+    } as ImageInfo;
+
+    const result = getTagForImage(buildStatuses, image);
+
+    expect(result).toEqual({ name: 'tag1', default: true });
+  });
+
+  it('should return undefined if image has no tags', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'imageName',
+      tags: undefined as unknown as ImageTagInfo[],
+    } as ImageInfo;
+
+    const result = getTagForImage(buildStatuses, image);
+
+    expect(result).toBeUndefined();
+  });
+});
+describe('getImageTagVersion', () => {
+  it('should return the selected tag version if image has multiple tags and a selected tag is provided', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'imageName',
+      tags: [{ name: 'tag1' }, { name: 'tag2' }] as ImageTagInfo[],
+    } as ImageInfo;
+
+    const selectedImage = 'imageName';
+    const selectedTag = 'tag2';
+
+    const result = getImageTagVersion(buildStatuses, image, selectedImage, selectedTag);
+
+    expect(result).toEqual('tag2');
+  });
+  it('should return the default tag version if image has multiple tags and no selected tag is provided', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      default: true,
+      name: 'imageName',
+      tags: [
+        { name: 'tag1', default: true },
+        { name: 'tag2', default: false },
+      ] as ImageTagInfo[],
+    } as ImageInfo;
+
+    const result = getImageTagVersion(buildStatuses, image);
+
+    expect(result).toEqual('tag1');
+  });
+
+  it('should return empty string if image has no tags', () => {
+    const buildStatuses: BuildStatus[] = [
+      {
+        name: 'Build1',
+        imageTag: 'imageName:tag1',
+        status: BUILD_PHASE.complete,
+        timestamp: '2022-01-01',
+      },
+    ];
+
+    const image = {
+      name: 'imageName',
+      tags: undefined as unknown as ImageTagInfo[],
+    } as ImageInfo;
+
+    const result = getImageTagVersion(buildStatuses, image);
+
+    expect(result).toEqual('');
+  });
+});
+describe('getDescriptionForTag', () => {
+  const createSoftware = (name: string, version: string): ImageSoftwareType => ({
+    name,
+    version,
+  });
+
+  it('should return software descriptions joined by commas if imageTag is provided', () => {
+    const imageTag: ImageTagInfo = {
+      name: 'tag1',
+      content: {
+        software: [createSoftware('Software1', 'v1'), createSoftware('Software2', 'v2')],
+      } as ImageTagInfo['content'],
+    } as ImageTagInfo;
+
+    // Mock the implementation of getNameVersionString
+    jest.mock('~/utilities/imageUtils', () => ({
+      ...jest.requireActual('~/utilities/imageUtils'),
+      getNameVersionString: jest.fn((software) => `${software.name} ${software.version}`),
+    }));
+
+    const result = getDescriptionForTag(imageTag);
+
+    expect(result).toEqual('Software1 v1, Software2 v2');
+  });
+
+  it('should return an empty string if imageTag is not provided', () => {
+    const result = getDescriptionForTag(undefined);
+    expect(result).toEqual('');
+  });
+
+  it('should return an empty string if imageTag has no content', () => {
+    const imageTag: ImageTagInfo = {
+      name: 'tag1',
+      content: undefined as unknown as ImageTagInfo['content'],
+    } as ImageTagInfo;
+
+    const result = getDescriptionForTag(imageTag);
+
+    expect(result).toEqual('');
+  });
+
+  it('should return an empty string if software array is empty', () => {
+    const imageTag = {
+      name: 'tag1',
+      content: {
+        software: [] as NameVersionPair[],
+      } as ImageTagInfo['content'],
+    } as ImageTagInfo;
+
+    const result = getDescriptionForTag(imageTag);
+
+    expect(result).toEqual('');
+  });
+});
+describe('getImageTagByContainer', () => {
+  const createImage = (name: string, tags: string[]) =>
+    ({
+      name,
+      tags: tags.map((tagName) => ({ name: tagName })),
+    } as ImageInfo);
+
+  it('should return ImageTag with image and tag when container has a valid image', () => {
+    const images = [
+      createImage('image1', ['tag1', 'tag2']),
+      createImage('image2', ['tag3', 'tag4']),
+    ] as ImageInfo[];
+
+    const container = {
+      name: 'container1',
+      image: 'registry.com/image1:tag2',
+      env: [],
+    } as NotebookContainer;
+
+    const result = getImageTagByContainer(images, container) as ImageTag;
+    expect(result).toEqual({ image: images[0], tag: images[0]?.tags[1] });
+  });
+
+  it('should return ImageTag with undefined image and tag when container has an invalid image format', () => {
+    const images = [
+      createImage('image1', ['tag1', 'tag2']),
+      createImage('image2', ['tag3', 'tag4']),
+    ] as ImageInfo[];
+
+    const container = {
+      name: 'container2',
+      image: 'registry.com/invalidImageFormat',
+      env: [],
+    } as NotebookContainer;
+
+    const result: ImageTag = getImageTagByContainer(images, container);
+
+    expect(result).toEqual({ image: undefined, tag: undefined });
+  });
+
+  it('should return ImageTag with undefined image and tag when container has an unknown image name', () => {
+    const images: ImageInfo[] = [
+      createImage('image1', ['tag1', 'tag2']),
+      createImage('image2', ['tag3', 'tag4']),
+    ];
+
+    const container = {
+      name: 'container3',
+      image: 'registry.com/unknownImage:tag3',
+      env: [],
+    };
+
+    const result: ImageTag = getImageTagByContainer(images, container);
+
+    expect(result).toEqual({ image: undefined, tag: undefined });
+  });
+
+  it('should return ImageTag with undefined image and tag when container has no image', () => {
+    const images: ImageInfo[] = [
+      createImage('image1', ['tag1', 'tag2']),
+      createImage('image2', ['tag3', 'tag4']),
+    ];
+
+    const container: NotebookContainer = {
+      name: 'container5',
+      image: '',
+      env: [],
+    };
+
+    const result = getImageTagByContainer(images, container) as ImageTag;
+    expect(result).toEqual({ image: undefined, tag: undefined });
+  });
+});

--- a/frontend/src/utilities/__tests__/imageUtils.spec.ts
+++ b/frontend/src/utilities/__tests__/imageUtils.spec.ts
@@ -22,7 +22,7 @@ import {
   ImageTag,
 } from '~/types';
 
-describe('Compare tag versions', () => {
+describe('compareTagVersions', () => {
   it('should sort recommended tags first', () => {
     const recemendedTagVersion = {
       tag: [
@@ -204,7 +204,6 @@ describe('getTagForImage', () => {
 
     expect(result).toEqual({ name: 'tag1', default: true });
   });
-
   it('should return undefined if image has no tags', () => {
     const buildStatuses: BuildStatus[] = [
       {
@@ -246,7 +245,7 @@ describe('getImageTagVersion', () => {
 
     const result = getImageTagVersion(buildStatuses, image, selectedImage, selectedTag);
 
-    expect(result).toEqual('tag2');
+    expect(result).toBe('tag2');
   });
   it('should return the default tag version if image has multiple tags and no selected tag is provided', () => {
     const buildStatuses: BuildStatus[] = [
@@ -269,9 +268,8 @@ describe('getImageTagVersion', () => {
 
     const result = getImageTagVersion(buildStatuses, image);
 
-    expect(result).toEqual('tag1');
+    expect(result).toBe('tag1');
   });
-
   it('should return empty string if image has no tags', () => {
     const buildStatuses: BuildStatus[] = [
       {
@@ -289,7 +287,7 @@ describe('getImageTagVersion', () => {
 
     const result = getImageTagVersion(buildStatuses, image);
 
-    expect(result).toEqual('');
+    expect(result).toBe('');
   });
 });
 describe('getDescriptionForTag', () => {
@@ -314,12 +312,12 @@ describe('getDescriptionForTag', () => {
 
     const result = getDescriptionForTag(imageTag);
 
-    expect(result).toEqual('Software1 v1, Software2 v2');
+    expect(result).toBe('Software1 v1, Software2 v2');
   });
 
   it('should return an empty string if imageTag is not provided', () => {
     const result = getDescriptionForTag(undefined);
-    expect(result).toEqual('');
+    expect(result).toBe('');
   });
 
   it('should return an empty string if imageTag has no content', () => {
@@ -330,7 +328,7 @@ describe('getDescriptionForTag', () => {
 
     const result = getDescriptionForTag(imageTag);
 
-    expect(result).toEqual('');
+    expect(result).toBe('');
   });
 
   it('should return an empty string if software array is empty', () => {
@@ -343,7 +341,7 @@ describe('getDescriptionForTag', () => {
 
     const result = getDescriptionForTag(imageTag);
 
-    expect(result).toEqual('');
+    expect(result).toBe('');
   });
 });
 describe('getImageTagByContainer', () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-1874](https://issues.redhat.com/browse/RHOAIENG-1874)

## Description
Unit Test Case for imageUtils.ts

## How Has This Been Tested?
`npm run test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<img width="841" alt="Screenshot 2024-01-16 at 8 55 38 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/e1b7ca07-be19-4153-a313-326afe86d2cd">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
