### PR TITLE
feat(DW): add workloads table

### DIFF
--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -1,0 +1,56 @@
+import { genUID } from '~/__mocks__/mockUtils';
+import { WorkloadKind } from '~/k8sTypes';
+
+type MockResourceConfigType = {
+  k8sName?: string;
+  namespace?: string;
+};
+export const mockWorkloadK8sResource = ({
+  k8sName = 'test-workload',
+  namespace = 'test-project',
+}: MockResourceConfigType): WorkloadKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  kind: 'Workload',
+  metadata: {
+    creationTimestamp: '2024-03-18T19:15:28Z',
+    generation: 2,
+    labels: {
+      'kueue.x-k8s.io/job-uid': 'e62a44fb-cd94-4602-bc8b-7cc9579d9559',
+    },
+    name: k8sName,
+    namespace,
+    resourceVersion: '9279356',
+    uid: genUID('workload'),
+  },
+  spec: {
+    active: true,
+    podSets: [],
+    priority: 0,
+    queueName: 'user-queue',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2024-03-18T19:15:28Z',
+        message: 'Quota reserved in ClusterQueue cluster-queue',
+        reason: 'QuotaReserved',
+        status: 'True',
+        type: 'QuotaReserved',
+      },
+      {
+        lastTransitionTime: '2024-03-18T19:15:28Z',
+        message: 'The workload is admitted',
+        reason: 'Admitted',
+        status: 'True',
+        type: 'Admitted',
+      },
+      {
+        lastTransitionTime: '2024-03-18T19:17:15Z',
+        message: 'Job finished successfully',
+        reason: 'JobFinished',
+        status: 'True',
+        type: 'Finished',
+      },
+    ],
+  },
+});

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -1,0 +1,12 @@
+import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';
+import { getStatusInfo } from '~/concepts/distributedWorkloads/utils';
+
+describe('getStatusInfo', () => {
+  it('provides correct info for completed workload', () => {
+    const wl = mockWorkloadK8sResource({ k8sName: 'test-workload' });
+    const info = getStatusInfo(wl);
+    expect(info?.color).toBe('green');
+    expect(info?.message).toBe('Job finished successfully');
+    expect(info?.status).toBe('Succeeded');
+  });
+});

--- a/frontend/src/concepts/distributedWorkloads/utils.tsx
+++ b/frontend/src/concepts/distributedWorkloads/utils.tsx
@@ -1,0 +1,75 @@
+import { LabelProps } from '@patternfly/react-core';
+import React from 'react';
+import {
+  ExclamationTriangleIcon,
+  PendingIcon,
+  InProgressIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  UnknownIcon,
+} from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import { WorkloadCondition, WorkloadKind } from '~/k8sTypes';
+
+//Workload utilities
+export type WorkloadStatusType =
+  | 'Inadmissible'
+  | 'Pending'
+  | 'Running'
+  | 'Succeeded'
+  | 'Failed'
+  | 'Unknown';
+
+export type WorkloadStatusInfo = {
+  status: WorkloadStatusType;
+  message: string;
+  color: LabelProps['color'];
+  icon: React.ComponentClass<SVGIconProps>;
+};
+
+export const WorkloadStatusColorAndIcon: Record<
+  WorkloadStatusType,
+  Pick<WorkloadStatusInfo, 'color' | 'icon'>
+> = {
+  Inadmissible: { color: 'gold', icon: ExclamationTriangleIcon },
+  Pending: { color: 'cyan', icon: PendingIcon },
+  Running: { color: 'blue', icon: InProgressIcon },
+  Succeeded: { color: 'green', icon: CheckCircleIcon },
+  Failed: { color: 'red', icon: ExclamationCircleIcon },
+  Unknown: { color: 'grey', icon: UnknownIcon },
+};
+
+export const getStatusInfo = (wl: WorkloadKind): WorkloadStatusInfo | null => {
+  const conditions = wl.status?.conditions;
+  const knownStatusConditions: Record<WorkloadStatusType, WorkloadCondition | undefined> = {
+    Failed: conditions?.find(
+      ({ type, status, message, reason }) =>
+        status === 'True' &&
+        (type === 'Failed' || /error|failed/.test(`${message} ${reason}`.toLowerCase())),
+    ),
+    Succeeded: conditions?.find(
+      ({ type, status, message, reason }) =>
+        status === 'True' &&
+        (type === 'Finished' || /success|succeeded/.test(`${message} ${reason}`.toLowerCase())),
+    ),
+    Inadmissible: conditions?.find(({ type, status }) => type === 'Admitted' && status === 'False'),
+    Pending: conditions?.find(({ type, status }) => type === 'QuotaReserved' && status === 'False'),
+    Running: conditions?.find(({ type, status }) => type === 'Admitted' && status === 'True'),
+    Unknown: undefined,
+  };
+  const statusType = (Object.keys(knownStatusConditions) as WorkloadStatusType[]).find(
+    (st) => !!knownStatusConditions[st],
+  );
+  if (!statusType) {
+    return {
+      status: 'Unknown',
+      message: 'Unknown status',
+      ...WorkloadStatusColorAndIcon.Unknown,
+    };
+  }
+  return {
+    status: statusType,
+    message: knownStatusConditions[statusType]?.message || 'No message',
+    ...WorkloadStatusColorAndIcon[statusType],
+  };
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -883,14 +883,7 @@ export type WorkloadKind = K8sResourceCommon & {
         tolerations?: Toleration[];
       }[];
     }[];
