### PR TITLE
Unit Test Case for markdown

### DIFF
--- a/frontend/src/utilities/__tests__/markdown.spec.ts
+++ b/frontend/src/utilities/__tests__/markdown.spec.ts
@@ -1,0 +1,44 @@
+import DOMPurify from 'dompurify';
+import { Converter } from 'showdown';
+import { markdownConverter } from '~/utilities/markdown';
+
+// Mocking external dependencies
+jest.mock('dompurify');
+jest.mock('showdown');
+
+describe('markdownConverter', () => {
+  it('should convert markdown to sanitized HTML and add hook to transform anchor tags', () => {
+    const mockMarkdown = '## Heading\n[Link](https://example.com)';
+    const expectedHtml =
+      '<h2>Heading</h2><p><a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a></p>';
+
+    // Mock Converter's makeHtml method
+    const converterInstanceMock = { makeHtml: jest.fn().mockReturnValue(expectedHtml) };
+    (Converter as jest.Mock).mockImplementation(() => converterInstanceMock);
+
+    // Mock DOMPurify's addHook and sanitize methods
+    DOMPurify.addHook = jest.fn();
+    (DOMPurify.sanitize as jest.Mock).mockImplementation((html) => html);
+
+    // Call the function to test
+    const result = markdownConverter.makeHtml(mockMarkdown);
+
+    // Assertions
+    expect(result).toEqual(expectedHtml);
+
+    // Converter's makeHtml method should be called with the provided markdown
+    expect(converterInstanceMock.makeHtml).toHaveBeenCalledWith(mockMarkdown);
+
+    // DOMPurify hooks and sanitize should be called
+    expect(DOMPurify.addHook).toHaveBeenCalledWith('beforeSanitizeElements', expect.any(Function));
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith(expectedHtml, expect.any(Object));
+
+    // Additional assertion for the specific hook function
+    const hookFunction = (DOMPurify.addHook as jest.Mock).mock.calls[0][1];
+    const mockNode = { nodeType: 1, nodeName: 'A', setAttribute: jest.fn() };
+    hookFunction(mockNode);
+
+    // Assertion for node transformation
+    expect(mockNode.setAttribute).toHaveBeenCalledWith('rel', 'noopener noreferrer');
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-1875 ](https://issues.redhat.com/browse/RHOAIENG-1875)

## Description
Unit Test Case for markdown

## How Has This Been Tested?
`npm run test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<img width="743" alt="Screenshot 2024-01-16 at 9 11 16 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/1818b2f4-3fc4-4971-8b80-87c3923616e2">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
