### PR TITLE
Fix tab custom CSS layout issue on pipelines

### DIFF
--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineRunsTabs.scss
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineRunsTabs.scss
@@ -4,6 +4,7 @@
 
   &:not([hidden]) {
     display: flex;
+    flex-direction: column;
   }
 }
 // This is another hack to get around a bug in PatternFly Tabs component.


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-3426

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is a one-liner fix, simply changes direction to `column` (because the default is `row` which causes the issue)

<img width="1256" alt="Screenshot 2024-03-08 at 1 29 37 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/d5f63aef-0c28-4963-84e3-1bd8109d7e1f">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to pipelines run page, and see the empty state, make sure your window is not very wide
2. The style should be fixed, and there will be no overflow text anymore

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, it's a one-liner CSS fix, needs manual test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
