### PR TITLE
use default cy.visit function

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/projects/ProjectList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/projects/ProjectList.cy.ts
@@ -11,13 +11,13 @@ import { ProjectModel } from '~/__tests__/cypress/cypress/utils/models';
 describe('Data science projects details', () => {
   it('should start with an empty project list', () => {
     initIntercepts();
-    cy.visitWithLogin('/projects');
+    cy.visit('/projects');
     projectListPage.shouldBeEmpty();
   });
 
   it('should open a modal to create a project', () => {
     initIntercepts();
-    cy.visitWithLogin('/projects');
+    cy.visit('/projects');
     projectListPage.findCreateProjectButton().click();
     createProjectModal.shouldBeOpen();
     createProjectModal.findCancelButton().click();
@@ -110,7 +110,7 @@ describe('Data science projects details', () => {
     };
 
     cy.intercept({ pathname: '/api/k8s/apis/project.openshift.io/v1/projects' }, projectsMock);
-    cy.visitWithLogin('/projects');
+    cy.visit('/projects');
 
     projectListPage.shouldHaveProjects();
     projectListPage.findProjectLink('DS Project 1').should('exist');

--- a/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
@@ -41,7 +41,7 @@ class TolerationRow extends TableRow {
 
 class AcceleratorProfile {
   visit() {
-    cy.visitWithLogin('/acceleratorProfiles');
+    cy.visit('/acceleratorProfiles');
     this.wait();
   }
 
@@ -198,7 +198,7 @@ class TolerationsModal extends Modal {
 
 class CreateAcceleratorProfile extends ManageAcceleratorProfile {
   visit() {
-    cy.visitWithLogin('/acceleratorProfiles/Create');
+    cy.visit('/acceleratorProfiles/Create');
     this.wait();
   }
 
@@ -210,7 +210,7 @@ class CreateAcceleratorProfile extends ManageAcceleratorProfile {
 
 class EditAcceleratorProfile extends ManageAcceleratorProfile {
   visit(name: string) {
-    cy.visitWithLogin(`/acceleratorProfiles/edit/${name}`);
+    cy.visit(`/acceleratorProfiles/edit/${name}`);
     cy.testA11y();
   }
 
@@ -225,7 +225,7 @@ class EditAcceleratorProfile extends ManageAcceleratorProfile {
 
 class IdentifierAcceleratorProfile extends ManageAcceleratorProfile {
   visit(multiple = false) {
-    cy.visitWithLogin(
+    cy.visit(
       multiple
         ? `/acceleratorProfiles/create?identifiers=test-identifier%2Ctest-identifier2`
         : `/acceleratorProfiles/create?identifiers=test-identifier`,

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
@@ -2,7 +2,7 @@ import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 
 class ClusterSettings {
   visit() {
-    cy.visitWithLogin('/clusterSettings');
+    cy.visit('/clusterSettings');
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -89,7 +89,7 @@ class ClusterStorageModal extends Modal {
 
 class ClusterStorage {
   visit(projectName: string) {
-    cy.visitWithLogin(`/projects/${projectName}?section=cluster-storages`);
+    cy.visit(`/projects/${projectName}?section=cluster-storages`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
@@ -2,7 +2,7 @@ import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 
 class GlobalDistributedWorkloads {
   visit(wait = true) {
-    cy.visitWithLogin(`/distributedWorkloads`);
+    cy.visit(`/distributedWorkloads`);
     if (wait) {
       this.wait();
     }

--- a/frontend/src/__tests__/cypress/cypress/pages/enabled.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/enabled.ts
@@ -1,6 +1,6 @@
 class EnabledPage {
   visit() {
-    cy.visitWithLogin('/');
+    cy.visit('/');
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/explore.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/explore.ts
@@ -1,6 +1,6 @@
 class ExplorePage {
   visit() {
-    cy.visitWithLogin('/explore');
+    cy.visit('/explore');
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelMetrics.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelMetrics.ts
@@ -28,7 +28,7 @@ class ModelMetricsChart extends Contextual<HTMLTableRowElement> {
 
 class ModelMetricsPerformance extends ModelMetricsGlobal {
   visit(project: string, model: string) {
-    cy.visitWithLogin(`/modelServing/${project}/metrics/${model}/performance`);
+    cy.visit(`/modelServing/${project}/metrics/${model}/performance`);
     this.wait();
   }
 
@@ -44,7 +44,7 @@ class ModelMetricsPerformance extends ModelMetricsGlobal {
 
 class ModelMetricsBias extends ModelMetricsGlobal {
   visit(project: string, model: string, disableA11y = false) {
-    cy.visitWithLogin(`/modelServing/${project}/metrics/${model}/bias`);
+    cy.visit(`/modelServing/${project}/metrics/${model}/bias`);
 
     // TODO: disableA11y should be removed once this PF bug is resolved: https://github.com/patternfly/patternfly-react/issues/9968
     this.wait(disableA11y);
@@ -85,7 +85,7 @@ class ModelMetricsBias extends ModelMetricsGlobal {
 
 class ServerMetrics extends ModelMetricsGlobal {
   visit(project: string, server: string) {
-    cy.visitWithLogin(`/projects/${project}/metrics/server/${server}`);
+    cy.visit(`/projects/${project}/metrics/server/${server}`);
     this.wait();
   }
 
@@ -97,7 +97,7 @@ class ServerMetrics extends ModelMetricsGlobal {
 
 class ModelMetricsConfigureSection {
   visit(project: string, model: string) {
-    cy.visitWithLogin(`/modelServing/${project}/metrics/${model}/configure`);
+    cy.visit(`/modelServing/${project}/metrics/${model}/configure`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -2,12 +2,12 @@ import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 
 class ModelRegistry {
   landingPage() {
-    cy.visitWithLogin('/');
+    cy.visit('/');
     this.waitLanding();
   }
 
   visit(modelRegistry?: string) {
-    cy.visitWithLogin(`/modelRegistry${modelRegistry}`);
+    cy.visit(`/modelRegistry${modelRegistry}`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -6,7 +6,7 @@ import { Contextual } from './components/Contextual';
 
 class ModelServingGlobal {
   visit(project?: string) {
-    cy.visitWithLogin(`/modelServing${project ? `/${project}` : ''}`);
+    cy.visit(`/modelServing${project ? `/${project}` : ''}`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
@@ -13,7 +13,7 @@ class NotebookImageSettingsTableToolbar extends TableToolbar {}
 
 class NotebookImageSettings {
   visit() {
-    cy.visitWithLogin('/notebookImages');
+    cy.visit('/notebookImages');
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pageNotFound.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pageNotFound.ts
@@ -1,6 +1,6 @@
 class PageNotFound {
   visit(name: string) {
-    cy.visitWithLogin(`/${name}`);
+    cy.visit(`/${name}`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/compareRuns.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/compareRuns.ts
@@ -1,8 +1,6 @@
 class CompareRunsGlobal {
   visit(projectName: string, experimentId: string, runIds: string[] = []) {
-    cy.visitWithLogin(
-      `/experiments/${projectName}/${experimentId}/compareRuns?runs=${runIds.join(',')}`,
-    );
+    cy.visit(`/experiments/${projectName}/${experimentId}/compareRuns?runs=${runIds.join(',')}`);
   }
 
   findInvalidRunsError() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
@@ -5,7 +5,7 @@ import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 
 class ExperimentsTabs {
   visit(namespace?: string, tab?: string) {
-    cy.visitWithLogin(`/experiments${namespace ? `/${namespace}` : ''}${tab ? `/${tab}` : ''}`);
+    cy.visit(`/experiments${namespace ? `/${namespace}` : ''}${tab ? `/${tab}` : ''}`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/manageRuns.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/manageRuns.ts
@@ -2,7 +2,7 @@ import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 
 class ManageRunsPage {
   visit(experimentId: string, projectName: string, runIds: string[]) {
-    cy.visitWithLogin(
+    cy.visit(
       `/experiments/${projectName}/${experimentId}/compareRuns/add?runs=${runIds.join(',')}`,
     );
     this.wait();

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
@@ -3,7 +3,7 @@ import { DeleteModal } from '~/__tests__/cypress/cypress/pages/components/Delete
 
 class PipelineRunsGlobal {
   visit(projectName: string, runType?: 'active' | 'archived' | 'scheduled') {
-    cy.visitWithLogin(
+    cy.visit(
       `/pipelineRuns/${projectName}${
         runType ? `?${PipelineRunSearchParam.RunType}=${runType}` : ''
       }`,

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -2,7 +2,7 @@ import { DeleteModal } from '~/__tests__/cypress/cypress/pages/components/Delete
 
 class PipelinesGlobal {
   visit(projectName: string) {
-    cy.visitWithLogin(`/pipelines/${projectName}`);
+    cy.visit(`/pipelines/${projectName}`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -2,7 +2,7 @@ import { Contextual } from '~/__tests__/cypress/cypress/pages/components/Context
 
 class PipelinesTopology {
   visit(namespace: string, pipelineId: string, pipelineVersionId: string) {
-    cy.visitWithLogin(`/pipelines/${namespace}/pipeline/view/${pipelineId}/${pipelineVersionId}`);
+    cy.visit(`/pipelines/${namespace}/pipeline/view/${pipelineId}/${pipelineVersionId}`);
     this.wait();
   }
 
@@ -71,7 +71,7 @@ class DetailsItem extends Contextual<HTMLElement> {
 
 class PipelineDetails extends PipelinesTopology {
   visit(namespace: string, pipelineId: string, pipelineVersionId: string) {
-    cy.visitWithLogin(`/pipelines/${namespace}/pipeline/view/${pipelineId}/${pipelineVersionId}`);
+    cy.visit(`/pipelines/${namespace}/pipeline/view/${pipelineId}/${pipelineVersionId}`);
     this.wait();
   }
 
@@ -114,7 +114,7 @@ class PipelineDetails extends PipelinesTopology {
 
 class PipelineRunJobDetails extends RunDetails {
   visit(namespace: string, pipelineId: string) {
-    cy.visitWithLogin(`/pipelineRuns/${namespace}/pipelineRunJob/view/${pipelineId}`);
+    cy.visit(`/pipelineRuns/${namespace}/pipelineRunJob/view/${pipelineId}`);
     this.wait();
   }
 
@@ -129,7 +129,7 @@ class PipelineRunJobDetails extends RunDetails {
 
 class PipelineRunDetails extends RunDetails {
   visit(namespace: string, pipelineId: string) {
-    cy.visitWithLogin(`/pipelineRuns/${namespace}/pipelineRun/view/${pipelineId}`);
+    cy.visit(`/pipelineRuns/${namespace}/pipelineRun/view/${pipelineId}`);
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -21,7 +21,7 @@ class ProjectRow extends TableRow {
 
 class ProjectListPage {
   visit() {
-    cy.visitWithLogin('/projects');
+    cy.visit('/projects');
     this.wait();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
@@ -33,7 +33,7 @@ class ServingRuntimeRow {
 
 class ServingRuntimes {
   visit() {
-    cy.visitWithLogin('/servingRuntimes');
+    cy.visit('/servingRuntimes');
     this.wait();
   }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-2808

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
It's still unclear exactly what is causing the initial page load to fail. It's possibly an issue with the HTTP server used hosting our frontend or something internally with cypress. However the check for the invalid status code is performed by the custom command `visitWithLogin`. This command is only useful if running against a live cluster (eg. for snapshot purposes). Therefore this PR replaces the use of `visitWithLogin` with a basic `visit` call. The hope here is that `visit` will reattempt the command if this situation and resolve itself. `visitWithLogin` used `{ failOnStatusCode: false }` which was needed to capture the `403`. An assumption here is that this option aborts any retry attempts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test automation.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
