### PR TITLE
fix lint error requiring dot notation

### DIFF
--- a/frontend/src/api/pipelines/__tests__/k8s.spec.ts
+++ b/frontend/src/api/pipelines/__tests__/k8s.spec.ts
@@ -101,7 +101,7 @@ describe('createPipelinesCR', () => {
   delete DSPipelinemock.status;
   it('should create pipelines CR', async () => {
     k8sCreateResourceMock.mockResolvedValue(DSPipelinemock);
-    const result = await createPipelinesCR('test-project', DSPipelinemock['spec']);
+    const result = await createPipelinesCR('test-project', DSPipelinemock.spec);
     expect(k8sCreateResourceMock).toHaveBeenCalledWith({
       fetchOptions: { requestInit: {} },
       model: {
@@ -119,9 +119,7 @@ describe('createPipelinesCR', () => {
 
   it('should handle errors and rethrow', async () => {
     k8sCreateResourceMock.mockRejectedValue(new Error('error1'));
-    await expect(createPipelinesCR('test-project', DSPipelinemock['spec'])).rejects.toThrow(
-      'error1',
-    );
+    await expect(createPipelinesCR('test-project', DSPipelinemock.spec)).rejects.toThrow('error1');
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
     expect(k8sCreateResourceMock).toHaveBeenCalledWith({
       fetchOptions: { requestInit: {} },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes a linting error for the `@typescript-eslint/dot-notation` rule.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test:lint` in frontend

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
