### PR TITLE
'Jupyter ' text is missing for Notebook tile in RHOAI Enabled/Explore tab

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/applications/explore.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/applications/explore.cy.ts
@@ -4,19 +4,21 @@ import { mockStatus } from '~/__mocks__/mockStatus';
 import { explorePage } from '~/__tests__/cypress/cypress/pages/explore';
 import { mockComponents } from '~/__mocks__/mockComponents';
 
-const initIntercepts = () => {
-  cy.intercept('/api/dsc/status', mockDscStatus({}));
-  cy.intercept('/api/status', mockStatus());
-  cy.intercept('/api/config', mockDashboardConfig({}));
-  cy.intercept('/api/components', mockComponents());
-};
-
 describe('Explore Page', { testIsolation: false }, () => {
-  it('should have selectable cards', () => {
-    initIntercepts();
+  beforeEach(() => {
+    cy.intercept('/api/dsc/status', mockDscStatus({}));
+    cy.intercept('/api/status', mockStatus());
+    cy.intercept('/api/config', mockDashboardConfig({}));
+    cy.intercept('/api/components', mockComponents());
+  });
 
+  it('should have selectable cards', () => {
     explorePage.visit();
     explorePage.findExploreCard('jupyter').click();
     explorePage.findDrawerPanel().should('be.visible');
+  });
+
+  it('card title should be visible', () => {
+    cy.get('span').should('contain', 'Jupyter');
   });
 });

--- a/frontend/src/components/SupportedAppTitle.tsx
+++ b/frontend/src/components/SupportedAppTitle.tsx
@@ -10,31 +10,25 @@ type SupportedAppTitleProps = {
 };
 
 const SupportedAppTitle: React.FC<SupportedAppTitleProps> = ({ odhApp, showProvider = false }) => {
-  let title = odhApp.spec.displayName;
-  let icon;
-
-  if (isRedHatSupported(odhApp)) {
-    const splitTitle = odhApp.spec.displayName.split(' ');
-    title = `${splitTitle.slice(0, -1).join(' ')} `;
-    icon = (
-      <span style={{ whiteSpace: 'nowrap' }}>
-        <Tooltip content={`${ODH_PRODUCT_NAME} certified and supported`}>
-          <Button variant="plain" style={{ padding: 0 }}>
-            <img
-              style={{ marginLeft: 'var(--pf-v5-global--spacer--xs)', verticalAlign: 'middle' }}
-              src="../images/CheckStar.svg"
-              alt={`${ODH_PRODUCT_NAME} certified and supported`}
-            />
-          </Button>
-        </Tooltip>
-      </span>
-    );
-  }
+  const title = odhApp.spec.displayName;
+  const icon = (
+    <span style={{ whiteSpace: 'nowrap' }}>
+      <Tooltip content={`${ODH_PRODUCT_NAME} certified and supported`}>
+        <Button variant="plain" style={{ padding: 0, verticalAlign: 'middle' }}>
+          <img
+            style={{ marginLeft: 'var(--pf-v5-global--spacer--xs)' }}
+            src="../images/CheckStar.svg"
+            alt={`${ODH_PRODUCT_NAME} certified and supported`}
+          />
+        </Button>
+      </Tooltip>
+    </span>
+  );
 
   return (
     <CardTitle>
       <span style={{ verticalAlign: 'text-bottom' }}>{title}</span>
-      {icon}
+      {isRedHatSupported(odhApp) && icon}
       {showProvider && odhApp.spec.provider && (
         <div>
           <span className="odh-card__provider">by {odhApp.spec.provider}</span>


### PR DESCRIPTION
Closes: [RHOAIENG-2041](https://issues.redhat.com/browse/RHOAIENG-2041)

## Description
Changed the functionality of how we fetch the displayName of the OdhApplication CR. Card titles are visible now.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/ee9167ef-a354-47c3-88bf-6768752061ba)


## How Has This Been Tested?
Run dashboard with check enabled page, card title should be visible.

## Test Impact
Added cypress test to check card title

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
