### PR TITLE
fix rendering issue on duplicate/create run page

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection.tsx
@@ -49,7 +49,7 @@ const ParamsSection: React.FC<ParamsSectionProps> = ({ value, onChange }) => {
               type="text"
               id={`${label}-param-field`}
               name={`${label}-param-field`}
-              value={value}
+              value={value ?? ''}
               onChange={(e, newValue) => handleChange(i, { label, value: newValue })}
             />
           </FormGroup>

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -36,7 +36,7 @@ const parseKFTime = (kfTime?: DateTimeKF): RunDateTime | undefined => {
   return { date, time: time ?? DEFAULT_TIME };
 };
 
-export const useUpdateRunType = (
+const useUpdateRunType = (
   setFunction: UpdateObjectAtPropAndValue<RunFormData>,
   initialData?: PipelineRunKF | PipelineRunJobKF,
 ): void => {
@@ -78,6 +78,22 @@ export const useUpdateRunType = (
   }, [setFunction, initialData]);
 };
 
+export const useUpdateParams = (
+  setFunction: UpdateObjectAtPropAndValue<RunFormData>,
+  initialData?: PipelineRunKF | PipelineRunJobKF,
+): void => {
+  React.useEffect(() => {
+    if (!initialData?.pipeline_spec.parameters) {
+      return;
+    }
+    const params: RunParam[] = initialData?.pipeline_spec.parameters.map((p) => ({
+      label: p.name,
+      value: p.value,
+    }));
+    setFunction('params', params);
+  }, [setFunction, initialData]);
+};
+
 const getPipelineInputParams = (
   version: PipelineVersionKF | undefined,
   pipeline?: PipelineKF | undefined,
@@ -106,11 +122,7 @@ const useUpdatePipelineRunFormData = (
     if (!formData.version && version) {
       setFormValue('version', version);
     }
-
-    if (!formData.params?.length && (version || pipeline)) {
-      setFormValue('params', getPipelineInputParams(version, pipeline));
-    }
-  }, [pipeline, version, formData.pipeline, formData.version, formData.params, setFormValue]);
+  }, [pipeline, version, formData.pipeline, formData.version, setFormValue]);
 };
 
 const useRunFormData = (
@@ -135,6 +147,7 @@ const useRunFormData = (
 
   useUpdatePipelineRunFormData(runFormDataState, pipeline, version);
   useUpdateRunType(setFormValue, initialData);
+  useUpdateParams(setFormValue, initialData);
 
   return runFormDataState;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-2475

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The setting of the params is incorrect and it will cause infinite re-renders, and the user can't change the input. Create a hook to fix it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Duplicate a run/ Create a new run from the pipeline details page, make sure there is no warning in the console and you can always get the correct params of the run you are duplicating.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
