### PR TITLE
[RHOAIENG-4996] Show popover help for non-empty pipelines/notebooks cards

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/NotebooksCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/NotebooksCard.tsx
@@ -96,8 +96,6 @@ const NotebooksCard: React.FC = () => {
         objectType={ProjectObjectType.notebook}
         sectionType={SectionType.training}
         title="Workbenches"
-        popoverHeaderContent="About workbenches"
-        popoverBodyContent="Creating a workbench allows you to add a Jupyter notebook to your project."
       >
         <CardBody>
           <EnsureCompatiblePipelineServer>

--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesCard.tsx
@@ -210,9 +210,9 @@ const PipelinesCard: React.FC = () => {
       objectType={ProjectObjectType.pipeline}
       sectionType={pipelinesCount ? SectionType.training : SectionType.organize}
       title="Pipelines"
-      popoverHeaderContent={!pipelinesCount ? 'About pipelines' : undefined}
+      popoverHeaderContent={pipelinesCount ? 'About pipelines' : undefined}
       popoverBodyContent={
-        !pipelinesCount
+        pipelinesCount
           ? 'Standardize and automate machine learning workflows to enable you to further enhance and deploy your data science models.'
           : undefined
       }


### PR DESCRIPTION
Closes: [RHOAIENG-4996](https://issues.redhat.com/browse/RHOAIENG-4996)

## Description
Remove the help popovers for the Project overview, workbench and pipeline empty state cards.
Add the help popovers for the Project overview, workbench and pipeline non-empty state cards.

 
## How Has This Been Tested?
Tested against projects with and without workbenches and pipelines

## Test Impact
None

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

