### PR TITLE
[RHOAIENG-5495] Landing page: resources section

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/home/homeResources.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/home/homeResources.cy.ts
@@ -1,0 +1,35 @@
+import { initHomeIntercepts } from '~/__tests__/cypress/cypress/e2e/home/homeUtils';
+import { mockDocs } from '~/__mocks__/mockDocs';
+import { mockComponents } from '~/__mocks__/mockComponents';
+import { mockQuickStarts } from '~/__mocks__/mockQuickStarts';
+
+describe('Home page Resources section', () => {
+  beforeEach(() => {
+    cy.interceptOdh('GET /api/docs', mockDocs());
+    cy.interceptOdh('GET /api/components', null, mockComponents());
+    cy.interceptOdh('GET /api/quickstarts', mockQuickStarts());
+
+    cy.visit('/');
+  });
+  it('should show the resources section', () => {
+    initHomeIntercepts({ disableHome: false });
+    cy.visit('/');
+
+    cy.findByTestId('landing-page-resources').should('be.visible');
+  });
+  it('should hide the the resource section if none are available', () => {
+    cy.interceptOdh('GET /api/quickstarts', []);
+
+    initHomeIntercepts({ disableHome: false });
+    cy.visit('/');
+
+    cy.findByTestId('landing-page-resources').should('not.exist');
+  });
+  it('should navigate to the project list', () => {
+    initHomeIntercepts({ disableHome: false });
+    cy.visit('/');
+
+    cy.findByTestId('goto-resources-link').click();
+    cy.findByTestId('app-page-title').should('have.text', 'Resources');
+  });
+});

--- a/frontend/src/components/OdhDocCard.tsx
+++ b/frontend/src/components/OdhDocCard.tsx
@@ -11,7 +11,6 @@ import {
   StackItem,
   Text,
   TextContent,
-  Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { QuickStartContextValues } from '@patternfly/quickstarts';
@@ -33,9 +32,10 @@ import './OdhCard.scss';
 
 type OdhDocCardProps = {
   odhDoc: OdhDocument;
-  favorite: boolean;
-  updateFavorite: (isFavorite: boolean) => void;
-};
+  showFavorite?: boolean;
+  favorite?: boolean;
+  updateFavorite?: (isFavorite: boolean) => void;
+} & React.HTMLProps<HTMLElement>;
 
 // fire an event when any resource on the Resource page is accessed
 const fireResourceAccessedEvent =
@@ -55,7 +55,13 @@ const RIGHT_JUSTIFIED_STATUSES = [
   LaunchStatusEnum.Continue,
   LaunchStatusEnum.Close,
 ];
