### PR TITLE
Add unit tests for utilities added in initial Distributed Workloads changes

### DIFF
--- a/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
+++ b/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
@@ -1,0 +1,104 @@
+import { ClusterQueueKind } from '~/k8sTypes';
+import { genUID } from '~/__mocks__/mockUtils';
+
+type MockResourceConfigType = {
+  name?: string;
+};
+
+export const mockClusterQueueK8sResource = ({
+  name = 'test-cluster-queue',
+}: MockResourceConfigType): ClusterQueueKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  kind: 'ClusterQueue',
+  metadata: {
+    creationTimestamp: '2024-02-22T17:26:19Z',
+    finalizers: ['kueue.x-k8s.io/resource-in-use'],
+    generation: 1,
+    name,
+    uid: genUID('clusterqueue'),
+  },
+  spec: {
+    flavorFungibility: {
+      whenCanBorrow: 'Borrow',
+      whenCanPreempt: 'TryNextFlavor',
+    },
+    namespaceSelector: {},
+    preemption: {
+      borrowWithinCohort: {
+        policy: 'Never',
+      },
+      reclaimWithinCohort: 'Never',
+      withinClusterQueue: 'Never',
+    },
+    queueingStrategy: 'BestEffortFIFO',
+    resourceGroups: [
+      {
+        coveredResources: ['cpu', 'memory'],
+        flavors: [
+          {
+            name: 'test-flavor',
+            resources: [
+              {
+                name: 'cpu',
+                nominalQuota: '20',
+              },
+              {
+                name: 'memory',
+                nominalQuota: '36Gi',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    stopPolicy: 'None',
+  },
+  status: {
+    admittedWorkloads: 0,
+    conditions: [
+      {
+        lastTransitionTime: '2024-02-22T17:26:19Z',
+        message: 'Can admit new workloads',
+        reason: 'Ready',
+        status: 'True',
+        type: 'Active',
+      },
+    ],
+    flavorsReservation: [
+      {
+        name: 'test-flavor',
+        resources: [
+          {
+            borrowed: '0',
+            name: 'cpu',
+            total: '0',
+          },
+          {
+            borrowed: '0',
+            name: 'memory',
+            total: '0',
+          },
+        ],
+      },
+    ],
+    flavorsUsage: [
+      {
+        name: 'test-flavor',
+        resources: [
+          {
+            borrowed: '0',
+            name: 'cpu',
+            total: '0',
+          },
+          {
+            borrowed: '0',
+            name: 'memory',
+            total: '0',
+          },
+        ],
+      },
+    ],
+    pendingWorkloads: 0,
+    reservingWorkloads: 0,
+  },
+});

--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -1,0 +1,56 @@
+import { genUID } from '~/__mocks__/mockUtils';
+import { WorkloadKind } from '~/k8sTypes';
+
+type MockResourceConfigType = {
+  k8sName?: string;
+  namespace?: string;
+};
+export const mockWorkloadK8sResource = ({
+  k8sName = 'test-workload',
+  namespace = 'test-project',
+}: MockResourceConfigType): WorkloadKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  kind: 'Workload',
+  metadata: {
+    creationTimestamp: '2024-03-18T19:15:28Z',
+    generation: 2,
+    labels: {
+      'kueue.x-k8s.io/job-uid': 'e62a44fb-cd94-4602-bc8b-7cc9579d9559',
+    },
+    name: k8sName,
+    namespace,
+    resourceVersion: '9279356',
+    uid: genUID('workload'),
+  },
+  spec: {
+    active: true,
+    podSets: [],
+    priority: 0,
+    queueName: 'user-queue',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2024-03-18T19:15:28Z',
+        message: 'Quota reserved in ClusterQueue cluster-queue',
+        reason: 'QuotaReserved',
+        status: 'True',
+        type: 'QuotaReserved',
+      },
+      {
+        lastTransitionTime: '2024-03-18T19:15:28Z',
+        message: 'The workload is admitted',
+        reason: 'Admitted',
+        status: 'True',
+        type: 'Admitted',
+      },
+      {
+        lastTransitionTime: '2024-03-18T19:17:15Z',
+        message: 'Job finished successfully',
+        reason: 'JobFinished',
+        status: 'True',
+        type: 'Finished',
+      },
+    ],
+  },
+});

