### PR TITLE
Fix issue when selecting a pipeline without version on the clone run page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -26,6 +26,10 @@ import { configIntercept, dspaIntercepts, projectsIntercept } from './intercepts
 
 const projectName = 'test-project-name';
 const mockPipeline = buildMockPipelineV2();
+const mockNoVersionPipeline = buildMockPipelineV2({
+  pipeline_id: 'no-version-pipeline',
+  display_name: 'No version pipeline',
+});
 const mockPipelineVersion = buildMockPipelineVersionV2({ pipeline_id: mockPipeline.pipeline_id });
 const pipelineVersionRef = {
   pipeline_id: mockPipeline.pipeline_id,
@@ -173,8 +177,9 @@ describe('Pipeline create runs', () => {
 
       // Mock experiments, pipelines & versions for form select dropdowns
       cloneRunPage.mockGetExperiments(mockExperiments);
-      cloneRunPage.mockGetPipelines([mockPipeline]);
+      cloneRunPage.mockGetPipelines([mockPipeline, mockNoVersionPipeline]);
       cloneRunPage.mockGetPipelineVersions([mockPipelineVersion], mockPipelineVersion.pipeline_id);
+      cloneRunPage.mockGetPipelineVersions([], mockNoVersionPipeline.pipeline_id);
       cloneRunPage.mockGetRun(mockRun);
       cloneRunPage.mockGetPipelineVersion(mockPipelineVersion);
       cloneRunPage.mockGetPipeline(mockPipeline);
@@ -199,6 +204,13 @@ describe('Pipeline create runs', () => {
       paramsSection.findParamById('neighbors').find('input').should('have.value', '1');
       paramsSection.findParamById('standard_scaler').should('have.value', 'false');
 
+      // Verify switch to a no-version pipeline will show the correct result
+      cloneRunPage.findPipelineSelect().click();
+      cloneRunPage.selectPipelineByName(mockNoVersionPipeline.display_name);
+      cloneRunPage.findPipelineVersionSelect().should('be.disabled');
+
+      cloneRunPage.findPipelineSelect().click();
+      cloneRunPage.selectPipelineByName(mockPipeline.display_name);
       cloneRunPage.mockCreateRun(mockPipelineVersion, mockDuplicateRun).as('duplicateRun');
       cloneRunPage.submit();
 

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -116,7 +116,7 @@ const useUpdatePipelineFormData = (
       setFormValue('pipeline', pipeline);
     }
 
-    if (!formData.version && version) {
+    if (!formData.version && version && formData.pipeline?.pipeline_id === pipeline?.pipeline_id) {
       setFormValue('version', version);
     }
   }, [formData.pipeline, formData.version, pipeline, setFormValue, version]);

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -43,7 +43,7 @@ const runTypeSafeDates = (runType: RunFormData['runType']): boolean =>
 export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData => {
   const inputDefinitionParams = getInputDefinitionParams(formData.version);
   const hasRequiredInputParams = Object.entries(formData.params || {}).every(
-    ([paramKey, paramValue]) => inputDefinitionParams?.[paramKey].isOptional || paramValue !== '',
+    ([paramKey, paramValue]) => inputDefinitionParams?.[paramKey]?.isOptional || paramValue !== '',
   );
 
   return (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-4258

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When switching to a pipeline that contains no versions in it, we always trigger the hook `useUpdatePipelineFormData` and set the version to the incorrect one. The solution is to add a check before setting it to make sure we are only doing this when setting the same pipeline but not switching to another.
Also, fix a small issue that could crash the page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create 2 pipelines (pipeline 1 and pipeline 2)
2. Delete the version in pipeline 2, make sure there is no version in it
3. Create a run using pipeline 1
4. Duplicate this run, and switch the pipeline selection to pipeline 2
5. Verify the version selector is disabled and showing "no versions available" in it

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add some conditions in the cypress test to verify the change works.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
