### PR TITLE
added test for  useAcceleratorProfiles

### DIFF
--- a/frontend/src/__mocks__/mockAcceleratorProfile.ts
+++ b/frontend/src/__mocks__/mockAcceleratorProfile.ts
@@ -5,6 +5,7 @@ import { genUID } from './mockUtils';
 type MockResourceConfigType = {
   name?: string;
   namespace?: string;
+  uid?: string;
   displayName?: string;
   identifier?: string;
   description?: string;
@@ -15,6 +16,7 @@ type MockResourceConfigType = {
 export const mockAcceleratorProfile = ({
   name = 'migrated-gpu',
   namespace = 'test-project',
+  uid = genUID('service'),
   displayName = 'Nvidia GPU',
   identifier = 'nvidia.com/gpu',
   description = '',
@@ -35,7 +37,7 @@ export const mockAcceleratorProfile = ({
     name,
     namespace,
     resourceVersion: '1309350',
-    uid: genUID('service'),
+    uid,
   },
   spec: {
     identifier,

--- a/frontend/src/pages/notebookController/screens/server/__tests__/useAcceleratorProfiles.spec.ts
+++ b/frontend/src/pages/notebookController/screens/server/__tests__/useAcceleratorProfiles.spec.ts
@@ -1,0 +1,67 @@
+import { act } from '@testing-library/react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
+import useAcceleratorProfiles from '~/pages/notebookController/screens/server/useAcceleratorProfiles';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+const k8sListResourceMock = k8sListResource as jest.Mock;
+
+describe('useAcceleratorProfiles', () => {
+  it('should return successful list of accelerators profiles', async () => {
+    k8sListResourceMock.mockReturnValue(
+      Promise.resolve(mockK8sResourceList([mockAcceleratorProfile({ uid: 'test-project-12m' })])),
+    );
+
+    const renderResult = testHook(useAcceleratorProfiles)('test-project');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([mockAcceleratorProfile({ uid: 'test-project-12m' })], true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(
+      Promise.resolve(mockK8sResourceList([mockAcceleratorProfile({})])),
+    );
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle other errors and rethrow', async () => {
+    k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error1')));
+
+    const renderResult = testHook(useAcceleratorProfiles)('test-project');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    k8sListResourceMock.mockReturnValue(Promise.reject(new Error('error2')));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-1946

## Description
unit test for use frontend/src/pages/notebookController/screens/server/useAcceleratorProfiles.ts
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
coverage
![Screenshot from 2024-01-18 11-03-56](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/b7adca7c-ad55-4541-8a10-88ef162327cf)

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
