### PR TITLE
added eslint rules for allSettledPromises

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -178,6 +178,14 @@
         ]
       }
     ],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "Promise",
+        "property": "allSettled",
+        "message": "Avoid using Promise.allSettled, use allSettledPromises utility function instead."
+      }
+    ],
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",
     "import/no-named-as-default": "error",

--- a/frontend/src/concepts/pipelines/content/DeletePipelineRunsModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelineRunsModal.tsx
@@ -66,6 +66,8 @@ const DeletePipelineRunsModal: React.FC<DeletePipelineRunsModalProps> = ({
               setDeleting(false);
             });
         } else {
+          //TODO: prefer a refactor for the use case to not depend on the index in the delete modal.
+          // eslint-disable-next-line no-restricted-properties
           Promise.allSettled(
             toDeleteResources.map((resource) => callFunc({ signal: abortSignal }, resource.id)),
           ).then((results) =>

--- a/frontend/src/concepts/pipelines/content/DeletePipelinesModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelinesModal.tsx
@@ -107,6 +107,8 @@ const DeletePipelinesModal: React.FC<DeletePipelinesModalProps> = ({
               setDeleting(false);
             });
         } else {
+          //TODO: prefer a refactor for the use case to not depend on the index in the delete modal.
+          // eslint-disable-next-line no-restricted-properties
           Promise.allSettled(allPromises).then((results) =>
             onBeforeClose(
               true,

--- a/frontend/src/concepts/pipelines/utils.ts
+++ b/frontend/src/concepts/pipelines/utils.ts
@@ -1,9 +1,10 @@
 import { deletePipelineCR, deleteSecret } from '~/api';
 import { ExternalDatabaseSecret } from '~/concepts/pipelines/content/configurePipelinesServer/const';
 import { ELYRA_SECRET_NAME } from '~/concepts/pipelines/elyra/const';
+import { allSettledPromises } from '~/utilities/allSettledPromises';
 
 export const deleteServer = (namespace: string): Promise<void> =>
-  Promise.allSettled([
+  allSettledPromises([
     deleteSecret(namespace, ExternalDatabaseSecret.NAME),
     deleteSecret(namespace, ELYRA_SECRET_NAME),
     deletePipelineCR(namespace),

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal.tsx
@@ -9,6 +9,7 @@ import {
   deleteServingRuntime,
 } from '~/api';
 import { getTokenNames } from '~/pages/modelServing/utils';
+import { allSettledPromises } from '~/utilities/allSettledPromises';
 
 type DeleteServingRuntimeModalProps = {
   servingRuntime?: ServingRuntimeKind;
@@ -45,7 +46,7 @@ const DeleteServingRuntimeModal: React.FC<DeleteServingRuntimeModalProps> = ({
             servingRuntime.metadata.namespace,
           );
 
-          Promise.allSettled<ServingRuntimeKind | K8sStatus>([
+          allSettledPromises<ServingRuntimeKind | K8sStatus>([
             deleteServingRuntime(servingRuntime.metadata.name, servingRuntime.metadata.namespace),
             ...inferenceServices
               .filter(

--- a/frontend/src/utilities/allSettledPromises.ts
+++ b/frontend/src/utilities/allSettledPromises.ts
@@ -3,6 +3,8 @@ type TypedPromiseRejectedResult<R> = Omit<PromiseRejectedResult, 'reason'> & { r
 export const allSettledPromises = <T, E = undefined>(
   data: Promise<T>[],
 ): Promise<[PromiseFulfilledResult<T>[], TypedPromiseRejectedResult<E>[]]> =>
+  //Use of `Promise.allSettled` is justified as this utility is a wrapper with type improvements.
+  // eslint-disable-next-line no-restricted-properties
   Promise.allSettled(data).then(
     (
       promiseStates: PromiseSettledResult<T>[],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-1295

## Description
added eslint to restrict using Promise.allSetttled
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
