### PR TITLE
Fixes an issue where users are unable to create duplicate bias metric requests

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -293,7 +293,7 @@ export const isBiasSelectOption = (obj: SelectOptionObject): obj is BiasSelectOp
   'biasMetricConfig' in obj;
 
 export const convertInputType = (input: string): number | boolean | string => {
-  if (input.trim() !== '' && !Number.isNaN(Number(input))) {
+  if (input !== '' && !Number.isNaN(Number(input))) {
     return Number(input);
   }
   if (input.toLowerCase() === 'true') {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-2620](https://issues.redhat.com//browse/RHOAIENG-2620)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes a bug where a user could not duplicate a bias metric request unless they cleared and changed certain fields.

Note: this is a minimal fix to a regression. A flaw in the dashboard's type definitions for TrustyAI have been discovered, which are not addressed in this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a bias metric configuration
2. Attempt to "duplicate" it, leave all the values as they are presented in the form
3. Click Configure

Validate the new configuration is created successfully.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
As this is the smallest possible fix to restore functionality, it doesn't make sense to alter the tests at this stage. Fixing our types in the future will ensure the existing test coverage provides us with adequate cover.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
