### PR TITLE
Add ImportPipelineButton to NoPipelineServer component

### DIFF
--- a/frontend/src/concepts/pipelines/NoPipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/NoPipelineServer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { CreatePipelineServerButton, usePipelinesAPI } from '~/concepts/pipelines/context';
 import EmptyDetailsView from '~/components/EmptyDetailsView';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
+import ImportPipelineButton from './content/import/ImportPipelineButton';
 
 type NoPipelineServerProps = {
   variant?: React.ComponentProps<typeof CreatePipelineServerButton>['variant'];
@@ -23,11 +24,11 @@ const NoPipelineServer: React.FC<NoPipelineServerProps> = ({ variant = 'link' })
       iconImage={typedEmptyImage(ProjectObjectType.pipeline)}
       imageAlt=""
       createButton={
-        <CreatePipelineServerButton
-          isInline
-          variant={variant}
-          title={installed ? 'Import pipeline' : undefined}
-        />
+        installed ? (
+          <ImportPipelineButton variant={variant} isInline />
+        ) : (
+          <CreatePipelineServerButton isInline variant={variant} />
+        )
       }
     />
   );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

closes: https://issues.redhat.com/browse/RHOAIENG-4846

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The NoPipelineServer component now handles both no pipeline server and no pipelines since the UI refresh. However this component would only ever open the no pipeline server modal. This PR does the lightest change possible and just adds a condition to render the correct modal. Ideally these should be separated into their own components, but to maintian the most stability i kept it like this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. open project pipelines tab from project details page (with no pipeline server installed)
2. empty state button should open configure pipeline server modal
3. configure the server
4. now the empty state should be no pipelines AND the button should open to the import pipeline modal

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no tests impacted

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
