### PR TITLE
chore(dw): address pr2644 feedback on testid vs class

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
@@ -196,22 +196,16 @@ describe('Project Metrics tab', () => {
 
     cy.findByText('Requested resources').should('exist');
 
-    cy.findByText('Top resource-consuming distributed workloads')
-      .closest('.dw-section-card')
-      .within(() => {
-        cy.findByText('No distributed workloads').should('exist');
-      });
-    cy.findByText('Distributed workload resource metrics')
-      .closest('.dw-section-card')
-      .within(() => {
-        cy.findByText('No distributed workloads').should('exist');
-      });
-    cy.findByText('Requested resources')
-      .closest('.dw-section-card')
-      .within(() => {
-        // Requested resources shows chart even if empty workload
-        cy.findByTestId('requested-resources-cpu-chart-container').should('exist');
-      });
+    cy.findByTestId('dw-top-consuming-workloads').within(() => {
+      cy.findByText('No distributed workloads').should('exist');
+    });
+    cy.findByTestId('dw-workloada-resource-metrics').within(() => {
+      cy.findByText('No distributed workloads').should('exist');
+    });
+    cy.findByTestId('dw-requested-resources').within(() => {
+      // Requested resources shows chart even if empty workload
+      cy.findByTestId('requested-resources-cpu-chart-container').should('exist');
+    });
   });
 
   it('Should render the workload resource metrics table', () => {

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -11,7 +11,7 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
 
   return (
     <Stack hasGutter>
-      <StackItem>
+      <StackItem data-testid="dw-requested-resources">
         <DWSectionCard
           title="Requested resources"
           helpTooltip={
@@ -22,13 +22,13 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
           content={<RequestedResources />}
         />
       </StackItem>
-      <StackItem>
+      <StackItem data-testid="dw-top-consuming-workloads">
         <DWSectionCard
           title="Top resource-consuming distributed workloads"
           content={<TopResourceConsumingWorkloads />}
         />
       </StackItem>
-      <StackItem>
+      <StackItem data-testid="dw-workloada-resource-metrics">
         <DWSectionCard
           title="Distributed workload resource metrics"
           hasDivider={false}

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/DWSectionCard.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/DWSectionCard.tsx
@@ -8,7 +8,7 @@ export const DWSectionCard: React.FC<{
   hasDivider?: boolean;
   content: React.ReactNode;
 }> = ({ title, hasDivider = true, helpTooltip, content }) => (
-  <Card isFullHeight className="dw-section-card">
+  <Card isFullHeight>
     <CardHeader>
       <CardTitle>
         {title} {helpTooltip ? <DashboardHelpTooltip content={helpTooltip} /> : null}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-5293

## Description
addresses leftover nit on pr2644, using testid instead of class

## How Has This Been Tested? / Test Impact
updated dom and tests, made sure tests still work and pass properly. made sure app still works.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
