### PR TITLE
Trim field input when configuring pipeline server

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -64,7 +64,10 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
 
   const submit = () => {
     const objectStorage: PipelineServerConfigType['objectStorage'] = {
-      newValue: config.objectStorage.newValue,
+      newValue: config.objectStorage.newValue.map((entry) => ({
+        ...entry,
+        value: entry.value.trim(),
+      })),
     };
     setFetching(true);
     setError(null);

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/utils.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/utils.ts
@@ -142,7 +142,7 @@ export const objectStorageIsValid = (objectStorage: EnvVariableDataEntry[]): boo
     PIPELINE_AWS_FIELDS.filter((field) => field.isRequired)
       .map((field) => field.key)
       .includes(key)
-      ? !!value
+      ? !!value.trim()
       : true,
   );
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-2317

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Trim all the fields of ObjectStorage when configuring a pipeline server to make sure the DSPA and secret creation is correct.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Configure a pipeline server, input some spaces before and after all the field inputs
2. Configure the server
3. View the server configuration, make sure all the fields are correct and without the spaces at the beginning and end.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
