### PR TITLE
Add InvalidArgoDeploymentAlert component to AppRoutes

### DIFF
--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { InvalidArgoDeploymentAlert } from '~/concepts/pipelines/content/InvalidArgoDeploymentAlert';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import UnauthorizedError from '~/pages/UnauthorizedError';
 import { useUser } from '~/redux/selectors';
@@ -66,6 +67,7 @@ const AppRoutes: React.FC = () => {
 
   return (
     <React.Suspense fallback={<ApplicationsPage title="" description="" loaded={false} empty />}>
+      <InvalidArgoDeploymentAlert />
       <Routes>
         <Route path="/" element={<InstalledApplications />} />
         <Route path="/explore" element={<ExploreApplications />} />

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -1,5 +1,10 @@
 import { EitherOrBoth } from '~/typeHelpers';
-import { DashboardCommonConfig } from '~/k8sTypes';
+import {
+  DashboardCommonConfig,
+  DashboardConfigKind,
+  DataScienceClusterInitializationKindStatus,
+  DataScienceClusterKindStatus,
+} from '~/k8sTypes';
 
 // TODO: clean up this definition / update the DashboardConfig to a better state
 export type FeatureFlag = keyof Omit<DashboardCommonConfig, 'modelMetricsNamespace'>;
@@ -12,6 +17,7 @@ export type IsAreaAvailableStatus = {
   reliantAreas: { [key in SupportedArea]?: boolean } | null; // only needs 1 to be true
   requiredComponents: { [key in StackComponent]?: boolean } | null;
   requiredCapabilities: { [key in StackCapability]?: boolean } | null;
+  customCondition: (conditionFunc: CustomConditionFunction) => boolean;
 };
 
 /** All areas that we need to support in some fashion or another */
@@ -71,6 +77,22 @@ export enum StackCapability {
   SERVICE_MESH = 'CapabilityServiceMesh',
   SERVICE_MESH_AUTHZ = 'CapabilityServiceMeshAuthorization',
 }
+
+/**
+ * Optional function to check for a condition that is not covered by other checks.
+ *
+ * Example, checking there exists a specific condition in the DSC status.
+ *
+ * @param state.dashboardConfigSpec The dashboard config spec
+ * @param state.dscStatus The data science cluster status
+ * @param state.dsciStatus The data science cluster initialization status
+ * @returns True if the condition is met, false otherwise
+ */
+export type CustomConditionFunction = (state: {
+  dashboardConfigSpec: DashboardConfigKind['spec'];
+  dscStatus: DataScienceClusterKindStatus | null;
+  dsciStatus: DataScienceClusterInitializationKindStatus | null;
+}) => boolean;
 
 // TODO: Support extra operators, like the pipelines operator -- maybe as a "external dependency need?"
 type SupportedComponentFlagValue = {

--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -99,5 +99,7 @@ export const isAreaAvailable = (
     featureFlags: featureFlagState,
     requiredComponents: requiredComponentsState,
     requiredCapabilities: requiredCapabilitiesState,
+    customCondition: (conditionFunc) =>
+      conditionFunc({ dashboardConfigSpec, dscStatus, dsciStatus }),
   };
 };

--- a/frontend/src/concepts/pipelines/content/InvalidArgoDeploymentAlert.tsx
+++ b/frontend/src/concepts/pipelines/content/InvalidArgoDeploymentAlert.tsx
@@ -1,0 +1,62 @@
+import { Alert, AlertActionCloseButton, AlertActionLink } from '@patternfly/react-core';
+import React from 'react';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
+
+const INVALID_ARGO_DEPLOYMENT_CLOUD_DOCUMENTATION_URL =
+  'https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.9/html/release_notes/new-features-and-enhancements_relnotes';
+
+const INVALID_ARGO_DEPLOYMENT_SELF_DOCUMENTATION_URL =
+  'https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud_service/1/html/release_notes/new-features-and-enhancements_relnotes';
+
+export const InvalidArgoDeploymentAlert: React.FC = () => {
+  const [invalidArgoDeploymentAlertDismissed, setInvalidArgoDeploymentAlertDismissed] =
+    useBrowserStorage('invalidArgoDeploymentAlertDismissed', false, true, true);
+
+  const showMessage =
+    useIsAreaAvailable(SupportedArea.DS_PIPELINES).customCondition(
+      ({ dscStatus }) =>
+        !!dscStatus?.conditions.some(
+          (c) => c.type === 'CapabilityDSPv2Argo' && c.status === 'False',
+        ),
+    ) && !invalidArgoDeploymentAlertDismissed;
+
+  if (!showMessage) {
+    return null;
+  }
+
+  return (
+    <Alert
+      actionLinks={
+        <>
+          <AlertActionLink
+            component="a"
+            href={INVALID_ARGO_DEPLOYMENT_SELF_DOCUMENTATION_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Self-Managed release notes
+          </AlertActionLink>
+          <AlertActionLink
+            component="a"
+            href={INVALID_ARGO_DEPLOYMENT_CLOUD_DOCUMENTATION_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Cloud Service release notes
+          </AlertActionLink>
+        </>
+      }
+      actionClose={
+        <AlertActionCloseButton onClose={() => setInvalidArgoDeploymentAlertDismissed(true)} />
+      }
+      isInline
+      variant="warning"
+      title="Data Science Pipelines enablement failed"
+    >
+      Data Science Pipelines could not be enabled because a version of Argo Workflows that is not
+      managed by Red Hat is installed on your cluster. To learn more, view the Red Hat Openshift AI
+      2.9 documentation.
+    </Alert>
+  );
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-5296

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a alert to the top of every page that can be dismissed (and stays dismissed) when the following are true:
- pipelines feature flag is enabled
- there exists a condition with the following `c.type === 'CapabilityDSPv2Argo' && c.status === 'False'` in the DSC
<img width="919" alt="Screenshot 2024-04-12 at 9 40 34 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/12587674/db96dd1f-2428-44c5-a020-08d323e832d8">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can add this mocked data to `backend/src/utils/dsc.ts`
```diff
diff --git a/backend/src/utils/dsc.ts b/backend/src/utils/dsc.ts
index eae01bc1..a5a7e81d 100644
--- a/backend/src/utils/dsc.ts
+++ b/backend/src/utils/dsc.ts
@@ -12,6 +12,26 @@ export const getClusterStatus = async (
   const result: DataScienceClusterKind | null = await fastify.kube.customObjectsApi
     .listClusterCustomObject('datasciencecluster.opendatahub.io', 'v1', 'datascienceclusters')
     .then((res) => (res.body as DataScienceClusterList).items[0])
+    .then((dsc) => {
+      return {
+        ...dsc,
+        status: {
+          ...dsc.status,
+          conditions: [
+            ...dsc.status.conditions,
+            {
+              lastHeartbeatTime: '2024-04-03T19:11:09Z',
+              lastTransitionTime: '2024-04-03T19:10:27Z',
+              message: 'Argo Workflow CRD already exists but not deployed by this operator',
+              reason: 'ArgoWorkflowExist',
+              status: 'False',
+              type: 'CapabilityDSPv2Argo',
+            },
+          ],
+        },
+      };
+    })
+
     .catch((e) => {
       fastify.log.error(`Failure to fetch dsc: ${e.response.body}`);
       return null;
```
Then try running with pipeline feature flag enabled and disabled. with it enabled and the mocked data, you should see the alert

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no tests added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).
@kywalker-rh 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
