### PR TITLE
feat(dw): move project selector to page head

### DIFF
--- a/frontend/src/pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes.tsx
+++ b/frontend/src/pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes.tsx
@@ -20,7 +20,7 @@ const GlobalDistributedWorkloadsRoutes: React.FC = () => {
         .map((tab) => (
           <Route
             key={tab.id}
-            path={`${tab.path}${tab.projectSelectorMode !== null ? '/:namespace?' : ''}`}
+            path={`${tab.path}/:namespace?`}
             element={
               <GlobalDistributedWorkloads
                 activeTab={tab}

--- a/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloads.tsx
@@ -9,6 +9,7 @@ import DistributedWorkloadsNoProjects from '~/pages/distributedWorkloads/global/
 import GlobalDistributedWorkloadsTabs from '~/pages/distributedWorkloads/global/GlobalDistributedWorkloadsTabs';
 import { MetricsCommonContextProvider } from '~/concepts/metrics/MetricsCommonContext';
 import { RefreshIntervalTitle } from '~/concepts/metrics/types';
+import ProjectSelectorNavigator from '~/concepts/projects/ProjectSelectorNavigator';
 
 const title = 'Workload Metrics';
 const description = 'Monitor the metrics of your active resources.';
@@ -35,31 +36,37 @@ const GlobalDistributedWorkloads: React.FC<GlobalDistributedWorkloadsProps> = ({
       />
     );
   }
-
-  if (activeTab.projectSelectorMode !== null) {
-    if (!namespace && (activeTab.projectSelectorMode === 'singleProjectOnly' || preferredProject)) {
-      // No namespace is in the path and either this tab requires one or we have a preferred one to go to
-      const redirectProject = preferredProject ?? projects[0];
-      return <Navigate to={getInvalidRedirectPath(redirectProject.metadata.name)} replace />;
-    }
-    if (namespace && !projects.find(byName(namespace))) {
-      // This tab allows or requires a namespace but was given an invalid one.
-      return (
-        <ApplicationsPage
-          {...{ title, description }}
-          loaded
-          empty
-          emptyStatePage={
-            <InvalidProject namespace={namespace} getRedirectPath={getInvalidRedirectPath} />
-          }
-        />
-      );
-    }
+  if (!namespace) {
+    const redirectProject = preferredProject ?? projects[0];
+    return <Navigate to={getInvalidRedirectPath(redirectProject.metadata.name)} replace />;
+  }
+  if (namespace && !projects.find(byName(namespace))) {
+    // The namespace in the URL is invalid
+    return (
+      <ApplicationsPage
+        {...{ title, description }}
+        loaded
+        empty
+        emptyStatePage={
+          <InvalidProject namespace={namespace} getRedirectPath={getInvalidRedirectPath} />
+        }
+      />
+    );
   }
 
   // We're all good, either no namespace is required or we have a valid one
   return (
-    <ApplicationsPage {...{ title, description }} loaded empty={false}>
+    <ApplicationsPage
+      {...{ title, description }}
+      loaded
+      empty={false}
+      headerContent={
+        <ProjectSelectorNavigator
+          getRedirectPath={(ns: string) => `/distributedWorkloads/${activeTab.path}/${ns}`}
+          showTitle
+        />
+      }
+    >
       <MetricsCommonContextProvider initialRefreshInterval={RefreshIntervalTitle.THIRTY_MINUTES}>
         <DistributedWorkloadsContextProvider namespace={namespace}>
           <GlobalDistributedWorkloadsTabs activeTabId={activeTab.id} />

--- a/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsTabs.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/GlobalDistributedWorkloadsTabs.tsx
@@ -7,11 +7,8 @@ import {
   PageSection,
   TabContent,
   TabContentBody,
-  ToolbarItem,
-  ToolbarGroup,
 } from '@patternfly/react-core';
 import MetricsPageToolbar from '~/concepts/metrics/MetricsPageToolbar';
-import ProjectSelectorNavigator from '~/concepts/projects/ProjectSelectorNavigator';
 import {
   DistributedWorkloadsTabId,
   useDistributedWorkloadsTabs,
@@ -36,7 +33,7 @@ const GlobalDistributedWorkloadsTabs: React.FC<GlobalDistributedWorkloadsTabsPro
           onSelect={(_, tabId) => {
             const tab = tabs.find(({ id }) => id === tabId);
             if (tab) {
-              const namespaceSuffix = tab.projectSelectorMode && !!namespace ? `/${namespace}` : '';
+              const namespaceSuffix = namespace ? `/${namespace}` : '';
               navigate(`/distributedWorkloads/${tab.path}${namespaceSuffix}`);
             }
           }}
@@ -56,23 +53,7 @@ const GlobalDistributedWorkloadsTabs: React.FC<GlobalDistributedWorkloadsTabsPro
             ))}
         </Tabs>
       </PageSection>
-      {activeTab ? (
-        <MetricsPageToolbar
-          leftToolbarItem={
-            <ToolbarGroup>
-              <ToolbarItem variant="label">Project</ToolbarItem>
-              <ToolbarItem spacer={{ default: 'spacerMd' }}>
-                <ProjectSelectorNavigator
-                  getRedirectPath={(newNamespace) =>
-                    `/distributedWorkloads/${activeTab.path}/${newNamespace}`
-                  }
-                />
-              </ToolbarItem>
-            </ToolbarGroup>
-          }
-          hasTimeRangeSelect={false}
-        />
-      ) : null}
+      {activeTab ? <MetricsPageToolbar hasTimeRangeSelect={false} /> : null}
       <PageSection isFilled>
         {tabs
           .filter((tab) => tab.isAvailable)

--- a/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
@@ -13,8 +13,6 @@ export type DistributedWorkloadsTabConfig = {
   title: string;
   path: string;
   isAvailable: boolean;
-  // TODO mturley remove this now that all our tabs here are single project only, or leave in case we add future tabs?
-  projectSelectorMode: 'singleProjectOnly' | 'projectOrAll' | null;
   ContentComponent: React.FC;
 };
 
@@ -26,7 +24,6 @@ export const useDistributedWorkloadsTabs = (): DistributedWorkloadsTabConfig[] =
       title: 'Project metrics',
       path: 'projectMetrics',
       isAvailable: dwAreaIsAvailable,
-      projectSelectorMode: 'singleProjectOnly',
       ContentComponent: GlobalDistributedWorkloadsProjectMetricsTab,
     },
     {
@@ -34,7 +31,6 @@ export const useDistributedWorkloadsTabs = (): DistributedWorkloadsTabConfig[] =
       title: 'Workload status',
       path: 'workloadStatus',
       isAvailable: dwAreaIsAvailable,
-      projectSelectorMode: 'singleProjectOnly',
       ContentComponent: GlobalDistributedWorkloadsWorkloadStatusTab,
     },
   ];


### PR DESCRIPTION
Closes: [RHOAIENG-4623](https://issues.redhat.com/browse/RHOAIENG-4623)

## Description
Moved the project selector to the header for workload metrics (was previously at the top of each tab page section)

Before:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/acba9a1e-c389-43af-8912-7b3160c1e6d9)

After:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/7c6a65c8-e2b8-4938-b122-6cb728ef08db)


## How Has This Been Tested?
Tested changes by checking:

- Project selector exists in header with both tabs selected
- Project selector does not exist in either tab anymore
- Selecting a project updates the data, reflecting the project has changed
- Selecting a project does not change the page/tab we are on

(operates in the same manner as previously, just shows up in a different area)

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
