### PR TITLE
Add dscinitializations resource to cluster-role.yaml and handle missing dsci status in ServingRuntimeList.cy.ts

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ServingRuntimeList.cy.ts
@@ -598,6 +598,7 @@ describe('Serving Runtime List', () => {
       initIntercepts({
         disableModelMeshConfig: false,
         disableKServeConfig: false,
+        disableKServeAuthConfig: true,
         servingRuntimes: [],
       });
 
@@ -617,6 +618,44 @@ describe('Serving Runtime List', () => {
       kserveModal.findSubmitButton().should('be.disabled');
       // check external route, token should be checked and no alert
       kserveModal.findAuthenticationCheckbox().should('not.exist');
+    });
+
+    it('Kserve auth should be hidden when no required capabilities', () => {
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
+        disableKServeAuthConfig: false,
+        servingRuntimes: [],
+        requiredCapabilities: [],
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+
+      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+
+      kserveModal.shouldBeOpen();
+
+      // check external route, token should be checked and no alert
+      kserveModal.findAuthenticationCheckbox().should('not.exist');
+    });
+
+    it('Kserve auth should be enabled if capabilities are prsent', () => {
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
+        disableKServeAuthConfig: false,
+        servingRuntimes: [],
+        requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+
+      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+
+      kserveModal.shouldBeOpen();
+
+      // check external route, token should be checked and no alert
+      kserveModal.findAuthenticationCheckbox().should('exist');
     });
 
     it('Do not deploy KServe model when user cannot edit namespace', () => {

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -1,7 +1,7 @@
 import { isAreaAvailable, SupportedArea } from '~/concepts/areas';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
-import { StackComponent } from '~/concepts/areas/types';
+import { StackCapability, StackComponent } from '~/concepts/areas/types';
 import { SupportedAreasStateMap } from '~/concepts/areas/const';
 import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';
 
@@ -186,6 +186,73 @@ describe('isAreaAvailable', () => {
           [SupportedArea.MODEL_SERVING]: false,
         });
         expect(isAvailable.requiredComponents).toBe(null);
+      });
+    });
+
+    describe('requiredCapabilities', () => {
+      it('should enable area if both capabilities are enabled', () => {
+        // Make sure this test is valid
+        expect(SupportedAreasStateMap[SupportedArea.K_SERVE_AUTH].requiredCapabilities).toEqual([
+          StackCapability.SERVICE_MESH,
+          StackCapability.SERVICE_MESH_AUTHZ,
+        ]);
+
+        // Test both reliant areas
+        const isAvailableKserveAuth = isAreaAvailable(
+          SupportedArea.K_SERVE_AUTH,
+          mockDashboardConfig({ disableKServeAuth: false }).spec,
+          mockDscStatus({
+            installedComponents: {
+              [StackComponent.K_SERVE]: true,
+            },
+          }),
+          mockDsciStatus({
+            requiredCapabilities: [
+              StackCapability.SERVICE_MESH,
+              StackCapability.SERVICE_MESH_AUTHZ,
+            ],
+          }),
+        );
+
+        expect(isAvailableKserveAuth.status).toBe(true);
+        expect(isAvailableKserveAuth.featureFlags).toEqual({
+          disableKServeAuth: 'on',
+        });
+        expect(isAvailableKserveAuth.requiredCapabilities).toEqual({
+          [StackCapability.SERVICE_MESH]: true,
+          [StackCapability.SERVICE_MESH_AUTHZ]: true,
+        });
+      });
+
+      it('should enable area if one capability is missing', () => {
+        // Make sure this test is valid
+        expect(SupportedAreasStateMap[SupportedArea.K_SERVE_AUTH].requiredCapabilities).toEqual([
+          StackCapability.SERVICE_MESH,
+          StackCapability.SERVICE_MESH_AUTHZ,
+        ]);
+
+        // Test both reliant areas
+        const isAvailableKserveAuth = isAreaAvailable(
+          SupportedArea.K_SERVE_AUTH,
+          mockDashboardConfig({ disableKServeAuth: false }).spec,
+          mockDscStatus({
+            installedComponents: {
+              [StackComponent.K_SERVE]: true,
+            },
+          }),
+          mockDsciStatus({
+            requiredCapabilities: [StackCapability.SERVICE_MESH],
+          }),
+        );
+
+        expect(isAvailableKserveAuth.status).toBe(false);
+        expect(isAvailableKserveAuth.featureFlags).toEqual({
+          disableKServeAuth: 'on',
+        });
+        expect(isAvailableKserveAuth.requiredCapabilities).toEqual({
+          [StackCapability.SERVICE_MESH]: true,
+          [StackCapability.SERVICE_MESH_AUTHZ]: false,
+        });
       });
     });
   });

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -172,3 +172,11 @@ rules:
       - get
     resources:
       - datascienceclusters
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    verbs:
+      - list
+      - watch
+      - get
+    resources:
+      - dscinitializations


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-6578 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Add permissions to fetch dsci by the dashboard serviceaccount and fixes a flaw in the area enablement util method that returned true if the dsci was missing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Run the changes in a cluster with dsci but no permissions
2. Use `npm run start:dev:ext` to get the deployed dashboard serviceaccount capabilities
3. Check that the kserve auth feature should be disabled
4. Now add the permissions to the cluster (see bellow)
5. Check that the feature should be enabled

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
**Tested with npm run start:dev:ext which sholud mimic this same behavior**
