### PR TITLE
feat(dw): move quota level issue states out of tabs

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
@@ -183,14 +183,11 @@ describe('Distributed Workload Metrics root page', () => {
 
     cy.findByText('No data science projects').should('exist');
   });
-});
 
-describe('Project Metrics tab', () => {
   it('Should render with no quota state when there is no clusterqueue', () => {
     initIntercepts({ clusterQueues: [] });
     globalDistributedWorkloads.visit();
-    cy.findByLabelText('Project metrics tab').click();
-    cy.findByText('Quota is not set').should('exist');
+    cy.findByText('Configure the cluster queue').should('exist');
   });
 
   it('Should render with no quota state when the clusterqueue has no resourceGroups', () => {
@@ -200,17 +197,17 @@ describe('Project Metrics tab', () => {
       ],
     });
     globalDistributedWorkloads.visit();
-    cy.findByLabelText('Project metrics tab').click();
-    cy.findByText('Quota is not set').should('exist');
+    cy.findByText('Configure the cluster queue').should('exist');
   });
 
   it('Should render with no quota state when there are no localqueues', () => {
     initIntercepts({ localQueues: [] });
     globalDistributedWorkloads.visit();
-    cy.findByLabelText('Project metrics tab').click();
-    cy.findByText('Quota is not set').should('exist');
+    cy.findByText('Configure the project queue').should('exist');
   });
+});
 
+describe('Project Metrics tab', () => {
   it('Should render with no workloads empty state', () => {
     initIntercepts({ workloads: [] });
     globalDistributedWorkloads.visit();

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -1,18 +1,6 @@
 import * as React from 'react';
-import {
-  Bullseye,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader,
-  EmptyStateIcon,
-  Spinner,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
-import { WrenchIcon } from '@patternfly/react-icons';
+import { Stack, StackItem } from '@patternfly/react-core';
 import { useUser } from '~/redux/selectors';
-import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
-import EmptyStateErrorMessage from '~/components/EmptyStateErrorMessage';
 import { RequestedResources } from './sections/RequestedResources';
 import { TopResourceConsumingWorkloads } from './sections/TopResourceConsumingWorkloads';
 import { WorkloadResourceMetricsTable } from './sections/WorkloadResourceMetricsTable';
@@ -21,71 +9,33 @@ import { DWSectionCard } from './sections/DWSectionCard';
 const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
   const { isAdmin } = useUser();
 
-  const { clusterQueue, localQueues } = React.useContext(DistributedWorkloadsContext);
-  const requiredFetches = [clusterQueue, localQueues];
-  const error = requiredFetches.find((f) => !!f.error)?.error;
-  const loaded = requiredFetches.every((f) => f.loaded);
-
-  if (error) {
-    return (
-      <EmptyStateErrorMessage
-        title="Error loading distributed workload metrics"
-        bodyText={error.message}
-      />
-    );
-  }
-
-  if (!loaded) {
-    return (
-      <Bullseye style={{ minHeight: 150 }}>
-        <Spinner />
-      </Bullseye>
-    );
-  }
-
-  // clusterQueue.data will only be defined here if it has spec.resourceGroups (see DistributedWorkloadsContext)
-  if (!clusterQueue.data || localQueues.data.length === 0) {
-    return (
-      <EmptyState>
-        <EmptyStateHeader
-          titleText="Quota is not set"
-          headingLevel="h4"
-          icon={<EmptyStateIcon icon={WrenchIcon} />}
-        />
-        <EmptyStateBody>Select another project or set the quota for this project.</EmptyStateBody>
-      </EmptyState>
-    );
-  }
-
   return (
-    <>
-      <Stack hasGutter>
-        <StackItem>
-          <DWSectionCard
-            title="Requested resources"
-            helpTooltip={
-              isAdmin
-                ? undefined
-                : 'In this section, all projects refers to all of the projects that share the specified resource. You might not have access to all of these projects.'
-            }
-            content={<RequestedResources />}
-          />
-        </StackItem>
-        <StackItem>
-          <DWSectionCard
-            title="Top resource-consuming distributed workloads"
-            content={<TopResourceConsumingWorkloads />}
-          />
-        </StackItem>
-        <StackItem>
-          <DWSectionCard
-            title="Distributed workload resource metrics"
-            hasDivider={false}
-            content={<WorkloadResourceMetricsTable />}
-          />
-        </StackItem>
-      </Stack>
-    </>
+    <Stack hasGutter>
+      <StackItem>
+        <DWSectionCard
+          title="Requested resources"
+          helpTooltip={
+            isAdmin
+              ? undefined
+              : 'In this section, all projects refers to all of the projects that share the specified resource. You might not have access to all of these projects.'
+          }
+          content={<RequestedResources />}
+        />
+      </StackItem>
+      <StackItem>
+        <DWSectionCard
+          title="Top resource-consuming distributed workloads"
+          content={<TopResourceConsumingWorkloads />}
+        />
+      </StackItem>
+      <StackItem>
+        <DWSectionCard
+          title="Distributed workload resource metrics"
+          hasDivider={false}
+          content={<WorkloadResourceMetricsTable />}
+        />
+      </StackItem>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
## Description
moving quota related error/empty/loading states out of the project metrics tab and to the full dw page.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/a427cbbc-be26-41d0-b630-c041cd4ea068)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/f675a2f7-25e4-4b7d-bd79-b45e42d717fb)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/dd329281-6455-49ec-94b0-549e83cdec8d)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/34e626d9-8f0f-438d-b54a-a7ff54adc4bc)


## How Has This Been Tested?
ran through some scenarios on my local

## Test Impact
updated some tests that were previously testing the existence of these states at the project metric tab level

## Request review criteria:
quota related states will now show at the page level instead of under the project metric tab

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
