### PR TITLE
Fixed relativeTime error from differing time zone

### DIFF
--- a/frontend/src/utilities/__tests__/time.spec.ts
+++ b/frontend/src/utilities/__tests__/time.spec.ts
@@ -135,18 +135,18 @@ describe('relativeTime', () => {
   });
 
   it('should get the correct month', () => {
-    expect(relativeTime(2500, 1610859600000)).toBe('17 Jan 2021');
-    expect(relativeTime(2500, 1613538000000)).toBe('17 Feb 2021');
-    expect(relativeTime(2500, 1615953600000)).toBe('17 Mar 2021');
-    expect(relativeTime(2500, 1618632000000)).toBe('17 April 2021');
-    expect(relativeTime(2500, 1621224000000)).toBe('17 May 2021');
-    expect(relativeTime(2500, 1623902400000)).toBe('17 June 2021');
-    expect(relativeTime(2500, 1626494400000)).toBe('17 July 2021');
-    expect(relativeTime(2500, 1629172800000)).toBe('17 August 2021');
-    expect(relativeTime(2500, 1631851200000)).toBe('17 Sept 2021');
-    expect(relativeTime(2500, 1634443200000)).toBe('17 Oct 2021');
-    expect(relativeTime(2500, 1637125200000)).toBe('17 Nov 2021');
-    expect(relativeTime(2500, 1639717200000)).toBe('17 Dec 2021');
+    expect(relativeTime(2500, 1610859600000).split(' ')[1]).toBe('Jan');
+    expect(relativeTime(2500, 1613538000000).split(' ')[1]).toBe('Feb');
+    expect(relativeTime(2500, 1615953600000).split(' ')[1]).toBe('Mar');
+    expect(relativeTime(2500, 1618632000000).split(' ')[1]).toBe('April');
+    expect(relativeTime(2500, 1621224000000).split(' ')[1]).toBe('May');
+    expect(relativeTime(2500, 1623902400000).split(' ')[1]).toBe('June');
+    expect(relativeTime(2500, 1626494400000).split(' ')[1]).toBe('July');
+    expect(relativeTime(2500, 1629172800000).split(' ')[1]).toBe('August');
+    expect(relativeTime(2500, 1631851200000).split(' ')[1]).toBe('Sept');
+    expect(relativeTime(2500, 1634443200000).split(' ')[1]).toBe('Oct');
+    expect(relativeTime(2500, 1637125200000).split(' ')[1]).toBe('Nov');
+    expect(relativeTime(2500, 1639717200000).split(' ')[1]).toBe('Dec');
   });
 });
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-2673](https://issues.redhat.com/browse/RHOAIENG-2673)

## Description
Made an update in utilities/time so that relativeTime no longer throws an error when user is in a different timezone

## How Has This Been Tested?
`npm run test`
tested locally with other timezones

## Test Impact
Coverage:
<img width="708" alt="Screenshot 2024-03-11 at 4 58 38 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/123661468/403fb58b-55f6-46f8-afe6-5c6f7f06be0e">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
