### PR TITLE
Add wrap text option for pipeline run logs

### DIFF
--- a/frontend/src/concepts/dashboard/DashboardLogViewer.tsx
+++ b/frontend/src/concepts/dashboard/DashboardLogViewer.tsx
@@ -8,7 +8,8 @@ const DashboardLogViewer: React.FC<{
   footer: JSX.Element | false;
   onScroll: React.ComponentProps<typeof LogViewer>['onScroll'];
   height?: number | string;
-}> = ({ data, logViewerRef, toolbar, footer, onScroll, height = '100%' }) => (
+  isTextWrapped?: boolean;
+}> = ({ data, logViewerRef, toolbar, footer, onScroll, height = '100%', isTextWrapped }) => (
   <LogViewer
     data-testid="logs"
     hasLineNumbers={false}
@@ -18,6 +19,7 @@ const DashboardLogViewer: React.FC<{
     toolbar={toolbar}
     footer={footer}
     onScroll={onScroll}
+    isTextWrapped={isTextWrapped}
   />
 );
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import {
   Button,
+  Checkbox,
   DropdownList,
   Icon,
   Spinner,
@@ -89,6 +90,7 @@ const LogsTabForPodName: React.FC<{ podName: string; isFailedPod: boolean }> = (
   const [isFullScreen, setIsFullScreen] = React.useState(false);
   const [showSearchbar, setShowsearchbar] = React.useState(false);
   const [isKebabOpen, setIsKebabOpen] = React.useState(false);
+  const [isTextWrapped, setIsTextWrapped] = React.useState(true);
 
   const logsTabRef = React.useRef<HTMLDivElement>(null);
   const dispatchResizeEvent = useDebounceCallback(
@@ -229,6 +231,7 @@ const LogsTabForPodName: React.FC<{ podName: string; isFailedPod: boolean }> = (
             height="calc(100% - 75px)"
             data={data}
             logViewerRef={logViewerRef}
+            isTextWrapped={isTextWrapped}
             toolbar={
               !error && (
                 <Toolbar className={isFullScreen ? 'pf-v5-u-p-sm' : ''}>
@@ -309,6 +312,15 @@ const LogsTabForPodName: React.FC<{ podName: string; isFailedPod: boolean }> = (
                       )}
                     </ToolbarGroup>
                     <ToolbarGroup align={{ default: 'alignRight' }}>
+                      <ToolbarItem alignSelf="center">
+                        <Checkbox
+                          label="Wrap text"
+                          aria-label="wrap text checkbox"
+                          isChecked={isTextWrapped}
+                          id="wrap-text-checkbox"
+                          onChange={(_event, value) => setIsTextWrapped(value)}
+                        />
+                      </ToolbarItem>
                       <ToolbarItem spacer={{ default: 'spacerNone' }}>
                         {downloading && <Spinner size="sm" className="pf-v5-u-my-sm" />}
                         {podContainers.length <= 1 ? (

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
@@ -71,8 +71,7 @@ const LogsTabStatus: React.FC<LogsTabStatusProps> = ({
     >
       <p>
         The log refreshes every {Math.floor(LOG_REFRESH_RATE / 1000)} seconds and displays the
-        latest {LOG_TAIL_LINES} lines. Exceptionally long lines are abridged. To view the full log
-        for this task, you can{' '}
+        latest {LOG_TAIL_LINES} lines. To view the full log for this task, you can{' '}
         <Button isDisabled={!isLogsAvailable} variant="link" isInline onClick={onDownload}>
           download all step logs
         </Button>{' '}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: [RHOAIENG-3830](https://issues.redhat.com/browse/RHOAIENG-3830)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There is some problem with the PF log viewer, which is causing the incorrect rendering for the extremely long log lines. In the OpenShift console, the solution is to truncate the line. However, it's limited currently in the dashboard for now because we haven't applied websocket on the logs, so it's hard to truncate a single line of the logs (it's a full string now). After a discussion with the UX, we decided to add an option to allow the users to check whether they want to wrap the text in the log viewer or not. In this way, they can view the incorrectly rendered logs by unchecking the `Wrap text` checkbox in the toolbar.

<img width="1728" alt="Screenshot 2024-03-20 at 11 17 46 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/e5c2660e-39c2-4ef2-970e-5d229e0cbd76">

Also, update the text in the alert because we don't truncate the exceptionally long lines :)

<img width="691" alt="Screenshot 2024-03-20 at 11 18 51 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/f0b7806c-cb69-4074-a15f-6e3a15290b5b">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a pipeline run
2. Check the logs in the steps, try to wrap and unwrap it
3. Make sure nothing is broken
4. Check the text in the alert

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, it's a simple update with the built-in log viewer interface.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
