### PR TITLE
add close button to error boundary

### DIFF
--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Title } from '@patternfly/react-core';
+import { Button, Split, SplitItem, Title } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import ErrorDetails from './ErrorDetails';
 
 type ErrorBoundaryProps = {
@@ -40,9 +41,24 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       const { error, errorInfo } = this.state;
       return (
         <div className="pf-v5-u-p-lg">
-          <Title headingLevel="h1" className="pf-v5-u-mb-lg">
-            An error occurred.
-          </Title>
+          <Split>
+            <SplitItem isFilled>
+              <Title headingLevel="h1" className="pf-v5-u-mb-lg">
+                An error occurred.
+              </Title>
+            </SplitItem>
+            <SplitItem>
+              <Button
+                variant="plain"
+                aria-label="Close"
+                onClick={() => {
+                  this.setState({ hasError: false });
+                }}
+              >
+                <TimesIcon />
+              </Button>
+            </SplitItem>
+          </Split>
           <ErrorDetails
             title={error.name}
             errorMessage={error.message}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Fixes https://issues.redhat.com/browse/RHOAIENG-2650

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a close button to the error boundary. Clicking the close button resets the internal error state causing the error boundary to unmount. When this occurs, the app will resume loading as if no error occurred by rendering the contents of the current URL.

![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/d3fae027-186d-43d4-877c-b26cb6c8025f)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Cause an uncaught error to occur. 
Through the web console, add a breakpoint to a react component. Once the break point is hit, edit a variable such that an exception will be thrown attempting to access a property of an undefined variable

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
