### PR TITLE
feat(dw): top consumption charts

### DIFF
--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -8,7 +8,7 @@ import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { POLL_INTERVAL } from '~/utilities/const';
 import {
   DWProjectCurrentMetrics,
-  TopResourceConsumingWorkloads,
+  TopWorkloadsByUsage,
   WorkloadCurrentUsage,
   WorkloadMetricPromQueryResponse,
   getTopResourceConsumingWorkloads,
@@ -225,7 +225,7 @@ describe('getTopResourceConsumingWorkloads', () => {
           { workload: 'other', usage: 16474092 },
         ],
       },
-    } satisfies TopResourceConsumingWorkloads);
+    } satisfies TopWorkloadsByUsage);
   });
 
   it('sorts all workloads and excludes the "other" group when there are exactly 6', () => {
@@ -254,7 +254,7 @@ describe('getTopResourceConsumingWorkloads', () => {
           { workload: mockWorkloads[5], usage: 8237036 },
         ],
       },
-    } satisfies TopResourceConsumingWorkloads);
+    } satisfies TopWorkloadsByUsage);
   });
 
   it('sorts all workloads and excludes the "other" group when there are less than 6', () => {
@@ -277,7 +277,7 @@ describe('getTopResourceConsumingWorkloads', () => {
           { workload: mockWorkloads[0], usage: 8237056 },
         ],
       },
-    } satisfies TopResourceConsumingWorkloads);
+    } satisfies TopWorkloadsByUsage);
   });
 });
 
