### PR TITLE
remove SDK initialize delay

### DIFF
--- a/frontend/src/SDKInitialize.tsx
+++ b/frontend/src/SDKInitialize.tsx
@@ -62,12 +62,15 @@ const SDKInitialize: React.FC<SDKInitializeProps> = ({ children }) => {
   // TODO: Figure out what's going on in the SDK
   const [ready, setReady] = React.useState(false);
   React.useEffect(() => {
-    const intervalId = setInterval(() => {
+    const handler = () => {
       if (isUtilsConfigSet()) {
         setReady(true);
         clearInterval(intervalId);
       }
-    }, 1000);
+    };
+    const intervalId = setInterval(handler, 100);
+    // Immediately check to prevent unecessary delays
+    handler();
   }, []);
 
   return (

--- a/frontend/src/__tests__/cypress/cypress/support/commands/intercept-snapshots.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/intercept-snapshots.ts
@@ -14,29 +14,6 @@ declare global {
   }
 }
 
-Cypress.Commands.add('visitWithLogin', (url) => {
-  cy.intercept('GET', url).as('visitWithLogin');
-
-  cy.visit(url, { failOnStatusCode: false });
-
-  cy.wait('@visitWithLogin').then((interception) => {
-    if (interception.response?.statusCode === 403) {
-      // do login
-      cy.findByRole('button', { name: 'Log in with OpenShift' }).click();
-      cy.findByRole('link', { name: 'customadmins' }).click();
-      cy.findByLabelText('Username *').type(Cypress.env('USERNAME'));
-      cy.findByLabelText('Password *').type(Cypress.env('PASSWORD'));
-      cy.findByRole('button', { name: 'Log in' }).click();
-    } else if (interception.response?.statusCode !== 200) {
-      throw new Error(
-        `Failed to visit '${url}'. Status code: ${interception.response?.statusCode || 'unknown'}`,
-      );
-    } else {
-      cy.log('Already logged in');
-    }
-  });
-});
-
 Cypress.Commands.add('readSnapshot', (path) => cy.task('readJSON', path));
 
 Cypress.Commands.add('waitSnapshot', (alias) => waitSnapshot(alias));

--- a/frontend/src/components/error/ErrorDetails.tsx
+++ b/frontend/src/components/error/ErrorDetails.tsx
@@ -23,7 +23,7 @@ const ErrorDetails: React.FC<ErrorDetailsProps> = ({
   stack,
 }) => (
   <>
-    <Title headingLevel="h3" className="pf-v5-u-mb-lg">
+    <Title headingLevel="h2" className="pf-v5-u-mb-lg">
       {title}
     </Title>
     <DescriptionList>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2952

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Removes the 1second delay that was arbitrarily added to work around an issue in the dynamic plugin SDK. Not the check is run immediately and the delay is reduced to 100ms. In testing, waiting for the effect to run is sufficient but kept the delay because of the async nature of the problem to be safe.

Cypress test execution time locally has also been reduce:
Before: `5m36s`
After: `3m25s`

It seems like the SDK also at one point was holding up rendering much like our app on the setting of config but was removed in this change: https://github.com/openshift/dynamic-plugin-sdk/commit/1b7f29515cbb43c67d5cf6c5010d5ac6adcaa27f

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the application.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
