### PR TITLE
notebook.spec.ts unit test flake

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -433,6 +433,7 @@ describe('startNotebook', () => {
   });
 });
 describe('stopNotebook', () => {
+  beforeEach(() => jest.useFakeTimers().setSystemTime(new Date('2024-04-15T19:38:21Z')));
   it('should stop a notebook', async () => {
     const name = 'test-notebook';
     const namespace = 'test-project';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-5447](https://issues.redhat.com//browse/RHOAIENG-5447)
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR addresses an issue where notebook.spec.ts is failing randomly due to its reliance on date timestamps. The failures occur because the test does not mock out the system date when using the Date object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
