### PR TITLE
Content update for cluster settings and notebook image settings

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/notebookImageSettings/NotebookImageSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/notebookImageSettings/NotebookImageSettings.cy.ts
@@ -10,7 +10,7 @@ import {
 } from '~/__tests__/cypress/cypress/pages/notebookImageSettings';
 import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 
-describe('Notebook Image Settings', () => {
+describe('Notebook images', () => {
   it('Table filtering, sorting, searching', () => {
     cy.intercept('/api/status', mockStatus());
     cy.intercept('/api/config', mockDashboardConfig({}));

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
@@ -11,7 +11,7 @@ class NotebookImageSettings {
   }
 
   navigate() {
-    appChrome.findNavItem('Notebook image settings', 'Settings').click();
+    appChrome.findNavItem('Notebook images', 'Settings').click();
     this.wait();
   }
 

--- a/frontend/src/pages/BYONImages/BYONImages.tsx
+++ b/frontend/src/pages/BYONImages/BYONImages.tsx
@@ -9,7 +9,7 @@ const BYONImages: React.FC = () => {
 
   return (
     <ApplicationsPage
-      title="Notebook image settings"
+      title="Notebook images"
       description="Manage your notebook images."
       loaded={loaded}
       empty={images.length === 0}

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -133,7 +133,7 @@ const ClusterSettings: React.FC = () => {
   return (
     <ApplicationsPage
       title="Cluster settings"
-      description="Update global settings for all users."
+      description="Manage global settings for all users."
       loaded={loaded}
       empty={false}
       loadError={loadError}

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -103,7 +103,7 @@ const useCustomNotebooksNav = (): NavDataHref[] =>
   useAreaCheck<NavDataHref>(SupportedArea.BYON, [
     {
       id: 'settings-notebook-images',
-      label: 'Notebook image settings',
+      label: 'Notebook images',
       href: '/notebookImages',
     },
   ]);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-1194
Closes: https://issues.redhat.com/browse/RHOAIENG-1195

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Content updates to Cluster settings subheader and Notebook image settings renamed to "Custom notebook images"

<img width="969" alt="Screenshot 2024-02-16 at 8 09 12 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/fd168b57-8576-4602-a021-75cc940eda91">

<img width="1006" alt="Screenshot 2024-02-12 at 5 24 51 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/02bd7611-16a6-4d8f-82bb-308faf60a417">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. As a `clusteradminuser` go to `Settings` in the left navbar, you should see `Custom notebook images` instead of `Notebook image settings` and the same applies to the title of the page.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fixed tests impacted by this change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
