### PR TITLE
sync query data by waiting on all pending queries

### DIFF
--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -154,7 +154,7 @@ export const useModelServingMetrics = (
 
   useRefreshInterval(RefreshIntervalValue[refreshInterval], refreshAllMetrics);
 
-  return React.useMemo(
+  const result = React.useMemo(
     () => ({
       data: {
         [ServerMetricType.REQUEST_COUNT]: serverRequestCount,
@@ -180,4 +180,22 @@ export const useModelServingMetrics = (
       refreshAllMetrics,
     ],
   );
+
+  // store the result in a reference and only update the reference so long as there are no pending queries
+  const resultRef = React.useRef(result);
+  if (
+    !(
+      serverRequestCount.pending ||
+      serverAverageResponseTime.pending ||
+      serverCPUUtilization.pending ||
+      serverMemoryUtilization.pending ||
+      modelRequestSuccessCount.pending ||
+      modelRequestFailedCount.pending ||
+      modelTrustyAIDIR.pending ||
+      modelTrustyAISPD.pending
+    )
+  ) {
+    resultRef.current = result;
+  }
+  return resultRef.current;
 };

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,5 +1,5 @@
 import { TimeframeTimeRange } from '~/pages/modelServing/screens/const';
-import { ContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
+import { PrometheusQueryRangeResultValue } from '~/types';
 import useRestructureContextResourceData from '~/utilities/useRestructureContextResourceData';
 import { TimeframeStepType, TimeframeTitle } from '~/pages/modelServing/screens/types';
 import usePrometheusQueryRange, { ResponsePredicate } from './usePrometheusQueryRange';
@@ -14,7 +14,7 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   responsePredicate: ResponsePredicate<T>,
   namespace: string,
   apiPath = '/api/prometheus/serving',
-): ContextResourceData<T> =>
+): ReturnType<typeof useRestructureContextResourceData<T>> =>
   useRestructureContextResourceData<T>(
     usePrometheusQueryRange<T>(
       active,

--- a/frontend/src/utilities/useRestructureContextResourceData.tsx
+++ b/frontend/src/utilities/useRestructureContextResourceData.tsx
@@ -3,17 +3,18 @@ import { FetchState } from '~/utilities/useFetchState';
 import { ContextResourceData } from '~/types';
 
 const useRestructureContextResourceData = <T,>(
-  resourceData: FetchState<T[]>,
-): ContextResourceData<T> => {
-  const [data, loaded, error, refresh] = resourceData;
+  resourceData: [...FetchState<T[]>, boolean],
+): ContextResourceData<T> & { pending: boolean } => {
+  const [data, loaded, error, refresh, pending] = resourceData;
   return React.useMemo(
     () => ({
       data,
       loaded,
       error,
       refresh,
+      pending,
     }),
-    [data, error, loaded, refresh],
+    [data, error, loaded, refresh, pending],
   );
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2805

FYI @alexcreasy 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fixes the intermitted "spikes" which occur in the model metrics stacked chart.

Cause:
Two separate queries are issued for `successes` and `failures`. The chart sometimes updates in between query responses which causes the data set for each query to be slightly off in time. When this happens, the data points no longer stack exactly on top of each other. The spikes occur because the `failures` have data points typically of `0` or `1`; much lower than the data points of the `successes`.

Fix:
Sync data return from the context such that new data is only returned when all pending queries have finalized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using a demo project setup by @alexcreasy 
Set refresh interval to the lowest number.
Set the range equal to 1 hour.
Prior to the fix, observed frequent updates displaying a chart with many spikes.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
