### PR TITLE
Add Model registry api

### DIFF
--- a/frontend/src/__mocks__/mockRegisteredModel.ts
+++ b/frontend/src/__mocks__/mockRegisteredModel.ts
@@ -1,0 +1,14 @@
+import { RegisteredModel, RegisteredModelState } from '~/concepts/modelRegistry/types';
+
+export const mockRegisteredModel = ({
+  name = 'test',
+  state = RegisteredModelState.LIVE,
+}: Partial<RegisteredModel>): RegisteredModel => ({
+  createTimeSinceEpoch: '1710404288975',
+  description: 'test',
+  externalID: '1234132asdfasdf',
+  id: '1',
+  lastUpdateTimeSinceEpoch: '1710404288975',
+  name,
+  state,
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -22,6 +22,9 @@ export * from './k8s/acceleratorProfiles';
 export * from './k8s/clusterQueues';
 export * from './k8s/workloads';
 
+// Model registry
+export * from './modelRegistry/custom';
+
 // Pipelines uses special redirected API
 export * from './pipelines/custom';
 export * from './pipelines/k8s';

--- a/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
+++ b/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
@@ -1,0 +1,299 @@
+import { proxyCREATE, proxyGET, proxyPATCH } from '~/api/proxyUtils';
+import { handleModelRegistryFailures } from '~/api/modelRegistry/errorUtils';
+import {
+  RegisteredModelState,
+  ModelVersionState,
+  ModelArtifactState,
+} from '~/concepts/modelRegistry/types';
+import {
+  createModelArtifact,
+  createModelVersion,
+  createRegisteredModel,
+  getRegisteredModel,
+  getModelVersion,
+  getModelArtifact,
+  getListModelVersions,
+  getListModelArtifacts,
+  getModelVersionsByRegisteredModel,
+  getListRegisteredModels,
+  patchModelArtifact,
+  patchModelVersion,
+  patchRegisteredModel,
+} from '~/api/modelRegistry/custom';
+
+const mockProxyPromise = Promise.resolve();
+
+jest.mock('~/api/proxyUtils', () => ({
+  proxyCREATE: jest.fn(() => mockProxyPromise),
+  proxyGET: jest.fn(() => mockProxyPromise),
+  proxyPATCH: jest.fn(() => mockProxyPromise),
+}));
+
+const mockResultPromise = Promise.resolve();
+
+jest.mock('~/api/modelRegistry/errorUtils', () => ({
+  handleModelRegistryFailures: jest.fn(() => mockResultPromise),
+}));
+
+const handleModelRegistryFailuresMock = jest.mocked(handleModelRegistryFailures);
+const proxyCREATEMock = jest.mocked(proxyCREATE);
+const proxyGETMock = jest.mocked(proxyGET);
+const proxyPATCHMock = jest.mocked(proxyPATCH);
+
+const K8sAPIOptionsMock = {};
+
+describe('createRegisteredModel', () => {
+  it('should call proxyCREATE and handleModelRegistryFailures to create registered model', () => {
+    expect(
+      createRegisteredModel('hostPath')(K8sAPIOptionsMock, {
+        description: 'test',
+        externalID: '1',
+        name: 'test new registered model',
+        state: RegisteredModelState.LIVE,
+      }),
+    ).toBe(mockResultPromise);
+    expect(proxyCREATEMock).toHaveBeenCalledTimes(1);
+    expect(proxyCREATEMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/registered_models',
+      {
+        description: 'test',
+        externalID: '1',
+        name: 'test new registered model',
+        state: RegisteredModelState.LIVE,
+      },
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('createModelVersion', () => {
+  it('should call proxyCREATE and handleModelRegistryFailures to create model version', () => {
+    expect(
+      createModelVersion('hostPath')(K8sAPIOptionsMock, {
+        description: 'test',
+        externalID: '1',
+        author: 'test author',
+        registeredModelID: '1',
+        name: 'test new model version',
+        state: ModelVersionState.LIVE,
+      }),
+    ).toBe(mockResultPromise);
+    expect(proxyCREATEMock).toHaveBeenCalledTimes(1);
+    expect(proxyCREATEMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_versions',
+      {
+        description: 'test',
+        externalID: '1',
+        author: 'test author',
+        registeredModelID: '1',
+        name: 'test new model version',
+        state: ModelVersionState.LIVE,
+      },
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('createModelArtifact', () => {
+  it('should call proxyCREATE and handleModelRegistryFailures to create model artifact', () => {
+    expect(
+      createModelArtifact('hostPath')(K8sAPIOptionsMock, {
+        description: 'test',
+        externalID: 'test',
+        uri: 'test-uri',
+        state: ModelArtifactState.LIVE,
+        name: 'test-name',
+        modelFormatName: 'test-modelformatname',
+        storageKey: 'teststoragekey',
+        storagePath: 'teststoragePath',
+        modelFormatVersion: 'testmodelFormatVersion',
+        serviceAccountName: 'testserviceAccountname',
+      }),
+    ).toBe(mockResultPromise);
+    expect(proxyCREATEMock).toHaveBeenCalledTimes(1);
+    expect(proxyCREATEMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_artifacts',
+      {
+        description: 'test',
+        externalID: 'test',
+        uri: 'test-uri',
+        state: ModelArtifactState.LIVE,
+        name: 'test-name',
+        modelFormatName: 'test-modelformatname',
+        storageKey: 'teststoragekey',
+        storagePath: 'teststoragePath',
+        modelFormatVersion: 'testmodelFormatVersion',
+        serviceAccountName: 'testserviceAccountname',
+      },
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getRegisteredModel', () => {
+  it('should call proxyGET and handleModelRegistryFailures to fetch registered model', () => {
+    expect(getRegisteredModel('hostPath')(K8sAPIOptionsMock, '1')).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/registered_models/1',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getModelVersion', () => {
+  it('should call proxyGET and handleModelRegistryFailures to fetch model version', () => {
+    expect(getModelVersion('hostPath')(K8sAPIOptionsMock, '1')).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_versions/1',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getModelArtifact', () => {
+  it('should call proxyGET and handleModelRegistryFailures to fetch model version', () => {
+    expect(getModelArtifact('hostPath')(K8sAPIOptionsMock, '1')).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_artifacts/1',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getListRegisteredModels', () => {
+  it('should call proxyGET and handleModelRegistryFailures to list registered models', () => {
+    expect(getListRegisteredModels('hostPath')({})).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/registered_models',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getListModelArtifacts', () => {
+  it('should call proxyGET and handleModelRegistryFailures to list models artifacts', () => {
+    expect(getListModelArtifacts('hostPath')({})).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_artifacts',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getListModelVersions', () => {
+  it('should call proxyGET and handleModelRegistryFailures to list models versions', () => {
+    expect(getListModelVersions('hostPath')({})).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_versions',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('getModelVersionsByRegisteredModel', () => {
+  it('should call proxyGET and handleModelRegistryFailures to list models versions by registered model', () => {
+    expect(getModelVersionsByRegisteredModel('hostPath')({}, '1')).toBe(mockResultPromise);
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/registered_models/1/versions',
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('patchRegisteredModel', () => {
+  it('should call proxyPATCH and handleModelRegistryFailures to update registered model', () => {
+    expect(
+      patchRegisteredModel('hostPath')(K8sAPIOptionsMock, { description: 'new test' }, '1'),
+    ).toBe(mockResultPromise);
+    expect(proxyPATCHMock).toHaveBeenCalledTimes(1);
+    expect(proxyPATCHMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/registered_models/1',
+      { description: 'new test' },
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('patchModelVersion', () => {
+  it('should call proxyPATCH and handleModelRegistryFailures to update model version', () => {
+    expect(patchModelVersion('hostPath')(K8sAPIOptionsMock, { description: 'new test' }, '1')).toBe(
+      mockResultPromise,
+    );
+    expect(proxyPATCHMock).toHaveBeenCalledTimes(1);
+    expect(proxyPATCHMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_versions/1',
+      { description: 'new test' },
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('patchModelArtifact', () => {
+  it('should call proxyPATCH and handleModelRegistryFailures to update model artifact', () => {
+    expect(
+      patchModelArtifact('hostPath')(K8sAPIOptionsMock, { description: 'new test' }, '1'),
+    ).toBe(mockResultPromise);
+    expect(proxyPATCHMock).toHaveBeenCalledTimes(1);
+    expect(proxyPATCHMock).toHaveBeenCalledWith(
+      'hostPath',
+      '/api/model_registry/v1alpha2/model_artifacts/1',
+      { description: 'new test' },
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});

--- a/frontend/src/api/modelRegistry/__tests__/errorUtils.spec.ts
+++ b/frontend/src/api/modelRegistry/__tests__/errorUtils.spec.ts
@@ -1,0 +1,33 @@
+import { NotReadyError } from '~/utilities/useFetchState';
+import { handleModelRegistryFailures } from '~/api/modelRegistry/errorUtils';
+import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
+import { ModelRegistryError } from '~/concepts/modelRegistry/types';
+
+describe('handleModelRegistryFailures', () => {
+  it('should successfully return registered models', async () => {
+    const modelRegistryMock = mockRegisteredModel({});
+    const result = await handleModelRegistryFailures(Promise.resolve(modelRegistryMock));
+    expect(result).toStrictEqual(modelRegistryMock);
+  });
+
+  it('should handle and throw model registry errors', async () => {
+    const statusMock: ModelRegistryError = {
+      code: '',
+      message: 'error',
+    };
+
+    await expect(handleModelRegistryFailures(Promise.resolve(statusMock))).rejects.toThrow('error');
+  });
+
+  it('should handle common state errors ', async () => {
+    await expect(
+      handleModelRegistryFailures(Promise.reject(new NotReadyError('error'))),
+    ).rejects.toThrow('error');
+  });
+
+  it('should handle other errors', async () => {
+    await expect(handleModelRegistryFailures(Promise.reject(new Error('error')))).rejects.toThrow(
+      'Error communicating with model registry server',
+    );
+  });
+});

--- a/frontend/src/api/modelRegistry/custom.ts
+++ b/frontend/src/api/modelRegistry/custom.ts
@@ -1,0 +1,147 @@
+import {
+  CreateModelArtifactData,
+  CreateModelVersionData,
+  CreateRegisteredModelData,
+  ModelArtifact,
+  ModelArtifactList,
+  ModelVersionList,
+  ModelVersion,
+  RegisteredModelList,
+  RegisteredModel,
+} from '~/concepts/modelRegistry/types';
+import { proxyCREATE, proxyGET, proxyPATCH } from '~/api/proxyUtils';
+import { K8sAPIOptions } from '~/k8sTypes';
+import { handleModelRegistryFailures } from './errorUtils';
+
+export const createRegisteredModel =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions, data: CreateRegisteredModelData): Promise<RegisteredModel> =>
+    handleModelRegistryFailures(
+      proxyCREATE(hostpath, '/api/model_registry/v1alpha2/registered_models', data, {}, opts),
+    );
+
+export const createModelVersion =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions, data: CreateModelVersionData): Promise<ModelVersion> =>
+    handleModelRegistryFailures(
+      proxyCREATE(hostpath, '/api/model_registry/v1alpha2/model_versions', data, {}, opts),
+    );
+
+export const createModelArtifact =
+  (hostPath: string) =>
+  (opts: K8sAPIOptions, data: CreateModelArtifactData): Promise<ModelArtifact> =>
+    handleModelRegistryFailures(
+      proxyCREATE(hostPath, '/api/model_registry/v1alpha2/model_artifacts', data, {}, opts),
+    );
+
+export const getRegisteredModel =
+  (hostPath: string) =>
+  (opts: K8sAPIOptions, registeredModelID: string): Promise<RegisteredModel> =>
+    handleModelRegistryFailures(
+      proxyGET(
+        hostPath,
+        `/api/model_registry/v1alpha2/registered_models/${registeredModelID}`,
+        {},
+        opts,
+      ),
+    );
+
+export const getModelVersion =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions, modelversionId: string): Promise<ModelVersion> =>
+    handleModelRegistryFailures(
+      proxyGET(hostpath, `/api/model_registry/v1alpha2/model_versions/${modelversionId}`, {}, opts),
+    );
+
+export const getModelArtifact =
+  (hostPath: string) =>
+  (opts: K8sAPIOptions, modelArtifactId: string): Promise<ModelArtifact> =>
+    handleModelRegistryFailures(
+      proxyGET(
+        hostPath,
+        `/api/model_registry/v1alpha2/model_artifacts/${modelArtifactId}`,
+        {},
+        opts,
+      ),
+    );
+
+export const getListModelArtifacts =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions): Promise<ModelArtifactList> =>
+    handleModelRegistryFailures(
+      proxyGET(hostpath, `/api/model_registry/v1alpha2/model_artifacts`, {}, opts),
+    );
+
+export const getListModelVersions =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions): Promise<ModelVersionList> =>
+    handleModelRegistryFailures(
+      proxyGET(hostpath, `/api/model_registry/v1alpha2/model_versions`, {}, opts),
+    );
+
+export const getListRegisteredModels =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions): Promise<RegisteredModelList> =>
+    handleModelRegistryFailures(
+      proxyGET(hostpath, `/api/model_registry/v1alpha2/registered_models`, {}, opts),
+    );
+
+export const getModelVersionsByRegisteredModel =
+  (hostpath: string) =>
+  (opts: K8sAPIOptions, registeredmodelId: string): Promise<ModelVersionList> =>
+    handleModelRegistryFailures(
+      proxyGET(
+        hostpath,
+        `/api/model_registry/v1alpha2/registered_models/${registeredmodelId}/versions`,
+        {},
+        opts,
+      ),
+    );
+
+export const patchRegisteredModel =
+  (hostPath: string) =>
+  (
+    opts: K8sAPIOptions,
+    data: Partial<RegisteredModel>,
+    registeredModelID: string,
+  ): Promise<RegisteredModel> =>
+    handleModelRegistryFailures(
+      proxyPATCH(
+        hostPath,
+        `/api/model_registry/v1alpha2/registered_models/${registeredModelID}`,
+        data,
+        opts,
+      ),
+    );
+
+export const patchModelVersion =
+  (hostPath: string) =>
+  (
+    opts: K8sAPIOptions,
+    data: Partial<ModelVersion>,
+    modelversionId: string,
+  ): Promise<ModelVersion> =>
+    handleModelRegistryFailures(
+      proxyPATCH(
+        hostPath,
+        `/api/model_registry/v1alpha2/model_versions/${modelversionId}`,
+        data,
+        opts,
+      ),
+    );
+
+export const patchModelArtifact =
+  (hostPath: string) =>
+  (
+    opts: K8sAPIOptions,
+    data: Partial<ModelArtifact>,
+    modelartifactId: string,
+  ): Promise<ModelArtifact> =>
+    handleModelRegistryFailures(
+      proxyPATCH(
+        hostPath,
+        `/api/model_registry/v1alpha2/model_artifacts/${modelartifactId}`,
+        data,
+        opts,
+      ),
+    );

--- a/frontend/src/api/modelRegistry/errorUtils.ts
+++ b/frontend/src/api/modelRegistry/errorUtils.ts
@@ -1,0 +1,27 @@
+import { ModelRegistryError } from '~/concepts/modelRegistry/types';
+import { isCommonStateError } from '~/utilities/useFetchState';
+
+const isError = (e: unknown): e is ModelRegistryError =>
+  ['code', 'message'].every((key) => key in (e as ModelRegistryError));
+
+export const handleModelRegistryFailures = <T>(promise: Promise<T>): Promise<T> =>
+  promise
+    .then((result) => {
+      if (isError(result)) {
+        throw result;
+      }
+      return result;
+    })
+    .catch((e) => {
+      if (isError(e)) {
+        throw new Error(e.message);
+      }
+      if (isCommonStateError(e)) {
+        // Common state errors are handled by useFetchState at storage level, let them deal with it
+        // TODO: check whether we need this or not
+        throw e;
+      }
+      // eslint-disable-next-line no-console
+      console.error('Unknown model registry API error', e);
+      throw new Error('Error communicating with model registry server');
+    });

--- a/frontend/src/api/proxyUtils.ts
+++ b/frontend/src/api/proxyUtils.ts
@@ -111,6 +111,17 @@ export const proxyUPDATE = <T>(
     parseJSON: options?.parseJSON,
   });
 
+export const proxyPATCH = <T>(
+  host: string,
+  path: string,
+  data: Record<string, unknown>,
+  options?: K8sAPIOptions,
+): Promise<T> =>
+  callProxyJSON<T>(host, path, mergeRequestInit(options, { method: 'PATCH' }), {
+    data,
+    parseJSON: options?.parseJSON,
+  });
+
 export const proxyDELETE = <T>(
   host: string,
   path: string,

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -1,0 +1,111 @@
+export enum RegisteredModelState {
+  LIVE = 'LIVE',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export enum ModelVersionState {
+  LIVE = 'LIVE',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export enum InferenceServiceState {
+  DEPLOYED = 'DEPLOYED',
+  UNDEPLOYED = 'UNDEPLOYED',
+}
+
+export enum ExecutionState {
+  UNKNOWN = 'UNKNOWN',
+  NEW = 'NEW',
+  RUNNING = 'RUNNING',
+  COMPLETE = 'COMPLETE',
+  FAILED = 'FAILED',
+  CACHED = 'CACHED',
+  CANCELED = 'CANCELED',
+}
+
+export enum ModelArtifactState {
+  UNKNOWN = 'UNKNOWN',
+  PENDING = 'PENDING',
+  LIVE = 'LIVE',
+  MARKED_FOR_DELETION = 'MARKED_FOR_DELETION',
+  DELETED = 'DELETED',
+  ABANDONED = 'ABANDONED',
+  REFERENCE = 'REFERENCE',
+}
+
+export type ModelRegistryBase = {
+  id?: string;
+  name?: string;
+  externalID?: string;
+  description?: string;
+  createTimeSinceEpoch?: string;
+  lastUpdateTimeSinceEpoch?: string;
+  customProperties?: Record<string, unknown>;
+};
+
+export type ModelArtifact = ModelRegistryBase & {
+  uri?: string;
+  state?: ModelArtifactState;
+  author?: string;
+  modelFormatName?: string;
+  storageKey?: string;
+  storagePath?: string;
+  modelFormatVersion?: string;
+  serviceAccountName?: string;
+  artifactType: string;
+};
+
+export type ModelVersion = ModelRegistryBase & {
+  state?: ModelVersionState;
+  author?: string;
+  registeredModelID: string;
+};
+
+export type RegisteredModel = ModelRegistryBase & {
+  state?: RegisteredModelState;
+};
+
+export type InferenceService = ModelRegistryBase & {
+  modelVersionId?: string;
+  runtime?: string;
+  desiredState?: InferenceServiceState;
+  registeredModelId: string;
+  servingEnvironmentId: string;
+};
+
+export type ServingEnvironment = ModelRegistryBase;
+
+export type ModelRegistryError = {
+  code: string;
+  message: string;
+};
+
+export type ServeModel = ModelRegistryBase & {
+  lastKnownState?: ExecutionState;
+  modelVersionId: string;
+};
+
+export type CreateRegisteredModelData = Omit<
+  RegisteredModel,
+  'lastUpdateTimeSinceEpoch' | 'createTimeSinceEpoch' | 'id'
+>;
+
+export type CreateModelVersionData = Omit<
+  ModelVersion,
+  'lastUpdateTimeSinceEpoch' | 'createTimeSinceEpoch' | 'id'
+>;
+
+export type CreateModelArtifactData = Omit<
+  ModelArtifact,
+  'lastUpdateTimeSinceEpoch' | 'createTimeSinceEpoch' | 'id' | 'artifactType'
+>;
+
+export type ModelRegistryListParams = {
+  size: number;
+  pageSize: number;
+  nextPageToken: string;
+};
+
+export type RegisteredModelList = ModelRegistryListParams & { items: RegisteredModel[] };
+export type ModelVersionList = ModelRegistryListParams & { items: ModelVersion[] };
+export type ModelArtifactList = ModelRegistryListParams & { items: ModelArtifact[] };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-2113

Collaborated with @dpanshug to create the model registry API and related tests

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds model registry API ([Swagger link](https://editor.swagger.io/?url=https://raw.githubusercontent.com/opendatahub-io/model-registry/main/api/openapi/model-registry.yaml))

As for the APIs not included in this PR - their usage has not been determined yet(not in UX - [confirmed by the backend team](https://redhat-internal.slack.com/archives/C05QB0A582E/p1710322379688809?thread_ts=1710314042.265519&cid=C05QB0A582E)).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can `console.log` the APIs to test 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests for the `custom.ts` and `errorUtils.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
