### PR TITLE
Enable GRPC support for model serving routes

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -1,4 +1,5 @@
 import { KnownLabels, ServingRuntimeKind } from '~/k8sTypes';
+import { ServingRuntimeAPIProtocol } from '~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -8,6 +9,7 @@ type MockResourceConfigType = {
   auth?: boolean;
   route?: boolean;
   acceleratorName?: string;
+  apiProtocol?: ServingRuntimeAPIProtocol;
 };
 
 export const mockServingRuntimeK8sResourceLegacy = ({
@@ -92,6 +94,7 @@ export const mockServingRuntimeK8sResource = ({
   route = false,
   displayName = 'OVMS Model Serving',
   acceleratorName = '',
+  apiProtocol = ServingRuntimeAPIProtocol.REST,
 }: MockResourceConfigType): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
@@ -108,6 +111,7 @@ export const mockServingRuntimeK8sResource = ({
       'enable-auth': auth ? 'true' : 'false',
       'enable-route': route ? 'true' : 'false',
       'openshift.io/display-name': displayName,
+      'opendatahub.io/apiProtocol': apiProtocol,
     },
     name,
     namespace,

--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,5 +1,5 @@
 import { TemplateKind } from '~/k8sTypes';
-import { ServingRuntimePlatform } from '~/types';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -7,6 +7,7 @@ type MockResourceConfigType = {
   displayName?: string;
   replicas?: number;
   platforms?: ServingRuntimePlatform[];
+  apiProtocol?: ServingRuntimeAPIProtocol;
   isModelmesh?: boolean;
 };
 
@@ -16,6 +17,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
   displayName = 'New OVMS Server',
   replicas = 1,
   isModelmesh = false,
+  apiProtocol = ServingRuntimeAPIProtocol.REST,
   platforms,
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
@@ -28,6 +30,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
     },
     annotations: {
       'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
+      'opendatahub.io/apiProtocol': apiProtocol,
     },
   },
   objects: [

--- a/frontend/src/__tests__/cypress/cypress/e2e/customServingRuntimes/CustomServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/customServingRuntimes/CustomServingRuntimes.cy.ts
@@ -4,7 +4,7 @@ import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { mockStatus } from '~/__mocks__/mockStatus';
 import { servingRuntimes } from '~/__tests__/cypress/cypress/pages/servingRuntimes';
-import { ServingRuntimePlatform } from '~/types';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 
 describe('Custom serving runtimes', () => {
   beforeEach(() => {
@@ -23,6 +23,7 @@ describe('Custom serving runtimes', () => {
           name: 'template-2',
           displayName: 'Caikit',
           platforms: [ServingRuntimePlatform.SINGLE],
+          apiProtocol: ServingRuntimeAPIProtocol.GRPC,
         }),
         mockServingRuntimeTemplateK8sResource({
           name: 'template-3',
@@ -54,14 +55,47 @@ describe('Custom serving runtimes', () => {
     servingRuntimes.getRowById('template-4').shouldBeSingleModel(false).shouldBeMultiModel(true);
   });
 
+  it('should display api protocol in table row', () => {
+    servingRuntimes.getRowById('template-1').shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.REST);
+    servingRuntimes.getRowById('template-2').shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.GRPC);
+    servingRuntimes.getRowById('template-3').shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.REST);
+    servingRuntimes.getRowById('template-4').shouldHaveAPIProtocol(ServingRuntimeAPIProtocol.REST);
+  });
+
   it('should add a new serving runtime', () => {
     servingRuntimes.findAddButton().click();
     cy.get('h1').should('contain', 'Add serving runtime');
-    servingRuntimes.shouldDisplayValues([
+
+    // Check serving runtime dropdown list
+    servingRuntimes.shouldDisplayServingRuntimeValues([
       'Single-model serving platform',
       'Multi-model serving platform',
-      'Single-model and multi-model serving platforms',
     ]);
+    servingRuntimes.findSelectServingPlatformButton().click();
+
+    // Create with single model
+    servingRuntimes.findCreateButton().should('be.disabled');
+    servingRuntimes.shouldSelectPlatform('Single-model serving platform');
+    servingRuntimes.shouldDisplayAPIProtocolValues([
+      ServingRuntimeAPIProtocol.REST,
+      ServingRuntimeAPIProtocol.GRPC,
+    ]);
+    servingRuntimes.shouldSelectAPIProtocol(ServingRuntimeAPIProtocol.REST);
+    servingRuntimes.findStartFromScratchButton().click();
+    servingRuntimes.shouldEnterData();
+    servingRuntimes.findCreateButton().should('be.enabled');
+    servingRuntimes.findCancelButton().click();
+
+    servingRuntimes.findAddButton().click();
+
+    // Create with multi model
+    servingRuntimes.findCreateButton().should('be.disabled');
+    servingRuntimes.shouldSelectPlatform('Multi-model serving platform');
+    servingRuntimes.findSelectAPIProtocolButton().should('not.be.enabled');
+    servingRuntimes.findSelectAPIProtocolButton().should('include.text', 'REST');
+    servingRuntimes.findStartFromScratchButton().click();
+    servingRuntimes.shouldEnterData();
+    servingRuntimes.findCreateButton().should('be.enabled');
   });
 
   it('should duplicate a serving runtime', () => {

--- a/frontend/src/__tests__/cypress/cypress/e2e/customServingRuntimes/CustomServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/customServingRuntimes/CustomServingRuntimes.cy.ts
@@ -17,7 +17,7 @@ describe('Custom serving runtimes', () => {
         mockServingRuntimeTemplateK8sResource({
           name: 'template-1',
           displayName: 'Multi Platform',
-          platforms: [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI],
+          platforms: [ServingRuntimePlatform.SINGLE],
         }),
         mockServingRuntimeTemplateK8sResource({
           name: 'template-2',
@@ -49,10 +49,10 @@ describe('Custom serving runtimes', () => {
   });
 
   it('should display platform labels in table rows', () => {
-    servingRuntimes.getRowById('template-1').shouldBeSingleModel(true).shouldBeMultiModel(true);
-    servingRuntimes.getRowById('template-2').shouldBeSingleModel(true).shouldBeMultiModel(false);
-    servingRuntimes.getRowById('template-3').shouldBeSingleModel(false).shouldBeMultiModel(true);
-    servingRuntimes.getRowById('template-4').shouldBeSingleModel(false).shouldBeMultiModel(true);
+    servingRuntimes.getRowById('template-1').shouldBeSingleModel(true);
+    servingRuntimes.getRowById('template-2').shouldBeSingleModel(true);
+    servingRuntimes.getRowById('template-3').shouldBeMultiModel(true);
+    servingRuntimes.getRowById('template-4').shouldBeMultiModel(true);
   });
 
   it('should display api protocol in table row', () => {

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
@@ -480,6 +480,9 @@ describe('Serving Runtime List', () => {
       // Check status of deployed model which loaded successfully after an error
       modelServingSection.findStatusTooltip('Loaded model').should('be.visible');
       modelServingSection.findStatusTooltipValue('Loaded model', 'Loaded');
+
+      // Check API protocol in row
+      modelServingSection.findAPIProtocol('Loaded model').should('have.text', 'REST');
     });
   });
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -283,6 +283,12 @@ class ModelServingSection {
         this.findStatusTooltip(name).trigger('mouseleave');
       });
   }
+
+  findAPIProtocol(name: string) {
+    return this.findInferenceServiceTable()
+      .contains('tr', name)
+      .find('td[data-label="API protocol"]');
+  }
 }
 
 export const modelServingGlobal = new ModelServingGlobal();

--- a/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
@@ -1,4 +1,5 @@
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+import { ServingRuntimeAPIProtocol } from '~/types';
 
 class ServingRuntimeRow {
   constructor(public readonly id: string) {}
@@ -21,6 +22,10 @@ class ServingRuntimeRow {
       .findByText('Single-model')
       .should(enabled ? 'exist' : 'not.exist');
     return this;
+  }
+
+  shouldHaveAPIProtocol(apiProtocol: ServingRuntimeAPIProtocol) {
+    this.find().get('[data-label="API protocol"]').should('include.text', apiProtocol);
   }
 }
 
@@ -54,14 +59,49 @@ class ServingRuntimes {
     return cy.findByRole('button', { name: 'Add serving runtime' });
   }
 
-  findSelectValueButton() {
-    return cy.findByRole('button', { name: 'Select a value' });
+  findStartFromScratchButton() {
+    return cy.findByRole('button', { name: 'Start from scratch' });
   }
 
-  shouldDisplayValues(values: string[]) {
-    this.findSelectValueButton().click();
+  findCreateButton() {
+    return cy.findByRole('button', { name: 'Create' });
+  }
+
+  findCancelButton() {
+    return cy.findByRole('button', { name: 'Cancel' });
+  }
+
+  findSelectServingPlatformButton() {
+    return cy.findByTestId('custom-serving-runtime-selection');
+  }
+
+  findSelectAPIProtocolButton() {
+    return cy.findByTestId('custom-serving-api-protocol-selection');
+  }
+
+  shouldDisplayServingRuntimeValues(values: string[]) {
+    this.findSelectServingPlatformButton().click();
     values.forEach((value) => cy.findByRole('menuitem', { name: value }).should('exist'));
     return this;
+  }
+
+  shouldDisplayAPIProtocolValues(values: ServingRuntimeAPIProtocol[]) {
+    this.findSelectAPIProtocolButton().click();
+    values.forEach((value) => cy.findByRole('menuitem', { name: value }).should('exist'));
+    return this;
+  }
+
+  shouldSelectPlatform(value: string) {
+    this.findSelectServingPlatformButton().click();
+    cy.findByRole('menuitem', { name: value }).click();
+  }
+
+  shouldSelectAPIProtocol(value: string) {
+    cy.findByRole('menuitem', { name: value }).click();
+  }
+
+  shouldEnterData() {
+    cy.get('.view-lines.monaco-mouse-cursor-text').type('test');
   }
 
   getRowById(id: string) {

--- a/frontend/src/api/k8s/__tests__/templates.spec.ts
+++ b/frontend/src/api/k8s/__tests__/templates.spec.ts
@@ -6,7 +6,7 @@ import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRu
 import { assembleServingRuntimeTemplate, deleteTemplate, listTemplates } from '~/api';
 import { TemplateModel } from '~/api/models';
 import { K8sDSGResource, TemplateKind } from '~/k8sTypes';
-import { ServingRuntimePlatform } from '~/types';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 import { genRandomChars } from '~/utilities/string';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -38,6 +38,7 @@ describe('assembleServingRuntimeTemplate', () => {
       servingRuntimeMock,
       namespace,
       [ServingRuntimePlatform.MULTI],
+      ServingRuntimeAPIProtocol.REST,
       'template-1',
     );
     expect(result).toStrictEqual(
@@ -47,9 +48,12 @@ describe('assembleServingRuntimeTemplate', () => {
   it('should assemble serving runtime template without templateName', () => {
     genRandomCharsMock.mockReturnValue('123');
     const servingRuntimeMock = JSON.stringify(createServingRuntime('template-123'));
-    const result = assembleServingRuntimeTemplate(servingRuntimeMock, namespace, [
-      ServingRuntimePlatform.MULTI,
-    ]);
+    const result = assembleServingRuntimeTemplate(
+      servingRuntimeMock,
+      namespace,
+      [ServingRuntimePlatform.MULTI],
+      ServingRuntimeAPIProtocol.REST,
+    );
     expect(result).toStrictEqual(
       mockServingRuntimeTemplateK8sResource({
         name: 'template-123',
@@ -61,7 +65,12 @@ describe('assembleServingRuntimeTemplate', () => {
   it('should throw an error when servingRuntime name doesnt exist', () => {
     const servingRuntimeMock = JSON.stringify(createServingRuntime(''));
     expect(() => {
-      assembleServingRuntimeTemplate(servingRuntimeMock, namespace, [ServingRuntimePlatform.MULTI]);
+      assembleServingRuntimeTemplate(
+        servingRuntimeMock,
+        namespace,
+        [ServingRuntimePlatform.MULTI],
+        ServingRuntimeAPIProtocol.REST,
+      );
     }).toThrow('Serving runtime name is required');
   });
 });

--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -3,12 +3,13 @@ import { k8sDeleteResource, k8sListResource } from '@openshift/dynamic-plugin-sd
 import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import { TemplateModel } from '~/api/models';
 import { genRandomChars } from '~/utilities/string';
-import { ServingRuntimePlatform } from '~/types';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 
 export const assembleServingRuntimeTemplate = (
   body: string,
   namespace: string,
   platforms: ServingRuntimePlatform[],
+  apiProtocol: ServingRuntimeAPIProtocol | undefined,
   templateName?: string,
 ): TemplateKind & { objects: ServingRuntimeKind[] } => {
   const servingRuntime: ServingRuntimeKind = YAML.parse(body);
@@ -30,6 +31,7 @@ export const assembleServingRuntimeTemplate = (
       },
       annotations: {
         'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
+        ...(apiProtocol && { 'opendatahub.io/apiProtocol': apiProtocol }),
       },
     },
     objects: [servingRuntime],

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -110,6 +110,7 @@ export type ServingRuntimeAnnotations = Partial<{
   'opendatahub.io/disable-gpu': string;
   'opendatahub.io/recommended-accelerators': string;
   'opendatahub.io/accelerator-name': string;
+  'opendatahub.io/apiProtocol': string;
   'enable-route': string;
   'enable-auth': string;
   'modelmesh-enabled': 'true' | 'false';
@@ -1074,6 +1075,7 @@ export type TemplateKind = K8sResourceCommon & {
       iconClass?: string;
       'opendatahub.io/template-enabled': string;
       'opendatahub.io/modelServingSupport': string;
+      'opendatahub.io/apiProtocol': string;
     }>;
     name: string;
     namespace: string;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeAPIProtocolLabel.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeAPIProtocolLabel.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Label, Text, TextVariants } from '@patternfly/react-core';
+import { TemplateKind } from '~/k8sTypes';
+import {
+  getAPIProtocolFromTemplate,
+  getEnabledPlatformsFromTemplate,
+} from '~/pages/modelServing/customServingRuntimes/utils';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
+
+type CustomServingRuntimeAPIProtocolLabelProps = {
+  template: TemplateKind;
+};
+
+const CustomServingRuntimeAPIProtocolLabel: React.FC<CustomServingRuntimeAPIProtocolLabelProps> = ({
+  template,
+}) => {
+  const apiProtocol = getAPIProtocolFromTemplate(template);
+  const isMultiModel = getEnabledPlatformsFromTemplate(template).includes(
+    ServingRuntimePlatform.MULTI,
+  );
+
+  // If it is multi-model, we use REST as default
+  if (!apiProtocol && isMultiModel) {
+    return <Label color="gold">{ServingRuntimeAPIProtocol.REST}</Label>;
+  }
+
+  if (!apiProtocol || !Object.values(ServingRuntimeAPIProtocol).includes(apiProtocol)) {
+    return <Text component={TextVariants.small}>Not defined</Text>;
+  }
+
+  return <Label color="gold">{apiProtocol}</Label>;
+};
+
+export default CustomServingRuntimeAPIProtocolLabel;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeAPIProtocolSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeAPIProtocolSelector.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { FormGroup } from '@patternfly/react-core';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
+import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
+
+type CustomServingRuntimeAPIProtocolSelectorProps = {
+  selectedAPIProtocol: ServingRuntimeAPIProtocol | undefined;
+  setSelectedAPIProtocol: (apiProtocol: ServingRuntimeAPIProtocol) => void;
+  selectedPlatforms: ServingRuntimePlatform[];
+};
+
+const CustomServingRuntimeAPIProtocolSelector: React.FC<
+  CustomServingRuntimeAPIProtocolSelectorProps
+> = ({ selectedAPIProtocol, setSelectedAPIProtocol, selectedPlatforms }) => {
+  const isOnlyModelMesh =
+    selectedPlatforms.includes(ServingRuntimePlatform.MULTI) &&
+    !selectedPlatforms.includes(ServingRuntimePlatform.SINGLE);
+
+  React.useEffect(() => {
+    if (isOnlyModelMesh) {
+      setSelectedAPIProtocol(ServingRuntimeAPIProtocol.REST);
+    }
+  }, [isOnlyModelMesh, setSelectedAPIProtocol]);
+
+  const options = [
+    {
+      key: ServingRuntimeAPIProtocol.REST,
+      label: ServingRuntimeAPIProtocol.REST,
+    },
+    ...(isOnlyModelMesh
+      ? []
+      : [
+          {
+            key: ServingRuntimeAPIProtocol.GRPC,
+            label: ServingRuntimeAPIProtocol.GRPC,
+          },
+        ]),
+  ];
+
+  return (
+    <FormGroup
+      label="Select the API protocol this runtime supports"
+      fieldId="custom-serving-api-protocol-selection"
+      isRequired
+    >
+      <SimpleDropdownSelect
+        data-testid="custom-serving-api-protocol-selection"
+        aria-label="Select a model serving api protocol"
+        placeholder="Select a value"
+        isDisabled={isOnlyModelMesh}
+        options={options}
+        value={selectedAPIProtocol || ''}
+        onChange={(key) => setSelectedAPIProtocol(key as ServingRuntimeAPIProtocol)}
+      />
+    </FormGroup>
+  );
+};
+
+export default CustomServingRuntimeAPIProtocolSelector;

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup.tsx
@@ -25,7 +25,9 @@ const CustomServingRuntimePlatformsLabelGroup: React.FC<
   return (
     <LabelGroup>
       {platforms.map((platform, i) => (
-        <Label key={i}>{ServingRuntimePlatformLabels[platform]}</Label>
+        <Label color="purple" key={i}>
+          {ServingRuntimePlatformLabels[platform]}
+        </Label>
       ))}
     </LabelGroup>
   );

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
@@ -48,7 +48,7 @@ const CustomServingRuntimePlatformsSelector: React.FC<
       isRequired
     >
       <SimpleDropdownSelect
-        id="custom-serving-runtime-selection"
+        data-testid="custom-serving-runtime-selection"
         aria-label="Select a model serving runtime platform"
         placeholder="Select a value"
         options={options}

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
@@ -27,10 +27,6 @@ const CustomServingRuntimePlatformsSelector: React.FC<
       key: ServingRuntimePlatform.MULTI,
       label: RuntimePlatformSelectOptionLabels[ServingRuntimePlatform.MULTI],
     },
-    {
-      key: 'both',
-      label: RuntimePlatformSelectOptionLabels.both,
-    },
   ];
 
   const selection =

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -11,6 +11,7 @@ import {
   getServingRuntimeNameFromTemplate,
   isTemplateOOTB,
 } from './utils';
+import CustomServingRuntimeAPIProtocolLabel from './CustomServingRuntimeAPIProtocolLabel';
 
 type CustomServingRuntimeTableRowProps = {
   obj: TemplateKind;
@@ -46,6 +47,9 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
       </Td>
       <Td dataLabel="Serving platforms supported">
         <CustomServingRuntimePlatformsLabelGroup template={template} />
+      </Td>
+      <Td dataLabel="API protocol">
+        <CustomServingRuntimeAPIProtocolLabel template={template} />
       </Td>
       <Td isActionCell>
         <ActionsColumn

--- a/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/templatedData.tsx
@@ -29,6 +29,11 @@ export const columns: SortableData<TemplateKind>[] = [
     sortable: false,
   },
   {
+    field: 'apiProtocol',
+    label: 'API protocol',
+    sortable: false,
+  },
+  {
     field: 'kebab',
     label: '',
     sortable: false,

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -1,7 +1,7 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource } from '~/pages/projects/utils';
-import { ServingRuntimePlatform } from '~/types';
+import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 
 export const getTemplateEnabled = (
   template: TemplateKind,
@@ -89,7 +89,20 @@ export const getServingRuntimeFromTemplate = (
   } catch (e) {
     return undefined;
   }
-  return template.objects[0];
+
+  // Add apiProtocol annotation if exists in template
+  const apiProtocolAttribute = 'opendatahub.io/apiProtocol';
+  const servingRuntimeObj = { ...template.objects[0] };
+  const metadata = { ...template.objects[0].metadata };
+
+  if (metadata.annotations && template.metadata.annotations?.[apiProtocolAttribute]) {
+    metadata.annotations[apiProtocolAttribute] =
+      template.metadata.annotations[apiProtocolAttribute];
+  }
+
+  servingRuntimeObj.metadata = metadata;
+
+  return servingRuntimeObj;
 };
 
 export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntimeKind): string => {
@@ -121,4 +134,23 @@ export const getEnabledPlatformsFromTemplate = (
   } catch (e) {
     return [ServingRuntimePlatform.MULTI];
   }
+};
+
+export const getAPIProtocolFromTemplate = (
+  template: TemplateKind,
+): ServingRuntimeAPIProtocol | undefined => {
+  if (!template.metadata.annotations?.['opendatahub.io/apiProtocol']) {
+    return undefined;
+  }
+
+  return template.metadata.annotations['opendatahub.io/apiProtocol'] as ServingRuntimeAPIProtocol;
+};
+
+export const getAPIProtocolFromServingRuntime = (
+  resource: ServingRuntimeKind,
+): ServingRuntimeAPIProtocol | undefined => {
+  if (!resource.metadata.annotations?.['opendatahub.io/apiProtocol']) {
+    return undefined;
+  }
+  return resource.metadata.annotations['opendatahub.io/apiProtocol'] as ServingRuntimeAPIProtocol;
 };

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceAPIProtocol.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceAPIProtocol.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Label, Text, TextVariants } from '@patternfly/react-core';
+import { ServingRuntimeKind } from '~/k8sTypes';
+import { getAPIProtocolFromServingRuntime } from '~/pages/modelServing/customServingRuntimes/utils';
+import { ServingRuntimeAPIProtocol } from '~/types';
+
+type Props = {
+  servingRuntime?: ServingRuntimeKind;
+  isMultiModel?: boolean;
+};
+
+const InferenceServiceAPIProtocol: React.FC<Props> = ({ servingRuntime, isMultiModel }) => {
+  const apiProtocol =
+    (servingRuntime && getAPIProtocolFromServingRuntime(servingRuntime)) ?? undefined;
+
+  // If it is multi-model, we use REST as default
+  if (!apiProtocol && isMultiModel) {
+    return <Label color="gold">{ServingRuntimeAPIProtocol.REST}</Label>;
+  }
+
+  if (!apiProtocol || !Object.values(ServingRuntimeAPIProtocol).includes(apiProtocol)) {
+    return <Text component={TextVariants.small}>Not defined</Text>;
+  }
+
+  return <Label color="gold">{apiProtocol}</Label>;
+};
+export default InferenceServiceAPIProtocol;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -11,6 +11,7 @@ import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
 import InferenceServiceServingRuntime from './InferenceServiceServingRuntime';
+import InferenceServiceAPIProtocol from './InferenceServiceAPIProtocol';
 
 type InferenceServiceTableRowProps = {
   obj: InferenceServiceKind;
@@ -70,6 +71,12 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
           inferenceService={inferenceService}
           servingRuntime={servingRuntime}
           isKserve={!isModelMesh(inferenceService)}
+        />
+      </Td>
+      <Td dataLabel="API protocol">
+        <InferenceServiceAPIProtocol
+          servingRuntime={servingRuntime}
+          isMultiModel={modelMetricsSupported(inferenceService)}
         />
       </Td>
       <Td dataLabel="Status">

--- a/frontend/src/pages/modelServing/screens/global/data.ts
+++ b/frontend/src/pages/modelServing/screens/global/data.ts
@@ -51,6 +51,13 @@ const COL_SERVING_RUNTIME: SortableData<InferenceServiceKind> = {
   sortable: false,
 };
 
+const COL_API_PROTOCOL: SortableData<InferenceServiceKind> = {
+  field: 'apiProtocol',
+  label: 'API protocol',
+  width: 10,
+  sortable: false,
+};
+
 const COL_STATUS: SortableData<InferenceServiceKind> = {
   field: 'status',
   label: 'Status',
@@ -69,12 +76,14 @@ export const getGlobalInferenceServiceColumns = (
   buildProjectCol(projects),
   COL_SERVING_RUNTIME,
   COL_ENDPOINT,
+  COL_API_PROTOCOL,
   COL_STATUS,
   COL_KEBAB,
 ];
 export const getProjectInferenceServiceColumns = (): SortableData<InferenceServiceKind>[] => [
   COL_NAME,
   COL_ENDPOINT,
+  COL_API_PROTOCOL,
   COL_STATUS,
   COL_KEBAB,
 ];
@@ -83,6 +92,7 @@ export const getKServeInferenceServiceColumns = (): SortableData<InferenceServic
   COL_NAME,
   COL_SERVING_RUNTIME,
   COL_ENDPOINT,
+  COL_API_PROTOCOL,
   COL_STATUS,
   COL_KEBAB,
 ];

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -710,3 +710,8 @@ export enum ServingRuntimePlatform {
   SINGLE = 'single',
   MULTI = 'multi',
 }
+
+export enum ServingRuntimeAPIProtocol {
+  REST = 'REST',
+  GRPC = 'gRPC',
+}

--- a/manifests/modelserving/caikit-ootb.yaml
+++ b/manifests/modelserving/caikit-ootb.yaml
@@ -12,60 +12,62 @@ metadata:
     template.openshift.io/long-description: This template defines resources needed to deploy caikit-tgis-serving servingruntime with Red Hat Data Science KServe for LLM model
     template.openshift.io/support-url: https://access.redhat.com
     opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
   name: caikit-tgis-serving-template
 objects:
-- apiVersion: serving.kserve.io/v1alpha1
-  kind: ServingRuntime
-  metadata:
-    name: caikit-tgis-runtime
-    annotations:
-      openshift.io/display-name: Caikit TGIS ServingRuntime for KServe
-      opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-  labels:
-    opendatahub.io/dashboard: 'true'
-  spec:
-    multiModel: false
-    supportedModelFormats:
-      - autoSelect: true
-        name: caikit
-    containers:
-      - name: kserve-container
-        image: text-generation-inference
-        command:
-          - text-generation-launcher
-        args:
-          - --model-name=/mnt/models/artifacts/
-        env:
-          - name: TRANSFORMERS_CACHE
-            value: /tmp/transformers_cache
-      - name: transformer-container
-        image: caikit-tgis-serving
-        env:
-          - name: RUNTIME_LOCAL_MODELS_DIR
-            value: /mnt/models
-          - name: TRANSFORMERS_CACHE
-            value: /tmp/transformers_cache
-          - name: RUNTIME_GRPC_ENABLED
-            value: "false"
-          - name: RUNTIME_HTTP_ENABLED
-            value: "true"
-          - name: RUNTIME_GRPC_SERVER_THREAD_POOL_SIZE
-            value: "64"
-        ports:
-          - containerPort: 8080
-            protocol: TCP
-        readinessProbe:
-          exec:
-            command:
-              - python
-              - -m
-              - caikit_health_probe
-              - readiness
-        livenessProbe:
-          exec:
-            command:
-              - python
-              - -m
-              - caikit_health_probe
-              - liveness
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: caikit-tgis-runtime
+      annotations:
+        openshift.io/display-name: Caikit TGIS ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+
+    labels:
+      opendatahub.io/dashboard: 'true'
+    spec:
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: caikit
+      containers:
+        - name: kserve-container
+          image: text-generation-inference
+          command:
+            - text-generation-launcher
+          args:
+            - --model-name=/mnt/models/artifacts/
+          env:
+            - name: TRANSFORMERS_CACHE
+              value: /tmp/transformers_cache
+        - name: transformer-container
+          image: caikit-tgis-serving
+          env:
+            - name: RUNTIME_LOCAL_MODELS_DIR
+              value: /mnt/models
+            - name: TRANSFORMERS_CACHE
+              value: /tmp/transformers_cache
+            - name: RUNTIME_GRPC_ENABLED
+              value: 'false'
+            - name: RUNTIME_HTTP_ENABLED
+              value: 'true'
+            - name: RUNTIME_GRPC_SERVER_THREAD_POOL_SIZE
+              value: '64'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - caikit_health_probe
+                - readiness
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - caikit_health_probe
+                - liveness
 parameters: []

--- a/manifests/modelserving/ovms-kserve-ootd.yaml
+++ b/manifests/modelserving/ovms-kserve-ootd.yaml
@@ -9,50 +9,51 @@ metadata:
     tags: 'kserve-ovms,servingruntime'
     description: 'OpenVino Model Serving Definition'
     opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
 objects:
-- apiVersion: serving.kserve.io/v1alpha1
-  kind: ServingRuntime
-  labels:
-    opendatahub.io/dashboard: 'true'
-  metadata:
-    annotations:
-      openshift.io/display-name: OpenVINO Model Server
-      opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-    name: kserve-ovms
-  spec:
-    multiModel: false
-    annotations:
-      prometheus.kserve.io/port: '8888'
-      prometheus.kserve.io/path: /metrics
-    supportedModelFormats:
-    - name: openvino_ir
-      version: opset11
-      autoSelect: true
-    - name: onnx
-      version: '1'
-    - name: tensorflow
-      version: '1'
-      autoSelect: true
-    - name: tensorflow
-      version: '2'
-      autoSelect: true
-    - name: paddle
-      version: '2'
-      autoSelect: true
-    protocolVersions:
-    - v2
-    - grpc-v2
-    containers:
-    - name: kserve-container
-      image: 'ovms-kserve'
-      args:
-      - '--model_name={{.Name}}'
-      - '--port=8001'
-      - '--rest_port=8888'
-      - '--model_path=/mnt/models'
-      - '--file_system_poll_wait_seconds=0'
-      - '--grpc_bind_address=127.0.0.1'
-      - '--rest_bind_address=127.0.0.1'
-      ports:
-      - containerPort: 8888
-        protocol: TCP
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    labels:
+      opendatahub.io/dashboard: 'true'
+    metadata:
+      annotations:
+        openshift.io/display-name: OpenVINO Model Server
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      name: kserve-ovms
+    spec:
+      multiModel: false
+      annotations:
+        prometheus.kserve.io/port: '8888'
+        prometheus.kserve.io/path: /metrics
+      supportedModelFormats:
+        - name: openvino_ir
+          version: opset11
+          autoSelect: true
+        - name: onnx
+          version: '1'
+        - name: tensorflow
+          version: '1'
+          autoSelect: true
+        - name: tensorflow
+          version: '2'
+          autoSelect: true
+        - name: paddle
+          version: '2'
+          autoSelect: true
+      protocolVersions:
+        - v2
+        - grpc-v2
+      containers:
+        - name: kserve-container
+          image: 'ovms-kserve'
+          args:
+            - '--model_name={{.Name}}'
+            - '--port=8001'
+            - '--rest_port=8888'
+            - '--model_path=/mnt/models'
+            - '--file_system_poll_wait_seconds=0'
+            - '--grpc_bind_address=127.0.0.1'
+            - '--rest_bind_address=127.0.0.1'
+          ports:
+            - containerPort: 8888
+              protocol: TCP

--- a/manifests/modelserving/ovms-ootb.yaml
+++ b/manifests/modelserving/ovms-ootb.yaml
@@ -9,6 +9,7 @@ metadata:
     tags: 'ovms,servingruntime'
     description: 'OpenVino Model Serving Definition'
     opendatahub.io/modelServingSupport: '["multi"]'
+    opendatahub.io/apiProtocol: 'REST'
 objects:
   - apiVersion: serving.kserve.io/v1alpha1
     kind: ServingRuntime
@@ -60,5 +61,5 @@ objects:
           version: '1'
         - autoSelect: true
           name: tensorflow
-          version: "2" 
+          version: '2'
 parameters: []

--- a/manifests/modelserving/tgis-ootb.yaml
+++ b/manifests/modelserving/tgis-ootb.yaml
@@ -6,53 +6,54 @@ metadata:
     opendatahub.io/ootb: 'true'
   annotations:
     description: Text Generation Inference Server (TGIS) is a high performance inference engine that deploys and serves Large Language Models.
-    openshift.io/display-name: TGIS Standalone ServingRuntime for KServe (gRPC)
+    openshift.io/display-name: TGIS Standalone ServingRuntime for KServe
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/text-generation-inference
     template.openshift.io/long-description: This template defines resources needed to deploy TGIS standalone servingruntime with KServe in Red Hat OpenShift AI
     opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'gRPC'
   name: tgis-grpc-serving-template
 objects:
-- apiVersion: serving.kserve.io/v1alpha1
-  kind: ServingRuntime
-  metadata:
-    name: tgis-grpc-runtime
-    annotations:
-      openshift.io/display-name: TGIS Standalone ServingRuntime for KServe (gRPC)
-      opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-  labels:
-    opendatahub.io/dashboard: 'true'
-  spec:
-    multiModel: false
-    supportedModelFormats:
-      - autoSelect: true
-        name: pytorch
-    containers:
-      - name: kserve-container
-        image: text-generation-inference
-        command: ["text-generation-launcher"]
-        args: 
-          - "--model-name=/mnt/models/"
-          - "--port=3000"
-          - "--grpc-port=8033"
-        env:
-          - name: TRANSFORMERS_CACHE
-            value: /tmp/transformers_cache
-        readinessProbe:
-          exec:
-            command:
-              - curl
-              - localhost:3000/health
-          initialDelaySeconds: 5
-        livenessProbe:
-          exec:
-            command:
-              - curl
-              - localhost:3000/health
-          initialDelaySeconds: 5
-        ports:
-        - containerPort: 8033
-          name: h2c
-          protocol: TCP
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: tgis-grpc-runtime
+      annotations:
+        openshift.io/display-name: TGIS Standalone ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    labels:
+      opendatahub.io/dashboard: 'true'
+    spec:
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: pytorch
+      containers:
+        - name: kserve-container
+          image: text-generation-inference
+          command: ['text-generation-launcher']
+          args:
+            - '--model-name=/mnt/models/'
+            - '--port=3000'
+            - '--grpc-port=8033'
+          env:
+            - name: TRANSFORMERS_CACHE
+              value: /tmp/transformers_cache
+          readinessProbe:
+            exec:
+              command:
+                - curl
+                - localhost:3000/health
+            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - localhost:3000/health
+            initialDelaySeconds: 5
+          ports:
+            - containerPort: 8033
+              name: h2c
+              protocol: TCP
 parameters: []


### PR DESCRIPTION
Closes: [RHOAIENG-560](https://issues.redhat.com/browse/RHOAIENG-560) [RHOAIENG-3875](https://issues.redhat.com/browse/RHOAIENG-3875)

## Description
Enable GRPC support for model serving routes

<details>
<summary>
Custom serving runtime list
</summary>

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/88ad8233-0b92-45a2-9a64-39b345415a1f)
</details>

<details>
<summary>
Add custom serving runtime
</summary>

<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/852657e3-e7e1-48d8-8d8b-e7c06196175c" width="350px" />

<img src="https://github.com/opendatahub-io/odh-dashboard/assets/97534722/a815fd7a-df1a-42f5-9f03-abd4d3b35a85" width="350px" />
</details>

<details>
<summary>
Project KServe list
</summary>

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/299d894a-d5e7-4622-a058-495dad6071ac)
</details>

<details>
<summary>
Project Multi-model list
</summary>

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/7e5af848-0aa7-4a0e-9a49-44e2f1d0b182)
</details>

<details>
<summary>
Global model serving
</summary>

![image](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/7e8060d7-91ca-4ac3-b3ee-96ede4f04001)
</details>

## How Has This Been Tested?

Custom Serving Runtimes Page:
1. Navigate to Settings > Serving Runtimes.
2. Click "Add Serving Runtime."
3. Choose "Multi Model" and observe REST as the default API protocol (disabled).
4. Toggle to "Single Model" or both, enabling the API protocol dropdown.
5. Select either HTTP or gRPC.
6. Create the runtime.
7. Verify the presence of the gRPC label under the API protocol column on the runtimes list page.

Projects Page:
1. Go to the Projects section.
2. Create a new project.
3. Add a model server for a Multi-model serving platform.
4. Deploy a new model.
5. Note the API protocol in the list.
6. Repeat for Single Model serving platform.

Global Model Serving Page:
1. Visit the Global Model Serving page.
2. Confirm the presence of the API protocol column.

## Test Impact
Added cypress test for Custom serving runtime and ServingRuntimeList

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@vconzola 