### PR TITLE
Change the resource handling to InferenceServices

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -1,6 +1,7 @@
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import { InferenceServiceKind, KnownLabels } from '~/k8sTypes';
 import { genUID } from '~/__mocks__/mockUtils';
+import { ContainerResources } from '~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -13,10 +14,10 @@ type MockResourceConfigType = {
   activeModelState?: string;
   url?: string;
   path?: string;
-  acceleratorIdentifier?: string;
   minReplicas?: number;
   maxReplicas?: number;
   lastFailureInfoMessage?: string;
+  resources?: ContainerResources;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -67,10 +68,10 @@ export const mockInferenceServiceK8sResource = ({
   activeModelState = 'Pending',
   url = '',
   path = 'path/to/model',
-  acceleratorIdentifier = '',
   minReplicas = 1,
   maxReplicas = 1,
   lastFailureInfoMessage = 'Waiting for runtime Pod to become available',
+  resources,
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',
@@ -106,18 +107,7 @@ export const mockInferenceServiceK8sResource = ({
           name: 'onnx',
           version: '1',
         },
-        ...(acceleratorIdentifier !== ''
-          ? {
-              resources: {
-                limits: {
-                  acceleratorIdentifier: '2',
-                },
-                requests: {
-                  acceleratorIdentifier: '2',
-                },
-              },
-            }
-          : {}),
+        ...(resources && { resources }),
         runtime: modelName,
         storage: {
           key: secretName,

--- a/frontend/src/__mocks__/mockInferenceServiceModalData.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceModalData.ts
@@ -21,6 +21,19 @@ export const mockInferenceServiceModalData = ({
   },
   minReplicas = 1,
   maxReplicas = 1,
+  modelSize = {
+    name: 'Small',
+    resources: {
+      requests: {
+        cpu: '1',
+        memory: '1Gi',
+      },
+      limits: {
+        cpu: '2',
+        memory: '2Gi',
+      },
+    },
+  },
 }: MockResourceConfigType): CreatingInferenceServiceObject => ({
   name,
   project,
@@ -29,4 +42,5 @@ export const mockInferenceServiceModalData = ({
   format,
   minReplicas,
   maxReplicas,
+  modelSize,
 });

--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -1,4 +1,5 @@
 import { KnownLabels, ServingRuntimeKind } from '~/k8sTypes';
+import { ContainerResources } from '~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -8,6 +9,7 @@ type MockResourceConfigType = {
   auth?: boolean;
   route?: boolean;
   acceleratorName?: string;
+  resources?: ContainerResources;
 };
 
 export const mockServingRuntimeK8sResourceLegacy = ({
@@ -92,6 +94,7 @@ export const mockServingRuntimeK8sResource = ({
   route = false,
   displayName = 'OVMS Model Serving',
   acceleratorName = '',
+  resources,
 }: MockResourceConfigType): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
@@ -132,16 +135,7 @@ export const mockServingRuntimeK8sResource = ({
         image:
           'registry.redhat.io/openshift-ai/odh-openvino-servingruntime-rhel8@sha256:8af20e48bb480a7ba1ee1268a3cf0a507e05b256c5fcf988f8e4a3de8b87edc6',
         name: 'ovms',
-        resources: {
-          limits: {
-            cpu: '2',
-            memory: '8Gi',
-          },
-          requests: {
-            cpu: '1',
-            memory: '4Gi',
-          },
-        },
+        ...(resources && { resources }),
       },
     ],
     grpcDataEndpoint: 'port:8001',

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
@@ -998,7 +998,14 @@ describe('Serving Runtime List', () => {
             displayName: 'Llama Caikit',
             url: 'http://llama-caikit.test-project.svc.cluster.local',
             activeModelState: 'Loaded',
-            acceleratorIdentifier: 'nvidia.com/gpu',
+            resources: {
+              requests: {
+                'nvidia.com/gpu': 1,
+              },
+              limits: {
+                'nvidia.com/gpu': 1,
+              },
+            },
           }),
         ],
       });
@@ -1055,7 +1062,14 @@ describe('Serving Runtime List', () => {
             displayName: 'Llama Caikit',
             url: 'http://llama-caikit.test-project.svc.cluster.local',
             activeModelState: 'Loaded',
-            acceleratorIdentifier: 'nvidia.com/gpu',
+            resources: {
+              requests: {
+                'nvidia.com/gpu': '2',
+              },
+              limits: {
+                'nvidia.com/gpu': '2',
+              },
+            },
           }),
         ],
       });
