### PR TITLE
Model deploy error is not informative

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -16,6 +16,7 @@ type MockResourceConfigType = {
   acceleratorIdentifier?: string;
   minReplicas?: number;
   maxReplicas?: number;
+  lastFailureInfoMessage?: string;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -69,6 +70,7 @@ export const mockInferenceServiceK8sResource = ({
   acceleratorIdentifier = '',
   minReplicas = 1,
   maxReplicas = 1,
+  lastFailureInfoMessage = 'Waiting for runtime Pod to become available',
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',
@@ -145,7 +147,7 @@ export const mockInferenceServiceK8sResource = ({
         totalCopies: 0,
       },
       lastFailureInfo: {
-        message: 'Waiting for runtime Pod to become available',
+        message: lastFailureInfoMessage,
         modelRevisionName: 'model-size__isvc-59ce37c85b',
         reason: 'RuntimeUnhealthy',
         location: '',

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
@@ -337,553 +337,600 @@ const initIntercepts = ({
 };
 
 describe('Serving Runtime List', () => {
-  it('Deploy ModelMesh model', () => {
-    initIntercepts({
-      projectEnableModelMesh: true,
-      disableKServeConfig: false,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
-        mockInferenceServiceK8sResource({
-          name: 'another-inference-service',
-          displayName: 'Another Inference Service',
-          deleted: true,
-          isModelMesh: true,
-        }),
-        mockInferenceServiceK8sResource({
-          name: 'ovms-testing',
-          displayName: 'OVMS ONNX',
-          isModelMesh: true,
-        }),
-      ],
-    });
+  describe('No server available', () => {
+    it('No model serving platform available', () => {
+      initIntercepts({
+        disableModelMeshConfig: true,
+        disableKServeConfig: true,
+        servingRuntimes: [],
+      });
 
-    projectDetails.visit('test-project');
+      projectDetails.visit('test-project');
 
-    modelServingSection.getModelMeshRow('ovms').findDeployModelButton().click();
-
-    inferenceServiceModal.shouldBeOpen();
-
-    // test that you can not submit on empty
-    inferenceServiceModal.findSubmitButton().should('be.disabled');
-
-    // test filling in minimum required fields
-    inferenceServiceModal.findModelNameInput().type('Test Name');
-    inferenceServiceModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
-    inferenceServiceModal.findSubmitButton().should('be.disabled');
-    inferenceServiceModal.findExistingConnectionSelect().findSelectOption('Test Secret').click();
-    inferenceServiceModal.findLocationPathInput().type('test-model/');
-    inferenceServiceModal.findSubmitButton().should('be.enabled');
-    inferenceServiceModal.findNewDataConnectionOption().click();
-    inferenceServiceModal.findLocationPathInput().clear();
-    inferenceServiceModal.findSubmitButton().should('be.disabled');
-    inferenceServiceModal.findLocationNameInput().type('Test Name');
-    inferenceServiceModal.findLocationAccessKeyInput().type('test-key');
-    inferenceServiceModal.findLocationSecretKeyInput().type('test-secret-key');
-    inferenceServiceModal.findLocationEndpointInput().type('test-endpoint');
-    inferenceServiceModal.findLocationBucketInput().type('test-bucket');
-    inferenceServiceModal.findLocationPathInput().type('test-model/');
-    inferenceServiceModal.findSubmitButton().should('be.enabled');
-  });
-
-  it('Deploy KServe model', () => {
-    initIntercepts({
-      disableModelMeshConfig: false,
-      disableKServeConfig: false,
-      servingRuntimes: [],
-    });
-
-    projectDetails.visit('test-project');
-
-    modelServingSection.findDeployModelButton().click();
-
-    kserveModal.shouldBeOpen();
-
-    // test that you can not submit on empty
-    kserveModal.findSubmitButton().should('be.disabled');
-
-    // test filling in minimum required fields
-    kserveModal.findModelNameInput().type('Test Name');
-    kserveModal.findServingRuntimeTemplateDropdown().findDropdownItem('Caikit').click();
-    kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
-    kserveModal.findSubmitButton().should('be.disabled');
-    kserveModal.findExistingConnectionSelect().findSelectOption('Test Secret').click();
-    kserveModal.findLocationPathInput().type('test-model/');
-    kserveModal.findSubmitButton().should('be.enabled');
-    kserveModal.findNewDataConnectionOption().click();
-    kserveModal.findLocationPathInput().clear();
-    kserveModal.findSubmitButton().should('be.disabled');
-    kserveModal.findLocationNameInput().type('Test Name');
-    kserveModal.findLocationAccessKeyInput().type('test-key');
-    kserveModal.findLocationSecretKeyInput().type('test-secret-key');
-    kserveModal.findLocationEndpointInput().type('test-endpoint');
-    kserveModal.findLocationBucketInput().type('test-bucket');
-    kserveModal.findLocationPathInput().type('test-model/');
-    kserveModal.findSubmitButton().should('be.enabled');
-
-    // test submitting form, the modal should close to indicate success.
-    kserveModal.findSubmitButton().click();
-    kserveModal.shouldBeOpen(false);
-
-    // the serving runtime should have been created
-    cy.get('@createServingRuntime.all').then((interceptions) => {
-      expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      cy.findByText('No model serving platform selected').should('be.visible');
     });
   });
 
-  it('Do not deploy KServe model when user cannot edit namespace', () => {
-    initIntercepts({
-      disableModelMeshConfig: false,
-      disableKServeConfig: false,
-      servingRuntimes: [],
-      rejectAddSupportServingPlatformProject: true,
+  describe('ModelMesh', () => {
+    it('Deploy ModelMesh model', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+        disableKServeConfig: false,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
+          mockInferenceServiceK8sResource({
+            name: 'another-inference-service',
+            displayName: 'Another Inference Service',
+            deleted: true,
+            isModelMesh: true,
+          }),
+          mockInferenceServiceK8sResource({
+            name: 'ovms-testing',
+            displayName: 'OVMS ONNX',
+            isModelMesh: true,
+          }),
+        ],
+      });
+
+      projectDetails.visit('test-project');
+
+      modelServingSection.getModelMeshRow('ovms').findDeployModelButton().click();
+
+      inferenceServiceModal.shouldBeOpen();
+
+      // test that you can not submit on empty
+      inferenceServiceModal.findSubmitButton().should('be.disabled');
+
+      // test filling in minimum required fields
+      inferenceServiceModal.findModelNameInput().type('Test Name');
+      inferenceServiceModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
+      inferenceServiceModal.findSubmitButton().should('be.disabled');
+      inferenceServiceModal.findExistingConnectionSelect().findSelectOption('Test Secret').click();
+      inferenceServiceModal.findLocationPathInput().type('test-model/');
+      inferenceServiceModal.findSubmitButton().should('be.enabled');
+      inferenceServiceModal.findNewDataConnectionOption().click();
+      inferenceServiceModal.findLocationPathInput().clear();
+      inferenceServiceModal.findSubmitButton().should('be.disabled');
+      inferenceServiceModal.findLocationNameInput().type('Test Name');
+      inferenceServiceModal.findLocationAccessKeyInput().type('test-key');
+      inferenceServiceModal.findLocationSecretKeyInput().type('test-secret-key');
+      inferenceServiceModal.findLocationEndpointInput().type('test-endpoint');
+      inferenceServiceModal.findLocationBucketInput().type('test-bucket');
+      inferenceServiceModal.findLocationPathInput().type('test-model/');
+      inferenceServiceModal.findSubmitButton().should('be.enabled');
     });
 
-    projectDetails.visit('test-project');
+    it('ModelMesh ServingRuntime list', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+        disableKServeConfig: false,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
+          mockInferenceServiceK8sResource({
+            name: 'another-inference-service',
+            displayName: 'Another Inference Service',
+            deleted: true,
+            isModelMesh: true,
+          }),
+          mockInferenceServiceK8sResource({
+            name: 'ovms-testing',
+            displayName: 'OVMS ONNX',
+            activeModelState: 'FailedToLoad',
+            isModelMesh: true,
+            lastFailureInfoMessage: 'Failed to pull model from storage due to error',
+          }),
+          mockInferenceServiceK8sResource({
+            name: 'loaded-model',
+            displayName: 'Loaded model',
+            activeModelState: 'Loaded',
+            isModelMesh: true,
+            lastFailureInfoMessage: 'Failed to pull model from storage due to error',
+          }),
+        ],
+      });
 
-    modelServingSection.findDeployModelButton().click();
+      projectDetails.visit('test-project');
 
-    kserveModal.shouldBeOpen();
+      // Check that the legacy serving runtime is shown with the default runtime name
+      modelServingSection.getModelMeshRow('ovms').find().should('exist');
+      // Check that the legacy serving runtime displays the correct Serving Runtime
+      modelServingSection.getModelMeshRow('ovms').shouldHaveServingRuntime('OpenVINO Model Server');
+      // Check that the legacy serving runtime has tokens disabled
+      modelServingSection.getModelMeshRow('ovms').shouldHaveTokens(false);
 
-    // test filling in minimum required fields
-    kserveModal.findModelNameInput().type('Test Name');
-    kserveModal.findServingRuntimeTemplateDropdown().findDropdownItem('Caikit').click();
-    kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
-    kserveModal.findExistingConnectionSelect().findSelectOption('Test Secret').click();
-    kserveModal.findNewDataConnectionOption().click();
-    kserveModal.findLocationNameInput().type('Test Name');
-    kserveModal.findLocationAccessKeyInput().type('test-key');
-    kserveModal.findLocationSecretKeyInput().type('test-secret-key');
-    kserveModal.findLocationEndpointInput().type('test-endpoint');
-    kserveModal.findLocationBucketInput().type('test-bucket');
-    kserveModal.findLocationPathInput().type('test-model/');
-    kserveModal.findSubmitButton().should('be.enabled');
+      modelServingSection.getModelMeshRow('ovms').findExpansion().should(be.collapsed);
+      modelServingSection.getModelMeshRow('ovms').findExpandButton().click();
+      modelServingSection.getModelMeshRow('ovms').findExpansion().should(be.expanded);
 
-    // test submitting form, an error should appear
-    kserveModal.findSubmitButton().click();
-    cy.findByText('Error creating model server');
+      // Check that the serving runtime is shown with the default runtime name
+      modelServingSection.getModelMeshRow('OVMS Model Serving').find().should('exist');
+      // Check that the serving runtime displays the correct Serving Runtime
+      modelServingSection
+        .getModelMeshRow('OVMS Model Serving')
+        .shouldHaveServingRuntime('OpenVINO Serving Runtime (Supports GPUs)');
 
-    // the serving runtime should NOT have been created
-    cy.get('@createServingRuntime.all').then((interceptions) => {
-      expect(interceptions).to.have.length(1); // 1 dry-run request only
-    });
+      // Check status of deployed model
+      modelServingSection
+        .getModelMeshRow('OVMS Model Serving')
+        .findDeployedModelExpansionButton()
+        .click();
+      modelServingSection.findInferenceServiceTable().should('exist');
+      modelServingSection.findStatusTooltip('OVMS ONNX').should('be.visible');
+      modelServingSection.findStatusTooltipValue(
+        'OVMS ONNX',
+        'Failed to pull model from storage due to error',
+      );
 
-    // the inference service should NOT have been created
-    cy.get('@createInferenceService.all').then((interceptions) => {
-      expect(interceptions).to.have.length(0);
-    });
-  });
-
-  it('No model serving platform available', () => {
-    initIntercepts({
-      disableModelMeshConfig: true,
-      disableKServeConfig: true,
-      servingRuntimes: [],
-    });
-
-    projectDetails.visit('test-project');
-
-    cy.findByText('No model serving platform selected').should('be.visible');
-  });
-
-  it('ModelMesh ServingRuntime list', () => {
-    initIntercepts({
-      projectEnableModelMesh: true,
-      disableKServeConfig: false,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
-        mockInferenceServiceK8sResource({
-          name: 'another-inference-service',
-          displayName: 'Another Inference Service',
-          deleted: true,
-          isModelMesh: true,
-        }),
-        mockInferenceServiceK8sResource({
-          name: 'ovms-testing',
-          displayName: 'OVMS ONNX',
-          activeModelState: 'FailedToLoad',
-          isModelMesh: true,
-          lastFailureInfoMessage: 'Failed to pull model from storage due to error',
-        }),
-        mockInferenceServiceK8sResource({
-          name: 'loaded-model',
-          displayName: 'Loaded model',
-          activeModelState: 'Loaded',
-          isModelMesh: true,
-          lastFailureInfoMessage: 'Failed to pull model from storage due to error',
-        }),
-      ],
-    });
-
-    projectDetails.visit('test-project');
-
-    // Check that the legacy serving runtime is shown with the default runtime name
-    modelServingSection.getModelMeshRow('ovms').find().should('exist');
-    // Check that the legacy serving runtime displays the correct Serving Runtime
-    modelServingSection.getModelMeshRow('ovms').shouldHaveServingRuntime('OpenVINO Model Server');
-    // Check that the legacy serving runtime has tokens disabled
-    modelServingSection.getModelMeshRow('ovms').shouldHaveTokens(false);
-
-    modelServingSection.getModelMeshRow('ovms').findExpansion().should(be.collapsed);
-    modelServingSection.getModelMeshRow('ovms').findExpandButton().click();
-    modelServingSection.getModelMeshRow('ovms').findExpansion().should(be.expanded);
-
-    // Check that the serving runtime is shown with the default runtime name
-    modelServingSection.getModelMeshRow('OVMS Model Serving').find().should('exist');
-    // Check that the serving runtime displays the correct Serving Runtime
-    modelServingSection
-      .getModelMeshRow('OVMS Model Serving')
-      .shouldHaveServingRuntime('OpenVINO Serving Runtime (Supports GPUs)');
-
-    // Check status of deployed model
-    modelServingSection
-      .getModelMeshRow('OVMS Model Serving')
-      .findDeployedModelExpansionButton()
-      .click();
-    modelServingSection.findInferenceServiceTable().should('exist');
-    modelServingSection.findStatusTooltip('OVMS ONNX').should('be.visible');
-    modelServingSection.findStatusTooltipValue(
-      'OVMS ONNX',
-      'Failed to pull model from storage due to error',
-    );
-
-    // Check status of deployed model which loaded successfully after an error
-    modelServingSection.findStatusTooltip('Loaded model').should('be.visible');
-    modelServingSection.findStatusTooltipValue('Loaded model', 'Loaded');
-  });
-
-  it('KServe Model list', () => {
-    initIntercepts({
-      projectEnableModelMesh: false,
-      disableKServeConfig: false,
-      disableModelMeshConfig: false,
-    });
-    projectDetails.visit('test-project');
-
-    // Check that we get the correct model name
-    modelServingSection
-      .getKServeRow('Test Inference Service')
-      .find()
-      .findByText('OpenVINO Serving Runtime (Supports GPUs)')
-      .should('exist');
-    // Check for resource marked for deletion
-    modelServingSection.getKServeRow('Another Inference Service').shouldBeMarkedForDeletion();
-  });
-
-  it('Add ModelMesh model server', () => {
-    initIntercepts({
-      projectEnableModelMesh: true,
-      disableKServeConfig: false,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
-        mockInferenceServiceK8sResource({
-          name: 'another-inference-service',
-          displayName: 'Another Inference Service',
-          deleted: true,
-          isModelMesh: true,
-        }),
-        mockInferenceServiceK8sResource({
-          name: 'ovms-testing',
-          displayName: 'OVMS ONNX',
-          isModelMesh: true,
-        }),
-      ],
-    });
-    projectDetails.visit('test-project');
-
-    modelServingSection.findAddModelServerButton().click();
-
-    createServingRuntimeModal.shouldBeOpen();
-
-    // test that you can not submit on empty
-    createServingRuntimeModal.findSubmitButton().should('be.disabled');
-
-    // test filling in minimum required fields
-    createServingRuntimeModal.findModelServerNameInput().type('Test Name');
-    createServingRuntimeModal
-      .findServingRuntimeTemplateDropdown()
-      .findDropdownItem('New OVMS Server')
-      .click();
-    createServingRuntimeModal.findSubmitButton().should('be.enabled');
-
-    // test the if the alert is visible when route is external while token is not set
-    createServingRuntimeModal.findModelRouteCheckbox().should('not.be.checked');
-    createServingRuntimeModal.findAuthenticationCheckbox().should('not.be.checked');
-    createServingRuntimeModal.findExternalRouteError().should('not.exist');
-    // check external route, token should be checked and no alert
-    createServingRuntimeModal.findModelRouteCheckbox().check();
-    createServingRuntimeModal.findAuthenticationCheckbox().should('be.checked');
-    createServingRuntimeModal.findExternalRouteError().should('not.exist');
-    createServingRuntimeModal.findServiceAccountNameInput().should('have.value', 'default-name');
-    // check external route, uncheck token, show alert
-    createServingRuntimeModal.findAuthenticationCheckbox().uncheck();
-    createServingRuntimeModal.findExternalRouteError().should('exist');
-    // internal route, set token, no alert
-    createServingRuntimeModal.findModelRouteCheckbox().uncheck();
-    createServingRuntimeModal.findAuthenticationCheckbox().check();
-    createServingRuntimeModal.findExternalRouteError().should('not.exist');
-  });
-
-  it('Edit ModelMesh model server', () => {
-    initIntercepts({
-      projectEnableModelMesh: true,
-      disableKServeConfig: false,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
-        mockInferenceServiceK8sResource({
-          name: 'ovms-testing',
-          displayName: 'OVMS ONNX',
-          isModelMesh: true,
-        }),
-      ],
-    });
-
-    projectDetails.visit('test-project');
-
-    // click on the toggle button and open edit model server
-    modelServingSection.getModelMeshRow('ovms').find().findKebabAction('Edit model server').click();
-
-    editServingRuntimeModal.shouldBeOpen();
-
-    // test name field
-    editServingRuntimeModal.findSubmitButton().should('be.disabled');
-    editServingRuntimeModal.findModelServerNameInput().clear();
-    editServingRuntimeModal.findModelServerNameInput().type('New name');
-    editServingRuntimeModal.findSubmitButton().should('be.enabled');
-    editServingRuntimeModal.findModelServerNameInput().clear();
-    editServingRuntimeModal.findModelServerNameInput().type('test-model-legacy');
-    editServingRuntimeModal.findSubmitButton().should('be.disabled');
-    // test replicas field
-    editServingRuntimeModal.findModelServerReplicasPlusButton().click();
-    editServingRuntimeModal.findSubmitButton().should('be.enabled');
-    editServingRuntimeModal.findModelServerReplicasMinusButton().click();
-    editServingRuntimeModal.findSubmitButton().should('be.disabled');
-    // test size field
-    editServingRuntimeModal
-      .findModelServerSizeSelect()
-      .findSelectOption(/Medium/)
-      .click();
-    editServingRuntimeModal.findSubmitButton().should('be.enabled');
-    editServingRuntimeModal.findModelServerSizeSelect().findSelectOption(/Small/).click();
-    editServingRuntimeModal.findSubmitButton().should('be.disabled');
-    // test external route field
-    editServingRuntimeModal.findModelRouteCheckbox().check();
-    editServingRuntimeModal.findSubmitButton().should('be.enabled');
-    editServingRuntimeModal.findModelRouteCheckbox().uncheck();
-    editServingRuntimeModal.findAuthenticationCheckbox().uncheck();
-    editServingRuntimeModal.findSubmitButton().should('be.disabled');
-    // test tokens field
-    editServingRuntimeModal.findAuthenticationCheckbox().check();
-    editServingRuntimeModal.findSubmitButton().should('be.enabled');
-    editServingRuntimeModal.findAuthenticationCheckbox().uncheck();
-    editServingRuntimeModal.findSubmitButton().should('be.disabled');
-  });
-
-  it('Successfully submit KServe Modal on edit', () => {
-    initIntercepts({
-      projectEnableModelMesh: false,
-      disableKServeConfig: true,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          modelName: 'llama-service',
-          isModelMesh: false,
-        }),
-      ],
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          namespace: 'test-project',
-        }),
-      ],
-    });
-
-    projectDetails.visit('test-project');
-
-    // click on the toggle button and open edit model server
-    modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
-
-    kserveModal.shouldBeOpen();
-
-    // Submit button should be enabled
-    kserveModal.findSubmitButton().should('be.enabled');
-
-    // Should allow editing
-    kserveModal.findSubmitButton().click();
-    kserveModal.shouldBeOpen(false);
-  });
-
-  it('Successfully add model server when user can edit namespace', () => {
-    initIntercepts({
-      projectEnableModelMesh: undefined,
-      disableKServeConfig: false,
-      disableModelMeshConfig: false,
-    });
-    projectDetails.visit('test-project');
-
-    modelServingSection.findAddModelServerButton().click();
-
-    createServingRuntimeModal.shouldBeOpen();
-
-    // fill in minimum required fields
-    createServingRuntimeModal.findModelServerNameInput().type('Test Name');
-    createServingRuntimeModal
-      .findServingRuntimeTemplateDropdown()
-      .findDropdownItem('New OVMS Server')
-      .click();
-    createServingRuntimeModal.findSubmitButton().should('be.enabled');
-
-    // test submitting form, the modal should close to indicate success.
-    createServingRuntimeModal.findSubmitButton().click();
-    createServingRuntimeModal.shouldBeOpen(false);
-
-    // the serving runtime should have been created
-    cy.get('@createServingRuntime.all').then((interceptions) => {
-      expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      // Check status of deployed model which loaded successfully after an error
+      modelServingSection.findStatusTooltip('Loaded model').should('be.visible');
+      modelServingSection.findStatusTooltipValue('Loaded model', 'Loaded');
     });
   });
 
