### PR TITLE
added test case for dashboardConfig

### DIFF
--- a/frontend/src/api/k8s/__tests__/dashboardConfig.spec.ts
+++ b/frontend/src/api/k8s/__tests__/dashboardConfig.spec.ts
@@ -1,0 +1,242 @@
+import {
+  k8sGetResource,
+  k8sPatchResource,
+  k8sUpdateResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
+import {
+  getDashboardConfig,
+  getDashboardConfigTemplateDisablement,
+  getDashboardConfigTemplateOrder,
+  patchDashboardConfigTemplateDisablement,
+  patchDashboardConfigTemplateOrder,
+  updateDashboardConfig,
+} from '~/api/k8s/dashboardConfig';
+import { ODHDashboardConfigModel } from '~/api/models';
+import { DASHBOARD_CONFIG } from '~/utilities/const';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+  k8sUpdateResource: jest.fn(),
+  k8sPatchResource: jest.fn(),
+}));
+
+const k8sGetResourceMock = k8sGetResource as jest.Mock;
+const k8sUpdateResourceMock = k8sUpdateResource as jest.Mock;
+const k8sPatchResourceMock = k8sPatchResource as jest.Mock;
+const projectName = 'project-test';
+
+describe('getDashboardConfig', () => {
+  it('should successfully return dashboard config', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    k8sGetResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await getDashboardConfig(projectName);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(result).toStrictEqual(dashboardConfigurationMock);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('error'));
+
+    await expect(getDashboardConfig(projectName)).rejects.toThrow('error');
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getDashboardConfigTemplateOrder', () => {
+  it('should successfully return dashboard config template order', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+
+    k8sGetResourceMock.mockResolvedValue(dashboardConfigurationMock);
+    const result = await getDashboardConfigTemplateOrder(projectName);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(result).toStrictEqual(dashboardConfigurationMock.spec.templateOrder);
+  });
+
+  it('should return empty array when template order is not configured', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    dashboardConfigurationMock.spec.templateOrder = undefined;
+    k8sGetResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await getDashboardConfigTemplateOrder(projectName);
+    expect(result).toStrictEqual([]);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getDashboardConfigTemplateDisablement', () => {
+  it('should successfully return dashboard config template disablement', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    k8sGetResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await getDashboardConfigTemplateDisablement(projectName);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(result).toStrictEqual(dashboardConfigurationMock.spec.templateDisablement);
+  });
+
+  it('should return empty array when template disablement is not configured ', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    dashboardConfigurationMock.spec.templateDisablement = undefined;
+    k8sGetResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await getDashboardConfigTemplateDisablement(projectName);
+    expect(result).toStrictEqual([]);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle errors and rethrows', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('error'));
+    await expect(getDashboardConfigTemplateDisablement(projectName)).rejects.toThrow('error');
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+    });
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('updateDashboardConfig', () => {
+  it('should update dashboard config', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    k8sUpdateResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await updateDashboardConfig(dashboardConfigurationMock);
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      resource: dashboardConfigurationMock,
+    });
+    expect(result).toStrictEqual(dashboardConfigurationMock);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    k8sUpdateResourceMock.mockRejectedValue(new Error('error'));
+
+    await expect(updateDashboardConfig(dashboardConfigurationMock)).rejects.toThrow('error');
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      resource: dashboardConfigurationMock,
+    });
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('patchDashboardConfigTemplateOrder', () => {
+  it('should patch dashboard config template order when template order is configured', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    const templateOrder = ['test'];
+    dashboardConfigurationMock.spec.templateOrder = templateOrder;
+    k8sPatchResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await patchDashboardConfigTemplateOrder(templateOrder, projectName);
+    expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+      patches: [
+        {
+          op: 'replace',
+          path: '/spec/templateOrder',
+          value: templateOrder,
+        },
+      ],
+    });
+    expect(result).toStrictEqual(templateOrder);
+  });
+
+  it('should throw error when template order is not configured', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    dashboardConfigurationMock.spec.templateOrder = undefined;
+    const templateOrder = ['test'];
+    k8sPatchResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    await expect(patchDashboardConfigTemplateOrder(templateOrder, projectName)).rejects.toThrow(
+      'Template order is not configured',
+    );
+    expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+      patches: [
+        {
+          op: 'replace',
+          path: '/spec/templateOrder',
+          value: templateOrder,
+        },
+      ],
+    });
+  });
+});
+
+describe('patchDashboardConfigTemplateDisablement', () => {
+  it('should patch dashboard config template disablement when template order is configured', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    const templateDisablement = ['test'];
+    dashboardConfigurationMock.spec.templateDisablement = templateDisablement;
+    k8sPatchResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    const result = await patchDashboardConfigTemplateDisablement(templateDisablement, projectName);
+    expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+      patches: [
+        {
+          op: 'replace',
+          path: '/spec/templateDisablement',
+          value: templateDisablement,
+        },
+      ],
+    });
+    expect(result).toStrictEqual(templateDisablement);
+  });
+
+  it('should throw error when template disablement is not configured', async () => {
+    const dashboardConfigurationMock = mockDashboardConfig({});
+    dashboardConfigurationMock.spec.templateDisablement = undefined;
+    const templateDisablement = ['test'];
+    k8sPatchResourceMock.mockResolvedValue(dashboardConfigurationMock);
+
+    await expect(
+      patchDashboardConfigTemplateDisablement(templateDisablement, projectName),
+    ).rejects.toThrow('Template disablement is not configured');
+    expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      model: ODHDashboardConfigModel,
+      queryOptions: { name: DASHBOARD_CONFIG, ns: projectName },
+      patches: [
+        {
+          op: 'replace',
+          path: '/spec/templateDisablement',
+          value: templateDisablement,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2118

## Description
Added test case for frontend/api/k8s/dashboardConfig file
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
test coverage : 
![Screenshot from 2024-01-29 17-01-03](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/a8901102-7d85-4bf5-ac06-30dd5beb66c3)

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
