### PR TITLE
[RHOAIENG-4727] Compare runs - Parameters expandable section

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/compareRuns.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/compareRuns.ts
@@ -1,3 +1,5 @@
+import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+
 class CompareRunsGlobal {
   visit(projectName: string, experimentId: string, runIds: string[] = []) {
     cy.visit(`/experiments/${projectName}/${experimentId}/compareRuns?runs=${runIds.join(',')}`);
@@ -6,14 +8,52 @@ class CompareRunsGlobal {
   findInvalidRunsError() {
     return cy.findByTestId('compare-runs-invalid-number-runs');
   }
+}
 
-  findRunList() {
+class CompareRunsListTableRow extends TableRow {
+  findCheckbox() {
+    return this.find().find(`[data-label=Checkbox]`).find('input');
+  }
+}
+
+class CompareRunsListTable {
+  find() {
     return cy.findByTestId('compare-runs-table');
   }
 
-  findRunListRowByName(name: string) {
-    return this.findRunList().findByText(name);
+  getRowByName(name: string) {
+    return new CompareRunsListTableRow(() =>
+      this.find().find(`[data-label=Run]`).contains(name).parents('tr'),
+    );
+  }
+
+  findRowByName(name: string) {
+    return this.getRowByName(name).find();
+  }
+
+  findSelectAllCheckbox() {
+    return this.find().findByLabelText('Select all rows');
+  }
+}
+
+class CompareRunParamsTable {
+  find() {
+    return cy.findByTestId('compare-runs-params-table');
+  }
+
+  findEmptyState() {
+    return this.find().parent().findByTestId('compare-runs-params-empty-state');
+  }
+
+  findColumnByName(name: string) {
+    return this.find().contains('th', name);
+  }
+
+  findParamName(name: string) {
+    return this.find().find(`[data-label="${name}"]`);
   }
 }
 
 export const compareRunsGlobal = new CompareRunsGlobal();
+export const compareRunsListTable = new CompareRunsListTable();
+export const compareRunParamsTable = new CompareRunParamsTable();

--- a/frontend/src/components/table/TableBase.tsx
+++ b/frontend/src/components/table/TableBase.tsx
@@ -160,6 +160,10 @@ const TableBase = <T,>({
         width={col.width}
         info={col.info}
         isSubheader={isSubheader}
+        isStickyColumn={col.isStickyColumn}
+        hasRightBorder={col.hasRightBorder}
+        modifier={col.modifier}
+        className={col.className}
       >
         {col.label}
       </Th>
@@ -256,16 +260,18 @@ const TableBase = <T,>({
         </div>
       )}
 
-      <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-w-100">
-        <ToolbarContent alignItems="center">
-          {bottomToolbarContent}
-          {showPagination && (
-            <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-              {pagination('bottom')}
-            </ToolbarItem>
-          )}
-        </ToolbarContent>
-      </Toolbar>
+      {(bottomToolbarContent || showPagination) && (
+        <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-w-100">
+          <ToolbarContent alignItems="center">
+            {bottomToolbarContent}
+            {showPagination && (
+              <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                {pagination('bottom')}
+              </ToolbarItem>
+            )}
+          </ToolbarContent>
+        </Toolbar>
+      )}
     </>
   );
 };

--- a/frontend/src/components/table/types.ts
+++ b/frontend/src/components/table/types.ts
@@ -2,13 +2,14 @@ import { ThProps } from '@patternfly/react-table';
 
 export type GetColumnSort = (columnIndex: number) => ThProps['sort'];
 
-export type SortableData<T> = {
+export type SortableData<T> = Pick<
+  ThProps,
+  'hasRightBorder' | 'isStickyColumn' | 'modifier' | 'width' | 'info' | 'className'
+> & {
   label: string;
   field: string;
   colSpan?: number;
   rowSpan?: number;
-  hasRightBorder?: boolean;
-  width?: ThProps['width'];
   /**
    * Set to false to disable sort.
    * Set to true to handle string and number fields automatically (everything else is equal).
@@ -16,5 +17,4 @@ export type SortableData<T> = {
    * Assume ASC -- the result will be inverted internally if needed.
    */
   sortable: boolean | ((a: T, b: T, keyField: string) => number);
-  info?: ThProps['info'];
 };

--- a/frontend/src/concepts/pipelines/content/PipelineJobReferenceName.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineJobReferenceName.tsx
@@ -20,7 +20,7 @@ const PipelineJobReferenceName: React.FC<PipelineJobReferenceNameProps> = ({
       {loading ? (
         'loading...'
       ) : data ? (
-        <Text component={TextVariants.p} className="pf-u-pb-sm">
+        <Text component={TextVariants.p} className="pf-v5-u-pb-sm">
           Run {getPipelineJobExecutionCount(runName)} of {data.display_name}
         </Text>
       ) : (

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
@@ -53,6 +53,7 @@ const CompareRunsRunList: React.FC = () => {
       toggleText="Run list"
       isExpanded={isExpanded}
       onToggle={(_, expanded) => setExpanded(expanded)}
+      isIndented
     >
       <Table
         {...checkboxTableProps}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabParameters.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabParameters.tsx
@@ -9,6 +9,7 @@ import {
 import { PipelineRunJobKFv2, PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
 import {
   DetailItem,
+  normalizeInputParamValue,
   renderDetailItems,
 } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
 
@@ -39,22 +40,10 @@ const PipelineRunTabParameters: React.FC<PipelineRunTabParametersProps> = ({ run
     );
   }
 
-  const details: DetailItem[] = parameters.map(([key, initialValue]) => {
-    let value = initialValue;
-
-    if (typeof value === 'boolean') {
-      value = value ? 'True' : 'False';
-    }
-
-    if (typeof value === 'object') {
-      value = JSON.stringify(value);
-    }
-
-    return {
-      key,
-      value,
-    };
-  });
+  const details: DetailItem[] = parameters.map(([key, value]) => ({
+    key,
+    value: normalizeInputParamValue(value),
+  }));
 
   return <>{renderDetailItems(details)}</>;
 };

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -11,7 +11,7 @@ import {
   TimestampFormat,
 } from '@patternfly/react-core';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
-import { DateTimeKF } from '~/concepts/pipelines/kfTypes';
+import { DateTimeKF, RuntimeConfigParamValue } from '~/concepts/pipelines/kfTypes';
 import { PodKind } from '~/k8sTypes';
 import { PodContainer } from '~/types';
 
@@ -79,4 +79,20 @@ export const checkPodContainersStatus = (
 export const isEmptyDateKF = (date: DateTimeKF): boolean => {
   const INVALID_TIMESTAMP = '1970-01-01T00:00:00Z';
   return date === INVALID_TIMESTAMP;
+};
+
+export const normalizeInputParamValue = (
+  initialValue: RuntimeConfigParamValue,
+): string | number => {
+  let value = initialValue;
+
+  if (typeof value === 'boolean') {
+    value = value ? 'True' : 'False';
+  }
+
+  if (typeof value === 'object') {
+    value = JSON.stringify(value);
+  }
+
+  return value;
 };

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -531,7 +531,7 @@ export type PipelineRunKFv2 = PipelineCoreResourceKFv2 & {
   pipeline_version_reference?: PipelineVersionReferenceKF;
   // in lue of pipeline_version_reference, the pipeline spec is included
   pipeline_spec?: PipelineSpecVariable;
-  runtime_config: PipelineSpecRuntimeConfig;
+  runtime_config?: PipelineSpecRuntimeConfig;
   service_account: string;
   scheduled_at: string;
   finished_at: string;

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunParamsSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunParamsSection.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateVariant,
+  ExpandableSection,
+  Flex,
+  Switch,
+} from '@patternfly/react-core';
+import { InnerScrollContainer, TableVariant, Td, Tr } from '@patternfly/react-table';
+
+import { SortableData, Table } from '~/components/table';
+import { useCompareRuns } from '~/concepts/pipelines/content/compareRuns/CompareRunsContext';
+import { RuntimeConfigParamValue } from '~/concepts/pipelines/kfTypes';
+import { normalizeInputParamValue } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
+
+export const CompareRunParamsSection: React.FunctionComponent = () => {
+  const { loaded, selectedRuns } = useCompareRuns();
+  const [isSectionOpen, setIsSectionOpen] = React.useState(true);
+  const [isHideSameRowsChecked, setIsHideSameRowsChecked] = React.useState<boolean>(false);
+
+  const runNameColumns: SortableData<[string, Record<string, RuntimeConfigParamValue>]>[] =
+    React.useMemo(
+      () => [
+        {
+          label: 'Run name',
+          field: 'run-name',
+          isStickyColumn: true,
+          hasRightBorder: true,
+          // https://github.com/patternfly/patternfly-react/discussions/10269
+          className: 'pf-v5-u-background-color-200',
+          sortable: false,
+        },
+        ...selectedRuns.map(
+          (run, index): SortableData<[string, Record<string, RuntimeConfigParamValue>]> => ({
+            label: run.display_name,
+            field: run.run_id,
+            sortable: false,
+            modifier: 'nowrap',
+            hasRightBorder: index !== selectedRuns.length - 1,
+          }),
+        ),
+      ],
+      [selectedRuns],
+    );
+
+  const runParamsMap = React.useMemo(
+    () =>
+      selectedRuns.reduce(
+        (acc: Record<string, Record<string, RuntimeConfigParamValue>>, selectedRun) => {
+          Object.entries(selectedRun.runtime_config?.parameters || {}).forEach(
+            ([paramKey, paramValue]) => {
+              if (!Object.keys(acc).includes(paramKey)) {
+                acc[paramKey] = { [selectedRun.run_id]: paramValue };
+              } else if (!Object.keys(acc[paramKey]).includes(selectedRun.run_id)) {
+                acc[paramKey] = { ...acc[paramKey], [selectedRun.run_id]: paramValue };
+              }
+            },
+          );
+
+          return acc;
+        },
+        {},
+      ),
+    [selectedRuns],
+  );
+  const hasParameters = !!Object.values(runParamsMap).length;
+
+  const rowRenderer = React.useCallback(
+    ([paramKey, paramValuesMap]: [string, Record<string, RuntimeConfigParamValue>]) => {
+      const paramValues = Object.values(paramValuesMap);
+      const hasSameParamValues = paramValues.every(
+        (value) => normalizeInputParamValue(value) === normalizeInputParamValue(paramValues[0]),
+      );
+
+      // Hide all rows that have the same parameter value for every run when switch for diff values only is on
+      if (
+        paramValues.length === selectedRuns.length &&
+        hasSameParamValues &&
+        isHideSameRowsChecked
+      ) {
+        return null;
+      }
+
+      return (
+        <Tr key={paramKey}>
+          <Td
+            dataLabel={paramKey}
+            hasRightBorder
+            isStickyColumn
+            modifier="fitContent"
+            className="pf-v5-u-background-color-200"
+          >
+            <b>{paramKey}</b>
+          </Td>
+
+          {selectedRuns.map(({ run_id: runId }, index) => {
+            const hasRightBorder = index !== selectedRuns.length - 1 && {
+              hasRightBorder: true,
+            };
+
+            if (Object.keys(paramValuesMap).includes(runId)) {
+              const paramId = `${runId}-value-${index}`;
+              const paramValue = paramValuesMap[runId];
+
+              return (
+                <Td key={paramId} dataLabel={paramId} {...hasRightBorder} modifier="nowrap">
+                  {normalizeInputParamValue(paramValue)}
+                </Td>
+              );
+            }
+
+            return <Td key={index} {...hasRightBorder} />;
+          })}
+        </Tr>
+      );
+    },
+    [isHideSameRowsChecked, selectedRuns],
+  );
+
+  return (
+    <ExpandableSection
+      toggleText="Parameters"
+      onToggle={(_, isOpen) => setIsSectionOpen(isOpen)}
+      isExpanded={isSectionOpen}
+      isIndented
+    >
+      <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+        {hasParameters && (
+          <Switch
+            label="Hide parameters with no differences"
+            isChecked={isHideSameRowsChecked}
+            onChange={(_, checked) => setIsHideSameRowsChecked(checked)}
+            id="hide-same-params-switch"
+            data-testid="hide-same-params-switch"
+          />
+        )}
+
+        <InnerScrollContainer>
+          <Table
+            loading={!loaded}
+            data={Object.entries(runParamsMap).sort()}
+            columns={hasParameters ? runNameColumns : []}
+            hasNestedHeader
+            emptyTableView={
+              <EmptyState
+                variant={EmptyStateVariant.xs}
+                data-testid="compare-runs-params-empty-state"
+              >
+                <EmptyStateHeader titleText="No parameters" headingLevel="h4" />
+                <EmptyStateBody>
+                  Select runs from the <b>Run list</b> to compare parameters.
+                </EmptyStateBody>
+              </EmptyState>
+            }
+            rowRenderer={rowRenderer}
+            variant={TableVariant.compact}
+            id="compare-runs-params-table"
+            data-testid="compare-runs-params-table"
+            gridBreakPoint=""
+          />
+        </InnerScrollContainer>
+      </Flex>
+    </ExpandableSection>
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsPage.tsx
@@ -5,6 +5,7 @@ import { PathProps } from '~/concepts/pipelines/content/types';
 import { useCompareRuns } from '~/concepts/pipelines/content/compareRuns/CompareRunsContext';
 import { CompareRunsInvalidRunCount } from '~/concepts/pipelines/content/compareRuns/CompareRunInvalidRunCount';
 import CompareRunsRunList from '~/concepts/pipelines/content/compareRuns/CompareRunsRunList';
+import { CompareRunParamsSection } from './CompareRunParamsSection';
 
 const CompareRunsPage: React.FC<PathProps> = ({ breadcrumbPath }) => {
   const { runs, loaded } = useCompareRuns();
@@ -28,9 +29,13 @@ const CompareRunsPage: React.FC<PathProps> = ({ breadcrumbPath }) => {
       empty={false}
       noHeader
     >
-      <Stack>
+      <Stack hasGutter>
         <StackItem>
           <CompareRunsRunList />
+        </StackItem>
+
+        <StackItem>
+          <CompareRunParamsSection />
         </StackItem>
       </Stack>
     </ApplicationsPage>


### PR DESCRIPTION
Closes: [RHOAIENG-4727](https://issues.redhat.com/browse/RHOAIENG-4727)

## Description
Compare runs - Parameters expandable section renders runtime config data associated with all selected runs from the `Run list`, where if a run does not share a parameter with another, empty cells are shown. The feature has a switch that allows for showing and hiding of parameter rows based on whether rows possess all of the same value. When row data extends beyond a certain point, horizontal scroll will kick in and the first column representing parameter names will stick while scrolling left and right.

**NOTE:** The design diverged slightly from what the mocks show at the moment. The implementation here is what was recently agreed upon with @yannnz.

<img width="1412" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/5afdb7a6-99ce-441e-bf66-d3db58182804">

**Only showing parameters with values that differ between runs**
<img width="1412" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/e5b23bde-a312-405b-96ac-74d00d965339">

**Empty state**
<img width="1412" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/1256c2c6-0496-438f-b862-24c5df1ebb9e">

## How Has This Been Tested?
Added cypress tests demonstrating interactions between the `Run list` and `Parameters` tables, along with hiding of parameters with values that are all equal.

## How to test
Navigate to the Compare runs page `/experiments/jps-fun-world/85c9d729-bf63-441f-af87-d6898e5db5f0/compareRuns?runs=[your list of runs here]`, verify the table design and interactions with the Run list above it.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
