### PR TITLE
Routes, feature flag, stub views and initial API request spike for Workload Metrics page

### DIFF
--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -28,6 +28,41 @@ const handleError = (e: createError.HttpError) => {
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.post(
+    '/query',
+    async (
+      request: OauthFastifyRequest<{
+        Body: { query: string };
+      }>,
+    ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
+      logRequestDetails(fastify, request);
+      const { query } = request.body;
+      return callPrometheusThanos<PrometheusQueryResponse>(fastify, request, query).catch(
+        handleError,
+      );
+    },
+  );
+
+  fastify.post(
+    '/queryRange',
+    async (
+      request: OauthFastifyRequest<{
+        Body: { query: string };
+      }>,
+    ): Promise<{ code: number; response: PrometheusQueryRangeResponse }> => {
+      logRequestDetails(fastify, request);
+      const { query } = request.body;
+      return callPrometheusThanos<PrometheusQueryRangeResponse>(
+        fastify,
+        request,
+        query,
+        QueryType.QUERY_RANGE,
+      ).catch(handleError);
+    },
+  );
+
+  // TODO the /pvc, /bias and /serving routes here should be removed in favor of the generic /query and /queryRange above
+
+  fastify.post(
     '/pvc',
     async (
       request: OauthFastifyRequest<{

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -18,6 +18,7 @@ type MockDashboardConfigType = {
   disableAcceleratorProfiles?: boolean;
   disablePerformanceMetrics?: boolean;
   disableBiasMetrics?: boolean;
+  disableDistributedWorkloads?: boolean;
 };
 
 export const mockDashboardConfig = ({
@@ -38,6 +39,7 @@ export const mockDashboardConfig = ({
   disableAcceleratorProfiles = false,
   disablePerformanceMetrics = false,
   disableBiasMetrics = false,
+  disableDistributedWorkloads = false,
 }: MockDashboardConfigType): DashboardConfigKind => ({
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',
@@ -69,6 +71,7 @@ export const mockDashboardConfig = ({
       disableKServe,
       disableModelMesh,
       disableAcceleratorProfiles,
+      disableDistributedWorkloads,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
@@ -1,0 +1,75 @@
+import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '~/__mocks__/mockDscStatus';
+import { mockStatus } from '~/__mocks__/mockStatus';
+import { mockComponents } from '~/__mocks__/mockComponents';
+import { explorePage } from '~/__tests__/cypress/cypress/pages/explore';
+import { globalDistributedWorkloads } from '~/__tests__/cypress/cypress/pages/distributedWorkloads';
+
+type HandlersProps = {
+  isKueueInstalled?: boolean;
+  disableDistributedWorkloads?: boolean;
+};
+
+const initIntercepts = ({
+  isKueueInstalled = true,
+  disableDistributedWorkloads = false,
+}: HandlersProps) => {
+  cy.intercept(
+    '/api/dsc/status',
+    mockDscStatus({
+      installedComponents: { kueue: isKueueInstalled },
+    }),
+  );
+  cy.intercept('/api/status', mockStatus());
+  cy.intercept(
+    '/api/config',
+    mockDashboardConfig({
+      disableDistributedWorkloads,
+    }),
+  );
+  cy.intercept('/api/components', mockComponents());
+
+  // TODO mturley other intercepts here
+};
+
+describe('Workload Metrics', () => {
+  it('Workload Metrics page does not exist if kueue is not installed', () => {
+    initIntercepts({
+      isKueueInstalled: false,
+      disableDistributedWorkloads: false,
+    });
+
+    explorePage.visit();
+    globalDistributedWorkloads.findNavItem().should('not.exist');
+
+    globalDistributedWorkloads.visit(false);
+    cy.findByText('We can‘t find that page').should('exist');
+  });
+
+  it('Workload Metrics page does not exist if feature is disabled', () => {
+    initIntercepts({
+      isKueueInstalled: true,
+      disableDistributedWorkloads: true,
+    });
+
+    explorePage.visit();
+    globalDistributedWorkloads.findNavItem().should('not.exist');
+
+    globalDistributedWorkloads.visit(false);
+    cy.findByText('We can‘t find that page').should('exist');
+  });
+
+  it('Workload Metrics page exists if kueue is installed and feature is enabled', () => {
+    initIntercepts({
+      isKueueInstalled: true,
+      disableDistributedWorkloads: false,
+    });
+    explorePage.visit();
+    globalDistributedWorkloads.findNavItem().should('exist');
+
+    globalDistributedWorkloads.visit();
+    globalDistributedWorkloads.findHeaderText().should('exist');
+  });
+
+  // TODO mturley other tests here for tab navigation, empty states, etc.
+});

--- a/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
@@ -1,0 +1,30 @@
+import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+
+class GlobalDistributedWorkloads {
+  visit(wait = true) {
+    cy.visitWithLogin(`/distributedWorkloads`);
+    if (wait) {
+      this.wait();
+    }
+  }
+
+  findNavItem() {
+    return appChrome.findNavItem('Workload Metrics');
+  }
+
+  navigate() {
+    this.findNavItem().click();
+    this.wait();
+  }
+
+  findHeaderText() {
+    return cy.findByText('Monitor the metrics of your active resources.');
+  }
+
+  private wait() {
+    this.findHeaderText();
+    cy.testA11y();
+  }
+}
+
+export const globalDistributedWorkloads = new GlobalDistributedWorkloads();

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -18,6 +18,8 @@ export * from './k8s/groups';
 export * from './k8s/templates';
 export * from './k8s/dashboardConfig';
 export * from './k8s/acceleratorProfiles';
+export * from './k8s/clusterQueues';
+export * from './k8s/workloads';
 
 // Pipelines uses special redirected API
 export * from './pipelines/custom';
@@ -26,6 +28,7 @@ export * from './pipelines/k8s';
 // Prometheus queries
 export * from './prometheus/pvcs';
 export * from './prometheus/serving';
+export * from './prometheus/distributedWorkloads';
 
 // Network error handling
 export * from './errorUtils';

--- a/frontend/src/api/k8s/clusterQueues.ts
+++ b/frontend/src/api/k8s/clusterQueues.ts
@@ -1,0 +1,13 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { ClusterQueueKind } from '~/k8sTypes';
+import { ClusterQueueModel } from '~/api/models/kueue';
+
+export const listClusterQueues = async (labelSelector?: string): Promise<ClusterQueueKind[]> => {
+  const queryOptions = {
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<ClusterQueueKind>({
+    model: ClusterQueueModel,
+    queryOptions,
+  });
+};

--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -1,0 +1,17 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { WorkloadKind } from '~/k8sTypes';
+import { WorkloadModel } from '~/api/models/kueue';
+
+export const listWorkloads = async (
+  namespace?: string,
+  labelSelector?: string,
+): Promise<WorkloadKind[]> => {
+  const queryOptions = {
+    ns: namespace,
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<WorkloadKind>({
+    model: WorkloadModel,
+    queryOptions,
+  });
+};

--- a/frontend/src/api/models/index.ts
+++ b/frontend/src/api/models/index.ts
@@ -2,3 +2,4 @@ export * from './k8s';
 export * from './odh';
 export * from './openShift';
 export * from './pipelines';
+export * from './kueue';

--- a/frontend/src/api/models/kueue.ts
+++ b/frontend/src/api/models/kueue.ts
@@ -1,0 +1,15 @@
+import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+export const ClusterQueueModel: K8sModelCommon = {
+  apiVersion: 'v1beta1',
+  apiGroup: 'kueue.x-k8s.io',
+  kind: 'ClusterQueue',
+  plural: 'clusterqueues',
+};
+
+export const WorkloadModel: K8sModelCommon = {
+  apiVersion: 'v1beta1',
+  apiGroup: 'kueue.x-k8s.io',
+  kind: 'Workload',
+  plural: 'workloads',
+};

--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -1,0 +1,202 @@
+import * as React from 'react';
+import { FetchStateObject, PrometheusQueryRangeResultValue } from '~/types';
+import { useMakeFetchObject } from '~/utilities/useMakeFetchObject';
+// TODO mturley these imports from ~/pages/modelServing/* should be moved somewhere page-agnostic
+import { TimeframeTitle } from '~/pages/modelServing/screens/types';
+import useRefreshInterval from '~/utilities/useRefreshInterval';
+import usePrometheusNumberValueQuery from './usePrometheusNumberValueQuery';
+import { defaultResponsePredicate } from './usePrometheusQueryRange';
+import useQueryRangeResourceData from './useQueryRangeResourceData';
+
+export type DWProjectMetricsValues = {
+  cpuRequested: number;
+  cpuUtilized: number;
+};
+export type DWProjectMetricType = keyof DWProjectMetricsValues;
+export type DWProjectMetrics = FetchStateObject<{
+  [key in DWProjectMetricType]: FetchStateObject<DWProjectMetricsValues[key] | undefined>;
+}>;
+
+// TODO mturley things to think about when it's time to implement the project metrics tab:
+//      * double-check the units we're getting back here - percent? absolute usage? int/float?
+//      * what about "utilized by all projects", how do we get that?
+//      * what about unused? do we just derive that by (all - used)?
+
+const getDWProjectMetricsQueries = (namespace: string): Record<DWProjectMetricType, string> => ({
+  cpuRequested: `namespace=${namespace}&query=kube_pod_container_resource_requests{namespace='${namespace}', resource='cpu'}`,
+  cpuUtilized: `namespace=${namespace}&query=pod:container_cpu_usage:sum{namespace='${namespace}'}`,
+});
+
+export const useDWProjectMetrics = (namespace?: string, refreshRate = 0): DWProjectMetrics => {
+  const queries = namespace ? getDWProjectMetricsQueries(namespace) : undefined;
+  const data: DWProjectMetrics['data'] = {
+    cpuRequested: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.cpuRequested, refreshRate),
+    ),
+    cpuUtilized: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.cpuUtilized, refreshRate),
+    ),
+  };
+  const cpuRequestedRefresh = data.cpuRequested.refresh;
+  const cpuUtilizedRefresh = data.cpuUtilized.refresh;
+  return {
+    data,
+    refresh: React.useCallback(() => {
+      cpuRequestedRefresh();
+      cpuUtilizedRefresh();
+    }, [cpuRequestedRefresh, cpuUtilizedRefresh]),
+    loaded: Object.values(data).every(({ loaded }) => loaded),
+    error: Object.values(data).find(({ error }) => !!error)?.error,
+  };
+};
+
+export type DWWorkloadCurrentMetricsValues = {
+  numJobsActive: number;
+  numJobsSucceeded: number;
+  numJobsFailed: number;
+  numJobsInadmissible: number;
+  numJobsPending: number;
+};
+export type DWWorkloadCurrentMetricType = keyof DWWorkloadCurrentMetricsValues;
+export type DWWorkloadCurrentMetrics = FetchStateObject<{
+  [key in DWWorkloadCurrentMetricType]: FetchStateObject<
+    DWWorkloadCurrentMetricsValues[key] | undefined
+  >;
+}>;
+
+const getDWWorkloadCurrentMetricsQueries = (
+  namespace: string,
+): Record<DWWorkloadCurrentMetricType, string> => ({
+  numJobsActive: `namespace=${namespace}&query=kube_job_status_active`,
+  numJobsSucceeded: `namespace=${namespace}&query=kube_job_status_succeeded`,
+  numJobsFailed: `namespace=${namespace}&query=kube_job_status_failed`,
+  numJobsInadmissible: `namespace=${namespace}&query=kueue_pending_workloads{status='inadmissible'}`,
+  numJobsPending: `namespace=${namespace}&query=kueue_pending_workloads{status!='inadmissible'}`,
+});
+
+export const useDWWorkloadCurrentMetrics = (
+  namespace?: string,
+  refreshRate = 0,
+): DWWorkloadCurrentMetrics => {
+  const queries = namespace ? getDWWorkloadCurrentMetricsQueries(namespace) : undefined;
+  const data: DWWorkloadCurrentMetrics['data'] = {
+    numJobsActive: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.numJobsActive, refreshRate),
+    ),
+    numJobsSucceeded: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.numJobsSucceeded, refreshRate),
+    ),
+    numJobsFailed: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.numJobsFailed, refreshRate),
+    ),
+    numJobsInadmissible: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.numJobsInadmissible, refreshRate),
+    ),
+    numJobsPending: useMakeFetchObject(
+      usePrometheusNumberValueQuery(queries?.numJobsPending, refreshRate),
+    ),
+  };
+  const numJobsActiveRefresh = data.numJobsActive.refresh;
+  const numJobsSucceededRefresh = data.numJobsSucceeded.refresh;
+  const numJobsFailedRefresh = data.numJobsFailed.refresh;
+  const numJobsInadmissibleRefresh = data.numJobsInadmissible.refresh;
+  const numJobsPendingRefresh = data.numJobsPending.refresh;
+  return {
+    data,
+    refresh: React.useCallback(() => {
+      numJobsActiveRefresh();
+      numJobsSucceededRefresh();
+      numJobsFailedRefresh();
+      numJobsInadmissibleRefresh();
+      numJobsPendingRefresh();
+    }, [
+      numJobsActiveRefresh,
+      numJobsSucceededRefresh,
+      numJobsFailedRefresh,
+      numJobsInadmissibleRefresh,
+      numJobsPendingRefresh,
+    ]),
+    loaded: Object.values(data).every(({ loaded }) => loaded),
+    error: Object.values(data).find(({ error }) => !!error)?.error,
+  };
+};
+
+export type DWWorkloadTrendMetricsValues = {
+  jobsActiveTrend: PrometheusQueryRangeResultValue[];
+  jobsInadmissibleTrend: PrometheusQueryRangeResultValue[];
+  jobsPendingTrend: PrometheusQueryRangeResultValue[];
+};
+
+export type DWWorkloadTrendMetricType = keyof DWWorkloadTrendMetricsValues;
+export type DWWorkloadTrendMetrics = FetchStateObject<{
+  [key in DWWorkloadTrendMetricType]: FetchStateObject<DWWorkloadTrendMetricsValues[key]> & {
+    pending?: boolean;
+  };
+}>;
+
+const getDWWorkloadTrendMetricsQueries = (
+  namespace: string,
+): Record<DWWorkloadTrendMetricType, string> => ({
+  jobsActiveTrend: `kube_job_status_active{namespace='${namespace}'}`,
+  jobsInadmissibleTrend: `kueue_pending_workloads{status='inadmissible', namespace='${namespace}'}`,
+  jobsPendingTrend: `kueue_pending_workloads{status!='inadmissible', namespace='${namespace}'}`,
+});
+
+export const useDWWorkloadTrendMetrics = (
+  timeframe: TimeframeTitle,
+  lastUpdateTime: number,
+  setLastUpdateTime: (time: number) => void,
+  namespace?: string,
+  refreshRate = 0,
+): DWWorkloadTrendMetrics => {
+  const [end, setEnd] = React.useState(lastUpdateTime);
+  const queries = namespace ? getDWWorkloadTrendMetricsQueries(namespace) : undefined;
+  const data: DWWorkloadTrendMetrics['data'] = {
+    jobsActiveTrend: useQueryRangeResourceData(
+      !!queries,
+      queries?.jobsActiveTrend || '',
+      end,
+      timeframe,
+      defaultResponsePredicate,
+      namespace || '',
+      '/api/prometheus/queryRange',
+    ),
+    jobsInadmissibleTrend: useQueryRangeResourceData(
+      !!queries,
+      queries?.jobsInadmissibleTrend || '',
+      end,
+      timeframe,
+      defaultResponsePredicate,
+      namespace || '',
+      '/api/prometheus/queryRange',
+    ),
+    jobsPendingTrend: useQueryRangeResourceData(
+      !!queries,
+      queries?.jobsPendingTrend || '',
+      end,
+      timeframe,
+      defaultResponsePredicate,
+      namespace || '',
+      '/api/prometheus/queryRange',
+    ),
+  };
+
+  React.useEffect(() => {
+    setLastUpdateTime(Date.now());
+    // re-compute lastUpdateTime when data changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.jobsActiveTrend, data.jobsInadmissibleTrend, data.jobsPendingTrend]);
+
+  const refreshAllMetrics = React.useCallback(() => {
+    setEnd(Date.now());
+  }, []);
+
+  useRefreshInterval(refreshRate, refreshAllMetrics);
+
+  return {
+    data,
+    refresh: refreshAllMetrics,
+    loaded: Object.values(data).every(({ loaded }) => loaded),
+    error: Object.values(data).find(({ error }) => !!error)?.error,
+  };
+};

--- a/frontend/src/api/prometheus/pvcs.ts
+++ b/frontend/src/api/prometheus/pvcs.ts
@@ -11,6 +11,7 @@ export const usePVCFreeAmount = (
     `namespace=${pvc.metadata.namespace}&query=kubelet_volume_stats_used_bytes{persistentvolumeclaim='${pvc.metadata.name}'}`,
   );
 
+  // TODO mturley we can probably get rid of this and just pass a refreshRate in fetchOptions to usePrometheusQuery
   React.useEffect(() => {
     const interval = setInterval(() => {
       refetch();

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -13,12 +13,15 @@ import {
   RefreshIntervalTitle,
   TimeframeTitle,
 } from '~/pages/modelServing/screens/types';
-import { ResponsePredicate } from '~/api/prometheus/usePrometheusQueryRange';
 import useRefreshInterval from '~/utilities/useRefreshInterval';
 import { RefreshIntervalValue } from '~/pages/modelServing/screens/const';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { PROMETHEUS_BIAS_PATH } from '~/api/prometheus/const';
 import useQueryRangeResourceData from './useQueryRangeResourceData';
+import {
+  defaultResponsePredicate,
+  prometheusQueryRangeResponsePredicate,
+} from './usePrometheusQueryRange';
 
 export const useModelServingMetrics = (
   type: PerformanceMetricType,
@@ -40,15 +43,6 @@ export const useModelServingMetrics = (
   const performanceMetricsAreaAvailable = useIsAreaAvailable(
     SupportedArea.PERFORMANCE_METRICS,
   ).status;
-
-  const defaultResponsePredicate = React.useCallback<ResponsePredicate>(
-    (data) => data.result?.[0]?.values || [],
-    [],
-  );
-
-  const prometheusQueryRangeResponsePredicate = React.useCallback<
-    ResponsePredicate<PrometheusQueryRangeResponseDataResult>
-  >((data) => data.result || [], []);
 
   const serverRequestCount = useQueryRangeResourceData(
     performanceMetricsAreaAvailable && type === PerformanceMetricType.SERVER,

--- a/frontend/src/api/prometheus/usePrometheusNumberValueQuery.ts
+++ b/frontend/src/api/prometheus/usePrometheusNumberValueQuery.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { PrometheusQueryResponse } from '~/types';
+import { FetchState } from '~/utilities/useFetchState';
+import usePrometheusQuery from './usePrometheusQuery';
+
+const parsePrometheusNumberValue = (result?: PrometheusQueryResponse | null) => {
+  const valueStr = result?.data.result[0]?.value[1];
+  return valueStr ? Number(valueStr) : undefined;
+};
+
+const usePrometheusNumberValueQuery = (
+  query?: string,
+  refreshRate = 0,
+): FetchState<number | undefined> => {
+  const [result, loaded, loadError, refetch] = usePrometheusQuery('/api/prometheus/query', query, {
+    initialPromisePurity: true,
+    refreshRate,
+  });
+  const value = React.useMemo(() => parsePrometheusNumberValue(result), [result]);
+  const refetchValue = React.useMemo(
+    () => async () => parsePrometheusNumberValue(await refetch()),
+    [refetch],
+  );
+  return [value, loaded, loadError, refetchValue];
+};
+
+export default usePrometheusNumberValueQuery;

--- a/frontend/src/api/prometheus/usePrometheusQuery.ts
+++ b/frontend/src/api/prometheus/usePrometheusQuery.ts
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import axios from 'axios';
 import { PrometheusQueryResponse } from '~/types';
-import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
+import useFetchState, { FetchOptions, FetchState, NotReadyError } from '~/utilities/useFetchState';
 
 type PromState = PrometheusQueryResponse | null;
 
-const usePrometheusQuery = (apiPath: string, query: string): FetchState<PromState> => {
+const usePrometheusQuery = (
+  apiPath: string,
+  query?: string,
+  fetchOptions?: Partial<FetchOptions>,
+): FetchState<PromState> => {
   const fetchData = React.useCallback(() => {
     if (!query) {
       return Promise.reject(new NotReadyError('No query'));
@@ -16,7 +20,7 @@ const usePrometheusQuery = (apiPath: string, query: string): FetchState<PromStat
       .then((response) => response.data.response);
   }, [query, apiPath]);
 
-  return useFetchState<PromState>(fetchData, null);
+  return useFetchState<PromState>(fetchData, null, fetchOptions);
 };
 
 export default usePrometheusQuery;

--- a/frontend/src/api/prometheus/usePrometheusQueryRange.ts
+++ b/frontend/src/api/prometheus/usePrometheusQueryRange.ts
@@ -9,6 +9,7 @@ import useFetchState, {
 import {
   PrometheusQueryRangeResponse,
   PrometheusQueryRangeResponseData,
+  PrometheusQueryRangeResponseDataResult,
   PrometheusQueryRangeResultValue,
 } from '~/types';
 
@@ -60,5 +61,11 @@ const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
 
   return [...useFetchState<T[]>(fetchData, []), pendingRef.current];
 };
+
+export const defaultResponsePredicate: ResponsePredicate = (data) => data.result?.[0]?.values || [];
+
+export const prometheusQueryRangeResponsePredicate: ResponsePredicate<
+  PrometheusQueryRangeResponseDataResult
+> = (data) => data.result || [];
 
 export default usePrometheusQueryRange;

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,3 +1,4 @@
+// TODO mturley these imports from ~/pages/modelServing/* should be moved somewhere page-agnostic
 import { TimeframeStep, TimeframeTimeRange } from '~/pages/modelServing/screens/const';
 import { PrometheusQueryRangeResultValue } from '~/types';
 import useRestructureContextResourceData from '~/utilities/useRestructureContextResourceData';

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -24,6 +24,10 @@ const GlobalPipelineRunsRoutes = React.lazy(
   () => import('../pages/pipelines/GlobalPipelineRunsRoutes'),
 );
 
+const GlobalDistributedWorkloadsRoutes = React.lazy(
+  () => import('../pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes'),
+);
+
 const ClusterSettingsPage = React.lazy(() => import('../pages/clusterSettings/ClusterSettings'));
 const CustomServingRuntimeRoutes = React.lazy(
   () => import('../pages/modelServing/customServingRuntimes/CustomServingRuntimeRoutes'),
@@ -73,6 +77,8 @@ const AppRoutes: React.FC = () => {
 
         <Route path="/pipelines/*" element={<GlobalPipelinesRoutes />} />
         <Route path="/pipelineRuns/*" element={<GlobalPipelineRunsRoutes />} />
+
+        <Route path="/distributedWorkloads/*" element={<GlobalDistributedWorkloadsRoutes />} />
 
         <Route path="/dependency-missing/:area" element={<DependencyMissingPage />} />
 

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -58,4 +58,8 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     requiredComponents: [StackComponent.TRUSTY_AI],
     reliantAreas: [SupportedArea.BIAS_METRICS],
   },
+  [SupportedArea.DISTRIBUTED_WORKLOADS]: {
+    featureFlags: ['disableDistributedWorkloads'],
+    requiredComponents: [StackComponent.KUEUE],
+  },
 };

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -40,6 +40,9 @@ export enum SupportedArea {
   BIAS_METRICS = 'bias-metrics',
   PERFORMANCE_METRICS = 'performance-metrics',
   TRUSTY_AI = 'trusty-ai',
+
+  /* Distributed Workloads areas */
+  DISTRIBUTED_WORKLOADS = 'distributed-workloads',
 }
 
 /** Components deployed by the Operator. Part of the DSC Status. */
@@ -53,6 +56,7 @@ export enum StackComponent {
   RAY = 'ray',
   WORKBENCHES = 'workbenches',
   TRUSTY_AI = 'trustyai',
+  KUEUE = 'kueue',
 }
 
 // TODO: Support extra operators, like the pipelines operator -- maybe as a "external dependency need?"

--- a/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
+++ b/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { Bullseye, Alert } from '@patternfly/react-core';
+import { ClusterQueueKind, WorkloadKind } from '~/k8sTypes';
+import { FetchStateObject } from '~/types';
+import {
+  DEFAULT_LIST_FETCH_STATE,
+  DEFAULT_VALUE_FETCH_STATE,
+  POLL_INTERVAL,
+} from '~/utilities/const';
+import { SupportedArea, conditionalArea } from '~/concepts/areas';
+import { useMakeFetchObject } from '~/utilities/useMakeFetchObject';
+import {
+  DWProjectMetrics,
+  DWWorkloadCurrentMetrics,
+  DWWorkloadTrendMetrics,
+  useDWProjectMetrics,
+  useDWWorkloadCurrentMetrics,
+  useDWWorkloadTrendMetrics,
+} from '~/api';
+// TODO mturley these imports from ~/pages/modelServing/* should be moved somewhere page-agnostic
+import { TimeframeTitle } from '~/pages/modelServing/screens/types';
+import useClusterQueues from './useClusterQueues';
+import useWorkloads from './useWorkloads';
+
+type DistributedWorkloadsContextType = {
+  clusterQueues: FetchStateObject<ClusterQueueKind[]>;
+  workloads: FetchStateObject<WorkloadKind[]>;
+  projectMetrics: DWProjectMetrics;
+  workloadCurrentMetrics: DWWorkloadCurrentMetrics;
+  workloadTrendMetrics: DWWorkloadTrendMetrics;
+  refreshAllData: () => void;
+  refreshRate: number;
+  setRefreshRate: (interval: number) => void;
+  lastUpdateTime: number;
+  setLastUpdateTime: (time: number) => void;
+  namespace?: string;
+};
+
+type DistributedWorkloadsContextProviderProps = {
+  children: React.ReactNode;
+  namespace?: string;
+};
+
+export const DistributedWorkloadsContext = React.createContext<DistributedWorkloadsContextType>({
+  clusterQueues: DEFAULT_LIST_FETCH_STATE,
+  workloads: DEFAULT_LIST_FETCH_STATE,
+  projectMetrics: {
+    ...DEFAULT_VALUE_FETCH_STATE,
+    data: {
+      cpuRequested: DEFAULT_VALUE_FETCH_STATE,
+      cpuUtilized: DEFAULT_VALUE_FETCH_STATE,
+    },
+  },
+  workloadCurrentMetrics: {
+    ...DEFAULT_VALUE_FETCH_STATE,
+    data: {
+      numJobsActive: DEFAULT_VALUE_FETCH_STATE,
+      numJobsFailed: DEFAULT_VALUE_FETCH_STATE,
+      numJobsSucceeded: DEFAULT_VALUE_FETCH_STATE,
+      numJobsInadmissible: DEFAULT_VALUE_FETCH_STATE,
+      numJobsPending: DEFAULT_VALUE_FETCH_STATE,
+    },
+  },
+  workloadTrendMetrics: {
+    ...DEFAULT_VALUE_FETCH_STATE,
+    data: {
+      jobsActiveTrend: DEFAULT_LIST_FETCH_STATE,
+      jobsInadmissibleTrend: DEFAULT_LIST_FETCH_STATE,
+      jobsPendingTrend: DEFAULT_LIST_FETCH_STATE,
+    },
+  },
+  refreshAllData: () => undefined,
+  refreshRate: POLL_INTERVAL,
+  setRefreshRate: () => undefined,
+  lastUpdateTime: 0,
+  setLastUpdateTime: () => undefined,
+});
+
+export const DistributedWorkloadsContextProvider =
+  conditionalArea<DistributedWorkloadsContextProviderProps>(
+    SupportedArea.DISTRIBUTED_WORKLOADS,
+    true,
+  )(({ children, namespace }) => {
+    const [refreshRate, setRefreshRate] = React.useState(POLL_INTERVAL);
+    const [lastUpdateTime, setLastUpdateTime] = React.useState<number>(Date.now());
+
+    // TODO mturley implement lazy loading, let the context consumers tell us what data they need and make the other ones throw a NotReadyError
+
+    const clusterQueues = useMakeFetchObject<ClusterQueueKind[]>(useClusterQueues(refreshRate));
+    const workloads = useMakeFetchObject<WorkloadKind[]>(useWorkloads(namespace, refreshRate));
+    const projectMetrics = useDWProjectMetrics(namespace, refreshRate);
+    const workloadCurrentMetrics = useDWWorkloadCurrentMetrics(namespace, refreshRate);
+
+    // TODO mturley this timeframe param is a placeholder, wire it up to real timeframe selector state
+    const workloadTrendMetrics = useDWWorkloadTrendMetrics(
+      TimeframeTitle.ONE_DAY,
+      lastUpdateTime,
+      setLastUpdateTime,
+      namespace,
+      refreshRate,
+    );
+
+    const clusterQueuesRefresh = clusterQueues.refresh;
+    const workloadsRefresh = workloads.refresh;
+    const projectMetricsRefresh = projectMetrics.refresh;
+    const workloadCurrentMetricsRefresh = workloadCurrentMetrics.refresh;
+    const workloadTrendMetricsRefresh = workloadTrendMetrics.refresh;
+    const refreshAllData = React.useCallback(() => {
+      clusterQueuesRefresh();
+      workloadsRefresh();
+      projectMetricsRefresh();
+      workloadCurrentMetricsRefresh();
+      workloadTrendMetricsRefresh();
+    }, [
+      clusterQueuesRefresh,
+      workloadsRefresh,
+      projectMetricsRefresh,
+      workloadCurrentMetricsRefresh,
+      workloadTrendMetricsRefresh,
+    ]);
+
+    const fetchError = [clusterQueues, workloads, projectMetrics, workloadCurrentMetrics].find(
+      ({ error }) => !!error,
+    )?.error;
+
+    if (fetchError) {
+      return (
+        <Bullseye>
+          <Alert title="Workload metrics load error" variant="danger" isInline>
+            {fetchError.message}
+          </Alert>
+        </Bullseye>
+      );
+    }
+
+    return (
+      <DistributedWorkloadsContext.Provider
+        value={{
+          clusterQueues,
+          workloads,
+          projectMetrics,
+          workloadCurrentMetrics,
+          workloadTrendMetrics,
+          refreshAllData,
+          refreshRate,
+          setRefreshRate,
+          lastUpdateTime,
+          setLastUpdateTime,
+          namespace,
+        }}
+      >
+        {children}
+      </DistributedWorkloadsContext.Provider>
+    );
+  });

--- a/frontend/src/concepts/distributedWorkloads/useClusterQueues.ts
+++ b/frontend/src/concepts/distributedWorkloads/useClusterQueues.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { ClusterQueueKind } from '~/k8sTypes';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
+import { listClusterQueues } from '~/api';
+
+const useClusterQueues = (refreshRate = 0): FetchState<ClusterQueueKind[]> => {
+  const dwEnabled = useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+  return useFetchState<ClusterQueueKind[]>(
+    React.useCallback(() => {
+      if (!dwEnabled) {
+        return Promise.reject(new NotReadyError('Distributed workloads is not enabled'));
+      }
+      return listClusterQueues();
+    }, [dwEnabled]),
+    [],
+    { refreshRate },
+  );
+};
+
+export default useClusterQueues;

--- a/frontend/src/concepts/distributedWorkloads/useWorkloads.ts
+++ b/frontend/src/concepts/distributedWorkloads/useWorkloads.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { WorkloadKind } from '~/k8sTypes';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
+import { listWorkloads } from '~/api';
+
+const useWorkloads = (namespace?: string, refreshRate = 0): FetchState<WorkloadKind[]> => {
+  const dwEnabled = useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+  return useFetchState<WorkloadKind[]>(
+    React.useCallback(() => {
+      if (!dwEnabled) {
+        return Promise.reject(new NotReadyError('Distributed workloads is not enabled'));
+      }
+      return listWorkloads(namespace);
+    }, [dwEnabled, namespace]),
+    [],
+    { refreshRate },
+  );
+};
+
+export default useWorkloads;

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -34,6 +34,8 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     ? projects.filter((project) => project.metadata.labels?.[filterLabel] !== undefined)
     : projects;
 
+  const toggleLabel = projects.length === 0 ? 'No projects' : selectionDisplayName;
+
   return (
     <Dropdown
       toggle={
@@ -41,8 +43,9 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           isDisabled={projects.length === 0}
           onToggle={() => setDropdownOpen(!dropdownOpen)}
           toggleVariant={primary ? 'primary' : undefined}
+          aria-label={`Project: ${toggleLabel}`}
         >
-          {projects.length === 0 ? 'No projects' : selectionDisplayName}
+          {toggleLabel}
         </DropdownToggle>
       }
       isOpen={dropdownOpen}

--- a/frontend/src/pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes.tsx
+++ b/frontend/src/pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Navigate, Route } from 'react-router-dom';
+import ProjectsRoutes from '~/concepts/projects/ProjectsRoutes';
+
+import { useDistributedWorkloadsTabs } from '~/pages/distributedWorkloads/global/useDistributedWorkloadsTabs';
+import GlobalDistributedWorkloads from '~/pages/distributedWorkloads/global/GlobalDistributedWorkloads';
+import NotFound from '~/pages/NotFound';
+
+const GlobalDistributedWorkloadsRoutes: React.FC = () => {
+  const tabs = useDistributedWorkloadsTabs();
+  const firstAvailableTab = tabs.find((tab) => tab.isAvailable);
+
+  return (
+    <ProjectsRoutes>
+      {firstAvailableTab && (
+        <Route index element={<Navigate to={firstAvailableTab.path} replace />} />
+      )}
+      {tabs
+        .filter((tab) => tab.isAvailable)
+        .map((tab) => (
+          <Route
+            key={tab.id}
+            path={`${tab.path}${tab.projectSelectorMode !== null ? '/:namespace?' : ''}`}
+            element={
+              <GlobalDistributedWorkloads
+                activeTab={tab}
+                getInvalidRedirectPath={(namespace) =>
+                  `/distributedWorkloads/${tab.path}/${namespace}`
+                }
+              />
+            }
+          />
+        ))}
+      <Route path="*" element={<NotFound />} />
+    </ProjectsRoutes>
+  );
+};
+
+export default GlobalDistributedWorkloadsRoutes;

--- a/frontend/src/pages/distributedWorkloads/global/DistributedWorkloadsNoProjects.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/DistributedWorkloadsNoProjects.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateFooter,
+} from '@patternfly/react-core';
+import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
+import { useNavigate } from 'react-router-dom';
+import NewProjectButton from '~/pages/projects/screens/projects/NewProjectButton';
+
+const DistributedWorkloadsNoProjects: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <EmptyState>
+      <EmptyStateHeader
+        titleText="No data science projects"
+        icon={<EmptyStateIcon icon={WrenchIcon} />}
+        headingLevel="h4"
+      />
+      <EmptyStateBody>
+        To view workload metrics, first create a data science project.
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <NewProjectButton
+          closeOnCreate
+          onProjectCreated={() => navigate('/distributedWorkloads')}
+        />
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+};
+
+export default DistributedWorkloadsNoProjects;

--- a/frontend/src/pages/distributedWorkloads/global/DistributedWorkloadsToolbar.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/DistributedWorkloadsToolbar.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import ProjectSelectorNavigator from '~/concepts/projects/ProjectSelectorNavigator';
+import { DistributedWorkloadsTabConfig } from './useDistributedWorkloadsTabs';
+
+type DistributedWorkloadsToolbarProps = {
+  tabConfig: DistributedWorkloadsTabConfig;
+};
+
+// TODO mturley reuse what's in MetricsPageToolbar and address the tech debt referenced in comments there
+
+const DistributedWorkloadsToolbar: React.FC<DistributedWorkloadsToolbarProps> = ({ tabConfig }) => (
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarItem variant="label">Project</ToolbarItem>
+      <ToolbarItem spacer={{ default: 'spacerMd' }}>
+        <ProjectSelectorNavigator
+          getRedirectPath={(newNamespace) =>
+            `/distributedWorkloads/${tabConfig.path}/${newNamespace}`
+          }
+        />
+      </ToolbarItem>
+      <ToolbarItem variant="label">Refresh interval</ToolbarItem>
+      <ToolbarItem spacer={{ default: 'spacerMd' }}>TODO dropdown here</ToolbarItem>
+      <ToolbarItem variant="label">Time range</ToolbarItem>
+      <ToolbarItem spacer={{ default: 'spacerMd' }}>TODO dropdown here</ToolbarItem>
+    </ToolbarContent>
+  </Toolbar>
+);
+export default DistributedWorkloadsToolbar;

--- a/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloads.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
+import InvalidProject from '~/concepts/projects/InvalidProject';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import { DistributedWorkloadsContextProvider } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import { DistributedWorkloadsTabConfig } from '~/pages/distributedWorkloads/global/useDistributedWorkloadsTabs';
+import DistributedWorkloadsNoProjects from '~/pages/distributedWorkloads/global/DistributedWorkloadsNoProjects';
+import GlobalDistributedWorkloadsTabs from '~/pages/distributedWorkloads/global/GlobalDistributedWorkloadsTabs';
+
+const title = 'Workload Metrics';
+const description = 'Monitor the metrics of your active resources.';
+
+type GlobalDistributedWorkloadsProps = {
+  activeTab: DistributedWorkloadsTabConfig;
+  getInvalidRedirectPath: (namespace: string) => string;
+};
+
+const GlobalDistributedWorkloads: React.FC<GlobalDistributedWorkloadsProps> = ({
+  activeTab,
+  getInvalidRedirectPath,
+}) => {
+  const { namespace } = useParams<{ namespace: string }>();
+  const { projects, preferredProject } = React.useContext(ProjectsContext);
+
+  if (projects.length === 0) {
+    return (
+      <ApplicationsPage
+        {...{ title, description }}
+        loaded
+        empty
+        emptyStatePage={<DistributedWorkloadsNoProjects />}
+      />
+    );
+  }
+
+  if (activeTab.projectSelectorMode !== null) {
+    if (!namespace && (activeTab.projectSelectorMode === 'singleProjectOnly' || preferredProject)) {
+      // No namespace is in the path and either this tab requires one or we have a preferred one to go to
+      const redirectProject = preferredProject ?? projects[0];
+      return <Navigate to={getInvalidRedirectPath(redirectProject.metadata.name)} replace />;
+    }
+    if (namespace && !projects.find(byName(namespace))) {
+      // This tab allows or requires a namespace but was given an invalid one.
+      return (
+        <ApplicationsPage
+          {...{ title, description }}
+          loaded
+          empty
+          emptyStatePage={
+            <InvalidProject namespace={namespace} getRedirectPath={getInvalidRedirectPath} />
+          }
+        />
+      );
+    }
+  }
+
+  // We're all good, either no namespace is required or we have a valid one
+  return (
+    <ApplicationsPage {...{ title, description }} loaded empty={false}>
+      <DistributedWorkloadsContextProvider namespace={namespace}>
+        <GlobalDistributedWorkloadsTabs activeTabId={activeTab.id} />
+      </DistributedWorkloadsContextProvider>
+    </ApplicationsPage>
+  );
+};
+
+export default GlobalDistributedWorkloads;

--- a/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Bullseye, PageSection, Spinner, TabContent, TabContentBody } from '@patternfly/react-core';
+import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
+import { DistributedWorkloadsTabConfig } from './useDistributedWorkloadsTabs';
+import DistributedWorkloadsToolbar from './DistributedWorkloadsToolbar';
+
+// TODO mturley render a "no data" state when we get undefined back for some metrics - why might we hit this? is there a message we can display about making sure things are configured correctly?
+
+type GlobalDistributedWorkloadsProjectMetricsTabProps = {
+  tabConfig: DistributedWorkloadsTabConfig;
+};
+
+const GlobalDistributedWorkloadsProjectMetricsTab: React.FC<
+  GlobalDistributedWorkloadsProjectMetricsTabProps
+> = ({ tabConfig }) => {
+  const { projectMetrics, namespace } = React.useContext(DistributedWorkloadsContext);
+
+  if (projectMetrics.error) {
+    return (
+      <EmptyStateErrorMessage
+        title="Error loading workload metrics"
+        bodyText={projectMetrics.error.message}
+      />
+    );
+  }
+
+  if (!projectMetrics.loaded) {
+    return (
+      <PageSection isFilled>
+        <Bullseye style={{ minHeight: 150 }}>
+          <Spinner />
+        </Bullseye>
+      </PageSection>
+    );
+  }
+
+  const { cpuRequested, cpuUtilized } = projectMetrics.data;
+
+  return (
+    <>
+      <DistributedWorkloadsToolbar tabConfig={tabConfig} />
+      <PageSection isFilled>
+        <TabContent
+          id={`${tabConfig.id}-tab-content`}
+          activeKey={tabConfig.id}
+          eventKey={tabConfig.id}
+          key={tabConfig.id}
+        >
+          <TabContentBody>
+            <h1>TODO tab content for project metrics -- these are placeholders</h1>
+            <br />
+            <h1>
+              CPU requested for project {namespace}: {cpuRequested.data}
+            </h1>
+            <h1>
+              CPU utilized for project {namespace}: {cpuUtilized.data}
+            </h1>
+          </TabContentBody>
+        </TabContent>
+      </PageSection>
+    </>
+  );
+};
+
+export default GlobalDistributedWorkloadsProjectMetricsTab;

--- a/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsTabs.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsTabs.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Tabs, Tab, TabTitleText, PageSection } from '@patternfly/react-core';
+import {
+  DistributedWorkloadsTabId,
+  useDistributedWorkloadsTabs,
+} from './useDistributedWorkloadsTabs';
+
+type GlobalDistributedWorkloadsTabsProps = {
+  activeTabId: DistributedWorkloadsTabId;
+};
+
+const GlobalDistributedWorkloadsTabs: React.FC<GlobalDistributedWorkloadsTabsProps> = ({
+  activeTabId,
+}) => {
+  const navigate = useNavigate();
+  const tabs = useDistributedWorkloadsTabs();
+  const activeTab = tabs.find(({ id }) => id === activeTabId);
+  const { namespace } = useParams<{ namespace: string }>();
+  return (
+    <>
+      <PageSection variant="light" type="tabs">
+        <Tabs
+          activeKey={activeTabId}
+          onSelect={(_, tabId) => {
+            const tab = tabs.find(({ id }) => id === tabId);
+            if (tab) {
+              const namespaceSuffix = tab.projectSelectorMode && !!namespace ? `/${namespace}` : '';
+              navigate(`/distributedWorkloads/${tab.path}${namespaceSuffix}`);
+            }
+          }}
+          aria-label="Workload metrics page tabs"
+          role="region"
+        >
+          {tabs
+            .filter((tab) => tab.isAvailable)
+            .map((tab) => (
+              <Tab
+                key={tab.id}
+                eventKey={tab.id}
+                title={<TabTitleText>{tab.title}</TabTitleText>}
+                aria-label={`${tab.title} tab`}
+                tabContentId={`${tab.id}-tab-content`}
+              />
+            ))}
+        </Tabs>
+      </PageSection>
+      {activeTab && <activeTab.ContentComponent tabConfig={activeTab} />}
+    </>
+  );
+};
+
+export default GlobalDistributedWorkloadsTabs;

--- a/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsWorkloadStatusTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsWorkloadStatusTab.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { Bullseye, PageSection, Spinner, TabContent, TabContentBody } from '@patternfly/react-core';
+import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
+import { DistributedWorkloadsTabConfig } from './useDistributedWorkloadsTabs';
+import DistributedWorkloadsToolbar from './DistributedWorkloadsToolbar';
+
+type GlobalDistributedWorkloadsWorkloadStatusTabProps = {
+  tabConfig: DistributedWorkloadsTabConfig;
+};
+
+const GlobalDistributedWorkloadsWorkloadStatusTab: React.FC<
+  GlobalDistributedWorkloadsWorkloadStatusTabProps
+> = ({ tabConfig }) => {
+  const { workloads, workloadCurrentMetrics, workloadTrendMetrics, namespace } = React.useContext(
+    DistributedWorkloadsContext,
+  );
+
+  const error = workloads.error || workloadCurrentMetrics.error || workloadTrendMetrics.error;
+  if (error) {
+    return (
+      <EmptyStateErrorMessage title="Error loading workload metrics" bodyText={error.message} />
+    );
+  }
+
+  if (!workloads.loaded || !workloadCurrentMetrics.loaded || !workloadTrendMetrics.loaded) {
+    return (
+      <PageSection isFilled>
+        <Bullseye style={{ minHeight: 150 }}>
+          <Spinner />
+        </Bullseye>
+      </PageSection>
+    );
+  }
+
+  const { numJobsActive, numJobsFailed, numJobsSucceeded, numJobsInadmissible, numJobsPending } =
+    workloadCurrentMetrics.data;
+
+  const { jobsActiveTrend, jobsInadmissibleTrend, jobsPendingTrend } = workloadTrendMetrics.data;
+
+  return (
+    <>
+      <DistributedWorkloadsToolbar tabConfig={tabConfig} />
+      <PageSection isFilled>
+        <TabContent
+          id={tabConfig.id}
+          activeKey={tabConfig.id}
+          eventKey={tabConfig.id}
+          key={tabConfig.id}
+        >
+          <TabContentBody>
+            <h1>TODO tab content for job metrics -- these are placeholders</h1>
+            <br />
+            <h1>Workloads matching statuses in project {namespace}:</h1>
+            <ul>
+              <li>Running: {numJobsActive.data}</li>
+              <li>Succeeded: {numJobsSucceeded.data}</li>
+              <li>Failed: {numJobsFailed.data}</li>
+              <li>Inadmissible: {numJobsInadmissible.data}</li>
+              <li>Pending: {numJobsPending.data}</li>
+            </ul>
+            <br />
+            <h1>Workloads for project {namespace}:</h1>
+            <pre>{JSON.stringify(workloads.data, undefined, 4)}</pre>
+            <br />
+            <h1>Active jobs trend:</h1>
+            <pre>{JSON.stringify(jobsActiveTrend.data)}</pre>
+            <br />
+            <h1>Inadmissible jobs trend:</h1>
+            <pre>{JSON.stringify(jobsInadmissibleTrend.data)}</pre>
+            <br />
+            <h1>Pending jobs trend:</h1>
+            <pre>{JSON.stringify(jobsPendingTrend.data)}</pre>
+            <br />
+          </TabContentBody>
+        </TabContent>
+      </PageSection>
+    </>
+  );
+};
+export default GlobalDistributedWorkloadsWorkloadStatusTab;

--- a/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import GlobalDistributedWorkloadsProjectMetricsTab from './GlobalDistributedWorkloadsProjectMetricsTab';
+import GlobalDistributedWorkloadsWorkloadStatusTab from './GlobalDistributedWorkloadsWorkloadStatusTab';
+
+export enum DistributedWorkloadsTabId {
+  PROJECT_METRICS = 'project-metrics',
+  WORKLOAD_STATUS = 'workload-status',
+}
+
+export type DistributedWorkloadsTabConfig = {
+  id: DistributedWorkloadsTabId;
+  title: string;
+  path: string;
+  isAvailable: boolean;
+  // TODO mturley remove this now that all our tabs here are single project only, or leave in case we add future tabs?
+  projectSelectorMode: 'singleProjectOnly' | 'projectOrAll' | null;
+  ContentComponent: React.FC<{ tabConfig: DistributedWorkloadsTabConfig }>;
+};
+
+export const useDistributedWorkloadsTabs = (): DistributedWorkloadsTabConfig[] => {
+  const dwAreaIsAvailable = useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+  return [
+    {
+      id: DistributedWorkloadsTabId.PROJECT_METRICS,
+      title: 'Project metrics',
+      path: 'projectMetrics',
+      isAvailable: dwAreaIsAvailable,
+      projectSelectorMode: 'singleProjectOnly',
+      ContentComponent: GlobalDistributedWorkloadsProjectMetricsTab,
+    },
+    {
+      id: DistributedWorkloadsTabId.WORKLOAD_STATUS,
+      title: 'Workload status',
+      path: 'workloadStatus',
+      isAvailable: dwAreaIsAvailable,
+      projectSelectorMode: 'singleProjectOnly',
+      ContentComponent: GlobalDistributedWorkloadsWorkloadStatusTab,
+    },
+  ];
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -684,12 +684,15 @@ export type ImageStreamAndVersion = {
   imageVersion?: ImageStreamSpecTagType;
 };
 
-export type ContextResourceData<T> = {
-  data: T[];
+export type FetchStateObject<T, E = Error> = {
+  data: T;
   loaded: boolean;
-  error?: Error | AxiosError;
+  error?: E;
   refresh: () => void;
 };
+
+// TODO this and useContextResourceData should probably be removed in favor of useMakeFetchObject
+export type ContextResourceData<T> = FetchStateObject<T[], Error | AxiosError>;
 
 export type BreadcrumbItemType = {
   label: string;

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -90,6 +90,11 @@ const useDSPipelinesNav = (): NavDataItem[] => {
   ];
 };
 
+const useDistributedWorkloadsNav = (): NavDataItem[] =>
+  useAreaCheck(SupportedArea.DISTRIBUTED_WORKLOADS, [
+    { id: 'workloadMetrics', label: 'Workload Metrics', href: '/distributedWorkloads' },
+  ]);
+
 const useModelServingNav = (): NavDataItem[] =>
   useAreaCheck(SupportedArea.MODEL_SERVING, [
     { id: 'modelServing', label: 'Model Serving', href: '/modelServing' },
@@ -171,6 +176,7 @@ export const useBuildNavData = (): NavDataItem[] => [
   ...useApplicationsNav(),
   ...useDSProjectsNav(),
   ...useDSPipelinesNav(),
+  ...useDistributedWorkloadsNav(),
   ...useModelServingNav(),
   ...useResourcesNav(),
   ...useSettingsNav(),

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -1,4 +1,4 @@
-import { ContextResourceData, OdhDocumentType } from '~/types';
+import { ContextResourceData, FetchStateObject, OdhDocumentType } from '~/types';
 
 const WS_HOSTNAME = process.env.WS_HOSTNAME || location.host;
 const DEV_MODE = process.env.APP_ENV === 'development';
@@ -43,6 +43,18 @@ export const CATEGORY_ANNOTATION = 'opendatahub.io/categories';
 
 export const DEFAULT_CONTEXT_DATA: ContextResourceData<never> = {
   data: [],
+  loaded: false,
+  refresh: () => undefined,
+};
+
+export const DEFAULT_LIST_FETCH_STATE: FetchStateObject<never[]> = {
+  data: [],
+  loaded: false,
+  refresh: () => undefined,
+};
+
+export const DEFAULT_VALUE_FETCH_STATE: FetchStateObject<never | undefined> = {
+  data: undefined,
   loaded: false,
   refresh: () => undefined,
 };

--- a/frontend/src/utilities/useContextResourceData.tsx
+++ b/frontend/src/utilities/useContextResourceData.tsx
@@ -2,23 +2,18 @@ import * as React from 'react';
 import { ContextResourceData } from '~/types';
 import { FetchState } from '~/utilities/useFetchState';
 import { POLL_INTERVAL } from './const';
+import { useMakeFetchObject } from './useMakeFetchObject';
 
+// TODO this should probably be removed in favor of useMakeFetchObject.
+//      useFetchState already supports a refreshRate option, and useMakeFetchObject supports single values and not just arrays.
 export const useContextResourceData = <T,>(
   resourceData: FetchState<T[]>,
   refreshInterval = POLL_INTERVAL,
 ): ContextResourceData<T> => {
-  const [values, loaded, error, refresh] = resourceData;
+  const [, , , refresh] = resourceData;
   React.useEffect(() => {
     const timer = setInterval(() => refresh(), refreshInterval);
     return () => clearInterval(timer);
   }, [refresh, refreshInterval]);
-  return React.useMemo(
-    () => ({
-      data: values,
-      loaded,
-      error,
-      refresh,
-    }),
-    [error, loaded, refresh, values],
-  );
+  return useMakeFetchObject(resourceData);
 };

--- a/frontend/src/utilities/useFetchState.ts
+++ b/frontend/src/utilities/useFetchState.ts
@@ -86,7 +86,7 @@ export type FetchStateCallbackPromiseAdHoc<Type> = FetchStateCallbackPromiseRetu
   Promise<AdHocUpdate<Type>>
 >;
 
-type FetchOptions = {
+export type FetchOptions = {
   /** To enable auto refresh */
   refreshRate: number;
   /**

--- a/frontend/src/utilities/useMakeFetchObject.ts
+++ b/frontend/src/utilities/useMakeFetchObject.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { FetchStateObject } from '~/types';
+import { FetchState } from '~/utilities/useFetchState';
+
+export const useMakeFetchObject = <T>(fetchState: FetchState<T>): FetchStateObject<T> => {
+  const [data, loaded, error, refresh] = fetchState;
+  return React.useMemo(() => ({ data, loaded, error, refresh }), [data, loaded, error, refresh]);
+};

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -61,6 +61,8 @@ spec:
                       type: boolean
                     disableAcceleratorProfiles:
                       type: boolean
+                    disableDistributedWorkloads:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -23,6 +23,7 @@ spec:
     disableAcceleratorProfiles: true
     disableKServe: false
     disableModelMesh: false
+    disableDistributedWorkloads: true
   notebookController:
     enabled: true
   notebookSizes:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Implements the following stories (I know... the next PR will be smaller!):

- https://issues.redhat.com/browse/RHOAIENG-2535 - Stub for new page
- https://issues.redhat.com/browse/RHOAIENG-2567 - Context architecture / data fetching spike
- https://issues.redhat.com/browse/RHOAIENG-2850 - Data fetching for status overview donut chart
- https://issues.redhat.com/browse/RHOAIENG-2851 - Data fetching for status trends line chart
- https://issues.redhat.com/browse/RHOAIENG-2853 - Data fetching for workloads table

<img width="1725" alt="Screenshot 2024-02-21 at 4 14 00 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/16a44235-d638-46c9-a9b6-2a30fd4a4aae">

<img width="1722" alt="Screenshot 2024-02-21 at 4 14 16 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/e9629627-035b-4141-aa7b-2416026b3384">

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR establishes the following new things:
* `StackComponent.KUEUE`, for the new `kueue` DataScienceCluster component
* A `disableDistributedWorkloads` feature flag in the OdhClusterConfig CRD
* `SupportedArea.DISTRIBUTED_WORKLOADS`, which requires both of the above in order to enable the new page via `useIsAreaAvailable()`
* The new "Workload Metrics" page and nav item, corresponding to...
* ...the new route `/distributedWorkloads/*` and its subroutes, which are dynamically generated based on...
* ...the `useDistributedWorkloadsTabs` hook, which returns a config object that defines the tabs at the top of the new page.
  * The `isAvailable` property here for both tabs is currently just whether the new SupportedArea is available, but can also be used to restrict individual tabs by RBAC or other logic. The root `/distributedWorkloads` route redirects to the first available tab based on this logic.
  * The `projectSelectorMode` here dictates whether there is a project dropdown on each tab, and if so, whether it allows the "all projects" selection or not. Currently both tabs are set to `singleProjectOnly` (if no project is selected when you reach the page, one will be selected automatically).
  * `isAvailable` and `projectSelectorMode` were originally implemented because we had a "Data science cluster metrics" tab that was going to be for admins only and was not going to have a project selector, and because the "Workload status" tab was originally also going to allow "all projects". I considered removing these two features as they are no longer currently leveraged, but they seem useful in case we need them later. If reviewers prefer, we could just remove them (and perhaps the whole `useDistributedWorkloadsTabs` hook in favor of hard-coded routes/tabs). 
* New components in `frontend/src/pages/distributedWorkloads/global` (the "Workload Metrics" page):
  * `GlobalDistributedWorkloads` - The page's root component. Determines what to render or redirect based on whether there are projects, which tab corresponds to the current route and whether that tab needs a valid selected project. If all is well, renders the `DistributedWorkloadsContextProvider` (see below) wrapped around...
  * ...`GlobalDistributedWorkloadsTabs` - Renders the tab bar and the active tab's `ContentComponent` (based on `useDistributedWorkloadsTabs`). Retains the selected project if present when navigating between tabs that have a project selector.
  * `GlobalDistributedWorkloadsProjectMetricsTab` - The content for the "Project metrics" tab. Currently renders some raw placeholder JSON from the `projectMetrics` data provided by the new context (see below).
  * `GlobalDistributedWorkloadsWorkloadStatusTab` - The content for the "Workload status" tab. Currently renders some raw placeholder JSON from the `workloadCurrentMetrics` and `workloadTrendMetrics` data provided by the new context (see below).
  * `DistributedWorkloadsToolbar` - The toolbar at the top of each of these tab content components, with the project dropdown and placeholders for refresh interval and time range dropdowns.
    * As stated in a TODO comment here, this should probably be replaced with the existing `MetricsPageToolbar` which could be decoupled from model metrics and moved somewhere common in a future PR.
* A new `frontend/src/concepts/distributedWorkloads` directory, where we can put DW-related things that could possibly be used in other places in the UI other than the "Workload Metrics" page (like future settings pages, or anywhere else that wants to show a few of these metrics). In here we have:
  * `DistributedWorkloadsContext`, which wraps each of the rendered routes that need to consume DW-related API data. This is similar to other React context providers in the UI: it provides state like the current refresh rate, last update time for charts, and fetched API data.
  * `useClusterQueues` and `useWorkloads`, described below.
* Two new backend prometheus routes `/api/prometheus/query` and `/api/prometheus/queryRange`, which came from a discussion with @andrewballantyne (the existing `/pvc`, `/bias` and `/serving` routes here are repetitive and all could be replaced with one of the two generic endpoints). There is a TODO comment for this.
* A few Cypress tests to ensure that the new nav item and route exist if and only if both the kueue component is installed and the feature is turned on.
  * More tests will come in a future PR -- I will open a Jira task for this and it will be required for the feature epics to be considered done. (Jira issue TBD)
* Types, models, API functions and hooks for listing k8s CRs from Kueue:
  * `ClusterQueueKind`/`listClusterQueues`/`useClusterQueues` - Not currently used. This was implemented when I thought we needed it for "Data science cluster metrics", but I left it in because we will need it for future admin settings pages and we may need it for the "project metrics" tab as well.
  * `WorkloadKind`/`listWorkloads`/`useWorkloads` - For the future table of individual workload statuses at the bottom of the "Workload status" tab.
* Types, functions and hooks for Prometheus queries related to Distributed Workloads (in `frontend/src/api/prometheus/distributedWorkloads.ts`):
  * `getDWProjectMetricsQueries` / `useDWProjectMetrics` - Part of the spike for loading individual number values for the "project metrics" tab. Not currently comprehensive, we will need more single- and range-value queries for that tab.
  * `getDWWorkloadCurrentMetricsQueries` / `useDWWorkloadCurrentMetrics` - The single number value metrics for the future donut chart on the "Workload status" tab.
  * `getDWWorkloadTrendMetricsQueries` / `useDWWorkloadTrendMetrics` - The time-series range queries for the future status trends line chart on the "Workload status" tab.
  * For each of these 3 groups of metrics, there is a `*MetricsValues` type which defines keys and data types for the underlying metrics we want to load, a `*MetricType` type derived from those keys, and a mapped `*Metrics` type. This last type is what is returned by the `use*Metrics` hooks, and it is a `FetchStateObject` (data, loaded, error, refresh) whose `data` property is a mapping of `*MetricType`s to inner `FetchStateObject`s for each individual metric. This allows us to define the names and types of data we need in one place and have TypeScript enforce that we are using those same keys everywhere we work with each of these groups of metrics. The outer `FetchStateObject` also encapsulates the loading/error/refresh state so each group of metrics is simpler to consume via context (no need to `||` all the loading booleans in rendering logic), while the inner `FetchStateObject`s still allow us to look inside and see the loading/error state of an individual metric or call the refresh function for an individual metric.
  * Note: I was originally going to copy the pattern used by `get[Server|Model]MetricsQueries` and the `[Server|Model]MetricType` enums. I went with this alternative pattern for two reasons:
    * Based on discussions with @andrewballantyne, I wanted to keep all of the queries and prometheus-related logic in `~/api/prometheus/*` and out of `~/pages` to avoid coupling the data structures to a specific page. The existing metrics stuff in `~/pages/modelServing` is more coupled with page-specific code.
    * With the data source decoupled from the page where it is initially used, I saw value in grouping queries and metrics that are likely to be used together into separate nested objects so you can consume only what you need. It made sense to separate the source of truth for what data is in each of these groups of metrics and what their queries are and define them next to each corresponding hook using mapped types instead of enums.
  * If we prefer to stick to the enum pattern and/or a single flat bundle of metrics, I am totally happy to conform to that pattern instead. I also just have a general preference against enums that are 1:1 with the keys of an object when a `keyof` will suffice 😉 and I might have been trying to be too clever here.
* A new `usePrometheusNumberValueQuery` helper hook to simplify the use of prometheus queries that return a single numeric value.
* A new `useMakeFetchObject` utility hook which turns the `[data, loaded, error, refresh]` tuple returned by `useFetchState` into an object with named properties, which is easier to work with for our purposes. Note that this is factored out of the existing `useContextResourceData` which provided both this and a refresh interval implementation, but I wanted to be able to rely on the `refreshRate` option of `useFetchState` instead. Based on a discussion with @andrewballantyne , we probably want to eventually replace usages of `useContextResourceData` with `useMakeFetchObject` and that `refreshRate` option.
  * To correspond with this, a new type `FetchStateObject` and new constants `DEFAULT_LIST_FETCH_STATE` (for fetching arrays, value defaults to `[]`) and `DEFAULT_VALUE_FETCH_STATE` (for fetching any type, value defaults to undefined) have been added.
  * I really am not sure about the name of `useMakeFetchObject`, suggestions are welcome.

There are also a few changes to existing code:
* `usePrometheusQuery` now accepts an optional third parameter `fetchOptions`, which can be used to pass a `refreshRate` or `initialPromisePurity` option down into the underlying `useFetchState` call. This simplifies things when using `refreshRate` with `useFetchState` directly alongside these prometheus queries in the context provider.
  * The new parameter is optional and this change does not affect any existing consumers of `usePrometheusQuery`.
* `useFetchState.ts` now exports its previously private `FetchOptions` type for use in `usePrometheusQuery` or elsewhere.
* The `defaultResponsePredicate` and `prometheusQueryRangeResponsePredicate` that were previously in `frontend/src/api/prometheus/serving.ts` (as `useCallback`s inline) have been moved to `usePrometheusQueryRange.ts` (as static exports). They are generically useful for any consumer of `usePrometheusQueryRange`, and the `useCallback`s they were using were unnecessary (they had no dependencies, so the memoized functions didn't rely on anything from their upper scope and were effectively static already).
  * This change has no effect on the behavior of the original model serving code.
* The `useContextResourceData` utility has been refactored to lift the tuple-to-object functionality out into `useMakeFetchObject`, described above.
  * The behavior is identical and this change does not affect any existing consumers of `useContextResourceData`.
* The `ProjectSelector` component has been enhanced with an `aria-label` for better accessibility. This came up when I was consulting with the PatternFly team on how best to accessibly render labels for each of the toolbar dropdowns on the new page, and it will also make the other pages that use it more accessible. It has no visual effect on the rendered page.
  * I would be fine with removing this from this PR if desired, since it is the only thing that actually modifies the HTML output of existing pages.

There are various `// TODO mturley` comments in here for things beyond the scope of this PR that need to be addressed in future changes before the feature is released. I left them in order to have reminders in context (with my name on them for accountability, as opposed to open-ended TODOs that could be picked up by anyone in the future).
* In particular, there are a few places where I said `these imports from ~/pages/modelServing/* should be moved somewhere page-agnostic`, which would have resulted in bloating this diff even more. It makes more sense to me to do that when we get to the point of abstracting out other reusable code from model serving metrics (coming up soon!)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The majority of the development was done in local dev mode using @Fiona-Waters 's cluster. The data fetching has all been manually tested this way, including all of the prometheus queries (using past data from test workloads Fiona ran).

I have also fully deployed the image generated by CI for this PR on a new AWS cluster (dw-dashboard) set up for me by @anishasthana. On that cluster we properly set up the kueue component and set the feature flag in the DashboardConfig CR, and verified that the SupportedArea logic is working as expected (and that the new page is not accessible if either the feature is turned off or the kueue component is not installed).

For the things mentioned above under "a few changes to existing code", I poked around on other pages that consume the relevant code and confirmed that there are no changes to the behavior of existing consumers of those few small utilities I touched.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Currently, the only tests I wrote here are in `frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts`, where the tests verify that the SupportedArea logic works correctly and that none of the new code will leak to any users who don't have the kueue component installed and the new feature flag enabled.

As mentioned above, more unit and integration tests should be added in a future PR. The only reason I am not writing more tests in this PR is because it has run too long and that would risk not merging it in the current sprint, and because none of the untested code is exposed to any users who don't use the feature flag. I will follow up to open a Jira task and ensure more tests for this PR's code are added in future PRs.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
