### PR TITLE
[RHOAIENG-3984] Make sure analytics.js is loaded via proxy

### DIFF
--- a/frontend/src/utilities/segmentIOUtils.tsx
+++ b/frontend/src/utilities/segmentIOUtils.tsx
@@ -96,7 +96,9 @@ export const initSegment = async (props: {
       const t = document.createElement('script');
       t.type = 'text/javascript';
       t.async = true;
-      t.src = `https://cdn.segment.com/analytics.js/v1/${encodeURIComponent(key)}/analytics.min.js`;
+      t.src = `https://console.redhat.com/connections/cdn/analytics.js/v1/${encodeURIComponent(
+        key,
+      )}/analytics.min.js`;
       const n = document.getElementsByTagName('script')[0];
       if (n.parentNode) {
         n.parentNode.insertBefore(t, n);
@@ -106,7 +108,6 @@ export const initSegment = async (props: {
     analytics.SNIPPET_VERSION = '4.13.1';
     if (segmentKey && enabled) {
       analytics.load(segmentKey, {
-        cdnURL: 'console.redhat.com/connections/cdn',
         integrations: {
           'Segment.io': {
             apiHost: 'console.redhat.com/connections/api/v1',


### PR DESCRIPTION
## Description

The previous setting (from #2557 ) was still loading the analytics.js directly from Segment.
The cdn setting in the options did not override this.
This is a followup on [RHOAIENG-3984](https://issues.redhat.com//browse/RHOAIENG-3984).

## How Has This Been Tested?

Manual testing in browser console without dev-mode.

Network calls should look like this:
<img width="629" alt="Bildschirmfoto 2024-04-16 um 16 27 18" src="https://github.com/opendatahub-io/odh-dashboard/assets/208246/f418156d-16a3-4569-b471-a22536f47a82">

## Test Impact

Should be none, as the tracking itself has not changed.

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X]  Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
