### PR TITLE
Properly dry-run all operations in KServe modal before submitting

### DIFF
--- a/backend/src/routes/api/namespaces/index.ts
+++ b/backend/src/routes/api/namespaces/index.ts
@@ -6,14 +6,20 @@ import { logRequestDetails } from '../../../utils/fileUtils';
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   fastify.get(
     '/:name/:context',
-    async (request: OauthFastifyRequest<{ Params: { name: string; context: string } }>) => {
+    async (
+      request: OauthFastifyRequest<{
+        Params: { name: string; context: string };
+        Querystring: { dryRun?: string };
+      }>,
+    ) => {
       logRequestDetails(fastify, request);
 
       const { name, context: contextAsString } = request.params;
+      const { dryRun } = request.query;
 
       const context = parseInt(contextAsString) as NamespaceApplicationCase;
 
-      return applyNamespaceChange(fastify, request, name, context);
+      return applyNamespaceChange(fastify, request, name, context, dryRun);
     },
   );
 };

--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -60,6 +60,7 @@ export const applyNamespaceChange = async (
   request: OauthFastifyRequest,
   name: string,
   context: NamespaceApplicationCase,
+  dryRun?: string,
 ): Promise<{ applied: boolean }> => {
   if (name.startsWith('openshift') || name.startsWith('kube')) {
     // Kubernetes and OpenShift namespaces are off limits to this flow
@@ -120,7 +121,7 @@ export const applyNamespaceChange = async (
   }
 
   return fastify.kube.coreV1Api
-    .patchNamespace(name, { metadata: { labels } }, undefined, undefined, undefined, undefined, {
+    .patchNamespace(name, { metadata: { labels } }, undefined, dryRun, undefined, undefined, {
       headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
     })
     .then(() => ({ applied: true }))

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -12,6 +12,7 @@ import { mockInferenceServiceModalData } from '~/__mocks__/mockInferenceServiceM
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mock200Status, mock404Error } from '~/__mocks__/mockK8sStatus';
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import {
   assembleInferenceService,
   createInferenceService,
@@ -413,20 +414,30 @@ describe('createInferenceService', () => {
     k8sCreateResourceMock.mockResolvedValue(inferenceServiceMock);
     const result = await createInferenceService(data);
     expect(result).toStrictEqual(inferenceServiceMock);
-    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
-      model: InferenceServiceModel,
-      resource: inferenceServiceMock,
-    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith(
+      applyK8sAPIOptions(
+        {
+          model: InferenceServiceModel,
+          resource: inferenceServiceMock,
+        },
+        {},
+      ),
+    );
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
   });
 
   it('should handle errors and rethrows', async () => {
     k8sCreateResourceMock.mockRejectedValueOnce(new Error('error'));
     await expect(createInferenceService(data)).rejects.toThrow('error');
-    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
-      model: InferenceServiceModel,
-      resource: inferenceServiceMock,
-    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith(
+      applyK8sAPIOptions(
+        {
+          model: InferenceServiceModel,
+          resource: inferenceServiceMock,
+        },
+        {},
+      ),
+    );
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
   });
 });
@@ -438,20 +449,30 @@ describe('updateInferenceService', () => {
     k8sUpdateResourceMock.mockResolvedValue(inferenceServiceMock);
     const result = await updateInferenceService(data, inferenceServiceMock);
     expect(result).toStrictEqual(inferenceServiceMock);
-    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
-      model: InferenceServiceModel,
-      resource: inferenceServiceMock,
-    });
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith(
+      applyK8sAPIOptions(
+        {
+          model: InferenceServiceModel,
+          resource: inferenceServiceMock,
+        },
+        {},
+      ),
+    );
     expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
   });
 
   it('should handle errors and rethrows', async () => {
     k8sUpdateResourceMock.mockRejectedValue(new Error('error'));
     await expect(updateInferenceService(data, inferenceServiceMock)).rejects.toThrow('error');
-    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
-      model: InferenceServiceModel,
-      resource: inferenceServiceMock,
-    });
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith(
+      applyK8sAPIOptions(
+        {
+          model: InferenceServiceModel,
+          resource: inferenceServiceMock,
+        },
+        {},
+      ),
+    );
     expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/api/k8s/__tests__/projects.spec.ts
