### PR TITLE
Add authorization to kserve

### DIFF
--- a/backend/src/routes/api/dsci/index.ts
+++ b/backend/src/routes/api/dsci/index.ts
@@ -1,0 +1,12 @@
+import { getClusterInitialization } from '../../../utils/dsci';
+import { KubeFastifyInstance } from '../../../types';
+import { secureRoute } from '../../../utils/route-security';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.get(
+    '/status',
+    secureRoute(fastify)(async () => {
+      return getClusterInitialization(fastify);
+    }),
+  );
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -31,6 +31,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableBiasMetrics: boolean;
       disablePerformanceMetrics: boolean;
       disableKServe: boolean;
+      disableKServeAuth: boolean;
       disableModelMesh: boolean;
       disableAcceleratorProfiles: boolean;
       disablePipelineExperiments: boolean;
@@ -945,7 +946,7 @@ type ComponentNames =
   | 'workbenches';
 
 export type DataScienceClusterKindStatus = {
-  conditions: [];
+  conditions: K8sCondition[];
   installedComponents: { [key in ComponentNames]?: boolean };
   phase?: string;
 };
@@ -958,6 +959,21 @@ export type DataScienceClusterKind = K8sResourceCommon & {
 export type DataScienceClusterList = {
   kind: 'DataScienceClusterList';
   items: DataScienceClusterKind[];
+};
+
+export type DataScienceClusterInitializationKindStatus = {
+  conditions: K8sCondition[];
+  phase?: string;
+};
+
+export type DataScienceClusterInitializationKind = K8sResourceCommon & {
+  spec: unknown; // we should never need to look into this
+  status: DataScienceClusterInitializationKindStatus;
+};
+
+export type DataScienceClusterInitializationList = {
+  kind: 'DataScienceClusterInitializationList';
+  items: DataScienceClusterInitializationKind[];
 };
 
 export type SubscriptionStatusData = {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -56,6 +56,7 @@ export const blankDashboardCR: DashboardConfig = {
       disablePerformanceMetrics: false,
       disablePipelines: false,
       disableKServe: false,
+      disableKServeAuth: false,
       disableModelMesh: false,
       disableAcceleratorProfiles: false,
       disablePipelineExperiments: true,

--- a/backend/src/utils/dsci.ts
+++ b/backend/src/utils/dsci.ts
@@ -1,0 +1,25 @@
+import {
+  DataScienceClusterInitializationKind,
+  DataScienceClusterInitializationKindStatus,
+  DataScienceClusterInitializationList,
+  KubeFastifyInstance,
+} from '../types';
+import { createCustomError } from './requestUtils';
+
+export const getClusterInitialization = async (
+  fastify: KubeFastifyInstance,
+): Promise<DataScienceClusterInitializationKindStatus> => {
+  const result: DataScienceClusterInitializationKind | null = await fastify.kube.customObjectsApi
+    .listClusterCustomObject('dscinitialization.opendatahub.io', 'v1', 'dscinitializations')
+    .then((res) => (res.body as DataScienceClusterInitializationList).items[0])
+    .catch((e) => {
+      fastify.log.error(`Failure to fetch dsci: ${e.response.body}`);
+      return null;
+    });
+
+  if (!result) {
+    throw createCustomError('DSCI Unavailable', 'Unable to get status', 404);
+  }
+
+  return result.status;
+};

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -25,6 +25,7 @@ The following are a list of features that are supported, along with there defaul
 | disableProjectSharing        | false   | Disables Project Sharing from Data Science Projects.                                                 |
 | disableCustomServingRuntimes | false   | Disables Custom Serving Runtimes from the Admin Panel.                                               |
 | disableKServe                | false   | Disables the ability to select KServe as a Serving Platform.                                         |
+| disableKServeAuth            | false   | Disables the ability to use auth in KServe.                                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
 | modelMetricsNamespace        | false   | Enables the namespace in which the Model Serving Metrics' Prometheus Operator is installed.          |

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -14,6 +14,7 @@ type MockDashboardConfigType = {
   disableModelServing?: boolean;
   disableCustomServingRuntimes?: boolean;
   disableKServe?: boolean;
+  disableKServeAuth?: boolean;
   disableModelMesh?: boolean;
   disableAcceleratorProfiles?: boolean;
   disablePerformanceMetrics?: boolean;
@@ -37,6 +38,7 @@ export const mockDashboardConfig = ({
   disableCustomServingRuntimes = false,
   disablePipelines = false,
   disableKServe = false,
+  disableKServeAuth = false,
   disableModelMesh = false,
   disableAcceleratorProfiles = false,
   disablePerformanceMetrics = false,
@@ -73,6 +75,7 @@ export const mockDashboardConfig = ({
       disableBiasMetrics,
       disablePerformanceMetrics,
       disableKServe,
+      disableKServeAuth,
       disableModelMesh,
       disableAcceleratorProfiles,
       disablePipelineExperiments,

--- a/frontend/src/__mocks__/mockDsciStatus.ts
+++ b/frontend/src/__mocks__/mockDsciStatus.ts
@@ -1,0 +1,37 @@
+import { StackCapability } from '~/concepts/areas/types';
+import { DataScienceClusterInitializationKindStatus, K8sCondition } from '~/k8sTypes';
+
+export type MockDsciStatus = {
+  conditions?: K8sCondition[];
+  requiredCapabilities?: StackCapability[];
+  phase?: string;
+};
+
+export const mockDsciStatus = ({
+  conditions = [],
+  requiredCapabilities = [],
+  phase = 'Ready',
+}: MockDsciStatus): DataScienceClusterInitializationKindStatus => ({
+  conditions: [
+    ...[
+      {
+        lastHeartbeatTime: '2023-10-20T11:45:04Z',
+        lastTransitionTime: '2023-10-20T11:45:04Z',
+        message: 'Reconcile completed successfully',
+        reason: 'ReconcileCompleted',
+        status: 'True',
+        type: 'ReconcileComplete',
+      },
+      ...requiredCapabilities.map((capability) => ({
+        lastHeartbeatTime: '2023-10-20T11:45:04Z',
+        lastTransitionTime: '2023-10-20T11:45:04Z',
+        message: `Capability ${capability} installed`,
+        reason: 'ReconcileCompleted',
+        status: 'True',
+        type: capability,
+      })),
+    ],
+    ...conditions,
+  ],
+  phase,
+});

--- a/frontend/src/__mocks__/mockInferenceServiceModalData.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceModalData.ts
@@ -21,6 +21,9 @@ export const mockInferenceServiceModalData = ({
   },
   minReplicas = 1,
   maxReplicas = 1,
+  externalRoute = false,
+  tokenAuth = false,
+  tokens = [],
 }: MockResourceConfigType): CreatingInferenceServiceObject => ({
   name,
   project,
@@ -29,4 +32,7 @@ export const mockInferenceServiceModalData = ({
   format,
   minReplicas,
   maxReplicas,
+  externalRoute,
+  tokenAuth,
+  tokens,
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -85,6 +85,14 @@ class InferenceServiceModal extends Modal {
     return this.find().findByTestId('existing-data-connection-radio');
   }
 
+  findExternalRouteError() {
+    return this.find().findByTestId('external-route-no-token-alert');
+  }
+
+  findServiceAccountNameInput() {
+    return this.find().findByTestId('service-account-form-name');
+  }
+
   findNewDataConnectionOption() {
     return this.find().findByTestId('new-data-connection-radio');
   }

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -52,6 +52,30 @@ describe('assembleInferenceService', () => {
     expect(inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe(
       undefined,
     );
+    expect(inferenceService.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(
+      undefined,
+    );
+    expect(
+      inferenceService.metadata.annotations?.['serving.knative.openshift.io/enablePassthrough'],
+    ).toBe('true');
+    expect(inferenceService.metadata.annotations?.['sidecar.istio.io/inject']).toBe('true');
+    expect(inferenceService.metadata.annotations?.['sidecar.istio.io/rewriteAppHTTPProbers']).toBe(
+      'true',
+    );
+  });
+
+  it('should have the right annotations when creating for Kserve with auth', async () => {
+    const inferenceService = assembleInferenceService(
+      mockInferenceServiceModalData({ tokenAuth: true }),
+    );
+
+    expect(inferenceService.metadata.annotations).toBeDefined();
+    expect(inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe(
+      undefined,
+    );
+    expect(inferenceService.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(
+      'true',
+    );
     expect(
       inferenceService.metadata.annotations?.['serving.knative.openshift.io/enablePassthrough'],
     ).toBe('true');

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -24,7 +24,8 @@ export const assembleInferenceService = (
   inferenceService?: InferenceServiceKind,
   acceleratorState?: AcceleratorProfileState,
 ): InferenceServiceKind => {
-  const { storage, format, servingRuntimeName, project, maxReplicas, minReplicas } = data;
+  const { storage, format, servingRuntimeName, project, maxReplicas, minReplicas, tokenAuth } =
+    data;
   const name = editName || translateDisplayNameForK8s(data.name);
   const { path, dataConnection } = storage;
   const dataConnectionKey = secretKey || dataConnection;
@@ -44,6 +45,7 @@ export const assembleInferenceService = (
                   'serving.knative.openshift.io/enablePassthrough': 'true',
                   'sidecar.istio.io/inject': 'true',
                   'sidecar.istio.io/rewriteAppHTTPProbers': 'true',
+                  ...(tokenAuth && { 'security.opendatahub.io/enable-auth': 'true' }),
                 }),
           },
         },
@@ -82,6 +84,7 @@ export const assembleInferenceService = (
                   'serving.knative.openshift.io/enablePassthrough': 'true',
                   'sidecar.istio.io/inject': 'true',
                   'sidecar.istio.io/rewriteAppHTTPProbers': 'true',
+                  ...(tokenAuth && { 'security.opendatahub.io/enable-auth': 'true' }),
                 }),
           },
         },
@@ -103,6 +106,10 @@ export const assembleInferenceService = (
           },
         },
       };
+
+  if (!tokenAuth && updateInferenceService.metadata.annotations) {
+    delete updateInferenceService.metadata.annotations['serving.knative.openshift.io/token-auth'];
+  }
 
   if (!isModelMesh && tolerations.length !== 0) {
     updateInferenceService.spec.predictor.tolerations = tolerations;

--- a/frontend/src/concepts/areas/AreaContext.tsx
+++ b/frontend/src/concepts/areas/AreaContext.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
 import useFetchDscStatus from '~/concepts/areas/useFetchDscStatus';
-import { DataScienceClusterKindStatus } from '~/k8sTypes';
+import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
+import {
+  DataScienceClusterInitializationKindStatus,
+  DataScienceClusterKindStatus,
+} from '~/k8sTypes';
 
 type AreaContextState = {
   /**
@@ -10,10 +14,12 @@ type AreaContextState = {
    *   TODO: Remove when we no longer want to support v1
    */
   dscStatus: DataScienceClusterKindStatus | null;
+  dsciStatus: DataScienceClusterInitializationKindStatus | null;
 };
 
 export const AreaContext = React.createContext<AreaContextState>({
   dscStatus: null,
+  dsciStatus: null,
 });
 
 type AreaContextProps = {
@@ -21,9 +27,13 @@ type AreaContextProps = {
 };
 
 const AreaContextProvider: React.FC<AreaContextProps> = ({ children }) => {
-  const [dscStatus, loaded, error] = useFetchDscStatus();
+  const [dscStatus, loadedDsc, errorDsc] = useFetchDscStatus();
+  const [dsciStatus, loadedDsci, errorDsci] = useFetchDsciStatus();
 
-  const contextValue = React.useMemo(() => ({ dscStatus }), [dscStatus]);
+  const error = errorDsc || errorDsci;
+  const loaded = loadedDsc && loadedDsci;
+
+  const contextValue = React.useMemo(() => ({ dscStatus, dsciStatus }), [dscStatus, dsciStatus]);
   if (error) {
     return (
       <Alert isInline variant="danger" title="Problem loading component state">

--- a/frontend/src/concepts/areas/__tests__/useFetchDsciStatus.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/useFetchDsciStatus.spec.ts
@@ -1,0 +1,102 @@
+import { act } from '@testing-library/react';
+import axios from 'axios';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';
+import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+const mockAxios = jest.mocked(axios.get);
+
+describe('useFetchDscStatus', () => {
+  it('should return successful dsci status', async () => {
+    const mockedResponse = { data: mockDsciStatus({}) };
+    mockAxios.mockResolvedValue(mockedResponse);
+
+    const renderResult = testHook(useFetchDsciStatus)();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith(`/api/dsci/status`);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    //  wait for update
+    await renderResult.waitForNextUpdate();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(mockedResponse.data, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    //refresh
+    mockAxios.mockResolvedValue({ data: mockedResponse.data });
+    await act(() => renderResult.result.current[3]());
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(`/api/dsci/status`);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle 404 as an error', async () => {
+    const error = {
+      response: {
+        status: 404,
+      },
+    };
+
+    mockAxios.mockRejectedValue(error);
+    const renderResult = testHook(useFetchDsciStatus)();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith(`/api/dsci/status`);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    await act(() => renderResult.result.current[3]());
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(`/api/dsci/status`);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, true));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+
+  it('should handle other errors and rethrow', async () => {
+    const error = (message: string) => ({
+      response: {
+        data: {
+          message,
+        },
+      },
+    });
+
+    mockAxios.mockRejectedValue(error('error1'));
+    const renderResult = testHook(useFetchDsciStatus)();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith(`/api/dsci/status`);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(mockAxios).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    mockAxios.mockRejectedValue(error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(mockAxios).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledWith(`/api/dsci/status`);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
 import { StackComponent } from '~/concepts/areas/types';
 import { SupportedAreasStateMap } from '~/concepts/areas/const';
+import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';
 
 describe('isAreaAvailable', () => {
   describe('v1 Operator (deprecated)', () => {
@@ -10,6 +11,7 @@ describe('isAreaAvailable', () => {
       const isAvailable = isAreaAvailable(
         SupportedArea.DS_PIPELINES,
         mockDashboardConfig({ disablePipelines: false }).spec,
+        null,
         null,
       );
 
@@ -24,6 +26,7 @@ describe('isAreaAvailable', () => {
         SupportedArea.DS_PIPELINES,
         mockDashboardConfig({ disablePipelines: true }).spec,
         null,
+        null,
       );
 
       expect(isAvailable.status).not.toBe(true);
@@ -36,6 +39,7 @@ describe('isAreaAvailable', () => {
       const isAvailable = isAreaAvailable(
         SupportedArea.WORKBENCHES,
         mockDashboardConfig({}).spec,
+        null,
         null,
       );
 
@@ -53,6 +57,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: false }).spec,
           mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: true } }),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).toBe(true);
@@ -66,6 +71,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: false }).spec,
           mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: false } }),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
@@ -79,6 +85,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: true }).spec,
           mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: true } }),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
@@ -92,6 +99,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: true }).spec,
           mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: false } }),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
@@ -105,6 +113,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.WORKBENCHES,
           mockDashboardConfig({}).spec,
           mockDscStatus({ installedComponents: { [StackComponent.WORKBENCHES]: true } }),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).toBe(true);
@@ -118,6 +127,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.WORKBENCHES,
           mockDashboardConfig({}).spec,
           mockDscStatus({ installedComponents: { [StackComponent.WORKBENCHES]: false } }),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
@@ -143,6 +153,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.CUSTOM_RUNTIMES,
           mockDashboardConfig({ disableModelServing: false }).spec,
           mockDscStatus({}),
+          mockDsciStatus({}),
         );
 
         expect(isAvailableReliantCustomRuntimes.status).toBe(true);
@@ -166,6 +177,7 @@ describe('isAreaAvailable', () => {
           SupportedArea.CUSTOM_RUNTIMES,
           mockDashboardConfig({ disableModelServing: true }).spec,
           mockDscStatus({}),
+          mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -1,4 +1,4 @@
-import { StackComponent, SupportedArea, SupportedAreasState } from './types';
+import { StackCapability, StackComponent, SupportedArea, SupportedAreasState } from './types';
 
 export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.BYON]: {
@@ -28,6 +28,11 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.K_SERVE]: {
     featureFlags: ['disableKServe'],
     requiredComponents: [StackComponent.K_SERVE],
+  },
+  [SupportedArea.K_SERVE_AUTH]: {
+    featureFlags: ['disableKServeAuth'],
+    reliantAreas: [SupportedArea.K_SERVE],
+    requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
   },
   [SupportedArea.MODEL_MESH]: {
     featureFlags: ['disableModelMesh'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -11,6 +11,7 @@ export type IsAreaAvailableStatus = {
   featureFlags: { [key in FeatureFlag]?: 'on' | 'off' } | null; // simplified. `disableX` flags are weird to read
   reliantAreas: { [key in SupportedArea]?: boolean } | null; // only needs 1 to be true
   requiredComponents: { [key in StackComponent]?: boolean } | null;
+  requiredCapabilities: { [key in StackCapability]?: boolean } | null;
 };
 
 /** All areas that we need to support in some fashion or another */
@@ -36,6 +37,7 @@ export enum SupportedArea {
   MODEL_SERVING = 'model-serving-shell',
   CUSTOM_RUNTIMES = 'custom-serving-runtimes',
   K_SERVE = 'kserve',
+  K_SERVE_AUTH = 'kserve-auth',
   MODEL_MESH = 'model-mesh',
   BIAS_METRICS = 'bias-metrics',
   PERFORMANCE_METRICS = 'performance-metrics',
@@ -64,6 +66,12 @@ export enum StackComponent {
   MODEL_REGISTRY = 'model-registry-operator',
 }
 
+/** Capabilities of the Operator. Part of the DSCI Status. */
+export enum StackCapability {
+  SERVICE_MESH = 'CapabilityServiceMesh',
+  SERVICE_MESH_AUTHZ = 'CapabilityServiceMeshAuthorization',
+}
+
 // TODO: Support extra operators, like the pipelines operator -- maybe as a "external dependency need?"
 type SupportedComponentFlagValue = {
   /**
@@ -75,6 +83,12 @@ type SupportedComponentFlagValue = {
    * TODO: support AND -- maybe double array?
    */
   reliantAreas?: SupportedArea[];
+  /**
+   * Required capabilities supported by the Operator. The list is "AND"-ed together.
+   * If the Operator does not support the capability, the area is not available.
+   * The capabilities are retrieved from the DSCI status.
+   */
+  requiredCapabilities?: StackCapability[];
 } & EitherOrBoth<
   {
     /**

--- a/frontend/src/concepts/areas/useFetchDsciStatus.ts
+++ b/frontend/src/concepts/areas/useFetchDsciStatus.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import { DataScienceClusterInitializationKindStatus } from '~/k8sTypes';
+
+/**
+ * Should only return `null` when on v1 Operator.
+ */
+const fetchDsciStatus = (): Promise<DataScienceClusterInitializationKindStatus | null> => {
+  const url = '/api/dsci/status';
+  return axios
+    .get(url)
+    .then((response) => response.data)
+    .catch((e) => {
+      if (e.response.status === 404) {
+        return null;
+      }
+      throw new Error(e.response.data.message);
+    });
+};
+
+const useFetchDsciStatus = (): FetchState<DataScienceClusterInitializationKindStatus | null> =>
+  useFetchState(fetchDsciStatus, null);
+
+export default useFetchDsciStatus;

--- a/frontend/src/concepts/areas/useIsAreaAvailable.ts
+++ b/frontend/src/concepts/areas/useIsAreaAvailable.ts
@@ -7,14 +7,15 @@ import { isAreaAvailable } from './utils';
 
 const useIsAreaAvailable = (area: SupportedArea): IsAreaAvailableStatus => {
   const { dashboardConfig } = useAppContext();
-  const { dscStatus } = React.useContext(AreaContext);
+  const { dscStatus, dsciStatus } = React.useContext(AreaContext);
 
   const dashboardConfigSpecSafe = useDeepCompareMemoize(dashboardConfig.spec);
   const dscStatusSafe = useDeepCompareMemoize(dscStatus);
+  const dsciStatusSafe = useDeepCompareMemoize(dsciStatus);
 
   return React.useMemo(
-    () => isAreaAvailable(area, dashboardConfigSpecSafe, dscStatusSafe),
-    [area, dashboardConfigSpecSafe, dscStatusSafe],
+    () => isAreaAvailable(area, dashboardConfigSpecSafe, dscStatusSafe, dsciStatusSafe),
+    [area, dashboardConfigSpecSafe, dscStatusSafe, dsciStatusSafe],
   );
 };
 

--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -1,4 +1,8 @@
-import { DashboardConfigKind, DataScienceClusterKindStatus } from '~/k8sTypes';
+import {
+  DashboardConfigKind,
+  DataScienceClusterInitializationKindStatus,
+  DataScienceClusterKindStatus,
+} from '~/k8sTypes';
 import { IsAreaAvailableStatus, FeatureFlag, SupportedArea } from './types';
 import { SupportedAreasStateMap } from './const';
 
@@ -27,14 +31,17 @@ export const isAreaAvailable = (
   area: SupportedArea,
   dashboardConfigSpec: DashboardConfigKind['spec'],
   dscStatus: DataScienceClusterKindStatus | null,
+  dsciStatus: DataScienceClusterInitializationKindStatus | null,
 ): IsAreaAvailableStatus => {
-  const { featureFlags, requiredComponents, reliantAreas } = SupportedAreasStateMap[area];
+  const { featureFlags, requiredComponents, reliantAreas, requiredCapabilities } =
+    SupportedAreasStateMap[area];
 
   const reliantAreasState = reliantAreas
     ? reliantAreas.reduce<IsAreaAvailableStatus['reliantAreas']>(
         (areaStates, currentArea) => ({
           ...areaStates,
-          [currentArea]: isAreaAvailable(currentArea, dashboardConfigSpec, dscStatus).status,
+          [currentArea]: isAreaAvailable(currentArea, dashboardConfigSpec, dscStatus, dsciStatus)
+            .status,
         }),
         {},
       )
@@ -65,10 +72,32 @@ export const isAreaAvailable = (
     ? Object.values(requiredComponentsState).every((v) => v)
     : true;
 
+  const requiredCapabilitiesState =
+    requiredCapabilities && dsciStatus
+      ? requiredCapabilities.reduce<IsAreaAvailableStatus['requiredCapabilities']>(
+          (acc, capability) => ({
+            ...acc,
+            [capability]: dsciStatus.conditions.some(
+              (c) => c.type === capability && c.status === 'True',
+            ),
+          }),
+          {},
+        )
+      : null;
+
+  const hasMetRequiredCapabilities = requiredCapabilitiesState
+    ? Object.values(requiredCapabilitiesState).every((v) => v)
+    : true;
+
   return {
-    status: hasMetReliantAreas && hasMetFeatureFlags && hasMetRequiredComponents,
+    status:
+      hasMetReliantAreas &&
+      hasMetFeatureFlags &&
+      hasMetRequiredComponents &&
+      hasMetRequiredCapabilities,
     reliantAreas: reliantAreasState,
     featureFlags: featureFlagState,
     requiredComponents: requiredComponentsState,
+    requiredCapabilities: requiredCapabilitiesState,
   };
 };

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -384,11 +384,16 @@ export type SupportedModelFormats = {
   autoSelect?: boolean;
 };
 
+export type InferenceServiceAnnotations = Partial<{
+  'security.opendatahub.io/enable-auth': string;
+}>;
+
 export type InferenceServiceKind = K8sResourceCommon & {
   metadata: {
     name: string;
     namespace: string;
-    annotations?: DisplayNameAnnotations &
+    annotations?: InferenceServiceAnnotations &
+      DisplayNameAnnotations &
       EitherOrNone<
         {
           'serving.kserve.io/deploymentMode': 'ModelMesh';
@@ -1131,6 +1136,7 @@ export type DashboardCommonConfig = {
   disableBiasMetrics: boolean;
   disablePerformanceMetrics: boolean;
   disableKServe: boolean;
+  disableKServeAuth: boolean;
   disableModelMesh: boolean;
   disableAcceleratorProfiles: boolean;
   // TODO Temp feature flag - remove with https://issues.redhat.com/browse/RHOAIENG-3826
@@ -1198,6 +1204,11 @@ export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> 
 export type DataScienceClusterKindStatus = {
   conditions: K8sCondition[];
   installedComponents: { [key in StackComponent]?: boolean };
+  phase?: string;
+};
+
+export type DataScienceClusterInitializationKindStatus = {
+  conditions: K8sCondition[];
   phase?: string;
 };
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceListView.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceListView.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ToolbarItem } from '@patternfly/react-core';
-import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
-import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import { InferenceServiceKind, SecretKind, ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import DashboardSearchField, { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import { getInferenceServiceDisplayName, getInferenceServiceProjectDisplayName } from './utils';
@@ -11,15 +10,16 @@ import ServeModelButton from './ServeModelButton';
 type InferenceServiceListViewProps = {
   inferenceServices: InferenceServiceKind[];
   servingRuntimes: ServingRuntimeKind[];
+  refresh: () => void;
+  filterTokens: (servingRuntime?: string | undefined) => SecretKind[];
 };
 
 const InferenceServiceListView: React.FC<InferenceServiceListViewProps> = ({
   inferenceServices: unfilteredInferenceServices,
   servingRuntimes,
+  refresh,
+  filterTokens,
 }) => {
-  const {
-    inferenceServices: { refresh },
-  } = React.useContext(ModelServingContext);
   const { projects } = React.useContext(ProjectsContext);
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.NAME);
   const [search, setSearch] = React.useState('');
@@ -52,7 +52,10 @@ const InferenceServiceListView: React.FC<InferenceServiceListViewProps> = ({
       clearFilters={resetFilters}
       servingRuntimes={servingRuntimes}
       inferenceServices={filteredInferenceServices}
-      refresh={refresh}
+      refresh={() => {
+        refresh();
+      }}
+      filterTokens={filterTokens}
       enablePagination
       toolbarContent={
         <>

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import { Table } from '~/components/table';
-import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, SecretKind, ServingRuntimeKind } from '~/k8sTypes';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import { isModelMesh } from '~/pages/modelServing/utils';
@@ -12,17 +12,19 @@ import { getGlobalInferenceServiceColumns, getProjectInferenceServiceColumns } f
 import DeleteInferenceServiceModal from './DeleteInferenceServiceModal';
 
 type InferenceServiceTableProps = {
-  clearFilters?: () => void;
   inferenceServices: InferenceServiceKind[];
   servingRuntimes: ServingRuntimeKind[];
   refresh: () => void;
+  clearFilters?: () => void;
+  filterTokens?: (servingRuntime?: string | undefined) => SecretKind[];
 } & Partial<Pick<React.ComponentProps<typeof Table>, 'enablePagination' | 'toolbarContent'>>;
 
 const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
-  clearFilters,
   inferenceServices,
   servingRuntimes,
   refresh,
+  filterTokens,
+  clearFilters,
   enablePagination,
   toolbarContent,
 }) => {
@@ -34,6 +36,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
   const mappedColumns = isGlobal
     ? getGlobalInferenceServiceColumns(projects)
     : getProjectInferenceServiceColumns();
+
   return (
     <>
       <Table
@@ -100,6 +103,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
               : undefined,
             secrets: [],
           },
+          secrets: filterTokens ? filterTokens(editInferenceService?.metadata.name) : [],
         }}
         onClose={(edited) => {
           if (edited) {

--- a/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
@@ -13,8 +13,18 @@ import ModelServingLoading from './ModelServingLoading';
 
 const ModelServingGlobal: React.FC = () => {
   const {
-    servingRuntimes: { data: servingRuntimes, loaded: servingRuntimesLoaded },
-    inferenceServices: { data: inferenceServices, loaded: inferenceServicesLoaded },
+    servingRuntimes: {
+      data: servingRuntimes,
+      loaded: servingRuntimesLoaded,
+      refresh: refreshServingRuntimes,
+    },
+    inferenceServices: {
+      data: inferenceServices,
+      loaded: inferenceServicesLoaded,
+      refresh: refreshInferenceServices,
+    },
+    serverSecrets: { refresh: refreshServerSecrets },
+    filterTokens,
     project: currentProject,
     preferredProject,
     projects,
@@ -62,6 +72,12 @@ const ModelServingGlobal: React.FC = () => {
       <InferenceServiceListView
         inferenceServices={inferenceServices}
         servingRuntimes={servingRuntimes}
+        refresh={() => {
+          refreshInferenceServices();
+          refreshServingRuntimes();
+          refreshServerSecrets();
+        }}
+        filterTokens={filterTokens}
       />
     </ApplicationsPage>
   );

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('~/pages/modelServing/useServingRuntimes', () => ({
 const useServingRuntimesMock = jest.mocked(useServingRuntimes);
 
 describe('ManageInferenceServiceModal', () => {
-  it('should not rerender serving runtime selection', async () => {
+  it('should not re-render serving runtime selection', async () => {
     useServingRuntimesMock.mockReturnValue([
       [
         mockServingRuntimeK8sResource({ name: 'runtime1', displayName: 'Runtime 1' }),

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -27,6 +27,8 @@ const KServeInferenceServiceTable: React.FC = () => {
     servingRuntimes: { refresh: refreshServingRuntime },
     dataConnections: { refresh: refreshDataConnections },
     inferenceServices: { data: inferenceServices, refresh: refreshInferenceServices },
+    serverSecrets: { refresh: refreshServerSecrets },
+    filterTokens,
   } = React.useContext(ProjectDetailsContext);
 
   return (
@@ -67,6 +69,7 @@ const KServeInferenceServiceTable: React.FC = () => {
             secrets: [],
           },
           inferenceServiceEditInfo: editKserveResources?.inferenceService,
+          secrets: filterTokens(editKserveResources?.inferenceService.metadata.name),
         }}
         onClose={(submit: boolean) => {
           setEditKServeResources(undefined);
@@ -74,6 +77,7 @@ const KServeInferenceServiceTable: React.FC = () => {
             refreshServingRuntime();
             refreshInferenceServices();
             refreshDataConnections();
+            refreshServerSecrets();
           }
         }}
       />

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
@@ -13,6 +13,9 @@ import InferenceServiceTableRow from '~/pages/modelServing/screens/global/Infere
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import ServingRuntimeDetails from '~/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails';
 import ResourceTr from '~/components/ResourceTr';
+import ServingRuntimeTokensTable from '~/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable';
+import { isInferenceServiceTokenEnabled } from '~/pages/modelServing/screens/projects/utils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 type KServeInferenceServiceTableRowProps = {
   obj: InferenceServiceKind;
@@ -33,6 +36,8 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
   onEditKServe,
   onDeleteKServe,
 }) => {
+  const isAuthorinoEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status;
+
   const [isExpanded, setExpanded] = React.useState(false);
   const {
     servingRuntimes: { data: servingRuntimes },
@@ -98,6 +103,21 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
               {servingRuntime && (
                 <StackItem>
                   <ServingRuntimeDetails obj={servingRuntime} isvc={obj} />
+                </StackItem>
+              )}
+              {isAuthorinoEnabled && (
+                <StackItem>
+                  <DescriptionList>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Token authorization</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <ServingRuntimeTokensTable
+                          obj={obj}
+                          isTokenEnabled={isInferenceServiceTokenEnabled(obj)}
+                        />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
                 </StackItem>
               )}
             </Stack>

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable.tsx
@@ -3,11 +3,11 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import { Table } from '~/components/table';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { tokenColumns } from '~/pages/modelServing/screens/global/data';
-import { ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import ServingRuntimeTokenTableRow from '~/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokenTableRow';
 
 type ServingRuntimeTokensTableProps = {
-  obj: ServingRuntimeKind;
+  obj: ServingRuntimeKind | InferenceServiceKind;
   isTokenEnabled: boolean;
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  FormGroup,
+  FormSection,
+  Popover,
+  Stack,
+  StackItem,
+  getUniqueId,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import {
+  CreatingInferenceServiceObject,
+  CreatingServingRuntimeObject,
+} from '~/pages/modelServing/screens/types';
+
+import ServingRuntimeTokenSection from './ServingRuntimeTokenSection';
+
+type AuthServingRuntimeSectionProps = {
+  data: CreatingServingRuntimeObject | CreatingInferenceServiceObject;
+  setData:
+    | UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>
+    | UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+  allowCreate: boolean;
+  publicRoute?: boolean;
+};
+
+const AuthServingRuntimeSection: React.FC<AuthServingRuntimeSectionProps> = ({
+  data,
+  setData,
+  allowCreate,
+  publicRoute,
+}) => {
+  const createNewToken = React.useCallback(() => {
+    const name = 'default-name';
+    const duplicated = data.tokens.filter((token) => token.name === name);
+    const duplicatedError = duplicated.length > 0 ? 'Duplicates are invalid' : '';
+    setData('tokens', [
+      ...data.tokens,
+      {
+        name,
+        uuid: getUniqueId('ml'),
+        error: duplicatedError,
+      },
+    ]);
+  }, [data.tokens, setData]);
+
+  return (
+    <Stack>
+      {!allowCreate && (
+        <StackItem>
+          <Popover
+            showClose
+            bodyContent={
+              publicRoute
+                ? 'Model route and token authorization can only be changed by administrator users.'
+                : 'Token authorization can only be changed by administrator users and component Authorino needs to be installed.'
+            }
+          >
+            <Button variant="link" icon={<OutlinedQuestionCircleIcon />} isInline>
+              {publicRoute
+                ? "Why can't I change the model route and token authorization fields?"
+                : "Why can't I change the token authorization field?"}
+            </Button>
+          </Popover>
+        </StackItem>
+      )}
+      {publicRoute && (
+        <StackItem>
+          <FormSection title="Model route" titleElement="div">
+            <FormGroup>
+              <Checkbox
+                label="Make deployed models available through an external route"
+                id="alt-form-checkbox-route"
+                data-testid="alt-form-checkbox-route"
+                name="alt-form-checkbox-route"
+                isChecked={data.externalRoute}
+                isDisabled={!allowCreate}
+                onChange={(e, check) => {
+                  setData('externalRoute', check);
+                  if (check && allowCreate) {
+                    setData('tokenAuth', check);
+                    if (data.tokens.length === 0) {
+                      createNewToken();
+                    }
+                  }
+                }}
+              />
+            </FormGroup>
+          </FormSection>
+        </StackItem>
+      )}
+      <StackItem>
+        <ServingRuntimeTokenSection
+          data={data}
+          setData={setData}
+          allowCreate={allowCreate}
+          createNewToken={createNewToken}
+        />
+      </StackItem>
+      {((publicRoute && data.externalRoute && !data.tokenAuth) ||
+        (!publicRoute && !data.tokenAuth)) && (
+        <StackItem>
+          <Alert
+            id="external-route-no-token-alert"
+            data-testid="external-route-no-token-alert"
+            variant="warning"
+            isInline
+            title="Making models available by external routes without requiring authorization can lead to security vulnerabilities."
+          />
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+export default AuthServingRuntimeSection;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenInput.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenInput.tsx
@@ -13,14 +13,17 @@ import {
 import { ExclamationCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import {
+  CreatingInferenceServiceObject,
   CreatingServingRuntimeObject,
   ServingRuntimeToken,
 } from '~/pages/modelServing/screens/types';
 import { translateDisplayNameForK8s } from '~/pages/projects/utils';
 
 type ServingRuntimeTokenInputProps = {
-  data: CreatingServingRuntimeObject;
-  setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
+  data: CreatingServingRuntimeObject | CreatingInferenceServiceObject;
+  setData:
+    | UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>
+    | UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
   token: ServingRuntimeToken;
   disabled?: boolean;
 };

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
@@ -11,12 +11,17 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import IndentSection from '~/pages/projects/components/IndentSection';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
-import { CreatingServingRuntimeObject } from '~/pages/modelServing/screens/types';
+import {
+  CreatingInferenceServiceObject,
+  CreatingServingRuntimeObject,
+} from '~/pages/modelServing/screens/types';
 import ServingRuntimeTokenInput from './ServingRuntimeTokenInput';
 
 type ServingRuntimeTokenSectionProps = {
-  data: CreatingServingRuntimeObject;
-  setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
+  data: CreatingServingRuntimeObject | CreatingInferenceServiceObject;
+  setData:
+    | UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>
+    | UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
   allowCreate: boolean;
   createNewToken: () => void;
 };

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -68,6 +68,9 @@ export type CreatingInferenceServiceObject = {
   format: InferenceServiceFormat;
   maxReplicas: number;
   minReplicas: number;
+  externalRoute: boolean;
+  tokenAuth: boolean;
+  tokens: ServingRuntimeToken[];
 };
 
 export enum InferenceServiceStorageType {

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -57,6 +57,8 @@ spec:
                       type: boolean
                     disableKServe:
                       type: boolean
+                    disableKServeAuth:
+                      type: boolean
                     disableModelMesh:
                       type: boolean
                     disableAcceleratorProfiles:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -23,6 +23,7 @@ spec:
     disablePerformanceMetrics: true
     disableAcceleratorProfiles: true
     disableKServe: false
+    disableKServeAuth: false
     disableModelMesh: false
     disableDistributedWorkloads: true
   notebookController:

--- a/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
@@ -22,6 +22,7 @@ spec:
     disablePerformanceMetrics: false
     disableAcceleratorProfiles: false
     disableKServe: false
+    disableKServeAuth: false
     disableModelMesh: false
     disableDistributedWorkloads: true
     disableModelRegistry: true


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-2223

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add the following changes:

<details>
<summary>
Add section to enable route protection in kserve
</summary>

<img width="1728" alt="Screenshot 2024-04-02 at 23 29 17" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/cd517b13-70ad-4e8c-9f51-3ebeaef419e2">
</details>

<details>
<summary>
New token section in kserve deployments
</summary>

<img width="1430" alt="Screenshot 2024-04-02 at 23 30 02" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/0c9c4cfe-bfd2-4774-9654-846b3601a976">
</details>


<details>
<summary>
Check of Authorino availability to enable/disable the feature in kserve
</summary>

<img width="1709" alt="Screenshot 2024-04-03 at 12 45 29" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/4a048680-cb90-4d42-bc85-13f770e7817b">
</details>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Local environment

1. Go to `backend/src/utils/dsci.ts` and add the following code in line 15
<details>
  <summary>Code</summary>
  
  ```js
  const result: DataScienceClusterInitializationKind | null = await fastify.kube.customObjectsApi
    .listClusterCustomObject('dscinitialization.opendatahub.io', 'v1', 'dscinitializations')
    .then((res) => (res.body as DataScienceClusterInitializationList).items[0])
    .then((dsci) => {
      return {
        ...dsci,
        status: {
          ...dsci.status,
          conditions: [
            {
              lastHeartbeatTime: '2024-04-03T18:25:35Z',
              lastTransitionTime: '2024-04-03T18:25:35Z',
              message: 'Initializing DSCInitialization resource',
              reason: 'ReconcileInit',
              status: 'Unknown',
              type: 'ReconcileComplete',
            },
            {
              lastHeartbeatTime: '2024-04-03T18:25:35Z',
              lastTransitionTime: '2024-04-03T18:25:35Z',
              message: 'Initializing DSCInitialization resource',
              reason: 'ReconcileInit',
              status: 'False',
              type: 'Available',
            },
            {
              lastHeartbeatTime: '2024-04-03T18:25:35Z',
              lastTransitionTime: '2024-04-03T18:25:35Z',
              message: 'Initializing DSCInitialization resource',
              reason: 'ReconcileInit',
              status: 'True',
              type: 'Progressing',
            },
            {
              lastHeartbeatTime: '2024-04-03T18:25:35Z',
              lastTransitionTime: '2024-04-03T18:25:35Z',
              message: 'Initializing DSCInitialization resource',
              reason: 'ReconcileInit',
              status: 'False',
              type: 'Degraded',
            },
            {
              lastHeartbeatTime: '2024-04-03T18:25:35Z',
              lastTransitionTime: '2024-04-03T18:25:35Z',
              message: 'Initializing DSCInitialization resource',
              reason: 'ReconcileInit',
              status: 'Unknown',
              type: 'Upgradeable',
            },
            {
              lastHeartbeatTime: '2024-04-03T19:11:08Z',
              lastTransitionTime: '2024-04-03T18:49:23Z',
              message: 'Service Mesh configured properly',
              reason: 'Configured',
              status: 'True',
              type: 'CapabilityServiceMesh',
            },
            {
              lastHeartbeatTime: '2024-04-03T19:11:09Z',
              lastTransitionTime: '2024-04-03T19:10:27Z',
              message:
                'Authorino operator is not installed on the cluster, skipping authorization capability',
              reason: 'MissingOperator',
              status: 'True',
              type: 'CapabilityServiceMeshAuthorization',
            },
          ],
        },
      };
    })
    .catch((e) => {
      fastify.log.error(`Failure to fetch dsci: ${e.response.body}`);
      return null;
    });
  ```
</details>

(note: you should add the feature flag and the crd with oc apply)

2. Go to model serving section and deploy a new model
3. You should see the auth token section
4. Deploy the model and check that you cannot access the model without the bearer token (you should have the authorino operator installed)
5. Add the bearer token to the request, it should work now
6. Edit the model and uncheck the auth token
7. You should. be able to do a request without authentication
8. Delete the block of code you've added
9. Token section should be hidden

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Testing added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
