### PR TITLE
Implement Status overview donut chart on DW Workload Status page, temporarily remove Status trends chart

### DIFF
--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -51,79 +51,6 @@ export const useDWProjectMetrics = (namespace?: string, refreshRate = 0): DWProj
   };
 };
 
-export type DWWorkloadCurrentMetricsValues = {
-  numJobsActive: number;
-  numJobsSucceeded: number;
-  numJobsFailed: number;
-  numJobsInadmissible: number;
-  numJobsPending: number;
-};
-export type DWWorkloadCurrentMetricType = keyof DWWorkloadCurrentMetricsValues;
-export type DWWorkloadCurrentMetrics = FetchStateObject<{
-  [key in DWWorkloadCurrentMetricType]: FetchStateObject<
-    DWWorkloadCurrentMetricsValues[key] | undefined
-  >;
-}>;
-
-const getDWWorkloadCurrentMetricsQueries = (
-  namespace: string,
-): Record<DWWorkloadCurrentMetricType, string> => ({
-  numJobsActive: `namespace=${namespace}&query=kube_job_status_active`,
-  numJobsSucceeded: `namespace=${namespace}&query=kube_job_status_succeeded`,
-  numJobsFailed: `namespace=${namespace}&query=kube_job_status_failed`,
-  numJobsInadmissible: `namespace=${namespace}&query=kueue_pending_workloads{status='inadmissible'}`,
-  numJobsPending: `namespace=${namespace}&query=kueue_pending_workloads{status!='inadmissible'}`,
-});
-
-// TODO mturley add unit tests for useDWProjectMetrics once RBAC issues are settled and we know these are really the queries we need
-
-export const useDWWorkloadCurrentMetrics = (
-  namespace?: string,
-  refreshRate = 0,
-): DWWorkloadCurrentMetrics => {
-  const queries = namespace ? getDWWorkloadCurrentMetricsQueries(namespace) : undefined;
-  const data: DWWorkloadCurrentMetrics['data'] = {
-    numJobsActive: useMakeFetchObject(
-      usePrometheusNumberValueQuery(queries?.numJobsActive, refreshRate),
-    ),
-    numJobsSucceeded: useMakeFetchObject(
-      usePrometheusNumberValueQuery(queries?.numJobsSucceeded, refreshRate),
-    ),
-    numJobsFailed: useMakeFetchObject(
-      usePrometheusNumberValueQuery(queries?.numJobsFailed, refreshRate),
-    ),
-    numJobsInadmissible: useMakeFetchObject(
-      usePrometheusNumberValueQuery(queries?.numJobsInadmissible, refreshRate),
-    ),
-    numJobsPending: useMakeFetchObject(
-      usePrometheusNumberValueQuery(queries?.numJobsPending, refreshRate),
-    ),
-  };
-  const numJobsActiveRefresh = data.numJobsActive.refresh;
-  const numJobsSucceededRefresh = data.numJobsSucceeded.refresh;
-  const numJobsFailedRefresh = data.numJobsFailed.refresh;
-  const numJobsInadmissibleRefresh = data.numJobsInadmissible.refresh;
-  const numJobsPendingRefresh = data.numJobsPending.refresh;
-  return {
-    data,
-    refresh: React.useCallback(() => {
-      numJobsActiveRefresh();
-      numJobsSucceededRefresh();
-      numJobsFailedRefresh();
-      numJobsInadmissibleRefresh();
-      numJobsPendingRefresh();
-    }, [
-      numJobsActiveRefresh,
-      numJobsSucceededRefresh,
-      numJobsFailedRefresh,
-      numJobsInadmissibleRefresh,
-      numJobsPendingRefresh,
-    ]),
-    loaded: Object.values(data).every(({ loaded }) => loaded),
-    error: Object.values(data).find(({ error }) => !!error)?.error,
-  };
-};
-
 export type DWWorkloadTrendMetricsValues = {
   jobsActiveTrend: PrometheusQueryRangeResultValue[];
   jobsInadmissibleTrend: PrometheusQueryRangeResultValue[];
@@ -145,7 +72,7 @@ const getDWWorkloadTrendMetricsQueries = (
   jobsPendingTrend: `kueue_pending_workloads{status!='inadmissible', namespace='${namespace}'}`,
 });
 
