### PR TITLE
add test case for usePrometheusQueryRange

### DIFF
--- a/frontend/src/api/prometheus/__tests__/usePrometheusQueryRange.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/usePrometheusQueryRange.spec.ts
@@ -1,0 +1,152 @@
+import axios from 'axios';
+import { act } from '@testing-library/react';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { mockPrometheusServing } from '~/__mocks__/mockPrometheusServing';
+import usePrometheusQueryRange from '~/api/prometheus/usePrometheusQueryRange';
+import { PrometheusQueryRangeResponseData } from '~/types';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
+
+const mockAxios = jest.mocked(axios.post);
+const responsePredicate = jest.fn(
+  (data: PrometheusQueryRangeResponseData) => data.result?.flatMap((item) => item.values[0]) || [],
+);
+describe('usePrometheusQueryRange', () => {
+  const queryLang = 'testQuery';
+  const span = 60;
+  const endInMs = 123456;
+  const step = 30;
+  const namespace = 'testNamespace';
+  const active = true;
+
+  it('should fetch data successfully and handle refresh ', async () => {
+    const mockedResponse = { data: { response: mockPrometheusServing({}).response } };
+    mockAxios.mockResolvedValue(mockedResponse);
+
+    const renderResult = testHook(usePrometheusQueryRange)(
+      active,
+      '/api/prometheus/serving',
+      queryLang,
+      span,
+      endInMs,
+      step,
+      responsePredicate,
+      namespace,
+    );
+
+    expect(renderResult).hookToStrictEqual([[], false, undefined, expect.any(Function), true]);
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/serving', {
+      query: 'namespace=testNamespace&query=testQuery&start=63.456&end=123.456&step=30',
+    });
+    expect(renderResult).hookToHaveUpdateCount(1);
+    expect(responsePredicate).not.toHaveBeenCalled();
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual([
+      [1704899825.644, '16'],
+      true,
+      undefined,
+      expect.any(Function),
+      false,
+    ]);
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/serving', {
+      query: 'namespace=testNamespace&query=testQuery&start=63.456&end=123.456&step=30',
+    });
+    expect(responsePredicate).toHaveBeenCalledWith(mockedResponse.data.response.data);
+    expect(responsePredicate).toBeCalledTimes(1);
+
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true, false]);
+
+    mockAxios.mockResolvedValue(mockedResponse);
+    await act(() => renderResult.result.current[3]());
+
+    expect(renderResult).hookToStrictEqual([
+      [1704899825.644, '16'],
+      true,
+      undefined,
+      expect.any(Function),
+      false,
+    ]);
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/serving', {
+      query: 'namespace=testNamespace&query=testQuery&start=63.456&end=123.456&step=30',
+    });
+    expect(responsePredicate).toHaveBeenCalledWith(mockedResponse.data.response.data);
+    expect(responsePredicate).toBeCalledTimes(2);
+
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true, true]);
+  });
+  it('should handle error when active is false', async () => {
+    const renderResult = testHook(usePrometheusQueryRange)(
+      false,
+      '/api/prometheus/serving',
+      queryLang,
+      span,
+      endInMs,
+      step,
+      responsePredicate,
+      namespace,
+    );
+
+    expect(renderResult).hookToStrictEqual([[], false, undefined, expect.any(Function), false]);
+    expect(mockAxios).not.toHaveBeenCalled();
+    expect(responsePredicate).not.toHaveBeenCalled();
+  });
+  it('should handle error when request fails', async () => {
+    mockAxios.mockRejectedValue(new Error('error1'));
+    const renderResult = testHook(usePrometheusQueryRange)(
+      active,
+      '/api/prometheus/serving',
+      queryLang,
+      span,
+      endInMs,
+      step,
+      responsePredicate,
+      namespace,
+    );
+    expect(renderResult).hookToStrictEqual([[], false, undefined, expect.any(Function), true]);
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/serving', {
+      query: 'namespace=testNamespace&query=testQuery&start=63.456&end=123.456&step=30',
+    });
+    expect(responsePredicate).not.toHaveBeenCalled();
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual([
+      [],
+      false,
+      new Error('error1'),
+      expect.any(Function),
+      false,
+    ]);
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(responsePredicate).not.toHaveBeenCalled();
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true, false]);
+
+    mockAxios.mockRejectedValue(new Error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual([
+      [],
+      false,
+      new Error('error2'),
+      expect.any(Function),
+      false,
+    ]);
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(responsePredicate).not.toHaveBeenCalled();
+    expect(renderResult).hookToHaveUpdateCount(3);
+
+    expect(renderResult).hookToBeStable([true, true, false, true, true]);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-2163](https://issues.redhat.com/browse/RHOAIENG-2163)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Unit test case for prometheus/usePrometheusQueryRange file

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
<img width="718" alt="Screenshot 2024-02-21 at 4 13 30 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/2117670/9bff33a7-f6d4-419d-9fea-cc4ec7328284">

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
