### PR TITLE
Followup to PR #2319 - permission check typo

### DIFF
--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -48,7 +48,7 @@ const checkEditNamespacePermission = (
 ): Promise<V1SelfSubjectAccessReview | K8sStatus> =>
   createSelfSubjectAccessReview(fastify, request, {
     group: 'serving.kserve.io',
-    resource: 'ServingRuntimes',
+    resource: 'servingruntimes',
     subresource: '',
     verb: 'create',
     name,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Followup to https://github.com/opendatahub-io/odh-dashboard/pull/2319
Fixes a bug in the resolution to https://issues.redhat.com/browse/RHOAIENG-548

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

There was a misunderstanding when verifying #2319: When a model or model server is deployed, not only should an error in updating the namespace prevent a servingruntime from being created, that error should also not happen in the first place for edit-permission users. @lucferbux pointed out that the `resource` field of the `SelfSubjectAccessReview` in `checkEditNamespacePermission` needs to be lowercase for it to check the permission properly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* As user1, create a project and assign user2 with "edit" permissions.
* As user2, deploy a model in the project.
* Check that there is no error, the serving platform label on the project is applied, and the model is deployed.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A: The changes are at the backend level, and we do not currently have e2e tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
