### PR TITLE
RHOAIENG-5067: Model Serving Metrics: Use real namespace name instead of project display name in queries

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/ProjectServerMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectServerMetricsWrapper.tsx
@@ -19,7 +19,7 @@ const ProjectServerMetricsWrapper: React.FC = () => (
           <ModelServingMetricsProvider
             queries={queries}
             type={PerformanceMetricType.SERVER}
-            namespace={projectDisplayName}
+            namespace={currentProject.metadata.name}
           >
             <MetricsPage
               title={`${serverName} metrics`}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-5067 (**Critical**)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

As identified by @christianvogt, the `ProjectServerMetricsWrapper` was passing the current project's display name into `ModelServingMetricsProvider` instead of the namespace name. This was making its way into the Prometheus query strings in the Model Serving Metrics page, causing 400 Bad Request errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created a model server in a project whose display name is different from its underlying namespace (e.g. it has capital letters or spaces in it). Tried to view the model server metrics (Projects -> [project] -> Models tab -> Kebab menu -> View model server metrics) and saw that before this change I got 400 errors in the dev tools Network tab and the loading spinners on the page never resolved. After this change the queries resolve correctly.

I also sent some requests to a deployed model with curl and observed that the metrics appear correctly on the page.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
