### PR TITLE
Remove collapsible borders and fix typo

### DIFF
--- a/frontend/src/concepts/design/CollapsibleSection.tsx
+++ b/frontend/src/concepts/design/CollapsibleSection.tsx
@@ -29,12 +29,6 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
   return (
     <div
       style={{
-        background: open ? undefined : 'var(--pf-v5-global--BackgroundColor--100)',
-        border:
-          open || showChildrenWhenClosed
-            ? undefined
-            : `1px solid ${sectionTypeBorderColor(sectionType)}`,
-        borderRadius: 16,
         padding: open ? undefined : 'var(--pf-v5-global--spacer--md)',
       }}
     >

--- a/frontend/src/concepts/design/CollapsibleSection.tsx
+++ b/frontend/src/concepts/design/CollapsibleSection.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { Button, Flex, FlexItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
-import { SectionType, sectionTypeBorderColor } from './utils';
 
 interface CollapsibleSectionProps {
-  sectionType: SectionType;
   initialOpen?: boolean;
   title: string;
   children?: React.ReactNode;
@@ -14,7 +12,6 @@ interface CollapsibleSectionProps {
 }
 
 const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
-  sectionType,
   initialOpen = true,
   title,
   children,

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsList.tsx
@@ -67,7 +67,7 @@ const DataConnectionsList: React.FC = () => {
         emptyState={
           <EmptyDetailsView
             title="Start by adding a data connection"
-            description="Adding a data connection to your project allows you toconnect data inputs to your workbenches."
+            description="Adding a data connection to your project allows you to connect data inputs to your workbenches."
             iconImage={typedEmptyImage(ProjectObjectType.dataConnection)}
             imageAlt="add a data connection"
             allowCreate={rbacLoaded && allowCreate}

--- a/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
@@ -19,7 +19,6 @@ const ConfigurationSection: React.FC = () => {
 
   return (
     <CollapsibleSection
-      sectionType={SectionType.setup}
       title="Project configuration"
       data-testid="section-config"
       onOpenChange={setOpen}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/NoProjectServingEnabledSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/NoProjectServingEnabledSection.tsx
@@ -5,11 +5,7 @@ import OverviewCard from '~/pages/projects/screens/detail/overview/components/Ov
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
 
 const NoProjectServingEnabledSection: React.FC = () => (
-  <CollapsibleSection
-    sectionType={SectionType.training}
-    title="Serve models"
-    data-testid="section-model-server"
-  >
+  <CollapsibleSection title="Serve models" data-testid="section-model-server">
     <FlexItem data-testid="no-model-serving-platform-selected">
       <OverviewCard
         objectType={ProjectObjectType.modelServer}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { Alert, Gallery, Stack, Text, TextContent } from '@patternfly/react-core';
-import { SectionType } from '~/concepts/design/utils';
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
 import SelectSingleModelCard from './SelectSingleModelCard';
 import SelectMultiModelCard from './SelectMultiModelCard';
 
 const PlatformSelectSection: React.FC = () => (
-  <CollapsibleSection
-    sectionType={SectionType.training}
-    title="Serve models"
-    data-testid="section-model-server"
-  >
+  <CollapsibleSection title="Serve models" data-testid="section-model-server">
     <Stack hasGutter>
       <TextContent
         data-testid="no-model-serving-platform-selected"

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -32,11 +32,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
 
   if (inferenceServices.length === 0) {
     return (
-      <CollapsibleSection
-        sectionType={isMultiPlatform ? SectionType.setup : SectionType.training}
-        title="Serve models"
-        data-testid="section-model-server"
-      >
+      <CollapsibleSection title="Serve models" data-testid="section-model-server">
         <OverviewCard
           objectType={ProjectObjectType.modelServer}
           sectionType={SectionType.setup}
@@ -64,11 +60,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
   }
 
   return (
-    <CollapsibleSection
-      sectionType={SectionType.training}
-      title="Serve models"
-      data-testid="model-server-section"
-    >
+    <CollapsibleSection title="Serve models" data-testid="model-server-section">
       <DeployedModelsCard isMultiPlatform={isMultiPlatform} />
     </CollapsibleSection>
   );

--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/TrainModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/TrainModelsSection.tsx
@@ -4,7 +4,6 @@ import { CreatePipelineServerButton, usePipelinesAPI } from '~/concepts/pipeline
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { useAccessReview } from '~/api';
 import { AccessReviewResource } from '~/pages/projects/screens/detail/const';
-import { SectionType } from '~/concepts/design/utils';
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import PipelinesCard from './PipelinesCard';
@@ -50,7 +49,7 @@ const TrainModelsSection: React.FC = () => {
   }, [pipelinesEnabled, pipelinesServer.initializing, pipelinesServer.installed, allowCreate]);
 
   return (
-    <CollapsibleSection sectionType={SectionType.training} title="Train models">
+    <CollapsibleSection title="Train models">
       {!pipelinesServer.installed && !alertClosed ? alert : null}
       <Gallery
         hasGutter


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-4995 and https://issues.redhat.com/browse/RHOAIENG-4882

## Description
Based on feedback from Jenn, Sim, and Tal, this PR removes the background and border colors for collapsed sections. This is in line with the future designs for expand/collapse sections and helps minimize logic needed to apply colors to borders. Also fixes a typo in the Data connections tab.
@simrandhaliw

![Image 4-1-24 at 11 35 AM](https://github.com/opendatahub-io/odh-dashboard/assets/28281340/3b0d30f6-67f1-4316-8e70-96d6bab71665)

## How Has This Been Tested?
Ran locally and did a visual test.

## Test Impact
Since this is just a styling update, other tests may not be necessary.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
