### PR TITLE
Add region field when configuring pipeline server

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
@@ -48,7 +48,7 @@ describe('configure pipeline server utils', () => {
           externalStorage: {
             bucket: '',
             host: '',
-            region: 'us-east-2',
+            region: 'us-east-1',
             s3CredentialsSecret: {
               accessKey: 'AWS_ACCESS_KEY_ID',
               secretKey: 'AWS_SECRET_ACCESS_KEY',
@@ -68,7 +68,7 @@ describe('configure pipeline server utils', () => {
       ];
       const spec = createDSPipelineResourceSpec(config, secretsResponse);
       expect(spec.objectStorage.externalStorage?.scheme).toBe('http');
-      expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.us-east-1.amazonaws.com');
     });
 
     it('should parse S3 endpoint without scheme', () => {
@@ -77,7 +77,30 @@ describe('configure pipeline server utils', () => {
       config.objectStorage.newValue = [{ key: AwsKeys.S3_ENDPOINT, value: 's3.amazonaws.com' }];
       const spec = createDSPipelineResourceSpec(config, secretsResponse);
       expect(spec.objectStorage.externalStorage?.scheme).toBe('https');
-      expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.us-east-1.amazonaws.com');
+    });
+
+    it('should convert S3 endpoint with region', () => {
+      const config = createPipelineServerConfig();
+      const secretsResponse = createSecretsResponse();
+      config.objectStorage.newValue = [
+        { key: AwsKeys.S3_ENDPOINT, value: 'http://s3.amazonaws.com' },
+        { key: AwsKeys.DEFAULT_REGION, value: 'us-east-2' },
+      ];
+      const spec = createDSPipelineResourceSpec(config, secretsResponse);
+      expect(spec.objectStorage.externalStorage?.scheme).toBe('http');
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.us-east-2.amazonaws.com');
+    });
+
+    it('should not convert endpoint when it is not S3', () => {
+      const config = createPipelineServerConfig();
+      const secretsResponse = createSecretsResponse();
+      config.objectStorage.newValue = [
+        { key: AwsKeys.S3_ENDPOINT, value: 'http://s3.not-amazonaws.com' },
+      ];
+      const spec = createDSPipelineResourceSpec(config, secretsResponse);
+      expect(spec.objectStorage.externalStorage?.scheme).toBe('http');
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.not-amazonaws.com');
     });
 
     it('should include bucket', () => {
@@ -124,7 +147,7 @@ describe('configure pipeline server utils', () => {
           externalStorage: {
             bucket: '',
             host: '',
-            region: 'us-east-2',
+            region: 'us-east-1',
             s3CredentialsSecret: {
               accessKey: 'AWS_ACCESS_KEY_ID',
               secretKey: 'AWS_SECRET_ACCESS_KEY',

--- a/frontend/src/pages/projects/dataConnections/const.ts
+++ b/frontend/src/pages/projects/dataConnections/const.ts
@@ -14,6 +14,7 @@ export const PIPELINE_AWS_KEY = [
   AwsKeys.SECRET_ACCESS_KEY,
   AwsKeys.S3_ENDPOINT,
   AwsKeys.AWS_S3_BUCKET,
+  AwsKeys.DEFAULT_REGION,
 ];
 export const AWS_FIELDS: FieldOptions[] = [
   {
@@ -61,6 +62,11 @@ export const PIPELINE_AWS_FIELDS: FieldOptions[] = [
   {
     key: AwsKeys.S3_ENDPOINT,
     label: 'Endpoint',
+    isRequired: true,
+  },
+  {
+    key: AwsKeys.DEFAULT_REGION,
+    label: 'Region',
     isRequired: true,
   },
   {
@@ -112,5 +118,9 @@ export const EMPTY_AWS_PIPELINE_DATA: AWSDataEntry = [
   {
     key: AwsKeys.S3_ENDPOINT,
     value: '',
+  },
+  {
+    key: AwsKeys.DEFAULT_REGION,
+    value: 'us-east-1',
   },
 ];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-2283

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add the region field and set it as required when configuring a pipeline server, the default value is `us-east-1`

<img width="1728" alt="Screenshot 2024-03-11 at 5 56 29 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/6fe70b19-5c2c-4c4f-ba7e-4c4bac569da8">

Also, when the endpoint is `s3.amazonaws.com`, we convert the `host` field in DSPA to add the region information in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a project
2. Configure a pipeline server
3. Make sure the region field is pre-filled and is required
4. When you submit the creation, go to DSPA to check whether the `spec.objectStorage.externalStorage.host` is converted. If the endpoint is `s3.amazonaws.com`, it should be converted. Otherwise, we keep it unchanged.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add unit tests to verify the converted host is correct.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
