### PR TITLE
When creating ServingRuntime, only create ServiceAccount if it's missing and token auth is selected

### DIFF
--- a/frontend/src/__mocks__/mock409Error.ts
+++ b/frontend/src/__mocks__/mock409Error.ts
@@ -1,0 +1,10 @@
+import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+
+export const mock409Error = ({ message = '409 Conflict' }: Partial<K8sStatus>): K8sStatus => ({
+  kind: 'Status',
+  apiVersion: 'v1',
+  status: 'Failure',
+  message,
+  reason: 'AlreadyExists',
+  code: 409,
+});

--- a/frontend/src/__mocks__/mockRoleBindingK8sResource.ts
+++ b/frontend/src/__mocks__/mockRoleBindingK8sResource.ts
@@ -1,0 +1,35 @@
+import { genUID } from '~/__mocks__/mockUtils';
+import { KnownLabels, RoleBindingKind } from '~/k8sTypes';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+};
+
+export const mockRoleBindingK8sResource = ({
+  name = 'test-name-view',
+  namespace = 'test-project',
+}: MockResourceConfigType): RoleBindingKind => ({
+  kind: 'RoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name,
+    namespace,
+    uid: genUID('rolebinding'),
+    creationTimestamp: '2023-02-14T21:43:59Z',
+    labels: {
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    },
+  },
+  subjects: [
+    {
+      kind: 'ServiceAccount',
+      name: 'test-name-sa',
+    },
+  ],
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'ClusterRole',
+    name: 'view',
+  },
+});