@@ -1180,5 +1194,152 @@ describe('Serving Runtime List', () => {
         expect(interceptions).to.have.length(0);
       });
     });
+  });
+
+  it('Check model size rendered with ServingRuntime size and no InferenceServiceSize', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableKServeConfig: true,
+      disableModelMeshConfig: true,
+      inferenceServices: [
+        mockInferenceServiceK8sResource({
+          name: 'llama-service',
+          displayName: 'Llama Service',
+          modelName: 'llama-service',
+          isModelMesh: false,
+          resources: undefined,
+        }),
+      ],
+      servingRuntimes: [
+        mockServingRuntimeK8sResource({
+          name: 'llama-service',
+          displayName: 'Llama Service',
+          namespace: 'test-project',
+          resources: {
+            limits: {
+              cpu: '2',
+              memory: '8Gi',
+            },
+            requests: {
+              cpu: '1',
+              memory: '4Gi',
+            },
+          },
+        }),
+      ],
+    });
+
+    projectDetails.visit('test-project');
+    modelServingSection.getKServeRow('Llama Service').findExpansion().should(be.collapsed);
+    modelServingSection.getKServeRow('Llama Service').findToggleButton().click();
+    modelServingSection
+      .findDescriptionListItem('Llama Service', 'Model server size')
+      .next('dd')
+      .should('contain.text', 'Small');
+
+    // click on the toggle button and open edit model server
+    modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
+
+    kserveModal.shouldBeOpen();
+
+    kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Small');
+  });
+
+  it('Check model size rendered with InferenceService size', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableKServeConfig: true,
+      disableModelMeshConfig: true,
+      inferenceServices: [
+        mockInferenceServiceK8sResource({
+          name: 'llama-service',
+          displayName: 'Llama Service',
+          modelName: 'llama-service',
+          isModelMesh: false,
+          resources: {
+            limits: {
+              cpu: '2',
+              memory: '8Gi',
+            },
+            requests: {
+              cpu: '1',
+              memory: '4Gi',
+            },
+          },
+        }),
+      ],
+      servingRuntimes: [
+        mockServingRuntimeK8sResource({
+          name: 'llama-service',
+          displayName: 'Llama Service',
+          namespace: 'test-project',
+          resources: undefined,
+        }),
+      ],
+    });
+
+    projectDetails.visit('test-project');
+    modelServingSection.getKServeRow('Llama Service').findExpansion().should(be.collapsed);
+    modelServingSection.getKServeRow('Llama Service').findToggleButton().click();
+    modelServingSection
+      .findDescriptionListItem('Llama Service', 'Model server size')
+      .next('dd')
+      .should('contain.text', 'Small');
+
+    // click on the toggle button and open edit model server
+    modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
+
+    kserveModal.shouldBeOpen();
+
+    kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Small');
+  });
+
+  it('Check model size rendered with InferenceService custom size', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableKServeConfig: true,
+      disableModelMeshConfig: true,
+      inferenceServices: [
+        mockInferenceServiceK8sResource({
+          name: 'llama-service',
+          displayName: 'Llama Service',
+          modelName: 'llama-service',
+          isModelMesh: false,
+          resources: {
+            limits: {
+              cpu: '1',
+              memory: '10Gi',
+            },
+            requests: {
+              cpu: '1',
+              memory: '4Gi',
+            },
+          },
+        }),
+      ],
+      servingRuntimes: [
+        mockServingRuntimeK8sResource({
+          name: 'llama-service',
+          displayName: 'Llama Service',
+          namespace: 'test-project',
+          resources: undefined,
+        }),
+      ],
+    });
+
+    projectDetails.visit('test-project');
+    modelServingSection.getKServeRow('Llama Service').findExpansion().should(be.collapsed);
+    modelServingSection.getKServeRow('Llama Service').findToggleButton().click();
+    modelServingSection
+      .findDescriptionListItem('Llama Service', 'Model server size')
+      .next('dd')
+      .should('contain.text', 'Custom');
+
+    // click on the toggle button and open edit model server
+    modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
+
+    kserveModal.shouldBeOpen();
+
+    kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Custom');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -134,6 +134,10 @@ class ServingRuntimeModal extends Modal {
     return this.find().findByLabelText('Model server name *');
   }
 
