### PR TITLE
Fixes Image selection dropdown scroll issue

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/projects/Workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/projects/Workbench.cy.ts
@@ -53,7 +53,56 @@ const initIntercepts = ({ isEmpty = false }: HandlersProps) => {
   cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
   cy.interceptK8sList(
     ImageStreamModel,
-    mockK8sResourceList([mockImageStreamK8sResource({ namespace: 'opendatahub' })]),
+    mockK8sResourceList([
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-1',
+        displayName: 'Test image 1',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-2',
+        displayName: 'Test image 2',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-3',
+        displayName: 'Test image 3',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-4',
+        displayName: 'Test image 4',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-5',
+        displayName: 'Test image 5',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-6',
+        displayName: 'Test image 6',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-7',
+        displayName: 'Test image 7',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-8',
+        displayName: 'Test image 8',
+      }),
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-9',
+        displayName: 'Test image 9',
+      }),
+    ]),
   );
   cy.interceptK8s(SecretModel, mockSecretK8sResource({ name: 'aws-connection-db-1' }));
   cy.interceptK8s('PATCH', NotebookModel, mockNotebookK8sResource({})).as('stopWorkbench');
@@ -107,7 +156,8 @@ describe('Workbench page', () => {
     verifyRelativeURL('/projects/test-project/spawner');
     createSpawnerPage.findNameInput().fill('test-project');
     createSpawnerPage.findDescriptionInput().fill('test-description');
-    createSpawnerPage.selectNotebookImage('Test Image Python v3.8');
+    //to check scrollable dropdown selection
+    createSpawnerPage.findNotebookImage('test-9').click();
     createSpawnerPage.selectContainerSize(
       'XSmall Limits: 0.5 CPU, 500Mi Memory Requests: 0.1 CPU, 100Mi Memory',
     );

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -146,7 +146,7 @@ class ServingRuntimeModal extends Modal {
   }
 
   findServingRuntimeTemplateDropdown() {
-    return this.find().find('#serving-runtime-template-selection');
+    return this.find().findByTestId('serving-runtime-template-selection');
   }
 
   findModelRouteCheckbox() {

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -234,8 +234,11 @@ class CreateSpawnerPage {
     );
   }
 
-  selectNotebookImage(name: string) {
-    cy.findByTestId('workbench-image-stream-selection').findDropdownItem(name).click();
+  findNotebookImage(name: string) {
+    return cy
+      .findByTestId('workbench-image-stream-selection')
+      .findDropdownItemByTestId(`dropdown-item ${name}`)
+      .scrollIntoView();
   }
 
   selectContainerSize(name: string) {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -1,6 +1,5 @@
 import { MatcherOptions } from '@testing-library/cypress';
 import { Matcher, MatcherOptions as DTLMatcherOptions } from '@testing-library/dom';
-
 /* eslint-disable @typescript-eslint/no-namespace */
 declare global {
   namespace Cypress {
@@ -27,6 +26,12 @@ declare global {
        */
       findDropdownItem(name: string | RegExp): Cypress.Chainable<JQuery>;
 
+      /**
+       * Finds a patternfly dropdown item by data-testid, first opening the dropdown if not already opened.
+       *
+       * @param testId the name of the item
+       */
+      findDropdownItemByTestId(testId: string): Cypress.Chainable<JQuery>;
       /**
        * Finds a patternfly select option by first opening the select menu if not already opened.
        *
@@ -115,7 +120,17 @@ Cypress.Commands.add('findDropdownItem', { prevSubject: 'element' }, (subject, n
     if ($el.find('[aria-expanded=false]').addBack().length) {
       cy.wrap($el).click();
     }
-    return cy.wrap($el).findByRole('menuitem', { name });
+    return cy.wrap($el).parent().findByRole('menuitem', { name });
+  });
+});
+
+Cypress.Commands.add('findDropdownItemByTestId', { prevSubject: 'element' }, (subject, testId) => {
+  Cypress.log({ displayName: 'findDropdownItemByTestId', message: testId });
+  return cy.wrap(subject).then(($el) => {
+    if ($el.find('[aria-expanded=false]').addBack().length) {
+      cy.wrap($el).click();
+    }
+    return cy.wrap($el).parent().findByTestId(testId);
   });
 });
 

--- a/frontend/src/components/SimpleDropdownSelect.tsx
+++ b/frontend/src/components/SimpleDropdownSelect.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Truncate } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
+import { Truncate, Dropdown, MenuToggle, DropdownList, DropdownItem } from '@patternfly/react-core';
 import './SimpleDropdownSelect.scss';
 
 export type SimpleDropdownOption = {
@@ -19,6 +18,7 @@ type SimpleDropdownProps = {
   isFullWidth?: boolean;
   isDisabled?: boolean;
   icon?: React.ReactNode;
+  dataTestId?: string;
 } & Omit<React.ComponentProps<typeof Dropdown>, 'isOpen' | 'toggle' | 'dropdownItems' | 'onChange'>;
 
 const SimpleDropdownSelect: React.FC<SimpleDropdownProps> = ({
@@ -29,6 +29,7 @@ const SimpleDropdownSelect: React.FC<SimpleDropdownProps> = ({
   value,
   isFullWidth,
   icon,
+  dataTestId,
   ...props
 }) => {
   const [open, setOpen] = React.useState(false);
@@ -39,32 +40,41 @@ const SimpleDropdownSelect: React.FC<SimpleDropdownProps> = ({
     <Dropdown
       {...props}
       isOpen={open}
-      className={isFullWidth ? 'full-width' : undefined}
-      toggle={
-        <DropdownToggle
+      onSelect={() => setOpen(false)}
+      onOpenChange={(isOpen: boolean) => setOpen(isOpen)}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          data-testid={dataTestId}
+          ref={toggleRef}
           isDisabled={isDisabled}
-          className={isFullWidth ? 'full-width' : undefined}
-          onToggle={() => setOpen(!open)}
           icon={icon}
+          isFullWidth={isFullWidth}
+          onClick={() => setOpen(!open)}
+          isExpanded={open}
         >
           <Truncate content={selectedLabel} className="truncate-no-min-width" />
-        </DropdownToggle>
-      }
-      dropdownItems={[...options]
-        .sort((a, b) => (a.isPlaceholder === b.isPlaceholder ? 0 : a.isPlaceholder ? -1 : 1))
-        .map(({ key, dropdownLabel, label, description, isPlaceholder }) => (
-          <DropdownItem
-            key={key}
-            description={description}
-            onClick={() => {
-              onChange(key, !!isPlaceholder);
-              setOpen(false);
-            }}
-          >
-            {dropdownLabel ?? label}
-          </DropdownItem>
-        ))}
-    />
+        </MenuToggle>
+      )}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        {[...options]
+          .sort((a, b) => (a.isPlaceholder === b.isPlaceholder ? 0 : a.isPlaceholder ? -1 : 1))
+          .map(({ key, dropdownLabel, label, description, isPlaceholder }) => (
+            <DropdownItem
+              data-testid={`dropdown-item ${key}`}
+              key={key}
+              description={description}
+              onClick={() => {
+                onChange(key, !!isPlaceholder);
+                setOpen(false);
+              }}
+            >
+              {dropdownLabel ?? label}
+            </DropdownItem>
+          ))}
+      </DropdownList>
+    </Dropdown>
   );
 };
 

--- a/frontend/src/concepts/dashboard/DashboardSearchField.tsx
+++ b/frontend/src/concepts/dashboard/DashboardSearchField.tsx
@@ -41,7 +41,7 @@ const DashboardSearchField: React.FC<DashboardSearchFieldProps> = ({
     <InputGroupItem>
       <SimpleDropdownSelect
         aria-label="Filter type"
-        data-testid="filter-dropdown-select"
+        dataTestId="filter-dropdown-select"
         options={types.map((key) => ({
           key,
           label: key,

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunTableToolbar.tsx
@@ -91,7 +91,7 @@ const CompareRunTableToolbar: React.FC<FilterProps> = ({ ...toolbarProps }) => {
               label: v,
             }))}
             onChange={(v) => onChange(v)}
-            data-testid="runtime-status-dropdown"
+            dataTestId="runtime-status-dropdown"
           />
         ),
       }}

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/TriggerTypeField.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/TriggerTypeField.tsx
@@ -89,7 +89,7 @@ const TriggerTypeField: React.FC<TriggerTypeFieldProps> = ({ data, onChange }) =
       <StackItem>
         <FormGroup label="Trigger type">
           <SimpleDropdownSelect
-            data-testid="triggerTypeSelector"
+            dataTestId="triggerTypeSelector"
             isFullWidth
             options={[
               { key: ScheduledType.PERIODIC, label: 'Periodic' },

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -243,7 +243,7 @@ const LogsTabForPodName: React.FC<{ podName: string; isFailedPod: boolean }> = (
                       {!showSearchbar && (
                         <ToolbarItem spacer={{ default: 'spacerSm' }} style={{ maxWidth: '200px' }}>
                           <SimpleDropdownSelect
-                            data-testid="logs-step-select"
+                            dataTestId="logs-step-select"
                             isDisabled={podStepStates.length <= 1}
                             options={podStepStates.map((podStepState) => ({
                               key: podStepState.stepName,

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar.tsx
@@ -95,7 +95,7 @@ const PipelineRunTableToolbar: React.FC<PipelineRunTableToolbarProps> = ({
               label: v,
             }))}
             onChange={(v) => onChange(v)}
-            data-testid="runtime-status-dropdown"
+            dataTestId="runtime-status-dropdown"
           />
         ),
       }}

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
@@ -41,7 +41,7 @@ const TolerationFields: React.FC<TolerationFieldsProps> = ({ toleration, onUpdat
           options={operatorDropdownOptions}
           value={toleration.operator || ''}
           onChange={(key) => handleFieldUpdate('operator', key)}
-          data-testid="toleration-operator-select"
+          dataTestId="toleration-operator-select"
         />
       </FormGroup>
 
@@ -51,7 +51,7 @@ const TolerationFields: React.FC<TolerationFieldsProps> = ({ toleration, onUpdat
           options={effectDropdownOptions}
           value={toleration.effect || ''}
           onChange={(key) => handleFieldUpdate('effect', key)}
-          data-testid="toleration-effect-select"
+          dataTestId="toleration-effect-select"
         />
       </FormGroup>
 

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeAPIProtocolSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeAPIProtocolSelector.tsx
@@ -44,7 +44,7 @@ const CustomServingRuntimeAPIProtocolSelector: React.FC<
       isRequired
     >
       <SimpleDropdownSelect
-        data-testid="custom-serving-api-protocol-selection"
+        dataTestId="custom-serving-api-protocol-selection"
         aria-label="Select a model serving api protocol"
         placeholder="Select a value"
         isDisabled={isOnlyModelMesh}

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsSelector.tsx
@@ -44,7 +44,7 @@ const CustomServingRuntimePlatformsSelector: React.FC<
       isRequired
     >
       <SimpleDropdownSelect
-        data-testid="custom-serving-runtime-selection"
+        dataTestId="custom-serving-runtime-selection"
         aria-label="Select a model serving runtime platform"
         placeholder="Select a value"
         options={options}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -64,6 +64,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
         isFullWidth
         isDisabled={isEditing || filteredTemplates.length === 0}
         id="serving-runtime-template-selection"
+        dataTestId="serving-runtime-template-selection"
         aria-label="Select a template"
         options={options}
         placeholder={

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -52,9 +52,10 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
   return (
     <FormGroup isRequired label="Image selection" fieldId="workbench-image-stream-selection">
       <SimpleDropdownSelect
+        isScrollable
         isFullWidth
         id="workbench-image-stream-selection"
-        data-testid="workbench-image-stream-selection"
+        dataTestId="workbench-image-stream-selection"
         aria-label="Select an image"
         options={options}
         placeholder="Select one"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-3412

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes the image selection dropdown scroll issue. Upgraded `SimpleDropdownSelect` component to PF5.

<img width="1301" alt="Screenshot 2024-04-10 at 7 23 06 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/2e834813-9712-4275-b6b2-f4927d5c8d80">

https://github.com/opendatahub-io/odh-dashboard/assets/22885912/3d8af954-c3cf-4d6c-8702-b14b5096b359


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Try creating a workbench after creating many custom images using the `Notebook images` section in the `Settings` section in the Dashboard. You should see a scroll bar while trying to select images in the `Image selection`, which doesn't break the layout. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fixed failing tests due to the PF5 migration. Added new tests for scrollable dropdown selection

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
