### PR TITLE
make explore card clickable with PF work around

### DIFF
--- a/frontend/src/pages/exploreApplication/DrawerContentBody.scss
+++ b/frontend/src/pages/exploreApplication/DrawerContentBody.scss
@@ -1,8 +1,0 @@
-// temp fix for the PF issue https://github.com/patternfly/patternfly-react/issues/8541
-// can be removed after the issue is solved
-.odh-explore-page {
-  &__drawer-body-content {
-    display: flex;
-    flex-direction: column;
-  }
-}

--- a/frontend/src/pages/exploreApplication/ExploreApplications.scss
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.scss
@@ -1,0 +1,13 @@
+// temp fix for the PF issue https://github.com/patternfly/patternfly-react/issues/8541
+// can be removed after the issue is solved
+.odh-explore-applications {
+  &__drawer-body-content {
+    display: flex;
+    flex-direction: column;
+
+    // Work around for PF issue https://github.com/patternfly/patternfly-react/issues/10104
+    & .pf-v5-c-card__selectable-actions .pf-v5-c-radio__label {
+      justify-self: auto;
+    }
+  }
+}

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -19,7 +19,7 @@ import { ODH_PRODUCT_NAME } from '~/utilities/const';
 import { useAppContext } from '~/app/AppContext';
 import GetStartedPanel from './GetStartedPanel';
 
-import './DrawerContentBody.scss';
+import './ExploreApplications.scss';
 
 const description = `Add optional applications to your ${ODH_PRODUCT_NAME} instance.`;
 const disabledDescription = `View optional applications for your ${ODH_PRODUCT_NAME} instance. Contact an administrator to install these applications.`;
@@ -54,7 +54,7 @@ const ExploreApplicationsInner: React.FC<ExploreApplicationsInnerProps> = React.
             />
           }
         >
-          <DrawerContentBody className="odh-explore-page__drawer-body-content">
+          <DrawerContentBody className="odh-explore-applications__drawer-body-content">
             <ApplicationsPage
               title="Explore"
               description={disableInfo ? disabledDescription : description}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes https://issues.redhat.com/browse/RHOAIENG-3773

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
PF selectable cards has are not functional in website v122.
PF has introduced a fix and this change applies that fix while waiting to adopt the latest PF release.

_note commits need to be squashed_

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Navigate to the explore page and click the Jupiter tile.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Existing cypress tests were failing with chrome v122. This change should see that test pass.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
