### PR TITLE
Fix a11y issues with Pipeline logs

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -9,7 +9,7 @@ import LogsTab from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/r
 import './PipelineRunDrawer.scss';
 
 enum PipelineRunNodeTabs {
-  INPUT_OUTPUT = 'Input / Output',
+  INPUT_OUTPUT = 'InputOutput',
   // VISUALIZATIONS = 'Visualizations',
   DETAILS = 'Details',
   VOLUMES = 'Volumes',
@@ -18,6 +18,13 @@ enum PipelineRunNodeTabs {
   // EVENTS = 'Events',
   // ML_METADATA = 'ML Metadata',
 }
+
+const PipelineRunNodeTabsTitles = {
+  [PipelineRunNodeTabs.INPUT_OUTPUT]: 'Input / Output',
+  [PipelineRunNodeTabs.DETAILS]: 'Details',
+  [PipelineRunNodeTabs.VOLUMES]: 'Volumes',
+  [PipelineRunNodeTabs.LOGS]: 'Logs',
+};
 
 type PipelineRunDrawerRightTabsProps = {
   task: PipelineRunTaskDetails;
@@ -55,7 +62,7 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
         {Object.values(PipelineRunNodeTabs).map((tab) => (
           <Tab
             key={tab}
-            title={tab}
+            title={PipelineRunNodeTabsTitles[tab]}
             eventKey={tab}
             tabContentId={tab}
             onClick={() => setSelection(tab)}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
@@ -23,6 +23,7 @@ const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
         <DropdownToggle
           className="pf-v5-u-px-sm"
           style={{ width: '60px' }}
+          aria-label="Download step logs"
           id="download-steps-logs-toggle"
           onToggle={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)}
         >

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -232,18 +232,16 @@ const LogsTabForPodName: React.FC<{ podName: string; isFailedPod: boolean }> = (
                       </ToolbarItem>
                     )}
                     <ToolbarItem spacer={{ default: 'spacerNone' }} style={{ maxWidth: '300px' }}>
-                      <Tooltip content="Search">
-                        <LogViewerSearch
-                          onFocus={() => setIsPaused(true)}
-                          placeholder="Search"
-                          minSearchChars={0}
-                          expandableInput={{
-                            isExpanded: showSearchbar,
-                            onToggleExpand,
-                            toggleAriaLabel: 'Expandable search input toggle',
-                          }}
-                        />
-                      </Tooltip>
+                      <LogViewerSearch
+                        onFocus={() => setIsPaused(true)}
+                        placeholder="Search"
+                        minSearchChars={0}
+                        expandableInput={{
+                          isExpanded: showSearchbar,
+                          onToggleExpand,
+                          toggleAriaLabel: 'Expandable search input toggle',
+                        }}
+                      />
                     </ToolbarItem>
                     {!podStatus?.completed && (
                       <ToolbarItem spacer={{ default: 'spacerNone' }}>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
@@ -49,7 +49,7 @@ const LogsTabStatus: React.FC<LogsTabStatusProps> = ({
       errorAlertMessage = error?.message;
     }
     return (
-      <Alert isInline variant="danger" title={errorAlertTitle}>
+      <Alert component="h2" isInline variant="danger" title={errorAlertTitle}>
         <p>{errorAlertMessage}</p>
       </Alert>
     );
@@ -61,7 +61,13 @@ const LogsTabStatus: React.FC<LogsTabStatusProps> = ({
   }
 
   return (
-    <Alert isExpandable isInline variant="warning" title="The log window displays partial content">
+    <Alert
+      component="h2"
+      isExpandable
+      isInline
+      variant="warning"
+      title="The log window displays partial content"
+    >
       <p>
         The log refreshes every {Math.floor(LOG_REFRESH_RATE / 1000)} seconds and displays the
         latest {LOG_TAIL_LINES} lines. Exceptionally long lines are abridged. To view the full log

--- a/frontend/src/pages/projects/screens/detail/pipelines/PipelinesList.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/PipelinesList.tsx
@@ -54,6 +54,7 @@ const PipelinesList: React.FC<PipelinesListProps> = ({ setIsPipelinesEmpty }) =>
           totalSize={totalSize}
           loading={!loaded}
           pipelines={pipelines}
+          aria-label="pipelines table"
           pipelineDetailsPath={(namespace, id) => `/projects/${namespace}/pipeline/view/${id}`}
           refreshPipelines={refresh}
           variant={TableVariant.compact}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes [RHOAIENG-2105](https://issues.redhat.com/browse/RHOAIENG-2105)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixing a11y issues with Pipeline logs section flagged by [axe Devtools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
1. `DownloadDropdown` button lacked an `aria-label`, Logs alert lacked a `component` prop

<img width="749" alt="Screenshot 2024-01-23 at 4 16 40 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/7543371d-d8aa-4d42-a87a-dbf30238b5c9">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Add [axe Devtools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) Chrome extension to your Chrome browser
2. Once you have Pipeline logs page open(Click on any node on any pipeline run), open Developer Tools and look for the "axe Devtools" tab, and Click on "Scan ALL of my page".
4. Do the same after clicking on the "View raw logs" from the kebab menu on the extreme right of the `LogViewer` toolbar.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Will be added in a future PR

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
