### PR TITLE
odh-532-2 update tile for RHOAI fraud detection tutorial

### DIFF
--- a/manifests/overlays/apps/base/rhoai/rhoai-docs.yaml
+++ b/manifests/overlays/apps/base/rhoai/rhoai-docs.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   displayName: OpenShift AI tutorial - Fraud detection example
   appName: rhoai
-  type: how-to
+  type: tutorial
   description: |-
-    Use OpenShift AI to develop and train an example model in Jupyter Notebooks, deploy the model, integrate the model into a fraud detection application, and refine the model by using automated pipelines. 
+    Use OpenShift AI to train an example model in a Jupyter notebook, deploy the model, integrate the model into a fraud detection application, and refine the model by using automated pipelines. 
   url: https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud-service/1/html-single/openshift_ai_tutorial_-_fraud_detection_example/
   durationMinutes: 60
 ---


### PR DESCRIPTION
small PR to update the Resources tile for the RHOAI tutorial - edit the description and change the type from "how-to" to "tutorial"

Closes: https://issues.redhat.com/browse/RHOAIENG-4317