### PR TITLE
DW: Consistently show resource usage for finished workloads that are still spinning down

### DIFF
--- a/frontend/src/__mocks__/mockDWUsageByJobPrometheusResponse.ts
+++ b/frontend/src/__mocks__/mockDWUsageByJobPrometheusResponse.ts
@@ -1,0 +1,13 @@
+import { WorkloadMetricPromQueryResponse } from '~/api';
+import { mockPrometheusQueryVectorResponse } from './mockPrometheusQueryVectorResponse';
+
+export const mockDWUsageByJobPrometheusResponse = (usageByJobName: {
+  [jobName: string]: number;
+}): WorkloadMetricPromQueryResponse =>
+  mockPrometheusQueryVectorResponse({
+    result: Object.entries(usageByJobName).map(([jobName, value]) => ({
+      // eslint-disable-next-line camelcase
+      metric: { workload: jobName, workload_type: 'job' },
+      value: [0, String(value)],
+    })),
+  });

--- a/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/distributedWorkloads.ts
@@ -50,6 +50,10 @@ class GlobalDistributedWorkloads {
     return cy.findByTestId('dw-status-overview-card');
   }
 
+  findWorkloadResourceMetricsTable() {
+    return cy.findByTestId('workload-resource-metrics-table');
+  }
+
   private wait() {
     this.shouldHavePageTitle();
     cy.testA11y();

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -20,7 +20,7 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => (
         content={<TopResourceConsumingWorkloads />}
       />
     </StackItem>
-    <StackItem data-testid="dw-workloada-resource-metrics">
+    <StackItem data-testid="dw-workload-resource-metrics">
       <DWSectionCard
         title="Distributed workload resource metrics"
         hasDivider={false}

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTable.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTable.tsx
@@ -65,7 +65,7 @@ export const WorkloadResourceMetricsTable: React.FC = () => {
       data={workloads.data}
       columns={columns}
       emptyTableView={<>No distributed workloads match your filters</>}
-      data-id="workload-resource-metrics-table"
+      data-testid="workload-resource-metrics-table"
       rowRenderer={(workload) => (
         <WorkloadResourceMetricsTableRow
           workload={workload}

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTableRow.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTableRow.tsx
@@ -22,7 +22,7 @@ const WorkloadResourceMetricsTableRow: React.FC<WorkloadResourceMetricsTableRowP
   usage,
   requested,
 }) => {
-  const showUsageBars = [
+  const inActiveState = [
     WorkloadStatusType.Pending,
     WorkloadStatusType.Admitted,
     WorkloadStatusType.Running,
@@ -33,7 +33,7 @@ const WorkloadResourceMetricsTableRow: React.FC<WorkloadResourceMetricsTableRowP
       <Td dataLabel="CPU usage (cores)" style={{ paddingRight: 'var(--pf-v5-global--spacer--xl)' }}>
         {' '}
         <WorkloadResourceUsageBar
-          showData={showUsageBars}
+          showData={inActiveState || (usage.cpuCoresUsed || 0) > 0}
           used={usage.cpuCoresUsed}
           requested={requested.cpuCoresRequested}
           metricLabel="CPU"
@@ -47,7 +47,7 @@ const WorkloadResourceMetricsTableRow: React.FC<WorkloadResourceMetricsTableRowP
       >
         {' '}
         <WorkloadResourceUsageBar
-          showData={showUsageBars}
+          showData={inActiveState || (usage.memoryBytesUsed || 0) > 0}
           used={bytesAsPreciseGiB(usage.memoryBytesUsed)}
           requested={bytesAsPreciseGiB(requested.memoryBytesRequested)}
           metricLabel="Memory"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes [RHOAIENG-5289](https://issues.redhat.com/browse/RHOAIENG-5289)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Previously in the workload resource metrics table, the resource usage bars would be shown only if a workload is in an active state (pending, admitted, or running) and otherwise the column would show a dash (-). In reality, when workloads are finished they don't release their resources right away, and there is still usage to show while the pods spin down. We did not have this "active state" condition for showing workloads in the other charts on the page, only in this table. However, we still don't want to show the empty resource bars after workloads are no longer using resources.

This change fixes the issue by adding an additional condition where the CPU or memory usage bar will appear if there is any continued usage of that resource, regardless of the workload's status. This makes the table's behavior consistent with the rest of the page.

![Screenshot 2024-04-19 at 5 19 19 PM](https://github.com/opendatahub-io/odh-dashboard/assets/811963/3c120ebb-4024-4e0b-924e-cb79e81988c6)

cc @yannnz @cfullam1 @xianli123 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually and observed that spinning-down workloads appear correctly.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added Cypress tests to assert whether or not the resource usage bars are shown in each relevant case.

Note: in order to support this, this PR also adds new mocks and Cypress request intercept logic to make it possible for us to mock specific Prometheus response data for each of the two queries on this page, so that we can test workloads with various amounts of CPU and memory usage. This will likely be useful for future tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
