### PR TITLE
added unit test for errorUtils file

### DIFF
--- a/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
+++ b/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
@@ -1,0 +1,39 @@
+/* eslint-disable camelcase */
+import { handlePipelineFailures } from '~/api/pipelines/errorUtils';
+import { mockPipelineKF } from '~/__mocks__/mockPipelineKF';
+import { NotReadyError } from '~/utilities/useFetchState';
+
+describe('handlePipelineFailures', () => {
+  it('should successfully return pipeline', async () => {
+    const pipelineMock = mockPipelineKF({});
+    const result = await handlePipelineFailures(Promise.resolve(pipelineMock));
+    expect(result).toStrictEqual(pipelineMock);
+  });
+
+  it('should handle and throw KF errors', async () => {
+    const statusMock = { error: 'error', code: '404', message: 'not-found' };
+
+    await expect(handlePipelineFailures(Promise.resolve(statusMock))).rejects.toThrow('error');
+  });
+
+  it('should handle error details', async () => {
+    const statusMock = {
+      error_details: 'not-found',
+      error_message: 'not-found',
+    };
+
+    await expect(handlePipelineFailures(Promise.resolve(statusMock))).rejects.toThrow('not-found');
+  });
+
+  it('should handle common state errors ', async () => {
+    await expect(
+      handlePipelineFailures(Promise.reject(new NotReadyError('error'))),
+    ).rejects.toThrow('error');
+  });
+
+  it('should handle other errors', async () => {
+    await expect(handlePipelineFailures(Promise.reject(new Error('error')))).rejects.toThrow(
+      'Error communicating with pipeline server',
+    );
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2166

## Description
added unit test for frontend/src/api/pipelines/errorUtils.ts
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
![Screenshot from 2024-02-27 21-54-47](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/40572422-e6f7-4e24-92be-30232a5eb3ce)

<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
