### PR TITLE
MetricsCommonContext (DW and Model Serving): Persist refresh interval selection in browser sessionStorage

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/distributedWorkloads/GlobalDistributedWorkloads.cy.ts
@@ -16,6 +16,7 @@ import {
   ProjectModel,
   WorkloadModel,
 } from '~/__tests__/cypress/cypress/utils/models';
+import { RefreshIntervalTitle } from '~/concepts/metrics/types';
 
 type HandlersProps = {
   isKueueInstalled?: boolean;
@@ -155,6 +156,19 @@ describe('Distributed Workload Metrics root page', () => {
 
     globalDistributedWorkloads.navigate();
     cy.url().should('include', '/projectMetrics/test-project-2');
+  });
+
+  it('Changing the refresh interval and reloading the page should retain the selection', () => {
+    initIntercepts({});
+    globalDistributedWorkloads.visit();
+
+    globalDistributedWorkloads.shouldHaveRefreshInterval(RefreshIntervalTitle.THIRTY_MINUTES);
+
+    globalDistributedWorkloads.selectRefreshInterval(RefreshIntervalTitle.FIFTEEN_SECONDS);
+    globalDistributedWorkloads.shouldHaveRefreshInterval(RefreshIntervalTitle.FIFTEEN_SECONDS);
+
+    cy.reload();
+    globalDistributedWorkloads.shouldHaveRefreshInterval(RefreshIntervalTitle.FIFTEEN_SECONDS);
   });
 
   it('Should show an empty state if there are no projects', () => {

--- a/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
@@ -1,4 +1,5 @@
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+import { RefreshIntervalTitle } from '~/concepts/metrics/types';
 
 class GlobalDistributedWorkloads {
   visit(wait = true) {
@@ -27,6 +28,18 @@ class GlobalDistributedWorkloads {
 
   findProjectSelect() {
     return cy.findByTestId('project-selector-dropdown');
+  }
+
+  findRefreshIntervalSelectToggle() {
+    return cy.get('#metrics-toolbar-refresh-interval-select-toggle');
+  }
+
+  selectRefreshInterval(interval: RefreshIntervalTitle) {
+    this.findRefreshIntervalSelectToggle().findSelectOption(interval).click();
+  }
+
+  shouldHaveRefreshInterval(interval: RefreshIntervalTitle) {
+    this.findRefreshIntervalSelectToggle().should('contain.text', interval);
   }
 
   selectProjectByName(name: string) {

--- a/frontend/src/concepts/metrics/MetricsCommonContext.tsx
+++ b/frontend/src/concepts/metrics/MetricsCommonContext.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import useCurrentTimeframeBrowserStorage from '~/concepts/metrics/useCurrentTimeframeBrowserStorage';
+import useRefreshIntervalBrowserStorage from '~/concepts/metrics/useRefreshIntervalBrowserStorage';
 import { RefreshIntervalTitle, TimeframeTitle } from '~/concepts/metrics/types';
 
 export type MetricsCommonContextType = {
@@ -27,12 +28,12 @@ type MetricsCommonContextProviderProps = {
 
 export const MetricsCommonContextProvider: React.FC<MetricsCommonContextProviderProps> = ({
   children,
-  initialRefreshInterval = RefreshIntervalTitle.FIVE_MINUTES,
+  initialRefreshInterval,
 }) => {
   const [currentTimeframe, setCurrentTimeframe] = useCurrentTimeframeBrowserStorage();
 
   const [currentRefreshInterval, setCurrentRefreshInterval] =
-    React.useState<RefreshIntervalTitle>(initialRefreshInterval);
+    useRefreshIntervalBrowserStorage(initialRefreshInterval);
 
   const [lastUpdateTime, setLastUpdateTime] = React.useState<number>(Date.now());
 

--- a/frontend/src/concepts/metrics/MetricsRefreshIntervalSelect.tsx
+++ b/frontend/src/concepts/metrics/MetricsRefreshIntervalSelect.tsx
@@ -20,6 +20,7 @@ export const MetricsRefreshIntervalSelect: React.FC = () => {
       }}
       selections={currentRefreshInterval}
       data-testid="metrics-toolbar-refresh-interval-select"
+      toggleId="metrics-toolbar-refresh-interval-select-toggle"
     >
       {Object.values(RefreshIntervalTitle).map((value) => (
         <SelectOption key={value} value={value} />

--- a/frontend/src/concepts/metrics/useRefreshIntervalBrowserStorage.ts
+++ b/frontend/src/concepts/metrics/useRefreshIntervalBrowserStorage.ts
@@ -1,0 +1,15 @@
+import { useBrowserStorage } from '~/components/browserStorage';
+import { SetBrowserStorageHook } from '~/components/browserStorage/BrowserStorageContext';
+import { RefreshIntervalTitle } from '~/concepts/metrics/types';
+
+const useRefreshIntervalBrowserStorage = (
+  initialRefreshInterval = RefreshIntervalTitle.FIVE_MINUTES,
+): [RefreshIntervalTitle, SetBrowserStorageHook<RefreshIntervalTitle>] =>
+  useBrowserStorage<RefreshIntervalTitle>(
+    'odh.dashboard.metrics.refresh_interval',
+    initialRefreshInterval,
+    false,
+    true,
+  );
+
+export default useRefreshIntervalBrowserStorage;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes [RHOAIENG-5290](https://issues.redhat.com/browse/RHOAIENG-5290)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

* Adds a new `useRefreshIntervalBrowserStorage` hook to match the existing `useCurrentTimeframeBrowserStorage` which was moved from ModelServingMetricsContext in https://github.com/opendatahub-io/odh-dashboard/pull/2609
* Replaces the `useState` for refresh interval in `MetricsCommonContextProvider` with the new hook
* Adds a `toggleId` to the Select for refresh interval to support Cypress tests (the existing `data-testid` gets applied only to the menu that appears on click, we still needed some way to find the toggle button for opening the menu)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by hand, made sure it's working as expected in both places MetricsCommonContext is used (Model Serving Metrics and Distributed Workload Metrics)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added a Cypress test to change the refresh interval via the dropdown and verify that the selection is retained after reloading the page

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