-    conditions?: {
-      lastTransitionTime: string;
-      message: string;
-      observedGeneration?: number;
-      reason: string;
-      status: 'True' | 'False' | 'Unknown';
-      type: string;
-    }[];
+    conditions?: WorkloadCondition[];
     reclaimablePods?: {
       count: number;
       name: string;
@@ -900,6 +893,15 @@ export type WorkloadKind = K8sResourceCommon & {
       requeueAt?: string;
     };
   };
+};
+
+export type WorkloadCondition = {
+  lastTransitionTime: string;
+  message: string;
+  observedGeneration?: number;
+  reason: string;
+  status: 'True' | 'False' | 'Unknown';
+  type: string;
 };
 
 export type AccessReviewResourceAttributes = {

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWWorkloadsTable.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWWorkloadsTable.tsx
@@ -1,7 +1,19 @@
 import * as React from 'react';
-import { Card, CardTitle, CardBody, Bullseye, Spinner } from '@patternfly/react-core';
+import {
+  Card,
+  CardTitle,
+  CardBody,
+  Bullseye,
+  Spinner,
+  Timestamp,
+  Label,
+} from '@patternfly/react-core';
+import { Td, Tr } from '@patternfly/react-table';
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import { SortableData, Table } from '~/components/table';
+import { WorkloadKind } from '~/k8sTypes';
+import { getStatusInfo } from '~/concepts/distributedWorkloads/utils';
 
 export const DWWorkloadsTable: React.FC = () => {
   const { workloads } = React.useContext(DistributedWorkloadsContext);
@@ -27,12 +39,78 @@ export const DWWorkloadsTable: React.FC = () => {
     );
   }
 
+  const columns: SortableData<WorkloadKind>[] = [
+    {
+      field: 'name',
+      label: 'Name',
+      sortable: (a, b) =>
+        (a.metadata?.name || 'Unnamed').localeCompare(b.metadata?.name || 'Unnamed'),
+    },
+    {
+      field: 'priority',
+      label: 'Priority',
+      sortable: (a, b) => (a.spec.priority || 0) - (b.spec.priority || 0),
+    },
+    {
+      field: 'status',
+      label: 'Status',
+      sortable: (a, b) =>
+        (getStatusInfo(a)?.status || '').localeCompare(getStatusInfo(b)?.status || ''),
+    },
+    {
+      field: 'created',
+      label: 'Created',
+      sortable: (a, b) =>
+        (a.metadata?.creationTimestamp || '').localeCompare(b.metadata?.creationTimestamp || ''),
+    },
+    {
+      field: 'latest-message',
+      label: 'Latest Message',
+      sortable: false,
+    },
+    {
+      field: 'kebab',
+      label: '',
+      sortable: false,
+    },
+  ];
+
   return (
     <Card>
       <CardTitle>Workloads</CardTitle>
       <CardBody>
-        <h2>TODO workloads table</h2>
-        <pre>{JSON.stringify(workloads.data, undefined, 4)}</pre>
+        <Table
+          enablePagination
+          data={workloads.data}
+          columns={columns}
+          emptyTableView={<>No workloads match your filters</>}
+          data-id="workload-table"
+          rowRenderer={(workload) => {
+            const statusInfo = getStatusInfo(workload);
+            if (!statusInfo) {
+              return <Tr />;
+            }
+            return (
+              <Tr key={workload.metadata?.uid}>
+                <Td dataLabel="Name">{workload.metadata?.name || 'Unnamed'}</Td>
+                <Td dataLabel="Priority">{workload.spec.priority}</Td>
+                <Td dataLabel="Status">
+                  <Label color={statusInfo.color} icon={<statusInfo.icon />}>
+                    {statusInfo.status}
+                  </Label>
+                </Td>
+                <Td dataLabel="Created">
+                  {workload.metadata?.creationTimestamp ? (
+                    <Timestamp date={new Date(workload.metadata.creationTimestamp)} />
+                  ) : (
+                    'Unknown'
+                  )}
+                </Td>
+                <Td dataLabel="Latest Message">{statusInfo.message}</Td>
+              </Tr>
+            );
+          }}
+        />
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
Closes: [RHOAIENG-3583](https://issues.redhat.com//browse/RHOAIENG-3583)

## Description
Implement first iteration of workloads table. More information is necessary before including links from the table. After selecting a project with workloads, go to the workload metrics -> workload status tab.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/f70c7bd0-eef0-44e8-8294-f77f17f97b05)

## Test Impact
Cypress tests to see that the table is there with a workload name and with the placeholder text if no workload. Unit test on a new utility function

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
