### PR TITLE
Add Elyra version check functions and ElyraInvalidVersion component

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -11,6 +11,10 @@ class NotebookRow extends TableRow {
   shouldHaveNotebookImageName(name: string) {
     return cy.findByTestId('image-display-name').should('have.text', name);
   }
+
+  findOutdatedElyraInfo() {
+    return cy.findByTestId('outdated-elyra-info');
+  }
 }
 
 class ProjectRow extends TableRow {
@@ -173,6 +177,14 @@ class ProjectDetails {
 
   findTab(name: string) {
     return cy.findByRole('tab', { name });
+  }
+
+  findElyraInvalidVersionAlert() {
+    return cy.findByTestId('elyra-invalid-version-alert');
+  }
+
+  findUnsupportedPipelineVersionAlert() {
+    return cy.findByTestId('unsupported-pipeline-version-alert');
   }
 }
 

--- a/frontend/src/concepts/pipelines/elyra/ElyraInvalidVersionAlerts.tsx
+++ b/frontend/src/concepts/pipelines/elyra/ElyraInvalidVersionAlerts.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import {
+  StackItem,
+  Alert,
+  Stack,
+  AlertActionLink,
+  Checkbox,
+  AlertActionCloseButton,
+} from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import { NotebookKind } from '~/k8sTypes';
+import useNamespaces from '~/pages/notebookController/useNamespaces';
+import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
+import { getNotebookImageData } from '~/pages/projects/screens/detail/notebooks/useNotebookImageData';
+import useImageStreams from '~/pages/projects/screens/spawner/useImageStreams';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
+import { isElyraVersionOutOfDate, isElyraVersionUpToDate } from './utils';
+
+type ElyraInvalidVersionProps = {
+  notebooks: NotebookKind[];
+  children: (showImpactedNotebookInfo: (notebook: NotebookKind) => boolean) => React.ReactNode;
+};
+
+export const ElyraInvalidVersionAlerts: React.FC<ElyraInvalidVersionProps> = ({
+  notebooks,
+  children,
+}) => {
+  const { dashboardNamespace } = useNamespaces();
+  const [images, loaded, loadError] = useImageStreams(dashboardNamespace, true);
+  const navigate = useNavigate();
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const { pipelinesServer } = usePipelinesAPI();
+  const [viewImpactedImages, setViewImpactedImages] = React.useState(true);
+  const [elyraInvalidVersionAlertDismissed, setElyraInvalidVersionAlertDismissed] =
+    useBrowserStorage('elyraInvalidVersionAlertDismissed', false, true, true);
+  const [unsupportedPipelineVersionAlertDismissed, setUnsupportedPipelineVersionAlertDismissed] =
+    useBrowserStorage('unsupportedPipelineVersionAlertDismissed', false, true, true);
+
+  const [outOfDateNotebooks, updatedNotebooks] = React.useMemo(() => {
+    if (!loaded || loadError) {
+      return [[], []];
+    }
+
+    return notebooks.reduce<[NotebookKind[], NotebookKind[]]>(
+      ([outOfDate, updated], notebook) => {
+        const imageData = getNotebookImageData(notebook, images);
+        if (imageData && imageData.imageAvailability !== NotebookImageAvailability.DELETED) {
+          // technically the image can have both out of date and up to date versions, but unlikely
+          if (isElyraVersionUpToDate(imageData.imageVersion)) {
+            updated.push(notebook);
+          }
+          if (isElyraVersionOutOfDate(imageData.imageVersion)) {
+            outOfDate.push(notebook);
+          }
+        }
+        return [outOfDate, updated];
+      },
+      [[], []],
+    );
+  }, [loaded, loadError, notebooks, images]);
+
+  const showElyraInvalidVersionsAlert =
+    outOfDateNotebooks.length > 0 &&
+    pipelinesServer.installed &&
+    pipelinesServer.compatible &&
+    !elyraInvalidVersionAlertDismissed;
+
+  const showUnsupportedPipelineVersionAlert =
+    pipelinesServer.installed &&
+    !pipelinesServer.compatible &&
+    updatedNotebooks.length > 0 &&
+    !unsupportedPipelineVersionAlertDismissed;
+
+  const showImpactedNotebookInfo = (notebook: NotebookKind) =>
+    outOfDateNotebooks.some((data) => data.metadata.name === notebook.metadata.name) &&
+    viewImpactedImages &&
+    showElyraInvalidVersionsAlert;
+
+  return (
+    <Stack hasGutter>
+      {showElyraInvalidVersionsAlert && (
+        <StackItem>
+          <Alert
+            data-testid="elyra-invalid-version-alert"
+            variant="info"
+            title="Images denoted with (i) don't support the latest pipeline version. To use Elyra for pipelines, update the images to the latest version"
+            isInline
+            actionLinks={
+              <Checkbox
+                label="View impacted images"
+                isChecked={viewImpactedImages}
+                onChange={(_e, checked) => setViewImpactedImages(checked)}
+                id="impacted-images-checkbox"
+              />
+            }
+            actionClose={
+              <AlertActionCloseButton onClose={() => setElyraInvalidVersionAlertDismissed(true)} />
+            }
+          />
+        </StackItem>
+      )}
+      {showUnsupportedPipelineVersionAlert && (
+        <StackItem>
+          <Alert
+            data-testid="unsupported-pipeline-version-alert"
+            variant="warning"
+            title="This pipeline version is no longer supported. To remove unsupported versions, go to the Pipelines tab, delete this project's pipeline server, and create a new one."
+            isInline
+            actionLinks={
+              <AlertActionLink
+                onClick={() =>
+                  navigate(
+                    `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.PIPELINES}`,
+                  )
+                }
+              >
+                Go to Pipelines
+              </AlertActionLink>
+            }
+            actionClose={
+              <AlertActionCloseButton
+                onClose={() => setUnsupportedPipelineVersionAlertDismissed(true)}
+              />
+            }
+          />
+        </StackItem>
+      )}
+      <StackItem>{children(showImpactedNotebookInfo)}</StackItem>
+    </Stack>
+  );
+};

--- a/frontend/src/concepts/pipelines/elyra/utils.ts
+++ b/frontend/src/concepts/pipelines/elyra/utils.ts
@@ -1,6 +1,7 @@
 import { Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   DSPipelineExternalStorageKind,
+  ImageStreamSpecTagType,
   KnownLabels,
   NotebookKind,
   RoleBindingKind,
@@ -17,6 +18,7 @@ import { Volume, VolumeMount } from '~/types';
 import { RUNTIME_MOUNT_PATH } from '~/pages/projects/pvc/const';
 import { createRoleBinding, getRoleBinding, patchRoleBindingOwnerRef } from '~/api';
 import { routePipelineRunDetailsNamespace } from '~/routes';
+import { getImageVersionDependencies } from '~/pages/projects/screens/spawner/spawnerUtils';
 
 type ElyraRoleBindingOwnerRef = {
   apiVersion: string;
@@ -201,4 +203,16 @@ export const createElyraServiceAccountRoleBinding = async (
   }
 
   return undefined;
+};
+
+// V2 -> odh-elyra: 3.16
+export const isElyraVersionUpToDate = (imageVersion: ImageStreamSpecTagType): boolean => {
+  const deps = getImageVersionDependencies(imageVersion);
+  return deps.some((dep) => dep.name.toLowerCase() === 'odh-elyra');
+};
+
+// V1 -> elyra: 3.15
+export const isElyraVersionOutOfDate = (imageVersion: ImageStreamSpecTagType): boolean => {
+  const deps = getImageVersionDependencies(imageVersion);
+  return deps.some((dep) => dep.name.toLowerCase() === 'elyra');
 };

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTable.tsx
@@ -6,6 +6,7 @@ import AddNotebookStorage from '~/pages/projects/pvc/AddNotebookStorage';
 import { NotebookState } from '~/pages/projects/notebook/types';
 import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableElyraPipelinesCheck';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { ElyraInvalidVersionAlerts } from '~/concepts/pipelines/elyra/ElyraInvalidVersionAlerts';
 import NotebookTableRow from './NotebookTableRow';
 import { columns } from './data';
 
@@ -21,27 +22,32 @@ const NotebookTable: React.FC<NotebookTableProps> = ({ notebookStates, refresh }
 
   return (
     <>
-      <CanEnableElyraPipelinesCheck namespace={currentProject.metadata.name}>
-        {(canEnablePipelines) => (
-          <Table
-            data-testid="notebook-table"
-            variant="compact"
-            data={notebookStates}
-            columns={columns}
-            disableRowRenderSupport
-            rowRenderer={(notebookState, i) => (
-              <NotebookTableRow
-                key={notebookState.notebook.metadata.uid}
-                rowIndex={i}
-                obj={notebookState}
-                onNotebookDelete={setNotebookToDelete}
-                onNotebookAddStorage={setAddNotebookStorage}
-                canEnablePipelines={canEnablePipelines}
+      <ElyraInvalidVersionAlerts notebooks={notebookStates.map((n) => n.notebook)}>
+        {(showImpactedNotebookInfo) => (
+          <CanEnableElyraPipelinesCheck namespace={currentProject.metadata.name}>
+            {(canEnablePipelines) => (
+              <Table
+                data-testid="notebook-table"
+                variant="compact"
+                data={notebookStates}
+                columns={columns}
+                disableRowRenderSupport
+                rowRenderer={(notebookState, i) => (
+                  <NotebookTableRow
+                    key={notebookState.notebook.metadata.uid}
+                    rowIndex={i}
+                    obj={notebookState}
+                    onNotebookDelete={setNotebookToDelete}
+                    onNotebookAddStorage={setAddNotebookStorage}
+                    canEnablePipelines={canEnablePipelines}
+                    showOutOfDateElyraInfo={showImpactedNotebookInfo(notebookState.notebook)}
+                  />
+                )}
               />
             )}
-          />
+          </CanEnableElyraPipelinesCheck>
         )}
-      </CanEnableElyraPipelinesCheck>
+      </ElyraInvalidVersionAlerts>
       <AddNotebookStorage
         notebook={addNotebookStorage}
         onClose={(submitted) => {

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
 import { ActionsColumn, ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
-import { Flex, FlexItem, Icon, Tooltip } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Icon,
+  Popover,
+  Split,
+  SplitItem,
+  Tooltip,
+} from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
 import { NotebookState } from '~/pages/projects/notebook/types';
 import { getNotebookDescription, getNotebookDisplayName } from '~/pages/projects/utils';
 import NotebookRouteLink from '~/pages/projects/notebook/NotebookRouteLink';
@@ -12,6 +21,7 @@ import NotebookImagePackageDetails from '~/pages/projects/notebook/NotebookImage
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { TableRowTitleDescription } from '~/components/table';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import useNotebookDeploymentSize from './useNotebookDeploymentSize';
 import useNotebookImage from './useNotebookImage';
 import NotebookSizeDetails from './NotebookSizeDetails';
@@ -26,6 +36,7 @@ type NotebookTableRowProps = {
   onNotebookAddStorage: (notebook: NotebookKind) => void;
   canEnablePipelines: boolean;
   compact?: boolean;
+  showOutOfDateElyraInfo: boolean;
 };
 
 const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
@@ -35,6 +46,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   onNotebookAddStorage,
   canEnablePipelines,
   compact,
+  showOutOfDateElyraInfo,
 }) => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const navigate = useNavigate();
@@ -81,12 +93,47 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           )}
         </Td>
         <Td dataLabel="Notebook image">
-          <NotebookImageDisplayName
-            notebookImage={notebookImage}
-            loaded={loaded}
-            loadError={loadError}
-            isExpanded
-          />
+          <Split>
+            <SplitItem>
+              <NotebookImageDisplayName
+                notebookImage={notebookImage}
+                loaded={loaded}
+                loadError={loadError}
+                isExpanded
+              />
+            </SplitItem>
+            {showOutOfDateElyraInfo && (
+              <SplitItem>
+                <Popover
+                  alertSeverityVariant="info"
+                  headerIcon={<InfoCircleIcon />}
+                  headerContent="Update image to the latest version"
+                  bodyContent="The selected image version does not support the latest pipeline version. To use Elyra for pipelines, update the image to the latest version by editing the workbench."
+                  footerContent={
+                    <Button
+                      onClick={() => {
+                        navigate(
+                          `/projects/${currentProject.metadata.name}/spawner/${obj.notebook.metadata.name}`,
+                        );
+                      }}
+                    >
+                      Edit workbench
+                    </Button>
+                  }
+                >
+                  <DashboardPopupIconButton
+                    aria-label="Notebook image has out of date Elrya version"
+                    data-testid="outdated-elyra-info"
+                    icon={
+                      <Icon status="info">
+                        <InfoCircleIcon />
+                      </Icon>
+                    }
+                  />
+                </Popover>
+              </SplitItem>
+            )}
+          </Split>
         </Td>
         {!compact ? (
           <Td dataLabel="Container size">

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -1,11 +1,67 @@
 import * as React from 'react';
-import { NotebookKind } from '~/k8sTypes';
+import { ImageStreamKind, NotebookKind } from '~/k8sTypes';
 import useNamespaces from '~/pages/notebookController/useNamespaces';
 import useImageStreams from '~/pages/projects/screens/spawner/useImageStreams';
 import { PodContainer } from '~/types';
 import { getImageStreamDisplayName } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { NotebookImageAvailability } from './const';
 import { NotebookImageData } from './types';
+
+export const getNotebookImageData = (
+  notebook: NotebookKind,
+  images: ImageStreamKind[],
+): NotebookImageData[0] => {
+  const container: PodContainer | undefined = notebook.spec.template.spec.containers.find(
+    (currentContainer) => currentContainer.name === notebook.metadata.name,
+  );
+  const imageTag = container?.image.split('/').at(-1)?.split(':');
+
+  // if image could not be parsed from the container, consider it deleted because the image tag is invalid
+  if (!imageTag || imageTag.length < 2 || !container) {
+    return {
+      imageAvailability: NotebookImageAvailability.DELETED,
+    };
+  }
+
+  const [imageName, versionName] = imageTag;
+  const imageStream = images.find((image) => image.metadata.name === imageName);
+
+  // if the image stream is not found, consider it deleted
+  if (!imageStream) {
+    // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
+    const imageDisplayName = notebook.metadata.annotations?.['opendatahub.io/image-display-name'];
+
+    return {
+      imageAvailability: NotebookImageAvailability.DELETED,
+      imageDisplayName,
+    };
+  }
+
+  const versions = imageStream.spec.tags || [];
+  const imageVersion = versions.find((version) => version.name === versionName);
+
+  // because the image stream was found, get its display name
+  const imageDisplayName = getImageStreamDisplayName(imageStream);
+
+  // if the image version is not found, consider the image stream deleted
+  if (!imageVersion) {
+    return {
+      imageAvailability: NotebookImageAvailability.DELETED,
+      imageDisplayName,
+    };
+  }
+
+  // if the image stream exists and the image version exists, return the image data
+  return {
+    imageStream,
+    imageVersion,
+    imageAvailability:
+      imageStream.metadata.labels?.['opendatahub.io/notebook-image'] === 'true'
+        ? NotebookImageAvailability.ENABLED
+        : NotebookImageAvailability.DISABLED,
+    imageDisplayName,
+  };
+};
 
 const useNotebookImageData = (notebook?: NotebookKind): NotebookImageData => {
   const { dashboardNamespace } = useNamespaces();
@@ -15,73 +71,13 @@ const useNotebookImageData = (notebook?: NotebookKind): NotebookImageData => {
     if (!loaded || !notebook) {
       return [null, false, loadError];
     }
+    const data = getNotebookImageData(notebook, images);
 
-    const container: PodContainer | undefined = notebook.spec.template.spec.containers.find(
-      (currentContainer) => currentContainer.name === notebook.metadata.name,
-    );
-    const imageTag = container?.image.split('/').at(-1)?.split(':');
-
-    // if image could not be parsed from the container, consider it deleted because the image tag is invalid
-    if (!imageTag || imageTag.length < 2 || !container) {
-      return [
-        {
-          imageAvailability: NotebookImageAvailability.DELETED,
-        },
-        true,
-        undefined,
-      ];
+    if (data === null) {
+      return [null, false, loadError];
     }
 
-    const [imageName, versionName] = imageTag;
-    const imageStream = images.find((image) => image.metadata.name === imageName);
-
-    // if the image stream is not found, consider it deleted
-    if (!imageStream) {
-      // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
-      const imageDisplayName = notebook.metadata.annotations?.['opendatahub.io/image-display-name'];
-
-      return [
-        {
-          imageAvailability: NotebookImageAvailability.DELETED,
-          imageDisplayName,
-        },
-        true,
-        undefined,
-      ];
-    }
-
-    const versions = imageStream.spec.tags || [];
-    const imageVersion = versions.find((version) => version.name === versionName);
-
-    // because the image stream was found, get its display name
-    const imageDisplayName = getImageStreamDisplayName(imageStream);
-
-    // if the image version is not found, consider the image stream deleted
-    if (!imageVersion) {
-      return [
-        {
-          imageAvailability: NotebookImageAvailability.DELETED,
-          imageDisplayName,
-        },
-        true,
-        undefined,
-      ];
-    }
-
-    // if the image stream exists and the image version exists, return the image data
-    return [
-      {
-        imageStream,
-        imageVersion,
-        imageAvailability:
-          imageStream.metadata.labels?.['opendatahub.io/notebook-image'] === 'true'
-            ? NotebookImageAvailability.ENABLED
-            : NotebookImageAvailability.DISABLED,
-        imageDisplayName,
-      },
-      true,
-      undefined,
-    ];
+    return [data, true, undefined];
   }, [images, notebook, loaded, loadError]);
 };
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -153,7 +153,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
         variant="light"
       >
         <GenericSidebar sections={sectionIDs} titles={SpawnerPageSectionTitles}>
-          <Form style={{ maxWidth: 600 }}>
+          <Form style={{ maxWidth: 625 }}>
             <FormSection
               id={SpawnerPageSectionID.NAME_DESCRIPTION}
               aria-label={SpawnerPageSectionTitles[SpawnerPageSectionID.NAME_DESCRIPTION]}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-4715

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds two new alerts above workbenches table in the project details section
- Info alert when you are on a v2 pipeline server but have at least one workbench with a notebook image using old version of python package Elyra.
   - has a checkbox to hide or show the notebook image info icon
- warning alert when you are on a v1 pipeline server but have at least one workbench with a notebook image using the updated version of python package ODH-Elyra
- an info icon with a popover on images with out of date elyra for when the info alert is shown (same criteria)
- both alerts can be dismissed and that is saved in session storage
- info icon for out of date elyra is added to version in workbench spawner only if the criteria are met (using new v2 pipeline server, have not dismissed popup). also a note is included below

here is my exact logic for my ref
```tsx
  const showElyraInvalidVersionsAlert =
    outOfDateNotebooks.length > 0 &&
    pipelinesServer.installed &&
    pipelinesServer.compatible &&
    !elyraInvalidVersionAlertDismissed;

  const showUnsupportedPipelineVersionAlert =
    pipelinesServer.installed &&
    !pipelinesServer.compatible &&
    updatedNotebooks.length > 0 &&
    !unsupportedPipelineVersionAlertDismissed;
```

When user is on v2 pipelines and has at least one out of date notebook version (elrya)
![Screenshot 2024-04-03 at 12 59 27 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/be4faf6d-8b58-4a6c-83ec-ba628e1d2aa3)
<img width="686" alt="Screenshot 2024-04-04 at 8 34 30 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/8d6f9aa2-97e5-4b71-9e21-0ec494932b29">
![Screenshot 2024-04-03 at 12 59 37 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/5f6d5c74-519b-41d1-81c1-a2a93e611d92)

When user is on v1 pipelines and has at least one updated notebook version (odh-elyra)
<img width="708" alt="Screenshot 2024-04-04 at 8 59 05 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/7812ba33-c5cb-41e9-876b-a27a4d11a8dc">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. verify the alerts and icons dont show when pipelines is not installed
   a. add a workbench with outdated elrya -> no alert
   b. add a workbench with updated elrya -> no alert
2. install v2 pipeline server (default)
   a. check workbench with outdated elrya -> **alert**
   b. check workbench with updated elrya -> no alert
3. go to workbench spawner, check that info alert is next to image version with out of date elyra
4. dismiss alert form notebook list view
5. refresh -> alert should be gone still
6. switch dspa yaml to use v1 pipeline server
   a. check workbench with outdated elrya -> no alert
   b. check workbench with updated elrya -> **alert**
7. dismiss alert form notebook list view
8. refresh -> alert should be gone still

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added tests for checking workbench table row shows info icon when criteria are met and both alerts show when criteria are met.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

@yannnz 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
