### PR TITLE
[RHOAIENG-4660] Compare runs - Manage runs page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/ManageRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/ManageRuns.cy.ts
@@ -1,0 +1,171 @@
+/* eslint-disable camelcase */
+import {
+  buildMockExperimentKF,
+  buildMockPipelineV2,
+  buildMockPipelineVersionV2,
+  buildMockPipelineVersionsV2,
+  buildMockPipelines,
+  buildMockRunKF,
+} from '~/__mocks__';
+import { PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import {
+  manageRunsPage,
+  manageRunsTable,
+} from '~/__tests__/cypress/cypress/pages/pipelines/manageRuns';
+import { configIntercept, dspaIntercepts, projectsIntercept, statusIntercept } from './intercepts';
+
+const projectName = 'test-project-name';
+const pipelineVersionId = 'test-version-id';
+const pipelineId = 'test-pipeline-id';
+const experimentId = 'test-experiment-id';
+const initialRunIds = ['test-run-1', 'test-run-2'];
+
+const mockRuns = Array(11)
+  .fill(buildMockRunKF())
+  .map((mockRun: Partial<PipelineRunKFv2>, index) => ({
+    ...mockRun,
+    display_name: `Test run ${index + 1}`,
+    run_id: `test-run-${index + 1}`,
+    experiment_id: experimentId,
+    pipeline_version_reference: {
+      pipeline_id: pipelineId,
+      pipeline_version_id: pipelineVersionId,
+    },
+  }));
+
+describe('Manage runs', () => {
+  beforeEach(() => {
+    initIntercepts();
+    manageRunsPage.visit(experimentId, projectName, initialRunIds);
+  });
+
+  it('renders the page with table data', () => {
+    manageRunsTable.getRowByName('Test run 1').find();
+  });
+
+  it('has param experiment filter by default', () => {
+    cy.findByTestId('experiment-filter-chip').should('have.text', 'Experiment: Default');
+  });
+
+  it('has param run IDs checked by default', () => {
+    manageRunsTable.getRowByName('Test run 1').findCheckbox().should('be.checked');
+    manageRunsTable.getRowByName('Test run 2').findCheckbox().should('be.checked');
+  });
+
+  it('maintains selections between page changes', () => {
+    manageRunsTable.getRowByName('Test run 1').findCheckbox().should('be.checked');
+    manageRunsTable.getRowByName('Test run 2').findCheckbox().should('be.checked');
+
+    cy.findByLabelText('top pagination').find('[data-action="next"]').click();
+    cy.findByLabelText('top pagination').find('[data-action="previous"]').click();
+
+    manageRunsTable.getRowByName('Test run 1').findCheckbox().should('be.checked');
+    manageRunsTable.getRowByName('Test run 2').findCheckbox().should('be.checked');
+  });
+
+  it('navigates back to "Compare runs" page when "Cancel" toolbar action is clicked', () => {
+    manageRunsTable.findCancelButton().click();
+    cy.location('pathname').should(
+      'equal',
+      `/experiments/${projectName}/${experimentId}/compareRuns`,
+    );
+    cy.location('search').should('equal', '?runs=test-run-1,test-run-2');
+  });
+
+  it('navigates to "Compare runs" page when "Compare runs" breadcrumb is clicked', () => {
+    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Compare runs' }).click();
+    cy.location('pathname').should(
+      'equal',
+      `/experiments/${projectName}/${experimentId}/compareRuns`,
+    );
+    cy.location('search').should('equal', '?runs=test-run-1,test-run-2');
+  });
+
+  it('navigates to experiment runs page when the experiment name breadcrumb is clicked', () => {
+    manageRunsPage.findBreadcrumb().findByRole('link', { name: 'Default' }).click();
+    cy.location('pathname').should('equal', `/experiments/${projectName}/${experimentId}/runs`);
+  });
+
+  it('navigates to experiment list page when the project name breadcrumb is clicked', () => {
+    manageRunsPage
+      .findBreadcrumb()
+      .findByRole('link', { name: 'Experiments - Test project' })
+      .click();
+    cy.location('pathname').should('equal', `/experiments/${projectName}`);
+  });
+
+  it('navigates to "Compare runs" page with updated run IDs when "Update" toolbar action is clicked', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/api/proxy/apis/v2beta1/runs/test-run-3',
+      },
+      mockRuns[2],
+    );
+
+    manageRunsTable.getRowByName('Test run 3').findCheckbox().click();
+    manageRunsTable.findUpdateButton().click();
+    cy.location('pathname').should(
+      'equal',
+      `/experiments/${projectName}/${experimentId}/compareRuns`,
+    );
+    cy.location('search').should('equal', '?runs=test-run-1,test-run-2,test-run-3');
+  });
+});
+
+const initIntercepts = () => {
+  statusIntercept();
+  configIntercept();
+  dspaIntercepts(projectName);
+  projectsIntercept([{ k8sName: projectName, displayName: 'Test project' }]);
+
+  cy.intercept(
+    {
+      pathname: '/api/proxy/apis/v2beta1/pipelines',
+    },
+    buildMockPipelines([buildMockPipelineV2({ pipeline_id: pipelineId })]),
+  );
+
+  const mockPipelineVersion = buildMockPipelineVersionV2({
+    pipeline_version_id: pipelineVersionId,
+    pipeline_id: pipelineId,
+  });
+
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: `/api/proxy/apis/v2beta1/pipelines/${pipelineId}/versions`,
+    },
+    buildMockPipelineVersionsV2([mockPipelineVersion]),
+  );
+
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: `/api/proxy/apis/v2beta1/experiments/${experimentId}`,
+    },
+    buildMockExperimentKF({ experiment_id: experimentId }),
+  );
+
+  initialRunIds.forEach((selectedRunId) => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: `/api/proxy/apis/v2beta1/runs/${selectedRunId}`,
+      },
+      mockRuns.find((mockRun) => mockRun.run_id === selectedRunId),
+    );
+  });
+
+  cy.intercept(
+    {
+      method: 'POST',
+      pathname: '/api/proxy/apis/v2beta1/runs',
+    },
+    {
+      runs: mockRuns,
+      total_size: mockRuns.length,
+      next_page_token: 'page-2-token',
+    },
+  );
+};

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -5,15 +5,9 @@ import {
   PipelineRunKFv2,
 } from '~/concepts/pipelines/kfTypes';
 import {
-  mockStatus,
-  mockDashboardConfig,
-  mockDataSciencePipelineApplicationK8sResource,
-  mockRouteK8sResource,
-  mockK8sResourceList,
   buildMockRunKF,
   buildMockPipelineV2,
   buildMockPipelineVersionV2,
-  mockProjectK8sResource,
   buildMockJobKF,
   buildMockExperimentKF,
 } from '~/__mocks__';
