### PR TITLE
start webpack dev server with external cluster target

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "format": "prettier --write \"./**/*.ts\" \"./**/*.tsx\" \"./**/*.scss\"",
     "lint:goal": "eslint --config ./.eslintrc.goal.js --ext .json,.js,.ts,.jsx,.tsx ./src ",
     "start:dev": "webpack serve --hot --color --config ./config/webpack.dev.js",
+    "start:dev:ext": "EXT_CLUSTER=true npm run start:dev",
     "test": "run-s test:lint test:type-check test:unit test:cypress-ci",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx ./src --fix",
     "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx ./src",

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -15,7 +15,7 @@ import {
   DropdownItem,
 } from '@patternfly/react-core/deprecated';
 import { ExternalLinkAltIcon, QuestionCircleIcon } from '@patternfly/react-icons';
-import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK, DEV_MODE } from '~/utilities/const';
+import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK, DEV_MODE, EXT_CLUSTER } from '~/utilities/const';
 import useNotification from '~/utilities/useNotification';
 import { updateImpersonateSettings } from '~/services/impersonateService';
 import { AppNotification } from '~/redux/types';
@@ -57,7 +57,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
     </DropdownItem>,
   ];
 
-  if (DEV_MODE && !isImpersonating) {
+  if (!EXT_CLUSTER && DEV_MODE && !isImpersonating) {
     userMenuItems.unshift(
       <DropdownItem
         key="impersonate"

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -15,6 +15,7 @@ const ODH_LOGO = process.env.ODH_LOGO || 'odh-logo.svg';
 const { ODH_PRODUCT_NAME } = process.env;
 const { ODH_NOTEBOOK_REPO } = process.env;
 const DASHBOARD_CONFIG = process.env.DASHBOARD_CONFIG || 'odh-dashboard-config';
+const { EXT_CLUSTER } = process.env;
 
 export {
   DEV_MODE,
@@ -30,6 +31,7 @@ export {
   ODH_NOTEBOOK_REPO,
   DASHBOARD_CONFIG,
   WS_HOSTNAME,
+  EXT_CLUSTER,
 };
 
 export const DOC_TYPE_TOOLTIPS = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-6353

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removes the requirement for frontend local development requiring also a local running backend server.

Support running the frontend dev server communicating with an external cluster by proxying all `/api` calls to the external cluster.

Requires logging into the cluster using `oc` before starting webpack dev server using `npm run start:dev:ext`.

Action to `Start impersonate` has been removed when using running with an external cluster.

```
▶ oc login -u clusteradmin -p "pasword" https://api.mytestserver.com:443
▶ npm run start:dev:ext

> odh-dashboard-frontend@0.1.0 start:dev:ext
> EXT_CLUSTER=true npm run start:dev


> odh-dashboard-frontend@0.1.0 start:dev
> webpack serve --hot --color --config ./config/webpack.dev.js


Prepping files...
  SRC DIR: /Users/.../odh-dashboard/frontend/src
  OUTPUT DIR: /Users/.../odh-dashboard/frontend/public
  PUBLIC PATH: /

Using project: opendatahub
Dashboard host: odh-dashboard-opendatahub.apps.mytestserver.com
Logged in as user: clusteradmin
<i> [webpack-dev-server] [HPM] Proxy created: /api  -> https://odh-dashboard-opendatahub.apps.mytestserver.com
<i> [webpack-dev-server] [HPM] Proxy created: /wss  -> wss://odh-dashboard-opendatahub.apps.mytestserver.com
<i> [webpack-dev-server] Project is running at:
<i> [webpack-dev-server] Loopback: http://localhost:4010/, http://[::1]:4010/
<i> [webpack-dev-server] Content not from webpack is served from '/Users/.../odh-dashboard/frontend/public' directory
<i> [webpack-dev-server] 404s will fallback to '/index.html'
✓ ODH Dashboard available at: http://localhost:4010
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Login to cluster.
Start dev server.
Go to `http://localhost:4010` and observe page loading.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
