### PR TITLE
[RHOAIENG-2213] FT: Pipelines global - upload a new pipeline version

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/index.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/index.ts
@@ -2,3 +2,4 @@ export * from './pipelineDetails';
 export * from './pipelinesTable';
 export * from './pipelinesGlobal';
 export * from './pipelineImportModal';
+export * from './pipelineVersionImportModal';

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -7,6 +7,10 @@ class PipelineImportModal extends Modal {
     super('Import pipeline');
   }
 
+  find() {
+    return cy.findByTestId('import-pipeline-modal').parents('div[role="dialog"]');
+  }
+
   findPipelineNameInput() {
     return this.find().findByRole('textbox', { name: 'Pipeline name' });
   }
@@ -24,11 +28,11 @@ class PipelineImportModal extends Modal {
   }
 
   fillPipelineName(value: string) {
-    this.findPipelineNameInput().type(value);
+    this.findPipelineNameInput().clear().type(value);
   }
 
   fillPipelineDescription(value: string) {
-    this.findPipelineDescriptionInput().type(value);
+    this.findPipelineDescriptionInput().clear().type(value);
   }
 
   uploadPipelineYaml(filePath: string) {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -10,6 +10,15 @@ class PipelinesGlobal {
     return cy.findByTestId(this.testId);
   }
 
+  findImportPipelineButton() {
+    return cy.findByRole('button', { name: 'Import pipeline' });
+  }
+
+  findUploadVersionButton() {
+    this.find().findByLabelText('Import pipeline and pipeline version button').click();
+    return cy.findByRole('menuitem').get('span').contains('Upload new version');
+  }
+
   findProjectSelect() {
     return this.find().findByTestId('project-selector-dropdown');
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
@@ -1,5 +1,7 @@
-import { PipelineKF } from '~/concepts/pipelines/kfTypes';
+/* eslint-disable camelcase */
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import { buildMockPipelines } from '~/__mocks__/mockPipelinesProxy';
+import { buildMockPipelineVersions } from '~/__mocks__/mockPipelineVersionsProxy';
 
 class PipelinesTable {
   private testId = 'pipelines-table';
@@ -18,6 +20,30 @@ class PipelinesTable {
         pathname: '/api/proxy/apis/v1beta1/pipelines',
       },
       buildMockPipelines(pipelines),
+    );
+  }
+
+  mockPipelineVersions(projectName: string, pipelineId: string, versions: PipelineVersionKF[]) {
+    return cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/api/proxy/apis/v1beta1/pipeline_versions',
+      },
+      (req) => {
+        req.body = {
+          path: '/apis/v1beta1/pipeline_versions',
+          method: 'GET',
+          host: `https://ds-pipeline-pipelines-definition-${projectName}.apps.user.com`,
+          queryParams: {
+            sort_by: 'created_at desc',
+            page_size: 10,
+            'resource_key.id': pipelineId,
+            'resource_key.type': 'PIPELINE',
+          },
+        };
+
+        req.reply(buildMockPipelineVersions(versions));
+      },
     );
   }
 

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
@@ -65,6 +65,7 @@ const PipelineImportModal: React.FC<PipelineImportModalProps> = ({ isOpen, onClo
         </Button>,
       ]}
       variant="medium"
+      data-testid="import-pipeline-modal"
     >
       <Form>
         <Stack hasGutter>


### PR DESCRIPTION
Closes: [RHOAIENG-2213](https://issues.redhat.com/browse/RHOAIENG-2213)

### Description
Test ability to upload a new pipeline version from the pipelines global page.

### How Has This Been Tested?
Terminal 1: 
`npm run cypress:server:build`
`npm run cypress:server:dev`

Terminal 2:
`npm run cypress:run:mock` or `npm run cypress:open:mock`