### PR TITLE
[RHOAIENG-4859] Fix for showing correct models in project overview

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsCard.tsx
@@ -17,7 +17,6 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import HeaderIcon from '~/concepts/design/HeaderIcon';
-import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import ModelServingContextProvider from '~/pages/modelServing/ModelServingContext';
 import { ProjectObjectType } from '~/concepts/design/utils';
 import TypeBorderedCard from '~/concepts/design/TypeBorderedCard';
@@ -30,10 +29,10 @@ enum FilterStates {
 
 interface DeployedModelsCardProps {
   isMultiPlatform: boolean;
+  namespace?: string;
 }
 
-const DeployedModelsCard: React.FC<DeployedModelsCardProps> = ({ isMultiPlatform }) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+const DeployedModelsCard: React.FC<DeployedModelsCardProps> = ({ isMultiPlatform, namespace }) => {
   const [filteredState, setFilteredState] = React.useState<FilterStates | undefined>();
 
   const renderError = (message?: string): React.ReactElement => (
@@ -92,10 +91,7 @@ const DeployedModelsCard: React.FC<DeployedModelsCardProps> = ({ isMultiPlatform
         </Flex>
       </CardHeader>
       <CardBody>
-        <ModelServingContextProvider
-          namespace={currentProject.metadata.namespace}
-          getErrorComponent={renderError}
-        >
+        <ModelServingContextProvider namespace={namespace} getErrorComponent={renderError}>
           <DeployedModelsGallery
             showSuccessful={!filteredState || filteredState === FilterStates.success}
             showFailed={!filteredState || filteredState === FilterStates.failed}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -61,7 +61,10 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
 
   return (
     <CollapsibleSection title="Serve models" data-testid="model-server-section">
-      <DeployedModelsCard isMultiPlatform={isMultiPlatform} />
+      <DeployedModelsCard
+        isMultiPlatform={isMultiPlatform}
+        namespace={currentProject.metadata.name}
+      />
     </CollapsibleSection>
   );
 };


### PR DESCRIPTION
Closes [RHOAIENG-4859](https://issues.redhat.com/browse/RHOAIENG-4859)

## Description
Fixes an issue where models from all projects are being shown in the models section of the overview page. The fix is to pass the project name to the models list rather than incorrectly using the current project namespace field.

## How Has This Been Tested?
Manually tested and verified that models from other projects no longer show in the cards list.

## Test Impact
None.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
