### PR TITLE
[RHOAIENG-6606] Correctly nav to application from Jupyter card

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/Card.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/Card.ts
@@ -33,6 +33,10 @@ export class Card {
     return this.find().findByTestId('cardbody');
   }
 
+  findApplicationLink(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('jupyter-app-link');
+  }
+
   findExploreCard(metadataName: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId(['card', metadataName]);
   }

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -105,7 +105,11 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
     <CardFooter className="odh-card__footer">
       {odhApp.metadata.name === 'jupyter' ? (
         odhApp.spec.internalRoute ? (
-          <Link to={odhApp.spec.internalRoute} className="odh-card__footer__link">
+          <Link
+            data-testid="jupyter-app-link"
+            to="/notebookController"
+            className="odh-card__footer__link"
+          >
             Launch application
           </Link>
         ) : null


### PR DESCRIPTION
Fixes: [RHOAIENG-6606](https://issues.redhat.com/browse/RHOAIENG-6606)

## Description
Update the link URL for the Jupyter card Launch application link to not be a relative path.

## How Has This Been Tested?
Tested with the home page disabled and enabled.

## Test Impact
Added an e2e test to check the launch application link with and without the home page feature enabled.

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

