### PR TITLE
Unit Test Case for useEventListener

### DIFF
--- a/frontend/src/utilities/__tests__/useEventListener.spec.ts
+++ b/frontend/src/utilities/__tests__/useEventListener.spec.ts
@@ -1,0 +1,30 @@
+import { useEventListener } from '~/utilities/useEventListener';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+
+describe('useEventListener', () => {
+  it('should add and remove event listener', () => {
+    const eventTarget: EventTarget = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    };
+
+    const mockCallback = jest.fn();
+
+    const { rerender } = testHook(useEventListener)(eventTarget, 'click', mockCallback);
+
+    // Check that the event listener is added
+    expect(eventTarget.addEventListener).toHaveBeenCalledWith('click', mockCallback);
+
+    // Rerender with the same props should not affect the event listener
+    rerender(eventTarget, 'click', mockCallback);
+    expect(eventTarget.addEventListener).toHaveBeenCalledTimes(1); // No new listener added
+
+    // Rerender with different props should remove the previous listener and add a new one
+    const newCallback = jest.fn();
+    rerender(eventTarget, 'mouseover', newCallback);
+
+    expect(eventTarget.removeEventListener).toHaveBeenCalledWith('click', mockCallback);
+    expect(eventTarget.addEventListener).toHaveBeenCalledWith('mouseover', newCallback);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-2141](https://issues.redhat.com/browse/RHOAIENG-2141)

## Description
Unit Test Case for useEventListener
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
`npm run test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<img width="717" alt="Screenshot 2024-01-24 at 3 45 37 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/c1acb45a-4cb1-40b0-a1ee-13b381f90639">

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
