### PR TITLE
Jupyter tile, merge cert info from old notebook to avoid loss

### DIFF
--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -73,8 +73,8 @@ export const enableNotebook = async (
   const url = request.headers.origin;
 
   try {
-    await getNotebook(fastify, notebookNamespace, name);
-    return await updateNotebook(fastify, username, url, notebookData);
+    const notebook = await getNotebook(fastify, notebookNamespace, name);
+    return await updateNotebook(fastify, username, url, notebookData, notebook);
   } catch (e) {
     if (e.response?.statusCode === 404) {
       return await createNotebook(fastify, username, url, notebookData);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-6455

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Merges in the volumeMounts, and the notebook container's volumes & envs to keep the cert information around instead of overriding it with the k8s patch logic.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually using the Jupyter tile.

Needs self signed cert stuff setup (cc @harshad16 for details)

1. Go to the Jupyter tile
2. Create a notebook - details do not matter (if you have one before this, delete it & the PVC)
3. Check the yaml on OpenShift Console (look for the `ca-bundle` references)
4. Stop Notebook
5. Create the notebook again
6. Check the yaml still has the `ca-bundle` references

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None, backend only change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

/cc @harshad16 