### PR TITLE
Update Accelerator profile cypress test 

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/acceleratorProfiles/AcceleratorProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/acceleratorProfiles/AcceleratorProfiles.cy.ts
@@ -1,10 +1,14 @@
 import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import { mockStatus } from '~/__mocks__/mockStatus';
-import { acceleratorProfile } from '~/__tests__/cypress/cypress/pages/acceleratorProfile';
+import {
+  acceleratorProfile,
+  disableAcceleratorProfileModal,
+} from '~/__tests__/cypress/cypress/pages/acceleratorProfile';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
+import { be } from '~/__tests__/cypress/cypress/utils/should';
 
 type HandlersProps = {
   isEmpty?: boolean;
@@ -41,7 +45,7 @@ describe('Accelerator Profile', () => {
     acceleratorProfile.findAddButton().should('be.enabled');
   });
 
-  it('list accelerator profiles', () => {
+  it('list accelerator profiles and Table filtering, sorting, searching', () => {
     initIntercepts({});
     acceleratorProfile.visit();
     const tableRow = acceleratorProfile.getRow('TensorRT');
@@ -49,17 +53,41 @@ describe('Accelerator Profile', () => {
       .findDescription()
       .contains('Lorem, ipsum dolor sit amet consectetur adipisicing elit. Saepe, quis');
     tableRow.shouldHaveIdentifier('tensor.com/gpu');
+
+    //sort by Name
+    acceleratorProfile.findTableHeaderButton('Name').click();
+    acceleratorProfile.findTableHeaderButton('Name').should(be.sortDescending);
+    acceleratorProfile.findTableHeaderButton('Name').click();
+    acceleratorProfile.findTableHeaderButton('Name').should(be.sortAscending);
+
+    // sort by Identifier
     acceleratorProfile.findTableHeaderButton('Identifier').click();
-    acceleratorProfile.shouldBeSortedByColumn('Identifier', 'asc');
+    acceleratorProfile.findTableHeaderButton('Identifier').should(be.sortAscending);
     acceleratorProfile.findTableHeaderButton('Identifier').click();
-    acceleratorProfile.shouldBeSortedByColumn('Identifier', 'desc');
+    acceleratorProfile.findTableHeaderButton('Identifier').should(be.sortDescending);
+
+    // sort by enable
+    acceleratorProfile.findTableHeaderButton('Enable').click();
+    acceleratorProfile.findTableHeaderButton('Enable').should(be.sortAscending);
+    acceleratorProfile.findTableHeaderButton('Enable').click();
+    acceleratorProfile.findTableHeaderButton('Enable').should(be.sortDescending);
+
+    // sort by last modified
+    acceleratorProfile.findTableHeaderButton('Last modified').click();
+    acceleratorProfile.findTableHeaderButton('Last modified').should(be.sortAscending);
+    acceleratorProfile.findTableHeaderButton('Last modified').click();
+    acceleratorProfile.findTableHeaderButton('Last modified').should(be.sortDescending);
+
     acceleratorProfile.findCreateButton().should('be.enabled');
-    acceleratorProfile.findFilterMenuOption().findDropdownItem('Name').click();
-    acceleratorProfile.findSearchInput().fill('Test');
+
+    const acceleratorTableToolbar = acceleratorProfile.getTableToolbar();
+    acceleratorTableToolbar.findFilterMenuOption('filter-dropdown-select', 'Name').click();
+    acceleratorTableToolbar.findSearchInput().fill('Test');
     acceleratorProfile.getRow('Test Accelerator').shouldHaveIdentifier('nvidia.com/gpu');
-    acceleratorProfile.findFilterMenuOption().findDropdownItem('Identifier').click();
-    acceleratorProfile.findResetButton().click();
-    acceleratorProfile.findSearchInput().fill('tensor.com/gpu');
+
+    acceleratorTableToolbar.findFilterMenuOption('filter-dropdown-select', 'Identifier').click();
+    acceleratorTableToolbar.findResetButton().click();
+    acceleratorTableToolbar.findSearchInput().fill('tensor.com/gpu');
     tableRow.shouldHaveIdentifier('tensor.com/gpu');
   });
 
@@ -78,5 +106,26 @@ describe('Accelerator Profile', () => {
     deleteModal.findInput().fill('TensorRT');
     deleteModal.findSubmitButton().should('be.enabled').click();
     cy.wait('@delete');
+  });
+
+  it('disable accelerator profile', () => {
+    initIntercepts({});
+    cy.intercept(
+      {
+        method: 'PUT',
+        pathname: '/api/accelerator-profiles/migrated-gpu',
+      },
+      {},
+    ).as('disableAcceleratorProfile');
+    acceleratorProfile.visit();
+    acceleratorProfile.getRow('TensorRT').findEnabled().should('not.be.checked');
+    acceleratorProfile.getRow('Test Accelerator').findEnabled().should('be.checked');
+    acceleratorProfile.getRow('Test Accelerator').findEnableSwitch().click();
+    disableAcceleratorProfileModal.findDisableButton().click();
+
+    cy.wait('@disableAcceleratorProfile').then((interception) => {
+      expect(interception.request.body).to.eql({ enabled: false });
+    });
+    acceleratorProfile.getRow('Test Accelerator').findEnabled().should('not.be.checked');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
@@ -529,6 +529,15 @@ describe('Serving Runtime List', () => {
 
       // Check API protocol in row
       inferenceServiceRow.findAPIProtocol().should('have.text', 'REST');
+
+      // sort by modelName
+      modelServingSection
+        .findInferenceServiceTableHeaderButton('Model name')
+        .should(be.sortAscending);
+      modelServingSection.findInferenceServiceTableHeaderButton('Model name').click();
+      modelServingSection
+        .findInferenceServiceTableHeaderButton('Model name')
+        .should(be.sortDescending);
     });
   });
 
@@ -738,6 +747,10 @@ describe('Serving Runtime List', () => {
         .should('exist');
       // Check for resource marked for deletion
       modelServingSection.getKServeRow('Another Inference Service').shouldBeMarkedForDeletion();
+
+      modelServingSection.findKServeTableHeaderButton('Model name').should(be.sortAscending);
+      modelServingSection.findKServeTableHeaderButton('Model name').click();
+      modelServingSection.findKServeTableHeaderButton('Model name').should(be.sortDescending);
     });
 
     it('Check number of replicas of model', () => {

--- a/frontend/src/__tests__/cypress/cypress/e2e/notebookImageSettings/NotebookImageSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/notebookImageSettings/NotebookImageSettings.cy.ts
@@ -87,20 +87,21 @@ describe('Notebook images', () => {
 
     // test filtering
     // by name
-    notebookImageSettings.findSearchInput().type('123');
+    const notebookImageTableToolbar = notebookImageSettings.getTableToolbar();
+    notebookImageTableToolbar.findSearchInput().type('123');
     notebookImageSettings.getRow('image-123').find().should('exist');
 
     // by provider
-    notebookImageSettings.findResetButton().click();
-    notebookImageSettings.findFilterMenuOption('Provider').click();
-    notebookImageSettings.findSearchInput().type('provider-321');
+    notebookImageTableToolbar.findResetButton().click();
+    notebookImageTableToolbar.findFilterMenuOption('filter-dropdown-select', 'Provider').click();
+    notebookImageTableToolbar.findSearchInput().type('provider-321');
     notebookImageSettings.getRow('image-321').find().should('exist');
 
     // by description
     // test switching filtering options
-    notebookImageSettings.findFilterMenuOption('Description').click();
+    notebookImageTableToolbar.findFilterMenuOption('filter-dropdown-select', 'Description').click();
     notebookImageSettings.findEmptyResults();
-    notebookImageSettings.findFilterMenuOption('Provider').click();
+    notebookImageTableToolbar.findFilterMenuOption('filter-dropdown-select', 'Provider').click();
     notebookImageSettings.getRow('image-321').find().should('exist');
   });
 

--- a/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
@@ -1,6 +1,8 @@
 import { Modal } from './components/Modal';
+import { TableToolbar } from './components/TableToolbar';
 import { TableRow } from './components/table';
 
+class AcceleratorTableToolbar extends TableToolbar {}
 class AcceleratorRow extends TableRow {
   findDescription() {
     return this.find().findByTestId('description');
@@ -9,6 +11,14 @@ class AcceleratorRow extends TableRow {
   shouldHaveIdentifier(name: string) {
     this.find().find(`[data-label=Identifier]`).should('have.text', name);
     return this;
+  }
+
+  findEnabled() {
+    return this.find().pfSwitchValue('enable-switch');
+  }
+
+  findEnableSwitch() {
+    return this.find().pfSwitch('enable-switch');
   }
 }
 
@@ -33,20 +43,6 @@ class AcceleratorProfile {
   visit() {
     cy.visitWithLogin('/acceleratorProfiles');
     this.wait();
-  }
-
-  shouldBeSortedByColumn(column: string, order: string) {
-    this.findColumn(column).then(($cells) => {
-      const cellValues = Array.from($cells).map((cell) => cell.textContent?.trim());
-      const sortedCellValues =
-        order === 'asc'
-          ? [...cellValues].sort()
-          : [...cellValues].sort((a, b) =>
-              b === undefined || a === undefined ? -1 : b.localeCompare(a),
-            );
-      expect(cellValues).to.deep.equal(sortedCellValues);
-    });
-    return this;
   }
 
   private wait() {
@@ -74,30 +70,18 @@ class AcceleratorProfile {
     return this.findTable().find('thead').findByRole('button', { name });
   }
 
-  findResetButton() {
-    return cy.findByRole('button', { name: 'Reset' });
-  }
-
-  findFilterMenuOption() {
-    return cy.findByTestId('filter-dropdown-select');
-  }
-
-  findSearchInput() {
-    return cy.findByRole('textbox', { name: 'Search input' });
-  }
-
   private findTable() {
     return cy.findByTestId('accelerator-profile-table');
-  }
-
-  private findColumn(column: string) {
-    return this.findTable().find('tbody').find(`[data-label=${column}]`);
   }
 
   getRow(name: string) {
     return new AcceleratorRow(() =>
       this.findTable().find(`[data-label=Name]`).contains(name).parents('tr'),
     );
+  }
+
+  getTableToolbar() {
+    return new AcceleratorTableToolbar(() => cy.findByTestId('dashboard-table-toolbar'));
   }
 }
 
@@ -135,6 +119,20 @@ class ManageAcceleratorProfile {
     return new TolerationRow(() =>
       this.findTable().find(`[data-label=Key]`).contains(name).parents('tr'),
     );
+  }
+}
+
+class DisableAcceleratorProfileModal extends Modal {
+  constructor() {
+    super('Disable accelerator profile');
+  }
+
+  findDisableButton() {
+    return this.findFooter().findByRole('button', { name: 'Disable' });
+  }
+
+  findCancelButton() {
+    return this.findFooter().findByRole('button', { name: 'Cancel' });
   }
 }
 
@@ -251,3 +249,4 @@ export const createTolerationModal = new TolerationsModal(false);
 export const editTolerationModal = new TolerationsModal(true);
 export const editAcceleratorProfile = new EditAcceleratorProfile();
 export const identifierAcceleratorProfile = new IdentifierAcceleratorProfile();
+export const disableAcceleratorProfileModal = new DisableAcceleratorProfileModal();

--- a/frontend/src/__tests__/cypress/cypress/pages/components/TableToolbar.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/TableToolbar.ts
@@ -1,0 +1,19 @@
+import { Contextual } from './Contextual';
+
+export class TableToolbar extends Contextual<HTMLElement> {
+  private findToggleButton(id: string) {
+    return cy.pfSwitch(id).click();
+  }
+
+  findFilterMenuOption(id: string, name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findToggleButton(id).parents().findByRole('menuitem', { name });
+  }
+
+  findSearchInput(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByLabelText('Search input');
+  }
+
+  findResetButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('button', { name: 'Reset' });
+  }
+}

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -269,6 +269,10 @@ class ModelServingSection {
     return this.find().findByTestId('serving-runtime-table');
   }
 
+  findKServeTableHeaderButton(name: string) {
+    return this.findKServeTable().find('thead').findByRole('button', { name });
+  }
+
   getKServeRow(name: string) {
     return new KServeRow(() =>
       this.findKServeTable().find('[data-label=Name]').contains(name).parents('tr'),
@@ -294,6 +298,10 @@ class ModelServingSection {
 
   findInferenceServiceTable() {
     return cy.findByTestId('inference-service-table');
+  }
+
+  findInferenceServiceTableHeaderButton(name: string) {
+    return this.findInferenceServiceTable().find('thead').findByRole('button', { name });
   }
 
   getInferenceServiceRow(name: string) {

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
@@ -2,12 +2,14 @@ import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 import { DeleteModal } from './components/DeleteModal';
+import { TableToolbar } from './components/TableToolbar';
 
 class NotebookRow extends TableRow {
   findDisplayedSoftware() {
     return this.find().findByTestId('displayed-software');
   }
 }
+class NotebookImageSettingsTableToolbar extends TableToolbar {}
 
 class NotebookImageSettings {
   visit() {
@@ -33,22 +35,8 @@ class NotebookImageSettings {
     return cy.findByTestId('import-new-image');
   }
 
-  // table tool bar
-  findFilterMenuOption(itemLabel: string) {
-    cy.findByTestId('filter-dropdown-select').click();
-    return cy.findByRole('menuitem', { name: itemLabel });
-  }
-
-  findSearchInput() {
-    return cy.findByRole('textbox', { name: 'Search input' });
-  }
-
   findErrorButton() {
     return cy.findByRole('button', { name: 'error icon' });
-  }
-
-  findResetButton() {
-    return cy.findByRole('button', { name: 'Reset' });
   }
 
   findEmptyResults() {
@@ -67,6 +55,10 @@ class NotebookImageSettings {
     return new NotebookRow(() =>
       this.findTable().find('[data-label=Name]').contains(name).parents('tr'),
     );
+  }
+
+  getTableToolbar() {
+    return new NotebookImageSettingsTableToolbar(() => cy.findByTestId('dashboard-table-toolbar'));
   }
 }
 
@@ -109,7 +101,6 @@ class ImportUpdateNotebookImageModal extends Modal {
   }
 
   // Software tab
-
   findSoftwareTab() {
     return this.find().findByTestId('displayed-content-software-tab');
   }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -181,14 +181,14 @@ Cypress.Commands.add('fill', { prevSubject: 'optional' }, (subject, text, option
   return cy.wrap(subject).type(text, options);
 });
 
-Cypress.Commands.add('pfSwitch', (dataId) => {
+Cypress.Commands.add('pfSwitch', { prevSubject: 'optional' }, (subject, dataId) => {
   Cypress.log({ displayName: 'pfSwitch', message: dataId });
-  return cy.findByTestId(dataId).parent();
+  return cy.wrap(subject).findByTestId(dataId).parent();
 });
 
-Cypress.Commands.add('pfSwitchValue', (dataId) => {
+Cypress.Commands.add('pfSwitchValue', { prevSubject: 'optional' }, (subject, dataId) => {
   Cypress.log({ displayName: 'pfSwitchValue', message: dataId });
-  return cy.pfSwitch(dataId).find('[type=checkbox]');
+  return cy.wrap(subject).pfSwitch(dataId).find('[type=checkbox]');
 });
 
 Cypress.Commands.overwriteQuery('findByTestId', function findByTestId(...args) {

--- a/frontend/src/concepts/dashboard/DashboardSearchField.tsx
+++ b/frontend/src/concepts/dashboard/DashboardSearchField.tsx
@@ -33,7 +33,7 @@ const DashboardSearchField: React.FC<DashboardSearchFieldProps> = ({
   onSearchValueChange,
   onSearchTypeChange,
 }) => (
-  <InputGroup>
+  <InputGroup data-testid="dashboard-table-toolbar">
     <InputGroupItem>
       <SimpleDropdownSelect
         aria-label="Filter type"

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfileEnableToggle.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfileEnableToggle.tsx
@@ -43,6 +43,7 @@ const AcceleratorProfileEnableToggle: React.FC<AcceleratorProfileEnableTogglePro
     <>
       <Switch
         aria-label={label}
+        data-testid="enable-switch"
         id={`${name}-enable-switch`}
         isChecked={isEnabled}
         isDisabled={isLoading}
@@ -55,6 +56,7 @@ const AcceleratorProfileEnableToggle: React.FC<AcceleratorProfileEnableTogglePro
         }}
       />
       <DisableAcceleratorProfileModal
+        data-testid="disable-accelerator-profile-modal"
         isOpen={isModalOpen}
         onClose={(confirmStatus) => {
           if (confirmStatus) {

--- a/frontend/src/pages/acceleratorProfiles/screens/list/DisableAcceleratorProfileModal.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/DisableAcceleratorProfileModal.tsx
@@ -16,10 +16,20 @@ const DisableAcceleratorProfileModal: React.FC<DisableAcceleratorProfileModalTyp
     isOpen={isOpen}
     onClose={() => onClose(false)}
     actions={[
-      <Button key="confirm-disable" variant="primary" onClick={() => onClose(true)}>
+      <Button
+        data-testid="disable-button"
+        key="confirm-disable"
+        variant="primary"
+        onClick={() => onClose(true)}
+      >
         Disable
       </Button>,
-      <Button key="cancel" variant="secondary" onClick={() => onClose(false)}>
+      <Button
+        data-testid="cancel-button"
+        key="cancel"
+        variant="secondary"
+        onClick={() => onClose(false)}
+      >
         Cancel
       </Button>,
     ]}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-3818

## Description
This PR aims to update the accelerator profile cypress test. Also added a generic component for filter and search functionality, and applied it to the `NotebookImageSetting` file and `ServingRuntimeList` file. 

## How Has This Been Tested?
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
