### PR TITLE
feat(dw): add empty state and placeholders

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
@@ -120,8 +120,7 @@ describe('Workload Metrics', () => {
     globalDistributedWorkloads.visit();
 
     cy.url().should('include', '/projectMetrics/test-project');
-    // TODO mturley replace this with real identifiable text on the loaded tab when it is completed
-    cy.findByText('TODO tab content for project metrics -- these are placeholders').should('exist');
+    cy.findByText('Top resource-consuming distributed workloads').should('exist');
   });
 
   it('Tabs navigate to corresponding routes and render their contents', () => {
@@ -134,8 +133,7 @@ describe('Workload Metrics', () => {
 
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/projectMetrics/test-project');
-    // TODO mturley replace this with real identifiable text on the loaded tab when it is completed
-    cy.findByText('TODO tab content for project metrics -- these are placeholders').should('exist');
+    cy.findByText('Top resource-consuming distributed workloads').should('exist');
   });
 
   it('Changing the project and navigating between tabs or to the root of the page retains the new project', () => {
@@ -177,5 +175,31 @@ describe('Workload Metrics', () => {
 
     cy.findByLabelText('Workload status tab').click();
     cy.findByText('No workloads match your filters').should('exist');
+  });
+
+  it('Should render the projects metrics with empty workload state', () => {
+    initIntercepts({ hasWorkloads: false });
+    globalDistributedWorkloads.visit();
+
+    cy.findByLabelText('Project metrics tab').click();
+
+    cy.findByText('Resource Usage').should('exist');
+
+    cy.findByText('Top resource-consuming distributed workloads')
+      .closest('.dw-section-card')
+      .within(() => {
+        cy.findByText('No distributed workloads');
+      });
+    cy.findByText('Distributed workload resource metrics')
+      .closest('.dw-section-card')
+      .within(() => {
+        cy.findByText('No distributed workloads');
+      });
+    cy.findByText('Resource Usage')
+      .closest('.dw-section-card')
+      .within(() => {
+        //Resource Usage shows chart even if empty workload\
+        cy.findByText('Charts Placeholder');
+      });
   });
 });

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye, Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
+import { ResourceUsage } from './sections/ResourceUsage';
+import { TopResourceConsumingWorkloads } from './sections/TopResourceConsumingWorkloads';
+import { WorkloadResourceMetrics } from './sections/WorkloadResourceMetrics';
+import { DWSectionCard } from './sections/DWSectionCard';
 
 const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
   const { projectCurrentMetrics } = React.useContext(DistributedWorkloadsContext);
@@ -28,9 +32,39 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
   // eslint-disable-next-line no-console
   console.log({ topResourceConsumingWorkloads });
 
+  //TODO: need 'no quota' logic
+  // if (false) {
+  //   return (
+  //     <EmptyState>
+  //       <EmptyStateHeader
+  //         titleText="Quota is not set"
+  //         headingLevel="h4"
+  //         icon={<EmptyStateIcon icon={WrenchIcon} />}
+  //       />
+  //       <EmptyStateBody>Select another project or set the quota for this project.</EmptyStateBody>
+  //     </EmptyState>
+  //   );
+  // }
+
   return (
     <>
-      <h1>TODO tab content for project metrics -- these are placeholders</h1>
+      <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
+        <FlexItem>
+          <DWSectionCard title="Resource Usage" content={<ResourceUsage />} />
+        </FlexItem>
+        <FlexItem>
+          <DWSectionCard
+            title="Top resource-consuming distributed workloads"
+            content={<TopResourceConsumingWorkloads />}
+          />
+        </FlexItem>
+        <FlexItem>
+          <DWSectionCard
+            title="Distributed workload resource metrics"
+            content={<WorkloadResourceMetrics />}
+          />
+        </FlexItem>
+      </Flex>
     </>
   );
 };

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/DWSectionCard.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/DWSectionCard.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Card, CardTitle, CardHeader, Divider } from '@patternfly/react-core';
+
+export const DWSectionCard: React.FC<{ title: string; content: React.ReactNode }> = ({
+  title,
+  content,
+}) => (
+  <Card isFullHeight className="dw-section-card">
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+    </CardHeader>
+    <Divider />
+    <Card>{content}</Card>
+  </Card>
+);

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/ResourceUsage.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/ResourceUsage.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { Card, CardTitle } from '@patternfly/react-core';
+import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import { ErrorWorkloadState, LoadingWorkloadState } from './SharedStates';
+
+export const ResourceUsage: React.FC = () => {
+  const { workloads } = React.useContext(DistributedWorkloadsContext);
+  if (workloads.error) {
+    return <ErrorWorkloadState message={workloads.error.message} />;
+  }
+
+  if (!workloads.loaded) {
+    return <LoadingWorkloadState />;
+  }
+
+  return (
+    <Card isPlain>
+      <CardTitle>Charts Placeholder</CardTitle>
+    </Card>
+  );
+};

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/SharedStates.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/SharedStates.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  Card,
+  Bullseye,
+  Spinner,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  CardBody,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
+
+export const NoWorkloadState: React.FC = () => (
+  <CardBody>
+    <EmptyState>
+      <EmptyStateHeader
+        titleText="No distributed workloads"
+        headingLevel="h4"
+        icon={<EmptyStateIcon icon={CubesIcon} />}
+      />
+      <EmptyStateBody>
+        Select another project or create a distributed workload in the selected project.
+      </EmptyStateBody>
+    </EmptyState>
+  </CardBody>
+);
+
+export const ErrorWorkloadState: React.FC<{ message: string }> = ({ message }) => (
+  <CardBody>
+    <EmptyStateErrorMessage title="Error loading workloads" bodyText={message} />
+  </CardBody>
+);
+
+export const LoadingWorkloadState: React.FC = () => (
+  <Card isFullHeight>
+    <Bullseye style={{ minHeight: 150 }}>
+      <Spinner />
+    </Bullseye>
+  </Card>
+);

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Card, CardTitle } from '@patternfly/react-core';
+import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import { ErrorWorkloadState, LoadingWorkloadState, NoWorkloadState } from './SharedStates';
+
+export const TopResourceConsumingWorkloads: React.FC = () => {
+  const { workloads } = React.useContext(DistributedWorkloadsContext);
+
+  if (workloads.error) {
+    return <ErrorWorkloadState message={workloads.error.message} />;
+  }
+
+  if (!workloads.loaded) {
+    return <LoadingWorkloadState />;
+  }
+
+  if (!workloads.data.length) {
+    return <NoWorkloadState />;
+  }
+
+  return (
+    <Card isPlain>
+      <CardTitle>Charts Placeholder</CardTitle>
+    </Card>
+  );
+};

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetrics.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetrics.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Card, CardTitle } from '@patternfly/react-core';
+import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import { ErrorWorkloadState, LoadingWorkloadState, NoWorkloadState } from './SharedStates';
+
+export const WorkloadResourceMetrics: React.FC = () => {
+  const { workloads } = React.useContext(DistributedWorkloadsContext);
+
+  if (workloads.error) {
+    return <ErrorWorkloadState message={workloads.error.message} />;
+  }
+
+  if (!workloads.loaded) {
+    return <LoadingWorkloadState />;
+  }
+
+  if (!workloads.data.length) {
+    return <NoWorkloadState />;
+  }
+
+  return (
+    <Card isPlain>
+      <CardTitle>Charts Placeholder</CardTitle>
+    </Card>
+  );
+};


### PR DESCRIPTION
 Closes: #https://issues.redhat.com/browse/RHOAIENG-4746

## Description
Add empty state, error state, loading state, and placeholders where we don't have the data/charts implemented yet

Showing multiple states (manually manipulated code to do so):
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/d7c8bef4-36ef-4bd5-b253-1defbd76bc0b)

With a project that has no workloads:
<img width="839" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/5322142/0656a103-1ed7-4541-8958-5c5af8fed587">

A project with workloads:
<img width="840" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/5322142/166d0756-7d3c-4283-988a-879d781573e1">

No quota:
<img width="841" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/5322142/4e889a56-8f07-4202-a920-3e717e7083c3">

no project (already existed, will show selector when merged with the "move project selector" PR)
<img width="1185" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/5322142/0caf7c76-1581-48c0-97cb-036d4b59eb2c">



## How Has This Been Tested?
tested manually loading data with and without workload data

## Test Impact
added tests to make sure the various empty states are showing up

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ x] The developer has manually tested the changes and verified that the changes work
- [ x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
