### PR TITLE
render AreaContextProvider higher in the tree to run network call in parallel

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -44,74 +44,78 @@ const App: React.FC = () => {
 
   useDetectUser();
 
-  if (!username || !configLoaded || !dashboardConfig) {
-    // We lack the critical data to startup the app
-    if (userError || fetchConfigError) {
-      // There was an error fetching critical data
-      return (
-        <Page>
-          <PageSection>
-            <Stack hasGutter>
-              <StackItem>
-                <Alert variant="danger" isInline title="General loading error">
-                  <p>
-                    {(userError ? userError.message : fetchConfigError?.message) ||
-                      'Unknown error occurred during startup.'}
-                  </p>
-                  <p>Logging out and logging back in may solve the issue.</p>
-                </Alert>
-              </StackItem>
-              <StackItem>
-                <Button
-                  variant="secondary"
-                  onClick={() => logout().then(() => window.location.reload())}
-                >
-                  Logout
-                </Button>
-              </StackItem>
-            </Stack>
-          </PageSection>
-        </Page>
-      );
-    }
-
-    // Assume we are still waiting on the API to finish
+  // We lack the critical data to startup the app
+  if (userError || fetchConfigError) {
+    // There was an error fetching critical data
     return (
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
+      <Page>
+        <PageSection>
+          <Stack hasGutter>
+            <StackItem>
+              <Alert variant="danger" isInline title="General loading error">
+                <p>
+                  {(userError ? userError.message : fetchConfigError?.message) ||
+                    'Unknown error occurred during startup.'}
+                </p>
+                <p>Logging out and logging back in may solve the issue.</p>
+              </Alert>
+            </StackItem>
+            <StackItem>
+              <Button
+                variant="secondary"
+                onClick={() => logout().then(() => window.location.reload())}
+              >
+                Logout
+              </Button>
+            </StackItem>
+          </Stack>
+        </PageSection>
+      </Page>
     );
   }
 
+  // Waiting on the API to finish
+  const loading = !username || !configLoaded || !dashboardConfig;
+
   return (
-    <AppContext.Provider
-      value={{
-        buildStatuses,
-        dashboardConfig,
-      }}
-    >
-      <AreaContextProvider>
-        <Page
-          className="odh-dashboard"
-          isManagedSidebar
-          header={<Header onNotificationsClick={() => setNotificationsOpen(!notificationsOpen)} />}
-          sidebar={isAllowed ? <NavSidebar /> : undefined}
-          notificationDrawer={<AppNotificationDrawer onClose={() => setNotificationsOpen(false)} />}
-          isNotificationDrawerExpanded={notificationsOpen}
-          mainContainerId={DASHBOARD_MAIN_CONTAINER_ID}
+    <AreaContextProvider>
+      {loading ? (
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      ) : (
+        <AppContext.Provider
+          value={{
+            buildStatuses,
+            dashboardConfig,
+          }}
         >
-          <ErrorBoundary>
-            <ProjectsContextProvider>
-              <QuickStarts>
-                <AppRoutes />
-              </QuickStarts>
-            </ProjectsContextProvider>
-            <ToastNotifications />
-            <TelemetrySetup />
-          </ErrorBoundary>
-        </Page>
-      </AreaContextProvider>
-    </AppContext.Provider>
+          <Page
+            className="odh-dashboard"
+            isManagedSidebar
+            header={
+              <Header onNotificationsClick={() => setNotificationsOpen(!notificationsOpen)} />
+            }
+            sidebar={isAllowed ? <NavSidebar /> : undefined}
+            notificationDrawer={
+              <AppNotificationDrawer onClose={() => setNotificationsOpen(false)} />
+            }
+            isNotificationDrawerExpanded={notificationsOpen}
+            mainContainerId={DASHBOARD_MAIN_CONTAINER_ID}
+          >
+            <ErrorBoundary>
+              <ProjectsContextProvider>
+                <QuickStarts>
+                  <AppRoutes />
+                </QuickStarts>
+              </ProjectsContextProvider>
+              <ToastNotifications />
+              <TelemetrySetup />
+            </ErrorBoundary>
+          </Page>
+        </AppContext.Provider>
+      )}
+    </AreaContextProvider>
   );
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2935

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
As shown in the `Before` screenshot, the call to `/api/dsc/status` comes only after the other calls to `status`, `builds`, `config`. While in the `After` all request are run in parallel

Before:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/6b1a08ba-586a-4712-9013-3593d347da8d)

After:
<img width="971" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/14068621/cf64ce74-81c5-400b-8aa1-3ef1cc814c0c">

_Note that the total request time differs in before and after because the before was taken from a prod install while the after was from a local dev environment._


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally running app and tests.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Test if app continues to load.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
