### PR TITLE
Force tls and add ca bundle to k8s library

### DIFF
--- a/backend/src/routes/api/proxy/index.ts
+++ b/backend/src/routes/api/proxy/index.ts
@@ -61,7 +61,6 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         url,
         overrideContentType: contentType,
         requestData,
-        rejectUnauthorized: false,
       })
         .then(([rawData]) => rawData)
         .catch((error) => {

--- a/backend/src/routes/wss/k8s/index.ts
+++ b/backend/src/routes/wss/k8s/index.ts
@@ -3,6 +3,7 @@ import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { getDirectCallOptions } from '../../../utils/directCallUtils';
 import { getAccessToken } from '../../../utils/directCallUtils';
 import { ClientRequest, IncomingMessage } from 'http';
+import https from 'https';
 
 const base64 = (data: string): string =>
   // This usage of toString is fine for decoding
@@ -67,7 +68,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
               req.headers.origin ||
               `http://${typeof serverAddress === 'string' ? serverAddress : serverAddress.address}`,
           },
-          ca: requestOptions.ca as WebSocket.CertMeta,
+          ca: https.globalAgent.options.ca as WebSocket.CertMeta,
         });
 
         const close = (code: number, reason: string) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -38,10 +38,15 @@ app.listen({ port: PORT, host: IP }, (err) => {
     app.log.error(err);
     process.exit(1); // eslint-disable-line
   }
+  // Load CA bundle used in our API calls
+  // ca.crt is the default CA bundle provided by the service account for kubernetes
+  // service-ca.crt is the CA bundle provided by the service account for kubernetes used by prometheus
+  // odh-ca-bundle.crt and odh-trusted-ca-bundle.crt are the CA bundles provided by the ODH platform
   const caPaths = [
     '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-    '/etc/pki/tls/certs/ca-bundle.crt',
+    '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt',
     '/etc/pki/tls/certs/odh-ca-bundle.crt',
+    '/etc/pki/tls/certs/odh-trusted-ca-bundle.crt',
   ]
     .map(getCABundle)
     .filter((ca) => ca !== undefined);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,8 @@ import pino from 'pino';
 import { APP_ENV, PORT, IP, LOG_LEVEL } from './utils/constants';
 import { initializeApp } from './app';
 import { AddressInfo } from 'net';
+import https from 'https';
+import fs from 'fs';
 
 const transport =
   APP_ENV === 'development'
@@ -36,7 +38,26 @@ app.listen({ port: PORT, host: IP }, (err) => {
     app.log.error(err);
     process.exit(1); // eslint-disable-line
   }
+  const caPaths = [
+    '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+    '/etc/pki/tls/certs/ca-bundle.crt',
+    '/etc/pki/tls/certs/odh-ca-bundle.crt',
+  ]
+    .map(getCABundle)
+    .filter((ca) => ca !== undefined);
+
+  https.globalAgent.options.ca = caPaths;
+
   const address: AddressInfo = app.server.address() as AddressInfo;
   console.log('Fastify Connected...');
   console.log(`Server listening on >>>  ${address.address}:${address.port}`);
 });
+
+const getCABundle = (path: string) => {
+  try {
+    return fs.readFileSync(path);
+  } catch (e) {
+    // ignore
+  }
+  return undefined;
+};

--- a/backend/src/utils/directCallUtils.ts
+++ b/backend/src/utils/directCallUtils.ts
@@ -12,12 +12,12 @@ export const getDirectCallOptions = async (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   url: string,
-): Promise<RequestOptions> => {
+): Promise<Pick<RequestOptions, 'headers'>> => {
   // Use our kube setup to boostrap our request
   const kc = fastify.kube.config;
   const kubeOptions: Parameters<typeof kc.applyToRequest>[0] = { url };
   await kc.applyToRequest(kubeOptions);
-  const { headers: kubeHeaders, ca } = kubeOptions;
+  const { headers: kubeHeaders } = kubeOptions;
 
   // Adjust the header auth token
   let headers;
@@ -49,7 +49,6 @@ export const getDirectCallOptions = async (
   }
 
   return {
-    ca,
     headers,
   };
 };

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -27,7 +27,6 @@ const callPrometheus = async <T>(
   return proxyCall(fastify, request, {
     method: 'GET',
     url,
-    isPrometheus: true,
   })
     .then(([rawData, status]) => {
       if (rejectOnHttpErrorCode && status.code >= 400) {

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -27,7 +27,7 @@ const callPrometheus = async <T>(
   return proxyCall(fastify, request, {
     method: 'GET',
     url,
-    rejectUnauthorized: false,
+    isPrometheus: true,
   })
     .then(([rawData, status]) => {
       if (rejectOnHttpErrorCode && status.code >= 400) {

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -118,6 +118,8 @@ spec:
             name: oauth-config
           - mountPath: /etc/oauth/client
             name: oauth-client
+          - mountPath: /etc/pki/tls/certs
+            name: trusted-ca-bundle
       volumes:
       - name: proxy-tls
         secret:

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -57,8 +57,18 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
-          - mountPath: /etc/pki/tls/certs
-            name: trusted-ca-bundle
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
       - name: oauth-proxy
         env:
           - name: NAMESPACE
@@ -118,8 +128,18 @@ spec:
             name: oauth-config
           - mountPath: /etc/oauth/client
             name: oauth-client
-          - mountPath: /etc/pki/tls/certs
-            name: trusted-ca-bundle
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
       volumes:
       - name: proxy-tls
         secret:
@@ -130,7 +150,17 @@ spec:
       - name: oauth-client
         secret:
           secretName: dashboard-oauth-client-generated
-      - name: trusted-ca-bundle
+      - name: odh-trusted-ca-cert
         configMap:
           name: odh-trusted-ca-bundle
+          items:
+          - key: ca-bundle.crt
+            path: odh-trusted-ca-bundle.crt
+          optional: true
+      - name: odh-ca-cert
+        configMap:
+          name: odh-trusted-ca-bundle
+          items:
+          - key: odh-ca-bundle.crt
+            path: odh-ca-bundle.crt
           optional: true


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-2380

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removes the option to allow unsecure connections throught the pass through API and check wethere k8s library should override the CA bundle

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Add a certificate in the DSCInitialization object in the ODH Operator
2. Deploy `quay.io/lferrnan/odh-dashboard:rhoaieng-2380` in your cluster
3. Enter the pod's terminal in the dashboard container
4. Check that these certificates does exist:

```bash
    '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
    '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt',
    '/etc/pki/tls/certs/odh-ca-bundle.crt',
    '/etc/pki/tls/certs/odh-trusted-ca-bundle.crt',
```
5. `odh-ca-bundle.crt` should contain the certificate added  in step 1
6. Log in into the odh dashboard
7. Create a pipeline server and create a pipeline run
8. Dashboard should be able to contact DSPA pipeline
9. Create a model server and deploy a model with modelmesh
10. Go to the metrics section
11. Dashboard should be able to access prometheus

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No testing suite since it's a certificate change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
