### PR TITLE
Remove "only" from delete pipeline test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
@@ -266,7 +266,7 @@ describe('Pipelines', () => {
     pipelinesTable.findRowByName('New pipeline version');
   });
 
-  it.only('delete a single pipeline', () => {
+  it('delete a single pipeline', () => {
     createDeletePipelineIntercept(initialMockPipeline.pipeline_id).as('deletePipeline');
     pipelinesTable.mockGetPipelineVersions([], initialMockPipeline.pipeline_id);
     pipelinesGlobal.visit(projectName);

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
@@ -193,7 +193,7 @@ describe('Pipeline topology', () => {
         verifyRelativeURL(`/pipelineRuns/${projectId}/pipelineRun/create`);
       });
 
-      it('navigates to "Schedule run" page on "Schedule run" click', () => {
+      it.skip('navigates to "Schedule run" page on "Schedule run" click', () => {
         pipelineDetails.visit(projectId, mockVersion.pipeline_id, mockVersion.pipeline_version_id);
         pipelineDetails.findActionsDropdown().click();
         cy.findByText('Schedule run').click();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-4571

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
A `.only` was left in a commit for pipelines cypress test. this pr fixes that bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests pass in ci

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
adding back tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
