### PR TITLE
Create cypress test for Notebook server tab

### DIFF
--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -13,6 +13,7 @@ type MockResourceConfigType = {
   description?: string;
   envFromName?: string;
   resources?: ContainerResources;
+  image?: string;
   opts?: RecursivePartial<NotebookKind>;
   uid?: string;
 };
@@ -25,6 +26,7 @@ export const mockNotebookK8sResource = ({
   user = 'test-user',
   description = '',
   resources = DEFAULT_NOTEBOOK_SIZES[0].resources,
+  image = 'test-imagestream:1.2',
   opts = {},
   uid = genUID('notebook'),
 }: MockResourceConfigType): NotebookKind =>
@@ -90,7 +92,7 @@ export const mockNotebookK8sResource = ({
                   {
                     name: 'JUPYTER_IMAGE',
                     value:
-                      'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.8-v1',
+                      'image-registry.openshift-image-registry.svc:5000/opendatahub/code-server-notebook:2023.2',
                   },
                 ],
                 envFrom: [
@@ -100,7 +102,7 @@ export const mockNotebookK8sResource = ({
                     },
                   },
                 ],
-                image: 'test-imagestream:1.2',
+                image,
                 imagePullPolicy: 'Always',
                 livenessProbe: {
                   failureThreshold: 3,

--- a/frontend/src/__tests__/cypress/cypress/e2e/applications/NotebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/applications/NotebookServer.cy.ts
@@ -1,0 +1,96 @@
+import { mockRoleBindingK8sResource } from '~/__mocks__/mockRoleBindingK8sResource';
+import { mockK8sResourceList, mockNotebookK8sResource } from '~/__mocks__';
+import { RoleBindingSubject } from '~/types';
+import { mockAllowedUsers } from '~/__mocks__/mockAllowedUsers';
+import { mockNotebookImageInfo } from '~/__mocks__/mockNotebookImageInfo';
+import { mockStartNotebookData } from '~/__mocks__/mockStartNotebookData';
+import { notebookServer } from '~/__tests__/cypress/cypress/pages/notebookServer';
+import { asProductAdminUser, asProjectEditUser } from '~/__tests__/cypress/cypress/utils/users';
+import { notebookController } from '~/__tests__/cypress/cypress/pages/administration';
+
+const groupSubjects: RoleBindingSubject[] = [
+  {
+    kind: 'Group',
+    apiGroup: 'rbac.authorization.k8s.io',
+    name: 'group-1',
+  },
+];
+const initIntercepts = () => {
+  cy.interceptOdh('POST /api/notebooks', mockStartNotebookData({})).as('startNotebookServer');
+  cy.interceptOdh(
+    'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
+    mockK8sResourceList([
+      mockRoleBindingK8sResource({
+        name: 'group-1',
+        subjects: groupSubjects,
+        roleRefName: 'edit',
+      }),
+    ]),
+  );
+  cy.interceptOdh('GET /api/images/:type', { path: { type: 'jupyter' } }, mockNotebookImageInfo());
+  cy.interceptOdh('GET /api/status/openshift-ai-notebooks/allowedUsers', mockAllowedUsers({}));
+};
+
+it('Administartion tab should not be accessible for non-project admins', () => {
+  initIntercepts();
+  asProjectEditUser();
+  notebookServer.visit();
+  notebookController.findAdministrationTab().should('not.exist');
+  notebookController.findSpawnerTab().should('not.exist');
+  notebookController.findAppTitle().should('contain', 'Start a notebook server');
+});
+
+describe('NotebookServer', () => {
+  beforeEach(() => {
+    initIntercepts();
+    asProductAdminUser();
+  });
+
+  it('should start notebook server', () => {
+    notebookServer.visit();
+    notebookServer.findStartServerButton().should('be.visible');
+    notebookServer.findStartServerButton().click();
+    notebookServer.findEventlog().click();
+
+    cy.wait('@startNotebookServer').then((interception) => {
+      expect(interception.request.body).to.eql({
+        notebookSizeName: 'XSmall',
+        imageName: 'code-server-notebook',
+        imageTagName: '2023.2',
+        acceleratorProfile: { acceleratorProfiles: [], count: 0, useExisting: false },
+        envVars: { configMap: {}, secrets: {} },
+        state: 'started',
+      });
+    });
+  });
+
+  it('should stop notebook server', () => {
+    cy.interceptOdh(
+      'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+      { path: { username: 'jupyter-nb-test-2duser' } },
+      {
+        notebook: mockNotebookK8sResource({ image: 'code-server-notebook:2023.2' }),
+        isRunning: true,
+      },
+    );
+    cy.interceptOdh('PATCH /api/notebooks', mockStartNotebookData({})).as('stopNotebookServer');
+    notebookServer.visit();
+    notebookServer.findStopServerButton().should('be.visible');
+    notebookServer.findStopServerButton().click();
+
+    cy.interceptOdh(
+      'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+      { path: { username: 'jupyter-nb-test-2duser' } },
+      {
+        notebook: mockNotebookK8sResource({ image: 'code-server-notebook:2023.2' }),
+        isRunning: false,
+      },
+    );
+    notebookServer.findStopNotebookServerButton().should('be.visible');
+    notebookServer.findStopNotebookServerButton().click();
+
+    cy.wait('@stopNotebookServer').then((interception) => {
+      expect(interception.request.body).to.eql({ state: 'stopped', username: 'test-user' });
+    });
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
@@ -1,0 +1,41 @@
+class NotebookServer {
+  visit() {
+    cy.visit('/notebookController/spawner');
+    this.wait();
+  }
+
+  private wait() {
+    this.findAppTitle();
+    cy.testA11y();
+  }
+
+  findAppTitle() {
+    return cy.findByTestId('app-page-title');
+  }
+
+  findAdministrationTab() {
+    return cy.findByTestId('admin-tab');
+  }
+
+  findSpawnerTab() {
+    return cy.findByTestId('spawner-tab');
+  }
+
+  findStartServerButton() {
+    return cy.findByTestId('start-server-button');
+  }
+
+  findEventlog() {
+    return cy.findByTestId('expand-logs').findByRole('button');
+  }
+
+  findStopServerButton() {
+    return cy.findByTestId('stop-nb-button');
+  }
+
+  findStopNotebookServerButton() {
+    return cy.findByTestId('stop-nb-server-button');
+  }
+}
+
+export const notebookServer = new NotebookServer();

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -10,7 +10,10 @@ import type {
   RoleBindingKind,
   ServingRuntimeKind,
   TemplateKind,
+  NotebookKind,
 } from '~/k8sTypes';
+
+import { StartNotebookData } from '~/pages/projects/types';
 import { AllowedUser } from '~/pages/notebookController/screens/admin/types';
 import { GroupsConfig } from '~/pages/groupSettings/groupTypes';
 import type { StatusResponse } from '~/redux/types';
@@ -103,6 +106,11 @@ declare global {
       interceptOdh(
         type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',
         response: OdhResponse<AllowedUser[]>,
+      ): Cypress.Chainable<null>;
+
+      interceptOdh(
+        type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',
+        response: OdhResponse<AllowedUser>,
       ): Cypress.Chainable<null>;
 
       interceptOdh(
@@ -210,6 +218,23 @@ declare global {
       ): Cypress.Chainable<null>;
 
       interceptOdh(
+        type: 'POST /api/notebooks',
+        response: OdhResponse<StartNotebookData>,
+      ): Cypress.Chainable<null>;
+
+      interceptOdh(
+        type: 'PATCH /api/notebooks',
+        response: OdhResponse<StartNotebookData>,
+      ): Cypress.Chainable<null>;
+
+      interceptOdh(
+        type: 'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+        options: {
+          path: { username: string };
+        },
+        response: OdhResponse<NotebookKind>,
+      ): Cypress.Chainable<null>;
+      interceptOdh(
         type: 'POST /api/prometheus/pvc',
         response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
       ): Cypress.Chainable<null>;
@@ -293,6 +318,19 @@ declare global {
       interceptOdh(
         type: 'GET /api/service/modelregistry/modelregistry-sample/api/model_registry/v1alpha3/registered_models/1/versions',
         response: OdhResponse<ModelVersionList | undefined>,
+      ): Cypress.Chainable<null>;
+
+      interceptOdh(
+        type: 'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
+        response: OdhResponse<K8sResourceListResult<RoleBindingKind>>,
+      ): Cypress.Chainable<null>;
+
+      interceptOdh(
+        type: 'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+        options: {
+          path: { username: string };
+        },
+        response: OdhResponse<{ notebook: NotebookKind; isRunning: boolean }>,
       ): Cypress.Chainable<null>;
     }
   }

--- a/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
@@ -72,7 +72,7 @@ const NotebookServer: React.FC = () => {
                   </Button>
                 </ActionListItem>
                 <ActionListItem onClick={() => setNotebooksToStop([notebook])}>
-                  <Button data-id="stop-nb-button" variant="secondary">
+                  <Button data-id="stop-nb-button" data-testid="stop-nb-button" variant="secondary">
                     Stop notebook server
                   </Button>
                 </ActionListItem>

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -211,6 +211,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgre
   const renderLogs = () => (
     <ExpandableSection
       data-id="expand-logs"
+      data-testid="expand-logs"
       toggleText={`${logsExpanded ? 'Collapse' : 'Expand'} event log`}
       onToggle={(e, isExpanded) => setLogsExpanded(isExpanded)}
       isExpanded={logsExpanded}

--- a/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
@@ -60,6 +60,7 @@ const StopServerModal: React.FC<StopServerModalProps> = ({ notebooksToStop, onNo
   const modalActions = [
     <Button
       data-id="stop-nb-button"
+      data-testid="stop-nb-server-button"
       isDisabled={isDeleting}
       key="confirm"
       variant="primary"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-3918](https://issues.redhat.com/browse/RHOAIENG-3918)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR aims to add cypress test for Notebook server tab.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
