### PR TITLE
Add unit tests for usePodContainers

### DIFF
--- a/frontend/src/concepts/k8s/pods/__tests__/usePodContainers.spec.ts
+++ b/frontend/src/concepts/k8s/pods/__tests__/usePodContainers.spec.ts
@@ -1,0 +1,35 @@
+import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockPipelinePodK8sResource } from '~/__mocks__/mockPipelinePodK8sResource';
+import { PodKind } from '~/k8sTypes';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import usePodContainers from '~/concepts/k8s/pods/usePodContainers';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+}));
+
+const k8sGetResourceMock = jest.mocked(k8sGetResource<PodKind>);
+
+describe('usePodContainers', () => {
+  it('should return and fetch pod containers', async () => {
+    const pipelinePodMock = mockPipelinePodK8sResource({});
+    k8sGetResourceMock.mockResolvedValue(pipelinePodMock);
+    const renderResult = testHook(usePodContainers)('test-project', 'test-pod');
+    expect(renderResult).hookToStrictEqual([]);
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(pipelinePodMock.spec.containers);
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+  it('should handle errors', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('error'));
+
+    const renderResult = testHook(usePodContainers)('test-project', 'test-pod');
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual([]);
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-4051

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds unit tests for `usePodContainers.ts`

<img width="768" alt="Screenshot 2024-03-11 at 8 07 22 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/434213f1-262f-4939-9bb1-169b6cac8810">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run `npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