@@ -325,7 +325,7 @@ describe('useDWProjectCurrentMetrics', () => {
       loaded: false,
       error: undefined,
       getWorkloadCurrentUsage: expect.any(Function),
-      topResourceConsumingWorkloads: {
+      topWorkloadsByUsage: {
         cpuCoresUsed: { totalUsage: 0, topWorkloads: [] },
         memoryBytesUsed: { totalUsage: 0, topWorkloads: [] },
       },
@@ -378,7 +378,7 @@ describe('useDWProjectCurrentMetrics', () => {
       loaded: true,
       error: undefined,
       getWorkloadCurrentUsage: expect.any(Function),
-      topResourceConsumingWorkloads: {
+      topWorkloadsByUsage: {
         cpuCoresUsed: {
           topWorkloads: [
             { workload: mockWorkloads[3], usage: 0.04300163333333333 },

--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -52,7 +52,7 @@ export type WorkloadWithUsage = {
   workload: WorkloadKind | 'other';
   usage: number | undefined;
 };
-export type TopResourceConsumingWorkloads = Record<
+export type TopWorkloadsByUsage = Record<
   keyof WorkloadCurrentUsage,
   { totalUsage: number; topWorkloads: WorkloadWithUsage[] }
 >;
@@ -63,7 +63,7 @@ export const getTotalUsage = (workloadsWithUsage: WorkloadWithUsage[]): number =
 export const getTopResourceConsumingWorkloads = (
   workloads: WorkloadKind[],
   getWorkloadCurrentUsage: (workload: WorkloadKind) => WorkloadCurrentUsage,
-): TopResourceConsumingWorkloads => {
+): TopWorkloadsByUsage => {
   const getTopWorkloadsFor = (
     usageType: keyof WorkloadCurrentUsage,
   ): { totalUsage: number; topWorkloads: WorkloadWithUsage[] } => {
@@ -110,7 +110,7 @@ export type DWProjectCurrentMetrics = FetchStateObject<{
   >;
 }> & {
   getWorkloadCurrentUsage: (workload: WorkloadKind) => WorkloadCurrentUsage;
-  topResourceConsumingWorkloads: TopResourceConsumingWorkloads;
+  topWorkloadsByUsage: TopWorkloadsByUsage;
 };
 
 const getDWProjectCurrentMetricsQueries = (
@@ -148,7 +148,7 @@ export const useDWProjectCurrentMetrics = (
     },
     [data.cpuCoresUsedByJobName, data.memoryBytesUsedByJobName],
   );
-  const topResourceConsumingWorkloads: TopResourceConsumingWorkloads = React.useMemo(
+  const topWorkloadsByUsage: TopWorkloadsByUsage = React.useMemo(
     () => getTopResourceConsumingWorkloads(workloads, getWorkloadCurrentUsage),
     [workloads, getWorkloadCurrentUsage],
   );
@@ -161,6 +161,6 @@ export const useDWProjectCurrentMetrics = (
     loaded: Object.values(data).every(({ loaded }) => loaded),
     error: Object.values(data).find(({ error }) => !!error)?.error,
     getWorkloadCurrentUsage,
-    topResourceConsumingWorkloads,
+    topWorkloadsByUsage,
   };
 };

--- a/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
+++ b/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
@@ -36,7 +36,7 @@ export const DistributedWorkloadsContext = React.createContext<DistributedWorklo
       memoryBytesUsedByJobName: DEFAULT_VALUE_FETCH_STATE,
     },
     getWorkloadCurrentUsage: () => ({ cpuCoresUsed: undefined, memoryBytesUsed: undefined }),
-    topResourceConsumingWorkloads: {
+    topWorkloadsByUsage: {
       cpuCoresUsed: { totalUsage: 0, topWorkloads: [] },
       memoryBytesUsed: { totalUsage: 0, topWorkloads: [] },
     },

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Bullseye, Flex, FlexItem, Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner, Stack, StackItem } from '@patternfly/react-core';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
 import { ResourceUsage } from './sections/ResourceUsage';
@@ -28,9 +28,9 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { getWorkloadCurrentUsage, topResourceConsumingWorkloads } = projectCurrentMetrics;
+  const { getWorkloadCurrentUsage, topWorkloadsByUsage } = projectCurrentMetrics;
   // eslint-disable-next-line no-console
-  console.log({ topResourceConsumingWorkloads });
+  console.log({ topWorkloadsByUsage });
 
   //TODO: need 'no quota' logic
   // if (false) {
@@ -48,23 +48,23 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
 
   return (
     <>
-      <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-        <FlexItem>
+      <Stack hasGutter>
+        <StackItem>
           <DWSectionCard title="Resource Usage" content={<ResourceUsage />} />
-        </FlexItem>
-        <FlexItem>
+        </StackItem>
+        <StackItem>
           <DWSectionCard
             title="Top resource-consuming distributed workloads"
             content={<TopResourceConsumingWorkloads />}
           />
-        </FlexItem>
-        <FlexItem>
+        </StackItem>
+        <StackItem>
           <DWSectionCard
             title="Distributed workload resource metrics"
             content={<WorkloadResourceMetrics />}
           />
-        </FlexItem>
-      </Flex>
+        </StackItem>
+      </Stack>
     </>
   );
 };

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/SharedStates.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/SharedStates.tsx
@@ -9,20 +9,22 @@ import {
   EmptyStateIcon,
   CardBody,
 } from '@patternfly/react-core';
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
 
-export const NoWorkloadState: React.FC = () => (
+export const NoWorkloadState: React.FC<{ title?: string; subTitle?: string; warn?: boolean }> = ({
+  title = 'No distributed workloads',
+  subTitle = 'No distributed workloads in the selected project are currently consuming resources.',
+  warn = false,
+}) => (
   <CardBody>
     <EmptyState>
       <EmptyStateHeader
-        titleText="No distributed workloads"
+        titleText={title}
         headingLevel="h4"
-        icon={<EmptyStateIcon icon={CubesIcon} />}
+        icon={<EmptyStateIcon icon={warn ? ExclamationTriangleIcon : CubesIcon} />}
       />
-      <EmptyStateBody>
-        Select another project or create a distributed workload in the selected project.
-      </EmptyStateBody>
+      <EmptyStateBody>{subTitle}</EmptyStateBody>
     </EmptyState>
   </CardBody>
 );

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
@@ -1,26 +1,159 @@
 import * as React from 'react';
-import { Card, CardTitle } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Gallery, GalleryItem } from '@patternfly/react-core';
+import { ChartLegend, ChartLabel, ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
+import { WorkloadStatusType, getStatusInfo } from '~/concepts/distributedWorkloads/utils';
 import { ErrorWorkloadState, LoadingWorkloadState, NoWorkloadState } from './SharedStates';
 
-export const TopResourceConsumingWorkloads: React.FC = () => {
-  const { workloads } = React.useContext(DistributedWorkloadsContext);
+//TODO: next 4 utility functions to be replaced or moved into a utility class
+const memoryBytesToGibStr = (bytes: number, excludeUnit = false): string => {
+  const gib = bytes / 1073741824;
+  return `${truncateNumberToStr(gib)}${excludeUnit ? '' : 'GiB'}`;
+};
 
-  if (workloads.error) {
-    return <ErrorWorkloadState message={workloads.error.message} />;
+const numberToCoreStr = (num: number): string => `${truncateNumberToStr(num)} cores`;
+
+const truncateNumberToStr = (num: number): string => {
+  if (num > 0.001) {
+    return String(parseFloat(num.toFixed(3)));
+  }
+  if (num === 0) {
+    return '0';
+  }
+  return '< 0.001';
+};
+
+const truncateStr = (str: string, length: number): string => {
+  if (str.length <= length) {
+    return str;
+  }
+  return `${str.substring(0, length)}...`;
+};
+
+interface TopResourceConsumingWorkloadsChartProps {
+  label: string;
+  title: string;
+  subTitle?: string;
+  data: Array<{ name: string; usage: number }>;
+  dataStrConverter: (num: number) => string;
+}
+
+const TopResourceConsumingWorkloadsChart: React.FC<TopResourceConsumingWorkloadsChartProps> = ({
+  label,
+  title,
+  subTitle = '',
+  data = [],
+  dataStrConverter,
+}) => (
+  <ChartDonut
+    ariaTitle={`${label} chart`}
+    constrainToVisibleArea
+    data={data.map((d: { name: string; usage: number }) => ({ x: d.name, y: d.usage }))}
+    height={150}
+    labels={({ datum }) => `${datum.x}: ${dataStrConverter(0 + datum.y)}`}
+    legendComponent={
+      <ChartLegend
+        data={data.map((d: { name: string; usage: number }) => ({
+          ...d,
+          name: truncateStr(d.name, 16),
+        }))}
+        gutter={5}
+        labelComponent={<ChartLabel style={{ fontSize: 10 }} />}
+        itemsPerRow={Math.ceil(data.length / 2)}
+      />
+    }
+    legendOrientation="vertical"
+    legendPosition="right"
+    name={`topResourceConsuming${label}`}
+    padding={{
+      bottom: 0,
+      left: 0,
+      right: 260, // Adjusted to accommodate legend
+      top: 0,
+    }}
+    subTitle={subTitle}
+    title={title}
+    themeColor={ChartThemeColor.multi}
+    width={375}
+  />
+);
+
+export const TopResourceConsumingWorkloads: React.FC = () => {
+  const { workloads, projectCurrentMetrics } = React.useContext(DistributedWorkloadsContext);
+  const { topWorkloadsByUsage } = projectCurrentMetrics;
+  const requiredFetches = [workloads, projectCurrentMetrics];
+  const error = requiredFetches.find((f) => !!f.error)?.error;
+  const loaded = requiredFetches.every((f) => f.loaded);
+
+  if (error) {
+    return <ErrorWorkloadState message={error.message} />;
   }
 
-  if (!workloads.loaded) {
+  if (!loaded) {
     return <LoadingWorkloadState />;
   }
 
-  if (!workloads.data.length) {
+  if (
+    !topWorkloadsByUsage.cpuCoresUsed.totalUsage &&
+    !topWorkloadsByUsage.memoryBytesUsed.totalUsage
+  ) {
+    const workloadStatuses = [];
+    if (workloads.data.some((wl) => getStatusInfo(wl).status === WorkloadStatusType.Succeeded)) {
+      workloadStatuses.push('completed');
+    }
+    if (workloads.data.some((wl) => getStatusInfo(wl).status === WorkloadStatusType.Failed)) {
+      workloadStatuses.push('failed');
+    }
+
+    if (workloadStatuses.length) {
+      return (
+        <NoWorkloadState
+          warn={workloadStatuses.includes('failed')}
+          title={`All distributed workloads have ${workloadStatuses.join(' or ')}`}
+        />
+      );
+    }
     return <NoWorkloadState />;
   }
 
   return (
-    <Card isPlain>
-      <CardTitle>Charts Placeholder</CardTitle>
-    </Card>
+    <Gallery minWidths={{ default: '100%', md: '50%' }}>
+      <GalleryItem>
+        <Card isPlain isCompact>
+          <CardTitle>CPU</CardTitle>
+          <CardBody>
+            <TopResourceConsumingWorkloadsChart
+              label="CPU"
+              title={truncateNumberToStr(topWorkloadsByUsage.cpuCoresUsed.totalUsage)}
+              subTitle="cores"
+              data={topWorkloadsByUsage.cpuCoresUsed.topWorkloads.map((data) => ({
+                name:
+                  data.workload === 'other' ? 'other' : data.workload.metadata?.name || 'unnamed',
+                usage: data.usage || 0,
+              }))}
+              dataStrConverter={numberToCoreStr}
+            />
+          </CardBody>
+        </Card>
+      </GalleryItem>
+      <GalleryItem>
+        <Card isPlain isCompact>
+          <CardTitle>Memory</CardTitle>
+          <CardBody>
+            <TopResourceConsumingWorkloadsChart
+              label="Memory"
+              title={memoryBytesToGibStr(topWorkloadsByUsage.memoryBytesUsed.totalUsage, true)}
+              subTitle="GiB"
+              data={topWorkloadsByUsage.memoryBytesUsed.topWorkloads.map((data) => ({
+                name:
+                  data.workload === 'other' ? 'other' : data.workload.metadata?.name || 'unnamed',
+                usage: data.usage || 0,
+              }))}
+              dataStrConverter={memoryBytesToGibStr}
+            />
+          </CardBody>
+        </Card>
+      </GalleryItem>
+    </Gallery>
   );
 };


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHOAIENG-2845

## Description
implement top consuming distributed workload charts

left some utility type stuff in the consuming chart component, this and the inner pf chart will be moved out once we get this and other chart stuff in and are able to combine/refactor a bit.

No workloads:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/b172a2a1-7a44-443b-859b-4d81c9a9309b)
No workloads consuming resources (similar message for if all or some have failed, but using <!> icon and noting that some or all have failed):
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/13760046-41ed-4982-97e8-426f580b715c)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/6e3e75d2-318e-407b-980e-a039acd883c6)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/93bfc3c6-afab-4564-aac4-31ec6e413ef2)
With data
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/d37b8aff-b6d6-4da9-ab1e-6f1a5f95a51b)
With narrow screen:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/cd8a3d99-2f2a-495d-9a84-9c9accf2051e)



## How Has This Been Tested?
Ran through with various data and lack of data

## Test Impact
tests for the empty state of this session are in place, not sure if we are testing charts

## Request review criteria:
empty state works (no workloads, no workloads with usage), if workloads with usage exist, two donut charts should show the details of that usage.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