@@ -29,6 +23,7 @@ import {
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url.cy';
 
 import { getCorePipelineSpec } from '~/concepts/pipelines/getCorePipelineSpec';
+import { configIntercept, dspaIntercepts, projectsIntercept, statusIntercept } from './intercepts';
 
 const projectName = 'test-project-name';
 const mockPipeline = buildMockPipelineV2();
@@ -708,18 +703,10 @@ describe('Pipeline create runs', () => {
 });
 
 const initIntercepts = () => {
-  cy.intercept('/api/status', mockStatus());
-  cy.intercept('/api/config', mockDashboardConfig({ disablePipelineExperiments: false }));
-  mockDspaIntercepts();
-
-  cy.intercept(
-    {
-      pathname: '/api/k8s/apis/project.openshift.io/v1/projects',
-    },
-    mockK8sResourceList([
-      mockProjectK8sResource({ k8sName: projectName, displayName: 'Test project filters' }),
-    ]),
-  );
+  statusIntercept();
+  configIntercept();
+  dspaIntercepts(projectName);
+  projectsIntercept([{ k8sName: projectName, displayName: 'Test project' }]);
 
   cy.intercept(
     {
@@ -735,39 +722,5 @@ const initIntercepts = () => {
       pathname: '/api/proxy/apis/v2beta1/runs',
     },
     { runs: initialMockRuns, total_size: initialMockRuns.length },
-  );
-};
-
-const mockDspaIntercepts = () => {
-  cy.intercept(
-    {
-      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/pipelines-definition`,
-    },
-    mockDataSciencePipelineApplicationK8sResource({ namespace: projectName }),
-  );
-
-  cy.intercept(
-    {
-      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications`,
-    },
-    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
-  );
-
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/dspa`,
-    },
-    mockDataSciencePipelineApplicationK8sResource({}),
-  );
-
-  cy.intercept(
-    {
-      pathname: `/api/k8s/apis/route.openshift.io/v1/namespaces/${projectName}/routes/ds-pipeline-dspa`,
-    },
-    mockRouteK8sResource({
-      notebookName: 'ds-pipeline-pipelines-definition',
-      namespace: projectName,
-    }),
   );
 };

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineRuns.cy.ts
@@ -599,7 +599,7 @@ const initIntercepts = () => {
       pathname: '/api/k8s/apis/project.openshift.io/v1/projects',
     },
     mockK8sResourceList([
-      mockProjectK8sResource({ k8sName: projectName, displayName: 'Test project filters' }),
+      mockProjectK8sResource({ k8sName: projectName, displayName: 'Test project' }),
     ]),
   );
 

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/intercepts.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/intercepts.ts
@@ -1,0 +1,66 @@
+import {
+  mockDashboardConfig,
+  mockDataSciencePipelineApplicationK8sResource,
+  mockK8sResourceList,
+  mockProjectK8sResource,
+  mockRouteK8sResource,
+  mockStatus,
+} from '~/__mocks__';
+
+export const statusIntercept = (): Cypress.Chainable<null> =>
+  cy.intercept('/api/status', mockStatus());
+
+export const configIntercept = (): Cypress.Chainable<null> =>
+  cy.intercept('/api/config', mockDashboardConfig({ disablePipelineExperiments: false }));
+
+export const projectsIntercept = (
+  projectResources: Parameters<typeof mockProjectK8sResource>,
+): Cypress.Chainable<null> =>
+  cy.intercept(
+    {
+      pathname: '/api/k8s/apis/project.openshift.io/v1/projects',
+    },
+    mockK8sResourceList(
+      projectResources.map((resource) =>
+        mockProjectK8sResource({
+          k8sName: resource.k8sName,
+          displayName: 'Test project',
+          ...resource,
+        }),
+      ),
+    ),
+  );
+
+export const dspaIntercepts = (projectName = 'test-project-name'): void => {
+  cy.intercept(
+    {
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/pipelines-definition`,
+    },
+    mockDataSciencePipelineApplicationK8sResource({ namespace: projectName }),
+  );
+
+  cy.intercept(
+    {
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications`,
+    },
+    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
+  );
+
+  cy.intercept(
+    {
+      method: 'GET',
+      pathname: `/api/k8s/apis/datasciencepipelinesapplications.opendatahub.io/v1alpha1/namespaces/${projectName}/datasciencepipelinesapplications/dspa`,
+    },
+    mockDataSciencePipelineApplicationK8sResource({}),
+  );
+
+  cy.intercept(
+    {
+      pathname: `/api/k8s/apis/route.openshift.io/v1/namespaces/${projectName}/routes/ds-pipeline-dspa`,
+    },
+    mockRouteK8sResource({
+      notebookName: 'ds-pipeline-pipelines-definition',
+      namespace: projectName,
+    }),
+  );
+};

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/manageRuns.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/manageRuns.ts
@@ -1,0 +1,66 @@
+import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+
+class ManageRunsPage {
+  visit(experimentId: string, projectName: string, runIds: string[]) {
+    cy.visitWithLogin(
+      `/experiments/${projectName}/${experimentId}/compareRuns/add?runs=${runIds.join(',')}`,
+    );
+    this.wait();
+  }
+
+  private wait() {
+    this.find();
+    cy.testA11y();
+  }
+
+  find() {
+    return cy.findByTestId('app-page-title').contains('Manage runs');
+  }
+
+  findBreadcrumb() {
+    return this.find()
+      .parents('[data-testid="dashboard-page-main"]')
+      .findByTestId('manage-runs-page-breadcrumb');
+  }
+}
+
+class ManageRunsRow extends TableRow {
+  findCheckbox() {
+    return this.find().find(`[data-label=Checkbox]`).find('input');
+  }
+
+  findColumnName(name: string) {
+    return this.find().find(`[data-label=Name]`).contains(name);
+  }
+
+  findColumnVersion(name: string) {
+    return this.find().find(`[data-label="Pipeline"]`).contains(name);
+  }
+
+  findStatusSwitchByRowName() {
+    return this.find().findByTestId('job-status-switch');
+  }
+}
+
+class ManageRunsTable {
+  find() {
+    return cy.findByTestId('manage-runs-table');
+  }
+
+  getRowByName(name: string) {
+    return new ManageRunsRow(() =>
+      this.find().find(`[data-label=Name]`).contains(name).parents('tr'),
+    );
+  }
+
+  findUpdateButton() {
+    return this.find().findByTestId('manage-runs-update-button');
+  }
+
+  findCancelButton() {
+    return this.find().findByTestId('manage-runs-cancel-button');
+  }
+}
+
+export const manageRunsPage = new ManageRunsPage();
+export const manageRunsTable = new ManageRunsTable();

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -112,6 +112,7 @@ const App: React.FC = () => {
             }
             isNotificationDrawerExpanded={notificationsOpen}
             mainContainerId={DASHBOARD_MAIN_CONTAINER_ID}
+            data-testid={DASHBOARD_MAIN_CONTAINER_ID}
           >
             <ErrorBoundary>
               <ProjectsContextProvider>

--- a/frontend/src/components/table/TableBase.tsx
+++ b/frontend/src/components/table/TableBase.tsx
@@ -35,6 +35,7 @@ type Props<DataType> = {
   enablePagination?: boolean | 'compact';
   truncateRenderingAt?: number;
   toolbarContent?: React.ReactElement<typeof ToolbarItem | typeof ToolbarGroup>;
+  bottomToolbarContent?: React.ReactElement<typeof ToolbarItem | typeof ToolbarGroup>;
   emptyTableView?: React.ReactNode;
   caption?: string;
   footerRow?: (pageNumber: number) => React.ReactElement<typeof Tr> | null;
@@ -77,6 +78,7 @@ const TableBase = <T,>({
   rowRenderer,
   enablePagination,
   toolbarContent,
+  bottomToolbarContent,
   emptyTableView,
   caption,
   disableRowRenderSupport,
@@ -222,7 +224,11 @@ const TableBase = <T,>({
   return (
     <>
       {(toolbarContent || showPagination) && (
-        <Toolbar inset={{ default: 'insetNone' }} customChipGroupContent={<></>}>
+        <Toolbar
+          inset={{ default: 'insetNone' }}
+          className="pf-v5-u-w-100"
+          customChipGroupContent={<></>}
+        >
           <ToolbarContent>
             {toolbarContent}
             {showPagination && (
@@ -249,15 +255,17 @@ const TableBase = <T,>({
           {emptyTableView}
         </div>
       )}
-      {showPagination && (
-        <Toolbar>
-          <ToolbarContent>
+
+      <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-w-100">
+        <ToolbarContent alignItems="center">
+          {bottomToolbarContent}
+          {showPagination && (
             <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
               {pagination('bottom')}
             </ToolbarItem>
-          </ToolbarContent>
-        </Toolbar>
-      )}
+          )}
+        </ToolbarContent>
+      </Toolbar>
     </>
   );
 };

--- a/frontend/src/components/table/useCheckboxTable.ts
+++ b/frontend/src/components/table/useCheckboxTable.ts
@@ -10,14 +10,19 @@ type UseCheckboxTable = {
   setSelections: (selections: string[]) => void;
 };
 
-const useCheckboxTable = (dataIds: string[]): UseCheckboxTable => {
-  const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
+const useCheckboxTable = (
+  dataIds: string[],
+  defaultSelectedIds?: string[],
+  persistSelections?: boolean,
+): UseCheckboxTable => {
+  const [selectedIds, setSelectedIds] = React.useState<string[]>(defaultSelectedIds ?? []);
 
   return useCheckboxTableBase<string>(
     dataIds,
     selectedIds,
     setSelectedIds,
     React.useCallback((d) => d, []),
+    { persistSelections },
   );
 };
 

--- a/frontend/src/components/table/useCheckboxTableBase.ts
+++ b/frontend/src/components/table/useCheckboxTableBase.ts
@@ -16,7 +16,7 @@ const useCheckboxTableBase = <T>(
   selectedData: T[],
   setSelectedData: React.Dispatch<React.SetStateAction<T[]>>,
   dataMappingHelper: (selectData: T) => string,
-  selectAll?: { selected?: boolean; disabled?: boolean },
+  options?: { selectAll?: { selected?: boolean; disabled?: boolean }; persistSelections?: boolean },
 ): UseCheckboxTableBaseProps<T> => {
   const dataIds = React.useMemo(() => data.map(dataMappingHelper), [data, dataMappingHelper]);
 
@@ -29,6 +29,10 @@ const useCheckboxTableBase = <T>(
 
   // remove selected ids that are no longer present in the provided dataIds
   React.useEffect(() => {
+    if (options?.persistSelections) {
+      return;
+    }
+
     const newSelectedIds = intersection(selectedDataIds, dataIds);
     const newSelectedData = newSelectedIds
       .map((id) => data.find((d) => dataMappingHelper(d) === id))
@@ -36,7 +40,15 @@ const useCheckboxTableBase = <T>(
     if (selectedData.length !== newSelectedData.length) {
       setSelectedData(newSelectedData);
     }
-  }, [data, dataIds, dataMappingHelper, selectedData, selectedDataIds, setSelectedData]);
+  }, [
+    data,
+    dataIds,
+    dataMappingHelper,
+    options?.persistSelections,
+    selectedData,
+    selectedDataIds,
+    setSelectedData,
+  ]);
 
   const disableCheck = React.useCallback<UseCheckboxTableBaseProps<T>['disableCheck']>(
     (item, disabled) =>
@@ -74,7 +86,7 @@ const useCheckboxTableBase = <T>(
             setSelectedData(value ? checkable : []);
           },
           selected: headerSelected,
-          ...selectAll,
+          ...options?.selectAll,
         },
       },
       disableCheck,
@@ -95,10 +107,10 @@ const useCheckboxTableBase = <T>(
     selectedDataIds,
     dataMappingHelper,
     selectedData,
-    selectAll,
-    disableCheck,
     disabledData,
     setSelectedData,
+    options?.selectAll,
+    disableCheck,
   ]);
 };
 

--- a/frontend/src/concepts/pipelines/content/tables/PipelineFilterBar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/PipelineFilterBar.tsx
@@ -16,9 +16,8 @@ type FilterOptionRenders = {
   label?: string;
 };
 
-type Child = React.ReactElement<typeof ToolbarItem>;
 type PipelineFilterBarProps<Options extends FilterOptions> = {
-  children: Child | Child[];
+  children?: React.ReactNode;
   filterOptions: { [key in Options]?: string };
   filterOptionRenders: Record<Options, (props: FilterOptionRenders) => React.ReactNode>;
   filterData: Record<Options, string | { label: string; value: string } | undefined>;
@@ -87,12 +86,12 @@ const PipelineFilterBar = <Options extends FilterOptions>({
                 return {
                   key: filterKey,
                   node: (
-                    <>
+                    <span data-testid={`${optionValue?.toLowerCase()}-filter-chip`}>
                       <b>{optionValue}:</b>{' '}
                       <Tooltip content={dataValue.value} position="top-start">
                         <span>{dataValue.label}</span>
                       </Tooltip>
-                    </>
+                    </span>
                   ),
                 };
               }

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -185,13 +185,16 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
         rowRenderer={(run) => (
           <PipelineRunTableRow
             key={run.run_id}
-            isChecked={isSelected(run.run_id)}
-            onToggleCheck={() => toggleSelection(run.run_id)}
+            checkboxProps={{
+              isChecked: isSelected(run.run_id),
+              onToggle: () => toggleSelection(run.run_id),
+            }}
             onDelete={() => {
               setSelectedIds([run.run_id]);
               setIsDeleteModalOpen(true);
             }}
             run={run}
+            hasExperiments={!(isExperimentsAvailable && experimentId)}
           />
         )}
         variant={TableVariant.compact}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowTitle.tsx
@@ -39,7 +39,7 @@ const PipelineRunTableRowTitle: React.FC<PipelineRunTableRowTitleProps> = ({ run
       }
       description={run.description}
       descriptionAsMarkdown
-      label={<PipelineRunTypeLabel run={run} />}
+      label={<PipelineRunTypeLabel run={run} isCompact />}
     />
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar.tsx
@@ -17,11 +17,13 @@ export type FilterProps = Pick<
 >;
 
 interface PipelineRunTableToolbarProps extends FilterProps {
-  actions: React.ReactNode[];
+  actions?: React.ReactNode[];
+  filterOptions?: React.ComponentProps<typeof PipelineFilterBar>['filterOptions'];
 }
 
 const PipelineRunTableToolbar: React.FC<PipelineRunTableToolbarProps> = ({
   actions,
+  filterOptions,
   ...toolbarProps
 }) => {
   const { versions } = React.useContext(PipelineRunVersionsContext);
@@ -31,7 +33,7 @@ const PipelineRunTableToolbar: React.FC<PipelineRunTableToolbarProps> = ({
     runtimeStateLabels;
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
-  const options = React.useMemo(
+  const defaultFilterOptions = React.useMemo(
     () => ({
       [FilterOptions.NAME]: 'Run',
       ...(!(isExperimentsAvailable && experimentId) && {
@@ -47,7 +49,7 @@ const PipelineRunTableToolbar: React.FC<PipelineRunTableToolbarProps> = ({
   return (
     <PipelineFilterBar
       {...toolbarProps}
-      filterOptions={options}
+      filterOptions={filterOptions || defaultFilterOptions}
       filterOptionRenders={{
         [FilterOptions.NAME]: ({ onChange, ...props }) => (
           <TextInput
@@ -98,7 +100,7 @@ const PipelineRunTableToolbar: React.FC<PipelineRunTableToolbarProps> = ({
         ),
       }}
     >
-      {actions.map((action, index) => (
+      {actions?.map((action, index) => (
         <ToolbarItem key={index}>{action}</ToolbarItem>
       ))}
     </PipelineFilterBar>

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/usePipelineRunTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/usePipelineRunTable.ts
@@ -2,7 +2,17 @@ import {
   usePipelineActiveRuns,
   usePipelineArchivedRuns,
 } from '~/concepts/pipelines/apiHooks/usePipelineRuns';
-import createUsePipelineTable from '~/concepts/pipelines/content/tables/usePipelineTable';
+import { useCreatePipelineRunTable } from '~/concepts/pipelines/content/tables/usePipelineTable';
+import { PipelineRunOptions } from '~/concepts/pipelines/types';
 
-export const usePipelineActiveRunsTable = createUsePipelineTable(usePipelineActiveRuns);
-export const usePipelineArchivedRunsTable = createUsePipelineTable(usePipelineArchivedRuns);
+export const usePipelineActiveRunsTable = (
+  options?: PipelineRunOptions,
+  limit?: number,
+): ReturnType<typeof useCreatePipelineRunTable> =>
+  useCreatePipelineRunTable(usePipelineActiveRuns, options, limit);
+
+export const usePipelineArchivedRunsTable = (
+  options?: PipelineRunOptions,
+  limit?: number,
+): ReturnType<typeof useCreatePipelineRunTable> =>
+  useCreatePipelineRunTable(usePipelineArchivedRuns, options, limit);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/usePipelineVersionsCheckboxTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/usePipelineVersionsCheckboxTable.ts
@@ -15,7 +15,7 @@ const usePipelineVersionsCheckboxTable = (
     selectedVersions,
     setSelectedVersions,
     React.useCallback((version) => version.pipeline_id, []),
-    { disabled: pipelineChecked, ...(pipelineChecked ? { selected: true } : {}) },
+    { selectAll: { disabled: pipelineChecked, ...(pipelineChecked ? { selected: true } : {}) } },
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -23,7 +23,7 @@ export const getDataValue = <T extends FilterProps['filterData'], R = T[keyof T]
   return (data as { label: string; value: string } | undefined)?.value;
 };
 
-const defaultValue: FilterProps['filterData'] = {
+const defaultFilterData: FilterProps['filterData'] = {
   [FilterOptions.NAME]: '',
   [FilterOptions.CREATED_AT]: '',
   [FilterOptions.STATUS]: '',
@@ -31,8 +31,14 @@ const defaultValue: FilterProps['filterData'] = {
   [FilterOptions.PIPELINE_VERSION]: '',
 };
 
-const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): FilterProps => {
-  const [filterData, setFilterData] = React.useState(defaultValue);
+const usePipelineFilter = (
+  setFilter: (filter?: PipelinesFilter) => void,
+  initialFilterData?: Partial<FilterProps['filterData']>,
+): FilterProps => {
+  const [filterData, setFilterData] = React.useState({
+    ...defaultFilterData,
+    ...initialFilterData,
+  });
 
   const toolbarProps: FilterProps = {
     filterData,
@@ -40,7 +46,7 @@ const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): Filte
       (key, value) => setFilterData((oldValues) => ({ ...oldValues, [key]: value })),
       [],
     ),
-    onClearFilters: React.useCallback(() => setFilterData(defaultValue), []),
+    onClearFilters: React.useCallback(() => setFilterData(defaultFilterData), []),
   };
 
   const doSetFilter = React.useCallback(

--- a/frontend/src/pages/pipelines/GlobalPipelineExperimentsRoutes.tsx
+++ b/frontend/src/pages/pipelines/GlobalPipelineExperimentsRoutes.tsx
@@ -18,6 +18,7 @@ import GlobalPipelineRuns from './global/runs/GlobalPipelineRuns';
 import { ExperimentRunsListBreadcrumb } from './global/experiments/ExperimentRunsListBreadcrumb';
 import GlobalComparePipelineRunsLoader from './global/experiments/compareRuns/GlobalComparePipelineRunsLoader';
 import CompareRunsPage from './global/experiments/compareRuns/CompareRunsPage';
+import { ManageRunsPage } from './global/experiments/compareRuns/ManageRunsPage';
 
 const GlobalPipelineExperimentsRoutes: React.FC = () => (
   <ProjectsRoutes>
@@ -75,11 +76,11 @@ const GlobalPipelineExperimentsRoutes: React.FC = () => (
           index
           element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CompareRunsPage} />}
         />
-        {/* <Route
-          path="add"
-          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={TODO} />}
-        /> */}
       </Route>
+      <Route
+        path=":experimentId/compareRuns/add"
+        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={ManageRunsPage} />}
+      />
       <Route path="*" element={<Navigate to="." />} />
     </Route>
   </ProjectsRoutes>

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsPage.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Spinner,
+  EmptyStateHeader,
+  EmptyStateFooter,
+  EmptyStateActions,
+  Button,
+  Breadcrumb,
+  BreadcrumbItem,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+
+import { usePipelineActiveRunsTable } from '~/concepts/pipelines/content/tables/pipelineRun/usePipelineRunTable';
+import { CompareRunsSearchParam, PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
+import {
+  experimentRunsRoute,
+  experimentsBaseRoute,
+  experimentsCompareRunsRoute,
+  experimentsCreateRunRoute,
+} from '~/routes';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import { useExperimentByParams } from '~/pages/pipelines/global/experiments/useExperimentByParams';
+import { getProjectDisplayName } from '~/pages/projects/utils';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import usePipelineFilter, {
+  FilterOptions,
+} from '~/concepts/pipelines/content/tables/usePipelineFilter';
+import { ExperimentKFv2 } from '~/concepts/pipelines/kfTypes';
+import { PipelineRunTabTitle, PipelineRunType } from '~/pages/pipelines/global/runs';
+import PipelineRunVersionsContextProvider from '~/pages/pipelines/global/runs/PipelineRunVersionsContext';
+import { ManageRunsTable } from './ManageRunsTable';
+
+interface ManageRunsPageInternalProps {
+  experiment: ExperimentKFv2;
+}
+
+export const ManageRunsPageInternal: React.FC<ManageRunsPageInternalProps> = ({ experiment }) => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { namespace, project } = usePipelinesAPI();
+  const [[{ items: runs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
+    usePipelineActiveRunsTable();
+  const filterProps = usePipelineFilter(tableProps.setFilter, {
+    [FilterOptions.EXPERIMENT]: {
+      label: experiment.display_name,
+      value: experiment.experiment_id,
+    },
+  });
+  const selectedRunIds = searchParams.get(CompareRunsSearchParam.RUNS)?.split(',') ?? [];
+
+  if (error) {
+    return (
+      <Bullseye>
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="There was an issue loading runs"
+            icon={<EmptyStateIcon icon={ExclamationCircleIcon} />}
+            headingLevel="h2"
+          />
+          <EmptyStateBody>{error.message}</EmptyStateBody>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
+
+  if (!loaded && !initialLoaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (loaded && totalSize === 0 && !tableProps.filter) {
+    return (
+      <EmptyState data-testid="runs-empty-state">
+        <EmptyStateHeader
+          titleText="No runs"
+          icon={<EmptyStateIcon icon={PlusCircleIcon} />}
+          headingLevel="h2"
+        />
+
+        <EmptyStateBody>
+          To get started, create a run. Alternatively, go to the{' '}
+          <b>{PipelineRunTabTitle.Schedules}</b> tab and create a schedule to execute recurring
+          runs.
+        </EmptyStateBody>
+
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button
+              data-testid="create-run-button"
+              variant="primary"
+              onClick={() =>
+                navigate({
+                  pathname: experimentsCreateRunRoute(namespace, experiment.experiment_id),
+                  search: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.Active}`,
+                })
+              }
+            >
+              Create run
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <ApplicationsPage
+      title="Manage runs"
+      loaded
+      empty={!runs}
+      breadcrumb={
+        <Breadcrumb data-testid="manage-runs-page-breadcrumb">
+          <BreadcrumbItem key="experiments">
+            <Link to={experimentsBaseRoute(namespace)}>
+              Experiments - {getProjectDisplayName(project)}
+            </Link>
+          </BreadcrumbItem>
+
+          <BreadcrumbItem key="experiment">
+            {experiment.display_name ? (
+              <Link to={experimentRunsRoute(namespace, experiment.experiment_id)}>
+                {experiment.display_name}
+              </Link>
+            ) : (
+              'Loading...'
+            )}
+          </BreadcrumbItem>
+
+          <BreadcrumbItem key="compare-runs">
+            <Link
+              to={experimentsCompareRunsRoute(namespace, experiment.experiment_id, selectedRunIds)}
+            >
+              Compare runs
+            </Link>
+          </BreadcrumbItem>
+
+          <BreadcrumbItem key="manage-runs">Manage runs</BreadcrumbItem>
+        </Breadcrumb>
+      }
+      provideChildrenPadding
+      removeChildrenTopPadding
+    >
+      <PipelineRunVersionsContextProvider>
+        <ManageRunsTable
+          runs={runs}
+          experiment={experiment}
+          filterProps={filterProps}
+          selectedRunIds={selectedRunIds}
+          loading={!loaded}
+          totalSize={totalSize}
+          {...tableProps}
+        />
+      </PipelineRunVersionsContextProvider>
+    </ApplicationsPage>
+  );
+};
+
+export const ManageRunsPage: React.FC = () => {
+  const experiment = useExperimentByParams();
+  return experiment ? <ManageRunsPageInternal experiment={experiment} /> : null;
+};

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Button, Flex, ToolbarGroup, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { TableVariant } from '@patternfly/react-table';
+
+import { TableBase, getTableColumnSort, useCheckboxTable } from '~/components/table';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
+import { pipelineRunColumns } from '~/concepts/pipelines/content/tables/columns';
+import PipelineRunTable from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable';
+import PipelineRunTableRow from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow';
+import PipelineRunTableToolbar, {
+  FilterProps,
+} from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar';
+import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFilter';
+import { ExperimentKFv2, PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import { experimentsCompareRunsRoute } from '~/routes';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+
+type ManageRunsTableProps = Omit<React.ComponentProps<typeof PipelineRunTable>, 'runType'> & {
+  filterProps: FilterProps;
+  selectedRunIds: string[];
+  experiment: ExperimentKFv2 | null;
+};
+
+export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
+  runs,
+  experiment,
+  selectedRunIds,
+  loading,
+  totalSize,
+  page,
+  pageSize,
+  setPage,
+  setPageSize,
+  filterProps,
+  ...tableProps
+}) => {
+  const navigate = useNavigate();
+  const { namespace } = usePipelinesAPI();
+  const pageRunIds = runs.map(({ run_id: runId }) => runId);
+
+  const {
+    selections,
+    tableProps: checkboxTableProps,
+    toggleSelection,
+  } = useCheckboxTable(pageRunIds, selectedRunIds, true);
+  const experimentId = experiment?.experiment_id ?? '';
+
+  const rowRenderer = React.useCallback(
+    (run: PipelineRunKFv2) => {
+      const isChecked = selections.includes(run.run_id);
+      const isDisabled = !isChecked && selections.length === 10;
+
+      return (
+        <PipelineRunTableRow
+          key={run.run_id}
+          checkboxProps={{
+            isChecked,
+            isDisabled,
+            onToggle: () => toggleSelection(run.run_id),
+            ...(isDisabled && { tooltip: 'Can only compare up to 10 runs' }),
+          }}
+          hasRowActions={false}
+          run={run}
+        />
+      );
+    },
+    [selections, toggleSelection],
+  );
+
+  return (
+    <Flex justifyContent={{ default: 'justifyContentCenter' }} data-testid="manage-runs-table">
+      <TableBase
+        {...checkboxTableProps}
+        loading={loading}
+        page={page}
+        perPage={pageSize}
+        onSetPage={(_, newPage) => {
+          if (newPage < page || !loading) {
+            setPage(newPage);
+          }
+        }}
+        onPerPageSelect={(_, newSize) => setPageSize(newSize)}
+        itemCount={totalSize}
+        data={runs}
+        columns={pipelineRunColumns}
+        enablePagination="compact"
+        emptyTableView={<DashboardEmptyTableView onClearFilters={filterProps.onClearFilters} />}
+        toolbarContent={
+          <PipelineRunTableToolbar
+            data-testid="manage-runs-table-toolbar"
+            filterOptions={{
+              [FilterOptions.NAME]: 'Run',
+              [FilterOptions.EXPERIMENT]: 'Experiment',
+              [FilterOptions.PIPELINE_VERSION]: 'Pipeline version',
+              [FilterOptions.CREATED_AT]: 'Started',
+              [FilterOptions.STATUS]: 'Status',
+            }}
+            {...filterProps}
+          />
+        }
+        rowRenderer={rowRenderer}
+        variant={TableVariant.compact}
+        getColumnSort={getTableColumnSort({ columns: pipelineRunColumns, ...tableProps })}
+        bottomToolbarContent={
+          <ToolbarGroup>
+            <ToolbarItem>
+              <Tooltip content="Select up to 10 runs to compare">
+                <Button
+                  data-testid="manage-runs-update-button"
+                  onClick={() =>
+                    navigate(experimentsCompareRunsRoute(namespace, experimentId, selections))
+                  }
+                  isAriaDisabled={selections.length < 1}
+                >
+                  Update
+                </Button>
+              </Tooltip>
+            </ToolbarItem>
+
+            <ToolbarItem>
+              <Button
+                data-testid="manage-runs-cancel-button"
+                variant="secondary"
+                onClick={() =>
+                  navigate(experimentsCompareRunsRoute(namespace, experimentId, selectedRunIds))
+                }
+              >
+                Cancel
+              </Button>
+            </ToolbarItem>
+          </ToolbarGroup>
+        }
+        id="manage-runs-table"
+      />
+    </Flex>
+  );
+};

