### PR TITLE
[RHOAIENG-4738] default & optional create run parameters

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -37,9 +37,9 @@ const RunForm: React.FC<RunFormProps> = ({ data, runType, onValueChange }) => {
     (version: PipelineVersionKFv2 | undefined) =>
       onValueChange(
         'params',
-        Object.keys(getInputDefinitionParams(version) || {}).reduce(
-          (acc: RuntimeConfigParameters, parameter) => {
-            acc[parameter] = paramsRef.current?.[parameter] ?? '';
+        Object.entries(getInputDefinitionParams(version) || {}).reduce(
+          (acc: RuntimeConfigParameters, [paramKey, paramValue]) => {
+            acc[paramKey] = paramsRef.current?.[paramKey] ?? paramValue.defaultValue ?? '';
             return acc;
           },
           {},

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection/ParamsSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection/ParamsSection.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Alert, FormGroup, FormSection, HelperText, TextInput } from '@patternfly/react-core';
+import {
+  Alert,
+  FormGroup,
+  FormHelperText,
+  FormSection,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
 import {
   CreateRunPageSections,
   runPageSectionTitles,
@@ -43,7 +51,7 @@ export const ParamsSection: React.FC<ParamsSectionProps> = ({
 
     const formGroups = Object.entries(runParams).map(([label, value]) => {
       const inputDefinitionParams = getInputDefinitionParams(version);
-      const parameterType = inputDefinitionParams?.[label]?.parameterType;
+      const { parameterType, isOptional, description } = inputDefinitionParams?.[label] || {};
       const inputProps = {
         value,
         id: label,
@@ -74,8 +82,21 @@ export const ParamsSection: React.FC<ParamsSectionProps> = ({
       }
 
       return (
-        <FormGroup key={label} label={label} fieldId={label} isRequired>
+        <FormGroup
+          key={label}
+          label={label}
+          fieldId={label}
+          isRequired={!isOptional}
+          data-testid={`${label}-form-group`}
+        >
           {input}
+          {description && (
+            <FormHelperText data-testid={`${label}-helper-text`}>
+              <HelperText>
+                <HelperTextItem>{description}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
       );
     });

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -40,13 +40,21 @@ const runTypeSafeDates = (runType: RunFormData['runType']): boolean =>
     isValidDate(runType.data.end) &&
     isStartBeforeEnd(runType.data.start, runType.data.end));
 
-export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData =>
-  !!formData.nameDesc.name &&
-  !!formData.pipeline &&
-  !!formData.version &&
-  Object.values(formData.params || {}).every((param) => param !== '') &&
-  runTypeSafeData(formData.runType) &&
-  runTypeSafeDates(formData.runType);
+export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData => {
+  const inputDefinitionParams = getInputDefinitionParams(formData.version);
+  const hasRequiredInputParams = Object.entries(formData.params || {}).every(
+    ([paramKey, paramValue]) => inputDefinitionParams?.[paramKey].isOptional || paramValue !== '',
+  );
+
+  return (
+    !!formData.nameDesc.name &&
+    !!formData.pipeline &&
+    !!formData.version &&
+    hasRequiredInputParams &&
+    runTypeSafeData(formData.runType) &&
+    runTypeSafeDates(formData.runType)
+  );
+};
 
 export const isFilledRunFormDataExperiment = (formData: RunFormData): formData is SafeRunFormData =>
   isFilledRunFormData(formData) && !!formData.experiment;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -27,17 +27,16 @@ export type PodStatus = {
 };
 
 export const renderDetailItems = (details: DetailItem[]): React.ReactNode => (
-  <DescriptionList
-    isHorizontal
-    horizontalTermWidthModifier={{
-      default: '15ch',
-    }}
-  >
+  <DescriptionList isHorizontal horizontalTermWidthModifier={{ lg: '22ch', md: '15ch' }}>
     {details.map((detail) => (
       <DescriptionListGroup key={detail.key} data-testid={`detail-item-${detail.key}`}>
         <DescriptionListTerm>{detail.key}</DescriptionListTerm>
         <DescriptionListDescription data-testid="detail-item-value">
-          {detail.value}
+          {!detail.value && detail.value !== 0 ? (
+            <span className="pf-v5-u-disabled-color-100">No value</span>
+          ) : (
+            detail.value
+          )}
         </DescriptionListDescription>
       </DescriptionListGroup>
     ))}

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -255,8 +255,12 @@ export enum TriggerStrategy {
   ALL_UPSTREAM_TASKS_COMPLETED = 'ALL_UPSTREAM_TASKS_COMPLETED',
 }
 
+// https://github.com/kubeflow/pipelines/blob/cc971c962596afab4d5d544c466836ea3ee2656d/api/v2alpha1/pipeline_spec.proto#L197
 export type ParameterKFV2 = {
   parameterType: InputDefinitionParameterType;
+  defaultValue?: RuntimeConfigParamValue;
+  isOptional?: boolean;
+  description?: string;
 };
 
 export type ParametersKF = Record<string, ParameterKFV2>;
@@ -353,7 +357,7 @@ export type UrlKF = {
   pipeline_url: string;
 };
 
-export type RuntimeConfigParamValue = string | number | boolean | object | Array<object>;
+export type RuntimeConfigParamValue = string | number | boolean | object | Array<object> | null;
 export type RuntimeConfigParameters = Record<string, RuntimeConfigParamValue>;
 
 export type PipelineSpecRuntimeConfig = {


### PR DESCRIPTION
Closes: [RHOAIENG-4738](https://issues.redhat.com/browse/RHOAIENG-4738)

## Description
Updates pipeline run parameter inputs to allow for descriptions to take form in helper text, `isOptional` to toggle isRequired for `FormGroup`s, and `defaultValue` to pre-populate parameter input values of all types without interfering with the pre-population used when cloning (aka, only for net-new creations).

Also, for description lists for post-creation display of input parameters, since values are possibly optional now, `No value` is now displayed next to labels of parameters with empty values. This was discussed with PF design as a solution instead of just showing whitespace next to labels (cc @yannnz).
<img width="563" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/664be4c8-4029-4d74-9a1c-c3f29de5abfa">


## How Has This Been Tested?
Added a cypress test which verifies the creation of a run with default values, optional parameters, and some with descriptions. Also tested manually with YAML files that possess `inputDefinitions` with `defaultValue`, `isOptional`, and `description`.

## Test Impact
Added cypress test to cover new input parameter features.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
