### PR TITLE
Fix pipeline version reference in pipeline run details

### DIFF
--- a/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
@@ -19,7 +19,6 @@ import { computeRunStatus } from '~/concepts/pipelines/content/utils';
 const run: PipelineRunKFv2 = {
   created_at: '2023-09-05T16:23:25Z',
   storage_state: StorageStateKF.AVAILABLE,
-  pipeline_version_id: 'version-id',
   finished_at: '2023-09-05T16:24:34Z',
   run_id: 'dc66a214-4df2-4d4d-a302-0d02d8bba0e7',
   display_name: 'flip-coin',

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
@@ -40,7 +40,7 @@ const CompareRunsRunList: React.FC = () => {
       const experimentIdMatch = !experimentId || run.experiment_id === experimentId;
       const pipelineVersionIdMatch =
         !pipelineVersionId ||
-        run.pipeline_version_reference.pipeline_version_id === pipelineVersionId;
+        run.pipeline_version_reference?.pipeline_version_id === pipelineVersionId;
 
       return (
         nameMatch && dateTimeMatch && stateMatch && experimentIdMatch && pipelineVersionIdMatch

--- a/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
@@ -45,8 +45,8 @@ const RunPage: React.FC<RunPageProps> = ({ cloneRun, contextPath, testId }) => {
   ]);
   const triggerType = asEnumMember(triggerTypeString, ScheduledType);
 
-  const cloneRunPipelineId = cloneRun?.pipeline_version_reference.pipeline_id || '';
-  const cloneRunVersionId = cloneRun?.pipeline_version_reference.pipeline_version_id || '';
+  const cloneRunPipelineId = cloneRun?.pipeline_version_reference?.pipeline_id || '';
+  const cloneRunVersionId = cloneRun?.pipeline_version_reference?.pipeline_version_id || '';
   const cloneRunExperimentId = cloneRun?.experiment_id || '';
 
   const [cloneRunPipelineVersion] = usePipelineVersionById(cloneRunPipelineId, cloneRunVersionId);

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -43,20 +43,18 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
   const { namespace } = usePipelinesAPI();
   const [runResource, runLoaded, runError] = usePipelineRunById(runId, true);
   const [version, versionLoaded, versionError] = usePipelineVersionById(
-    runResource?.pipeline_version_reference.pipeline_id,
-    runResource?.pipeline_version_reference.pipeline_version_id,
+    runResource?.pipeline_version_reference?.pipeline_id,
+    runResource?.pipeline_version_reference?.pipeline_version_id,
   );
+  const pipelineSpec = version?.pipeline_spec ?? runResource?.pipeline_spec;
   const [deleting, setDeleting] = React.useState(false);
   const [detailsTab, setDetailsTab] = React.useState<RunDetailsTabSelection>(
     RunDetailsTabs.DETAILS,
   );
   const [selectedId, setSelectedId] = React.useState<string | null>(null);
-  const { taskMap, nodes } = usePipelineTaskTopology(
-    version?.pipeline_spec,
-    runResource ?? undefined,
-  );
+  const { taskMap, nodes } = usePipelineTaskTopology(pipelineSpec, runResource ?? undefined);
 
-  const loaded = versionLoaded && runLoaded;
+  const loaded = runLoaded && (versionLoaded || !!runResource?.pipeline_spec);
   const error = versionError || runError;
   if (!loaded && !error) {
     return (
@@ -100,9 +98,7 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
                       setDetailsTab(selection);
                       setSelectedId(null);
                     }}
-                    pipelineRunDetails={
-                      runResource && version?.pipeline_spec ? runResource : undefined
-                    }
+                    pipelineRunDetails={runResource && pipelineSpec ? runResource : undefined}
                   />
                 }
               >

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
@@ -33,8 +33,8 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({
 }) => {
   const { namespace, project } = usePipelinesAPI();
   const [version, loaded, error] = usePipelineVersionById(
-    pipelineRunKF?.pipeline_version_reference.pipeline_id,
-    pipelineRunKF?.pipeline_version_reference.pipeline_version_id,
+    pipelineRunKF?.pipeline_version_reference?.pipeline_id,
+    pipelineRunKF?.pipeline_version_reference?.pipeline_version_id,
   );
 
   if (!pipelineRunKF || !workflowName) {

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineRunVersionInfo.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineRunVersionInfo.ts
@@ -15,7 +15,7 @@ const usePipelineRunVersionInfo = (
 } => {
   const { versions, loaded, error } = React.useContext(PipelineRunVersionsContext);
   const version = versions.find(
-    (v) => v.pipeline_version_id === run?.pipeline_version_reference.pipeline_version_id,
+    (v) => v.pipeline_version_id === run?.pipeline_version_reference?.pipeline_version_id,
   );
 
   return { version, loaded, error };

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -527,8 +527,10 @@ export type PipelineRunKFv2 = PipelineCoreResourceKFv2 & {
   experiment_id: string;
   run_id: string;
   storage_state: StorageStateKF;
-  pipeline_version_id?: string;
-  pipeline_version_reference: PipelineVersionReferenceKF;
+  // run might not have a parent pipeline/version
+  pipeline_version_reference?: PipelineVersionReferenceKF;
+  // in lue of pipeline_version_reference, the pipeline spec is included
+  pipeline_spec?: PipelineSpecVariable;
   runtime_config: PipelineSpecRuntimeConfig;
   service_account: string;
   scheduled_at: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-5245

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- handles sdk flow where user creates a run using `kfp.Client.create_run_from_pipeline_package` which produces a run without a reference to a pipeline/pipeline version. This PR adjusts the types to make it the reference optional so we dont run into this type error in the future
- also now will fallback to run.pipeline_spec (is only available when creating a run using `create_run_from_pipeline_package`) instead of fetching the version and getting the spec from there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a pipeline run using the v2 sdk
   - I used this tutorial: https://www.kubeflow.org/docs/components/pipelines/v2/hello-world/
   - I had ssl issues, you may not, but to get around it see: https://v1-5-branch.kubeflow.org/docs/components/pipelines/sdk/connect-api/#connect-to-kubeflow-pipelines-from-outside-your-cluster
   - i ended up portforwarding like this: `oc port-forward svc/ds-pipeline-dspa 4000:8888 --namespace <namespace>`
   - and then set the host i your python script to `http://localhost:4000`
2. this should kick of a pipeline with no reference to a pipeline version.
3. you should be able to interact fully with the run by going to the details and seeing all the run details and task details
4. you cna clone the run, but it wont pull in the pipeline spec so the pipeline dropdown will be empty - not sure if thats possible or not from the api so i left it out of this PR

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no impact to tests other than removing an unused param that could cause future confusion

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