-  it('Do not add model server when user cannot edit namespace', () => {
-    initIntercepts({
-      projectEnableModelMesh: undefined,
-      disableKServeConfig: false,
-      disableModelMeshConfig: false,
-      rejectAddSupportServingPlatformProject: true,
+  describe('KServe', () => {
+    it('Deploy KServe model', () => {
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
+        servingRuntimes: [],
+      });
+
+      projectDetails.visit('test-project');
+
+      modelServingSection.findDeployModelButton().click();
+
+      kserveModal.shouldBeOpen();
+
+      // test that you can not submit on empty
+      kserveModal.findSubmitButton().should('be.disabled');
+
+      // test filling in minimum required fields
+      kserveModal.findModelNameInput().type('Test Name');
+      kserveModal.findServingRuntimeTemplateDropdown().findDropdownItem('Caikit').click();
+      kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
+      kserveModal.findSubmitButton().should('be.disabled');
+      kserveModal.findExistingConnectionSelect().findSelectOption('Test Secret').click();
+      kserveModal.findLocationPathInput().type('test-model/');
+      kserveModal.findSubmitButton().should('be.enabled');
+      kserveModal.findNewDataConnectionOption().click();
+      kserveModal.findLocationPathInput().clear();
+      kserveModal.findSubmitButton().should('be.disabled');
+      kserveModal.findLocationNameInput().type('Test Name');
+      kserveModal.findLocationAccessKeyInput().type('test-key');
+      kserveModal.findLocationSecretKeyInput().type('test-secret-key');
+      kserveModal.findLocationEndpointInput().type('test-endpoint');
+      kserveModal.findLocationBucketInput().type('test-bucket');
+      kserveModal.findLocationPathInput().type('test-model/');
+      kserveModal.findSubmitButton().should('be.enabled');
+
+      // test submitting form, the modal should close to indicate success.
+      kserveModal.findSubmitButton().click();
+      kserveModal.shouldBeOpen(false);
+
+      // the serving runtime should have been created
+      cy.get('@createServingRuntime.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
     });
-    projectDetails.visit('test-project');
 
-    modelServingSection.findAddModelServerButton().click();
+    it('Do not deploy KServe model when user cannot edit namespace', () => {
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
+        servingRuntimes: [],
+        rejectAddSupportServingPlatformProject: true,
+      });
 
-    createServingRuntimeModal.shouldBeOpen();
+      projectDetails.visit('test-project');
 
-    // fill in minimum required fields
-    createServingRuntimeModal.findModelServerNameInput().type('Test Name');
-    createServingRuntimeModal
-      .findServingRuntimeTemplateDropdown()
-      .findDropdownItem('New OVMS Server')
-      .click();
-    createServingRuntimeModal.findSubmitButton().should('be.enabled');
+      modelServingSection.findDeployModelButton().click();
 
-    // test submitting form, an error should appear
-    createServingRuntimeModal.findSubmitButton().click();
-    cy.findByText('Error creating model server');
+      kserveModal.shouldBeOpen();
 
-    // the serving runtime should NOT have been created
-    cy.get('@createServingRuntime.all').then((interceptions) => {
-      expect(interceptions).to.have.length(1); // 1 dry-run request only
+      // test filling in minimum required fields
+      kserveModal.findModelNameInput().type('Test Name');
+      kserveModal.findServingRuntimeTemplateDropdown().findDropdownItem('Caikit').click();
+      kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
+      kserveModal.findExistingConnectionSelect().findSelectOption('Test Secret').click();
+      kserveModal.findNewDataConnectionOption().click();
+      kserveModal.findLocationNameInput().type('Test Name');
+      kserveModal.findLocationAccessKeyInput().type('test-key');
+      kserveModal.findLocationSecretKeyInput().type('test-secret-key');
+      kserveModal.findLocationEndpointInput().type('test-endpoint');
+      kserveModal.findLocationBucketInput().type('test-bucket');
+      kserveModal.findLocationPathInput().type('test-model/');
+      kserveModal.findSubmitButton().should('be.enabled');
+
+      // test submitting form, an error should appear
+      kserveModal.findSubmitButton().click();
+      cy.findByText('Error creating model server');
+
+      // the serving runtime should NOT have been created
+      cy.get('@createServingRuntime.all').then((interceptions) => {
+        expect(interceptions).to.have.length(1); // 1 dry-run request only
+      });
+
+      // the inference service should NOT have been created
+      cy.get('@createInferenceService.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0);
+      });
+    });
+
+    it('Successfully submit KServe Modal on edit', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: true,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            modelName: 'llama-service',
+            isModelMesh: false,
+          }),
+        ],
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            namespace: 'test-project',
+          }),
+        ],
+      });
+
+      projectDetails.visit('test-project');
+
+      // click on the toggle button and open edit model server
+      modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
+
+      kserveModal.shouldBeOpen();
+
+      // Submit button should be enabled
+      kserveModal.findSubmitButton().should('be.enabled');
+
+      // Should allow editing
+      kserveModal.findSubmitButton().click();
+      kserveModal.shouldBeOpen(false);
+    });
+
+    it('KServe Model list', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+      });
+      projectDetails.visit('test-project');
+
+      // Check that we get the correct model name
+      modelServingSection
+        .getKServeRow('Test Inference Service')
+        .find()
+        .findByText('OpenVINO Serving Runtime (Supports GPUs)')
+        .should('exist');
+      // Check for resource marked for deletion
+      modelServingSection.getKServeRow('Another Inference Service').shouldBeMarkedForDeletion();
+    });
+
+    it('Check number of replicas of model', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: true,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            modelName: 'llama-service',
+            isModelMesh: false,
+            minReplicas: 3,
+            maxReplicas: 3,
+          }),
+        ],
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            namespace: 'test-project',
+          }),
+        ],
+      });
+
+      projectDetails.visit('test-project');
+      modelServingSection.getKServeRow('Llama Service').findExpansion().should(be.collapsed);
+      modelServingSection.getKServeRow('Llama Service').findToggleButton().click();
+      modelServingSection
+        .findDescriptionListItem('Llama Service', 'Model server replicas')
+        .next('dd')
+        .should('have.text', '3');
     });
   });
 
