### PR TITLE
fix(resource): RHOAIENG-1150, fix typo in tutorial

### DIFF
--- a/manifests/overlays/apps/base/watson/watson-docs.yaml
+++ b/manifests/overlays/apps/base/watson/watson-docs.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   appName: watson-studio
   type: tutorial
-  displayName: Buildng a binary classification model
+  displayName: Building a binary classification model
   description: |-
     Train a model to predict if a customer is likely to subscribe to a bank promotion.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/analyze-data/autoai_example_binary_classifier.html


### PR DESCRIPTION
Closes: #[RHOAIENG-1150](https://issues.redhat.com//browse/RHOAIENG-1150)

## Description
One of the tutorial in the Dashboard > Resources page has a typo in the title: **Buildng** a binary classification model
