### PR TITLE
[RHOAIENG-5496] Landing page: New home page hint

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -23,6 +23,7 @@ type MockDashboardConfigType = {
   disablePipelineExperiments?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
+  disableNotebookController?: boolean;
 };
 
 export const mockDashboardConfig = ({
@@ -48,6 +49,7 @@ export const mockDashboardConfig = ({
   disablePipelineExperiments = true,
   disableDistributedWorkloads = false,
   disableModelRegistry = true,
+  disableNotebookController = false,
 }: MockDashboardConfigType): DashboardConfigKind => ({
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',
@@ -86,7 +88,7 @@ export const mockDashboardConfig = ({
       disableModelRegistry,
     },
     notebookController: {
-      enabled: true,
+      enabled: !disableNotebookController,
       notebookNamespace: 'openshift-ai-notebooks',
       notebookTolerationSettings: {
         enabled: true,

--- a/frontend/src/__tests__/cypress/cypress/e2e/home/home.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/home/home.cy.ts
@@ -18,4 +18,45 @@ describe('Home page', () => {
     cy.interceptOdh('GET /api/components', { query: { installed: 'true' } }, mockComponents());
     enabledPage.visit(true);
   });
+  it('should show the home page hint', () => {
+    initHomeIntercepts({ disableHome: false });
+    cy.interceptOdh('GET /api/components', { query: { installed: 'true' } }, mockComponents());
+
+    cy.visit('/');
+    cy.findByTestId('home-page-hint').should('be.visible');
+
+    cy.findByTestId('jupyter-hint-icon').should('be.visible');
+    cy.findByTestId('hint-body-text').should('contain', 'Jupyter');
+
+    // enabled applications page is still navigable
+    cy.findByTestId('home-page-hint-navigate').click();
+
+    cy.findByTestId('enabled-application').should('be.visible');
+  });
+  it('should hide the home page hint when the notebook controller is disabled.', () => {
+    initHomeIntercepts({ disableHome: false, disableNotebookController: true });
+    cy.interceptOdh('GET /api/components', { query: { installed: 'true' } }, mockComponents());
+
+    cy.visit('/');
+
+    cy.findByTestId('home-page-hint').should('not.exist');
+  });
+  it('should hide the home page hint when closed', () => {
+    initHomeIntercepts({ disableHome: false });
+    cy.interceptOdh('GET /api/components', { query: { installed: 'true' } }, mockComponents());
+
+    cy.visit('/');
+    cy.findByTestId('home-page-hint').should('be.visible');
+
+    // enabled applications page is still navigable
+    cy.findByTestId('home-page-hint-close').click();
+
+    cy.findByTestId('home-page-hint').should('not.exist');
+
+    cy.visit('/enabled');
+    cy.findByTestId('enabled-application').should('be.visible');
+
+    cy.visit('/');
+    cy.findByTestId('home-page-hint').should('not.exist');
+  });
 });

--- a/frontend/src/__tests__/cypress/cypress/e2e/home/homeResources.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/home/homeResources.cy.ts
@@ -15,7 +15,8 @@ describe('Home page Resources section', () => {
     initHomeIntercepts({ disableHome: false });
     cy.visit('/');
 
-    cy.findByTestId('landing-page-resources').should('be.visible');
+    cy.findByTestId('landing-page-resources').scrollIntoView();
+    cy.findByTestId('resource-card-create-jupyter-notebook').should('be.visible');
   });
   it('should hide the the resource section if none are available', () => {
     cy.interceptOdh('GET /api/quickstarts', []);
@@ -25,7 +26,7 @@ describe('Home page Resources section', () => {
 
     cy.findByTestId('landing-page-resources').should('not.exist');
   });
-  it('should navigate to the project list', () => {
+  it('should navigate to the resources page', () => {
     initHomeIntercepts({ disableHome: false });
     cy.visit('/');
 

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -15,6 +15,7 @@ import ProjectsSection from './projects/ProjectsSection';
 import { useAIFlows } from './aiFlows/useAIFlows';
 import { useResourcesSection } from './resources/useResourcesSection';
 import { useEnableTeamSection } from './useEnableTeamSection';
+import HomeHint from './HomeHint';
 
 const Home: React.FC = () => {
   const { status: projectsAvailable } = useIsAreaAvailable(SupportedArea.DS_PROJECTS_VIEW);
@@ -25,22 +26,26 @@ const Home: React.FC = () => {
 
   if (!projectsAvailable && !aiFlows && !resourcesSection && !enableTeamSection) {
     return (
-      <PageSection data-testid="home-page-empty" variant={PageSectionVariants.default}>
-        <Bullseye>
-          <EmptyState variant="full">
-            <EmptyStateHeader
-              titleText={`Welcome to ${ODH_PRODUCT_NAME}`}
-              headingLevel="h4"
-              icon={<EmptyStateIcon icon={HomeIcon} />}
-            />
-          </EmptyState>
-        </Bullseye>
-      </PageSection>
+      <>
+        <HomeHint />
+        <PageSection data-testid="home-page-empty" variant={PageSectionVariants.default}>
+          <Bullseye>
+            <EmptyState variant="full">
+              <EmptyStateHeader
+                titleText={`Welcome to ${ODH_PRODUCT_NAME}`}
+                headingLevel="h4"
+                icon={<EmptyStateIcon icon={HomeIcon} />}
+              />
+            </EmptyState>
+          </Bullseye>
+        </PageSection>
+      </>
     );
   }
 
   return (
     <div data-testid="home-page">
+      <HomeHint />
       <ProjectsSection />
       {aiFlows}
       {resourcesSection}

--- a/frontend/src/pages/home/HomeHint.tsx
+++ b/frontend/src/pages/home/HomeHint.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Flex,
+  FlexItem,
+  PageSection,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+import jupyterImg from '~/images/jupyter.svg';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
+import { useCheckJupyterEnabled } from '~/utilities/notebookControllerUtils';
+
+const HomeHint: React.FC = () => {
+  const navigate = useNavigate();
+  const [hintHidden, setHintHidden] = useBrowserStorage<boolean>(
+    'odh.dashboard.landing.hint',
+    false,
+  );
+  const jupyterEnabled = useCheckJupyterEnabled();
+
+  if (hintHidden || !jupyterEnabled) {
+    return null;
+  }
+
+  return (
+    <PageSection>
+      <Card data-testid="home-page-hint" style={{ borderRadius: 16 }}>
+        <CardHeader>
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          >
+            <FlexItem>
+              <TextContent>
+                <Text component="h2">Looking for the previous landing page?</Text>
+              </TextContent>
+            </FlexItem>
+            <FlexItem>
+              <Button
+                data-testid="home-page-hint-close"
+                aria-label="close landing page hint"
+                isInline
+                variant="plain"
+                onClick={() => setHintHidden(true)}
+              >
+                <TimesIcon />
+              </Button>
+            </FlexItem>
+          </Flex>
+        </CardHeader>
+        <CardBody style={{ maxWidth: 880 }}>
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            gap={{ default: 'gapMd' }}
+            flexWrap={{ default: 'nowrap' }}
+          >
+            <img
+              data-testid="jupyter-hint-icon"
+              src={jupyterImg}
+              alt="Jupyter"
+              style={{ height: 42, maxWidth: 'unset' }}
+            />
+            <FlexItem>
+              <TextContent>
+                <Text component="p" data-testid="hint-body-text">
+                  {ODH_PRODUCT_NAME} has a new landing page. You can access applications that are
+                  enabled for your organization, such as Jupyter, from the{' '}
+                  <Button
+                    data-testid="home-page-hint-navigate"
+                    variant="link"
+                    isInline
+                    component="a"
+                    style={{ fontSize: 'var(--pf-v5-global--FontSize--md)' }}
+                    onClick={() => navigate('/enabled')}
+                  >
+                    Enabled applications
+                  </Button>{' '}
+                  page.
+                </Text>
+              </TextContent>
+            </FlexItem>
+          </Flex>
+        </CardBody>
+      </Card>
+    </PageSection>
+  );
+};
+
+export default HomeHint;

--- a/frontend/src/pages/home/projects/EmptyProjectsCard.tsx
+++ b/frontend/src/pages/home/projects/EmptyProjectsCard.tsx
@@ -19,7 +19,7 @@ type EmptyProjectsCardProps = {
 };
 
 const EmptyProjectsCard: React.FC<EmptyProjectsCardProps> = ({ allowCreate, onCreateProject }) => (
-  <Card data-testid="landing-page-projects-empty">
+  <Card data-testid="landing-page-projects-empty" style={{ borderRadius: 16 }}>
     <CardBody>
       <Flex
         gap={{ default: 'gapLg' }}

--- a/frontend/src/pages/home/resources/useResourcesSection.tsx
+++ b/frontend/src/pages/home/resources/useResourcesSection.tsx
@@ -70,6 +70,10 @@ export const useResourcesSection = (): React.ReactNode => {
                   key={`${doc.metadata.name}`}
                   odhDoc={doc as unknown as OdhDocument}
                   showFavorite={false}
+                  style={{
+                    border: '1px solid var(--pf-v5-global--BorderColor--100)',
+                    borderRadius: 16,
+                  }}
                 />
               ))}
             </ScrolledGallery>


### PR DESCRIPTION
Closes: [RHOAIENG-5496](https://issues.redhat.com/browse/RHOAIENG-5496)

## Description
Adds a hint to the landing page directing users how to find the previous landing page

## How Has This Been Tested?
Tested locally

## Test Impact
Added e2e tests

## Screenshots

![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/dc861a78-2646-4bf5-990d-b36137a8105d)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/2cf41593-6b1c-4f13-b88e-90a969f0ff9c)

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

/cc @jgiardino