--- a/frontend/src/pages/pipelines/global/runs/ActiveRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ActiveRuns.tsx
@@ -25,7 +25,7 @@ export const ActiveRuns: React.FC = () => {
   const navigate = useNavigate();
   const { namespace, experimentId } = useParams();
   const [[{ items: runs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
-    usePipelineActiveRunsTable();
+    usePipelineActiveRunsTable({ experimentId });
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
   if (error) {

--- a/frontend/src/pages/pipelines/global/runs/ArchivedRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ArchivedRuns.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useParams } from 'react-router-dom';
 import {
   Bullseye,
   EmptyState,
@@ -13,8 +14,9 @@ import { usePipelineArchivedRunsTable } from '~/concepts/pipelines/content/table
 import { PipelineRunType } from './types';
 
 export const ArchivedRuns: React.FC = () => {
+  const { experimentId } = useParams();
   const [[{ items: runs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
-    usePipelineArchivedRunsTable();
+    usePipelineArchivedRunsTable({ experimentId });
 
   if (error) {
     return (

--- a/frontend/src/routes/pipelines/experiments.ts
+++ b/frontend/src/routes/pipelines/experiments.ts
@@ -65,7 +65,8 @@ export const experimentScheduleDetailsRoute = (
     ? experimentsBaseRoute(namespace)
     : `${experimentSchedulesRoute(namespace, experimentId)}/${recurringRunId}`;
 
-const generateCompareRunsQueryString = (runIds: string[]) => `?runs=${runIds.join(',')}`;
+const generateCompareRunsQueryString = (runIds: string[]) =>
+  runIds.length > 0 ? `?runs=${runIds.join(',')}` : '';
 
 export const experimentsCompareRunsRoute = (
   namespace: string,


### PR DESCRIPTION
Closes: [RHOAIENG-4660](https://issues.redhat.com/browse/RHOAIENG-4660)

## Description
Manage runs page uses selected runs from the Compare runs page initially as pre-selected table rows (runs), and the user has the ability to select up to 10 total (and change what was initially selected if they want). Selections are maintained between pages, cancelling uses what was initially selected by the Compare runs page, and "Update" will update the selections and bring the user back to the Compare runs page.

## Tests
Cypress tests for main interactions

## How to test
1. Navigate to `http://localhost:4010/experiments/jps-fun-world/85c9d729-bf63-441f-af87-d6898e5db5f0/compareRuns/add`
2. Verify the initial Experiment filter is set to the experiment associated with the ID in your URL path
3. Select up to 10 table rows on a single or multiple pages
4. "Update" and verify you're navigated to the Compare runs page with URL search string updated with all run valid IDs
5. Navigate to the same path from step 1
6. "Cancel" and verify you're navigated to the Compare runs page with no "runs" in the search param
7. Navigate to the same path from step 1, except with `?runs=` following with a comma delimited list of run IDs to verify initial rows are checked (assuming those IDs are valid)
8. Verify filter, row links, pagination, sorting works for the Manage runs table
9. Verify selections between pages persist
10. Verify breadcrumbs bring you to the correct locations

<img width="1487" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/d3c5f2df-1876-454b-8c94-791bcb7ed305">
<img width="1156" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/1f2ac84f-8fac-450c-b408-c60bcd7f5644">

(cc @yannnz)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
