### PR TITLE
Add Readiness/Liveness probes to caikit-ootb

### DIFF
--- a/manifests/modelserving/caikit-ootb.yaml
+++ b/manifests/modelserving/caikit-ootb.yaml
@@ -43,9 +43,29 @@ objects:
         env:
           - name: RUNTIME_LOCAL_MODELS_DIR
             value: /mnt/models
+          - name: TRANSFORMERS_CACHE
+            value: /tmp/transformers_cache
+          - name: RUNTIME_GRPC_ENABLED
+            value: "false"
+          - name: RUNTIME_HTTP_ENABLED
+            value: "true"
           - name: RUNTIME_GRPC_SERVER_THREAD_POOL_SIZE
             value: "64"
         ports:
           - containerPort: 8080
             protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+              - python
+              - -m
+              - caikit_health_probe
+              - readiness
+        livenessProbe:
+          exec:
+            command:
+              - python
+              - -m
+              - caikit_health_probe
+              - liveness
 parameters: []


### PR DESCRIPTION
Add liveness/readiness probes and env variables

Related to:

- https://github.com/opendatahub-io/caikit-tgis-serving/pull/205
- https://github.com/opendatahub-io/caikit-tgis-serving/pull/186

## Description

## How Has This Been Tested?

Manifest has been deployed in a fresh cluster with a fresh kserve install: https://github.com/opendatahub-io/caikit-tgis-serving/pull/220

## Test Impact


## Request review criteria:

<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)
