### PR TITLE
Fix run type switch link in createRunPage and RunPage

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -87,6 +87,20 @@ describe('Pipeline create runs', () => {
       });
     });
 
+    it('switches to scheduled runs from triggered', () => {
+      // Mock experiments, pipelines & versions for form select dropdowns
+      createRunPage.mockGetExperiments(mockExperiments);
+      createRunPage.mockGetPipelines([mockPipeline]);
+      createRunPage.mockGetPipelineVersions([mockPipelineVersion], mockPipelineVersion.pipeline_id);
+
+      // Navigate to the 'Create run' page
+      pipelineRunsGlobal.findCreateRunButton().click();
+      verifyRelativeURL(`/pipelineRuns/${projectName}/pipelineRun/create`);
+      createRunPage.find();
+      createRunPage.findRunTypeSwitchLink().click();
+      cy.url().should('include', '?runType=scheduled');
+    });
+
     it('creates an active run', () => {
       const createRunParams: Partial<PipelineRunKFv2> = {
         display_name: 'New run',
@@ -475,6 +489,23 @@ describe('Pipeline create runs', () => {
       });
 
       pipelineRunsGlobal.findSchedulesTab().click();
+    });
+
+    it('switches to scheduled runs from triggered', () => {
+      // Mock experiments, pipelines & versions for form select dropdowns
+      createSchedulePage.mockGetExperiments(mockExperiments);
+      createSchedulePage.mockGetPipelines([mockPipeline]);
+      createSchedulePage.mockGetPipelineVersions(
+        [mockPipelineVersion],
+        mockPipelineVersion.pipeline_id,
+      );
+
+      // Navigate to the 'Create run' page
+      pipelineRunsGlobal.findScheduleRunButton().click();
+      verifyRelativeURL(`/pipelineRuns/${projectName}/pipelineRun/create?runType=scheduled`);
+      createSchedulePage.find();
+      createSchedulePage.findRunTypeSwitchLink().click();
+      cy.url().should('include', '?runType=active');
     });
 
     it('creates a schedule', () => {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -42,6 +42,10 @@ export class CreateRunPage {
     return cy.findByTestId('run-description');
   }
 
+  findRunTypeSwitchLink(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('run-type-section-alert-link');
+  }
+
   findExperimentSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().findByTestId('experiment-toggle-button');
   }

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import { Form, FormSection, Text } from '@patternfly/react-core';
 import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
-import {
-  RunFormData,
-  RunTypeOption,
-  ScheduledRunType,
-} from '~/concepts/pipelines/content/createRun/types';
+import { RunFormData, RunTypeOption } from '~/concepts/pipelines/content/createRun/types';
 import { ValueOf } from '~/typeHelpers';
 import { ParamsSection } from '~/concepts/pipelines/content/createRun/contentSections/ParamsSection';
 import { getProjectDisplayName } from '~/pages/projects/utils';
@@ -102,13 +98,13 @@ const RunForm: React.FC<RunFormProps> = ({ data, runType, onValueChange }) => {
         }}
       />
 
-      {runType === PipelineRunType.Scheduled && (
+      {runType === PipelineRunType.Scheduled && data.runType.type === RunTypeOption.SCHEDULED && (
         <FormSection
           id={CreateRunPageSections.SCHEDULE_SETTINGS}
           title={runPageSectionTitles[CreateRunPageSections.SCHEDULE_SETTINGS]}
         >
           <RunTypeSectionScheduled
-            data={(data.runType as ScheduledRunType).data}
+            data={data.runType.data}
             onChange={(scheduleData) =>
               onValueChange('runType', { type: RunTypeOption.SCHEDULED, data: scheduleData })
             }

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/RunTypeSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/RunTypeSection.tsx
@@ -8,8 +8,7 @@ import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
-import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
-import { runsBaseRoute } from '~/routes';
+import { createRunRoute, scheduleRunRoute } from '~/routes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 interface RunTypeSectionProps {
@@ -26,7 +25,8 @@ export const RunTypeSection: React.FC<RunTypeSectionProps> = ({ runType }) => {
   let alertProps = {
     title: 'Go to Schedules to create schedules that execute recurring runs',
     label: `Go to ${PipelineRunTabTitle.Schedules}`,
-    navSearch: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.Scheduled}`,
+    search: '?runType=scheduled',
+    pathname: scheduleRunRoute(namespace, isExperimentsAvailable ? experimentId : undefined),
   };
 
   if (runType === PipelineRunType.Scheduled) {
@@ -34,7 +34,8 @@ export const RunTypeSection: React.FC<RunTypeSectionProps> = ({ runType }) => {
     alertProps = {
       title: 'Go to Active runs to create a run that executes once immediately after creation.',
       label: `Go to ${PipelineRunTabTitle.Active} runs`,
-      navSearch: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.Active}`,
+      search: '?runType=active',
+      pathname: createRunRoute(namespace, isExperimentsAvailable ? experimentId : undefined),
     };
   }
 
@@ -54,15 +55,8 @@ export const RunTypeSection: React.FC<RunTypeSectionProps> = ({ runType }) => {
             <Button
               isInline
               variant="link"
-              onClick={() =>
-                navigate({
-                  pathname: runsBaseRoute(
-                    namespace,
-                    isExperimentsAvailable ? experimentId : undefined,
-                  ),
-                  search: alertProps.navSearch,
-                })
-              }
+              onClick={() => navigate({ pathname: alertProps.pathname, search: alertProps.search })}
+              data-testid="run-type-section-alert-link"
             >
               {alertProps.label}
             </Button>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-4739

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- switching from triggered run to scheduled run and vise versa now directs to the create form and not the list
- doing this from a clone will direct to a non clone route 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- create a run, switch run to scheduled
- create a schedule, switch run to triggered
- clone a run, switch to non clone route schedule
- clone a schedule, switch to non clone triggered

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added tests for the redirects in both directions

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