--- a/frontend/src/api/k8s/__tests__/clusterQueues.spec.ts
+++ b/frontend/src/api/k8s/__tests__/clusterQueues.spec.ts
@@ -1,0 +1,45 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockClusterQueueK8sResource } from '~/__mocks__/mockClusterQueueK8sResource';
+import { ClusterQueueKind } from '~/k8sTypes';
+import { listClusterQueues } from '~/api/k8s/clusterQueues';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResourceItems: jest.fn(),
+}));
+
+const k8sListResourceItemsMock = jest.mocked(k8sListResourceItems<ClusterQueueKind>);
+
+const clusterQueueMock = mockClusterQueueK8sResource({ name: 'test-cluster-queue' });
+
+describe('listClusterQueues', () => {
+  it('should fetch and return clusterqueues', async () => {
+    k8sListResourceItemsMock.mockResolvedValue([clusterQueueMock]);
+    const result = await listClusterQueues();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'kueue.x-k8s.io',
+        apiVersion: 'v1beta1',
+        kind: 'ClusterQueue',
+        plural: 'clusterqueues',
+      },
+      queryOptions: {},
+    });
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([clusterQueueMock]);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceItemsMock.mockRejectedValue(new Error('error1'));
+    await expect(listClusterQueues()).rejects.toThrow('error1');
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceItemsMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'kueue.x-k8s.io',
+        apiVersion: 'v1beta1',
+        kind: 'ClusterQueue',
+        plural: 'clusterqueues',
+      },
+      queryOptions: {},
+    });
+  });
+});

--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -1,0 +1,48 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';
+import { WorkloadKind } from '~/k8sTypes';
+import { listWorkloads } from '~/api/k8s/workloads';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResourceItems: jest.fn(),
+}));
+
+const k8sListResourceItemsMock = jest.mocked(k8sListResourceItems<WorkloadKind>);
+
+const mockedWorkload = mockWorkloadK8sResource({
+  k8sName: 'test-workload',
+  namespace: 'test-project',
+});
+
+describe('listClusterQueues', () => {
+  it('should fetch and return clusterqueues', async () => {
+    k8sListResourceItemsMock.mockResolvedValue([mockedWorkload]);
+    const result = await listWorkloads('test-project');
+    expect(k8sListResourceItemsMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'kueue.x-k8s.io',
+        apiVersion: 'v1beta1',
+        kind: 'Workload',
+        plural: 'workloads',
+      },
+      queryOptions: { ns: 'test-project' },
+    });
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockedWorkload]);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceItemsMock.mockRejectedValue(new Error('error1'));
+    await expect(listWorkloads('test-project')).rejects.toThrow('error1');
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceItemsMock).toHaveBeenCalledWith({
+      model: {
+        apiGroup: 'kueue.x-k8s.io',
+        apiVersion: 'v1beta1',
+        kind: 'Workload',
+        plural: 'workloads',
+      },
+      queryOptions: { ns: 'test-project' },
+    });
+  });
+});

--- a/frontend/src/api/prometheus/__tests__/usePrometheusNumberValueQuery.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/usePrometheusNumberValueQuery.spec.ts
@@ -1,0 +1,75 @@
+import { act } from '@testing-library/react';
+import axios from 'axios';
+import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import usePrometheusNumberValueQuery from '~/api/prometheus/usePrometheusNumberValueQuery';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
+
+const mockAxios = jest.mocked(axios.post);
+
+describe('usePrometheusNumberValueQuery', () => {
+  const query = `namespace=test-project`;
+
+  it('should return and fetch prometheus query', async () => {
+    const prometheusResponse = {
+      data: { response: mockPrometheusQueryResponse({ value: [0, '5'] }) },
+    };
+    mockAxios.mockResolvedValue(prometheusResponse);
+    const renderResult = await testHook(usePrometheusNumberValueQuery)(query);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(undefined));
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
+      query: 'namespace=test-project',
+    });
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(5, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    mockAxios.mockResolvedValue(prometheusResponse);
+    await act(() => renderResult.result.current[3]());
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle when query is empty string', async () => {
+    await testHook(usePrometheusNumberValueQuery)('');
+    expect(mockAxios).toHaveBeenCalledTimes(0);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    mockAxios.mockRejectedValue(new Error('error1'));
+
+    const renderResult = testHook(usePrometheusNumberValueQuery)(query);
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(undefined));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(undefined, false, new Error('error1')),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    mockAxios.mockRejectedValue(new Error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(undefined, false, new Error('error2')),
+    );
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -27,6 +27,8 @@ const getDWProjectMetricsQueries = (namespace: string): Record<DWProjectMetricTy
   cpuUtilized: `namespace=${namespace}&query=pod:container_cpu_usage:sum{namespace='${namespace}'}`,
 });
 