+  findModelServerSizeValue() {
+    return this.find().findByLabelText('Model server size');
+  }
+
   findServingRuntimeTemplateDropdown() {
     return this.find().get('#serving-runtime-template-selection');
   }

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -25,6 +25,7 @@ import {
 } from '~/api/k8s/inferenceServices';
 import { InferenceServiceModel, ProjectModel } from '~/api/models';
 import { InferenceServiceKind, ProjectKind } from '~/k8sTypes';
+import { ModelServingSize } from '~/pages/modelServing/screens/types';
 import { translateDisplayNameForK8s } from '~/pages/projects/utils';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
 
@@ -208,6 +209,89 @@ describe('assembleInferenceService', () => {
 
     expect(inferenceService.spec.predictor.maxReplicas).toBeUndefined();
     expect(inferenceService.spec.predictor.minReplicas).toBeUndefined();
+  });
+
+  it('should add requests on kserve', async () => {
+    const acceleratorProfileState: AcceleratorProfileState = {
+      acceleratorProfile: mockAcceleratorProfile({}),
+      acceleratorProfiles: [mockAcceleratorProfile({})],
+      initialAcceleratorProfile: mockAcceleratorProfile({}),
+      count: 1,
+      additionalOptions: {},
+      useExisting: false,
+    };
+
+    const modelSize: ModelServingSize = {
+      name: 'Small',
+      resources: {
+        requests: {
+          cpu: '1',
+          memory: '1Gi',
+        },
+        limits: {
+          cpu: '2',
+          memory: '2Gi',
+        },
+      },
+    };
+
+    const inferenceService = assembleInferenceService(
+      mockInferenceServiceModalData({ modelSize }),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      acceleratorProfileState,
+    );
+
+    expect(inferenceService.spec.predictor.model.resources?.requests?.cpu).toBe(
+      modelSize.resources.requests?.cpu,
+    );
+    expect(inferenceService.spec.predictor.model.resources?.requests?.memory).toBe(
+      modelSize.resources.requests?.memory,
+    );
+    expect(inferenceService.spec.predictor.model.resources?.limits?.cpu).toBe(
+      modelSize.resources.limits?.cpu,
+    );
+    expect(inferenceService.spec.predictor.model.resources?.limits?.memory).toBe(
+      modelSize.resources.limits?.memory,
+    );
+  });
+
+  it('should omit requests on mdoelmesh', async () => {
+    const acceleratorProfileState: AcceleratorProfileState = {
+      acceleratorProfile: mockAcceleratorProfile({}),
+      acceleratorProfiles: [mockAcceleratorProfile({})],
+      initialAcceleratorProfile: mockAcceleratorProfile({}),
+      count: 1,
+      additionalOptions: {},
+      useExisting: false,
+    };
+
+    const modelSize: ModelServingSize = {
+      name: 'Small',
+      resources: {
+        requests: {
+          cpu: '1',
+          memory: '1Gi',
+        },
+        limits: {
+          cpu: '2',
+          memory: '2Gi',
+        },
+      },
+    };
+
+    const inferenceService = assembleInferenceService(
+      mockInferenceServiceModalData({ modelSize }),
+      undefined,
+      undefined,
+      true,
+      undefined,
+      acceleratorProfileState,
+    );
+
+    expect(inferenceService.spec.predictor.model.resources).toBeUndefined();
   });
 });
 

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -13,6 +13,7 @@ import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/typ
 import { translateDisplayNameForK8s } from '~/pages/projects/utils';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
+import { ContainerResources } from '~/types';
 import { getModelServingProjects } from './projects';
 import { assemblePodSpecOptions } from './utils';
 
