### PR TITLE
Update ModelServingGlobal Cypress test to account for sorting and filtering

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelServingGlobal.cy.ts
@@ -21,6 +21,7 @@ import {
 } from '~/__tests__/cypress/cypress/pages/modelServing';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { ServingRuntimePlatform } from '~/types';
+import { be } from '~/__tests__/cypress/cypress/utils/should';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -571,5 +572,61 @@ describe('Model Serving Global', () => {
     // Check that the error message is gone
     modelServingGlobal.findDeployModelButton().click();
     cy.findByText('Error creating model server').should('not.exist');
+  });
+
+  describe('Table filter', () => {
+    it('filter by name', () => {
+      initIntercepts({});
+      modelServingGlobal.visit('test-project');
+
+      // Verify initial run rows exist
+      modelServingGlobal.getModelRow('Test Inference Service').should('have.length', 1);
+
+      // Select the "Name" filter
+      const modelServingGlobalToolbar = modelServingGlobal.getTableToolbar();
+      modelServingGlobalToolbar.findFilterMenuOption('filter-dropdown-select', 'Name').click();
+      modelServingGlobalToolbar.findSearchInput().type('Test Inference Service');
+      // Verify only rows with the typed run name exist
+      modelServingGlobal.getModelRow('Test Inference Service').should('exist');
+      // Verify sort button works
+      modelServingGlobal.findSortButton('Model name').click();
+      modelServingGlobal.findSortButton('Model name').should(be.sortDescending);
+      modelServingGlobal.findSortButton('Model name').click();
+      modelServingGlobal.findSortButton('Model name').should(be.sortAscending);
+
+      // Search for non-existent run name
+      modelServingGlobalToolbar.findSearchInput().clear().type('Test Service');
+
+      // Verify no results were found
+      modelServingGlobal.findEmptyResults().should('exist');
+    });
+
+    it('filter by project', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+      });
+      modelServingGlobal.visit('test-project');
+
+      // Verify initial run rows exist
+      modelServingGlobal.getModelRow('Test Inference Service').should('have.length', 1);
+
+      // Select the "Project" filter
+      const modelServingGlobalToolbar = modelServingGlobal.getTableToolbar();
+      modelServingGlobalToolbar.findFilterMenuOption('filter-dropdown-select', 'Project').click();
+      modelServingGlobalToolbar.findSearchInput().type('test project');
+      // Verify only rows with the typed run name exist
+      modelServingGlobal.getModelRow('Test Inference Service').should('exist');
+      // Verify sort button works
+      modelServingGlobal.findSortButton('Project').click();
+      modelServingGlobal.findSortButton('Project').should(be.sortAscending);
+      modelServingGlobal.findSortButton('Project').click();
+      modelServingGlobal.findSortButton('Project').should(be.sortDescending);
+
+      // Search for non-existent run name
+      modelServingGlobalToolbar.findSearchInput().clear().type('Test Service');
+
+      // Verify no results were found
+      modelServingGlobal.findEmptyResults().should('exist');
+    });
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/components/TableToolbar.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/TableToolbar.ts
@@ -2,7 +2,7 @@ import { Contextual } from './Contextual';
 
 export class TableToolbar extends Contextual<HTMLElement> {
   private findToggleButton(id: string) {
-    return cy.pfSwitch(id).click();
+    return this.find().pfSwitch(id).click();
   }
 
   findFilterMenuOption(id: string, name: string): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -10,10 +10,10 @@ export class TableToolbar extends Contextual<HTMLElement> {
   }
 
   findSearchInput(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByLabelText('Search input');
+    return this.find().findByLabelText('Search input');
   }
 
   findResetButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('button', { name: 'Reset' });
+    return this.find().findByRole('button', { name: 'Reset' });
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -3,7 +3,9 @@ import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 import { mixin } from '~/__tests__/cypress/cypress/utils/mixin';
 import { Contextual } from './components/Contextual';
+import { TableToolbar } from './components/TableToolbar';
 
+class ModelServingToolbar extends TableToolbar {}
 class ModelServingGlobal {
   visit(project?: string) {
     cy.visitWithLogin(`/modelServing${project ? `/${project}` : ''}`);
@@ -57,6 +59,18 @@ class ModelServingGlobal {
 
   getModelRow(name: string) {
     return this.findModelsTable().find(`[data-label=Name]`).contains(name).parents('tr');
+  }
+
+  findEmptyResults() {
+    return cy.findByTestId('no-result-found-title');
+  }
+
+  findSortButton(name: string) {
+    return this.findModelsTable().find('thead').findByRole('button', { name });
+  }
+
+  getTableToolbar() {
+    return new ModelServingToolbar(() => cy.findByTestId('dashboard-table-toolbar'));
   }
 }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-3837](https://issues.redhat.com/browse/RHOAIENG-3837)

## Description
This PR validates that the Name and Project table filtering, searching, and sorting functionality works properly

## How Has This Been Tested?
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
