### PR TITLE
Update unit test case for servingRuntimes file

### DIFF
--- a/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
+++ b/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
@@ -1,13 +1,46 @@
+import {
+  K8sStatus,
+  k8sCreateResource,
+  k8sDeleteResource,
+  k8sGetResource,
+  k8sListResource,
+  k8sUpdateResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
 import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { mock200Status, mock404Error } from '~/__mocks__/mockK8sStatus';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
 import { mockServingRuntimeModalData } from '~/__mocks__/mockServingRuntimeModalData';
 import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
-import { assembleServingRuntime } from '~/api/k8s/servingRuntimes';
-import { ServingRuntimeKind } from '~/k8sTypes';
+import {
+  assembleServingRuntime,
+  createServingRuntime,
+  deleteServingRuntime,
+  getServingRuntime,
+  getServingRuntimeContext,
+  listScopedServingRuntimes,
+  listServingRuntimes,
+  updateServingRuntime,
+} from '~/api/k8s/servingRuntimes';
+import { ProjectKind, ServingRuntimeKind } from '~/k8sTypes';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
 
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+  k8sGetResource: jest.fn(),
+  k8sUpdateResource: jest.fn(),
+  k8sCreateResource: jest.fn(),
+  k8sDeleteResource: jest.fn(),
+}));
+
+const k8sListResourceMock = jest.mocked(k8sListResource<ServingRuntimeKind | ProjectKind>);
+const k8sGetResourceMock = jest.mocked(k8sGetResource<ServingRuntimeKind>);
+const k8sUpdateResourceMock = jest.mocked(k8sUpdateResource<ServingRuntimeKind>);
+const k8sCreateResourceMock = jest.mocked(k8sCreateResource<ServingRuntimeKind>);
+const k8sDeleteResourceMock = jest.mocked(k8sDeleteResource<ServingRuntimeKind, K8sStatus>);
 describe('assembleServingRuntime', () => {
   it('should omit enable-xxxx annotations when creating', async () => {
     const servingRuntime = assembleServingRuntime(
@@ -169,5 +202,512 @@ describe('assembleServingRuntime', () => {
     );
 
     expect(servingRuntime.spec.replicas).toBeUndefined();
+  });
+});
+
+describe('listServingRuntimes', () => {
+  it('should list serving runtimes', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([mockServingRuntimeK8sResource({})]));
+    const result = await listServingRuntimes();
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: {},
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockServingRuntimeK8sResource({})]);
+  });
+
+  it('should list serving runtimes with namespace and label selector', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([mockServingRuntimeK8sResource({})]));
+    const result = await listServingRuntimes('namespace', 'labelselector');
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'namespace', queryParams: { labelSelector: 'labelselector' } },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockServingRuntimeK8sResource({})]);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(listServingRuntimes('namespace', 'labelselector')).rejects.toThrow('error1');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'namespace', queryParams: { labelSelector: 'labelselector' } },
+    });
+  });
+});
+
+describe('listScopedServingRuntimes', () => {
+  it('should return list scoped serving runtimes with no label selector', async () => {
+    const mock = mockServingRuntimeK8sResource({});
+    k8sListResourceMock
+      .mockResolvedValueOnce(
+        mockK8sResourceList([mockProjectK8sResource({ k8sName: mock.metadata.name })]),
+      )
+      .mockResolvedValueOnce(mockK8sResourceList([mock]));
+    const result = await listScopedServingRuntimes();
+    expect(result).toStrictEqual([mock]);
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(1, {
+      model: {
+        apiGroup: 'project.openshift.io',
+        apiVersion: 'v1',
+        kind: 'Project',
+        plural: 'projects',
+      },
+      queryOptions: {
+        queryParams: { labelSelector: 'opendatahub.io/dashboard=true,modelmesh-enabled' },
+      },
+    });
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(2, {
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'test-model' },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+  });
+  it('should return list scoped serving runtimes with label selector', async () => {
+    const inferenceServiceMock = mockServingRuntimeK8sResource({});
+    const { name } = inferenceServiceMock.metadata;
+    k8sListResourceMock
+      .mockResolvedValueOnce(mockK8sResourceList([mockProjectK8sResource({ k8sName: name })]))
+      .mockResolvedValueOnce(mockK8sResourceList([inferenceServiceMock]));
+    const result = await listScopedServingRuntimes('labelSelector');
+    expect(result).toStrictEqual([inferenceServiceMock]);
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(1, {
+      model: {
+        apiGroup: 'project.openshift.io',
+        apiVersion: 'v1',
+        kind: 'Project',
+        plural: 'projects',
+      },
+      queryOptions: {
+        queryParams: { labelSelector: 'opendatahub.io/dashboard=true,modelmesh-enabled' },
+      },
+    });
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(2, {
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'test-model', queryParams: { labelSelector: 'labelSelector' } },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle errors and rethrows when failed to fetch serving runtimes', async () => {
+    const projectMock = mockProjectK8sResource({});
+    k8sListResourceMock
+      .mockResolvedValueOnce(mockK8sResourceList([projectMock]))
+      .mockRejectedValueOnce(new Error('error'));
+    await expect(listScopedServingRuntimes('labelSelector')).rejects.toThrow('error');
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(1, {
+      model: {
+        apiGroup: 'project.openshift.io',
+        apiVersion: 'v1',
+        kind: 'Project',
+        plural: 'projects',
+      },
+      queryOptions: {
+        queryParams: { labelSelector: 'opendatahub.io/dashboard=true,modelmesh-enabled' },
+      },
+    });
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(2, {
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'test-project', queryParams: { labelSelector: 'labelSelector' } },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle errors and rethrows when failed to fetch project', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error'));
+    await expect(listScopedServingRuntimes('labelSelector')).rejects.toThrow('error');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(1, {
+      model: {
+        apiGroup: 'project.openshift.io',
+        apiVersion: 'v1',
+        kind: 'Project',
+        plural: 'projects',
+      },
+      queryOptions: {
+        queryParams: { labelSelector: 'opendatahub.io/dashboard=true,modelmesh-enabled' },
+      },
+    });
+  });
+});
+
+describe('getServingRuntimeContext', () => {
+  it('should return serving runtime context with namespace', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([mockServingRuntimeK8sResource({})]));
+    const result = await getServingRuntimeContext('namespace', 'labelSelector');
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'namespace', queryParams: { labelSelector: 'labelSelector' } },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockServingRuntimeK8sResource({})]);
+  });
+
+  it('should return serving runtime context without namespace', async () => {
+    const mock = mockServingRuntimeK8sResource({});
+    k8sListResourceMock
+      .mockResolvedValueOnce(
+        mockK8sResourceList([mockProjectK8sResource({ k8sName: mock.metadata.name })]),
+      )
+      .mockResolvedValueOnce(mockK8sResourceList([mock]));
+    const result = await getServingRuntimeContext();
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(1, {
+      model: {
+        apiGroup: 'project.openshift.io',
+        apiVersion: 'v1',
+        kind: 'Project',
+        plural: 'projects',
+      },
+      queryOptions: {
+        queryParams: { labelSelector: 'opendatahub.io/dashboard=true,modelmesh-enabled' },
+      },
+    });
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(2, {
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'test-model' },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(result).toStrictEqual([mockServingRuntimeK8sResource({})]);
+  });
+
+  it('should handle errors and rethrows when failed to fetch inference service', async () => {
+    k8sListResourceMock
+      .mockResolvedValueOnce(mockK8sResourceList([mockProjectK8sResource({})]))
+      .mockRejectedValueOnce(new Error('error'));
+    await expect(getServingRuntimeContext()).rejects.toThrow('error');
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(1, {
+      model: {
+        apiGroup: 'project.openshift.io',
+        apiVersion: 'v1',
+        kind: 'Project',
+        plural: 'projects',
+      },
+      queryOptions: {
+        queryParams: { labelSelector: 'opendatahub.io/dashboard=true,modelmesh-enabled' },
+      },
+    });
+    expect(k8sListResourceMock).toHaveBeenNthCalledWith(2, {
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'test-project' },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(getServingRuntimeContext('namespace', 'labelSelector')).rejects.toThrow('error1');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { ns: 'namespace', queryParams: { labelSelector: 'labelSelector' } },
+    });
+  });
+});
+
+describe('getServingRuntime', () => {
+  it('should list serving runtimes', async () => {
+    k8sGetResourceMock.mockResolvedValue(mockServingRuntimeK8sResource({}));
+    const result = await getServingRuntime('name', 'namespace');
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { name: 'name', ns: 'namespace' },
+    });
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockServingRuntimeK8sResource({}));
+  });
+  it('should handle errors and rethrow', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(getServingRuntime('name', 'namespace')).rejects.toThrow('error1');
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { name: 'name', ns: 'namespace' },
+    });
+  });
+});
+
+describe('updateServingRuntime', () => {
+  const existingData = assembleServingRuntime(
+    mockServingRuntimeModalData({}),
+    'test',
+    mockServingRuntimeK8sResource({}),
+    true,
+    false,
+    undefined,
+    false,
+  );
+  it('should update serving runtimes when isCustomServingRuntimesEnabled is false', async () => {
+    const option = {
+      data: mockServingRuntimeModalData({}),
+      existingData,
+      isCustomServingRuntimesEnabled: false,
+    };
+    k8sUpdateResourceMock.mockResolvedValue(mockServingRuntimeK8sResource({}));
+    const result = await updateServingRuntime(option);
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { queryParams: {} },
+      resource: existingData,
+    });
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockServingRuntimeK8sResource({}));
+  });
+
+  it('should update serving runtimes when isCustomServingRuntimesEnabled is true', async () => {
+    const option = {
+      data: mockServingRuntimeModalData({}),
+      existingData,
+      isCustomServingRuntimesEnabled: true,
+    };
+    k8sUpdateResourceMock.mockResolvedValue(mockServingRuntimeK8sResource({}));
+    const result = await updateServingRuntime(option);
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { queryParams: {} },
+      resource: existingData,
+    });
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockServingRuntimeK8sResource({}));
+  });
+
+  it('should handle errors and rethrow', async () => {
+    const option = {
+      data: mockServingRuntimeModalData({}),
+      existingData,
+      isCustomServingRuntimesEnabled: true,
+    };
+    k8sUpdateResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(updateServingRuntime(option)).rejects.toThrow('error1');
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { queryParams: {} },
+      resource: existingData,
+    });
+  });
+});
+
+describe('createServingRuntime', () => {
+  const MocksevingRuntime = mockServingRuntimeK8sResource({
+    auth: false,
+    route: false,
+    displayName: 'my-inference-service',
+    name: 'my-inference-service',
+  });
+  const existingData = assembleServingRuntime(
+    mockServingRuntimeModalData({}),
+    'test',
+    MocksevingRuntime,
+    true,
+    false,
+    undefined,
+    false,
+  );
+  it('should create serving runtimes when isCustomServingRuntimesEnabled is false', async () => {
+    const option = {
+      data: mockServingRuntimeModalData({}),
+      namespace: 'test',
+      servingRuntime: existingData,
+      isCustomServingRuntimesEnabled: false,
+    };
+    k8sCreateResourceMock.mockResolvedValue(mockServingRuntimeK8sResource({}));
+    const result = await createServingRuntime(option);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { queryParams: {} },
+      resource: {
+        ...existingData,
+        metadata: { ...existingData.metadata, name: 'model-server-test' },
+      },
+    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockServingRuntimeK8sResource({}));
+  });
+
+  it('should create serving runtimes when isCustomServingRuntimesEnabled is true', async () => {
+    const option = {
+      data: mockServingRuntimeModalData({}),
+      namespace: 'test',
+      servingRuntime: existingData,
+      isCustomServingRuntimesEnabled: true,
+    };
+    k8sCreateResourceMock.mockResolvedValue(mockServingRuntimeK8sResource({}));
+    const result = await createServingRuntime(option);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { queryParams: {} },
+      resource: existingData,
+    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockServingRuntimeK8sResource({}));
+  });
+  it('should handle errors and rethrow', async () => {
+    const option = {
+      data: mockServingRuntimeModalData({}),
+      namespace: 'test',
+      servingRuntime: existingData,
+      isCustomServingRuntimesEnabled: true,
+    };
+    k8sCreateResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(createServingRuntime(option)).rejects.toThrow('error1');
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { queryParams: {} },
+      resource: existingData,
+    });
+  });
+});
+
+describe('deleteServingRuntime', () => {
+  it('should return status as Success', async () => {
+    const mockK8sStatus = mock200Status({});
+    k8sDeleteResourceMock.mockResolvedValue(mockK8sStatus);
+    const result = await deleteServingRuntime('name', 'namespace');
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { name: 'name', ns: 'namespace', queryParams: {} },
+    });
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockK8sStatus);
+  });
+
+  it('should return status as Failure', async () => {
+    const mockK8sStatus = mock404Error({});
+    k8sDeleteResourceMock.mockResolvedValue(mockK8sStatus);
+    const result = await deleteServingRuntime('name', 'namespace');
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { name: 'name', ns: 'namespace', queryParams: {} },
+    });
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockK8sStatus);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sDeleteResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(deleteServingRuntime('name', 'namespace')).rejects.toThrow('error1');
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: {
+        apiGroup: 'serving.kserve.io',
+        apiVersion: 'v1alpha1',
+        kind: 'ServingRuntime',
+        plural: 'servingruntimes',
+      },
+      queryOptions: { name: 'name', ns: 'namespace', queryParams: {} },
+    });
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes:  [RHOAIENG-2151](https://issues.redhat.com/browse/RHOAIENG-2151)

## Description
This PR aims to update unit test case for: frontend/src/api/servingRuntimes.ts

## How Has This Been Tested?
`npm run test`

## Test Impact
 Coverage:

before:
![Screenshot from 2024-02-02 17-50-42](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/8fcf2d56-cc72-4671-acd1-2c2ff170749a)

After:
![Screenshot from 2024-02-05 20-04-50](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/cbe3f9b2-946d-493d-95b4-275457f5864c)



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