+// TODO mturley add unit tests for useDWProjectMetrics once RBAC issues are settled and we know these are really the queries we need
+
 export const useDWProjectMetrics = (namespace?: string, refreshRate = 0): DWProjectMetrics => {
   const queries = namespace ? getDWProjectMetricsQueries(namespace) : undefined;
   const data: DWProjectMetrics['data'] = {
@@ -73,6 +75,8 @@ const getDWWorkloadCurrentMetricsQueries = (
   numJobsInadmissible: `namespace=${namespace}&query=kueue_pending_workloads{status='inadmissible'}`,
   numJobsPending: `namespace=${namespace}&query=kueue_pending_workloads{status!='inadmissible'}`,
 });
+
+// TODO mturley add unit tests for useDWProjectMetrics once RBAC issues are settled and we know these are really the queries we need
 
 export const useDWWorkloadCurrentMetrics = (
   namespace?: string,
@@ -141,6 +145,8 @@ const getDWWorkloadTrendMetricsQueries = (
   jobsInadmissibleTrend: `kueue_pending_workloads{status='inadmissible', namespace='${namespace}'}`,
   jobsPendingTrend: `kueue_pending_workloads{status!='inadmissible', namespace='${namespace}'}`,
 });
+
+// TODO mturley add unit tests for useDWProjectMetrics once RBAC issues are settled and we know these are really the queries we need
 
 export const useDWWorkloadTrendMetrics = (
   timeframe: TimeframeTitle,

--- a/frontend/src/concepts/distributedWorkloads/__tests__/useClusterQueues.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/useClusterQueues.spec.ts
@@ -1,0 +1,72 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { act } from '@testing-library/react';
+import { mockClusterQueueK8sResource } from '~/__mocks__/mockClusterQueueK8sResource';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';
+import { ClusterQueueKind } from '~/k8sTypes';
+import useClusterQueues from '~/concepts/distributedWorkloads/useClusterQueues';
+
+const mockedClusterQueues = [mockClusterQueueK8sResource({ name: 'test-cluster-queue' })];
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResourceItems: jest.fn(),
+}));
+
+jest.mock('~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const k8sListResourceItemsMock = jest.mocked(k8sListResourceItems<ClusterQueueKind>);
+const useDistributedWorkloadsEnabledMock = jest.mocked(useDistributedWorkloadsEnabled);
+
+describe('useClusterQueues', () => {
+  it('should return cluster queues', async () => {
+    useDistributedWorkloadsEnabledMock.mockReturnValue(true);
+
+    k8sListResourceItemsMock.mockResolvedValue(mockedClusterQueues);
+
+    const renderResult = testHook(useClusterQueues)();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(mockedClusterQueues, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceItemsMock.mockResolvedValue([]);
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceItemsMock.mockRejectedValue(new Error('error1'));
+
+    const renderResult = testHook(useClusterQueues)();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    k8sListResourceItemsMock.mockRejectedValue(new Error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/concepts/distributedWorkloads/__tests__/useWorkloads.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/useWorkloads.spec.ts
@@ -1,0 +1,84 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { act } from '@testing-library/react';
+import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';
+import { WorkloadKind } from '~/k8sTypes';
+import useWorkloads from '~/concepts/distributedWorkloads/useWorkloads';
+
+const mockedWorkloads = [
+  mockWorkloadK8sResource({
+    k8sName: 'test-workload',
+    namespace: 'test-project',
+  }),
+];
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResourceItems: jest.fn(),
+}));
+
+jest.mock('~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const k8sListResourceItemsMock = jest.mocked(k8sListResourceItems<WorkloadKind>);
+const useDistributedWorkloadsEnabledMock = jest.mocked(useDistributedWorkloadsEnabled);
+
+describe('useWorkloads', () => {
+  it('should return workloads for a namespace', async () => {
+    useDistributedWorkloadsEnabledMock.mockReturnValue(true);
+
+    k8sListResourceItemsMock.mockResolvedValue(mockedWorkloads);
+
+    const renderResult = testHook(useWorkloads)('test-project');
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(mockedWorkloads, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceItemsMock.mockResolvedValue([]);
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle no namespace error', async () => {
+    const renderResult = testHook(useWorkloads)();
+    expect(k8sListResourceItemsMock).not.toHaveBeenCalled();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceItemsMock.mockRejectedValue(new Error('error1'));
+
+    const renderResult = testHook(useWorkloads)('test-project');
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    k8sListResourceItemsMock.mockRejectedValue(new Error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceItemsMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/concepts/distributedWorkloads/useClusterQueues.ts
+++ b/frontend/src/concepts/distributedWorkloads/useClusterQueues.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { ClusterQueueKind } from '~/k8sTypes';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';
 import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 import { listClusterQueues } from '~/api';
 
 const useClusterQueues = (refreshRate = 0): FetchState<ClusterQueueKind[]> => {
-  const dwEnabled = useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+  const dwEnabled = useDistributedWorkloadsEnabled();
   return useFetchState<ClusterQueueKind[]>(
     React.useCallback(() => {
       if (!dwEnabled) {

--- a/frontend/src/concepts/distributedWorkloads/useDistributedWorkloadsEnabled.ts
+++ b/frontend/src/concepts/distributedWorkloads/useDistributedWorkloadsEnabled.ts
@@ -1,0 +1,6 @@
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+
+const useDistributedWorkloadsEnabled = (): boolean =>
+  useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+
+export default useDistributedWorkloadsEnabled;

--- a/frontend/src/concepts/distributedWorkloads/useWorkloads.ts
+++ b/frontend/src/concepts/distributedWorkloads/useWorkloads.ts
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import { WorkloadKind } from '~/k8sTypes';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';
 import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
 import { listWorkloads } from '~/api';
 
 const useWorkloads = (namespace?: string, refreshRate = 0): FetchState<WorkloadKind[]> => {
-  const dwEnabled = useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+  const dwEnabled = useDistributedWorkloadsEnabled();
   return useFetchState<WorkloadKind[]>(
     React.useCallback(() => {
       if (!dwEnabled) {
         return Promise.reject(new NotReadyError('Distributed workloads is not enabled'));
+      }
+      if (!namespace) {
+        return Promise.reject(new NotReadyError('No namespace'));
       }
       return listWorkloads(namespace);
     }, [dwEnabled, namespace]),

--- a/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';
 import GlobalDistributedWorkloadsProjectMetricsTab from './projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab';
 import GlobalDistributedWorkloadsWorkloadStatusTab from './workloadStatus/GlobalDistributedWorkloadsWorkloadStatusTab';
 
@@ -19,7 +19,7 @@ export type DistributedWorkloadsTabConfig = {
 };
 
 export const useDistributedWorkloadsTabs = (): DistributedWorkloadsTabConfig[] => {
-  const dwAreaIsAvailable = useIsAreaAvailable(SupportedArea.DISTRIBUTED_WORKLOADS).status;
+  const dwAreaIsAvailable = useDistributedWorkloadsEnabled();
   return [
     {
       id: DistributedWorkloadsTabId.PROJECT_METRICS,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes [RHOAIENG-3578](https://issues.redhat.com/browse/RHOAIENG-3578).

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Followup to #2587. Adds remaining unit tests for code introduced in #2469 that were not covered by #2587, with the exception of the hooks related to specific prometheus queries in `frontend/src/api/prometheus/distributedWorkloads.ts`. The code in that file is very likely to change significantly in the short term, and many of those queries will likely no longer be used due to RBAC issues that are still being resolved. As a result, unit testing those now would likely be throwaway work. This code will be unit tested as part of completing the stories for the Project Metrics epic ([RHOAIENG-2533](https://issues.redhat.com/browse/RHOAIENG-2533)) which will include rewriting/replacing the code in this file.

In order to support some of these tests, the new `useDistributedWorkloadsEnabled` hook has been added to abstract away the `useIsAreaAvailable` hook to make mocking easier (similar to how it is done for `useModelServingEnabled`).

Note also: the `mockWorkloadK8sResource.ts` file has been copied directly from https://github.com/opendatahub-io/odh-dashboard/pull/2610 with no changes, so we should be able to rebase one of these PRs on top of the other with no issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Made sure new and existing tests pass, made sure the page still works.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

See above. This is making up for missing tests in earlier changes.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
