### PR TITLE
Fix format of Pipeline logs

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -172,7 +172,8 @@ const LogsTabForPodName: React.FC<{ podName: string; isFailedPod: boolean }> = (
   } else if (!logsLoaded) {
     data = 'Loading...';
   } else if (logs) {
-    data = logs;
+    const [newlogs] = JSON.parse(logs);
+    data = newlogs;
   } else {
     data = 'No logs available';
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes [RHOAIENG-2445](https://issues.redhat.com/browse/RHOAIENG-2445)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The logs showed a `JSON` instead of `string` because of earlier changes. Fixed it to show string.

Before:

<img width="464" alt="Screenshot 2024-01-31 at 4 43 42 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/5d878b9b-50be-49ce-9b7a-83cefcc7a71a">

After:

<img width="482" alt="Screenshot 2024-01-31 at 6 44 38 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/fd840df9-3ce6-4801-ba64-9d6168c05fff">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Check the Logs tab after creating a run and clicking on a node.
2. The logs should show a string instead of an array containing `message` and `code` as well as a string.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Minor fix, tests will be added in a later PR

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
