### PR TITLE
added test for useWatchSegmentKey

### DIFF
--- a/frontend/src/utilities/__tests__/useWatchSegmentKey.spec.ts
+++ b/frontend/src/utilities/__tests__/useWatchSegmentKey.spec.ts
@@ -1,0 +1,56 @@
+import { useWatchSegmentKey } from '~/utilities/useWatchSegmentKey';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { fetchSegmentKey } from '~/services/segmentKeyService';
+
+jest.mock('~/services/segmentKeyService', () => ({
+  fetchSegmentKey: jest.fn(),
+}));
+
+const fetchSegmentKeyMock = fetchSegmentKey as jest.Mock;
+
+describe('useWatchSegmentKey', () => {
+  it('should fetch segment key successfully', async () => {
+    const segmentKeyMock = {
+      segmentKey: 'test-key',
+    };
+    fetchSegmentKeyMock.mockResolvedValue(segmentKeyMock);
+
+    const renderResult = testHook(useWatchSegmentKey)();
+    expect(fetchSegmentKeyMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual({
+      segmentKey: '',
+      loaded: false,
+      loadError: undefined,
+    });
+
+    // Wait for the update
+    await renderResult.waitForNextUpdate();
+    expect(fetchSegmentKeyMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual({
+      segmentKey: 'test-key',
+      loaded: true,
+      loadError: undefined,
+    });
+  });
+
+  it('should handle errors', async () => {
+    fetchSegmentKeyMock.mockRejectedValue(new Error('error1'));
+
+    const renderResult = testHook(useWatchSegmentKey)();
+    expect(fetchSegmentKeyMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual({
+      segmentKey: '',
+      loaded: false,
+      loadError: undefined,
+    });
+
+    // Wait for the update
+    await renderResult.waitForNextUpdate();
+    expect(fetchSegmentKeyMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual({
+      segmentKey: '',
+      loaded: false,
+      loadError: new Error('error1'),
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2110

## Description
Added test for frontend/src/utilities/useWatchSegmentKey.tsx
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
test coverage :
![Screenshot from 2024-01-23 16-50-16](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/98e69b1b-9f22-481d-83e3-bd6f788a6f65)

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
