### PR TITLE
dspa is not name specific anymore

### DIFF
--- a/frontend/src/__mocks__/mockDataSciencePipelinesApplicationK8sResource.ts
+++ b/frontend/src/__mocks__/mockDataSciencePipelinesApplicationK8sResource.ts
@@ -12,7 +12,7 @@ export const mockDataSciencePipelineApplicationK8sResource = ({
   apiVersion: 'datasciencepipelinesapplications.opendatahub.io/v1alpha1',
   kind: 'DataSciencePipelinesApplication',
   metadata: {
-    name: 'pipelines-definition',
+    name: 'dspa',
     namespace,
   },
   spec: {

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/GlobalPipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/GlobalPipelines.cy.ts
@@ -14,7 +14,7 @@ const initIntercepts = () => {
   cy.intercept(
     {
       pathname:
-        '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-pipelines-definition',
+        '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-dspa',
     },
     mockRouteK8sResource({ notebookName: 'ds-pipeline-pipelines-definition' }),
   );
@@ -40,7 +40,15 @@ const initIntercepts = () => {
     {
       method: 'GET',
       pathname:
-        '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/pipelines-definition',
+        '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications',
+    },
+    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({ dspVersion: 'v1' })]),
+  );
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname:
+        '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/dspa',
     },
     mockDataSciencePipelineApplicationK8sResource({ dspVersion: 'v1' }),
   );

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -202,13 +202,20 @@ const initIntercepts = () => {
   cy.intercept('/api/config', mockDashboardConfig({}));
   cy.intercept(
     {
-      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/pipelines-definition`,
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications`,
     },
-    mockDataSciencePipelineApplicationK8sResource({ namespace: projectName }),
+    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
   );
   cy.intercept(
     {
-      pathname: `/api/k8s/apis/route.openshift.io/v1/namespaces/${projectName}/routes/ds-pipeline-pipelines-definition`,
+      method: 'GET',
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/dspa`,
+    },
+    mockDataSciencePipelineApplicationK8sResource({}),
+  );
+  cy.intercept(
+    {
+      pathname: `/api/k8s/apis/route.openshift.io/v1/namespaces/${projectName}/routes/ds-pipeline-dspa`,
     },
     mockRouteK8sResource({
       notebookName: 'ds-pipeline-pipelines-definition',

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineDeleteRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineDeleteRuns.cy.ts
@@ -78,7 +78,7 @@ const initIntercepts = () => {
   cy.intercept(
     {
       pathname:
-        '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-pipelines-definition',
+        '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-dspa',
     },
     mockRouteK8sResource({ notebookName: 'ds-pipeline-pipelines-definition' }),
   );
@@ -103,10 +103,25 @@ const initIntercepts = () => {
     cy.intercept(
       {
         pathname:
-          '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/pipelines-definition',
+          '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications',
       },
-      mockDataSciencePipelineApplicationK8sResource({}),
+      mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
     );
+  cy.intercept(
+    {
+      pathname:
+        '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications',
+    },
+    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
+  );
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname:
+        '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/dspa',
+    },
+    mockDataSciencePipelineApplicationK8sResource({}),
+  );
   cy.intercept(
     {
       pathname: '/api/k8s/apis/kubeflow.org/v1/namespaces/test-project/notebooks',

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
@@ -126,13 +126,20 @@ const initIntercepts = () => {
   cy.intercept('/api/config', mockDashboardConfig({}));
   cy.intercept(
     {
-      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/pipelines-definition`,
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications`,
     },
-    mockDataSciencePipelineApplicationK8sResource({ namespace: projectName }),
+    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
   );
   cy.intercept(
     {
-      pathname: `/api/k8s/apis/route.openshift.io/v1/namespaces/${projectName}/routes/ds-pipeline-pipelines-definition`,
+      method: 'GET',
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/dspa`,
+    },
+    mockDataSciencePipelineApplicationK8sResource({}),
+  );
+  cy.intercept(
+    {
+      pathname: `/api/k8s/apis/route.openshift.io/v1/namespaces/${projectName}/routes/ds-pipeline-dspa`,
     },
     mockRouteK8sResource({
       notebookName: 'ds-pipeline-pipelines-definition',

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
@@ -62,7 +62,7 @@ const initIntercepts = () => {
   cy.intercept(
     {
       pathname:
-        '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-pipelines-definition',
+        '/api/k8s/apis/route.openshift.io/v1/namespaces/test-project/routes/ds-pipeline-dspa',
     },
     mockRouteK8sResource({ notebookName: 'ds-pipeline-pipelines-definition' }),
   );
@@ -81,10 +81,18 @@ const initIntercepts = () => {
     cy.intercept(
       {
         pathname:
-          '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/pipelines-definition',
+          '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications',
       },
-      mockDataSciencePipelineApplicationK8sResource({}),
+      mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
     );
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname:
+        '/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/test-project/datasciencepipelinesapplications/dspa',
+    },
+    mockDataSciencePipelineApplicationK8sResource({}),
+  );
   cy.intercept(
     {
       pathname: '/api/k8s/apis/kubeflow.org/v1/namespaces/test-project/notebooks',

--- a/frontend/src/api/pipelines/k8s.ts
+++ b/frontend/src/api/pipelines/k8s.ts
@@ -2,6 +2,7 @@ import {
   k8sCreateResource,
   k8sDeleteResource,
   k8sGetResource,
+  k8sListResource,
   K8sStatus,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { DataSciencePipelineApplicationModel } from '~/api/models';
@@ -9,7 +10,7 @@ import { DSPipelineKind, K8sAPIOptions, RouteKind, SecretKind } from '~/k8sTypes
 import { getRoute } from '~/api/k8s/routes';
 import { getSecret } from '~/api/k8s/secrets';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
-import { PIPELINE_DEFINITION_NAME, PIPELINE_ROUTE_NAME } from '~/concepts/pipelines/const';
+import { DEFAULT_PIPELINE_DEFINITION_NAME } from '~/concepts/pipelines/const';
 import { ELYRA_SECRET_NAME } from '~/concepts/pipelines/elyra/const';
 
 export const getElyraSecret = async (namespace: string, opts: K8sAPIOptions): Promise<SecretKind> =>
@@ -17,8 +18,9 @@ export const getElyraSecret = async (namespace: string, opts: K8sAPIOptions): Pr
 
 export const getPipelineAPIRoute = async (
   namespace: string,
+  name: string,
   opts?: K8sAPIOptions,
-): Promise<RouteKind> => getRoute(PIPELINE_ROUTE_NAME, namespace, opts);
+): Promise<RouteKind> => getRoute(name, namespace, opts);
 
 export const createPipelinesCR = async (
   namespace: string,
@@ -31,7 +33,7 @@ export const createPipelinesCR = async (
     apiVersion: `${DataSciencePipelineApplicationModel.apiGroup}/${DataSciencePipelineApplicationModel.apiVersion}`,
     kind: DataSciencePipelineApplicationModel.kind,
     metadata: {
-      name: PIPELINE_DEFINITION_NAME,
+      name: DEFAULT_PIPELINE_DEFINITION_NAME,
       namespace,
     },
     spec: {
@@ -52,22 +54,35 @@ export const createPipelinesCR = async (
 
 export const getPipelinesCR = async (
   namespace: string,
+  name: string,
   opts?: K8sAPIOptions,
 ): Promise<DSPipelineKind> =>
   k8sGetResource<DSPipelineKind>(
     applyK8sAPIOptions(opts, {
       model: DataSciencePipelineApplicationModel,
-      queryOptions: { name: PIPELINE_DEFINITION_NAME, ns: namespace },
+      queryOptions: { name, ns: namespace },
     }),
   );
 
+export const listPipelinesCR = async (
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<DSPipelineKind[]> =>
+  k8sListResource<DSPipelineKind>(
+    applyK8sAPIOptions(opts, {
+      model: DataSciencePipelineApplicationModel,
+      queryOptions: { ns: namespace },
+    }),
+  ).then((r) => r.items);
+
 export const deletePipelineCR = async (
   namespace: string,
+  name: string,
   opts?: K8sAPIOptions,
 ): Promise<K8sStatus> =>
   k8sDeleteResource<DSPipelineKind, K8sStatus>(
     applyK8sAPIOptions(opts, {
       model: DataSciencePipelineApplicationModel,
-      queryOptions: { name: PIPELINE_DEFINITION_NAME, ns: namespace },
+      queryOptions: { name, ns: namespace },
     }),
   );

--- a/frontend/src/concepts/pipelines/const.ts
+++ b/frontend/src/concepts/pipelines/const.ts
@@ -1,4 +1,4 @@
-export const PIPELINE_ROUTE_NAME = 'ds-pipeline-pipelines-definition';
-export const PIPELINE_DEFINITION_NAME = 'pipelines-definition';
+export const DEFAULT_PIPELINE_DEFINITION_NAME = 'dspa';
+export const PIPELINE_ROUTE_NAME_PREFIX = 'ds-pipeline-';
 export const TABLE_CONTENT_LIMIT = 5;
 export const LIMIT_MAX_ITEM_COUNT = TABLE_CONTENT_LIMIT + 1;

--- a/frontend/src/concepts/pipelines/content/DeletePipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelineServerModal.tsx
@@ -15,7 +15,7 @@ const DeletePipelineServerModal: React.FC<DeletePipelineServerModalProps> = ({
 }) => {
   const [deleting, setDeleting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
-  const { project, namespace } = usePipelinesAPI();
+  const { project, namespace, pipelinesServer } = usePipelinesAPI();
 
   const onBeforeClose = (deleted: boolean) => {
     onClose(deleted);
@@ -32,7 +32,7 @@ const DeletePipelineServerModal: React.FC<DeletePipelineServerModalProps> = ({
       error={error}
       onDelete={() => {
         setDeleting(true);
-        deleteServer(namespace)
+        deleteServer(namespace, pipelinesServer.name)
           .then(() => onBeforeClose(true))
           .catch((e) => {
             onBeforeClose(false);

--- a/frontend/src/concepts/pipelines/context/usePipelineNamespaceCR.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelineNamespaceCR.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DSPipelineKind } from '~/k8sTypes';
-import { getPipelinesCR } from '~/api';
+import { getPipelinesCR, listPipelinesCR } from '~/api';
 import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
 import { FAST_POLL_INTERVAL } from '~/utilities/const';
 
@@ -29,16 +29,23 @@ export const hasServerTimedOut = (
 };
 
 const usePipelineNamespaceCR = (namespace: string): FetchState<State> => {
+  const [name, setName] = React.useState<string>();
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
-    (opts) =>
-      getPipelinesCR(namespace, opts).catch((e) => {
-        if (e.statusObject?.code === 404) {
-          // Not finding is okay, not an error
-          return null;
+    (opts) => {
+      if (name) {
+        return getPipelinesCR(namespace, name, opts);
+      }
+
+      return listPipelinesCR(namespace, opts).then((r) => {
+        if (r.length > 0) {
+          setName(r[0].metadata.name);
+          return r[0];
         }
-        throw e;
-      }),
-    [namespace],
+
+        return null;
+      });
+    },
+    [name, namespace],
   );
 
   const [isStarting, setIsStarting] = React.useState(false);

--- a/frontend/src/concepts/pipelines/context/usePipelinesAPIRoute.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelinesAPIRoute.ts
@@ -7,17 +7,22 @@ import useFetchState, {
   NotReadyError,
 } from '~/utilities/useFetchState';
 import { FAST_POLL_INTERVAL } from '~/utilities/const';
+import { PIPELINE_ROUTE_NAME_PREFIX } from '~/concepts/pipelines/const';
 
 type State = string | null;
 
-const usePipelinesAPIRoute = (hasCR: boolean, namespace: string): FetchState<State> => {
+const usePipelinesAPIRoute = (
+  hasCR: boolean,
+  dspaName: string,
+  namespace: string,
+): FetchState<State> => {
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
     (opts) => {
       if (!hasCR) {
         return Promise.reject(new NotReadyError('CR not created'));
       }
 
-      return getPipelineAPIRoute(namespace, opts)
+      return getPipelineAPIRoute(namespace, PIPELINE_ROUTE_NAME_PREFIX + dspaName, opts)
         .then((result: RouteKind) => `https://${result.spec.host}`)
         .catch((e) => {
           if (e.statusObject?.code === 404) {
@@ -27,7 +32,7 @@ const usePipelinesAPIRoute = (hasCR: boolean, namespace: string): FetchState<Sta
           throw e;
         });
     },
-    [hasCR, namespace],
+    [hasCR, dspaName, namespace],
   );
 
   const state = useFetchState<State>(callback, null, {

--- a/frontend/src/concepts/pipelines/elyra/const.ts
+++ b/frontend/src/concepts/pipelines/elyra/const.ts
@@ -1,7 +1,7 @@
-import { PIPELINE_DEFINITION_NAME } from '~/concepts/pipelines/const';
+import { DEFAULT_PIPELINE_DEFINITION_NAME } from '~/concepts/pipelines/const';
 
 export const ELYRA_SECRET_NAME = 'ds-pipeline-config';
 export const ELYRA_SECRET_DATA_KEY = 'odh_dsp.json';
 export const ELYRA_SECRET_DATA_TYPE = 'cos_auth_type';
 export const ELYRA_SECRET_DATA_ENDPOINT = 'public_api_endpoint';
-export const ELYRA_ROLE_NAME = `ds-pipeline-user-access-${PIPELINE_DEFINITION_NAME}`;
+export const ELYRA_ROLE_NAME = `ds-pipeline-user-access-${DEFAULT_PIPELINE_DEFINITION_NAME}`;

--- a/frontend/src/concepts/pipelines/utils.ts
+++ b/frontend/src/concepts/pipelines/utils.ts
@@ -2,9 +2,9 @@ import { deletePipelineCR, deleteSecret } from '~/api';
 import { EXTERNAL_DATABASE_SECRET } from '~/concepts/pipelines/content/configurePipelinesServer/const';
 import { ELYRA_SECRET_NAME } from '~/concepts/pipelines/elyra/const';
 
-export const deleteServer = (namespace: string): Promise<void> =>
+export const deleteServer = (namespace: string, crName: string): Promise<void> =>
   Promise.allSettled([
     deleteSecret(namespace, EXTERNAL_DATABASE_SECRET.NAME),
     deleteSecret(namespace, ELYRA_SECRET_NAME),
-    deletePipelineCR(namespace),
+    deletePipelineCR(namespace, crName),
   ]).then(() => undefined);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-945

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- name  for new dspa is now `dspa-def`
- we now  fetch the list of dspa resources and get the first one. Empty list returns null
- adjusted get cr and delete cr to accept a name and also storing cr name in the pipelines API

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
create a pipelines server, make sure it uses new name
test that it grabs the dspa correctly

I understand there will possible issues where a user incorrectly has multiple dspas in their project. We will grab the first one so deletion will act funny, and if the add a new one that ends up at the top of the list, then their will be weird issues too. The frontend already prevents users from making multiple, but the backend team needs to also prevent this on their end.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Make sure all old test pass and grab the dspa

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
