### PR TITLE
Unit Test Update for utilities/useWatchGroups

### DIFF
--- a/frontend/src/utilities/__tests__/useWatchGroups.spec.tsx
+++ b/frontend/src/utilities/__tests__/useWatchGroups.spec.tsx
@@ -1,41 +1,136 @@
-import * as React from 'react';
-import { Provider } from 'react-redux';
-import { renderHook } from '~/__tests__/unit/testUtils/hooks';
+import { act } from 'react-dom/test-utils';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { GroupsConfig } from '~/pages/groupSettings/groupTypes';
-import { ReduxContext } from '~/redux/context';
-import { store } from '~/redux/store/store';
-import { fetchGroupsSettings } from '~/services/groupSettingsService';
+import { fetchGroupsSettings, updateGroupsSettings } from '~/services/groupSettingsService';
 import { useWatchGroups } from '~/utilities/useWatchGroups';
+import useNotification from '~/utilities/useNotification';
 
 jest.mock('~/services/groupSettingsService', () => ({
   fetchGroupsSettings: jest.fn(),
+  updateGroupsSettings: jest.fn(),
 }));
-
+// Mock the useNotification hook
+jest.mock('../useNotification', () => {
+  const mock = {
+    success: jest.fn(),
+    error: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    default: jest.fn(() => mock),
+  };
+});
 const fetchGroupSettingsMock = jest.mocked(fetchGroupsSettings);
+const useNotificationMock = jest.mocked(useNotification);
+const updateGroupSettingsMock = jest.mocked(updateGroupsSettings);
+const mockEmptyGroupSettings = {
+  adminGroups: [],
+  allowedGroups: [],
+};
+
+const createResult = (r: Partial<ReturnType<typeof useWatchGroups>>) =>
+  Object.assign(
+    {
+      groupSettings: mockEmptyGroupSettings,
+      loaded: true,
+      isLoading: false,
+      isGroupSettingsChanged: false,
+      loadError: undefined,
+      updateGroups: expect.any(Function),
+      setGroupSettings: expect.any(Function),
+      setIsGroupSettingsChanged: expect.any(Function),
+    },
+    r,
+  );
 
 describe('useWatchGroups', () => {
   it('should fetch groups successfully', async () => {
-    const mockEmptyGroupSettings = {
-      adminGroups: [],
-      allowedGroups: [],
-    };
     const mockGroupSettings: GroupsConfig = {
       adminGroups: [{ id: 1, name: 'odh-admins', enabled: true }],
       allowedGroups: [],
     };
+    updateGroupSettingsMock.mockImplementation((group) => Promise.resolve(group));
     fetchGroupSettingsMock.mockResolvedValue(mockGroupSettings);
-
-    const renderResult = renderHook(() => useWatchGroups(), {
-      wrapper: ({ children }) => (
-        <Provider store={store} context={ReduxContext}>
-          {children}
-        </Provider>
-      ),
-    });
+    const renderResult = testHook(useWatchGroups)();
     expect(fetchGroupSettingsMock).toHaveBeenCalledTimes(1);
-    expect(renderResult.result.current.groupSettings).toStrictEqual(mockEmptyGroupSettings);
-
+    expect(renderResult).hookToStrictEqual(createResult({ loaded: false, isLoading: true }));
     await renderResult.waitForNextUpdate();
-    expect(renderResult.result.current.groupSettings).toStrictEqual(mockGroupSettings);
+    expect(fetchGroupSettingsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(createResult({ groupSettings: mockGroupSettings }));
+    renderResult.rerender();
+    expect(renderResult).hookToBeStable({
+      groupSettings: true,
+      loaded: true,
+      isLoading: true,
+      isGroupSettingsChanged: true,
+      loadError: true,
+      updateGroups: true,
+      setGroupSettings: true,
+      setIsGroupSettingsChanged: true,
+    });
+    const mockUpdatedGroupSettings: GroupsConfig = {
+      adminGroups: [{ id: 2, name: 'odh-admins', enabled: false }],
+      allowedGroups: [],
+    };
+    act(() => {
+      renderResult.result.current.setIsGroupSettingsChanged(true);
+    });
+    expect(renderResult).hookToStrictEqual(
+      createResult({ groupSettings: mockGroupSettings, isGroupSettingsChanged: true }),
+    );
+    act(() => {
+      renderResult.result.current.updateGroups(mockUpdatedGroupSettings);
+    });
+    expect(renderResult).hookToStrictEqual(
+      createResult({
+        groupSettings: mockGroupSettings,
+        isLoading: true,
+        isGroupSettingsChanged: true,
+      }),
+    );
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(
+      createResult({ groupSettings: mockUpdatedGroupSettings }),
+    );
+  });
+
+  it('should handle error', async () => {
+    fetchGroupSettingsMock.mockRejectedValue(new Error(`Error updating group settings`));
+    const renderResult = testHook(useWatchGroups)();
+    expect(fetchGroupSettingsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(createResult({ loaded: false, isLoading: true }));
+    await renderResult.waitForNextUpdate();
+    expect(fetchGroupSettingsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      createResult({ loaded: false, loadError: new Error('Error updating group settings') }),
+    );
+    expect(useNotificationMock().error).toHaveBeenCalledWith(
+      'Error',
+      'Error updating group settings',
+    );
+  });
+
+  it('should test admin error', async () => {
+    const mockGroupSettings: GroupsConfig = {
+      adminGroups: [{ id: 1, name: 'odh-admins', enabled: true }],
+      allowedGroups: [],
+      errorAdmin: 'errorAdmin',
+    };
+    fetchGroupSettingsMock.mockResolvedValue(mockGroupSettings);
+    const renderResult = testHook(useWatchGroups)();
+    await renderResult.waitForNextUpdate();
+    expect(useNotificationMock().error).toHaveBeenCalledWith('Group error', 'errorAdmin');
+  });
+
+  it('should test user error', async () => {
+    const mockGroupSettings: GroupsConfig = {
+      adminGroups: [{ id: 1, name: 'odh-admins', enabled: true }],
+      allowedGroups: [],
+      errorUser: 'errorUser',
+    };
+    fetchGroupSettingsMock.mockResolvedValue(mockGroupSettings);
+    const renderResult = testHook(useWatchGroups)();
+    await renderResult.waitForNextUpdate();
+    expect(useNotificationMock().error).toHaveBeenCalledWith('Group error', 'errorUser');
   });
 });

--- a/frontend/src/utilities/useWatchGroups.tsx
+++ b/frontend/src/utilities/useWatchGroups.tsx
@@ -55,25 +55,28 @@ export const useWatchGroups = (): {
     }
   }, [errorAdmin, errorUser, notification]);
 
