### PR TITLE
Enable Distributed Workloads feature flag by default in manifests

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -35,6 +35,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableModelMesh: boolean;
       disableAcceleratorProfiles: boolean;
       disablePipelineExperiments: boolean;
+      disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
     };
     groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -60,6 +60,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableModelMesh: false,
       disableAcceleratorProfiles: false,
       disablePipelineExperiments: true,
+      disableDistributedWorkloads: false,
       disableModelRegistry: true,
     },
     notebookController: {

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -31,6 +31,7 @@ The following are a list of features that are supported, along with there defaul
 | modelMetricsNamespace        | false   | Enables the namespace in which the Model Serving Metrics' Prometheus Operator is installed.          |
 | disableBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
+| disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | true    | Disables Model Registry from the dashboard.                                                          |
 
 ## Defaults
@@ -59,6 +60,7 @@ spec:
     disableBiasMetrics: false
     disablePerformanceMetrics: false
     disablePipelineExperiments: false
+    disableDistributedWorkloads: false
 ```
 
 ## Additional fields

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -25,7 +25,7 @@ spec:
     disableKServe: false
     disableKServeAuth: false
     disableModelMesh: false
-    disableDistributedWorkloads: true
+    disableDistributedWorkloads: false
   notebookController:
     enabled: true
   notebookSizes:

--- a/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
@@ -24,7 +24,7 @@ spec:
     disableKServe: false
     disableKServeAuth: false
     disableModelMesh: false
-    disableDistributedWorkloads: true
+    disableDistributedWorkloads: false
     disableModelRegistry: true
   groupsConfig:
     adminGroups: "<admin_groups>"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Enables the Distributed Workloads feature by default for its GA in the upcoming release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
