### PR TITLE
Error when creating new data connection in InferenceService

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -253,7 +253,10 @@ export const getProjectModelServingPlatform = (
   };
 };
 
-export const createAWSSecret = (createData: CreatingInferenceServiceObject): Promise<SecretKind> =>
+export const createAWSSecret = (
+  createData: CreatingInferenceServiceObject,
+  dryRun: boolean,
+): Promise<SecretKind> =>
   createSecret(
     assembleSecret(
       createData.project,
@@ -263,6 +266,7 @@ export const createAWSSecret = (createData: CreatingInferenceServiceObject): Pro
       ),
       'aws',
     ),
+    { dryRun },
   );
 
 const createInferenceServiceAndDataConnection = (
@@ -274,7 +278,7 @@ const createInferenceServiceAndDataConnection = (
   dryRun = false,
 ) => {
   if (!existingStorage) {
-    return createAWSSecret(inferenceServiceData).then((secret) =>
+    return createAWSSecret(inferenceServiceData, dryRun).then((secret) =>
       editInfo
         ? updateInferenceService(
             inferenceServiceData,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-3312](https://issues.redhat.com/browse/RHOAIENG-3312)

## Description
Dry run Data connection secret when inferenceService is running on dry run

## How Has This Been Tested?
Deploy new model with new data connection. 

## Test Impact
Added cypress test to check dry run of Data connection secret.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
