### PR TITLE
Cypress tests: Runs - Restore & Archive

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   chromeWebSecurity: false,
   viewportWidth: 1440,
   viewportHeight: 900,
-  numTestsKeptInMemory: 0,
+  numTestsKeptInMemory: 1,
   env: {
     MOCK: !!process.env.MOCK,
     USERNAME: process.env.USERNAME,

--- a/frontend/src/__tests__/cypress/cypress/e2e/applications/explore.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/applications/explore.cy.ts
@@ -10,11 +10,11 @@ describe('Explore Page', { testIsolation: false }, () => {
     cy.intercept('/api/status', mockStatus());
     cy.intercept('/api/config', mockDashboardConfig({}));
     cy.intercept('/api/components', mockComponents());
+    explorePage.visit();
   });
 
   it('should have selectable cards', () => {
-    explorePage.visit();
-    explorePage.findExploreCard('jupyter').click();
+    explorePage.findExploreCard('jupyter').findByRole('radio').click();
     explorePage.findDrawerPanel().should('be.visible');
   });
 

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -138,7 +138,7 @@ describe('Pipeline create runs', () => {
       cloneRunPage.mockGetPipeline(mockPipeline);
 
       // Mock runs list with newly cloned run
-      activeRunsTable.mockGetRuns([...initialMockRuns, mockDuplicateRun]).as('refreshRuns');
+      activeRunsTable.mockGetActiveRuns([...initialMockRuns, mockDuplicateRun]).as('refreshRuns');
 
       // Navigate to clone run page for a given active run
       pipelineRunsGlobal.findActiveRunsTab().click();

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
@@ -10,12 +10,12 @@ import {
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockRouteK8sResource } from '~/__mocks__/mockRouteK8sResource';
 import { mockStatus } from '~/__mocks__/mockStatus';
-import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import {
   pipelinesGlobal,
   pipelinesTable,
   pipelineImportModal,
   pipelineVersionImportModal,
+  pipelineDeleteModal,
 } from '~/__tests__/cypress/cypress/pages/pipelines';
 
 const projectName = 'test-project-name';
@@ -158,8 +158,8 @@ describe('Pipelines', () => {
       .findRowByName(initialMockPipelineVersion.display_name)
       .findByText('Delete pipeline version')
       .click();
-    deleteModal.shouldBeOpen();
-    deleteModal.findInput().type(initialMockPipelineVersion.display_name);
+    pipelineDeleteModal.shouldBeOpen();
+    pipelineDeleteModal.findInput().type(initialMockPipelineVersion.display_name);
     cy.intercept(
       {
         method: 'POST',
@@ -167,7 +167,7 @@ describe('Pipelines', () => {
       },
       buildMockPipelineVersionsV2([]),
     ).as('refreshVersions');
-    deleteModal.findSubmitButton().click();
+    pipelineDeleteModal.findSubmitButton().click();
 
     cy.wait('@deleteVersion');
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/archiveRunModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/archiveRunModal.ts
@@ -1,0 +1,25 @@
+import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
+
+class ArchiveRunModal extends Modal {
+  protected testId;
+
+  constructor(testId = 'archive-run-modal') {
+    super('Archive run?');
+    this.testId = testId;
+  }
+
+  find() {
+    return cy.findByTestId(this.testId).parents('div[role="dialog"]');
+  }
+
+  findConfirmInput() {
+    return this.find().findByTestId('confirm-archive-input');
+  }
+
+  findSubmitButton() {
+    return this.findFooter().findByRole('button', { name: 'Archive', hidden: true });
+  }
+}
+
+export const archiveRunModal = new ArchiveRunModal();
+export const bulkArchiveRunModal = new ArchiveRunModal('bulk-archive-run-modal');

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -115,7 +115,9 @@ export class CreateRunPage {
   }
 
   findSubmitButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findByRole('button', { name: `Create ${this.type}` });
+    return this.find().findByRole('button', {
+      name: `${this.type === 'schedule' ? 'Schedule' : 'Create'} run`,
+    });
   }
 
   findParamByLabel(label: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/index.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/index.ts
@@ -8,3 +8,5 @@ export * from './pipelineRunTable';
 export * from './createRunPage';
 export * from './cloneRunPage';
 export * from './pipelineFilterBar';
+export * from './restoreRunModal';
+export * from './archiveRunModal';

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
@@ -41,7 +41,11 @@ class PipelineRunsGlobal {
   }
 
   findCreateScheduleButton() {
-    return cy.findByRole('button', { name: 'Create schedule' });
+    return cy.findByRole('button', { name: 'Schedule run' });
+  }
+
+  findRestoreRunButton() {
+    return cy.findByRole('button', { name: 'Restore' });
   }
 
   findActiveRunsToolbar() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -1,3 +1,5 @@
+import { DeleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
+
 class PipelinesGlobal {
   visit(projectName: string) {
     cy.visitWithLogin(`/pipelines/${projectName}`);
@@ -40,4 +42,15 @@ class PipelinesGlobal {
   }
 }
 
+class PipelineDeleteModal extends DeleteModal {
+  constructor() {
+    super();
+  }
+
+  find() {
+    return cy.findByTestId('delete-pipeline-modal').parents('div[role="dialog"]');
+  }
+}
+
+export const pipelineDeleteModal = new PipelineDeleteModal();
 export const pipelinesGlobal = new PipelinesGlobal();

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
@@ -14,16 +14,8 @@ class PipelinesTable {
     return this.find().findAllByRole('heading', { name }).parents('tr');
   }
 
-  private shouldRowExist = (name: string) => this.find().get('tr').contains(name).should('exist');
-
-  private shouldRowNotExist = (name: string) =>
-    this.find().get('tr').contains(name).should('not.exist');
-
-  checkRow() {
-    return {
-      shouldExist: (name: string) => this.shouldRowExist(name),
-      shouldNotExist: (name: string) => this.shouldRowNotExist(name),
-    };
+  shouldRowNotBeVisible(name: string) {
+    return this.find().get('tr').contains(name).should('not.be.visible');
   }
 
   mockGetPipelines(pipelines: PipelineKFv2[]) {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/restoreRunModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/restoreRunModal.ts
@@ -1,0 +1,21 @@
+import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
+
+class RestoreRunModal extends Modal {
+  protected testId;
+
+  constructor(testId = 'restore-run-modal') {
+    super('Restore run?');
+    this.testId = testId;
+  }
+
+  find() {
+    return cy.findByTestId(this.testId).parents('div[role="dialog"]');
+  }
+
+  findSubmitButton() {
+    return this.findFooter().findByRole('button', { name: 'Restore', hidden: true });
+  }
+}
+
+export const restoreRunModal = new RestoreRunModal();
+export const bulkRestoreRunModal = new RestoreRunModal('bulk-restore-run-modal');

--- a/frontend/src/concepts/pipelines/content/DeletePipelineRunsModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelineRunsModal.tsx
@@ -7,7 +7,7 @@ import { K8sAPIOptions } from '~/k8sTypes';
 import { PipelineRunType } from '~/pages/pipelines/global/runs/types';
 import DeletePipelineModalExpandableSection from '~/concepts/pipelines/content/DeletePipelineModalExpandableSection';
 import useDeleteStatuses from '~/concepts/pipelines/content/useDeleteStatuses';
-import { runTypeCategoryLabel } from './createRun/types';
+import { runTypeCategory } from './createRun/types';
 
 type DeletePipelineRunsModalProps = {
   onClose: (deleted?: boolean) => void;
@@ -31,7 +31,7 @@ const DeletePipelineRunsModal: React.FC<DeletePipelineRunsModalProps> = ({
   const { deleting, setDeleting, error, setError, deleteStatuses, onBeforeClose, abortSignal } =
     useDeleteStatuses({ onClose, type, toDeleteResources });
   const resourceCount = toDeleteResources.length;
-  const typeCategory = runTypeCategoryLabel[type];
+  const typeCategory = runTypeCategory[type];
 
   return (
     <DeleteModal

--- a/frontend/src/concepts/pipelines/content/createRun/CloneRunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/CloneRunPage.tsx
@@ -7,13 +7,13 @@ import useCloneRunData from '~/concepts/pipelines/content/createRun/useCloneRunD
 import { PathProps, PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
 import { useGetSearchParamValues } from '~/utilities/useGetSearchParamValues';
 import { PipelineRunType } from '~/pages/pipelines/global/runs';
-import { runTypeCategoryLabel } from './types';
+import { runTypeCategory } from './types';
 
 const CloneRunPage: React.FC<PathProps> = ({ breadcrumbPath, contextPath }) => {
   const [run, loaded, error] = useCloneRunData();
   const { runType } = useGetSearchParamValues([PipelineRunSearchParam.RunType]);
   const title = `Duplicate ${
-    runTypeCategoryLabel[(runType as PipelineRunType) || PipelineRunType.Active]
+    runTypeCategory[(runType as PipelineRunType) || PipelineRunType.Active]
   }`;
 
   return (

--- a/frontend/src/concepts/pipelines/content/createRun/CreateRunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/CreateRunPage.tsx
@@ -6,13 +6,10 @@ import { PathProps, PipelineRunSearchParam } from '~/concepts/pipelines/content/
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { PipelineRunType } from '~/pages/pipelines/global/runs';
 import { useGetSearchParamValues } from '~/utilities/useGetSearchParamValues';
-import { runTypeCategoryLabel } from './types';
 
 const CreateRunPage: React.FC<PathProps> = ({ breadcrumbPath, contextPath }) => {
   const { runType } = useGetSearchParamValues([PipelineRunSearchParam.RunType]);
-  const title = `Create ${
-    runTypeCategoryLabel[(runType as PipelineRunType) || PipelineRunType.Active]
-  }`;
+  const title = `${runType === PipelineRunType.Scheduled ? 'Schedule' : 'Create'} run`;
 
   return (
     <ApplicationsPage

--- a/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert, Button, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { RunFormData, runTypeCategoryLabel } from '~/concepts/pipelines/content/createRun/types';
+import { RunFormData } from '~/concepts/pipelines/content/createRun/types';
 import { isFilledRunFormData } from '~/concepts/pipelines/content/createRun/utils';
 import { handleSubmit } from '~/concepts/pipelines/content/createRun/submitUtils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
@@ -54,7 +54,7 @@ const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath }) => {
                   });
               }}
             >
-              Create {runTypeCategoryLabel[(runType as PipelineRunType) || PipelineRunType.Active]}
+              {`${runType === PipelineRunType.Scheduled ? 'Schedule' : 'Create'} run`}
             </Button>
           </SplitItem>
           <SplitItem>

--- a/frontend/src/concepts/pipelines/content/createRun/types.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/types.ts
@@ -57,7 +57,7 @@ export type SafeRunFormData = RunFormData & {
   params: RuntimeConfigParameters;
 };
 
-export const runTypeCategoryLabel: Record<PipelineRunType, 'run' | 'schedule'> = {
+export const runTypeCategory: Record<PipelineRunType, 'run' | 'schedule'> = {
   [PipelineRunType.Active]: 'run',
   [PipelineRunType.Archived]: 'run',
   [PipelineRunType.Scheduled]: 'schedule',

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -188,16 +188,40 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
 
       {isArchiveModalOpen &&
         (selectedRuns.length === 1 ? (
-          <ArchiveRunModal run={selectedRuns[0]} onCancel={() => setIsArchiveModalOpen(false)} />
+          <ArchiveRunModal
+            run={selectedRuns[0]}
+            onCancel={() => {
+              setIsArchiveModalOpen(false);
+              setSelectedIds([]);
+            }}
+          />
         ) : (
-          <BulkArchiveRunModal runs={selectedRuns} onCancel={() => setIsArchiveModalOpen(false)} />
+          <BulkArchiveRunModal
+            runs={selectedRuns}
+            onCancel={() => {
+              setIsArchiveModalOpen(false);
+              setSelectedIds([]);
+            }}
+          />
         ))}
 
       {isRestoreModalOpen &&
         (selectedRuns.length === 1 ? (
-          <RestoreRunModal run={selectedRuns[0]} onCancel={() => setIsRestoreModalOpen(false)} />
+          <RestoreRunModal
+            run={selectedRuns[0]}
+            onCancel={() => {
+              setIsRestoreModalOpen(false);
+              setSelectedIds([]);
+            }}
+          />
         ) : (
-          <BulkRestoreRunModal runs={selectedRuns} onCancel={() => setIsRestoreModalOpen(false)} />
+          <BulkRestoreRunModal
+            runs={selectedRuns}
+            onCancel={() => {
+              setIsRestoreModalOpen(false);
+              setSelectedIds([]);
+            }}
+          />
         ))}
 
       {isDeleteModalOpen && (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
@@ -65,7 +65,7 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
             })
           }
         >
-          Create schedule
+          Schedule run
         </Button>
       </ToolbarItem>
       <ToolbarItem data-testid="job-table-toolbar-item">{dropdownActions}</ToolbarItem>

--- a/frontend/src/pages/pipelines/global/runs/ArchiveRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ArchiveRunModal.tsx
@@ -82,6 +82,7 @@ export const ArchiveRunModal: React.FC<ArchiveRunModalProps> = ({ run, onCancel 
 
             <TextInput
               id="confirm-archive-input"
+              data-testid="confirm-archive-input"
               aria-label="confirm archive input"
               value={confirmInputValue}
               onChange={(_e, newValue) => setConfirmInputValue(newValue)}

--- a/frontend/src/pages/pipelines/global/runs/BulkArchiveRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/runs/BulkArchiveRunModal.tsx
@@ -89,8 +89,9 @@ export const BulkArchiveRunModal: React.FC<BulkArchiveRunModalProps> = ({ runs, 
             </FlexItem>
 
             <TextInput
-              id="confirm-archive-input"
-              aria-label="confirm archive input"
+              id="confirm-bulk-archive-input"
+              data-testid="confirm-archive-input"
+              aria-label="confirm bulk archive input"
               value={confirmInputValue}
               onChange={(_e, newValue) => setConfirmInputValue(newValue)}
               onKeyDown={(event) => {

--- a/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
@@ -73,7 +73,7 @@ const ScheduledRuns: React.FC = () => {
                 })
               }
             >
-              Create schedule
+              Schedule run
             </Button>
           </EmptyStateActions>
         </EmptyStateFooter>

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -77,7 +77,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
         </Button>,
       ]}
       variant="small"
-      data-testid={testId}
+      data-testid={testId || 'delete-modal'}
     >
       <Stack hasGutter>
         <StackItem>{children}</StackItem>
@@ -90,6 +90,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
 
             <TextInput
               id="delete-modal-input"
+              data-testid="delete-modal-input"
               aria-label="Delete modal input"
               value={value}
               onChange={(_e, newValue) => setValue(newValue)}


### PR DESCRIPTION
Closes: [RHOAIENG-3886](https://issues.redhat.com/browse/RHOAIENG-3886)
Starts: [RHOAIENG-3887](https://issues.redhat.com/browse/RHOAIENG-3887)

## Description
Test scenarios covered from Active & Archived run list pages:
- single Restore
- multiple Restore
- single Archive
- multiple Archive

Also includes:
- Fix for `explore.cy.ts` test that is unrelated and not owned by our scrum team, but is impeding on CI builds.
- A simple name change of `Create Schedule` -> `Schedule run`, which is a part of [RHOAIENG-3887](https://issues.redhat.com//browse/RHOAIENG-3887), but only captures a small amount that still could change more as a part of that ticket which is not yet fully vetted.

## How Has This Been Tested?
Cypress tests, regression tests

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
