### PR TITLE
Unit test case for useQueryRangeResourceData

### DIFF
--- a/frontend/src/api/prometheus/__tests__/useQueryRangeResourceData.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/useQueryRangeResourceData.spec.ts
@@ -1,0 +1,66 @@
+import { TimeframeTitle } from '~/concepts/metrics/types';
+import useQueryRangeResourceData from '~/api/prometheus/useQueryRangeResourceData';
+import { TimeframeStep, TimeframeTimeRange } from '~/concepts/metrics/const';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import * as usePrometheusQueryRangeModule from '~/api/prometheus/usePrometheusQueryRange';
+import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
+
+describe('useQueryRangeResourceData', () => {
+  const active = true;
+  const query = 'testQuery';
+  const end = 123456;
+  const timeframe: TimeframeTitle = TimeframeTitle.ONE_HOUR;
+  const responsePredicate = jest.fn();
+  const namespace = 'testNamespace';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call usePrometheusQueryRange with correct arguments and restructure the returned data', async () => {
+    const spy = jest.spyOn(usePrometheusQueryRangeModule, 'default');
+    const mockedResponse = { data: { result: mockPrometheusQueryResponse({}) } };
+
+    spy.mockReturnValue([
+      mockedResponse.data.result.data.result,
+      true,
+      undefined,
+      expect.any(Function),
+      false,
+    ]);
+
+    const renderResult = testHook(useQueryRangeResourceData)(
+      active,
+      query,
+      end,
+      timeframe,
+      responsePredicate,
+      namespace,
+    );
+
+    expect(renderResult).hookToStrictEqual({
+      data: mockedResponse.data.result.data.result,
+      loaded: true,
+      error: undefined,
+      refresh: expect.any(Function),
+      pending: false,
+    });
+
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    expect(spy).toHaveBeenCalledWith(
+      active,
+      '/api/prometheus/serving',
+      query,
+      TimeframeTimeRange[timeframe],
+      end,
+      TimeframeStep[timeframe],
+      responsePredicate,
+      namespace,
+      undefined,
+    );
+
+    // Restore the spy
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-2176](https://issues.redhat.com/browse/RHOAIENG-2176)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Unit test case for useQueryRangeResourceData

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
<img width="684" alt="Screenshot 2024-02-09 at 7 13 52 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/71a9866c-1e20-4692-8757-24bb9d9779a8">

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
