### PR TITLE
Fixes stack charts broken when no datapoints available for one or more lines (RHOAIENG-535)

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -53,10 +53,10 @@ export const getModelMetricsQueries = (
   return {
     [ModelMetricType.REQUEST_COUNT_SUCCESS]: `round(sum(increase(modelmesh_api_request_milliseconds_count{namespace='${namespace}',vModelId='${name}', code='OK'}[${
       QueryTimeframeStep[ModelMetricType.REQUEST_COUNT_SUCCESS][currentTimeframe]
-    }s])))`,
+    }s]))) OR on() vector(0)`,
     [ModelMetricType.REQUEST_COUNT_FAILED]: `round(sum(increase(modelmesh_api_request_milliseconds_count{namespace='${namespace}',vModelId='${name}', code!='OK'}[${
       QueryTimeframeStep[ModelMetricType.REQUEST_COUNT_FAILED][currentTimeframe]
-    }s])))`,
+    }s]))) OR on() vector(0)`,
     [ModelMetricType.TRUSTY_AI_SPD]: `trustyai_spd{model="${name}"}`,
     [ModelMetricType.TRUSTY_AI_DIR]: `trustyai_dir{model="${name}"}`,
   };


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-535](https://issues.redhat.com//browse/RHOAIENG-535)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes an issue where metrics stack charts - specifically the Model performance http requests chart would break when there was no data for a given line. See before and after screenshots for comparison.

Before:
<img width="2560" alt="Screenshot 2024-01-24 at 11 43 24" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/b5f366db-9aef-476a-9d38-96474eaaeb11">

After:
<img width="2560" alt="Screenshot 2024-01-24 at 11 46 04" src="https://github.com/opendatahub-io/odh-dashboard/assets/4092230/fcb36381-4f21-4a96-97b9-efeb405abc87">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Navigate to the endpoint performance metric chart for a model that has no data.
2. Verify the graph does not look like the before screenshot, but instead looks like the after screenshot -- tooltip displays success 0, failed 0 and the plotted line runs along the x axis at 0.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
We currently don't have test coverage to validate what the chart looks like therefore it's not being added in this issue.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
