### PR TITLE
Inconsistent Model Path

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
@@ -285,8 +285,23 @@ describe('Model Serving Global', () => {
     inferenceServiceModal.findModelNameInput().clear();
     inferenceServiceModal.findLocationPathInput().clear();
     inferenceServiceModal.findSubmitButton().should('be.disabled');
+
+    // test with invalid path name
     inferenceServiceModal.findLocationPathInput().type('/');
+    inferenceServiceModal
+      .findLocationPathInputError()
+      .should('be.visible')
+      .contains('The path must not point to a root folder');
     inferenceServiceModal.findSubmitButton().should('be.disabled');
+    inferenceServiceModal.findLocationPathInput().clear();
+    inferenceServiceModal.findLocationPathInput().type('test//path');
+    inferenceServiceModal
+      .findLocationPathInputError()
+      .should('be.visible')
+      .contains('Invalid path format');
+    inferenceServiceModal.findSubmitButton().should('be.disabled');
+    inferenceServiceModal.findLocationPathInput().clear();
+
     // test that you can update the name to a different name
     inferenceServiceModal.findModelNameInput().type('Updated Model Name');
     inferenceServiceModal.findLocationPathInput().type('test-model/');
@@ -305,6 +320,7 @@ describe('Model Serving Global', () => {
     inferenceServiceModal.findLocationSecretKeyInput().type('test-secret-key');
     inferenceServiceModal.findLocationEndpointInput().type('test-endpoint');
     inferenceServiceModal.findLocationBucketInput().type('test-bucket');
+    inferenceServiceModal.findLocationPathInput().clear();
     inferenceServiceModal.findLocationPathInput().type('test-model/');
     inferenceServiceModal.findSubmitButton().should('be.enabled');
   });
@@ -333,7 +349,19 @@ describe('Model Serving Global', () => {
     inferenceServiceModal.findLocationPathInput().clear();
     inferenceServiceModal.findSubmitButton().should('be.disabled');
     inferenceServiceModal.findLocationPathInput().type('/');
+    inferenceServiceModal
+      .findLocationPathInputError()
+      .should('be.visible')
+      .contains('The path must not point to a root folder');
     inferenceServiceModal.findSubmitButton().should('be.disabled');
+    inferenceServiceModal.findLocationPathInput().clear();
+    inferenceServiceModal.findLocationPathInput().type('test//path');
+    inferenceServiceModal
+      .findLocationPathInputError()
+      .should('be.visible')
+      .contains('Invalid path format');
+    inferenceServiceModal.findSubmitButton().should('be.disabled');
+    inferenceServiceModal.findLocationPathInput().clear();
     inferenceServiceModal.findLocationNameInput().type('Test Name');
     inferenceServiceModal.findLocationAccessKeyInput().type('test-key');
     inferenceServiceModal.findLocationSecretKeyInput().type('test-secret-key');

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -115,6 +115,10 @@ class InferenceServiceModal extends Modal {
   findLocationPathInput() {
     return this.find().findByLabelText('folder-path');
   }
+
+  findLocationPathInputError() {
+    return this.find().findByTestId('folder-path-error');
+  }
 }
 
 class ServingRuntimeModal extends Modal {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionFolderPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionFolderPathField.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
 import {
   FormGroup,
-  InputGroup,
-  InputGroupText,
   TextInput,
-  InputGroupItem,
   FormHelperText,
   HelperText,
   HelperTextItem,
 } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { containsOnlySlashes, removeLeadingSlashes } from '~/utilities/string';
 
 type DataConnectionFolderPathFieldProps = {
   folderPath: string;
@@ -30,7 +28,7 @@ const DataConnectionFolderPathField: React.FC<DataConnectionFolderPathFieldProps
   };
   React.useEffect(() => {
     const timer = setTimeout(() => {
-      if (folderPath === '/' || folderPath.includes('//')) {
+      if (containsOnlySlashes(folderPath) || removeLeadingSlashes(folderPath).includes('//')) {
         setValidated('error');
       } else {
         setValidated('default');
@@ -40,27 +38,25 @@ const DataConnectionFolderPathField: React.FC<DataConnectionFolderPathFieldProps
   }, [folderPath]);
   return (
     <FormGroup fieldId="folder-path" label="Path" isRequired>
-      <InputGroup>
-        <InputGroupText isPlain>/</InputGroupText>
-        <InputGroupItem isFill>
-          <TextInput
-            aria-label="folder-path"
-            type="text"
-            value={folderPath}
-            validated={validated}
-            placeholder="Example, data_folder"
-            onChange={(e, folderPath: string) => handlePathChange(folderPath)}
-          />
-        </InputGroupItem>
-      </InputGroup>
+      <TextInput
+        aria-label="folder-path"
+        type="text"
+        value={folderPath}
+        validated={validated}
+        placeholder="Example, data_folder"
+        onChange={(e, folderPath: string) => handlePathChange(folderPath)}
+      />
       <FormHelperText>
         <HelperText>
           <HelperTextItem
+            data-testid="folder-path-error"
             {...(validated === 'error' && { icon: <ExclamationCircleIcon /> })}
             variant={validated}
           >
             {validated === 'error'
-              ? 'The path must not point to a root folder.'
+              ? containsOnlySlashes(folderPath)
+                ? 'The path must not point to a root folder.'
+                : 'Invalid path format'
               : 'Enter a path to a model or folder. This path cannot point to a root folder.'}
           </HelperTextItem>
         </HelperText>

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -12,6 +12,7 @@ import { InferenceServiceStorageType } from '~/pages/modelServing/screens/types'
 import { isAWSValid } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { AWS_KEYS } from '~/pages/projects/dataConnections/const';
 import { getProjectDisplayName, translateDisplayNameForK8s } from '~/pages/projects/utils';
+import { containsOnlySlashes, removeLeadingSlashes } from '~/utilities/string';
 import DataConnectionSection from './DataConnectionSection';
 import ProjectSection from './ProjectSection';
 import InferenceServiceFrameworkSection from './InferenceServiceFrameworkSection';
@@ -64,9 +65,9 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     createData.name.trim() === '' ||
     createData.project === '' ||
     createData.format.name === '' ||
-    createData.storage.path.includes('//') ||
+    removeLeadingSlashes(createData.storage.path).includes('//') ||
+    containsOnlySlashes(createData.storage.path) ||
     createData.storage.path === '' ||
-    createData.storage.path === '/' ||
     !isInferenceServiceNameWithinLimit ||
     !storageCanCreate();
 

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -28,6 +28,7 @@ import InferenceServiceNameSection from '~/pages/modelServing/screens/projects/I
 import InferenceServiceFrameworkSection from '~/pages/modelServing/screens/projects/InferenceServiceModal/InferenceServiceFrameworkSection';
 import DataConnectionSection from '~/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionSection';
 import { getProjectDisplayName, translateDisplayNameForK8s } from '~/pages/projects/utils';
+import { containsOnlySlashes, removeLeadingSlashes } from '~/utilities/string';
 
 type ManageKServeModalProps = {
   isOpen: boolean;
@@ -102,9 +103,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     createDataInferenceService.name.trim() === '' ||
     createDataInferenceService.project === '' ||
     createDataInferenceService.format.name === '' ||
-    createDataInferenceService.storage.path.includes('//') ||
+    removeLeadingSlashes(createDataInferenceService.storage.path).includes('//') ||
+    containsOnlySlashes(createDataInferenceService.storage.path) ||
     createDataInferenceService.storage.path === '' ||
-    createDataInferenceService.storage.path === '/' ||
     !isInferenceServiceNameWithinLimit ||
     !storageCanCreate();
 

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -44,6 +44,7 @@ import {
   updateServingRuntime,
 } from '~/api';
 import { isDataConnectionAWS } from '~/pages/projects/screens/detail/data-connections/utils';
+import { removeLeadingSlashes } from '~/utilities/string';
 
 export const getServingRuntimeSizes = (config: DashboardConfigKind): ServingRuntimeSize[] => {
   let sizes = config.spec.modelServerSizes || [];
@@ -312,6 +313,12 @@ export const submitInferenceServiceResource = (
     ...(servingRuntimeName !== undefined && {
       servingRuntimeName: translateDisplayNameForK8s(servingRuntimeName),
     }),
+    ...{
+      storage: {
+        ...createData.storage,
+        path: removeLeadingSlashes(createData.storage.path),
+      },
+    },
   };
 
   const existingStorage =

--- a/frontend/src/utilities/__tests__/string.spec.ts
+++ b/frontend/src/utilities/__tests__/string.spec.ts
@@ -1,4 +1,9 @@
-import { replaceNonNumericPartWithString, replaceNumericPartWithString } from '~/utilities/string';
+import {
+  containsOnlySlashes,
+  removeLeadingSlashes,
+  replaceNonNumericPartWithString,
+  replaceNumericPartWithString,
+} from '~/utilities/string';
 
 describe('replaceNumericPartWithString', () => {
   it('should replace the numeric part of a string with a number', () => {
@@ -69,5 +74,38 @@ describe('replaceNonNumericPartWithString', () => {
 
   it('should handle default Pipeline scheduled time', () => {
     expect(replaceNonNumericPartWithString('1Week', 'Minute')).toBe('1Minute');
+  });
+});
+
+describe('removeLeadingSlashes', () => {
+  it('removes leading slashes from a string if present', () => {
+    expect(removeLeadingSlashes('/example')).toBe('example');
+    expect(removeLeadingSlashes('//example')).toBe('example');
+    expect(removeLeadingSlashes('//example/')).toBe('example/');
+    expect(removeLeadingSlashes('///example')).toBe('example');
+  });
+
+  it('does not modify string if it does not start with a slash', () => {
+    expect(removeLeadingSlashes('example')).toBe('example');
+  });
+
+  it('returns an empty string if input is an empty string', () => {
+    expect(removeLeadingSlashes('')).toBe('');
+  });
+});
+
+describe('containsOnlySlashes', () => {
+  it('returns true if string only contains slashes', () => {
+    expect(containsOnlySlashes('/')).toBe(true);
+    expect(containsOnlySlashes('///')).toBe(true);
+  });
+
+  it('returns false if string contains other words', () => {
+    expect(containsOnlySlashes('/test')).toBe(false);
+    expect(containsOnlySlashes('/test///')).toBe(false);
+  });
+
+  it('returns false if input string is an empty string', () => {
+    expect(containsOnlySlashes('')).toBe(false);
   });
 });

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -58,3 +58,11 @@ export const replaceNonNumericPartWithString = (
   }
   return updatedString;
 };
+
+/**
+ * This function removes the leading slash (/) from string if exists
+ */
+export const removeLeadingSlashes = (inputString: string): string =>
+  inputString.replace(/^\/+/, '');
+
+export const containsOnlySlashes = (inputString: string): boolean => /^\/+$/.test(inputString);


### PR DESCRIPTION
[RHOAIENG-542](https://issues.redhat.com/browse/RHOAIENG-542)

## Description
Removes the leading slash `/` single or multiple and throws error msg for invalid path

[Screencast from 2024-01-30 14-49-34.webm](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/32451a96-cf75-407c-a12d-b38f0e85ab80)

Invalid path

![Screenshot from 2024-01-30 14-47-38](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/1020eb0c-0619-4193-9a28-8a4e281eccf7)

Error when only slash `/` in path 

![Screenshot from 2024-01-30 14-47-30](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/1f96fa6d-bd35-40e0-a496-9cf231ef5915)


## How Has This Been Tested?
1. Deploy new model KServe or Multi model
2. Enter path name starting with '/'
3. Edit the model created, you can see the '/' removed from path.

## Test Impact
Added unit test for utility function.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@vconzola 



