### PR TITLE
add support for cypress websockets

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,13 +42,13 @@
     "storybook": "storybook dev -p 6006 -s ../config",
     "cypress:open": "cypress open --project src/__tests__/cypress",
     "cypress:run": "cypress run -b chrome --project src/__tests__/cypress",
-    "cypress:open:mock": "MOCK=1 npm run cypress:open",
-    "cypress:run:mock": "MOCK=1 npm run cypress:run",
+    "cypress:open:mock": "MOCK=1 WS_PORT=9002 npm run cypress:open",
+    "cypress:run:mock": "MOCK=1 WS_PORT=9002 npm run cypress:run",
     "cypress:open:record": "RECORD=1 npm run cypress:open",
     "cypress:run:record": "RECORD=1 npm run cypress:run && npm run cypress:format",
-    "cypress:server:build": "ODH_DIST_DIR=./public-cypress POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 npm run build",
+    "cypress:server:build": "ODH_DIST_DIR=./public-cypress POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 WS_HOSTNAME=localhost:9002 npm run build",
     "cypress:server": "serve ./public-cypress -p 9001 -s -L",
-    "cypress:server:dev": "POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 ODH_PORT=9001 npm run start:dev",
+    "cypress:server:dev": "POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 ODH_PORT=9001 WS_HOSTNAME=localhost:9002 npm run start:dev",
     "cypress:format": "prettier --write src/__tests__/**/*.snap.json"
   },
   "dependencies": {

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { defineConfig } from 'cypress';
 import dotenv from 'dotenv';
 import { interceptSnapshotFile } from '~/__tests__/cypress/cypress/utils/snapshotUtils';
+import { setup as setupWebsockets } from '~/__tests__/cypress/cypress/support/websockets';
 
 dotenv.config({
   path: path.resolve(__dirname, `../../../.env.cypress${process.env.MOCK ? '.mock' : ''}`),
@@ -20,6 +21,7 @@ export default defineConfig({
     USERNAME: process.env.USERNAME,
     PASSWORD: process.env.PASSWORD,
     RECORD: !!process.env.RECORD,
+    WS_PORT: process.env.WS_PORT,
   },
   defaultCommandTimeout: 10000,
   e2e: {
@@ -30,7 +32,8 @@ export default defineConfig({
       ? `cypress/e2e/**/*.scy.ts`
       : `cypress/e2e/**/*.(s)?cy.ts`,
     experimentalInteractiveRunEvents: true,
-    setupNodeEvents(on) {
+    setupNodeEvents(on, config) {
+      setupWebsockets(on, config);
       on('task', {
         readJSON(filePath: string) {
           const absPath = path.resolve(__dirname, filePath);

--- a/frontend/src/__tests__/cypress/cypress/support/commands/index.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/index.ts
@@ -2,3 +2,4 @@ import '@testing-library/cypress/add-commands';
 import './application';
 import './axe';
 import './intercept-snapshots';
+import './k8s';

--- a/frontend/src/__tests__/cypress/cypress/support/commands/k8s.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/k8s.ts
@@ -1,0 +1,45 @@
+import type { K8sModelCommon, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { getK8sWebSocketResourceURL } from '~/__tests__/cypress/cypress/utils/k8s';
+
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Send a web socket K8s resource deleted message.
+       */
+      wsK8sDeleted<K extends K8sResourceCommon>(
+        model: K8sModelCommon,
+        resource: K,
+      ): Cypress.Chainable<undefined>;
+
+      /**
+       * Send a web socket K8s resource add message.
+       */
+      wsK8sAdded<K extends K8sResourceCommon>(
+        model: K8sModelCommon,
+        resource: K,
+      ): Cypress.Chainable<undefined>;
+
+      /**
+       * Send a web socket K8s resource modified message.
+       */
+      wsK8sModified<K extends K8sResourceCommon>(
+        model: K8sModelCommon,
+        resource: K,
+      ): Cypress.Chainable<undefined>;
+    }
+  }
+}
+
+Cypress.Commands.add('wsK8sDeleted', (model, resource) => {
+  cy.wsSend(getK8sWebSocketResourceURL(model), { type: 'DELETED', object: resource });
+});
+
+Cypress.Commands.add('wsK8sAdded', (model, resource) => {
+  cy.wsSend(getK8sWebSocketResourceURL(model), { type: 'ADDED', object: resource });
+});
+
+Cypress.Commands.add('wsK8sModified', (model, resource) => {
+  cy.wsSend(getK8sWebSocketResourceURL(model), { type: 'MODIFIED', object: resource });
+});

--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -14,6 +14,9 @@
 // ***********************************************************
 
 import './commands';
+import { addCommands as webSocketsAddCommands } from './websockets';
+
+webSocketsAddCommands();
 
 Cypress.Keyboard.defaults({
   keystrokeDelay: 0,

--- a/frontend/src/__tests__/cypress/cypress/support/websockets.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/websockets.ts
@@ -1,0 +1,89 @@
+import WebSocket, { WebSocketServer } from 'ws';
+
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Send data to through websockets to all matching connections.
+       */
+      wsSend(
+        matcher: string | { pathname: string; searchParams?: URLSearchParams },
+        data: string | object,
+      ): void;
+    }
+  }
+}
+
+export const addCommands = (): void => {
+  Cypress.Commands.add('wsSend', (matcher, data) => {
+    cy.task('wsSend', { matcher, data });
+  });
+};
+
+export const setup = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void => {
+  const openSockets = new Map<string, { ws: WebSocket; searchParams: URLSearchParams }[]>();
+  on('after:spec', () => {
+    openSockets.clear();
+  });
+
+  if (config.env.MOCK) {
+    const wss = new WebSocketServer({ port: Number(config.env.WS_PORT) });
+    wss.on('connection', function connection(ws, req) {
+      if (req.url) {
+        const { pathname, searchParams } = new URL(req.url, `http://${req.headers.host}`);
+
+        if (!openSockets.has(pathname)) {
+          openSockets.set(pathname, []);
+        }
+
+        openSockets.get(pathname)?.push({ ws, searchParams });
+
+        const close = () => {
+          const items = openSockets.get(pathname);
+          if (items) {
+            const idx = items.findIndex((i) => i.ws === ws);
+            items.splice(idx, 1);
+          }
+        };
+        ws.on('close', close);
+        ws.on('error', close);
+      }
+    });
+  }
+
+  on('task', {
+    wsSend: ({
+      matcher,
+      data,
+    }: {
+      matcher: string | { pathname: string; searchParams?: URLSearchParams };
+      data: string | object;
+    }) => {
+      let pathname: string;
+      let searchParams: URLSearchParams | undefined;
+
+      if (typeof matcher === 'string') {
+        const url = new URL(matcher, `http://localhost`);
+        pathname = url.pathname;
+        searchParams = url.searchParams;
+      } else {
+        pathname = matcher.pathname;
+        searchParams = matcher.searchParams;
+      }
+
+      openSockets.get(pathname)?.forEach((i) => {
+        let hasAll = true;
+        searchParams?.forEach((v, k) => {
+          hasAll = hasAll && i.searchParams.get(k) === v;
+        });
+
+        if (hasAll) {
+          i.ws.send(typeof data === 'string' ? data : JSON.stringify(data));
+        }
+      });
+
+      return null;
+    },
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/k8s.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/k8s.ts
@@ -1,0 +1,30 @@
+import type { K8sModelCommon, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+const getK8sAPIPath = ({ apiGroup = 'core', apiVersion }: K8sModelCommon) => {
+  const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
+  return isLegacy ? `/api/${apiVersion}` : `/apis/${apiGroup}/${apiVersion}`;
+};
+
+const getK8sResourceURL = (model: K8sModelCommon, resource?: K8sResourceCommon) => {
+  let resourcePath = getK8sAPIPath(model);
+
+  if (resource?.metadata?.namespace) {
+    resourcePath += `/namespaces/${resource.metadata.namespace}`;
+  }
+
+  resourcePath += `/${model.plural}`;
+
+  if (resource?.metadata?.name) {
+    resourcePath += `/${encodeURIComponent(resource.metadata.name)}`;
+  }
+
+  return resourcePath;
+};
+
+export const getK8sWebSocketResourceURL = (
+  model: K8sModelCommon,
+  resource?: K8sResourceCommon,
+): string => `/wss/k8s${getK8sResourceURL(model, resource)}`;
+
+export const getK8sAPIResourceURL = (model: K8sModelCommon, resource?: K8sResourceCommon): string =>
+  `/api/k8s${getK8sResourceURL(model, resource)}`;

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -1,5 +1,6 @@
 import { ContextResourceData, OdhDocumentType } from '~/types';
 
+const WS_HOSTNAME = process.env.WS_HOSTNAME || location.host;
 const DEV_MODE = process.env.APP_ENV === 'development';
 const API_PORT = process.env.BACKEND_PORT || 8080;
 const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTERVAL) : 30000;
@@ -28,6 +29,7 @@ export {
   ODH_PRODUCT_NAME,
   ODH_NOTEBOOK_REPO,
   DASHBOARD_CONFIG,
+  WS_HOSTNAME,
 };
 
 export const DOC_TYPE_TOOLTIPS = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes: https://issues.redhat.com/browse/RHOAIENG-836

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This change adds support to send updates through websockets to the frontend.
Requires a change to the frontend to accept overriding the websocket connection. The cypress scripts in the `package.json` override `WS_HOSTNAME`. By default we continue to use `localhost.host` as a fallback.

Added three new cypress commands:
- `wsSend`: Generic command to send arbitrary data through websockets.
- `wsK8sDeleted`: Send a web socket K8s resource deleted message.
- `wsK8sAdded`: Send a web socket K8s resource add message.
- `wsK8sModified`: Send a web socket K8s resource modified message.

Example usage:
`cy.wsK8sAdded(ProjectModel, {... k8s resource ...);`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Replaced project polling with websockets locally.
Created a sample test case updating the project list page through websockets.
Ensured app continues to work in dev mode and production.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