--- a/frontend/src/__mocks__/mockServiceAccountK8sResource.ts
+++ b/frontend/src/__mocks__/mockServiceAccountK8sResource.ts
@@ -7,7 +7,7 @@ type MockResourceConfigType = {
 };
 
 export const mockServiceAccountK8sResource = ({
-  name = 'test-model-sa',
+  name = 'test-name-sa',
   namespace = 'test-project',
 }: MockResourceConfigType): ServiceAccountKind => ({
   kind: 'ServiceAccount',

--- a/frontend/src/pages/modelServing/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { resourcesArePositive } from '~/pages/modelServing/utils';
+import { resourcesArePositive, setUpTokenAuth } from '~/pages/modelServing/utils';
 import {
   mockServingRuntimeK8sResource,
   mockServingRuntimeK8sResourceLegacy,
@@ -11,6 +11,25 @@ import {
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { ContainerResources, ServingRuntimePlatform } from '~/types';
 import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
+import { mockServiceAccountK8sResource } from '~/__mocks__/mockServiceAccountK8sResource';
+import { mock404Error } from '~/__mocks__/mock404Error';
+import { mockRoleBindingK8sResource } from '~/__mocks__/mockRoleBindingK8sResource';
+import {
+  createRoleBinding,
+  createSecret,
+  createServiceAccount,
+  getRoleBinding,
+  getServiceAccount,
+} from '~/api';
+
+jest.mock('~/api', () => ({
+  ...jest.requireActual('~/api'),
+  getServiceAccount: jest.fn(),
+  createServiceAccount: jest.fn(),
+  getRoleBinding: jest.fn(),
+  createRoleBinding: jest.fn(),
+  createSecret: jest.fn(),
+}));
 
 describe('resourcesArePositive', () => {
   it('should return true for undefined limits and request', () => {
@@ -59,6 +78,88 @@ describe('resourcesArePositive', () => {
       requests: { cpu: 1, memory: '1Gi' },
     };
     expect(resourcesArePositive(resources)).toBe(true);
+  });
+});
+
+describe('setUpTokenAuth', () => {
+  const setMockImplementations = (serviceAccountAndRoleBindingAlreadyExist = false) => {
+    if (serviceAccountAndRoleBindingAlreadyExist) {
+      jest
+        .mocked(getServiceAccount)
+        .mockImplementation((name: string, namespace: string) =>
+          Promise.resolve(mockServiceAccountK8sResource({ name, namespace })),
+        );
+      jest
+        .mocked(getRoleBinding)
+        .mockImplementation((name: string, namespace: string) =>
+          Promise.resolve(mockRoleBindingK8sResource({ name, namespace })),
+        );
+    } else {
+      jest
+        .mocked(getServiceAccount)
+        .mockImplementation(() => Promise.reject({ statusObject: mock404Error({}) }));
+      jest
+        .mocked(getRoleBinding)
+        .mockImplementation(() => Promise.reject({ statusObject: mock404Error({}) }));
+    }
+  };
+
+  const fillData: Parameters<typeof setUpTokenAuth>[0] = {
+    name: 'test-name-sa',
+    servingRuntimeTemplateName: '',
+    numReplicas: 1,
+    modelSize: {
+      name: '',
+      resources: {
+        requests: {},
+        limits: {},
+      },
+    },
+    externalRoute: false,
+    tokenAuth: false,
+    tokens: [{ uuid: '', name: 'default-name', error: '' }],
+  };
+
+  it('should create service account, role binding and secrets if createTokenAuth is true', async () => {
+    setMockImplementations(false);
+    await setUpTokenAuth(
+      { ...fillData, tokenAuth: true },
+      'test-name',
+      'test-project',
+      true,
+      mockServingRuntimeK8sResource({ name: 'test-name-sa', namespace: 'test-project' }),
+    );
+    expect(createServiceAccount).toHaveBeenCalled();
+    expect(createRoleBinding).toHaveBeenCalled();
+    expect(createSecret).toHaveBeenCalled();
+  });
+
+  it('should not create service account and role binding if they already exist', async () => {
+    setMockImplementations(true);
+    await setUpTokenAuth(
+      { ...fillData, tokenAuth: true },
+      'test-name',
+      'test-project',
+      true,
+      mockServingRuntimeK8sResource({ name: 'test-name-sa', namespace: 'test-project' }),
+    );
+    expect(createServiceAccount).not.toHaveBeenCalled();
+    expect(createRoleBinding).not.toHaveBeenCalled();
+    expect(createSecret).toHaveBeenCalled();
+  });
+
+  it('should not create service account and role binding if createTokenAuth is false', async () => {
+    setMockImplementations(false);
+    await setUpTokenAuth(
+      { ...fillData, tokenAuth: false },
+      'test-name',
+      'test-project',
+      false,
+      mockServingRuntimeK8sResource({ name: 'test-name-sa', namespace: 'test-project' }),
+    );
+    expect(createServiceAccount).not.toHaveBeenCalled();
+    expect(createRoleBinding).not.toHaveBeenCalled();
+    expect(createSecret).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -352,7 +352,7 @@ export const submitServingRuntimeResources = async (
     ...(name !== undefined && { name }),
   };
   const servingRuntimeName = translateDisplayNameForK8s(servingRuntimeData.name);
-  const createRolebinding = servingRuntimeData.tokenAuth && allowCreate;
+  const createTokenAuth = servingRuntimeData.tokenAuth && allowCreate;
 
   const controlledState = isGpuDisabled(servingRuntimeSelected)
     ? { count: 0, acceleratorProfiles: [], useExisting: false }
@@ -375,7 +375,7 @@ export const submitServingRuntimeResources = async (
             servingRuntimeData,
             servingRuntimeName,
             namespace,
-            createRolebinding,
+            createTokenAuth,
             editInfo.servingRuntime,
             editInfo.secrets,
             {
@@ -399,7 +399,7 @@ export const submitServingRuntimeResources = async (
               servingRuntimeData,
               servingRuntimeName,
               namespace,
-              createRolebinding,
+              createTokenAuth,
               servingRuntime,
               editInfo?.secrets,
               {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Resolves https://issues.redhat.com/browse/RHOAIENG-554

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When deploying a model, there is a "Require token authentication" checkbox:

![Screenshot 2024-01-19 at 18 11 24](https://github.com/opendatahub-io/odh-dashboard/assets/811963/dde70d46-7233-4a67-a841-48aa70168423)

If and only if this box is checked (`servingRuntimeData.tokenAuth` is true), a ServiceAccount and RoleBinding should be created. Currently, the ServiceAccount is created even if the box is not checked. Also, the ServiceAccount creation is attempted even if a ServiceAccount of the same name already exists.

This fix ensures that the ServiceAccount and RoleBinding will only be created if the token auth box is checked AND each of them do not already exist.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reproduced the bug on the kserve-pm cluster by creating a model server with the auth checkbox unchecked and observing that the ServiceAccount still gets created. Then tested on the same cluster with my changes in place and observed that the ServiceAccount is only created if the box is checked.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added Cypress tests with new intercepts to assert that the correct network calls are being made / not being made in each case. Also added new unit tests for the `setUpTokenAuth` util function to assert that the equivalent API module functions are being called / not called in each case (`createTokenAuth` being true or false, and the SA/RB not existing / already existing).

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
