### PR TITLE
Unit Test Update for utilities/string

### DIFF
--- a/frontend/src/utilities/__tests__/string.spec.ts
+++ b/frontend/src/utilities/__tests__/string.spec.ts
@@ -1,9 +1,33 @@
 import {
   containsOnlySlashes,
+  downloadString,
   removeLeadingSlashes,
   replaceNonNumericPartWithString,
   replaceNumericPartWithString,
 } from '~/utilities/string';
+
+global.URL.createObjectURL = jest.fn(() => 'test-url');
+
+describe('downloadString', () => {
+  it('should download a string as a file', () => {
+    const createElementMock = jest.spyOn(document, 'createElement');
+    const appendChildMock = jest.spyOn(document.body, 'appendChild');
+    const removeChildMock = jest.spyOn(document.body, 'removeChild');
+
+    downloadString('test.txt', 'test string');
+    const linkElement = createElementMock.mock.results[0].value;
+
+    expect(linkElement.download).toBe('test.txt');
+    expect(linkElement.href).toBe('http://localhost/test-url');
+    expect(createElementMock).toHaveBeenCalledTimes(1);
+    expect(createElementMock).toHaveBeenCalledWith('a');
+    expect(appendChildMock).toHaveBeenCalledTimes(1);
+    expect(appendChildMock).toHaveBeenCalledWith(linkElement);
+    expect(removeChildMock).toHaveBeenCalledTimes(1);
+    expect(removeChildMock).toHaveBeenCalledWith(linkElement);
+    expect(document.body.innerHTML).toBe('');
+  });
+});
 
 describe('replaceNumericPartWithString', () => {
   it('should replace the numeric part of a string with a number', () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-2677](https://issues.redhat.com/browse/RHOAIENG-2677)

## Description
Updated unit test case for frontend/src/utilities/string.ts

## How Has This Been Tested?
`npm run test`

## Test Impact
Coverage:

Before:
<img width="762" alt="Screenshot 2024-02-19 at 11 29 21 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/123661468/b75fb9d9-cca2-45fc-a179-04afc869991c">

After:
<img width="722" alt="Screenshot 2024-02-22 at 1 27 55 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/123661468/d2a19794-055c-498e-b166-76213d73e17a">

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
