### PR TITLE
Add pipeline url submit modal

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -1,4 +1,4 @@
-import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
+import { CreatePipelineAndVersionKFData, PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 import { buildMockPipelineV2 } from '~/__mocks__/mockPipelinesProxy';
 import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 
@@ -27,6 +27,18 @@ class PipelineImportModal extends Modal {
     return this.findFooter().findByRole('button', { name: 'Import pipeline' });
   }
 
+  findUploadPipelineRadio() {
+    return this.find().findByTestId('upload-file-radio');
+  }
+
+  findImportPipelineRadio() {
+    return this.find().findByTestId('import-url-radio');
+  }
+
+  findPipelineUrlInput() {
+    return this.find().findByTestId('pipeline-url-input');
+  }
+
   fillPipelineName(value: string) {
     this.findPipelineNameInput().clear().type(value);
   }
@@ -37,6 +49,17 @@ class PipelineImportModal extends Modal {
 
   uploadPipelineYaml(filePath: string) {
     this.findUploadPipelineInput().selectFile([filePath], { force: true });
+  }
+
+  mockCreatePipelineAndVersion(params: CreatePipelineAndVersionKFData) {
+    return cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/api/proxy/apis/v2beta1/pipelines/create',
+        times: 1,
+      },
+      buildMockPipelineV2(params.pipeline),
+    );
   }
 
   mockUploadPipeline(params: Partial<PipelineKFv2>) {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
@@ -1,4 +1,4 @@
-import { PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
+import { CreatePipelineVersionKFData, PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
 import { buildMockPipelineVersionV2 } from '~/__mocks__/mockPipelineVersionsProxy';
 import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 
@@ -38,6 +38,22 @@ class PipelineImportModal extends Modal {
     this.findUploadPipelineInput().selectFile([filePath], { force: true });
   }
 
+  findUploadPipelineRadio() {
+    return this.find().findByTestId('upload-file-radio');
+  }
+
+  findImportPipelineRadio() {
+    return this.find().findByTestId('import-url-radio');
+  }
+
+  findPipelineUrlInput() {
+    return this.find().findByTestId('pipeline-url-input');
+  }
+
+  findCodeSourceInput() {
+    return this.find().findByTestId('code-source-input');
+  }
+
   selectPipelineByName(name: string) {
     this.findPipelineSelect()
       .click()
@@ -56,6 +72,17 @@ class PipelineImportModal extends Modal {
 
   submit(): void {
     this.findSubmitButton().click();
+  }
+
+  mockCreatePipelineVersion(params: CreatePipelineVersionKFData) {
+    return cy.intercept(
+      {
+        method: 'POST',
+        pathname: `/api/proxy/apis/v2beta1/pipelines/${params.pipeline_id}/versions`,
+        times: 1,
+      },
+      buildMockPipelineVersionV2(params),
+    );
   }
 
   mockUploadVersion(params: Partial<PipelineVersionKFv2>) {

--- a/frontend/src/api/pipelines/callTypes.ts
+++ b/frontend/src/api/pipelines/callTypes.ts
@@ -20,6 +20,8 @@ import {
   GetPipelineVersion,
   DeletePipelineVersion,
   ListPipelineVersions,
+  CreatePipelineAndVersion,
+  CreatePipelineVersion,
 } from '~/concepts/pipelines/types';
 import { K8sAPIOptions } from '~/k8sTypes';
 
@@ -28,6 +30,8 @@ import { K8sAPIOptions } from '~/k8sTypes';
 type KubeflowSpecificAPICall = (opts: K8sAPIOptions, ...args: any[]) => Promise<unknown>;
 type KubeflowAPICall<ActualCall extends KubeflowSpecificAPICall> = (hostPath: string) => ActualCall;
 
+export type CreatePipelineVersionAPI = KubeflowAPICall<CreatePipelineVersion>;
+export type CreatePipelineAndVersionAPI = KubeflowAPICall<CreatePipelineAndVersion>;
 export type CreateExperimentAPI = KubeflowAPICall<CreateExperiment>;
 export type CreatePipelineRunAPI = KubeflowAPICall<CreatePipelineRun>;
 export type CreatePipelineRunJobAPI = KubeflowAPICall<CreatePipelineRunJob>;

--- a/frontend/src/api/pipelines/custom.ts
+++ b/frontend/src/api/pipelines/custom.ts
@@ -23,6 +23,8 @@ import {
   GetPipelineVersionAPI,
   ListPipelineVersionsAPI,
   UpdatePipelineRunAPI,
+  CreatePipelineAndVersionAPI,
+  CreatePipelineVersionAPI,
 } from './callTypes';
 import { handlePipelineFailures } from './errorUtils';
 
@@ -46,6 +48,15 @@ const pipelineParamsToQuery = (params?: PipelineParams) => ({
 
 export const createExperiment: CreateExperimentAPI = (hostPath) => (opts, data) =>
   handlePipelineFailures(proxyCREATE(hostPath, `/apis/v2beta1/experiments`, data, {}, opts));
+
+export const createPipelineAndVersion: CreatePipelineAndVersionAPI = (hostPath) => (opts, data) =>
+  handlePipelineFailures(proxyCREATE(hostPath, `/apis/v2beta1/pipelines/create`, data, {}, opts));
+
+export const createPipelineVersion: CreatePipelineVersionAPI =
+  (hostPath) => (opts, pipelineId, data) =>
+    handlePipelineFailures(
+      proxyCREATE(hostPath, `/apis/v2beta1/pipelines/${pipelineId}/versions`, data, {}, opts),
+    );
 
 export const createPipelineRun: CreatePipelineRunAPI = (hostPath) => (opts, data) =>
   handlePipelineFailures(proxyCREATE(hostPath, `/apis/v2beta1/runs`, data, {}, opts));

--- a/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import {
+  Alert,
+  AlertActionLink,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Radio,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { COMPILE_PIPELINE_DOCUMENTATION_URL, PipelineUploadOption } from './utils';
+import PipelineFileUpload from './PipelineFileUpload';
+
+type PipelineFileUploadProps = {
+  fileContents: string;
+  setFileContents: (fileContents: string) => void;
+  pipelineUrl: string;
+  setPipelineUrl: (url: string) => void;
+  uploadOption: PipelineUploadOption;
+  setUploadOption: (option: PipelineUploadOption) => void;
+};
+
+const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
+  fileContents,
+  setFileContents,
+  pipelineUrl,
+  setPipelineUrl,
+  uploadOption,
+  setUploadOption,
+}) => (
+  <Stack hasGutter>
+    <StackItem>
+      <Split hasGutter>
+        <SplitItem>
+          <Radio
+            isChecked={uploadOption === PipelineUploadOption.FILE_UPLOAD}
+            name="upload-file"
+            onChange={() => {
+              setUploadOption(PipelineUploadOption.FILE_UPLOAD);
+              setPipelineUrl('');
+            }}
+            label="Upload a file"
+            id="upload-file"
+            data-testid="upload-file-radio"
+          />
+        </SplitItem>
+        <SplitItem>
+          <Radio
+            isChecked={uploadOption === PipelineUploadOption.URL_IMPORT}
+            name="import-url"
+            onChange={() => {
+              setUploadOption(PipelineUploadOption.URL_IMPORT);
+              setFileContents('');
+            }}
+            label="Import by url"
+            id="import-url"
+            data-testid="import-url-radio"
+          />
+        </SplitItem>
+      </Split>
+    </StackItem>
+    <StackItem>
+      <Alert
+        variant="info"
+        title="For expected file format, refer to Compile Pipeline Documentation."
+        isInline
+        actionLinks={
+          <>
+            <AlertActionLink
+              component="a"
+              href={COMPILE_PIPELINE_DOCUMENTATION_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Split hasGutter>
+                <SplitItem>View documentation</SplitItem>
+                <SplitItem>
+                  <ExternalLinkAltIcon />
+                </SplitItem>
+              </Split>
+            </AlertActionLink>
+          </>
+        }
+      />
+    </StackItem>
+    <StackItem>
+      {uploadOption === PipelineUploadOption.FILE_UPLOAD ? (
+        <PipelineFileUpload fileContents={fileContents} onUpload={setFileContents} />
+      ) : (
+        <FormGroup fieldId="pipeline-url">
+          <TextInput
+            type="url"
+            id="pipeline-url"
+            name="pipeline-url"
+            data-testid="pipeline-url-input"
+            value={pipelineUrl}
+            onChange={(_e, value) => setPipelineUrl(value)}
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>URL must be publicly accessible</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      )}
+    </StackItem>
+  </Stack>
+);
+
+export default PipelineUploadRadio;

--- a/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
+++ b/frontend/src/concepts/pipelines/content/import/useImportModalData.ts
@@ -1,26 +1,35 @@
 import React from 'react';
-import { generatePipelineVersionName } from '~/concepts/pipelines/content/import/utils';
+import {
+  PipelineUploadOption,
+  generatePipelineVersionName,
+} from '~/concepts/pipelines/content/import/utils';
 import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
 
 type PipelineModalData = {
   name: string;
   description: string;
+  uploadOption: PipelineUploadOption;
   fileContents: string;
+  pipelineUrl: string;
 };
 
 export const usePipelineImportModalData = (): GenericObjectState<PipelineModalData> =>
   useGenericObjectState<PipelineModalData>({
     name: '',
     description: '',
+    uploadOption: PipelineUploadOption.FILE_UPLOAD,
     fileContents: '',
+    pipelineUrl: '',
   });
 
 type PipelineVersionModalData = {
   name: string;
   description: string;
   pipeline: PipelineKFv2 | null;
+  uploadOption: PipelineUploadOption;
   fileContents: string;
+  pipelineUrl: string;
 };
 
 export const usePipelineVersionImportModalData = (
@@ -30,7 +39,9 @@ export const usePipelineVersionImportModalData = (
     name: React.useMemo(() => generatePipelineVersionName(existingPipeline), [existingPipeline]),
     description: '',
     pipeline: existingPipeline ?? null,
+    uploadOption: PipelineUploadOption.FILE_UPLOAD,
     fileContents: '',
+    pipelineUrl: '',
   });
 
   return createDataState;

--- a/frontend/src/concepts/pipelines/content/import/utils.ts
+++ b/frontend/src/concepts/pipelines/content/import/utils.ts
@@ -2,3 +2,11 @@ import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 
 export const generatePipelineVersionName = (pipeline?: PipelineKFv2 | null): string =>
   pipeline ? `${pipeline.display_name}_version_at_${new Date().toISOString()}` : '';
+
+export const COMPILE_PIPELINE_DOCUMENTATION_URL =
+  'https://www.kubeflow.org/docs/components/pipelines/v2/compile-a-pipeline/';
+
+export enum PipelineUploadOption {
+  URL_IMPORT,
+  FILE_UPLOAD,
+}

--- a/frontend/src/concepts/pipelines/context/usePipelineAPIState.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelineAPIState.ts
@@ -25,6 +25,8 @@ import {
   uploadPipelineVersion,
   archivePipelineRun,
   unarchivePipelineRun,
+  createPipelineAndVersion,
+  createPipelineVersion,
 } from '~/api';
 import { PipelineAPIs } from '~/concepts/pipelines/types';
 import { APIState } from '~/concepts/proxy/types';
@@ -37,6 +39,8 @@ const usePipelineAPIState = (
 ): [apiState: PipelineAPIState, refreshAPIState: () => void] => {
   const createAPI = React.useCallback(
     (path: string) => ({
+      createPipelineVersion: createPipelineVersion(path),
+      createPipelineAndVersion: createPipelineAndVersion(path),
       createExperiment: createExperiment(path),
       createPipelineRun: createPipelineRun(path),
       createPipelineRunJob: createPipelineRunJob(path),

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -472,6 +472,19 @@ export type ListPipelineVersionsKF = PipelineKFCallCommon<{
   pipeline_versions: PipelineVersionKFv2[];
 }>;
 
+export type CreatePipelineAndVersionKFData = {
+  pipeline: Omit<PipelineKFv2, 'pipeline_id' | 'error' | 'created_at'>;
+  pipeline_version: Omit<
+    PipelineVersionKFv2,
+    'pipeline_id' | 'pipeline_version_id' | 'error' | 'created_at' | 'pipeline_spec'
+  >;
+};
+
+export type CreatePipelineVersionKFData = Omit<
+  PipelineVersionKFv2,
+  'pipeline_version_id' | 'error' | 'created_at' | 'pipeline_spec'
+>;
+
 export type CreateExperimentKFData = Omit<
   ExperimentKFv2,
   'experiment_id' | 'created_at' | 'namespace' | 'storage_state'

--- a/frontend/src/concepts/pipelines/types.ts
+++ b/frontend/src/concepts/pipelines/types.ts
@@ -14,6 +14,8 @@ import {
   PipelineCoreResourceKFv2,
   PipelineRunKFv2,
   PipelineRunJobKFv2,
+  CreatePipelineAndVersionKFData,
+  CreatePipelineVersionKFData,
   CreateExperimentKFData,
 } from './kfTypes';
 
@@ -41,6 +43,15 @@ export type PipelineListPaged<T extends PipelineCoreResourceKFv2> = {
   items: T[];
 };
 
+export type CreatePipelineVersion = (
+  opts: K8sAPIOptions,
+  pipelineId: string,
+  data: CreatePipelineVersionKFData,
+) => Promise<PipelineVersionKFv2>;
+export type CreatePipelineAndVersion = (
+  opts: K8sAPIOptions,
+  data: CreatePipelineAndVersionKFData,
+) => Promise<PipelineKFv2>;
 export type CreateExperiment = (
   opts: K8sAPIOptions,
   data: CreateExperimentKFData,
@@ -118,6 +129,8 @@ export type UploadPipelineVersion = (
 ) => Promise<PipelineVersionKFv2>;
 
 export type PipelineAPIs = {
+  createPipelineVersion: CreatePipelineVersion;
+  createPipelineAndVersion: CreatePipelineAndVersion;
   createExperiment: CreateExperiment;
   createPipelineRun: CreatePipelineRun;
   createPipelineRunJob: CreatePipelineRunJob;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-2299

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- adds url upload option for both import pipeline and import pipeline version modal
   - uses radio button to switch between
- adds two new pipelines api funcs to manage the import

![image](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/e8dca5e2-9cd3-4a89-b95a-b5995e0537e9)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/cdcb5bc7-7ac2-403d-a508-8fcf355f5aff)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. open import pipeline modal
2. fill out required fields
3. select url import'
4. use this for example `https://raw.githubusercontent.com/amadhusu/data-science-pipelines/8dfd0c5fc8db1f4b18a8e22d13dacb4c02c50dbf/samples/core/exit_handler/exit_handler.py.yaml`
5. code source should be optional but url is not optional
6. code source should not show up when doing file upload
7. submit form
8. pipeline should be in table
9. do the same thing but for importing a pipeline version

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added 2 tests for url import for pipeline and pipeline version

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).
@yannnz @xianli123 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