-  it('Add model server - do not create ServiceAccount or RoleBinding if token auth is not selected', () => {
-    initIntercepts({
-      projectEnableModelMesh: undefined,
-      disableKServeConfig: false,
-      disableModelMeshConfig: false,
+  describe('ModelMesh model server', () => {
+    it('Add ModelMesh model server', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+        disableKServeConfig: false,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
+          mockInferenceServiceK8sResource({
+            name: 'another-inference-service',
+            displayName: 'Another Inference Service',
+            deleted: true,
+            isModelMesh: true,
+          }),
+          mockInferenceServiceK8sResource({
+            name: 'ovms-testing',
+            displayName: 'OVMS ONNX',
+            isModelMesh: true,
+          }),
+        ],
+      });
+      projectDetails.visit('test-project');
+
+      modelServingSection.findAddModelServerButton().click();
+
+      createServingRuntimeModal.shouldBeOpen();
+
+      // test that you can not submit on empty
+      createServingRuntimeModal.findSubmitButton().should('be.disabled');
+
+      // test filling in minimum required fields
+      createServingRuntimeModal.findModelServerNameInput().type('Test Name');
+      createServingRuntimeModal
+        .findServingRuntimeTemplateDropdown()
+        .findDropdownItem('New OVMS Server')
+        .click();
+      createServingRuntimeModal.findSubmitButton().should('be.enabled');
+
+      // test the if the alert is visible when route is external while token is not set
+      createServingRuntimeModal.findModelRouteCheckbox().should('not.be.checked');
+      createServingRuntimeModal.findAuthenticationCheckbox().should('not.be.checked');
+      createServingRuntimeModal.findExternalRouteError().should('not.exist');
+      // check external route, token should be checked and no alert
+      createServingRuntimeModal.findModelRouteCheckbox().check();
+      createServingRuntimeModal.findAuthenticationCheckbox().should('be.checked');
+      createServingRuntimeModal.findExternalRouteError().should('not.exist');
+      createServingRuntimeModal.findServiceAccountNameInput().should('have.value', 'default-name');
+      // check external route, uncheck token, show alert
+      createServingRuntimeModal.findAuthenticationCheckbox().uncheck();
+      createServingRuntimeModal.findExternalRouteError().should('exist');
+      // internal route, set token, no alert
+      createServingRuntimeModal.findModelRouteCheckbox().uncheck();
+      createServingRuntimeModal.findAuthenticationCheckbox().check();
+      createServingRuntimeModal.findExternalRouteError().should('not.exist');
     });
-    projectDetails.visit('test-project');
 
-    modelServingSection.findAddModelServerButton().click();
+    it('Edit ModelMesh model server', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+        disableKServeConfig: false,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({ name: 'test-inference', isModelMesh: true }),
+          mockInferenceServiceK8sResource({
+            name: 'ovms-testing',
+            displayName: 'OVMS ONNX',
+            isModelMesh: true,
+          }),
+        ],
+      });
 
