### PR TITLE
Update unit test case for api/k8sUtils file

### DIFF
--- a/frontend/src/api/__tests__/k8sUtils.spec.ts
+++ b/frontend/src/api/__tests__/k8sUtils.spec.ts
@@ -2,16 +2,16 @@ import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 import { addOwnerReference } from '~/api/k8sUtils';
 
+const resource = mockSecretK8sResource({});
+
 describe('addOwnerReference', () => {
   it('should not add any owner reference for undefined owner', () => {
-    const resource = mockSecretK8sResource({});
     const target = addOwnerReference(resource, undefined);
     expect(target).toBe(resource);
     expect(target.metadata.ownerReferences).toBeUndefined();
   });
 
   it('should add owner reference only once', () => {
-    const resource = mockSecretK8sResource({});
     const owner = mockProjectK8sResource({});
     let target = addOwnerReference(resource, owner);
     expect(target).not.toBe(resource);
@@ -34,8 +34,49 @@ describe('addOwnerReference', () => {
     expect(target.metadata.ownerReferences).toHaveLength(1);
   });
 
+  it('should not add owner reference when uid is not present', () => {
+    const owner = mockProjectK8sResource({});
+    owner.metadata.uid = '';
+    const target = addOwnerReference(resource, owner);
+    expect(target).not.toBe(resource);
+    expect(target).toStrictEqual({
+      ...resource,
+      metadata: {
+        ...resource.metadata,
+        ownerReferences: [],
+      },
+    });
+  });
+
+  it('should not add owner reference when name is not present', () => {
+    const owner = mockProjectK8sResource({});
+    owner.metadata.name = '';
+    const target = addOwnerReference(resource, owner);
+    expect(target).not.toBe(resource);
+    expect(target).toStrictEqual({
+      ...resource,
+      metadata: {
+        ...resource.metadata,
+        ownerReferences: [],
+      },
+    });
+  });
+
+  it('should return owner reference when owner reference uid is equal to owner uid', () => {
+    const owner = mockProjectK8sResource({});
+    const resource = mockSecretK8sResource({ uid: 'test2' });
+    resource.metadata.ownerReferences = [{ apiVersion: '', kind: '', name: '', uid: 'test2' }];
+    const target = addOwnerReference(resource, owner);
+    expect(target).not.toBe(resource);
+    expect(target).toStrictEqual({
+      ...resource,
+      metadata: {
+        ...resource.metadata,
+        ownerReferences: resource.metadata.ownerReferences,
+      },
+    });
+  });
   it('should override blockOwnerDeletion', () => {
-    const resource = mockSecretK8sResource({});
     const owner = mockProjectK8sResource({});
     const target = addOwnerReference(resource, owner, true);
     expect(target).toStrictEqual({


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes: [RHOAIENG-2153](https://issues.redhat.com/browse/RHOAIENG-2153)

## Description
This PR aims to update unit test case for: frontend/src/api/k8sUtils.ts

## How Has This Been Tested?
`npm run test`

## Test Impact
Previous coverage:
![Screenshot from 2024-02-02 14-35-10](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/a315c30d-4932-43ff-adb1-b523594ae503)

updated coverage:
![Screenshot from 2024-02-02 16-11-38](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/a076a098-8962-4ce4-a18e-52ed4511c2cd)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
