### PR TITLE
Add kebab toggle to the pipeline version row

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -55,12 +55,7 @@ export const pipelineVersionColumns: SortableData<PipelineVersionKFv2>[] = [
     sortable: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     width: 20,
   },
-  {
-    label: '',
-    field: 'Action',
-    sortable: false,
-    width: 20,
-  },
+  kebabTableColumn(),
 ];
 
 export const pipelineRunColumns: SortableData<PipelineRunKFv2>[] = [

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { Td, Tr } from '@patternfly/react-table';
-import { Button } from '@patternfly/react-core';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { Link, useNavigate } from 'react-router-dom';
-import { PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
+import { PipelineKFv2, PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd, TableRowTitleDescription } from '~/components/table';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
@@ -14,6 +13,8 @@ type PipelineVersionTableRowProps = {
   pipelineVersionDetailsPath: (namespace: string, id: string) => string;
   version: PipelineVersionKFv2;
   isDisabled: boolean;
+  pipeline: PipelineKFv2;
+  onDeleteVersion: () => void;
 };
 
 const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
@@ -22,6 +23,8 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
   pipelineVersionDetailsPath,
   version,
   isDisabled,
+  pipeline,
+  onDeleteVersion,
 }) => {
   const navigate = useNavigate();
   const { namespace } = usePipelinesAPI();
@@ -49,24 +52,42 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
       <Td>
         <PipelinesTableRowTime date={createdDate} />
       </Td>
-      <Td>
-        <Button
-          variant="link"
-          isInline
-          onClick={() =>
-            navigate(
-              {
-                pathname: `/pipelineRuns/${namespace}`,
-                search: `?runType=${PipelineRunType.Triggered}`,
+      <Td isActionCell>
+        <ActionsColumn
+          items={[
+            {
+              title: 'Create run',
+              onClick: () => {
+                navigate(`/pipelines/${namespace}/pipelineRun/create`, {
+                  state: { lastPipeline: pipeline, lastVersion: version },
+                });
               },
-              {
-                state: { lastVersion: version },
+            },
+            {
+              title: 'View runs',
+              onClick: () => {
+                navigate(
+                  {
+                    pathname: `/pipelineRuns/${namespace}`,
+                    search: `?runType=${PipelineRunType.Triggered}`,
+                  },
+                  {
+                    state: { lastVersion: version },
+                  },
+                );
               },
-            )
-          }
-        >
-          View runs
-        </Button>
+            },
+            {
+              isSeparator: true,
+            },
+            {
+              title: 'Delete pipeline version',
+              onClick: () => {
+                onDeleteVersion();
+              },
+            },
+          ]}
+        />
       </Td>
     </Tr>
   );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-2644

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a kebab toggle to the pipeline version row to replace the previous `View runs` button. In the dropdown menu, user could create a run using the version, view all runs from that version, or delete the single version.

<img width="1728" alt="Screenshot 2024-02-14 at 1 41 12 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/3d502b4c-f39d-43fc-a29a-29f600b50587">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to global pipelines table
2. Expand the pipeline row, check the version table, make sure the pipeline version row has the kebab toggle
3. Check the buttons in the dropdown menu, make sure they works (e.g. You can delete a single version. You can also click on `Create run`, which can take you to the create run page with pipeline and version prefilled...)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add a cypress test to delete a single version using the dropdown menu on the version table row.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