-    createServingRuntimeModal.shouldBeOpen();
+      projectDetails.visit('test-project');
 
-    // fill in minimum required fields
-    createServingRuntimeModal.findModelServerNameInput().type('Test Name');
-    createServingRuntimeModal
-      .findServingRuntimeTemplateDropdown()
-      .findDropdownItem('New OVMS Server')
-      .click();
-    createServingRuntimeModal.findSubmitButton().should('be.enabled');
+      // click on the toggle button and open edit model server
+      modelServingSection
+        .getModelMeshRow('ovms')
+        .find()
+        .findKebabAction('Edit model server')
+        .click();
 
-    // test submitting form, the modal should close to indicate success.
-    createServingRuntimeModal.findSubmitButton().click();
-    createServingRuntimeModal.shouldBeOpen(false);
+      editServingRuntimeModal.shouldBeOpen();
 
-    // the service account and role binding should not have been created
-    cy.get('@createServiceAccount.all').then((interceptions) => {
-      expect(interceptions).to.have.length(0);
+      // test name field
+      editServingRuntimeModal.findSubmitButton().should('be.disabled');
+      editServingRuntimeModal.findModelServerNameInput().clear();
+      editServingRuntimeModal.findModelServerNameInput().type('New name');
+      editServingRuntimeModal.findSubmitButton().should('be.enabled');
+      editServingRuntimeModal.findModelServerNameInput().clear();
+      editServingRuntimeModal.findModelServerNameInput().type('test-model-legacy');
+      editServingRuntimeModal.findSubmitButton().should('be.disabled');
+      // test replicas field
+      editServingRuntimeModal.findModelServerReplicasPlusButton().click();
+      editServingRuntimeModal.findSubmitButton().should('be.enabled');
+      editServingRuntimeModal.findModelServerReplicasMinusButton().click();
+      editServingRuntimeModal.findSubmitButton().should('be.disabled');
+      // test size field
+      editServingRuntimeModal
+        .findModelServerSizeSelect()
+        .findSelectOption(/Medium/)
+        .click();
+      editServingRuntimeModal.findSubmitButton().should('be.enabled');
+      editServingRuntimeModal.findModelServerSizeSelect().findSelectOption(/Small/).click();
+      editServingRuntimeModal.findSubmitButton().should('be.disabled');
+      // test external route field
+      editServingRuntimeModal.findModelRouteCheckbox().check();
+      editServingRuntimeModal.findSubmitButton().should('be.enabled');
+      editServingRuntimeModal.findModelRouteCheckbox().uncheck();
+      editServingRuntimeModal.findAuthenticationCheckbox().uncheck();
+      editServingRuntimeModal.findSubmitButton().should('be.disabled');
+      // test tokens field
+      editServingRuntimeModal.findAuthenticationCheckbox().check();
+      editServingRuntimeModal.findSubmitButton().should('be.enabled');
+      editServingRuntimeModal.findAuthenticationCheckbox().uncheck();
+      editServingRuntimeModal.findSubmitButton().should('be.disabled');
     });
