### PR TITLE
chore(dw): requested resources always show tooltip

### DIFF
--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -1,42 +1,33 @@
 import * as React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
-import { useUser } from '~/redux/selectors';
 import { RequestedResources } from './sections/RequestedResources';
 import { TopResourceConsumingWorkloads } from './sections/TopResourceConsumingWorkloads';
 import { WorkloadResourceMetricsTable } from './sections/WorkloadResourceMetricsTable';
 import { DWSectionCard } from './sections/DWSectionCard';
 
-const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => {
-  const { isAdmin } = useUser();
-
-  return (
-    <Stack hasGutter>
-      <StackItem data-testid="dw-requested-resources">
-        <DWSectionCard
-          title="Requested resources"
-          helpTooltip={
-            isAdmin
-              ? undefined
-              : 'In this section, all projects refers to all of the projects that share the specified resource. You might not have access to all of these projects.'
-          }
-          content={<RequestedResources />}
-        />
-      </StackItem>
-      <StackItem data-testid="dw-top-consuming-workloads">
-        <DWSectionCard
-          title="Top resource-consuming distributed workloads"
-          content={<TopResourceConsumingWorkloads />}
-        />
-      </StackItem>
-      <StackItem data-testid="dw-workloada-resource-metrics">
-        <DWSectionCard
-          title="Distributed workload resource metrics"
-          hasDivider={false}
-          content={<WorkloadResourceMetricsTable />}
-        />
-      </StackItem>
-    </Stack>
-  );
-};
+const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => (
+  <Stack hasGutter>
+    <StackItem data-testid="dw-requested-resources">
+      <DWSectionCard
+        title="Requested resources"
+        helpTooltip="In this section, all projects refers to all of the projects that share the specified resource. You might not have access to all of these projects."
+        content={<RequestedResources />}
+      />
+    </StackItem>
+    <StackItem data-testid="dw-top-consuming-workloads">
+      <DWSectionCard
+        title="Top resource-consuming distributed workloads"
+        content={<TopResourceConsumingWorkloads />}
+      />
+    </StackItem>
+    <StackItem data-testid="dw-workloada-resource-metrics">
+      <DWSectionCard
+        title="Distributed workload resource metrics"
+        hasDivider={false}
+        content={<WorkloadResourceMetricsTable />}
+      />
+    </StackItem>
+  </Stack>
+);
 
 export default GlobalDistributedWorkloadsProjectMetricsTab;


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/RHOAIENG-5293

## Description
removing logic that hides the "you might not have access to all of these projects" for admin, as `isAdmin` is not a cluster admin and doesn't mean they will have access to all projects.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/4e34d08c-1f35-44a6-83a7-6c32070d0852)


## How Has This Been Tested?
ran locally, ran tests - still pass

## Test Impact
none

## Request review criteria:
help tooltip shows up for odh admins

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
