### PR TITLE
fix(overview): Don't show pipeline compatibility error in notebooks card

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/NotebooksCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/NotebooksCard.tsx
@@ -20,8 +20,7 @@ import { useAccessReview } from '~/api';
 import { AccessReviewResource } from '~/pages/projects/screens/detail/const';
 import { ProjectObjectType, SectionType, typedEmptyImage } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import NotebooksCardItems from '~/pages/projects/screens/detail/overview/trainModels/NotebooksCardItems';
-import EnsureCompatiblePipelineServer from '~/concepts/pipelines/EnsureCompatiblePipelineServer';
+import NotebooksCardItems from './NotebooksCardItems';
 import MetricsContents from './MetricsContents';
 
 const NotebooksCard: React.FC = () => {
@@ -100,46 +99,39 @@ const NotebooksCard: React.FC = () => {
         popoverBodyContent="Creating a workbench allows you to add a Jupyter notebook to your project."
       >
         <CardBody>
-          <EnsureCompatiblePipelineServer>
-            <Flex
-              gap={{ default: 'gapMd' }}
-              flexWrap={{ default: 'nowrap' }}
-              alignItems={{ default: 'alignItemsFlexStart' }}
-            >
-              <FlexItem>
-                <img
-                  src={typedEmptyImage(ProjectObjectType.project)}
-                  alt=""
-                  style={{ width: 200 }}
-                />
-              </FlexItem>
-              <FlexItem flex={{ default: 'flex_1' }}>
-                <Flex gap={{ default: 'gapMd' }}>
-                  <TextContent>
-                    <Text component="small">
-                      A workbench is an isolated area where you can work with models in your
-                      preferred IDE, such as a Jupyter notebook. You can add accelerators and data
-                      connections, create pipelines, and configure cluster storage in your
-                      workbench.
-                    </Text>
-                  </TextContent>
-                  <Button
-                    variant={ButtonVariant.primary}
-                    onClick={() => navigate(`/projects/${currentProject.metadata.name}/spawner`)}
+          <Flex
+            gap={{ default: 'gapMd' }}
+            flexWrap={{ default: 'nowrap' }}
+            alignItems={{ default: 'alignItemsFlexStart' }}
+          >
+            <FlexItem>
+              <img src={typedEmptyImage(ProjectObjectType.project)} alt="" style={{ width: 200 }} />
+            </FlexItem>
+            <FlexItem flex={{ default: 'flex_1' }}>
+              <Flex gap={{ default: 'gapMd' }}>
+                <TextContent>
+                  <Text component="small">
+                    A workbench is an isolated area where you can work with models in your preferred
+                    IDE, such as a Jupyter notebook. You can add accelerators and data connections,
+                    create pipelines, and configure cluster storage in your workbench.
+                  </Text>
+                </TextContent>
+                <Button
+                  variant={ButtonVariant.primary}
+                  onClick={() => navigate(`/projects/${currentProject.metadata.name}/spawner`)}
+                >
+                  <Flex
+                    gap={{ default: 'gapMd' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    flexWrap={{ default: 'nowrap' }}
                   >
-                    <Flex
-                      gap={{ default: 'gapMd' }}
-                      alignItems={{ default: 'alignItemsCenter' }}
-                      flexWrap={{ default: 'nowrap' }}
-                    >
-                      <FlexItem>Create a workbench</FlexItem>
-                      <ArrowRightIcon />
-                    </Flex>
-                  </Button>
-                </Flex>
-              </FlexItem>
-            </Flex>
-          </EnsureCompatiblePipelineServer>
+                    <FlexItem>Create a workbench</FlexItem>
+                    <ArrowRightIcon />
+                  </Flex>
+                </Button>
+              </Flex>
+            </FlexItem>
+          </Flex>
         </CardBody>
       </OverviewCard>
     );


### PR DESCRIPTION
Closes: [RHOAIENG-4847](https://issues.redhat.com/browse/RHOAIENG-4847)

## Description
Remove the check for pipeline server compatibility from the notebooks overview card

## How Has This Been Tested?
Tested manually on a server with an incompatible pipeline server version.

## Test Impact
None

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
