### PR TITLE
feat(DW): gray donuts for empty data top-consuming charts

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
@@ -270,6 +270,8 @@ describe('Workload Status tab', () => {
     globalDistributedWorkloads.visit();
 
     cy.findByLabelText('Distributed workload status tab').click();
-    cy.findByText('No distributed workloads').should('exist');
+    cy.findByTestId('dw-workloads-table-card').within(() => {
+      cy.findByText('No distributed workloads').should('exist');
+    });
   });
 });

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
@@ -30,12 +30,20 @@ const TopResourceConsumingWorkloadsChart: React.FC<TopResourceConsumingWorkloads
   <ChartDonut
     ariaTitle={`${metricLabel} chart`}
     constrainToVisibleArea
-    data={data.topWorkloads.map(({ workload, usage }) => ({
-      x: getWorkloadName(workload),
-      y: roundNumber(convertUnits(usage), 3),
-    }))}
+    data={
+      data.topWorkloads.length
+        ? data.topWorkloads.map(({ workload, usage }) => ({
+            x: getWorkloadName(workload),
+            y: roundNumber(convertUnits(usage), 3),
+          }))
+        : [{ x: `No workload is consuming ${unitLabel}`, y: 1 }]
+    }
     height={150}
-    labels={({ datum }) => `${datum.x}: ${datum.y} ${unitLabel}`}
+    labels={
+      data.topWorkloads.length
+        ? ({ datum }) => `${datum.x}: ${datum.y} ${unitLabel}`
+        : ({ datum }) => datum.x
+    }
     legendComponent={
       <ChartLegend
         data={data.topWorkloads.map(({ workload }) => ({
@@ -57,7 +65,7 @@ const TopResourceConsumingWorkloadsChart: React.FC<TopResourceConsumingWorkloads
     }}
     subTitle={unitLabel}
     title={String(roundNumber(convertUnits(data.totalUsage)))}
-    themeColor={ChartThemeColor.multi}
+    themeColor={data.topWorkloads.length ? ChartThemeColor.multi : ChartThemeColor.gray}
     width={375}
   />
 );

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWStatusOverviewDonutChart.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWStatusOverviewDonutChart.tsx
@@ -8,6 +8,7 @@ import {
   getStatusCounts,
 } from '~/concepts/distributedWorkloads/utils';
 import { LoadingState } from '~/pages/distributedWorkloads/components/LoadingState';
+import { NoWorkloadState } from '~/pages/distributedWorkloads/components/NoWorkloadState';
 
 export const DWStatusOverviewDonutChart: React.FC = () => {
   const { workloads } = React.useContext(DistributedWorkloadsContext);
@@ -32,6 +33,11 @@ export const DWStatusOverviewDonutChart: React.FC = () => {
     (statusType) => statusCounts[statusType] > 0,
   );
 
+  if (!workloads.data.length) {
+    return (
+      <NoWorkloadState subTitle="Select another project or create a distributed workload in the selected project." />
+    );
+  }
   return (
     <ChartDonut
       ariaDesc="Distributed workload status overview"

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/GlobalDistributedWorkloadsWorkloadStatusTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/GlobalDistributedWorkloadsWorkloadStatusTab.tsx
@@ -14,7 +14,7 @@ const GlobalDistributedWorkloadsWorkloadStatusTab: React.FC = () => (
       </Card>
     </StackItem>
     <StackItem>
-      <Card>
+      <Card data-testid="dw-workloads-table-card">
         <CardTitle>Distributed Workloads</CardTitle>
         <DWWorkloadsTable />
       </Card>


### PR DESCRIPTION
addresses feedback on empty charts in the "top-consuming" section while we have data in other charts (happens when winding down?). also adds empty state for status overview chart

charts with no data will now show a gray donut, with a "No workload is consuming {unit}" tooltip and no legend.

## Description
charts with no data will now show a gray donut, with a "No workload is consuming {unit}" tooltip and no legend.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/a46d9769-6dc0-4a0a-a030-ddd8aeb44f23)
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/bf65c53d-c14b-41c1-9b6f-81e1679ae328)



## How Has This Been Tested?
manually modifying data to test with empty data

## Test Impact
no test impact, mostly a design change that doesn't impact data

## Request review criteria:
no workloads at all will still show the empty state screen, if there is data a specific chart doesn't have data, it will get the new gray donut

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
