### PR TITLE
fix(projects list): fix style issue on striped rows, add default sort

### DIFF
--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -56,6 +56,7 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({ allowCreate, scope })
       <Table
         enablePagination
         variant="compact"
+        defaultSortColumn={3}
         data={filteredProjects}
         hasNestedHeader
         columns={columns}

--- a/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
@@ -88,7 +88,10 @@ const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
               {loaded ? (
                 <>
                   {notebookState ? (
-                    <Td dataLabel="workbenchName" className="odh-project-table__workbench-column">
+                    <Td
+                      dataLabel="workbenchName"
+                      style={{ paddingLeft: 'var(--pf-v5-global--spacer--sm)' }}
+                    >
                       <NotebookRouteLink
                         label={getNotebookDisplayName(notebookState.notebook)}
                         notebook={notebookState.notebook}


### PR DESCRIPTION
Closes: [RHOAIENG-4853](https://issues.redhat.com/browse/RHOAIENG-4853)

## Description
Fixes padding on the first column of a striped row. Since it is the first column in the row, PF adds a larger padding which we don't want.
Sets the default sort column to the project name.

## How Has This Been Tested?
Manual testing

## Test Impact
None

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
