### PR TITLE
Fix an issue with the model server dropdown state

### DIFF
--- a/frontend/src/__mocks__/mockProjectK8sResource.ts
+++ b/frontend/src/__mocks__/mockProjectK8sResource.ts
@@ -9,6 +9,7 @@ type MockResourceConfigType = {
   k8sName?: string;
   enableModelMesh?: boolean;
   isDSProject?: boolean;
+  phase?: 'Active' | 'Terminating';
 };
 
 export const mockProjectK8sResource = ({
@@ -18,6 +19,7 @@ export const mockProjectK8sResource = ({
   enableModelMesh,
   description = '',
   isDSProject = true,
+  phase = 'Active',
 }: MockResourceConfigType): ProjectKind => ({
   kind: 'Project',
   apiVersion: 'project.openshift.io/v1',
@@ -39,7 +41,7 @@ export const mockProjectK8sResource = ({
     },
   },
   status: {
-    phase: 'Active',
+    phase,
   },
 });
 

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -45,13 +45,13 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
   const isInferenceServiceNameWithinLimit =
     translateDisplayNameForK8s(createData.name).length <= 253;
 
+  const currentProjectName = projectContext?.currentProject.metadata.name || '';
+  const currentServingRuntimeName = projectContext?.currentServingRuntime?.metadata.name || '';
+
   React.useEffect(() => {
-    if (projectContext) {
-      const { currentProject, currentServingRuntime } = projectContext;
-      setCreateData('project', currentProject.metadata.name);
-      setCreateData('servingRuntimeName', currentServingRuntime?.metadata.name || '');
-    }
-  }, [projectContext, setCreateData]);
+    setCreateData('project', currentProjectName);
+    setCreateData('servingRuntimeName', currentServingRuntimeName);
+  }, [setCreateData, currentProjectName, currentServingRuntimeName]);
 
   const storageCanCreate = (): boolean => {
     if (createData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
@@ -65,6 +65,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     createData.name.trim() === '' ||
     createData.project === '' ||
     createData.format.name === '' ||
+    createData.servingRuntimeName === '' ||
     removeLeadingSlashes(createData.storage.path).includes('//') ||
     containsOnlySlashes(createData.storage.path) ||
     createData.storage.path === '' ||

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
+import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
+import useServingRuntimes from '~/pages/modelServing/useServingRuntimes';
+import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
+
+jest.mock('~/pages/modelServing/useServingRuntimes', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const useServingRuntimesMock = jest.mocked(useServingRuntimes);
+
+describe('ManageInferenceServiceModal', () => {
+  it('should not rerender serving runtime selection', async () => {
+    useServingRuntimesMock.mockReturnValue([
+      [
+        mockServingRuntimeK8sResource({ name: 'runtime1', displayName: 'Runtime 1' }),
+        mockServingRuntimeK8sResource({ name: 'runtime2' }),
+      ],
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+
+    const currentProject = mockProjectK8sResource({});
+    const wrapper = render(
+      <ManageInferenceServiceModal
+        isOpen={true}
+        projectContext={{
+          currentProject,
+          dataConnections: [],
+        }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    // Find the dropdown
+    const dropdown = await wrapper.findByText('Select a model server');
+
+    fireEvent.click(dropdown);
+
+    const option = await wrapper.findByText('Runtime 1');
+    fireEvent.click(option);
+    expect(dropdown.textContent).toBe('Runtime 1');
+
+    const projectChange = mockProjectK8sResource({ phase: 'Terminating' });
+
+    // Change the currentProject prop
+    await act(async () => {
+      wrapper.rerender(
+        <ManageInferenceServiceModal
+          isOpen={true}
+          projectContext={{
+            currentProject: projectChange,
+            dataConnections: [],
+          }}
+          onClose={jest.fn()}
+        />,
+      );
+    });
+
+    expect(dropdown.textContent).toBe('Runtime 1');
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-2724

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix an issue regarding states of the model server dropdown being restored on each project polling

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Go to model serving global
2. Select a modelmesh project
3. Click on deploy new model
4. Select a model server
5. Wait around 15 seconds
6. The selection should not disappear

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
