### PR TITLE
[RHOAIENG-2977] Artifacts table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
@@ -140,7 +140,7 @@ class ExperimentsTable {
   findFilterTextField() {
     return this.findContainer()
       .findByTestId('experiment-table-toolbar')
-      .findByTestId('run-table-toolbar-filter-text-field');
+      .findByTestId('pipeline-filter-text-field');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
@@ -12,7 +12,7 @@ class PipelineRunFilterBar extends PipelineFilterBar {
   }
 
   findExperimentInput() {
-    return cy.findByTestId('run-table-toolbar-filter-text-field').find('#experiment-search-input');
+    return cy.findByTestId('pipeline-filter-text-field').find('#experiment-search-input');
   }
 
   findPipelineVersionSelect() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
@@ -152,9 +152,7 @@ class PipelineRunJobTable extends PipelineRunsTable {
   }
 
   findFilterTextField() {
-    return cy
-      .findByTestId('schedules-table-toolbar')
-      .findByTestId('run-table-toolbar-filter-text-field');
+    return cy.findByTestId('schedules-table-toolbar').findByTestId('pipeline-filter-text-field');
   }
 
   findExperimentFilterSelect() {

--- a/frontend/src/components/table/TableBase.tsx
+++ b/frontend/src/components/table/TableBase.tsx
@@ -46,12 +46,24 @@ type Props<DataType> = {
     tooltip?: string;
   };
   getColumnSort?: GetColumnSort;
+  disableItemCount?: boolean;
 } & EitherNotBoth<
   { disableRowRenderSupport?: boolean },
   { tbodyProps?: TbodyProps & { ref?: React.Ref<HTMLTableSectionElement> } }
 > &
   Omit<TableProps, 'ref' | 'data'> &
-  Pick<PaginationProps, 'itemCount' | 'onPerPageSelect' | 'onSetPage' | 'page' | 'perPage'>;
+  Pick<
+    PaginationProps,
+    | 'itemCount'
+    | 'onPerPageSelect'
+    | 'onSetPage'
+    | 'page'
+    | 'perPage'
+    | 'perPageOptions'
+    | 'toggleTemplate'
+    | 'onNextClick'
+    | 'onPreviousClick'
+  >;
 
 export const MIN_PAGE_SIZE = 10;
 
@@ -87,26 +99,35 @@ const TableBase = <T,>({
   tbodyProps,
   perPage = 10,
   page = 1,
+  perPageOptions = defaultPerPageOptions,
   onSetPage,
+  onNextClick,
+  onPreviousClick,
   onPerPageSelect,
   getColumnSort,
   itemCount = 0,
   loading,
+  toggleTemplate,
+  disableItemCount = false,
   ...props
 }: Props<T>): React.ReactElement => {
   const selectAllRef = React.useRef(null);
-  const showPagination = enablePagination && itemCount > MIN_PAGE_SIZE;
+  const showPagination = enablePagination;
+
   const pagination = (variant: 'top' | 'bottom') => (
     <Pagination
       isCompact={enablePagination === 'compact'}
-      itemCount={itemCount}
+      {...(!disableItemCount && { itemCount })}
       perPage={perPage}
       page={page}
       onSetPage={onSetPage}
+      onNextClick={onNextClick}
+      onPreviousClick={onPreviousClick}
       onPerPageSelect={onPerPageSelect}
+      toggleTemplate={toggleTemplate}
       variant={variant}
       widgetId="table-pagination"
-      perPageOptions={defaultPerPageOptions}
+      perPageOptions={perPageOptions}
       titles={{
         paginationAriaLabel: `${variant} pagination`,
       }}

--- a/frontend/src/concepts/pipelines/content/tables/PipelineFilterBar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/PipelineFilterBar.tsx
@@ -16,42 +16,44 @@ type FilterOptionRenders = {
   label?: string;
 };
 
-type PipelineFilterBarProps<Options extends FilterOptions> = {
+type ToolbarFilterProps<T extends string> = React.ComponentProps<typeof ToolbarGroup> & {
   children?: React.ReactNode;
-  filterOptions: { [key in Options]?: string };
-  filterOptionRenders: Record<Options, (props: FilterOptionRenders) => React.ReactNode>;
-  filterData: Record<Options, string | { label: string; value: string } | undefined>;
-  onFilterUpdate: (filterType: Options, value?: string | { label: string; value: string }) => void;
+  filterOptions: { [key in T]?: string };
+  filterOptionRenders: Record<T, (props: FilterOptionRenders) => React.ReactNode>;
+  filterData: Record<T, string | { label: string; value: string } | undefined>;
+  onFilterUpdate: (filterType: T, value?: string | { label: string; value: string }) => void;
   onClearFilters: () => void;
+  testId?: string;
 };
 
 export type FilterProps = Pick<
-  React.ComponentProps<typeof PipelineFilterBar>,
+  React.ComponentProps<typeof FilterToolbar>,
   'filterData' | 'onFilterUpdate' | 'onClearFilters'
 >;
 
-const PipelineFilterBar = <Options extends FilterOptions>({
+export function FilterToolbar<T extends string>({
   filterOptions,
   filterOptionRenders,
   filterData,
   onFilterUpdate,
   onClearFilters,
   children,
-  ...props
-}: PipelineFilterBarProps<Options>): React.JSX.Element => {
-  const keys = Object.keys(filterOptions) as Array<Options>;
+  testId = 'filter-toolbar',
+  ...toolbarGroupProps
+}: ToolbarFilterProps<T>): React.JSX.Element {
+  const keys = Object.keys(filterOptions) as Array<T>;
   const [open, setOpen] = React.useState(false);
-  const [currentFilterType, setCurrentFilterType] = React.useState<Options>(keys[0]);
-  const isToolbarChip = (v: unknown): v is ToolbarChip & { key: Options } =>
+  const [currentFilterType, setCurrentFilterType] = React.useState<T>(keys[0]);
+  const isToolbarChip = (v: unknown): v is ToolbarChip & { key: T } =>
     !!v && Object.keys(v as ToolbarChip).every((k) => ['key', 'node'].includes(k));
 
   return (
     <>
-      <ToolbarGroup variant="filter-group" data-testid="pipeline-filter-toolbar" {...props}>
+      <ToolbarGroup variant="filter-group" data-testid={testId} {...toolbarGroupProps}>
         <ToolbarItem>
           <Dropdown
             toggle={
-              <DropdownToggle id="pipeline-filter-toggle-button" onToggle={() => setOpen(!open)}>
+              <DropdownToggle id={`${testId}-toggle-button`} onToggle={() => setOpen(!open)}>
                 <>
                   <FilterIcon /> {filterOptions[currentFilterType]}
                 </>
@@ -60,7 +62,8 @@ const PipelineFilterBar = <Options extends FilterOptions>({
             isOpen={open}
             dropdownItems={keys.map((filterKey) => (
               <DropdownItem
-                key={filterKey.toString()}
+                key={filterKey}
+                id={filterKey}
                 onClick={() => {
                   setOpen(false);
                   setCurrentFilterType(filterKey);
@@ -69,12 +72,12 @@ const PipelineFilterBar = <Options extends FilterOptions>({
                 {filterOptions[filterKey]}
               </DropdownItem>
             ))}
-            data-testid="pipeline-filter-dropdown"
+            data-testid={`${testId}-dropdown`}
           />
         </ToolbarItem>
         <ToolbarFilter
           categoryName="Filters"
-          data-testid="run-table-toolbar-filter-text-field"
+          data-testid={`${testId}-text-field`}
           variant="search-filter"
           chips={keys
             .map<ToolbarChip | null>((filterKey) => {
@@ -100,7 +103,7 @@ const PipelineFilterBar = <Options extends FilterOptions>({
             .filter(isToolbarChip)}
           deleteChip={(_, chip) => {
             if (isToolbarChip(chip)) {
-              onFilterUpdate(chip.key);
+              onFilterUpdate(chip.key, '');
             }
           }}
           deleteChipGroup={() => onClearFilters()}
@@ -117,6 +120,10 @@ const PipelineFilterBar = <Options extends FilterOptions>({
       {children}
     </>
   );
-};
+}
+
+const PipelineFilterBar = <Options extends FilterOptions>(
+  props: ToolbarFilterProps<Options>,
+): React.JSX.Element => <FilterToolbar {...props} testId="pipeline-filter" />;
 
 export default PipelineFilterBar;

--- a/frontend/src/concepts/pipelines/context/MlmdListContext.tsx
+++ b/frontend/src/concepts/pipelines/context/MlmdListContext.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+interface MlmdOrderBy {
+  field: string;
+  direction: 'asc' | 'desc';
+}
+
+interface MlmdListContextProps {
+  filterQuery: string | undefined;
+  pageToken: string | undefined;
+  maxResultSize: number;
+  orderBy: MlmdOrderBy | undefined;
+  setFilterQuery: (filterQuery: string | undefined) => void;
+  setPageToken: (pageToken: string | undefined) => void;
+  setMaxResultSize: (maxResultSize: number) => void;
+  setOrderBy: (orderBy: MlmdOrderBy | undefined) => void;
+}
+
+const MlmdListContext = React.createContext({} as MlmdListContextProps);
+
+export const MlmdListContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [filterQuery, setFilterQuery] = React.useState<string>();
+  const [pageToken, setPageToken] = React.useState<string>();
+  const [maxResultSize, setMaxResultSize] = React.useState(10);
+  const [orderBy, setOrderBy] = React.useState<MlmdOrderBy>();
+  const value = React.useMemo(
+    () => ({
+      filterQuery,
+      pageToken,
+      maxResultSize,
+      orderBy,
+      setFilterQuery,
+      setPageToken,
+      setMaxResultSize,
+      setOrderBy,
+    }),
+    [filterQuery, maxResultSize, orderBy, pageToken],
+  );
+
+  return <MlmdListContext.Provider value={value}>{children}</MlmdListContext.Provider>;
+};
+
+export const useMlmdListContext = (nextPageToken?: string): MlmdListContextProps => {
+  // https://github.com/patternfly/patternfly-react/issues/10312
+  // Force disabled state to pagination when there is no nextPageToken
+  React.useEffect(() => {
+    const paginationNextButtons = document.querySelectorAll('button[aria-label="Go to next page"]');
+
+    if (paginationNextButtons.length > 0) {
+      paginationNextButtons.forEach((button) => {
+        if (!nextPageToken) {
+          button.setAttribute('disabled', '');
+        } else {
+          button.removeAttribute('disabled');
+        }
+      });
+    }
+  }, [nextPageToken]);
+
+  return React.useContext(MlmdListContext);
+};

--- a/frontend/src/concepts/pipelines/context/index.ts
+++ b/frontend/src/concepts/pipelines/context/index.ts
@@ -6,3 +6,4 @@ export {
   ViewServerModal,
   PipelineServerTimedOut,
 } from './PipelinesContext';
+export * from './MlmdListContext';

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsList.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsList.tsx
@@ -3,18 +3,23 @@ import React from 'react';
 import {
   Bullseye,
   EmptyState,
-  EmptyStateBody,
+  EmptyStateVariant,
   EmptyStateHeader,
   EmptyStateIcon,
-  EmptyStateVariant,
+  EmptyStateBody,
   Spinner,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
+import { useMlmdListContext } from '~/concepts/pipelines/context';
 import { useGetArtifactsList } from './useGetArtifactsList';
+import { ArtifactsTable } from './ArtifactsTable';
 
-export const ArtifactsListTable: React.FC = () => {
-  const [artifacts, isArtifactsLoaded, artifactsError] = useGetArtifactsList();
+export const ArtifactsList: React.FC = () => {
+  const { filterQuery } = useMlmdListContext();
+  const [artifactsResponse, isArtifactsLoaded, artifactsError] = useGetArtifactsList();
+  const { artifacts, nextPageToken } = artifactsResponse || {};
+  const filterQueryRef = React.useRef(filterQuery);
 
   if (artifactsError) {
     return (
@@ -39,7 +44,7 @@ export const ArtifactsListTable: React.FC = () => {
     );
   }
 
-  if (!artifacts?.length) {
+  if (!artifacts?.length && !filterQuery && filterQueryRef.current === filterQuery) {
     return (
       <EmptyState data-testid="artifacts-list-empty-state" variant={EmptyStateVariant.lg}>
         <EmptyStateHeader
@@ -55,5 +60,11 @@ export const ArtifactsListTable: React.FC = () => {
     );
   }
 
-  return <></>;
+  return (
+    <ArtifactsTable
+      artifacts={artifacts}
+      nextPageToken={nextPageToken}
+      isLoaded={isArtifactsLoaded}
+    />
+  );
 };

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTable.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Flex, FlexItem, TextInput, Truncate } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { TableVariant, Td, Tr } from '@patternfly/react-table';
+
+import { Artifact } from '~/third_party/mlmd';
+import { TableBase } from '~/components/table';
+import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
+import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
+import { FilterToolbar } from '~/concepts/pipelines/content/tables/PipelineFilterBar';
+import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
+import { ArtifactType } from '~/concepts/pipelines/kfTypes';
+import { useMlmdListContext } from '~/concepts/pipelines/context';
+import { FilterOptions, columns, initialFilterData, options } from './constants';
+
+interface ArtifactsTableProps {
+  artifacts: Artifact[] | null | undefined;
+  nextPageToken: string | undefined;
+  isLoaded: boolean;
+}
+
+export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
+  artifacts,
+  isLoaded,
+  nextPageToken,
+}) => {
+  const {
+    maxResultSize,
+    setFilterQuery,
+    setPageToken: setRequestToken,
+    setMaxResultSize,
+  } = useMlmdListContext(nextPageToken);
+  const [page, setPage] = React.useState(1);
+  const [filterData, setFilterData] = React.useState(initialFilterData);
+  const onClearFilters = React.useCallback(() => setFilterData(initialFilterData), []);
+  const [pageTokens, setPageTokens] = React.useState<Record<number, string>>({});
+
+  const onFilterUpdate = React.useCallback(
+    (key: string, value: string | { label: string; value: string } | undefined) =>
+      setFilterData((prevValues) => ({ ...prevValues, [key]: value })),
+    [],
+  );
+
+  const onNextPageClick = React.useCallback(
+    (_: React.SyntheticEvent<HTMLButtonElement>, nextPage: number) => {
+      if (nextPageToken) {
+        setPageTokens((prevTokens) => ({ ...prevTokens, [nextPage]: nextPageToken }));
+        setRequestToken(nextPageToken);
+        setPage(nextPage);
+      }
+    },
+    [nextPageToken, setRequestToken],
+  );
+
+  const onPrevPageClick = React.useCallback(
+    (_: React.SyntheticEvent<HTMLButtonElement>, prevPage: number) => {
+      if (pageTokens[prevPage]) {
+        setRequestToken(pageTokens[prevPage]);
+        setPage(prevPage);
+      } else {
+        setRequestToken(undefined);
+      }
+    },
+    [pageTokens, setRequestToken],
+  );
+
+  React.useEffect(() => {
+    if (Object.values(filterData).some((filterOption) => !!filterOption)) {
+      let filterQuery = '';
+
+      if (filterData[FilterOptions.Artifact]) {
+        const artifactNameQuery = `custom_properties.display_name.string_value LIKE '%${
+          filterData[FilterOptions.Artifact]
+        }%'`;
+        filterQuery += filterQuery.length ? ` AND ${artifactNameQuery}` : artifactNameQuery;
+      }
+
+      if (filterData[FilterOptions.Id]) {
+        const artifactIdQuery = `id = cast(${filterData[FilterOptions.Id]} as int64)`;
+        filterQuery += filterQuery.length ? ` AND ${artifactIdQuery}` : artifactIdQuery;
+      }
+
+      if (filterData[FilterOptions.Type]) {
+        const artifactTypeQuery = `type LIKE '%${filterData[FilterOptions.Type]}%'`;
+        filterQuery += filterQuery.length ? ` AND ${artifactTypeQuery}` : artifactTypeQuery;
+      }
+
+      setFilterQuery(filterQuery);
+    } else {
+      setFilterQuery('');
+    }
+  }, [filterData, setFilterQuery]);
+
+  const toolbarContent = React.useMemo(
+    () => (
+      <FilterToolbar<keyof typeof options>
+        filterOptions={options}
+        filterOptionRenders={{
+          [FilterOptions.Artifact]: ({ onChange, ...props }) => (
+            <TextInput
+              {...props}
+              aria-label="Search artifact name"
+              placeholder="Search..."
+              onChange={(_event, value) => onChange(value)}
+            />
+          ),
+          [FilterOptions.Id]: ({ onChange, ...props }) => (
+            <TextInput
+              {...props}
+              aria-label="Search ID"
+              placeholder="Search..."
+              type="number"
+              min={1}
+              onChange={(_event, value) => onChange(value)}
+            />
+          ),
+          [FilterOptions.Type]: ({ value, onChange, ...props }) => (
+            <SimpleDropdownSelect
+              {...props}
+              value={value ?? ''}
+              aria-label="Search type"
+              options={Object.values(ArtifactType).map((v) => ({
+                key: v,
+                label: v,
+              }))}
+              onChange={(v) => onChange(v)}
+            />
+          ),
+        }}
+        filterData={filterData}
+        onClearFilters={onClearFilters}
+        onFilterUpdate={onFilterUpdate}
+      />
+    ),
+    [filterData, onClearFilters, onFilterUpdate],
+  );
+
+  const rowRenderer = React.useCallback(
+    (artifact: Artifact.AsObject) => (
+      <Tr key={artifact.id}>
+        <Td>
+          {artifact.name ||
+            artifact.customPropertiesMap.find(([name]) => name === 'display_name')?.[1].stringValue}
+        </Td>
+        <Td>{artifact.id}</Td>
+        <Td>{artifact.type}</Td>
+        <Td>
+          <Link to={artifact.uri} target="_blank">
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsSm' }}
+              flexWrap={{ default: 'nowrap' }}
+            >
+              <FlexItem>
+                <Truncate content={artifact.uri} />
+              </FlexItem>
+
+              <FlexItem>
+                <ExternalLinkAltIcon />
+              </FlexItem>
+            </Flex>
+          </Link>
+        </Td>
+        <Td>
+          <PipelinesTableRowTime date={new Date(artifact.createTimeSinceEpoch)} />
+        </Td>
+      </Tr>
+    ),
+    [],
+  );
+
+  return (
+    <TableBase
+      loading={!isLoaded}
+      data={artifacts?.map((artifact) => artifact.toObject()) ?? []}
+      columns={columns}
+      enablePagination="compact"
+      page={page}
+      perPage={maxResultSize}
+      disableItemCount
+      onNextClick={onNextPageClick}
+      onPreviousClick={onPrevPageClick}
+      onSetPage={(_, newPage) => {
+        if (newPage < page || !isLoaded) {
+          setPage(newPage);
+        }
+      }}
+      onPerPageSelect={(_, newSize) => setMaxResultSize(newSize)}
+      toggleTemplate={() => <>{maxResultSize} per page </>}
+      toolbarContent={toolbarContent}
+      emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
+      rowRenderer={rowRenderer}
+      variant={TableVariant.compact}
+      data-testid="artifacts-list-table"
+      id="artifacts-list-table"
+    />
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/GlobalArtifactsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/GlobalArtifactsPage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { usePipelinesAPI, MlmdListContextProvider } from '~/concepts/pipelines/context';
 import PipelineServerActions from '~/concepts/pipelines/content/PipelineServerActions';
 import PipelineCoreApplicationPage from '~/pages/pipelines/global/PipelineCoreApplicationPage';
 import EnsureAPIAvailability from '~/concepts/pipelines/EnsureAPIAvailability';
 import EnsureCompatiblePipelineServer from '~/concepts/pipelines/EnsureCompatiblePipelineServer';
 import { artifactsBaseRoute } from '~/routes';
-import { ArtifactsListTable } from './ArtifactsListTable';
+import { ArtifactsList } from './ArtifactsList';
 
 export const GlobalArtifactsPage: React.FC = () => {
   const pipelinesAPI = usePipelinesAPI();
@@ -17,11 +17,12 @@ export const GlobalArtifactsPage: React.FC = () => {
       description="View your artifacts and their metadata."
       headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
       getRedirectPath={artifactsBaseRoute}
-      overrideChildPadding
     >
       <EnsureAPIAvailability>
         <EnsureCompatiblePipelineServer>
-          <ArtifactsListTable />
+          <MlmdListContextProvider>
+            <ArtifactsList />
+          </MlmdListContextProvider>
         </EnsureCompatiblePipelineServer>
       </EnsureAPIAvailability>
     </PipelineCoreApplicationPage>

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/constants.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/constants.ts
@@ -1,0 +1,51 @@
+import { SortableData } from '~/components/table';
+import { Artifact as MlmdArtifact } from '~/third_party/mlmd';
+
+export enum FilterOptions {
+  Artifact = 'name',
+  Id = 'id',
+  Type = 'type',
+}
+export const initialFilterData: Record<FilterOptions, string | undefined> = {
+  [FilterOptions.Artifact]: '',
+  [FilterOptions.Id]: '',
+  [FilterOptions.Type]: undefined,
+};
+
+export const options = {
+  [FilterOptions.Artifact]: 'Artifact',
+  [FilterOptions.Id]: 'ID',
+  [FilterOptions.Type]: 'Type',
+};
+
+export const columns: SortableData<MlmdArtifact.AsObject>[] = [
+  {
+    label: 'Artifact',
+    field: 'name',
+    sortable: false,
+    width: 20,
+  },
+  {
+    label: 'ID',
+    field: 'id',
+    sortable: false,
+    width: 10,
+  },
+  {
+    label: 'Type',
+    field: 'type',
+    sortable: false,
+    width: 15,
+  },
+  {
+    label: 'URI',
+    field: 'uri',
+    sortable: false,
+  },
+  {
+    label: 'Created',
+    field: 'createTimeSinceEpoch',
+    sortable: false,
+    width: 15,
+  },
+];

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/useGetArtifactsList.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/useGetArtifactsList.ts
@@ -1,18 +1,43 @@
 import React from 'react';
 
-import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { usePipelinesAPI, useMlmdListContext } from '~/concepts/pipelines/context';
 import { Artifact, GetArtifactsRequest } from '~/third_party/mlmd';
+import { ListOperationOptions } from '~/third_party/mlmd/generated/ml_metadata/proto/metadata_store_pb';
 import useFetchState, { FetchState } from '~/utilities/useFetchState';
+
+export interface ArtifactsListResponse {
+  artifacts: Artifact[];
+  nextPageToken: string;
+}
 
 export const useGetArtifactsList = (
   refreshRate?: number,
-): FetchState<Artifact.AsObject[] | null> => {
+): FetchState<ArtifactsListResponse | null> => {
+  const { pageToken, maxResultSize, filterQuery } = useMlmdListContext();
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
   const fetchArtifactsList = React.useCallback(async () => {
-    const response = await metadataStoreServiceClient.getArtifacts(new GetArtifactsRequest());
-    return response.toObject().artifactsList;
-  }, [metadataStoreServiceClient]);
+    const request = new GetArtifactsRequest();
+    const listOperationOptions = new ListOperationOptions();
+
+    if (filterQuery) {
+      listOperationOptions.setFilterQuery(filterQuery);
+    }
+
+    if (pageToken) {
+      listOperationOptions.setNextPageToken(pageToken);
+    }
+
+    listOperationOptions.setMaxResultSize(maxResultSize);
+    request.setOptions(listOperationOptions);
+
+    const response = await metadataStoreServiceClient.getArtifacts(request);
+
+    return {
+      artifacts: response.getArtifactsList(),
+      nextPageToken: response.getNextPageToken(),
+    };
+  }, [filterQuery, pageToken, maxResultSize, metadataStoreServiceClient]);
 
   return useFetchState(fetchArtifactsList, null, {
     refreshRate,


### PR DESCRIPTION
Closes: [RHOAIENG-2977](https://issues.redhat.com/browse/RHOAIENG-2977)

## Description
Artifacts table, filter toolbar, pagination. 

<img width="1434" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/e0a44015-abd7-4ede-b2b3-09c8be324e31">
(cc @yannnz)

## Demos
**Filtering**
https://github.com/opendatahub-io/odh-dashboard/assets/96431149/53a04653-b833-49ec-94ec-70d7bcc666a1

**Pagination**
https://github.com/opendatahub-io/odh-dashboard/assets/96431149/a532700a-2edd-4288-a013-9731fc5eef89

## Testing instructions
Navigate to the Artifacts page from the left nav. Using a project with multiple artifacts, verify pagination, and toolbar filtering works as expected.

## How Has This Been Tested?
Cypress does not support intercepting `application/grpc-web+proto` content type requests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
