### PR TITLE
Add unit tests for usePod

### DIFF
--- a/frontend/src/concepts/k8s/pods/__tests__/usePod.spec.ts
+++ b/frontend/src/concepts/k8s/pods/__tests__/usePod.spec.ts
@@ -1,0 +1,43 @@
+import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { act } from '@testing-library/react';
+import { PodKind } from '~/k8sTypes';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import usePod from '~/concepts/k8s/pods/usePod';
+import { mockPipelinePodK8sResource } from '~/__mocks__/mockPipelinePodK8sResource';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+}));
+
+const k8sGetResourceMock = jest.mocked(k8sGetResource<PodKind>);
+
+describe('usePod', () => {
+  it('should return pod', async () => {
+    const mockPod = mockPipelinePodK8sResource({});
+    k8sGetResourceMock.mockResolvedValue(mockPod);
+    const renderResult = testHook(usePod)('test-project', 'test-pod');
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(mockPod, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sGetResourceMock.mockResolvedValue(mockPod);
+    await act(() => renderResult.result.current[3]());
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+  it('should handle errors', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('No pod name'));
+
+    const renderResult = testHook(usePod)('test-project', '');
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false));
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-4049

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds unit tests for `usePod.ts`

<img width="775" alt="Screenshot 2024-03-11 at 8 07 08 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/17190d5d-780a-426d-b55f-d0b2f6d2d042">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run `npm run test` 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
