### PR TITLE
fix hook array stability comparison

### DIFF
--- a/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
+++ b/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
@@ -168,6 +168,10 @@ describe('hook test utils', () => {
       expect([1, 2, 3]).toStrictEqual(createComparativeValue([1, 2, 4], [true, true, false]));
       expect([1, 2, 3]).toStrictEqual(createComparativeValue([1, 2, 4], [true, true]));
       expect([1, 2, 3]).not.toStrictEqual(createComparativeValue([1, 4, 3], [true, true, true]));
+      expect([3, 2, 1]).not.toStrictEqual(createComparativeValue([1, 2, 3], [true, true, true]));
+      expect([true, false]).not.toStrictEqual(createComparativeValue([false, true], [true, true]));
+      // array comparison must have the same length, however the stability array may have a lesser length
+      expect([1, 2, 3, 4]).toStrictEqual(createComparativeValue([1, 2, 3, 5], [true, true, true]));
     });
 
     it('should extract object values according to the boolean object', () => {
@@ -198,7 +202,7 @@ describe('hook test utils', () => {
       };
       expect(testValue).toStrictEqual(
         createComparativeValue(
-          { a: 10, b: { c: 2, d: [null, 'f'] } },
+          { a: 10, b: { c: 2, d: [null, 'f', null] } },
           {
             b: {
               c: true,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Hook stability comparison utility, `createComparativeValue`, used `expect.arrayContaining()` internally when constructing the array comparators. The issue with using `expect.arrayContaining()` is that it doesn't take into consideration the order of elements. This error becomes apparent when asserting `[true, false]` is comparatively equal to `[false, true]` passed when it would be expected to fail.

The fix here is to not rely on `expect.arrayContaining()` when creating array comparators and instead always create an array equal to the size of the expected array and then fill each value with a custom comparator equal to any value when the value is irrelevant or a nested comparator such as the `expect.isIdentityEqual` comparator.

Also, `expect.anything()` doesn't match `null` or `undefined`. Therefore a new custom asymmetric matcher was added that would return `true` always. This was necessary because two tests where passing because of the previous bug but would then fail due to use of `expect.anything()` since the value was null and therefore did not match. The test was created correctly and should pass.

This issue came to light when writing a test for a hook where the hook return value contained multiple boolean values and the test unexpectedly passed because a matching boolean value was found at a different index in the array.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added additional unit tests.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added additional unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
