### PR TITLE
Add useIsAreaAvailable hook to check if experiments are available and hide jump to section

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
@@ -25,6 +25,7 @@ import { useGetSearchParamValues } from '~/utilities/useGetSearchParamValues';
 import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
 import { PipelineRunType } from '~/pages/pipelines/global/runs';
 import useExperimentById from '~/concepts/pipelines/apiHooks/useExperimentById';
+import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
 
 type RunPageProps = {
   cloneRun?: PipelineRunKFv2 | PipelineRunJobKFv2 | null;
@@ -47,6 +48,14 @@ const RunPage: React.FC<RunPageProps> = ({ cloneRun, contextPath, testId }) => {
   const [cloneRunPipelineVersion] = usePipelineVersionById(cloneRunPipelineId, cloneRunVersionId);
   const [cloneRunPipeline] = usePipelineById(cloneRunPipelineId);
   const [cloneRunExperiment] = useExperimentById(cloneRunExperimentId);
+
+  const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
+
+  const sections = isExperimentsAvailable
+    ? Object.values(CreateRunPageSections)
+    : Object.values(CreateRunPageSections).filter(
+        (section) => section !== CreateRunPageSections.EXPERIMENT,
+      );
 
   const [formData, setFormDataValue] = useRunFormData(cloneRun, {
     runType: {
@@ -73,11 +82,7 @@ const RunPage: React.FC<RunPageProps> = ({ cloneRun, contextPath, testId }) => {
   return (
     <div data-testid={testId}>
       <PageSection isFilled variant="light">
-        <GenericSidebar
-          sections={Object.values(CreateRunPageSections)}
-          titles={runPageSectionTitles}
-          maxWidth={175}
-        >
+        <GenericSidebar sections={sections} titles={runPageSectionTitles} maxWidth={175}>
           <RunForm
             data={formData}
             runType={runType as PipelineRunType}

--- a/frontend/src/concepts/pipelines/content/createRun/const.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/const.ts
@@ -19,16 +19,16 @@ export const RUN_OPTION_LABEL_SIZE = 100;
 
 export enum CreateRunPageSections {
   NAME_DESC = 'run-section-name-desc',
+  EXPERIMENT = 'run-section-experiment',
   PIPELINE = 'run-section-pipeline',
   PIPELINE_VERSION = 'run-section-pipeline-version',
-  EXPERIMENT = 'run-section-experiment',
   PARAMS = 'run-section-params',
 }
 
 export const runPageSectionTitles: Record<CreateRunPageSections, string> = {
   [CreateRunPageSections.NAME_DESC]: 'Name and description',
+  [CreateRunPageSections.EXPERIMENT]: 'Experiment',
   [CreateRunPageSections.PIPELINE]: 'Pipeline',
   [CreateRunPageSections.PIPELINE_VERSION]: 'Pipeline version',
-  [CreateRunPageSections.EXPERIMENT]: 'Experiment',
   [CreateRunPageSections.PARAMS]: 'Pipeline input parameters',
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
hides experiment section jump to section on feature flag disable
<img width="795" alt="Screenshot 2024-03-07 at 10 31 31 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/459a9dc7-6880-4650-8f2c-a51a6e40c7b0">
<img width="595" alt="Screenshot 2024-03-07 at 10 28 25 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/6d8a30df-9b5d-4e53-a91a-d794f9a043ec">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
disable/enable the feature flag and make sure the section is removed

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
n/a

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

Not a UX needed UI change. It is quick fix that is already approved via mocks

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
