### PR TITLE
Added no-only-tests eslint rule

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -19,6 +19,7 @@
     "react-hooks",
     "eslint-plugin-react-hooks",
     "import",
+    "no-only-tests",
     "no-relative-import-paths",
     "prettier"
   ],
@@ -68,6 +69,7 @@
     "react/no-unused-prop-types": "error",
     "arrow-body-style": "error",
     "curly": "error",
+    "no-only-tests/no-only-tests": "error",
     "@typescript-eslint/default-param-last": "error",
     "@typescript-eslint/dot-notation": ["error", { "allowKeywords": true }],
     "@typescript-eslint/lines-between-class-members": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -117,6 +117,7 @@
         "eslint-plugin-cypress": "^2.15.1",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsx-a11y": "^6.8.0",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-no-relative-import-paths": "^1.5.2",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
@@ -9668,6 +9669,15 @@
       "optional": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "optional": true,
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-no-relative-import-paths": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,6 +154,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^29.4.3",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-4575

## Description
utilize a new eslint rule to prevent  committing test code containing `.only`
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test:lint
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
