### PR TITLE
Fix ownership of parsing proxyCall() for passThroughText

### DIFF
--- a/backend/src/routes/api/k8s/index.ts
+++ b/backend/src/routes/api/k8s/index.ts
@@ -49,7 +49,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           promise = passThroughResource(fastify, req, passThroughData);
           break;
         default:
-          promise = passThroughText(fastify, req, passThroughData).then((d) => d[0]);
+          promise = passThroughText(fastify, req, passThroughData);
       }
 
       return promise.catch((error) => {

--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -42,11 +42,11 @@ export const passThroughText = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   data: PassThroughData,
-): Promise<[string, ProxyCallStatus]> => {
+): Promise<string> => {
   return (
     proxyCall(fastify, request, data)
       // TODO: is there bad text states that we want to error out on?
-      .then((rawData) => rawData) // noop intentionally until above inquiry is figured out
+      .then(([rawData]) => rawData) // noop intentionally until above inquiry is figured out
       .catch(passThroughCatch(fastify))
   );
 };


### PR DESCRIPTION
Shifting logic to the proper owner.

/cc @DaoDaoNoCode @christianvogt 