### PR TITLE
Fix issue when uploading a version on create pipeline run page

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -53,9 +53,12 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange }) => (
       }}
     />
     <PipelineVersionSection
-      pipeline={data.pipeline}
+      selectedPipeline={data.pipeline}
       value={data.version}
-      onChange={(version) => {
+      onChange={(version, pipeline) => {
+        if (pipeline) {
+          onValueChange('pipeline', pipeline);
+        }
         onValueChange('version', version);
         onValueChange(
           'params',

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionSection.tsx
@@ -10,13 +10,13 @@ import ImportPipelineVersionButton from '~/concepts/pipelines/content/import/Imp
 import PipelineVersionSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineVersionSelector';
 
 type PipelineVersionSectionProps = {
-  pipeline: PipelineKF | null;
+  selectedPipeline: PipelineKF | null;
   value: PipelineVersionKF | null;
-  onChange: (version: PipelineVersionKF) => void;
+  onChange: (version: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
 };
 
 const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
-  pipeline,
+  selectedPipeline,
   value,
   onChange,
 }) => (
@@ -32,7 +32,7 @@ const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
         <StackItem>
           <PipelineVersionSelector
             selection={value?.name}
-            pipelineId={pipeline?.id}
+            pipelineId={selectedPipeline?.id}
             onSelect={(version) => {
               onChange(version);
             }}
@@ -40,10 +40,10 @@ const PipelineVersionSection: React.FC<PipelineVersionSectionProps> = ({
         </StackItem>
         <StackItem>
           <ImportPipelineVersionButton
-            pipeline={pipeline}
+            selectedPipeline={selectedPipeline}
             variant="link"
             icon={<PlusCircleIcon />}
-            onCreate={(pipelineVersion) => onChange(pipelineVersion)}
+            onCreate={(pipelineVersion, pipeline) => onChange(pipelineVersion, pipeline)}
           />
         </StackItem>
       </Stack>

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
@@ -5,12 +5,12 @@ import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import PipelineVersionImportModal from '~/concepts/pipelines/content/import/PipelineVersionImportModal';
 
 type ImportPipelineVersionButtonProps = {
-  pipeline: PipelineKF | null;
-  onCreate?: (pipelineVersion: PipelineVersionKF) => void;
+  selectedPipeline: PipelineKF | null;
+  onCreate?: (pipelineVersion: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
 } & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
 
 const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = ({
-  pipeline,
+  selectedPipeline,
   onCreate,
   children,
   ...buttonProps
@@ -29,11 +29,11 @@ const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = 
       </Button>
       {open && (
         <PipelineVersionImportModal
-          existingPipeline={pipeline}
-          onClose={(pipelineVersion) => {
+          existingPipeline={selectedPipeline}
+          onClose={(pipelineVersion, pipeline) => {
             setOpen(false);
             if (pipelineVersion) {
-              onCreate && onCreate(pipelineVersion);
+              onCreate && onCreate(pipelineVersion, pipeline);
               refreshAllAPI();
             }
           }}

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -19,7 +19,7 @@ import { generatePipelineVersionName } from '~/concepts/pipelines/content/import
 
 type PipelineVersionImportModalProps = {
   existingPipeline?: PipelineKF | null;
-  onClose: (pipelineVersion?: PipelineVersionKF) => void;
+  onClose: (pipelineVersion?: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
 };
 
 const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
@@ -29,14 +29,16 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
   const { project, api, apiAvailable } = usePipelinesAPI();
   const [importing, setImporting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
-  const [{ name, description, pipelineId, pipelineName, fileContents }, setData, resetData] =
+  const [{ name, description, pipeline, fileContents }, setData, resetData] =
     usePipelineVersionImportModalData(existingPipeline);
 
-  const isImportButtonDisabled =
-    !apiAvailable || importing || !name || !fileContents || !pipelineId;
+  const pipelineId = pipeline?.id || '';
+  const pipelineName = pipeline?.name || '';
 
-  const onBeforeClose = (pipelineVersion?: PipelineVersionKF) => {
-    onClose(pipelineVersion);
+  const isImportButtonDisabled = !apiAvailable || importing || !name || !fileContents || !pipeline;
+
+  const onBeforeClose = (pipelineVersion?: PipelineVersionKF, pipeline?: PipelineKF | null) => {
+    onClose(pipelineVersion, pipeline);
     setImporting(false);
     setError(undefined);
     resetData();
@@ -58,7 +60,7 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
             setError(undefined);
             api
               .uploadPipelineVersion({}, name, description, fileContents, pipelineId)
-              .then((pipelineVersion) => onBeforeClose(pipelineVersion))
+              .then((pipelineVersion) => onBeforeClose(pipelineVersion, pipeline))
               .catch((e) => {
                 setImporting(false);
                 setError(e);
@@ -85,8 +87,7 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
               <PipelineSelector
                 selection={pipelineName}
                 onSelect={(pipeline) => {
-                  setData('pipelineId', pipeline.id);
-                  setData('pipelineName', pipeline.name);
+                  setData('pipeline', pipeline);
                   setData('name', generatePipelineVersionName(pipeline));
                 }}
               />

--- a/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
+++ b/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
@@ -19,19 +19,17 @@ export const usePipelineImportModalData = (): GenericObjectState<PipelineModalDa
 type PipelineVersionModalData = {
   name: string;
   description: string;
-  pipelineId: string;
-  pipelineName: string;
+  pipeline: PipelineKF | null;
   fileContents: string;
 };
 
 export const usePipelineVersionImportModalData = (
-  pipeline?: PipelineKF | null,
+  existingPipeline?: PipelineKF | null,
 ): GenericObjectState<PipelineVersionModalData> => {
   const createDataState = useGenericObjectState<PipelineVersionModalData>({
-    name: React.useMemo(() => generatePipelineVersionName(pipeline), [pipeline]),
+    name: React.useMemo(() => generatePipelineVersionName(existingPipeline), [existingPipeline]),
     description: '',
-    pipelineId: pipeline?.id ?? '',
-    pipelineName: pipeline?.name ?? '',
+    pipeline: existingPipeline ?? null,
     fileContents: '',
   });
 

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableExpandedRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableExpandedRow.tsx
@@ -56,7 +56,7 @@ const PipelinesTableExpandedRow: React.FC<PipelinesTableExpandedRowProps> = ({
               <EmptyStateHeader titleText="No pipeline versions" headingLevel="h3" />
               <EmptyStateFooter>
                 <EmptyStateActions>
-                  <ImportPipelineVersionButton pipeline={pipeline} variant="link" />
+                  <ImportPipelineVersionButton selectedPipeline={pipeline} variant="link" />
                 </EmptyStateActions>
               </EmptyStateFooter>
             </EmptyState>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-1123

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
It's just a small fix, expose the selection of the pipeline when uploading a pipeline version, so the pipeline selector can get that value and set it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the create run page with all the fields empty
2. Click `Upload new version` button on that pipeline
3. Select a pipeline and upload a version
4. Verify both pipeline and version selectors are auto-filled
5. Now click on `Upload new version` button again, it should auto-fill the pipeline selector in the modal too
6. Change the selection
7. Upload a new version for that different pipeline
8. Verify both pipeline and version selector are changed to the version you just uploaded

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
