### PR TITLE
chore(DW): 5294 refactor resourceUsageBar

### DIFF
--- a/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.scss
+++ b/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.scss
@@ -1,21 +1,5 @@
-.dw-workload-resource-usage-bar-container {
-  // Vertically aligns the bar and the text to its left/right
-  align-items: center;
-  // Extra margin to space out the adjacent numbers of bars in two columns
-  margin-right: var(--pf-v5-global--spacer--xl);
-}
-
 .dw-workload-resource-usage-bar {
   // Prevents extra whitespace to the right of the bar when combining measureLocation="none" with no title prop
+  // TODO: can remove this after https://github.com/patternfly/patternfly-react/issues/10278 is in place
   grid-gap: 0;
-}
-
-.dw-workload-resource-usage-bar-color-swatch {
-  font-size: var(--pf-v5-global--icon--FontSize--md);
-  &.used {
-    color: var(--pf-v5-global--primary-color--100);
-  }
-  &.requested {
-    color: #d1e0f5; // Can't find where this is defined in PF CSS...
-  }
 }

--- a/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.tsx
+++ b/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Split, SplitItem, Progress, Tooltip, Stack, StackItem } from '@patternfly/react-core';
+import { Progress, Tooltip, Stack, StackItem, Flex, FlexItem } from '@patternfly/react-core';
 import { roundNumber } from '~/utilities/number';
-
 import './WorkloadResourceUsageBar.scss';
 
 type WorkloadResourceUsageBarProps = {
@@ -24,27 +23,23 @@ export const WorkloadResourceUsageBar: React.FC<WorkloadResourceUsageBarProps> =
   if (!showData) {
     return '-';
   }
-  const getColorSwatch = (className: string) => (
-    <span className={`dw-workload-resource-usage-bar-color-swatch ${className}`}>&#x25A0;</span>
-  );
   return (
     <Tooltip
       isContentLeftAligned
       content={
         <Stack>
           <StackItem>
-            {getColorSwatch('used')} {metricLabel} usage: {roundNumber(used, 3)} {unitLabel}
+            {metricLabel} usage: {roundNumber(used, 3)} {unitLabel}
           </StackItem>
           <StackItem>
-            {getColorSwatch('requested')} {metricLabel} requested: {roundNumber(requested, 3)}{' '}
-            {unitLabel}
+            {metricLabel} requested: {roundNumber(requested, 3)} {unitLabel}
           </StackItem>
         </Stack>
       }
     >
-      <Split hasGutter className="dw-workload-resource-usage-bar-container">
-        <SplitItem>{roundNumber(used)}</SplitItem>
-        <SplitItem isFilled style={{ textAlign: 'center', verticalAlign: 'middle' }}>
+      <Flex alignItems={{ default: 'alignItemsCenter' }}>
+        <FlexItem>{roundNumber(used)}</FlexItem>
+        <FlexItem grow={{ default: 'grow' }}>
           <Progress
             className="dw-workload-resource-usage-bar"
             value={used}
@@ -53,9 +48,9 @@ export const WorkloadResourceUsageBar: React.FC<WorkloadResourceUsageBarProps> =
             measureLocation="none"
             aria-label={progressBarAriaLabel}
           />
-        </SplitItem>
-        <SplitItem>{roundNumber(requested)}</SplitItem>
-      </Split>
+        </FlexItem>
+        <FlexItem>{roundNumber(requested)}</FlexItem>
+      </Flex>
     </Tooltip>
   );
 };

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTable.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTable.tsx
@@ -81,7 +81,10 @@ export const WorkloadResourceMetricsTable: React.FC = () => {
         return (
           <Tr key={workload.metadata?.uid}>
             <Td dataLabel="Name">{workload.metadata?.name || 'Unnamed'}</Td>
-            <Td dataLabel="CPU usage (cores)">
+            <Td
+              dataLabel="CPU usage (cores)"
+              style={{ paddingRight: 'var(--pf-v5-global--spacer--xl)' }}
+            >
               <WorkloadResourceUsageBar
                 showData={showUsageBars}
                 used={usage.cpuCoresUsed}
@@ -91,7 +94,10 @@ export const WorkloadResourceMetricsTable: React.FC = () => {
                 progressBarAriaLabel="CPU usage/requested"
               />
             </Td>
-            <Td dataLabel="Memory usage (GiB)">
+            <Td
+              dataLabel="Memory usage (GiB)"
+              style={{ paddingRight: 'var(--pf-v5-global--spacer--xl)' }}
+            >
               <WorkloadResourceUsageBar
                 showData={showUsageBars}
                 used={bytesAsPreciseGiB(usage.memoryBytesUsed)}


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHOAIENG-5294

## Description
factored out css from the resourceUsageBar aside from a gap which is a temporary fix until patternfly can fix the progress bar on their side - https://github.com/patternfly/patternfly-react/issues/10278 

moved spacing styling (giving progress bar a better gap on the right to distinguish, necessary as there are gaps between the progress bar and the numbers associated with them) to the table

removed the color swatches in the progress bar tooltip as a result of this convo:  https://redhat-internal.slack.com/archives/C06J77CPB7S/p1713293363066699

![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/90f1f7a0-a4a2-465b-8a50-61427203f81a)


## How Has This Been Tested?
ran locally to see changes, tests pass

## Test Impact
none

## Request review criteria:
everything still works as expected, color swatches are removed from progress bar tooltip

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