-// TODO mturley add unit tests for useDWProjectMetrics once RBAC issues are settled and we know these are really the queries we need
+// TODO mturley this workloadTrendMetrics is currently unused until RBAC issues are resolved and the DWStatusTrendsChart is restored.
 
 export const useDWWorkloadTrendMetrics = (
   timeframe: TimeframeTitle,

--- a/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
+++ b/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
@@ -9,10 +9,8 @@ import { ProjectsContext, byName } from '~/concepts/projects/ProjectsContext';
 import { useMakeFetchObject } from '~/utilities/useMakeFetchObject';
 import {
   DWProjectMetrics,
-  DWWorkloadCurrentMetrics,
   DWWorkloadTrendMetrics,
   useDWProjectMetrics,
-  useDWWorkloadCurrentMetrics,
   useDWWorkloadTrendMetrics,
 } from '~/api';
 import { RefreshIntervalValue } from '~/concepts/metrics/const';
@@ -24,7 +22,6 @@ type DistributedWorkloadsContextType = {
   clusterQueues: FetchStateObject<ClusterQueueKind[]>;
   workloads: FetchStateObject<WorkloadKind[]>;
   projectMetrics: DWProjectMetrics;
-  workloadCurrentMetrics: DWWorkloadCurrentMetrics;
   workloadTrendMetrics: DWWorkloadTrendMetrics;
   refreshAllData: () => void;
   namespace?: string;
@@ -43,16 +40,6 @@ export const DistributedWorkloadsContext = React.createContext<DistributedWorklo
     data: {
       cpuRequested: DEFAULT_VALUE_FETCH_STATE,
       cpuUtilized: DEFAULT_VALUE_FETCH_STATE,
-    },
-  },
-  workloadCurrentMetrics: {
-    ...DEFAULT_VALUE_FETCH_STATE,
-    data: {
-      numJobsActive: DEFAULT_VALUE_FETCH_STATE,
-      numJobsFailed: DEFAULT_VALUE_FETCH_STATE,
-      numJobsSucceeded: DEFAULT_VALUE_FETCH_STATE,
-      numJobsInadmissible: DEFAULT_VALUE_FETCH_STATE,
-      numJobsPending: DEFAULT_VALUE_FETCH_STATE,
     },
   },
   workloadTrendMetrics: {
@@ -85,7 +72,6 @@ export const DistributedWorkloadsContextProvider =
     const clusterQueues = useMakeFetchObject<ClusterQueueKind[]>(useClusterQueues(refreshRate));
     const workloads = useMakeFetchObject<WorkloadKind[]>(useWorkloads(namespace, refreshRate));
     const projectMetrics = useDWProjectMetrics(namespace, refreshRate);
-    const workloadCurrentMetrics = useDWWorkloadCurrentMetrics(namespace, refreshRate);
 
     const workloadTrendMetrics = useDWWorkloadTrendMetrics(
       currentTimeframe,
@@ -98,23 +84,21 @@ export const DistributedWorkloadsContextProvider =
     const clusterQueuesRefresh = clusterQueues.refresh;
     const workloadsRefresh = workloads.refresh;
     const projectMetricsRefresh = projectMetrics.refresh;
-    const workloadCurrentMetricsRefresh = workloadCurrentMetrics.refresh;
+
     const workloadTrendMetricsRefresh = workloadTrendMetrics.refresh;
     const refreshAllData = React.useCallback(() => {
       clusterQueuesRefresh();
       workloadsRefresh();
       projectMetricsRefresh();
-      workloadCurrentMetricsRefresh();
       workloadTrendMetricsRefresh();
     }, [
       clusterQueuesRefresh,
       workloadsRefresh,
       projectMetricsRefresh,
-      workloadCurrentMetricsRefresh,
       workloadTrendMetricsRefresh,
     ]);
 
-    const fetchError = [clusterQueues, workloads, projectMetrics, workloadCurrentMetrics].find(
+    const fetchError = [clusterQueues, workloads, projectMetrics].find(
       ({ error }) => !!error,
     )?.error;
 
@@ -134,7 +118,6 @@ export const DistributedWorkloadsContextProvider =
           clusterQueues,
           workloads,
           projectMetrics,
-          workloadCurrentMetrics,
           workloadTrendMetrics,
           refreshAllData,
           namespace,

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -1,12 +1,30 @@
 import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';
-import { getStatusInfo } from '~/concepts/distributedWorkloads/utils';
+import { getStatusCounts, getStatusInfo } from '~/concepts/distributedWorkloads/utils';
 
 describe('getStatusInfo', () => {
   it('provides correct info for completed workload', () => {
     const wl = mockWorkloadK8sResource({ k8sName: 'test-workload' });
     const info = getStatusInfo(wl);
-    expect(info?.color).toBe('green');
-    expect(info?.message).toBe('Job finished successfully');
-    expect(info?.status).toBe('Succeeded');
+    expect(info.color).toBe('green');
+    expect(info.message).toBe('Job finished successfully');
+    expect(info.status).toBe('Succeeded');
+  });
+});
+
+describe('getStatusCounts', () => {
+  it('correctly aggregates counts of workload statuses', () => {
+    const workloads = [
+      mockWorkloadK8sResource({ k8sName: 'test-workload' }),
+      mockWorkloadK8sResource({ k8sName: 'test-workload-2' }),
+    ];
+    const statusCounts = getStatusCounts(workloads);
+    expect(statusCounts).toEqual({
+      Inadmissible: 0,
+      Pending: 0,
+      Running: 0,
+      Succeeded: 2,
+      Failed: 0,
+      Unknown: 0,
+    });
   });
 });

--- a/frontend/src/concepts/distributedWorkloads/utils.tsx
+++ b/frontend/src/concepts/distributedWorkloads/utils.tsx
@@ -24,22 +24,47 @@ export type WorkloadStatusInfo = {
   status: WorkloadStatusType;
   message: string;
   color: LabelProps['color'];
+  chartColor: string;
   icon: React.ComponentClass<SVGIconProps>;
 };
 
 export const WorkloadStatusColorAndIcon: Record<
   WorkloadStatusType,
-  Pick<WorkloadStatusInfo, 'color' | 'icon'>
+  Pick<WorkloadStatusInfo, 'color' | 'chartColor' | 'icon'>
 > = {
-  Inadmissible: { color: 'gold', icon: ExclamationTriangleIcon },
-  Pending: { color: 'cyan', icon: PendingIcon },
-  Running: { color: 'blue', icon: InProgressIcon },
-  Succeeded: { color: 'green', icon: CheckCircleIcon },
-  Failed: { color: 'red', icon: ExclamationCircleIcon },
-  Unknown: { color: 'grey', icon: UnknownIcon },
+  Inadmissible: {
+    color: 'gold',
+    chartColor: 'var(--pf-v5-chart-color-gold-300, #F4C145)',
+    icon: ExclamationTriangleIcon,
+  },
+  Pending: {
+    color: 'cyan',
+    chartColor: 'var(--pf-v5-chart-color-cyan-300, #009596)',
+    icon: PendingIcon,
+  },
+  Running: {
+    color: 'blue',
+    chartColor: 'var(--pf-v5-chart-color-blue-300, #06C)',
+    icon: InProgressIcon,
+  },
+  Succeeded: {
+    color: 'green',
+    chartColor: 'var(--pf-v5-chart-color-green-300, #4CB140)',
+    icon: CheckCircleIcon,
+  },
+  Failed: {
+    color: 'red',
+    chartColor: 'var(--pf-chart-color-red-100, #C9190B)',
+    icon: ExclamationCircleIcon,
+  },
+  Unknown: {
+    color: 'grey',
+    chartColor: 'var(--pf-chart-color-black-300, #B8BBBE)',
+    icon: UnknownIcon,
+  },
 };
 
-export const getStatusInfo = (wl: WorkloadKind): WorkloadStatusInfo | null => {
+export const getStatusInfo = (wl: WorkloadKind): WorkloadStatusInfo => {
   const conditions = wl.status?.conditions;
   const knownStatusConditions: Record<WorkloadStatusType, WorkloadCondition | undefined> = {
     Failed: conditions?.find(
@@ -72,4 +97,21 @@ export const getStatusInfo = (wl: WorkloadKind): WorkloadStatusInfo | null => {
     message: knownStatusConditions[statusType]?.message || 'No message',
     ...WorkloadStatusColorAndIcon[statusType],
   };
+};
+
+export type WorkloadStatusCounts = Record<WorkloadStatusType, number>;
+
+export const getStatusCounts = (workloads: WorkloadKind[]): WorkloadStatusCounts => {
+  const statusCounts: WorkloadStatusCounts = {
+    Inadmissible: 0,
+    Pending: 0,
+    Running: 0,
+    Succeeded: 0,
+    Failed: 0,
+    Unknown: 0,
+  };
+  workloads.forEach((wl) => {
+    statusCounts[getStatusInfo(wl).status]++;
+  });
+  return statusCounts;
 };

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWStatusOverviewDonutChart.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWStatusOverviewDonutChart.tsx
@@ -1,23 +1,31 @@
 import * as React from 'react';
 import { Card, CardTitle, CardBody, Bullseye, Spinner } from '@patternfly/react-core';
+import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import {
+  WorkloadStatusColorAndIcon,
+  WorkloadStatusType,
+  getStatusCounts,
+} from '~/concepts/distributedWorkloads/utils';
 
 export const DWStatusOverviewDonutChart: React.FC = () => {
-  const { workloadCurrentMetrics } = React.useContext(DistributedWorkloadsContext);
+  const { workloads } = React.useContext(DistributedWorkloadsContext);
 
-  if (workloadCurrentMetrics.error) {
+  const statusCounts = React.useMemo(() => getStatusCounts(workloads.data), [workloads.data]);
+
+  if (workloads.error) {
     return (
       <Card isFullHeight>
         <EmptyStateErrorMessage
-          title="Error loading current workload status"
-          bodyText={workloadCurrentMetrics.error.message}
+          title="Error loading workloads"
+          bodyText={workloads.error.message}
         />
       </Card>
     );
   }
 
-  if (!workloadCurrentMetrics.loaded) {
+  if (!workloads.loaded) {
     return (
       <Card isFullHeight>
         <Bullseye style={{ minHeight: 150 }}>
@@ -27,21 +35,45 @@ export const DWStatusOverviewDonutChart: React.FC = () => {
     );
   }
 
-  const { numJobsActive, numJobsFailed, numJobsSucceeded, numJobsInadmissible, numJobsPending } =
-    workloadCurrentMetrics.data;
-
   return (
     <Card isFullHeight>
       <CardTitle>Status overview</CardTitle>
-      <CardBody>
-        <h2>TODO status overview donut chart</h2>
-        <ul>
-          <li>Running: {numJobsActive.data}</li>
-          <li>Succeeded: {numJobsSucceeded.data}</li>
-          <li>Failed: {numJobsFailed.data}</li>
-          <li>Inadmissible: {numJobsInadmissible.data}</li>
-          <li>Pending: {numJobsPending.data}</li>
-        </ul>
+      <CardBody style={{ maxHeight: 280 }}>
+        <Bullseye>
+          <ChartDonut
+            ariaDesc="Workload status overview"
+            ariaTitle="Status overview donut chart"
+            constrainToVisibleArea
+            data={Object.keys(statusCounts).map((statusType) => ({
+              x: statusType,
+              y: statusCounts[statusType as WorkloadStatusType],
+            }))}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
+            legendData={(Object.keys(statusCounts) as (keyof typeof statusCounts)[]).map(
+              (statusType) => ({
+                name: `${statusType}: ${statusCounts[statusType]}`,
+              }),
+            )}
+            colorScale={Object.keys(statusCounts).map(
+              (statusType) =>
+                WorkloadStatusColorAndIcon[statusType as WorkloadStatusType].chartColor ||
+                WorkloadStatusColorAndIcon.Unknown.chartColor,
+            )}
+            legendOrientation="vertical"
+            legendPosition="right"
+            name="status-overview"
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 140, // Adjusted to accommodate legend
+              top: 20,
+            }}
+            subTitle="Workloads"
+            title={String(workloads.data.length)}
+            themeColor={ChartThemeColor.multiOrdered}
+            width={300}
+          />
+        </Bullseye>
       </CardBody>
     </Card>
   );

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWStatusTrendsChart.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWStatusTrendsChart.tsx
@@ -3,6 +3,8 @@ import { Card, CardTitle, CardBody, Bullseye, Spinner } from '@patternfly/react-
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
 
+// TODO mturley this is unused until RBAC issues are resolved, we should remove it
+
 export const DWStatusTrendsChart: React.FC = () => {
   const { workloadTrendMetrics } = React.useContext(DistributedWorkloadsContext);
 

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWWorkloadsTable.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWWorkloadsTable.tsx
@@ -54,8 +54,7 @@ export const DWWorkloadsTable: React.FC = () => {
     {
       field: 'status',
       label: 'Status',
-      sortable: (a, b) =>
-        (getStatusInfo(a)?.status || '').localeCompare(getStatusInfo(b)?.status || ''),
+      sortable: (a, b) => getStatusInfo(a).status.localeCompare(getStatusInfo(b).status),
     },
     {
       field: 'created',
@@ -87,9 +86,6 @@ export const DWWorkloadsTable: React.FC = () => {
           data-id="workload-table"
           rowRenderer={(workload) => {
             const statusInfo = getStatusInfo(workload);
-            if (!statusInfo) {
-              return <Tr />;
-            }
             return (
               <Tr key={workload.metadata?.uid}>
                 <Td dataLabel="Name">{workload.metadata?.name || 'Unnamed'}</Td>

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/GlobalDistributedWorkloadsWorkloadStatusTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/GlobalDistributedWorkloadsWorkloadStatusTab.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { DWStatusOverviewDonutChart } from './DWStatusOverviewDonutChart';
-import { DWStatusTrendsChart } from './DWStatusTrendsChart';
 import { DWWorkloadsTable } from './DWWorkloadsTable';
 
 const GlobalDistributedWorkloadsWorkloadStatusTab: React.FC = () => (
   <Grid hasGutter>
-    <GridItem span={6}>
+    <GridItem span={12}>
       <DWStatusOverviewDonutChart />
-    </GridItem>
-    <GridItem span={6}>
-      <DWStatusTrendsChart />
     </GridItem>
     <GridItem span={12}>
       <DWWorkloadsTable />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes [RHOAIENG-2881](https://issues.redhat.com/browse/RHOAIENG-2881)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

* Replaces the old Prometheus-based `workloadCurrentMetrics` with aggregate status counts based on the conditions of Workload CRs. A new `getStatusCounts` helper uses the `getStatusInfo` helper introduced by https://github.com/opendatahub-io/odh-dashboard/pull/2610 for this.
* Temporarily removes the "Status trends" card from the page since it has been descoped from GA due to RBAC issues.
   * Leaves the unused `workloadTrendMetrics` fetching code in place for now because it will be reused when the RBAC issues are resolved. A comment to this effect has been added.

cc @xianli123 

<img width="1723" alt="Screenshot 2024-03-21 at 12 10 30 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/3d307ca4-0864-4811-801f-022a4ac1a77e">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested that the donut chart and card layout look correct and accurately represent the data.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Unit test added for the new `getStatusCounts` helper.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
