### PR TITLE
Model Registry: Initial content of model details tab with stub editable fields and tab navigation handling

### DIFF
--- a/frontend/src/components/DashboardDescriptionListGroup.scss
+++ b/frontend/src/components/DashboardDescriptionListGroup.scss
@@ -1,0 +1,4 @@
+.odh-custom-description-list-term-with-action > span {
+  /* Workaround for missing functionality in PF DescriptionList, see https://github.com/patternfly/patternfly/issues/6583 */
+  width: 100%;
+}

--- a/frontend/src/components/DashboardDescriptionListGroup.tsx
+++ b/frontend/src/components/DashboardDescriptionListGroup.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import {
+  ActionList,
+  ActionListItem,
+  Button,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
+import { CheckIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
+
+import './DashboardDescriptionListGroup.scss';
+
+type EditableProps = {
+  isEditing: boolean;
+  contentWhenEditing: React.ReactNode;
+  isSavingEdits?: boolean;
+  onEditClick: () => void;
+  onSaveEditsClick: () => void;
+  onDiscardEditsClick: () => void;
+};
+
+export type DashboardDescriptionListGroupProps = {
+  title: React.ReactNode;
+  action?: React.ReactNode;
+  isEmpty?: boolean;
+  contentWhenEmpty?: React.ReactNode;
+  children: React.ReactNode;
+} & (({ isEditable: true } & EditableProps) | ({ isEditable?: false } & Partial<EditableProps>));
+
+const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps> = (props) => {
+  const {
+    title,
+    action,
+    isEmpty,
+    contentWhenEmpty,
+    isEditable = false,
+    isEditing,
+    contentWhenEditing,
+    isSavingEdits = false,
+    onEditClick,
+    onSaveEditsClick,
+    onDiscardEditsClick,
+    children,
+  } = props;
+  return (
+    <DescriptionListGroup>
+      {action || isEditable ? (
+        <DescriptionListTerm className="odh-custom-description-list-term-with-action">
+          <Split>
+            <SplitItem isFilled>{title}</SplitItem>
+            <SplitItem>
+              {action ||
+                (isEditing ? (
+                  <ActionList isIconList>
+                    <ActionListItem>
+                      <Button
+                        data-testid={`save-edit-button-${title}`}
+                        aria-label={`Save edits to ${title}`}
+                        variant="link"
+                        onClick={onSaveEditsClick}
+                        isDisabled={isSavingEdits}
+                      >
+                        <CheckIcon />
+                      </Button>
+                    </ActionListItem>
+                    <ActionListItem>
+                      <Button
+                        data-testid={`discard-edit-button-${title} `}
+                        aria-label={`Discard edits to ${title} `}
+                        variant="plain"
+                        onClick={onDiscardEditsClick}
+                        isDisabled={isSavingEdits}
+                      >
+                        <TimesIcon />
+                      </Button>
+                    </ActionListItem>
+                  </ActionList>
+                ) : (
+                  <Button
+                    data-testid={`edit-button-${title}`}
+                    aria-label={`Edit ${title}`}
+                    isInline
+                    variant="link"
+                    icon={<PencilAltIcon />}
+                    iconPosition="end"
+                    onClick={onEditClick}
+                  >
+                    Edit
+                  </Button>
+                ))}
+            </SplitItem>
+          </Split>
+        </DescriptionListTerm>
+      ) : (
+        <DescriptionListTerm>{title}</DescriptionListTerm>
+      )}
+      <DescriptionListDescription className={isEmpty && !isEditing ? text.disabledColor_100 : ''}>
+        {isEditing ? contentWhenEditing : isEmpty ? contentWhenEmpty : children}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default DashboardDescriptionListGroup;

--- a/frontend/src/components/EditableLabelsDescriptionListGroup.tsx
+++ b/frontend/src/components/EditableLabelsDescriptionListGroup.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+import {
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Label,
+  LabelGroup,
+  Modal,
+  TextInput,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import DashboardDescriptionListGroup, {
+  DashboardDescriptionListGroupProps,
+} from './DashboardDescriptionListGroup';
+
+type EditableTextDescriptionListGroupProps = Partial<
+  Pick<DashboardDescriptionListGroupProps, 'title' | 'contentWhenEmpty'>
+> & {
+  labels: string[];
+  saveEditedLabels: (labels: string[]) => Promise<void>;
+};
+
+const EditableLabelsDescriptionListGroup: React.FC<EditableTextDescriptionListGroupProps> = ({
+  title = 'Labels',
+  contentWhenEmpty = 'No labels',
+  labels,
+  saveEditedLabels,
+}) => {
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [unsavedLabels, setUnsavedLabels] = React.useState(labels);
+  const [isSavingEdits, setIsSavingEdits] = React.useState(false);
+
+  const editUnsavedLabel = (newText: string, index: number) => {
+    if (isSavingEdits) {
+      return;
+    }
+    const copy = [...unsavedLabels];
+    copy[index] = newText;
+    setUnsavedLabels(copy);
+  };
+  const removeUnsavedLabel = (text: string) => {
+    if (isSavingEdits) {
+      return;
+    }
+    setUnsavedLabels(unsavedLabels.filter((label) => label !== text));
+  };
+  const addUnsavedLabel = (text: string) => {
+    if (isSavingEdits) {
+      return;
+    }
+    setUnsavedLabels([...unsavedLabels, text]);
+  };
+
+  const [isAddLabelModalOpen, setIsAddLabelModalOpen] = React.useState(false);
+  const [addLabelInputValue, setAddLabelInputValue] = React.useState('');
+  const addLabelInputRef = React.useRef<HTMLInputElement>(null);
+  const addLabelInputTooLong = addLabelInputValue.length > 63;
+
+  const toggleAddLabelModal = () => {
+    setAddLabelInputValue('');
+    setIsAddLabelModalOpen(!isAddLabelModalOpen);
+  };
+  React.useEffect(() => {
+    if (isAddLabelModalOpen && addLabelInputRef.current) {
+      addLabelInputRef.current.focus();
+    }
+  }, [isAddLabelModalOpen]);
+  const addLabelModalSubmitDisabled = !addLabelInputValue || addLabelInputTooLong;
+  const submitAddLabelModal = (event?: React.FormEvent) => {
+    event?.preventDefault();
+    if (!addLabelModalSubmitDisabled) {
+      addUnsavedLabel(addLabelInputValue);
+      toggleAddLabelModal();
+    }
+  };
+
+  return (
+    <>
+      <DashboardDescriptionListGroup
+        title={title}
+        isEmpty={labels.length === 0}
+        contentWhenEmpty={contentWhenEmpty}
+        isEditable
+        isEditing={isEditing}
+        isSavingEdits={isSavingEdits}
+        contentWhenEditing={
+          <LabelGroup
+            isEditable={!isSavingEdits}
+            numLabels={unsavedLabels.length}
+            addLabelControl={
+              !isSavingEdits && (
+                <Label color="blue" variant="outline" isOverflowLabel onClick={toggleAddLabelModal}>
+                  Add label
+                </Label>
+              )
+            }
+          >
+            {unsavedLabels.map((label, index) => (
+              <Label
+                key={label}
+                color="blue"
+                data-testid="label"
+                isEditable={!isSavingEdits}
+                editableProps={{ 'aria-label': `Editable label with text ${label}` }}
+                onClose={() => removeUnsavedLabel(label)}
+                closeBtnProps={{ isDisabled: isSavingEdits }}
+                onEditComplete={(_event, newText) => editUnsavedLabel(newText, index)}
+              >
+                {label}
+              </Label>
+            ))}
+          </LabelGroup>
+        }
+        onEditClick={() => {
+          setUnsavedLabels(labels);
+          setIsEditing(true);
+        }}
+        onSaveEditsClick={async () => {
+          setIsSavingEdits(true);
+          try {
+            await saveEditedLabels(unsavedLabels);
+          } finally {
+            setIsSavingEdits(false);
+          }
+          setIsEditing(false);
+        }}
+        onDiscardEditsClick={() => {
+          setUnsavedLabels(labels);
+          setIsEditing(false);
+        }}
+      >
+        <LabelGroup>
+          {labels.map((label) => (
+            <Label key={label} color="blue" data-testid="label">
+              {label}
+            </Label>
+          ))}
+        </LabelGroup>
+      </DashboardDescriptionListGroup>
+      <Modal
+        variant="small"
+        title="Add label"
+        isOpen={isAddLabelModalOpen}
+        onClose={toggleAddLabelModal}
+        actions={[
+          <Button
+            key="save"
+            variant="primary"
+            form="add-label-form"
+            onClick={submitAddLabelModal}
+            isDisabled={addLabelModalSubmitDisabled}
+          >
+            Save
+          </Button>,
+          <Button key="cancel" variant="link" onClick={toggleAddLabelModal}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        <Form id="add-label-form" onSubmit={submitAddLabelModal}>
+          <FormGroup label="Label text" fieldId="add-label-form-label-text" isRequired>
+            <TextInput
+              type="text"
+              id="add-label-form-label-text"
+              name="add-label-form-label-text"
+              value={addLabelInputValue}
+              onChange={(_event: React.FormEvent<HTMLInputElement>, value: string) =>
+                setAddLabelInputValue(value)
+              }
+              ref={addLabelInputRef}
+              isRequired
+              validated={addLabelInputTooLong ? 'error' : 'default'}
+            />
+            {addLabelInputTooLong && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
+                    Label text can&apos;t exceed 63 characters
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </FormGroup>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default EditableLabelsDescriptionListGroup;

--- a/frontend/src/components/EditableTextDescriptionListGroup.tsx
+++ b/frontend/src/components/EditableTextDescriptionListGroup.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { ExpandableSection, TextArea } from '@patternfly/react-core';
+import DashboardDescriptionListGroup, {
+  DashboardDescriptionListGroupProps,
+} from './DashboardDescriptionListGroup';
+
+type EditableTextDescriptionListGroupProps = Pick<
+  DashboardDescriptionListGroupProps,
+  'title' | 'contentWhenEmpty'
+> & {
+  value: string;
+  saveEditedValue: (value: string) => Promise<void>;
+};
+
+const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGroupProps> = ({
+  title,
+  contentWhenEmpty,
+  value,
+  saveEditedValue,
+}) => {
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [unsavedValue, setUnsavedValue] = React.useState(value);
+  const [isSavingEdits, setIsSavingEdits] = React.useState(false);
+  const [isTextExpanded, setIsTextExpanded] = React.useState(false);
+  return (
+    <DashboardDescriptionListGroup
+      title={title}
+      isEmpty={!value}
+      contentWhenEmpty={contentWhenEmpty}
+      isEditable
+      isEditing={isEditing}
+      isSavingEdits={isSavingEdits}
+      contentWhenEditing={
+        <TextArea
+          data-testid={`edit-text-area-${title}`}
+          aria-label={`Text box for editing ${title}`}
+          value={unsavedValue}
+          onChange={(_event, v) => setUnsavedValue(v)}
+          isDisabled={isSavingEdits}
+        />
+      }
+      onEditClick={() => {
+        setUnsavedValue(value);
+        setIsEditing(true);
+      }}
+      onSaveEditsClick={async () => {
+        setIsSavingEdits(true);
+        try {
+          await saveEditedValue(unsavedValue);
+        } finally {
+          setIsSavingEdits(false);
+        }
+        setIsEditing(false);
+      }}
+      onDiscardEditsClick={() => {
+        setUnsavedValue(value);
+        setIsEditing(false);
+      }}
+    >
+      <ExpandableSection
+        variant="truncate"
+        truncateMaxLines={12}
+        toggleText={isTextExpanded ? 'Show less' : 'Show more'}
+        onToggle={(_event, isExpanded) => setIsTextExpanded(isExpanded)}
+        isExpanded={isTextExpanded}
+      >
+        {value}
+      </ExpandableSection>
+    </DashboardDescriptionListGroup>
+  );
+};
+
+export default EditableTextDescriptionListGroup;

--- a/frontend/src/pages/modelRegistry/ModelRegistryRoutes.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryRoutes.tsx
@@ -18,10 +18,18 @@ const ModelRegistryRoutes: React.FC = () => (
         }
       >
         <Route index element={<ModelRegistry />} />
-        <Route
-          path="registeredModels/:registeredModelId"
-          element={<ModelVersions tab={ModelVersionsTabs.VERSIONS} empty={false} />}
-        />
+        <Route path="registeredModels/:registeredModelId">
+          <Route index element={<Navigate to={ModelVersionsTabs.VERSIONS} />} />
+          <Route
+            path={ModelVersionsTabs.VERSIONS}
+            element={<ModelVersions tab={ModelVersionsTabs.VERSIONS} empty={false} />}
+          />
+          <Route
+            path={ModelVersionsTabs.DETAILS}
+            element={<ModelVersions tab={ModelVersionsTabs.DETAILS} empty={false} />}
+          />
+          <Route path="*" element={<Navigate to="." />} />
+        </Route>
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/frontend/src/pages/modelRegistry/screens/GlobalModelVersionsTabs.tsx
+++ b/frontend/src/pages/modelRegistry/screens/GlobalModelVersionsTabs.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import '~/pages/pipelines/global/runs/GlobalPipelineRunsTabs.scss';
 import { ModelVersion, RegisteredModel } from '~/concepts/modelRegistry/types';
 import { ModelVersionsTabs, ModelVersionsTabTitle } from './const';
 import ModelVersionListView from './ModelVersionListView';
+import ModelDetailsView from './ModelDetailsView';
 
 type GlobalModelVersionsTabProps = {
   tab: ModelVersionsTabs;
-  registeredModel?: RegisteredModel;
+  registeredModel: RegisteredModel;
   modelVersions: ModelVersion[];
 };
 
@@ -15,33 +17,37 @@ const GlobalModelVersionsTabs: React.FC<GlobalModelVersionsTabProps> = ({
   tab,
   registeredModel: rm,
   modelVersions,
-}) => (
-  <Tabs
-    activeKey={tab}
-    aria-label="Model versions page tabs"
-    role="region"
-    data-testid="model-versions-page-tabs"
-  >
-    <Tab
-      eventKey={ModelVersionsTabs.VERSIONS}
-      title={<TabTitleText>{ModelVersionsTabTitle.VERSIONS}</TabTitleText>}
-      aria-label="Model versions tab"
-      data-testid="model-versions-tab"
+}) => {
+  const navigate = useNavigate();
+  return (
+    <Tabs
+      activeKey={tab}
+      aria-label="Model versions page tabs"
+      role="region"
+      data-testid="model-versions-page-tabs"
+      onSelect={(_event, eventKey) => navigate(`../${eventKey}`, { relative: 'path' })}
     >
-      <PageSection isFilled variant="light" data-testid="model-versions-tab-content">
-        <ModelVersionListView modelVersions={modelVersions} registeredModelName={rm?.name} />
-      </PageSection>
-    </Tab>
-    <Tab
-      eventKey={ModelVersionsTabs.DETAILS}
-      title={<TabTitleText>{ModelVersionsTabTitle.DETAILS}</TabTitleText>}
-      aria-label="Model Details tab"
-      data-testid="model-details-tab"
-    >
-      <PageSection isFilled variant="light" data-testid="model-details-tab-content">
-        {/* TODO: Fill Model Details Page Component here */}
-      </PageSection>
-    </Tab>
-  </Tabs>
-);
+      <Tab
+        eventKey={ModelVersionsTabs.VERSIONS}
+        title={<TabTitleText>{ModelVersionsTabTitle.VERSIONS}</TabTitleText>}
+        aria-label="Model versions tab"
+        data-testid="model-versions-tab"
+      >
+        <PageSection isFilled variant="light" data-testid="model-versions-tab-content">
+          <ModelVersionListView modelVersions={modelVersions} registeredModelName={rm.name} />
+        </PageSection>
+      </Tab>
+      <Tab
+        eventKey={ModelVersionsTabs.DETAILS}
+        title={<TabTitleText>{ModelVersionsTabTitle.DETAILS}</TabTitleText>}
+        aria-label="Model Details tab"
+        data-testid="model-details-tab"
+      >
+        <PageSection isFilled variant="light" data-testid="model-details-tab-content">
+          <ModelDetailsView registeredModel={rm} />
+        </PageSection>
+      </Tab>
+    </Tabs>
+  );
+};
 export default GlobalModelVersionsTabs;

--- a/frontend/src/pages/modelRegistry/screens/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelDetailsView.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { Button, ClipboardCopy, DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { RegisteredModel } from '~/concepts/modelRegistry/types';
+import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
+import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
+import EditableLabelsDescriptionListGroup from '~/components/EditableLabelsDescriptionListGroup';
+import RegisteredModelOwner from './RegisteredModelOwner';
+import ModelTimestamp from './ModelTimestamp';
+import { getLabels } from './utils';
+
+type ModelDetailsViewProps = {
+  registeredModel: RegisteredModel;
+};
+
+const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm }) => (
+  <Flex
+    direction={{ default: 'column', md: 'row' }}
+    columnGap={{ default: 'columnGap4xl' }}
+    rowGap={{ default: 'rowGapLg' }}
+  >
+    <FlexItem flex={{ default: 'flex_1' }}>
+      <DescriptionList isFillColumns>
+        <EditableTextDescriptionListGroup
+          title="Description"
+          contentWhenEmpty="No description"
+          value={rm.description || ''}
+          saveEditedValue={(value) => {
+            // eslint-disable-next-line no-console
+            console.log('TODO: save description', value); // TODO API patch and refetch
+            return new Promise((resolve) => {
+              setTimeout(() => {
+                resolve();
+              }, 2000);
+            });
+          }}
+        />
+        <EditableLabelsDescriptionListGroup
+          labels={getLabels(rm.customProperties)}
+          saveEditedLabels={(editedLabels) => {
+            // eslint-disable-next-line no-console
+            console.log('TODO: save labels', editedLabels); // TODO API patch and refetch
+            return new Promise((resolve) => {
+              setTimeout(() => {
+                resolve();
+              }, 2000);
+            });
+          }}
+        />
+        <DashboardDescriptionListGroup
+          title="Properties"
+          action={
+            <Button isInline variant="link" icon={<PlusCircleIcon />} iconPosition="start">
+              Add property
+            </Button>
+          }
+          isEmpty // TODO
+          contentWhenEmpty="No properties"
+        >
+          TODO properties here
+        </DashboardDescriptionListGroup>
+      </DescriptionList>
+    </FlexItem>
+    <FlexItem flex={{ default: 'flex_1' }}>
+      <DescriptionList isFillColumns>
+        <DashboardDescriptionListGroup
+          title="Model ID"
+          isEmpty={!rm.externalID}
+          contentWhenEmpty="No model ID"
+        >
+          <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
+            {rm.externalID}
+          </ClipboardCopy>
+        </DashboardDescriptionListGroup>
+        <DashboardDescriptionListGroup title="Owner">
+          <RegisteredModelOwner registeredModelId={rm.id} />
+        </DashboardDescriptionListGroup>
+        <DashboardDescriptionListGroup
+          title="Last modified at"
+          isEmpty={!rm.lastUpdateTimeSinceEpoch}
+          contentWhenEmpty="Unknown"
+        >
+          <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
+        </DashboardDescriptionListGroup>
+        <DashboardDescriptionListGroup
+          title="Created at"
+          isEmpty={!rm.createTimeSinceEpoch}
+          contentWhenEmpty="Unknown"
+        >
+          <ModelTimestamp timeSinceEpoch={rm.createTimeSinceEpoch} />
+        </DashboardDescriptionListGroup>
+      </DescriptionList>
+    </FlexItem>
+  </Flex>
+);
+
+export default ModelDetailsView;

--- a/frontend/src/pages/modelRegistry/screens/ModelTimestamp.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelTimestamp.tsx
@@ -2,16 +2,16 @@ import { Timestamp, TimestampTooltipVariant } from '@patternfly/react-core';
 import React from 'react';
 import { relativeTime } from '~/utilities/time';
 
-type ModelLastModifiedProps = {
-  lastUpdateTimeSinceEpoch?: string;
+type ModelTimestampProps = {
+  timeSinceEpoch?: string;
 };
 
-const ModelLastModified: React.FC<ModelLastModifiedProps> = ({ lastUpdateTimeSinceEpoch }) => {
-  if (!lastUpdateTimeSinceEpoch) {
+const ModelTimestamp: React.FC<ModelTimestampProps> = ({ timeSinceEpoch }) => {
+  if (!timeSinceEpoch) {
     return '--';
   }
 
-  const time = new Date(parseInt(lastUpdateTimeSinceEpoch)).getTime();
+  const time = new Date(parseInt(timeSinceEpoch)).getTime();
 
   if (Number.isNaN(time)) {
     return '--';
@@ -19,7 +19,7 @@ const ModelLastModified: React.FC<ModelLastModifiedProps> = ({ lastUpdateTimeSin
 
   return (
     <Timestamp
-      date={new Date(lastUpdateTimeSinceEpoch)}
+      date={new Date(timeSinceEpoch)}
       tooltip={{
         variant: TimestampTooltipVariant.default,
       }}
@@ -29,4 +29,4 @@ const ModelLastModified: React.FC<ModelLastModifiedProps> = ({ lastUpdateTimeSin
   );
 };
 
-export default ModelLastModified;
+export default ModelTimestamp;

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions.tsx
@@ -21,7 +21,9 @@ const ModelVersions: React.FC<ModelVersionsProps> = ({ tab, ...pageProps }) => {
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const { registeredModelId: rmId } = useParams();
   const [modelVersions, mvLoaded, mvLoadError] = useModelVersionsByRegisteredModel(rmId);
-  const [rm] = useRegisteredModelById(rmId);
+  const [rm, rmLoaded, rmLoadError] = useRegisteredModelById(rmId);
+  const loadError = mvLoadError || rmLoadError;
+  const loaded = mvLoaded && rmLoaded;
 
   return (
     <ApplicationsPage
@@ -41,8 +43,8 @@ const ModelVersions: React.FC<ModelVersionsProps> = ({ tab, ...pageProps }) => {
       title={rm?.name}
       headerAction={<ModelVersionsHeaderActions />}
       description={rm?.description}
-      loadError={mvLoadError}
-      loaded={mvLoaded}
+      loadError={loadError}
+      loaded={loaded}
       provideChildrenPadding
     >
       {rm !== null && (

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsTableRow.tsx
@@ -3,7 +3,7 @@ import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { Text, TextVariants, Truncate } from '@patternfly/react-core';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import ModelLabels from './ModelLabels';
-import ModelLastModified from './ModelLastModified';
+import ModelTimestamp from './ModelTimestamp';
 
 type ModelVersionsTableRowProps = {
   modelVersion: ModelVersion;
@@ -22,7 +22,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({ modelVers
       )}
     </Td>
     <Td dataLabel="Last modified">
-      <ModelLastModified lastUpdateTimeSinceEpoch={mv.lastUpdateTimeSinceEpoch} />
+      <ModelTimestamp timeSinceEpoch={mv.lastUpdateTimeSinceEpoch} />
     </Td>
     <Td dataLabel="Owner">{mv.author}</Td>
     <Td dataLabel="Labels">

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModelLink.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModelLink.tsx
@@ -1,24 +1,17 @@
 import { Truncate } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { RegisteredModel } from '~/concepts/modelRegistry/types';
+import useRegisteredModelUrl from './useRegisteredModelUrl';
 
 type RegisteredModelLinkProps = {
   registeredModel: RegisteredModel;
 };
 
-const RegisteredModelLink: React.FC<RegisteredModelLinkProps> = ({ registeredModel }) => {
-  const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
-  const registeredModelId = registeredModel.id;
-
-  return (
-    <Link
-      to={`/modelRegistry/${preferredModelRegistry?.metadata.name}/registeredModels/${registeredModelId}`}
-    >
-      <Truncate content={registeredModel.name} />
-    </Link>
-  );
-};
+const RegisteredModelLink: React.FC<RegisteredModelLinkProps> = ({ registeredModel }) => (
+  <Link to={useRegisteredModelUrl(registeredModel)}>
+    <Truncate content={registeredModel.name} />
+  </Link>
+);
 
 export default RegisteredModelLink;

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModelTableRow.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { FlexItem, Text, TextVariants, Truncate } from '@patternfly/react-core';
 import { RegisteredModel } from '~/concepts/modelRegistry/types';
 import RegisteredModelOwner from './RegisteredModelOwner';
 import RegisteredModelLink from './RegisteredModelLink';
 import ModelLabels from './ModelLabels';
-import ModelLastModified from './ModelLastModified';
+import ModelTimestamp from './ModelTimestamp';
+import useRegisteredModelUrl from './useRegisteredModelUrl';
+import { ModelVersionsTabs } from './const';
 
 type RegisteredModelTableRowProps = {
   registeredModel: RegisteredModel;
@@ -13,45 +16,48 @@ type RegisteredModelTableRowProps = {
 
 const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
   registeredModel: rm,
-}) => (
-  <Tr>
-    <Td dataLabel="Model name">
-      <div id="model-name" data-testid="model-name">
-        <FlexItem>
-          <RegisteredModelLink registeredModel={rm} />
-        </FlexItem>
-      </div>
-      {rm.description && (
-        <Text data-testid="description" component={TextVariants.small}>
-          <Truncate content={rm.description} />
-        </Text>
-      )}
-    </Td>
-    <Td dataLabel="Labels">
-      <ModelLabels customProperties={rm.customProperties} name={rm.name} />
-    </Td>
-    <Td dataLabel="Last modified">
-      <ModelLastModified lastUpdateTimeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
-    </Td>
-    <Td dataLabel="Owner">
-      <RegisteredModelOwner registeredModelId={rm.id} />
-    </Td>
-    <Td isActionCell>
-      <ActionsColumn
-        items={[
-          {
-            title: 'View details',
-            // TODO: Implement functionality for onClick. This will be added in another PR
-            onClick: () => undefined,
-          },
-          {
-            title: 'Archive model',
-            isDisabled: true, // This feature is currently disabled but will be enabled in a future PR post-summit release.
-          },
-        ]}
-      />
-    </Td>
-  </Tr>
-);
+}) => {
+  const navigate = useNavigate();
+  const rmUrl = useRegisteredModelUrl(rm);
+  return (
+    <Tr>
+      <Td dataLabel="Model name">
+        <div id="model-name" data-testid="model-name">
+          <FlexItem>
+            <RegisteredModelLink registeredModel={rm} />
+          </FlexItem>
+        </div>
+        {rm.description && (
+          <Text data-testid="description" component={TextVariants.small}>
+            <Truncate content={rm.description} />
+          </Text>
+        )}
+      </Td>
+      <Td dataLabel="Labels">
+        <ModelLabels customProperties={rm.customProperties} name={rm.name} />
+      </Td>
+      <Td dataLabel="Last modified">
+        <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
+      </Td>
+      <Td dataLabel="Owner">
+        <RegisteredModelOwner registeredModelId={rm.id} />
+      </Td>
+      <Td isActionCell>
+        <ActionsColumn
+          items={[
+            {
+              title: 'View details',
+              onClick: () => navigate(`${rmUrl}/${ModelVersionsTabs.DETAILS}`),
+            },
+            {
+              title: 'Archive model',
+              isDisabled: true, // This feature is currently disabled but will be enabled in a future PR post-summit release.
+            },
+          ]}
+        />
+      </Td>
+    </Tr>
+  );
+};
 
 export default RegisteredModelTableRow;

--- a/frontend/src/pages/modelRegistry/screens/useRegisteredModelUrl.ts
+++ b/frontend/src/pages/modelRegistry/screens/useRegisteredModelUrl.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
+import { RegisteredModel } from '~/concepts/modelRegistry/types';
+
+const useRegisteredModelUrl = (rm: RegisteredModel): string => {
+  const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
+  const registeredModelId = rm.id;
+  return `/modelRegistry/${preferredModelRegistry?.metadata.name}/registeredModels/${registeredModelId}`;
+};
+
+export default useRegisteredModelUrl;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Part of [RHOAIENG-2235](https://issues.redhat.com/browse/RHOAIENG-2235)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Implements most of the "Details" tab of the registered model page. Note that the "Properties" section is not functional and will be implemented in a followup PR. Also note that while the Description and Labels sections have editable functionality implemented, the actual last step of persisting the edits to the API is a stub promise that simply waits 2 seconds in order to show the "saving" state (edits are not allowed while saving). Implementing the real API patch requests will be in a separate PR.

Model details tab:
<img width="1724" alt="Screenshot 2024-04-29 at 7 31 32 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/dac09b30-7422-4b60-8e0a-b6c4bb2c12b3">

Description field in edit mode:
<img width="747" alt="Screenshot 2024-04-29 at 7 15 02 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/12793178-755d-49b7-96d4-cb96e950fc48">

Description field disabled while saving (currently a stub 2-second-delay promise):
<img width="740" alt="Screenshot 2024-04-29 at 7 24 38 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/6880a185-ab7b-4a2b-8baa-8c93c2210dc2">

Labels in edit mode:
<img width="757" alt="Screenshot 2024-04-29 at 7 15 13 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/0d92b52f-68a3-4608-91d2-e55396d59056">

Editing an existing label:
<img width="760" alt="Screenshot 2024-04-29 at 7 15 21 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/66a8889f-5ab7-4dfc-9171-649dd0920281">

Add label modal:
<img width="696" alt="Screenshot 2024-04-29 at 7 24 49 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/ea6c65a4-27eb-4b82-a6e3-c005e5ec20ac">
<img width="693" alt="Screenshot 2024-04-29 at 7 24 56 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/e0c7072f-6970-4a1f-8dfe-7865db27a4f1">

Label editing disabled while saving (currently a stub 2-second-delay promise):
<img width="743" alt="Screenshot 2024-04-29 at 7 25 53 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/fb6e712d-ff6d-465d-9ff8-2adb49739f23">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Go to `Model Registry` tab
2. Click on any registered model in the `Registered Models` table and then click the `Details` tab, or click the kebab menu at the right of a registered model and click `View details`
3. You will be taken to the model details view shown above
4. Click between the tabs and note that the URL route is changing and using the new `/details` and `/versions` subpaths

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Will be added shortly.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