-const OdhDocCard: React.FC<OdhDocCardProps> = ({ odhDoc, favorite, updateFavorite }) => {
+const OdhDocCard: React.FC<OdhDocCardProps> = ({
+  odhDoc,
+  showFavorite = true,
+  favorite = false,
+  updateFavorite,
+  ...rest
+}) => {
   const [qsContext, selected] = useQuickStartCardSelected(
     odhDoc.metadata.name,
     odhDoc.metadata.name,
@@ -152,12 +158,16 @@ const OdhDocCard: React.FC<OdhDocCardProps> = ({ odhDoc, favorite, updateFavorit
       isSelected={selected}
       isSelectable
       isClickable
+      {...rest}
     >
       <CardHeader
         actions={{
-          actions: (
-            <FavoriteButton isFavorite={favorite} onClick={() => updateFavorite(!favorite)} />
-          ),
+          actions: showFavorite ? (
+            <FavoriteButton
+              isFavorite={favorite}
+              onClick={() => updateFavorite && updateFavorite(!favorite)}
+            />
+          ) : undefined,
           hasNoOffset: true,
           className: undefined,
         }}
@@ -179,9 +189,7 @@ const OdhDocCard: React.FC<OdhDocCardProps> = ({ odhDoc, favorite, updateFavorit
             <DocCardBadges odhDoc={odhDoc} />
           </StackItem>
           <StackItem>
-            <Tooltip content={odhDoc.spec.description}>
-              <TruncatedText maxLines={4} content={odhDoc.spec.description} />
-            </Tooltip>
+            <TruncatedText maxLines={4} content={odhDoc.spec.description} />
           </StackItem>
         </Stack>
       </CardBody>

--- a/frontend/src/concepts/design/CollapsibleSection.tsx
+++ b/frontend/src/concepts/design/CollapsibleSection.tsx
@@ -3,39 +3,37 @@ import { Button, Flex, FlexItem, Text, TextContent, TextVariants } from '@patter
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 
 interface CollapsibleSectionProps {
-  initialOpen?: boolean;
+  open?: boolean;
+  setOpen?: (update: boolean) => void;
   title: string;
+  titleVariant?: TextVariants.h1 | TextVariants.h2;
   children?: React.ReactNode;
   id?: string;
   showChildrenWhenClosed?: boolean;
-  onOpenChange?: (isOpen: boolean) => void;
 }
 
 const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
-  initialOpen = true,
+  open,
+  setOpen,
   title,
+  titleVariant = TextVariants.h2,
   children,
   id,
   showChildrenWhenClosed,
-  onOpenChange,
 }) => {
-  const [open, setOpen] = React.useState<boolean>(initialOpen);
+  const [innerOpen, setInnerOpen] = React.useState<boolean>(true);
   const localId = id || title.replace(' ', '-');
   const titleId = `${localId}-title`;
 
   return (
-    <div
-      style={{
-        padding: open ? undefined : 'var(--pf-v5-global--spacer--md)',
-      }}
-    >
+    <>
       <Flex
         gap={{ default: 'gapMd' }}
+        alignItems={{ default: 'alignItemsCenter' }}
         style={
-          open || showChildrenWhenClosed
+          (open ?? innerOpen) || showChildrenWhenClosed
             ? {
                 marginBottom: 'var(--pf-v5-global--spacer--md)',
-                marginLeft: open ? 'var(--pf-v5-global--spacer--md)' : undefined,
               }
             : undefined
         }
@@ -44,30 +42,30 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
           <Button
             aria-labelledby={titleId}
             aria-expanded={open}
-            isInline
-            variant="link"
-            onClick={() => {
-              setOpen((prev) => {
-                if (onOpenChange) {
-                  onOpenChange(!prev);
-                }
-                return !prev;
-              });
+            variant="plain"
+            style={{
+              paddingLeft: 0,
+              paddingRight: 0,
+              fontSize:
+                titleVariant === TextVariants.h2
+                  ? 'var(--pf-v5-global--FontSize--xl)'
+                  : 'var(--pf-v5-global--FontSize--2xl)',
             }}
+            onClick={() => (setOpen ? setOpen(!open) : setInnerOpen((prev) => !prev))}
           >
-            {open ? <AngleDownIcon /> : <AngleRightIcon />}
+            {open ?? innerOpen ? <AngleDownIcon /> : <AngleRightIcon />}
           </Button>
         </FlexItem>
         <FlexItem>
           <TextContent>
-            <Text id={titleId} component={TextVariants.h2}>
+            <Text id={titleId} component={titleVariant}>
               {title}
             </Text>
           </TextContent>
         </FlexItem>
       </Flex>
-      {open || showChildrenWhenClosed ? children : null}
-    </div>
+      {(open ?? innerOpen) || showChildrenWhenClosed ? children : null}
+    </>
   );
 };
 

--- a/frontend/src/concepts/design/ScrolledGallery.tsx
+++ b/frontend/src/concepts/design/ScrolledGallery.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+type ScrolledGalleryProps = {
+  count: number;
+  childWidth: string;
+} & React.HTMLProps<HTMLDivElement>;
+
+const ScrolledGallery: React.FC<ScrolledGalleryProps> = ({
+  children,
+  count,
+  childWidth,
+  ...rest
+}) => {
+  let gridTemplateColumns = childWidth;
+  for (let i = 1; i < count; i++) {
+    gridTemplateColumns = `${gridTemplateColumns} ${childWidth}`;
+  }
+  return (
+    <div
+      style={{
+        gridTemplateColumns,
+        display: 'grid',
+        gridAutoFlow: 'column',
+        overflowY: 'auto',
+        gap: 'var(--pf-v5-global--spacer--md)',
+        paddingBottom: 'var(--pf-v5-global--spacer--sm)',
+      }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default ScrolledGallery;

--- a/frontend/src/concepts/docResources/docUtils.ts
+++ b/frontend/src/concepts/docResources/docUtils.ts
@@ -1,0 +1,41 @@
+import * as _ from 'lodash-es';
+import { QuickStart } from '@patternfly/quickstarts/src/utils/quick-start-types';
+import { OdhApplication, OdhDocument, OdhDocumentType } from '~/types';
+import { combineCategoryAnnotations } from '~/utilities/utils';
+
+export const updateDocToComponent = (
+  odhDoc: OdhDocument,
+  components: OdhApplication[],
+): OdhDocument => {
+  const odhApp = components.find((c) => c.metadata.name === odhDoc.spec.appName);
+  const updatedDoc = _.cloneDeep(odhDoc);
+  if (odhApp) {
+    combineCategoryAnnotations(odhDoc, odhApp);
+    updatedDoc.spec.appDisplayName = odhApp.spec.displayName;
+    updatedDoc.spec.appEnabled = odhApp.spec.isEnabled ?? false;
+    updatedDoc.spec.img = odhDoc.spec.img || odhApp.spec.img;
+    updatedDoc.spec.description = odhDoc.spec.description || odhApp.spec.description;
+    updatedDoc.spec.provider = odhDoc.spec.provider || odhApp.spec.provider;
+    updatedDoc.spec.appCategory = odhDoc.spec.appCategory || odhApp.spec.category;
+  } else {
+    updatedDoc.spec.appEnabled = false;
+  }
+  return updatedDoc;
+};
+
+export const getQuickStartDocs = (
+  quickStarts: QuickStart[],
+  components: OdhApplication[],
+): OdhDocument[] => {
+  // Get doc cards for the quick starts
+  const docs: OdhDocument[] = quickStarts.map(
+    (quickStart) =>
+      _.merge({}, quickStart, {
+        spec: {
+          type: OdhDocumentType.QuickStart,
+        },
+      }) as unknown as OdhDocument, // TODO: Fix QuickStart type dependency -- they updated their types and broke us
+  );
+
+  return docs.map((odhDoc) => updateDocToComponent(odhDoc, components));
+};

--- a/frontend/src/concepts/docResources/useDocResources.tsx
+++ b/frontend/src/concepts/docResources/useDocResources.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
+import { useWatchDocs } from '~/utilities/useWatchDocs';
+import { useWatchComponents } from '~/utilities/useWatchComponents';
+import { OdhDocument, OdhDocumentType } from '~/types';
+import { getQuickStartDocs, updateDocToComponent } from './docUtils';
+
+export const useDocResources = (): { docs: OdhDocument[]; loaded: boolean; loadError?: Error } => {
+  const { docs: odhDocs, loaded: docsLoaded, loadError: docsLoadError } = useWatchDocs();
+  const { components, loaded, loadError } = useWatchComponents(false);
+  const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
+
+  return React.useMemo(() => {
+    if (docsLoadError || loadError) {
+      return { docs: [], loaded: loaded && docsLoaded, loadError: loadError || docsLoadError };
+    }
+
+    if (!loaded || !docsLoaded) {
+      return { docs: [], loaded: false };
+    }
+
+    const docs = [...odhDocs];
+
+    // Add doc cards for all components' documentation
+    components.forEach((component) => {
+      if (component.spec.docsLink) {
+        const odhDoc: OdhDocument = {
+          kind: 'OdhDocLink',
+          metadata: {
+            name: `${component.metadata.name}-doc`,
+          },
+          spec: {
+            type: OdhDocumentType.Documentation,
+            appName: component.metadata.name,
+            provider: component.spec.provider,
+            url: component.spec.docsLink,
+            displayName: component.spec.displayName,
+            description: component.spec.description,
+          },
+        };
+        docs.push(odhDoc);
+      }
+    });
+
+    const updatedDocApps = docs
+      .filter((doc) => doc.spec.type !== 'getting-started')
+      .map((odhDoc) => updateDocToComponent(odhDoc, components));
+
+    const quickStartDocs = getQuickStartDocs(qsContext.allQuickStarts || [], components);
+
+    return { docs: [...updatedDocApps, ...quickStartDocs], loaded: true };
+  }, [components, loaded, loadError, odhDocs, docsLoaded, docsLoadError, qsContext.allQuickStarts]);
+};

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -13,12 +13,14 @@ import useIsAreaAvailable from '~/concepts/areas/useIsAreaAvailable';
 import { SupportedArea } from '~/concepts/areas';
 import ProjectsSection from './projects/ProjectsSection';
 import { useAIFlows } from './aiFlows/useAIFlows';
+import { useResourcesSection } from './resources/useResourcesSection';
 
 const Home: React.FC = () => {
   const { status: projectsAvailable } = useIsAreaAvailable(SupportedArea.DS_PROJECTS_VIEW);
   const aiFlows = useAIFlows();
+  const resourcesSection = useResourcesSection();
 
-  if (!projectsAvailable && !aiFlows) {
+  if (!projectsAvailable && !aiFlows && !resourcesSection) {
     return (
       <PageSection data-testid="home-page-empty" variant={PageSectionVariants.default}>
         <Bullseye>
@@ -38,6 +40,7 @@ const Home: React.FC = () => {
     <div data-testid="home-page">
       <ProjectsSection />
       {aiFlows}
+      {resourcesSection}
     </div>
   );
 };

--- a/frontend/src/pages/home/resources/ResourcesLoading.tsx
+++ b/frontend/src/pages/home/resources/ResourcesLoading.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Gallery, Skeleton } from '@patternfly/react-core';
+
+const ResourcesLoading: React.FC = () => (
+  <Gallery hasGutter minWidths={{ default: '330px' }} maxWidths={{ default: '330px' }}>
+    <Skeleton style={{ height: 385 }} />
+    <Skeleton style={{ height: 385 }} />
+    <Skeleton style={{ height: 385 }} />
+  </Gallery>
+);
+
+export default ResourcesLoading;

--- a/frontend/src/pages/home/resources/useResourcesSection.tsx
+++ b/frontend/src/pages/home/resources/useResourcesSection.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  Stack,
+  TextVariants,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { OdhDocument } from '~/types';
+import OdhDocCard from '~/components/OdhDocCard';
+import ScrolledGallery from '~/concepts/design/ScrolledGallery';
+import CollapsibleSection from '~/concepts/design/CollapsibleSection';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { useSpecifiedResources } from './useSpecifiedResources';
+import ResourcesLoading from './ResourcesLoading';
+
+const includedCards = [
+  { name: 'create-jupyter-notebook', kind: 'OdhQuickStart' },
+  { name: 'rhoai-tutorial-fraud', kind: 'OdhDocument' },
+  { name: 'rhoai-documentation', kind: 'OdhDocument' },
+  { name: 'watson-x-use-case', kind: 'OdhDocument' },
+  { name: 'openvino-inference-notebook', kind: 'OdhQuickStart' },
+];
+
+export const useResourcesSection = (): React.ReactNode => {
+  const navigate = useNavigate();
+  const { docs, loaded, loadError } = useSpecifiedResources(includedCards);
+  const [resourcesOpen, setResourcesOpen] = useBrowserStorage<boolean>(
+    'odh.home.resources.open',
+    true,
+    true,
+    false,
+  );
+
+  if (loaded && !loadError && docs.length === 0) {
+    return null;
+  }
+
+  return (
+    <PageSection data-testid="landing-page-resources">
+      <CollapsibleSection
+        title="Get oriented with learning resources"
+        titleVariant={TextVariants.h1}
+        open={resourcesOpen}
+        setOpen={setResourcesOpen}
+      >
+        <Stack hasGutter>
+          {loadError ? (
+            <EmptyState variant={EmptyStateVariant.lg} data-id="error-empty-state">
+              <EmptyStateHeader
+                titleText="Error loading resources"
+                icon={<EmptyStateIcon icon={ExclamationCircleIcon} />}
+                headingLevel="h3"
+              />
+              <EmptyStateBody>{loadError.message}</EmptyStateBody>
+            </EmptyState>
+          ) : !loaded ? (
+            <ResourcesLoading />
+          ) : (
+            <ScrolledGallery count={docs.length} childWidth="330px">
+              {docs.map((doc) => (
+                <OdhDocCard
+                  data-testid={`resource-card-${doc.metadata.name}`}
+                  key={`${doc.metadata.name}`}
+                  odhDoc={doc as unknown as OdhDocument}
+                  showFavorite={false}
+                />
+              ))}
+            </ScrolledGallery>
+          )}
+          <Button variant="link" isInline onClick={() => navigate('/resources')}>
+            <Button
+              data-testid="goto-resources-link"
+              component="a"
+              isInline
+              variant="link"
+              onClick={() => navigate('/resources')}
+            >
+              Go to <b>Resources</b>
+            </Button>
+          </Button>
+        </Stack>
+      </CollapsibleSection>
+    </PageSection>
+  );
+};

--- a/frontend/src/pages/home/resources/useSpecifiedResources.tsx
+++ b/frontend/src/pages/home/resources/useSpecifiedResources.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { OdhDocument } from '~/types';
+import { useDocResources } from '~/concepts/docResources/useDocResources';
+
+export const useSpecifiedResources = (
+  specifiedDocs: { name: string; kind: string }[],
+): { docs: OdhDocument[]; loaded: boolean; loadError?: Error } => {
+  const { docs, loaded, loadError } = useDocResources();
+  return React.useMemo(() => {
+    if (!loaded || loadError) {
+      return { docs: [], loaded, loadError };
+    }
+    const foundDocs = specifiedDocs.reduce((acc, included) => {
+      const doc = docs.find((d) => d.metadata.name === included.name && d.kind === included.kind);
+      if (doc) {
+        acc.push(doc);
+      }
+      return acc;
+    }, [] as OdhDocument[]);
+    return { docs: foundDocs, loaded, loadError };
+  }, [docs, specifiedDocs, loadError, loaded]);
+};

--- a/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
@@ -37,7 +37,8 @@ const ConfigurationSection: React.FC = () => {
     <CollapsibleSection
       title="Project configuration"
       data-testid="section-config"
-      onOpenChange={setOpen}
+      open={open}
+      setOpen={setOpen}
       showChildrenWhenClosed
     >
       <DividedGallery

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -181,6 +181,7 @@ export enum OdhDocumentType {
 }
 
 export type OdhDocument = {
+  kind?: string;
   metadata: {
     name: string;
     annotations?: { [key: string]: string };


### PR DESCRIPTION
Closes: [RHOAIENG-5495](https://issues.redhat.com/browse/RHOAIENG-5495)

## Description
Adds a learning resource section to the landing page

## How Has This Been Tested?
Manually tested.

## Test Impact
Added e2e tests

## Screen shots
![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/51336069-d1a4-4c42-934e-921aaaafbb62)

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x ] Included any necessary screenshots or gifs if it was a UI change.
- [x ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

/cc @jgiardino