### PR TITLE
[RHOAIENG-2321] Fix Elyra Secret for new DSP Server Modal

### DIFF
--- a/frontend/src/concepts/secrets/apiHooks/useAWSSecret.ts
+++ b/frontend/src/concepts/secrets/apiHooks/useAWSSecret.ts
@@ -4,11 +4,11 @@ import useFetchState, {
   FetchStateCallbackPromise,
   NotReadyError,
 } from '~/utilities/useFetchState';
-import { DATA_CONNECTION_PREFIX, getSecret } from '~/api';
+import { getSecret } from '~/api';
 import { AWSSecretKind, SecretKind } from '~/k8sTypes';
 
 const isAWSSecret = (secret: SecretKind): secret is AWSSecretKind =>
-  secret.metadata.name.startsWith(DATA_CONNECTION_PREFIX);
+  !!secret.data?.AWS_SECRET_ACCESS_KEY && !!secret.data.AWS_ACCESS_KEY_ID;
 
 const useAWSSecret = (name: string | null, namespace: string): FetchState<AWSSecretKind | null> => {
   const callback = React.useCallback<FetchStateCallbackPromise<AWSSecretKind | null>>(


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-2321

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When the DSP Server got a rework, it no longer used Data Connections as a source for the secret name. The elyra secret was crafted using a Data Connection structure, it required the secret to be named the same thing as a data connection. That was not done, so we ended up with a fail to create the `ds-pipeline-config` secret that was attached to Notebooks for Elyra to work.

The fix is basically to change the rules to what is an AWS secret, instead of the name, it's the key and secret values. This still will present a limitation in manually crafted DSPAs, but this is a blocker for 2.6 RHOAI, so the solution is intentionally small.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a project
2. Create a DSP Server
3. See the `ds-pipeline-config` secret was created after

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
