### PR TITLE
[RHOAIENG-246] Updated TrustyAIKind apiVersion to trustyai.opendatahub.io

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelMetrics.cy.ts
@@ -190,7 +190,7 @@ const initIntercepts = ({
     {
       method: 'GET',
       pathname:
-        '/api/k8s/apis/trustyai.opendatahub.io.trustyai.opendatahub.io/v1alpha1/namespaces/test-project/trustyaiservices/trustyai-service',
+        '/api/k8s/apis/trustyai.opendatahub.io/v1alpha1/namespaces/test-project/trustyaiservices/trustyai-service',
     },
     mockTrustyAIServiceK8sResource(),
   );

--- a/frontend/src/api/models/trustyai.ts
+++ b/frontend/src/api/models/trustyai.ts
@@ -2,7 +2,7 @@ import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
 
 export const TrustyAIApplicationsModel: K8sModelCommon = {
   apiVersion: 'v1alpha1',
-  apiGroup: 'trustyai.opendatahub.io.trustyai.opendatahub.io',
+  apiGroup: 'trustyai.opendatahub.io',
   kind: 'TrustyAIService',
   plural: 'trustyaiservices',
 };


### PR DESCRIPTION
[WIP] Testing on a cluster in progress
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-346](https://issues.redhat.com//browse/RHOAIENG-346)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updates the apiVersion of the TrustyAI CRD to  `trustyai.opendatahub.io` to match a last minute update on the backend.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy TrustyAI using these devflags:
```
    trustyai:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: >-
              https://github.com/ruivieira/trustyai-service-operator/tarball/issue-168-apiversion-ui-test
      managementState: Managed
```

2. Deploy dashboard image from this PR.
3. Enable TrustyAI on a project through the dashboard, verify the service is correctly installed.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Small change, existing tests updated, no drop in coverage.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