+++ b/frontend/src/api/k8s/__tests__/projects.spec.ts
@@ -324,7 +324,7 @@ describe('addSupportServingPlatformProject', () => {
     );
     expect(result).toStrictEqual(name);
     expect(mockedAxios).toHaveBeenCalledTimes(1);
-    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1');
+    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1', { params: {} });
   });
 
   it('should handle error when failed to enable model serving platform', async () => {
@@ -335,7 +335,7 @@ describe('addSupportServingPlatformProject', () => {
       `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
     );
     expect(mockedAxios).toHaveBeenCalledTimes(1);
-    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1');
+    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1', { params: {} });
   });
 
   it('should handle error when axios response data is undefined', async () => {
@@ -346,7 +346,7 @@ describe('addSupportServingPlatformProject', () => {
       `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
     );
     expect(mockedAxios).toHaveBeenCalledTimes(1);
-    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1');
+    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1', { params: {} });
   });
 
   it('should handle other axios errors', async () => {
@@ -356,7 +356,7 @@ describe('addSupportServingPlatformProject', () => {
       addSupportServingPlatformProject(name, NamespaceApplicationCase.MODEL_MESH_PROMOTION),
     ).rejects.toThrow(`error-message`);
     expect(mockedAxios).toHaveBeenCalledTimes(1);
-    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1');
+    expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1', { params: {} });
   });
 });
 

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -182,6 +182,7 @@ export const createInferenceService = (
   secretKey?: string,
   isModelMesh?: boolean,
   acceleratorState?: AcceleratorProfileState,
+  dryRun = false,
 ): Promise<InferenceServiceKind> => {
   const inferenceService = assembleInferenceService(
     data,
@@ -191,10 +192,15 @@ export const createInferenceService = (
     undefined,
     acceleratorState,
   );
-  return k8sCreateResource<InferenceServiceKind>({
-    model: InferenceServiceModel,
-    resource: inferenceService,
-  });
+  return k8sCreateResource<InferenceServiceKind>(
+    applyK8sAPIOptions(
+      {
+        model: InferenceServiceModel,
+        resource: inferenceService,
+      },
+      { dryRun },
+    ),
+  );
 };
 
 export const updateInferenceService = (
@@ -203,6 +209,7 @@ export const updateInferenceService = (
   secretKey?: string,
   isModelMesh?: boolean,
   acceleratorState?: AcceleratorProfileState,
+  dryRun = false,
 ): Promise<InferenceServiceKind> => {
   const inferenceService = assembleInferenceService(
     data,
@@ -213,10 +220,15 @@ export const updateInferenceService = (
     acceleratorState,
   );
 
-  return k8sUpdateResource<InferenceServiceKind>({
-    model: InferenceServiceModel,
-    resource: inferenceService,
-  });
+  return k8sUpdateResource<InferenceServiceKind>(
+    applyK8sAPIOptions(
+      {
+        model: InferenceServiceModel,
+        resource: inferenceService,
+      },
+      { dryRun },
+    ),
+  );
 };
 
 export const deleteInferenceService = (

--- a/frontend/src/api/k8s/projects.ts
+++ b/frontend/src/api/k8s/projects.ts
@@ -116,8 +116,11 @@ export const getModelServingProjectsAvailable = async (): Promise<ProjectKind[]>
 export const addSupportServingPlatformProject = (
   name: string,
   servingPlatform: NamespaceApplicationCase,
+  dryRun = false,
 ): Promise<string> =>
-  axios(`/api/namespaces/${name}/${servingPlatform}`)
+  axios(`/api/namespaces/${name}/${servingPlatform}`, {
+    params: dryRun ? { dryRun: 'All' } : {},
+  })
     .then((response) => {
       const applied = response.data?.applied ?? false;
       if (!applied) {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Form, FormSection, Modal, Stack, StackItem } from '@patternfly/react-core';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import {
-  submitInferenceServiceResource,
+  submitInferenceServiceResourceWithDryRun,
   useCreateInferenceServiceObject,
 } from '~/pages/modelServing/screens/projects/utils';
 import { InferenceServiceKind, ProjectKind, ServingRuntimeKind } from '~/k8sTypes';
@@ -91,7 +91,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     setError(undefined);
     setActionInProgress(true);
 
-    submitInferenceServiceResource(createData, editInfo, undefined, true)
+    submitInferenceServiceResourceWithDryRun(createData, editInfo, undefined, true)
       .then(() => onSuccess())
       .catch((e) => {
         setErrorModal(e);

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -15,7 +15,7 @@ import {
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import { HelpIcon } from '@patternfly/react-icons';
 import {
-  submitServingRuntimeResources,
+  submitServingRuntimeResourcesWithDryRun,
   useCreateServingRuntimeObject,
 } from '~/pages/modelServing/screens/projects/utils';
 import { TemplateKind, ProjectKind, AccessReviewResourceAttributes } from '~/k8sTypes';
@@ -121,7 +121,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
     setError(undefined);
     setActionInProgress(true);
 
-    submitServingRuntimeResources(
+    submitServingRuntimeResourcesWithDryRun(
       servingRuntimeSelected,
       createData,
       customServingRuntimesEnabled,

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -271,6 +271,7 @@ const createInferenceServiceAndDataConnection = (
   editInfo?: InferenceServiceKind,
   isModelMesh?: boolean,
   acceleratorProfileState?: AcceleratorProfileState,
+  dryRun = false,
 ) => {
   if (!existingStorage) {
     return createAWSSecret(inferenceServiceData).then((secret) =>
@@ -281,12 +282,14 @@ const createInferenceServiceAndDataConnection = (
             secret.metadata.name,
             isModelMesh,
             acceleratorProfileState,
+            dryRun,
           )
         : createInferenceService(
             inferenceServiceData,
             secret.metadata.name,
             isModelMesh,
             acceleratorProfileState,
+            dryRun,
           ),
     );
   }
@@ -297,17 +300,24 @@ const createInferenceServiceAndDataConnection = (
         undefined,
         isModelMesh,
         acceleratorProfileState,
+        dryRun,
       )
-    : createInferenceService(inferenceServiceData, undefined, isModelMesh, acceleratorProfileState);
+    : createInferenceService(
+        inferenceServiceData,
+        undefined,
+        isModelMesh,
+        acceleratorProfileState,
+        dryRun,
+      );
 };
 
-export const submitInferenceServiceResource = (
+export const getSubmitInferenceServiceResourceFn = (
   createData: CreatingInferenceServiceObject,
   editInfo?: InferenceServiceKind,
   servingRuntimeName?: string,
   isModelMesh?: boolean,
   acceleratorProfileState?: AcceleratorProfileState,
-): Promise<InferenceServiceKind> => {
+): ((opts: { dryRun?: boolean }) => Promise<InferenceServiceKind>) => {
   const inferenceServiceData = {
     ...createData,
     ...(servingRuntimeName !== undefined && {
@@ -324,16 +334,26 @@ export const submitInferenceServiceResource = (
   const existingStorage =
     inferenceServiceData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE;
 
-  return createInferenceServiceAndDataConnection(
-    inferenceServiceData,
-    existingStorage,
-    editInfo,
-    isModelMesh,
-    acceleratorProfileState,
-  );
+  return ({ dryRun = false }) =>
+    createInferenceServiceAndDataConnection(
+      inferenceServiceData,
+      existingStorage,
+      editInfo,
+      isModelMesh,
+      acceleratorProfileState,
+      dryRun,
+    );
 };
 
-export const submitServingRuntimeResources = async (
+export const submitInferenceServiceResourceWithDryRun = async (
+  ...params: Parameters<typeof getSubmitInferenceServiceResourceFn>
+): Promise<InferenceServiceKind> => {
+  const submitInferenceServiceResource = getSubmitInferenceServiceResourceFn(...params);
+  await submitInferenceServiceResource({ dryRun: true });
+  return submitInferenceServiceResource({ dryRun: false });
+};
+
+export const getSubmitServingRuntimeResourcesFn = (
   servingRuntimeSelected: ServingRuntimeKind | undefined,
   createData: CreatingServingRuntimeObject,
   customServingRuntimesEnabled: boolean,
@@ -345,13 +365,14 @@ export const submitServingRuntimeResources = async (
   currentProject?: ProjectKind,
   name?: string,
   isModelMesh?: boolean,
-): Promise<void | (string | void | ServingRuntimeKind)[]> => {
+): ((opts: { dryRun?: boolean }) => Promise<void | (string | void | ServingRuntimeKind)[]>) => {
   if (!servingRuntimeSelected) {
-    return Promise.reject(
-      new Error(
-        'Error, the Serving Runtime selected might be malformed or could not have been retrieved.',
-      ),
-    );
+    return () =>
+      Promise.reject(
+        new Error(
+          'Error, the Serving Runtime selected might be malformed or could not have been retrieved.',
+        ),
+      );
   }
   const servingRuntimeData = {
     ...createData,
@@ -365,73 +386,80 @@ export const submitServingRuntimeResources = async (
     ? { count: 0, acceleratorProfiles: [], useExisting: false }
     : acceleratorProfileState;
 
-  const getUpdatePromises = (dryRun = false) =>
-    editInfo?.servingRuntime
-      ? [
-          updateServingRuntime({
-            data: servingRuntimeData,
-            existingData: editInfo.servingRuntime,
-            isCustomServingRuntimesEnabled: customServingRuntimesEnabled,
-            opts: {
+  if (!editInfo && !currentProject) {
+    // This should be impossible to hit on resource creation, current project is undefined only on edit
+    return () => Promise.reject(new Error('Cannot update project with no project selected'));
+  }
+
+  return ({ dryRun = false }) =>
+    Promise.all([
+      ...(currentProject && currentProject.metadata.labels?.['modelmesh-enabled'] === undefined
+        ? [
+            addSupportServingPlatformProject(
+              currentProject.metadata.name,
+              servingPlatformEnablement,
               dryRun,
-            },
-            acceleratorProfileState: controlledState,
-            isModelMesh,
-          }),
-          setUpTokenAuth(
-            servingRuntimeData,
-            servingRuntimeName,
-            namespace,
-            createTokenAuth,
-            editInfo.servingRuntime,
-            editInfo.secrets,
-            {
-              dryRun,
-            },
-          ),
-        ]
-      : [
-          createServingRuntime({
-            data: servingRuntimeData,
-            namespace,
-            servingRuntime: servingRuntimeSelected,
-            isCustomServingRuntimesEnabled: customServingRuntimesEnabled,
-            opts: {
-              dryRun,
-            },
-            acceleratorProfileState: controlledState,
-            isModelMesh,
-          }).then((servingRuntime) =>
+            ),
+          ]
+        : []),
+      ...(editInfo?.servingRuntime
+        ? [
+            updateServingRuntime({
+              data: servingRuntimeData,
+              existingData: editInfo.servingRuntime,
+              isCustomServingRuntimesEnabled: customServingRuntimesEnabled,
+              opts: {
+                dryRun,
+              },
+              acceleratorProfileState: controlledState,
+              isModelMesh,
+            }),
             setUpTokenAuth(
               servingRuntimeData,
               servingRuntimeName,
               namespace,
               createTokenAuth,
-              servingRuntime,
-              editInfo?.secrets,
+              editInfo.servingRuntime,
+              editInfo.secrets,
               {
                 dryRun,
               },
             ),
-          ),
-        ];
+          ]
+        : [
+            createServingRuntime({
+              data: servingRuntimeData,
+              namespace,
+              servingRuntime: servingRuntimeSelected,
+              isCustomServingRuntimesEnabled: customServingRuntimesEnabled,
+              opts: {
+                dryRun,
+              },
+              acceleratorProfileState: controlledState,
+              isModelMesh,
+            }).then((servingRuntime) =>
+              setUpTokenAuth(
+                servingRuntimeData,
+                servingRuntimeName,
+                namespace,
+                createTokenAuth,
+                servingRuntime,
+                editInfo?.secrets,
+                {
+                  dryRun,
+                },
+              ),
+            ),
+          ]),
+    ]);
+};
 
-  try {
-    await Promise.all<ServingRuntimeKind | string | void>(getUpdatePromises(true));
-    if (!editInfo && !currentProject) {
-      // This should be impossible to hit, currentProject just comes from React context that could be undefined
-      return await Promise.reject(new Error('Cannot update project with no project selected'));
-    }
-    if (currentProject && currentProject.metadata.labels?.['modelmesh-enabled'] === undefined) {
-      await addSupportServingPlatformProject(
-        currentProject?.metadata.name,
-        servingPlatformEnablement,
-      );
-    }
-    return await Promise.all<ServingRuntimeKind | string | void>(getUpdatePromises());
-  } catch (e) {
-    return Promise.reject(e);
-  }
+export const submitServingRuntimeResourcesWithDryRun = async (
+  ...params: Parameters<typeof getSubmitServingRuntimeResourcesFn>
+): Promise<void | (string | void | ServingRuntimeKind)[]> => {
+  const submitServingRuntimeResources = getSubmitServingRuntimeResourcesFn(...params);
+  await submitServingRuntimeResources({ dryRun: true });
+  return submitServingRuntimeResources({ dryRun: false });
 };
 
 export const getUrlFromKserveInferenceService = (


### PR DESCRIPTION
Closes: [RHOAIENG-556](https://issues.redhat.com/browse/RHOAIENG-556)

## Description
In progress to https://github.com/opendatahub-io/odh-dashboard/pull/2319, this PR improves the functionality to dry run ServingRuntime and InferenceService before creating the KServe model.

## How Has This Been Tested?
Create a KServe modal and check the network logs to find dryRun API executed first.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
