### PR TITLE
High severity snyk issues for: @adobe/css-tools

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -156,7 +156,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
       "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",


### PR DESCRIPTION
Closes: [RHOAIENG-2551](https://issues.redhat.com/browse/RHOAIENG-2551)

## Description
Need to update @adobe/css-tools which is sub-dependency of @storybook/jest@0.1.0
This was already fixed by https://github.com/opendatahub-io/odh-dashboard/pull/2256, but seems to reintroduced with the recent feature merge with main.

## How Has This Been Tested?
Check `npm audit` in odh-dashboard/frontend

## Test Impact
Just a package update

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