-    cy.get('@createRoleBinding.all').then((interceptions) => {
-      expect(interceptions).to.have.length(0);
+
+    it('Successfully add model server when user can edit namespace', () => {
+      initIntercepts({
+        projectEnableModelMesh: undefined,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+      });
+      projectDetails.visit('test-project');
+
+      modelServingSection.findAddModelServerButton().click();
+
+      createServingRuntimeModal.shouldBeOpen();
+
+      // fill in minimum required fields
+      createServingRuntimeModal.findModelServerNameInput().type('Test Name');
+      createServingRuntimeModal
+        .findServingRuntimeTemplateDropdown()
+        .findDropdownItem('New OVMS Server')
+        .click();
+      createServingRuntimeModal.findSubmitButton().should('be.enabled');
+
+      // test submitting form, the modal should close to indicate success.
+      createServingRuntimeModal.findSubmitButton().click();
+      createServingRuntimeModal.shouldBeOpen(false);
+
+      // the serving runtime should have been created
+      cy.get('@createServingRuntime.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+    });
+
+    it('Do not add model server when user cannot edit namespace', () => {
+      initIntercepts({
+        projectEnableModelMesh: undefined,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+        rejectAddSupportServingPlatformProject: true,
+      });
+      projectDetails.visit('test-project');
+
+      modelServingSection.findAddModelServerButton().click();
+
+      createServingRuntimeModal.shouldBeOpen();
+
+      // fill in minimum required fields
+      createServingRuntimeModal.findModelServerNameInput().type('Test Name');
+      createServingRuntimeModal
+        .findServingRuntimeTemplateDropdown()
+        .findDropdownItem('New OVMS Server')
+        .click();
+      createServingRuntimeModal.findSubmitButton().should('be.enabled');
+
+      // test submitting form, an error should appear
+      createServingRuntimeModal.findSubmitButton().click();
+      cy.findByText('Error creating model server');
+
+      // the serving runtime should NOT have been created
+      cy.get('@createServingRuntime.all').then((interceptions) => {
+        expect(interceptions).to.have.length(1); // 1 dry-run request only
+      });
     });
   });
 
-  it('Add model server - create ServiceAccount and RoleBinding if token auth is selected', () => {
-    initIntercepts({
-      projectEnableModelMesh: undefined,
-      disableKServeConfig: false,
-      disableModelMeshConfig: false,
+  describe('Model server with SericeAccount and RoleBinding', () => {
+    it('Add model server - do not create ServiceAccount or RoleBinding if token auth is not selected', () => {
+      initIntercepts({
+        projectEnableModelMesh: undefined,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+      });
+      projectDetails.visit('test-project');
+
+      modelServingSection.findAddModelServerButton().click();
+
+      createServingRuntimeModal.shouldBeOpen();
+
+      // fill in minimum required fields
+      createServingRuntimeModal.findModelServerNameInput().type('Test Name');
+      createServingRuntimeModal
+        .findServingRuntimeTemplateDropdown()
+        .findDropdownItem('New OVMS Server')
+        .click();
+      createServingRuntimeModal.findSubmitButton().should('be.enabled');
+
+      // test submitting form, the modal should close to indicate success.
+      createServingRuntimeModal.findSubmitButton().click();
+      createServingRuntimeModal.shouldBeOpen(false);
+
+      // the service account and role binding should not have been created
+      cy.get('@createServiceAccount.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0);
+      });
+      cy.get('@createRoleBinding.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0);
+      });
     });
-    projectDetails.visit('test-project');
 
-    modelServingSection.findAddModelServerButton().click();
+    it('Add model server - create ServiceAccount and RoleBinding if token auth is selected', () => {
+      initIntercepts({
+        projectEnableModelMesh: undefined,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+      });
+      projectDetails.visit('test-project');
 
-    createServingRuntimeModal.shouldBeOpen();
+      modelServingSection.findAddModelServerButton().click();
 
-    // fill in minimum required fields
-    createServingRuntimeModal.findModelServerNameInput().type('Test Name');
-    createServingRuntimeModal
-      .findServingRuntimeTemplateDropdown()
-      .findDropdownItem('New OVMS Server')
-      .click();
-    createServingRuntimeModal.findSubmitButton().should('be.enabled');
+      createServingRuntimeModal.shouldBeOpen();
 
-    // enable auth
-    createServingRuntimeModal.findAuthenticationCheckbox().check();
+      // fill in minimum required fields
+      createServingRuntimeModal.findModelServerNameInput().type('Test Name');
+      createServingRuntimeModal
+        .findServingRuntimeTemplateDropdown()
+        .findDropdownItem('New OVMS Server')
+        .click();
+      createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
-    // test submitting form, the modal should close to indicate success.
-    createServingRuntimeModal.findSubmitButton().click();
-    createServingRuntimeModal.shouldBeOpen(false);
+      // enable auth
+      createServingRuntimeModal.findAuthenticationCheckbox().check();
 
-    // the service account and role binding should have been created
-    cy.get('@createServiceAccount.all').then((interceptions) => {
-      expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      // test submitting form, the modal should close to indicate success.
+      createServingRuntimeModal.findSubmitButton().click();
+      createServingRuntimeModal.shouldBeOpen(false);
+
+      // the service account and role binding should have been created
+      cy.get('@createServiceAccount.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+      cy.get('@createRoleBinding.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
     });
-    cy.get('@createRoleBinding.all').then((interceptions) => {
-      expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
-    });
-  });
 
-  it('Add model server - do not create ServiceAccount or RoleBinding if they already exist', () => {
-    initIntercepts({
-      projectEnableModelMesh: undefined,
-      disableKServeConfig: false,
-      disableModelMeshConfig: false,
-      serviceAccountAlreadyExists: true,
-      roleBindingAlreadyExists: true,
-    });
-    projectDetails.visit('test-project');
+    it('Add model server - do not create ServiceAccount or RoleBinding if they already exist', () => {
+      initIntercepts({
+        projectEnableModelMesh: undefined,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+        serviceAccountAlreadyExists: true,
+        roleBindingAlreadyExists: true,
+      });
+      projectDetails.visit('test-project');
 
-    modelServingSection.findAddModelServerButton().click();
+      modelServingSection.findAddModelServerButton().click();
 
-    createServingRuntimeModal.shouldBeOpen();
+      createServingRuntimeModal.shouldBeOpen();
 
-    // fill in minimum required fields
-    createServingRuntimeModal.findModelServerNameInput().type('Test Name');
-    createServingRuntimeModal
-      .findServingRuntimeTemplateDropdown()
-      .findDropdownItem('New OVMS Server')
-      .click();
-    createServingRuntimeModal.findSubmitButton().should('be.enabled');
+      // fill in minimum required fields
+      createServingRuntimeModal.findModelServerNameInput().type('Test Name');
+      createServingRuntimeModal
+        .findServingRuntimeTemplateDropdown()
+        .findDropdownItem('New OVMS Server')
+        .click();
+      createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
-    // enable auth
-    createServingRuntimeModal.findAuthenticationCheckbox().check();
+      // enable auth
+      createServingRuntimeModal.findAuthenticationCheckbox().check();
 
-    // test submitting form, the modal should close to indicate success.
-    createServingRuntimeModal.findSubmitButton().click();
-    createServingRuntimeModal.shouldBeOpen(false);
+      // test submitting form, the modal should close to indicate success.
+      createServingRuntimeModal.findSubmitButton().click();
+      createServingRuntimeModal.shouldBeOpen(false);
 
-    // the service account and role binding should have been created
-    cy.get('@createServiceAccount.all').then((interceptions) => {
-      expect(interceptions).to.have.length(0);
-    });
-    cy.get('@createRoleBinding.all').then((interceptions) => {
-      expect(interceptions).to.have.length(0);
+      // the service account and role binding should have been created
+      cy.get('@createServiceAccount.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0);
+      });
+      cy.get('@createRoleBinding.all').then((interceptions) => {
+        expect(interceptions).to.have.length(0);
+      });
     });
   });
 
@@ -1001,39 +1048,6 @@ describe('Serving Runtime List', () => {
         .findDescriptionListItem('Llama Caikit', 'Number of accelerators')
         .should('exist');
     });
-  });
-
-  it('Check number of replicas of model', () => {
-    initIntercepts({
-      projectEnableModelMesh: false,
-      disableKServeConfig: true,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          modelName: 'llama-service',
-          isModelMesh: false,
-          minReplicas: 3,
-          maxReplicas: 3,
-        }),
-      ],
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          namespace: 'test-project',
-        }),
-      ],
-    });
-
-    projectDetails.visit('test-project');
-    modelServingSection.getKServeRow('Llama Service').findExpansion().should(be.collapsed);
-    modelServingSection.getKServeRow('Llama Service').findToggleButton().click();
-    modelServingSection
-      .findDescriptionListItem('Llama Service', 'Model server replicas')
-      .next('dd')
-      .should('have.text', '3');
   });
 
   describe('Dry run check', () => {

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -204,6 +204,10 @@ class ModelMeshRow extends ModelServingRow {
   findExpansion() {
     return this.find().siblings();
   }
+
+  findDeployedModelExpansionButton() {
+    return this.find().find('[data-label="Deployed models"] button');
+  }
 }
 
 class KServeRow extends ModelMeshRow {
@@ -248,6 +252,36 @@ class ModelServingSection {
 
   findDescriptionListItem(rowName: string, itemName: string) {
     return this.findRow(rowName).next('tr').find(`dt:contains("${itemName}")`);
+  }
+
+  findInferenceServiceTable() {
+    return cy.findByTestId('inference-service-table');
+  }
+
+  findInferenceServiceRowStatus(name: string) {
+    return this.findInferenceServiceTable()
+      .contains('tr', name)
+      .within(() => {
+        cy.get('td[data-label="Status"]');
+      });
+  }
+
+  findStatusTooltip(name: string) {
+    return this.findInferenceServiceRowStatus(name)
+      .findByTestId('status-tooltip')
+      .trigger('mouseenter')
+      .then(() => {
+        cy.findByTestId('model-status-tooltip');
+      });
+  }
+
+  findStatusTooltipValue(name: string, msg: string) {
+    this.findStatusTooltip(name)
+      .invoke('text')
+      .should('contain', msg)
+      .then(() => {
+        this.findStatusTooltip(name).trigger('mouseleave');
+      });
   }
 }
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -34,13 +34,27 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
       case InferenceServiceModelState.LOADED:
       case InferenceServiceModelState.STANDBY:
         return (
-          <Icon role="button" aria-label="success icon" status="success" isInline tabIndex={0}>
+          <Icon
+            data-testid="status-tooltip"
+            role="button"
+            aria-label="success icon"
+            status="success"
+            isInline
+            tabIndex={0}
+          >
             <CheckCircleIcon />
           </Icon>
         );
       case InferenceServiceModelState.FAILED_TO_LOAD:
         return (
-          <Icon role="button" aria-label="error icon" status="danger" isInline tabIndex={0}>
+          <Icon
+            data-testid="status-tooltip"
+            role="button"
+            aria-label="error icon"
+            status="danger"
+            isInline
+            tabIndex={0}
+          >
             <ExclamationCircleIcon />
           </Icon>
         );
@@ -53,13 +67,27 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
         );
       case InferenceServiceModelState.UNKNOWN:
         return (
-          <Icon role="button" aria-label="warning icon" status="warning" isInline tabIndex={0}>
+          <Icon
+            data-testid="status-tooltip"
+            role="button"
+            aria-label="warning icon"
+            status="warning"
+            isInline
+            tabIndex={0}
+          >
             <OutlinedQuestionCircleIcon />
           </Icon>
         );
       default:
         return (
-          <Icon role="button" aria-label="warning icon" status="warning" isInline tabIndex={0}>
+          <Icon
+            data-testid="status-tooltip"
+            role="button"
+            aria-label="warning icon"
+            status="warning"
+            isInline
+            tabIndex={0}
+          >
             <OutlinedQuestionCircleIcon />
           </Icon>
         );
@@ -69,6 +97,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
   return (
     <Tooltip
       role="none"
+      data-testid="model-status-tooltip"
       content={
         modelStatus?.failedToSchedule ? (
           <Text>Insufficient resources</Text>

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -37,6 +37,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
   return (
     <>
       <Table
+        data-testid="inference-service-table"
         data={inferenceServices}
         columns={mappedColumns}
         variant={isGlobal ? undefined : 'compact'}

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -15,10 +15,18 @@ export const getInferenceServiceActiveModelState = (
   <InferenceServiceModelState | undefined>is.status?.modelStatus.states.targetModelState ||
   InferenceServiceModelState.UNKNOWN;
 
-export const getInferenceServiceStatusMessage = (is: InferenceServiceKind): string =>
-  is.status?.modelStatus.states.activeModelState ||
-  is.status?.modelStatus.lastFailureInfo?.message ||
-  'Unknown';
+export const getInferenceServiceStatusMessage = (is: InferenceServiceKind): string => {
+  const activeModelState = is.status?.modelStatus.states.activeModelState;
+  const targetModelState = is.status?.modelStatus.states.targetModelState;
+
+  const failedToLoad = InferenceServiceModelState.FAILED_TO_LOAD;
+  const isFailedToLoad = activeModelState === failedToLoad || targetModelState === failedToLoad;
+
+  const lastFailureMessage = is.status?.modelStatus.lastFailureInfo?.message;
+  const stateMessage = activeModelState ?? targetModelState ?? 'Unknown';
+
+  return isFailedToLoad ? lastFailureMessage ?? stateMessage : stateMessage;
+};
 
 export const getInferenceServiceProjectDisplayName = (
   is: InferenceServiceKind,

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
@@ -40,6 +40,7 @@ const ServingRuntimeTable: React.FC = () => {
   return (
     <>
       <Table
+        data-testid="serving-runtime-table"
         data={modelServers}
         columns={columns}
         disableRowRenderSupport


### PR DESCRIPTION
Closes: [RHOAIENG-2627](https://issues.redhat.com/browse/RHOAIENG-2627)

## Description
Improved the functionality to display model error status. 
Now the user can see error message properly listed under `lastFailureInfo.message` in InferenceService CR.

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/5aaf0f99-0c94-4010-9ed7-87c7bab5c940)

## How Has This Been Tested?
Deploy a model with wrong AWS credentials and check it's status, error message should be proper and informative. 

## Test Impact
Added cypress test to check error message.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