@@ -24,12 +25,11 @@ export const assembleInferenceService = (
   inferenceService?: InferenceServiceKind,
   acceleratorState?: AcceleratorProfileState,
 ): InferenceServiceKind => {
-  const { storage, format, servingRuntimeName, project, maxReplicas, minReplicas } = data;
+  const { storage, format, servingRuntimeName, project, modelSize, maxReplicas, minReplicas } =
+    data;
   const name = editName || translateDisplayNameForK8s(data.name);
   const { path, dataConnection } = storage;
   const dataConnectionKey = secretKey || dataConnection;
-
-  const { tolerations, resources } = assemblePodSpecOptions({}, acceleratorState);
 
   const updateInferenceService: InferenceServiceKind = inferenceService
     ? {
@@ -104,11 +104,25 @@ export const assembleInferenceService = (
         },
       };
 
-  if (!isModelMesh && tolerations.length !== 0) {
-    updateInferenceService.spec.predictor.tolerations = tolerations;
-  }
+  // Resource and Accelerator support for KServe
+  if (!isModelMesh) {
+    const resourceSettings: ContainerResources = {
+      requests: {
+        cpu: modelSize.resources.requests?.cpu,
+        memory: modelSize.resources.requests?.memory,
+      },
+      limits: {
+        cpu: modelSize.resources.limits?.cpu,
+        memory: modelSize.resources.limits?.memory,
+      },
+    };
 
-  if (!isModelMesh && resources.limits && resources.requests) {
+    const { tolerations, resources } = assemblePodSpecOptions(resourceSettings, acceleratorState);
+
+    if (tolerations.length !== 0) {
+      updateInferenceService.spec.predictor.tolerations = tolerations;
+    }
+
     updateInferenceService.spec.predictor.model.resources = resources;
   }
 

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -121,9 +121,11 @@ export const assembleServingRuntime = (
         volumeMounts.push(getshmVolumeMount());
       }
 
+      const containerWithoutResources = _.omit(container, 'resources');
+
       return {
-        ...container,
-        resources: isModelMesh ? resources : resourceSettings,
+        ...containerWithoutResources,
+        ...(isModelMesh ? { resources } : {}),
         affinity,
         volumeMounts,
       };

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -14,7 +14,7 @@ import {
   ImageStreamStatusTagCondition,
   VolumeMount,
 } from './types';
-import { ServingRuntimeSize } from './pages/modelServing/screens/types';
+import { ModelServingSize } from './pages/modelServing/screens/types';
 
 export enum KnownLabels {
   DASHBOARD_RESOURCE = 'opendatahub.io/dashboard',
@@ -1128,7 +1128,7 @@ export type DashboardConfigKind = K8sResourceCommon & {
       allowedGroups: string;
     };
     notebookSizes?: NotebookSize[];
-    modelServerSizes?: ServingRuntimeSize[];
+    modelServerSizes?: ModelServingSize[];
     notebookController?: {
       enabled: boolean;
       pvcSize?: string;

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -1,13 +1,13 @@
 import {
   RefreshIntervalTitle,
   RefreshIntervalValueType,
-  ServingRuntimeSize,
+  ModelServingSize,
   TimeframeStepType,
   TimeframeTimeType,
   TimeframeTitle,
 } from './types';
 
-export const DEFAULT_MODEL_SERVER_SIZES: ServingRuntimeSize[] = [
+export const DEFAULT_MODEL_SERVER_SIZES: ModelServingSize[] = [
   {
     name: 'Small',
     resources: {

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash-es';
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -12,6 +11,7 @@ import { AppContext } from '~/app/AppContext';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { getServingRuntimeSizes } from '~/pages/modelServing/screens/projects/utils';
 import useServingAcceleratorProfile from '~/pages/modelServing/screens/projects/useServingAcceleratorProfile';
+import { getResourceSize } from '~/pages/modelServing/utils';
 
 type ServingRuntimeDetailsProps = {
   obj: ServingRuntimeKind;
@@ -25,9 +25,11 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc
   const enabledAcceleratorProfiles = acceleratorProfile.acceleratorProfiles.filter(
     (ac) => ac.spec.enabled,
   );
-  const container = obj.spec.containers[0]; // can we assume the first container?
+  const resources = obj.spec.containers[0].resources || isvc?.spec.predictor.model.resources; // can we assume the first container?
   const sizes = getServingRuntimeSizes(dashboardConfig);
-  const size = sizes.find((currentSize) => _.isEqual(currentSize.resources, container.resources));
+  const size = sizes.find(
+    (currentSize) => getResourceSize(sizes, resources || {}).name === currentSize.name,
+  );
 
   return (
     <DescriptionList isHorizontal horizontalTermWidthModifier={{ default: '250px' }}>
@@ -37,17 +39,17 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc
           {isvc?.spec.predictor.minReplicas || obj.spec.replicas || 'Unknown'}
         </DescriptionListDescription>
       </DescriptionListGroup>
-      {container.resources && (
+      {resources && (
         <DescriptionListGroup>
           <DescriptionListTerm>Model server size</DescriptionListTerm>
           <DescriptionListDescription>
             <List isPlain>
               <ListItem>{size?.name || 'Custom'}</ListItem>
               <ListItem>
-                {`${container.resources.requests?.cpu} CPUs, ${container.resources.requests?.memory} Memory requested`}
+                {`${resources.requests?.cpu} CPUs, ${resources.requests?.memory} Memory requested`}
               </ListItem>
               <ListItem>
-                {`${container.resources.limits?.cpu} CPUs, ${container.resources.limits?.memory} Memory limit`}
+                {`${resources.limits?.cpu} CPUs, ${resources.limits?.memory} Memory limit`}
               </ListItem>
             </List>
           </DescriptionListDescription>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeExpandedField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeExpandedField.tsx
@@ -2,14 +2,19 @@ import * as React from 'react';
 import { FormGroup, Grid } from '@patternfly/react-core';
 import IndentSection from '~/pages/projects/components/IndentSection';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
-import { CreatingServingRuntimeObject } from '~/pages/modelServing/screens/types';
+import {
+  CreatingInferenceServiceObject,
+  CreatingServingRuntimeObject,
+} from '~/pages/modelServing/screens/types';
 import { ContainerResourceAttributes, ContainerResources } from '~/types';
 import CPUField from '~/components/CPUField';
 import MemoryField from '~/components/MemoryField';
 
 type ServingRuntimeSizeExpandedFieldProps = {
-  data: CreatingServingRuntimeObject;
-  setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
+  data: CreatingServingRuntimeObject | CreatingInferenceServiceObject;
+  setData:
+    | UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>
+    | UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
 };
 
 type ResourceKeys = keyof ContainerResources;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -4,8 +4,9 @@ import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import {
+  CreatingInferenceServiceObject,
   CreatingServingRuntimeObject,
-  ServingRuntimeSize,
+  ModelServingSize,
 } from '~/pages/modelServing/screens/types';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import { isGpuDisabled } from '~/pages/modelServing/screens/projects/utils';
@@ -15,9 +16,11 @@ import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState'
 import ServingRuntimeSizeExpandedField from './ServingRuntimeSizeExpandedField';
 
 type ServingRuntimeSizeSectionProps = {
-  data: CreatingServingRuntimeObject;
-  setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
-  sizes: ServingRuntimeSize[];
+  data: CreatingServingRuntimeObject | CreatingInferenceServiceObject;
+  setData:
+    | UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>
+    | UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+  sizes: ModelServingSize[];
   servingRuntimeSelected?: ServingRuntimeKind;
   acceleratorProfileState: AcceleratorProfileState;
   setAcceleratorProfileState: UpdateObjectAtPropAndValue<AcceleratorProfileState>;

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -59,7 +59,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const [createDataServingRuntime, setCreateDataServingRuntime, resetDataServingRuntime, sizes] =
     useCreateServingRuntimeObject(editInfo?.servingRuntimeEditInfo);
   const [createDataInferenceService, setCreateDataInferenceService, resetDataInferenceService] =
-    useCreateInferenceServiceObject(editInfo?.inferenceServiceEditInfo);
+    useCreateInferenceServiceObject(
+      editInfo?.inferenceServiceEditInfo,
+      editInfo?.servingRuntimeEditInfo?.servingRuntime,
+    );
   const [acceleratorProfileState, setAcceleratorProfileState, resetAcceleratorProfileData] =
     useServingAcceleratorProfile(
       editInfo?.servingRuntimeEditInfo?.servingRuntime,
@@ -83,12 +86,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     projectContext?.currentProject.metadata.name || createDataInferenceService.project;
 
   // Serving Runtime Validation
-  const baseInputValueValid =
-    createDataServingRuntime.numReplicas >= 0 &&
-    resourcesArePositive(createDataServingRuntime.modelSize.resources) &&
-    requestsUnderLimits(createDataServingRuntime.modelSize.resources);
-
-  const isDisabledServingRuntime = namespace === '' || actionInProgress || !baseInputValueValid;
+  const isDisabledServingRuntime = namespace === '' || actionInProgress;
 
   // Inference Service Validation
   const storageCanCreate = (): boolean => {
@@ -97,6 +95,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     }
     return isAWSValid(createDataInferenceService.storage.awsData, [AwsKeys.AWS_S3_BUCKET]);
   };
+
+  const baseInputValueValid = //createDataInferenceService.numReplicas >= 0 && TODO: Conflict with pending PR
+    resourcesArePositive(createDataInferenceService.modelSize.resources) &&
+    requestsUnderLimits(createDataInferenceService.modelSize.resources);
 
   const isDisabledInferenceService =
     actionInProgress ||
@@ -107,7 +109,8 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     containsOnlySlashes(createDataInferenceService.storage.path) ||
     createDataInferenceService.storage.path === '' ||
     !isInferenceServiceNameWithinLimit ||
-    !storageCanCreate();
+    !storageCanCreate() ||
+    !baseInputValueValid;
 
   const servingRuntimeSelected = React.useMemo(
     () =>
@@ -255,8 +258,8 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
           </StackItem>
           <StackItem>
             <ServingRuntimeSizeSection
-              data={createDataServingRuntime}
-              setData={setCreateDataServingRuntime}
+              data={createDataInferenceService}
+              setData={setCreateDataInferenceService}
               sizes={sizes}
               servingRuntimeSelected={servingRuntimeSelected}
               acceleratorProfileState={acceleratorProfileState}

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -71,7 +71,7 @@ export type CreatingServingRuntimeObject = {
   name: string;
   servingRuntimeTemplateName: string;
   numReplicas: number;
-  modelSize: ServingRuntimeSize;
+  modelSize: ModelServingSize;
   externalRoute: boolean;
   tokenAuth: boolean;
   tokens: ServingRuntimeToken[];
@@ -84,7 +84,7 @@ export type ServingRuntimeToken = {
   editName?: string;
 };
 
-export type ServingRuntimeSize = {
+export type ModelServingSize = {
   name: string;
   resources: ContainerResources;
 };
@@ -94,6 +94,7 @@ export type CreatingInferenceServiceObject = {
   project: string;
   servingRuntimeName: string;
   storage: InferenceServiceStorage;
+  modelSize: ModelServingSize;
   format: InferenceServiceFormat;
   maxReplicas: number;
   minReplicas: number;

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
@@ -3,7 +3,7 @@ import { AppContext } from '~/app/AppContext';
 import { PodContainer, NotebookSize } from '~/types';
 import { getNotebookSizes } from '~/pages/notebookController/screens/server/usePreferredNotebookSize';
 import { NotebookKind } from '~/k8sTypes';
-import { isCpuLimitEqual, isMemoryLimitEqual } from '~/utilities/valueUnits';
+import { isCpuResourceEqual, isMemoryResourceEqual } from '~/utilities/valueUnits';
 
 const useNotebookDeploymentSize = (
   notebook?: NotebookKind,
@@ -21,8 +21,11 @@ const useNotebookDeploymentSize = (
   const sizes = getNotebookSizes(dashboardConfig);
   const size = sizes.find(
     (currentSize) =>
-      isCpuLimitEqual(currentSize.resources.limits?.cpu, container.resources?.limits?.cpu) &&
-      isMemoryLimitEqual(currentSize.resources.limits?.memory, container.resources?.limits?.memory),
+      isCpuResourceEqual(currentSize.resources.limits?.cpu, container.resources?.limits?.cpu) &&
+      isMemoryResourceEqual(
+        currentSize.resources.limits?.memory,
+        container.resources?.limits?.memory,
+      ),
   );
 
   if (!size) {

--- a/frontend/src/utilities/__tests__/valueUnits.spec.ts
+++ b/frontend/src/utilities/__tests__/valueUnits.spec.ts
@@ -1,36 +1,36 @@
 import {
-  isCpuLimitEqual,
-  isMemoryLimitEqual,
+  isCpuResourceEqual,
+  isMemoryResourceEqual,
   isCpuLimitLarger,
   isMemoryLimitLarger,
 } from '~/utilities/valueUnits';
 
-describe('isCpuLimitEqual', () => {
+describe('isCpuResourceEqual', () => {
   test('correctly compares non-undefined values', () => {
-    expect(isCpuLimitEqual('1', '1')).toBe(true);
-    expect(isCpuLimitEqual(1, '1')).toBe(true);
-    expect(isCpuLimitEqual('1000m', '1')).toBe(true);
-    expect(isCpuLimitEqual('1000m', 1)).toBe(true);
-    expect(isCpuLimitEqual('1001m', '1')).toBe(false);
+    expect(isCpuResourceEqual('1', '1')).toBe(true);
+    expect(isCpuResourceEqual(1, '1')).toBe(true);
+    expect(isCpuResourceEqual('1000m', '1')).toBe(true);
+    expect(isCpuResourceEqual('1000m', 1)).toBe(true);
+    expect(isCpuResourceEqual('1001m', '1')).toBe(false);
   });
   test('correctly compares undefined values', () => {
-    expect(isCpuLimitEqual('1000m', undefined)).toBe(false);
-    expect(isCpuLimitEqual('1', undefined)).toBe(false);
-    expect(isCpuLimitEqual(1, undefined)).toBe(false);
-    expect(isCpuLimitEqual(undefined, undefined)).toBe(true);
+    expect(isCpuResourceEqual('1000m', undefined)).toBe(false);
+    expect(isCpuResourceEqual('1', undefined)).toBe(false);
+    expect(isCpuResourceEqual(1, undefined)).toBe(false);
+    expect(isCpuResourceEqual(undefined, undefined)).toBe(true);
   });
 });
 
-describe('isMemoryLimitEqual', () => {
+describe('isMemoryResourceEqual', () => {
   test('correctly compares non-undefined values', () => {
-    expect(isMemoryLimitEqual('1Gi', '1Gi')).toBe(true);
-    expect(isMemoryLimitEqual('1Gi', '1024Mi')).toBe(true);
-    expect(isMemoryLimitEqual('1Gi', '1025Mi')).toBe(false);
+    expect(isMemoryResourceEqual('1Gi', '1Gi')).toBe(true);
+    expect(isMemoryResourceEqual('1Gi', '1024Mi')).toBe(true);
+    expect(isMemoryResourceEqual('1Gi', '1025Mi')).toBe(false);
   });
   test('correctly compares undefined values', () => {
-    expect(isMemoryLimitEqual('1Gi', undefined)).toBe(false);
-    expect(isMemoryLimitEqual('1024Mi', undefined)).toBe(false);
-    expect(isMemoryLimitEqual(undefined, undefined)).toBe(true);
+    expect(isMemoryResourceEqual('1Gi', undefined)).toBe(false);
+    expect(isMemoryResourceEqual('1024Mi', undefined)).toBe(false);
+    expect(isMemoryResourceEqual(undefined, undefined)).toBe(true);
   });
 });
 

--- a/frontend/src/utilities/valueUnits.ts
+++ b/frontend/src/utilities/valueUnits.ts
@@ -57,7 +57,7 @@ export const isEqual = (
   units: UnitOption[],
 ): boolean => calculateDelta(value1, value2, units) === 0;
 
-export const isCpuLimitEqual = (cpu1?: ValueUnitCPU, cpu2?: ValueUnitCPU): boolean => {
+export const isCpuResourceEqual = (cpu1?: ValueUnitCPU, cpu2?: ValueUnitCPU): boolean => {
   const cpu1String = typeof cpu1 === 'number' ? `${cpu1}` : cpu1;
   const cpu2String = typeof cpu2 === 'number' ? `${cpu2}` : cpu2;
 
@@ -72,7 +72,7 @@ export const isCpuLimitEqual = (cpu1?: ValueUnitCPU, cpu2?: ValueUnitCPU): boole
   return isEqual(cpu1String, cpu2String, CPU_UNITS);
 };
 
-export const isMemoryLimitEqual = (
+export const isMemoryResourceEqual = (
   memory1?: ValueUnitString,
   memory2?: ValueUnitString,
 ): boolean => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-340
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change the way we handle resources for KServe, moving the specification to the `InferenceService` object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Already deployed model

1. Deploy a model with a custom size with KServe
2. Switch to this new changelog
3. Edit the model
4. Check that you get the right model size
5. Either change the size or submit
6. Check that now the `ServingRuntimeSpec` lacks of model size and `InferenceService` contains those changes

### New model 

1. Deploy a model with a custom size with KServe
2. Check that the `ServingRuntime` CR lacks of model size and `InferenceService` contains the resources.

### Edit model

1. Now edit that created model
2. Select a custom size
3. Change the values
4. Submit the values
5. Check that is reflected

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
[TBD] Waiting on https://github.com/opendatahub-io/odh-dashboard/pull/2391

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