-  const updateGroups = (group: GroupsConfig) => {
-    setIsLoading(true);
-    updateGroupsSettings(group)
-      .then((response) => {
-        setGroupSettings(response);
-        notification.success(
-          'Group settings changes saved',
-          'It may take up to 2 minutes for configuration changes to be applied.',
-        );
-      })
-      .catch((error) => {
-        setLoadError(error);
-        setLoaded(false);
-      })
-      .finally(() => {
-        setIsLoading(false);
-        setIsGroupSettingsChanged(false);
-      });
-  };
+  const updateGroups = React.useCallback(
+    (group: GroupsConfig) => {
+      setIsLoading(true);
+      updateGroupsSettings(group)
+        .then((response) => {
+          setGroupSettings(response);
+          notification.success(
+            'Group settings changes saved',
+            'It may take up to 2 minutes for configuration changes to be applied.',
+          );
+        })
+        .catch((error) => {
+          setLoadError(error);
+          setLoaded(false);
+        })
+        .finally(() => {
+          setIsLoading(false);
+          setIsGroupSettingsChanged(false);
+        });
+    },
+    [notification],
+  );
 
   return {
     groupSettings,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-2674](https://issues.redhat.com/browse/RHOAIENG-2674)

## Description
Updated unit test case for frontend/src/utilities/useWatchGroups.tsx

## How Has This Been Tested?
`npm run test`

## Test Impact
Coverage:

Before:
<img width="837" alt="Screenshot 2024-03-08 at 4 43 34 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/123661468/4c1bb15e-511f-445b-9da7-40851f7b83ef">

After:
<img width="721" alt="Screenshot 2024-03-08 at 4 43 59 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/123661468/4eee36d3-4aca-4651-be5f-1b465b5b1cf3">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
