### PR TITLE
Update PipelineRuns Cypress test to account for sorting and filtering

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Experiments.cy.ts
@@ -75,7 +75,11 @@ describe('Experiments', () => {
 
       // Verify only rows with the typed experiment name exist
       experimentsTabs.getActiveExperimentsTable().findRows().should('have.length', 1);
-      experimentsTabs.getActiveExperimentsTable().getRowByName('Test experiment 2');
+      experimentsTabs
+        .getActiveExperimentsTable()
+        .getRowByName('Test experiment 2')
+        .find()
+        .should('exist');
     });
 
     it('archive a single experiment', () => {

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -68,10 +68,10 @@ describe('Pipeline create runs', () => {
 
   it('renders the page with scheduled and active runs table data', () => {
     pipelineRunsGlobal.findSchedulesTab().click();
-    pipelineRunJobTable.getRowByName('Test job');
+    pipelineRunJobTable.getRowByName('Test job').find().should('exist');
 
     pipelineRunsGlobal.findActiveRunsTab().click();
-    activeRunsTable.getRowByName('Test run');
+    activeRunsTable.getRowByName('Test run').find().should('exist');
   });
 
   describe('Runs', () => {

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
@@ -35,7 +35,7 @@ describe('Pipelines', () => {
 
   it('renders the page with pipelines table data', () => {
     pipelinesTable.find();
-    pipelinesTable.getRowByName('Test pipeline');
+    pipelinesTable.getRowByName('Test pipeline').find().should('exist');
   });
 
   it('incompatible dpsa version shows error', () => {
@@ -113,7 +113,7 @@ describe('Pipelines', () => {
     });
 
     // Verify the uploaded pipeline is in the table
-    pipelinesTable.getRowByName('New pipeline');
+    pipelinesTable.getRowByName('New pipeline').find().should('exist');
   });
 
   it('imports a new pipeline by url', () => {
@@ -160,7 +160,7 @@ describe('Pipelines', () => {
     cy.wait('@refreshPipelines');
 
     // Verify the uploaded pipeline is in the table
-    pipelinesTable.getRowByName('New pipeline');
+    pipelinesTable.getRowByName('New pipeline').find().should('exist');
   });
 
   it('uploads a new pipeline version', () => {
@@ -219,7 +219,7 @@ describe('Pipelines', () => {
 
     // Verify the uploaded pipeline version is in the table
     pipelinesTable.getRowByName('Test pipeline').toggleExpandByIndex(0);
-    pipelinesTable.getRowByName('New pipeline version');
+    pipelinesTable.getRowByName('New pipeline version').find().should('exist');
   });
 
   it('imports a new pipeline version by url', () => {
@@ -263,7 +263,7 @@ describe('Pipelines', () => {
 
     // Verify the uploaded pipeline version is in the table
     pipelinesTable.getRowByName('Test pipeline').toggleExpandByIndex(0);
-    pipelinesTable.getRowByName('New pipeline version');
+    pipelinesTable.getRowByName('New pipeline version').find().should('exist');
   });
 
   it('delete a single pipeline', () => {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
@@ -27,6 +27,30 @@ class PipelineRunFilterBar extends PipelineFilterBar {
     return cy.findByTestId('runtime-status-dropdown');
   }
 
+  findSortButtonForActive(name: string) {
+    return this.findActiveRunsTable().find('thead').findByRole('button', { name });
+  }
+
+  private findActiveRunsTable() {
+    return cy.findByTestId('active-runs-table');
+  }
+
+  findSortButtonForArchive(name: string) {
+    return this.findArchiveRunsTable().find('thead').findByRole('button', { name });
+  }
+
+  private findArchiveRunsTable() {
+    return cy.findByTestId('archived-runs-table');
+  }
+
+  findSortButtonforSchedules(name: string) {
+    return this.findSchedulesTable().find('thead').findByRole('button', { name });
+  }
+
+  private findSchedulesTable() {
+    return cy.findByTestId('schedules-table');
+  }
+
   selectStatusByName(name: string) {
     this.findStatusSelect().findDropdownItem(name).click();
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-3819](https://issues.redhat.com/browse/RHOAIENG-3819)

## Description
This PR validates that the Archived runs table filtering, searching and sorting functionality works properly, and that the Active and Scheduled runs table sorting functionality works. 
<!--- I have noted a TODO on line 585 regarding the “filter by start date.” Using the .clear() causes the entire table to clear, and not just the input field. Possible bug, and I’ve left it commented out for now. (FIXED)  -->

## How Has This Been Tested?
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
