### PR TITLE
added test case for useElyraSecret

### DIFF
--- a/frontend/src/__mocks__/mockSecretK8sResource.ts
+++ b/frontend/src/__mocks__/mockSecretK8sResource.ts
@@ -6,6 +6,7 @@ type MockResourceConfigType = {
   namespace?: string;
   displayName?: string;
   s3Bucket?: string;
+  uid?: string;
 };
 
 export const mockSecretK8sResource = ({
@@ -13,13 +14,14 @@ export const mockSecretK8sResource = ({
   namespace = 'test-project',
   displayName = 'Test Secret',
   s3Bucket = 'test-bucket',
+  uid = genUID('secret'),
 }: MockResourceConfigType): SecretKind => ({
   kind: 'Secret',
   apiVersion: 'route.openshift.io/v1',
   metadata: {
     name,
     namespace,
-    uid: genUID('secret'),
+    uid,
     resourceVersion: '5985371',
     creationTimestamp: '2023-03-22T16:18:56Z',
     labels: {

--- a/frontend/src/concepts/pipelines/elyra/__tests__/useElyraSecret.spec.ts
+++ b/frontend/src/concepts/pipelines/elyra/__tests__/useElyraSecret.spec.ts
@@ -1,0 +1,97 @@
+import { act } from '@testing-library/react';
+import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import useElyraSecret from '~/concepts/pipelines/elyra/useElyraSecret';
+import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+}));
+
+const k8sGetResourceMock = k8sGetResource as jest.Mock;
+
+describe('useElyraSecret', () => {
+  it('should return elyra secret when there is a DSPA', async () => {
+    k8sGetResourceMock.mockReturnValue(
+      Promise.resolve(mockSecretK8sResource({ uid: 'test-project-12m' })),
+    );
+
+    const renderResult = testHook(useElyraSecret)('test-project', true);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(mockSecretK8sResource({ uid: 'test-project-12m' }), true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sGetResourceMock.mockReturnValue(Promise.resolve(mockSecretK8sResource({})));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle when there is no DSPA', async () => {
+    testHook(useElyraSecret)('test-project', false);
+    expect(k8sGetResourceMock).toBeCalledTimes(0);
+  });
+
+  it('should handle 404 as an error', async () => {
+    const error = {
+      statusObject: {
+        code: 404,
+      },
+    };
+    k8sGetResourceMock.mockReturnValue(Promise.reject(error));
+
+    const renderResult = testHook(useElyraSecret)('test-project', true);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    await act(() => renderResult.result.current[3]());
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, true));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+
+  it('should handle other errors and rethrow', async () => {
+    k8sGetResourceMock.mockReturnValue(Promise.reject(new Error('error1')));
+
+    const renderResult = testHook(useElyraSecret)('test-project', true);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    k8sGetResourceMock.mockReturnValue(Promise.reject(new Error('error2')));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-1967

## Description
added test for frontend/src/concepts/pipelines/elyra/useElyraSecret.ts

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
test coverage
![Screenshot from 2024-01-22 16-33-31](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/72f00c74-18eb-4e04-a254-2136ef7ecd81)

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
