### PR TITLE
Improves query for Average Response Time charts, so it is only a single area.

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -37,7 +37,7 @@ export const getServerMetricsQueries = (
     [ServerMetricType.REQUEST_COUNT]: `round(sum(increase(modelmesh_api_request_milliseconds_count{namespace="${namespace}",pod=~"modelmesh-serving-${name}-.*"}[${
       QueryTimeframeStep[ServerMetricType.REQUEST_COUNT][currentTimeframe]
     }s])))`,
-    [ServerMetricType.AVG_RESPONSE_TIME]: `increase(modelmesh_api_request_milliseconds_sum{namespace="${namespace}",pod=~"modelmesh-serving-${name}-.*"}[${responseTimeStep}s])/increase(modelmesh_api_request_milliseconds_count{namespace="${namespace}",pod=~"modelmesh-serving-${name}-.*"}[${responseTimeStep}s])`,
+    [ServerMetricType.AVG_RESPONSE_TIME]: `sum without (vModelId, modelId) (increase(modelmesh_api_request_milliseconds_sum{namespace="${namespace}",pod=~"modelmesh-serving-${name}-.*", code='OK'}[${responseTimeStep}s])) / sum without (vModelId, modelId) (increase(modelmesh_api_request_milliseconds_count{namespace="${namespace}",pod=~"modelmesh-serving-${name}-.*", code='OK'}[${responseTimeStep}s]))`,
     [ServerMetricType.CPU_UTILIZATION]: `sum(pod:container_cpu_usage:sum{namespace="${namespace}", pod=~"modelmesh-serving-${name}-.*"})/sum(kube_pod_resource_limit{resource="cpu", pod=~"modelmesh-serving-${name}-.*", namespace="${namespace}"})`,
     [ServerMetricType.MEMORY_UTILIZATION]: `sum(container_memory_working_set_bytes{namespace="${namespace}", pod=~"modelmesh-serving-${name}-.*"})/sum(kube_pod_resource_limit{resource="memory", pod=~"modelmesh-serving-${name}-.*", namespace="${namespace}"})`,
   };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-1743](https://issues.redhat.com//browse/RHOAIENG-1743)
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updates the prometheus query for the "Average response time" server metrics chart. Previously the chart displayed multiple lines, representing each model running on the server (see before / after pics below). Following the PM signoff it was requested that the chart be one single line representing the whole model server - this PR implements this.

*BEFORE*
![odh-dashboard-opendatahub apps acreasy dev datahub redhat com_projects_vince-test](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/b39151bd-80d1-4838-b2d2-3f8ea5fae993)


*AFTER*
![localhost_4010_projects_model-namespace_metrics_model_demo-loan-nn-onnx-alpha_configure](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/8fbad901-c87a-4e5f-907b-e96b05df7112)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Run locally against a server with models running and performance data pre-seeded.
* Verify the Average response time chart, shows a single area.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
* Does not reduce existing test coverage

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
- Skipped, the server is required for a customer demo tomorrow, so I'm not replacing the image. This change is small enough that I'll make an exception on this.
