### PR TITLE
added test for accelerator Profile api

### DIFF
--- a/frontend/src/api/k8s/__tests__/acceleratorProfiles.spec.ts
+++ b/frontend/src/api/k8s/__tests__/acceleratorProfiles.spec.ts
@@ -1,0 +1,81 @@
+import { k8sGetResource, k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
+import { AcceleratorProfileModel } from '~/api/models';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { getAcceleratorProfile, listAcceleratorProfiles } from '~/api/k8s/acceleratorProfiles';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+  k8sGetResource: jest.fn(),
+}));
+
+const mockListResource = k8sListResource as jest.Mock;
+const mockGetResource = k8sGetResource as jest.Mock;
+
+describe('listAcceleratorProfile', () => {
+  it('should fetch and return list of accelerator profile', async () => {
+    const namespace = 'test-project';
+    mockListResource.mockResolvedValue(
+      mockK8sResourceList([mockAcceleratorProfile({ uid: 'test-project-12' })]),
+    );
+
+    const result = await listAcceleratorProfiles(namespace);
+    expect(mockListResource).toHaveBeenCalledWith({
+      model: AcceleratorProfileModel,
+      queryOptions: {
+        ns: namespace,
+      },
+    });
+    expect(mockListResource).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockAcceleratorProfile({ uid: 'test-project-12' })]);
+  });
+
+  it('should handle errors when fetching list of accelerator profile', async () => {
+    const namespace = 'test-project';
+    mockListResource.mockRejectedValue(new Error('error1'));
+
+    await expect(listAcceleratorProfiles(namespace)).rejects.toThrow('error1');
+    expect(mockListResource).toHaveBeenCalledTimes(1);
+    expect(mockListResource).toHaveBeenCalledWith({
+      model: AcceleratorProfileModel,
+      queryOptions: {
+        ns: namespace,
+      },
+    });
+  });
+});
+
+describe('getAcceleratorProfile', () => {
+  it('should fetch and return  specific accelerator profile', async () => {
+    const namespace = 'test-project';
+    const projectName = 'test';
+    mockGetResource.mockResolvedValue(mockAcceleratorProfile({ uid: 'test-project-12' }));
+
+    const result = await getAcceleratorProfile(projectName, namespace);
+    expect(mockGetResource).toHaveBeenCalledWith({
+      model: AcceleratorProfileModel,
+      queryOptions: {
+        name: projectName,
+        ns: namespace,
+      },
+    });
+    expect(mockGetResource).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockAcceleratorProfile({ uid: 'test-project-12' }));
+  });
+
+  it('should handle errors when fetching a specific accelerator profile', async () => {
+    const namespace = 'test-project';
+    const projectName = 'test';
+    mockGetResource.mockRejectedValue(new Error('error1'));
+
+    await expect(getAcceleratorProfile(projectName, namespace)).rejects.toThrow('error1');
+    expect(mockGetResource).toHaveBeenCalledTimes(1);
+    expect(mockGetResource).toHaveBeenCalledWith({
+      model: AcceleratorProfileModel,
+      queryOptions: {
+        name: projectName,
+        ns: namespace,
+      },
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2004

## Description
added unit test case for frontend/src/api/k8s/acceleratorProfiles.ts
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
test coverage: 
![Screenshot from 2024-01-23 16-59-29](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/aa24342a-cea7-4854-ba37-85b9d1d9d57f)

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
