### PR TITLE
[RHOAIENG-5104] Fix empty state image for global model servers

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
@@ -228,10 +228,6 @@ describe('Model Serving Global', () => {
 
     modelServingGlobal.shouldBeEmpty();
 
-    modelServingGlobal.findGoToProjectButton().click();
-    cy.findByTestId('kserve-inference-service-table');
-
-    // Test that the button is enabled
     modelServingGlobal.findDeployModelButton().click();
 
     // test that you can not submit on empty
@@ -271,8 +267,12 @@ describe('Model Serving Global', () => {
 
     modelServingGlobal.shouldBeEmpty();
 
-    // Test that the select a project button is shown
-    modelServingGlobal.findSelectAProjectButton().should('be.visible');
+    // Test that the button is disabled
+    modelServingGlobal.findDeployModelButton().should('have.attr', 'aria-disabled');
+
+    // Test that the tooltip appears on hover of the disabled button
+    modelServingGlobal.findDeployModelButton().trigger('mouseenter');
+    modelServingGlobal.findNoProjectSelectedTooltip().should('be.visible');
   });
 
   it('Delete model', () => {

--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -8,6 +8,8 @@ import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformS
 import { getProjectDisplayName } from '~/pages/projects/utils';
 import EmptyDetailsView from '~/components/EmptyDetailsView';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
+import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
+import ServeModelButton from '~/pages/modelServing/screens/global/ServeModelButton';
 
 const EmptyModelServing: React.FC = () => {
   const navigate = useNavigate();
@@ -24,9 +26,9 @@ const EmptyModelServing: React.FC = () => {
   ) {
     return (
       <EmptyDetailsView
-        title="No deployed models yet"
-        description="To get started, deploy a model from the Model servers section of a project."
-        iconImage={typedEmptyImage(ProjectObjectType.pipeline)}
+        title="No deployed models"
+        description="To get started, deploy a model from the Models section of a project."
+        iconImage={typedEmptyImage(ProjectObjectType.modelServer)}
         imageAlt="deploy a model"
         allowCreate
         createButton={
@@ -35,7 +37,9 @@ const EmptyModelServing: React.FC = () => {
             variant="link"
             onClick={() =>
               navigate(
-                project ? `/projects/${project.metadata.name}?section=model-servers` : '/projects',
+                project
+                  ? `/projects/${project.metadata.name}?section=${ProjectSectionID.MODEL_SERVER}`
+                  : '/projects',
               )
             }
           >
@@ -49,23 +53,11 @@ const EmptyModelServing: React.FC = () => {
   return (
     <EmptyDetailsView
       title="No deployed models"
-      description="To get started, deploy a model from the Model servers section of a project."
+      description="To get started, deploy a model."
       iconImage={typedEmptyImage(ProjectObjectType.modelServer)}
       imageAlt="deploy a model"
       allowCreate
-      createButton={
-        <Button
-          data-testid="empty-state-action-button"
-          variant="link"
-          onClick={() =>
-            navigate(
-              project ? `/projects/${project.metadata.name}?section=model-server` : '/projects',
-            )
-          }
-        >
-          {project ? `Go to ${getProjectDisplayName(project)}` : 'Select a project'}
-        </Button>
-      }
+      createButton={<ServeModelButton />}
     />
   );
 };


### PR DESCRIPTION
Closes: [RHOAIENG-5104](https://issues.redhat.com/browse/RHOAIENG-5104)

## Description
Fix to use the correct model serving empty state image. Also, reverted code that removed the ability to deploy a model from the empty state form multi-serving runtime platforms.

## How Has This Been Tested?
Manually and with e2e tests

## Test Impact
None

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
