### PR TITLE
[RHOAIENG-2987] Artifacts - Details Page

### DIFF
--- a/frontend/src/components/MaxHeightCodeEditor.tsx
+++ b/frontend/src/components/MaxHeightCodeEditor.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { CodeEditor } from '@patternfly/react-code-editor';
+
+export const MaxHeightCodeEditor: React.FC<
+  Partial<Omit<React.ComponentProps<typeof CodeEditor>, 'ref'>> & { maxHeight: number }
+> = ({ maxHeight, ...props }) => {
+  const [contentHeight, setContentHeight] = React.useState<number>(maxHeight);
+
+  return (
+    <CodeEditor
+      onEditorDidMount={(editor) => setContentHeight(editor.getContentHeight())}
+      editorProps={{
+        height: `${contentHeight <= maxHeight ? contentHeight : maxHeight}px`,
+      }}
+      {...props}
+    />
+  );
+};

--- a/frontend/src/components/NoValue.tsx
+++ b/frontend/src/components/NoValue.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const NoValue: React.FC = () => <span className="pf-v5-u-color-200">No value</span>;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -14,6 +14,7 @@ import { GlobeAmericasIcon } from '@patternfly/react-icons';
 import { DateTimeKF, RuntimeConfigParamValue } from '~/concepts/pipelines/kfTypes';
 import { PodKind } from '~/k8sTypes';
 import { PodContainer } from '~/types';
+import { NoValue } from '~/components/NoValue';
 
 export type DetailItem = {
   key: string;
@@ -32,11 +33,7 @@ export const renderDetailItems = (details: DetailItem[]): React.ReactNode => (
       <DescriptionListGroup key={detail.key} data-testid={`detail-item-${detail.key}`}>
         <DescriptionListTerm>{detail.key}</DescriptionListTerm>
         <DescriptionListDescription data-testid="detail-item-value">
-          {!detail.value && detail.value !== 0 ? (
-            <span className="pf-v5-u-disabled-color-100">No value</span>
-          ) : (
-            detail.value
-          )}
+          {!detail.value && detail.value !== 0 ? <NoValue /> : detail.value}
         </DescriptionListDescription>
       </DescriptionListGroup>
     ))}

--- a/frontend/src/concepts/pipelines/context/usePipelinesUiRoute.ts
+++ b/frontend/src/concepts/pipelines/context/usePipelinesUiRoute.ts
@@ -1,0 +1,23 @@
+import { PIPELINE_ROUTE_NAME_PREFIX } from '~/concepts/pipelines/const';
+import { usePipelinesAPI } from './PipelinesContext';
+import usePipelineNamespaceCR, { dspaLoaded } from './usePipelineNamespaceCR';
+import usePipelinesAPIRoute from './usePipelinesAPIRoute';
+
+export const usePipelinesUiRoute = (): [string, boolean] => {
+  const { namespace } = usePipelinesAPI();
+  const crState = usePipelineNamespaceCR(namespace);
+  const isCrReady = dspaLoaded(crState);
+  const [pipelinesApiRoute, isPipelinesApiRouteLoaded] = usePipelinesAPIRoute(
+    isCrReady,
+    crState[0]?.metadata.name ?? '',
+    namespace,
+  );
+  let uiRoute = '';
+
+  if (pipelinesApiRoute) {
+    const [protocol, appHost] = pipelinesApiRoute.split(PIPELINE_ROUTE_NAME_PREFIX);
+    uiRoute = `${protocol}${PIPELINE_ROUTE_NAME_PREFIX}ui-${appHost}`;
+  }
+
+  return [uiRoute, isPipelinesApiRouteLoaded];
+};

--- a/frontend/src/pages/pipelines/GlobalArtifactsRoutes.tsx
+++ b/frontend/src/pages/pipelines/GlobalArtifactsRoutes.tsx
@@ -5,6 +5,8 @@ import ProjectsRoutes from '~/concepts/projects/ProjectsRoutes';
 import GlobalPipelineCoreLoader from '~/pages/pipelines/global/GlobalPipelineCoreLoader';
 import { artifactsBaseRoute } from '~/routes';
 import { GlobalArtifactsPage } from './global/experiments/artifacts';
+import GlobalPipelineCoreDetails from './global/GlobalPipelineCoreDetails';
+import { ArtifactDetails } from './global/experiments/artifacts/ArtifactDetails';
 
 const GlobalArtifactsRoutes: React.FC = () => (
   <ProjectsRoutes>
@@ -13,6 +15,16 @@ const GlobalArtifactsRoutes: React.FC = () => (
       element={<GlobalPipelineCoreLoader getInvalidRedirectPath={artifactsBaseRoute} />}
     >
       <Route index element={<GlobalArtifactsPage />} />
+      <Route
+        path=":artifactId"
+        element={
+          <GlobalPipelineCoreDetails
+            pageName="Artifacts"
+            redirectPath={artifactsBaseRoute}
+            BreadcrumbDetailsComponent={ArtifactDetails}
+          />
+        }
+      />
       <Route path="*" element={<Navigate to="." />} />
     </Route>
   </ProjectsRoutes>

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetails.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useParams } from 'react-router';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Spinner,
+  Tab,
+  TabTitleText,
+  Tabs,
+  Truncate,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import { PipelineCoreDetailsPageComponent } from '~/concepts/pipelines/content/types';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import { useGetArtifactById } from '~/pages/pipelines/global/experiments/artifacts/useGetArtifactById';
+import { getArtifactName } from '~/pages/pipelines/global/experiments/artifacts/utils';
+import { ArtifactDetailsTabKey } from '~/pages/pipelines/global/experiments/artifacts/constants';
+import { ArtifactOverviewDetails } from './ArtifactOverviewDetails';
+
+export const ArtifactDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) => {
+  const { artifactId } = useParams();
+  const [artifactResponse, isArtifactLoaded, artifactError] = useGetArtifactById(
+    Number(artifactId),
+  );
+  const artifact = artifactResponse?.toObject();
+  const artifactName = getArtifactName(artifact);
+
+  if (artifactError) {
+    return (
+      <EmptyState variant={EmptyStateVariant.lg}>
+        <EmptyStateHeader
+          titleText="Error loading artifact details"
+          icon={<EmptyStateIcon icon={ExclamationCircleIcon} />}
+          headingLevel="h4"
+        />
+        <EmptyStateBody>{artifactError.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  if (!isArtifactLoaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <ApplicationsPage
+      title={artifactName ?? 'Error loading artifact'}
+      loaded={isArtifactLoaded}
+      loadError={artifactError}
+      breadcrumb={
+        <Breadcrumb>
+          {breadcrumbPath}
+          <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
+            <Truncate content={artifactName ?? 'Loading...'} />
+          </BreadcrumbItem>
+        </Breadcrumb>
+      }
+      empty={false}
+      provideChildrenPadding
+    >
+      <Tabs aria-label="Artifact details tabs" activeKey={ArtifactDetailsTabKey.Overview}>
+        <Tab
+          eventKey={ArtifactDetailsTabKey.Overview}
+          title={<TabTitleText>Overview</TabTitleText>}
+          aria-label="Overview"
+        >
+          <ArtifactOverviewDetails artifact={artifact} />
+        </Tab>
+        <Tab
+          eventKey={ArtifactDetailsTabKey.LineageExplorer}
+          title={<TabTitleText>Lineage explorer</TabTitleText>}
+          isAriaDisabled
+        />
+      </Tabs>
+    </ApplicationsPage>
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactOverviewDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactOverviewDetails.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import {
+  Flex,
+  FlexItem,
+  Stack,
+  Title,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
+
+import { Artifact } from '~/third_party/mlmd';
+import { usePipelinesUiRoute } from '~/concepts/pipelines/context/usePipelinesUiRoute';
+import { ArtifactUriLink } from '~/pages/pipelines/global/experiments/artifacts/ArtifactUriLink';
+import { ArtifactPropertyDescriptionList } from './ArtifactPropertyDescriptionList';
+
+interface ArtifactOverviewDetailsProps {
+  artifact: Artifact.AsObject | undefined;
+}
+
+export const ArtifactOverviewDetails: React.FC<ArtifactOverviewDetailsProps> = ({ artifact }) => {
+  const [pipelinesUiRoute, isPipelinesUiRouteLoaded] = usePipelinesUiRoute();
+
+  return (
+    <Flex
+      spaceItems={{ default: 'spaceItems2xl' }}
+      direction={{ default: 'column' }}
+      className="pf-v5-u-pt-lg pf-v5-u-pb-lg"
+    >
+      <FlexItem>
+        <Stack hasGutter>
+          <Title headingLevel="h3">Live system dataset</Title>
+          <DescriptionList isHorizontal data-testid="dataset-description-list">
+            <DescriptionListGroup>
+              {artifact?.uri && (
+                <>
+                  <DescriptionListTerm>URI</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <ArtifactUriLink
+                      uri={artifact.uri}
+                      downloadHost={pipelinesUiRoute}
+                      isLoaded={isPipelinesUiRouteLoaded}
+                    />
+                  </DescriptionListDescription>
+                </>
+              )}
+            </DescriptionListGroup>
+          </DescriptionList>
+        </Stack>
+      </FlexItem>
+
+      {!!artifact?.propertiesMap.length && (
+        <FlexItem>
+          <Stack hasGutter>
+            <Title headingLevel="h3">Properties</Title>
+            <ArtifactPropertyDescriptionList
+              propertiesMap={artifact.propertiesMap}
+              testId="props-description-list"
+            />
+          </Stack>
+        </FlexItem>
+      )}
+
+      {!!artifact?.customPropertiesMap.length && (
+        <FlexItem>
+          <Stack hasGutter>
+            <Title headingLevel="h3">Custom properties</Title>
+            <ArtifactPropertyDescriptionList
+              propertiesMap={artifact.customPropertiesMap}
+              testId="custom-props-description-list"
+            />
+          </Stack>
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactPropertyDescriptionList.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactPropertyDescriptionList.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import {
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
+
+import { Value } from '~/third_party/mlmd';
+import { NoValue } from '~/components/NoValue';
+import { MaxHeightCodeEditor } from '~/components/MaxHeightCodeEditor';
+
+interface ArtifactPropertyDescriptionListProps {
+  testId?: string;
+  propertiesMap: [string, Value.AsObject][];
+}
+
+export const ArtifactPropertyDescriptionList: React.FC<ArtifactPropertyDescriptionListProps> = ({
+  propertiesMap,
+  testId,
+}) => {
+  const getPropertyValue = React.useCallback((property: Value.AsObject): React.ReactNode => {
+    let propValue: React.ReactNode =
+      property.stringValue || property.intValue || property.doubleValue || property.boolValue || '';
+
+    if (property.structValue || property.protoValue) {
+      propValue = (
+        <MaxHeightCodeEditor
+          isReadOnly
+          maxHeight={300}
+          code={JSON.stringify(property.structValue || property.protoValue, null, 2)}
+        />
+      );
+    }
+
+    return propValue;
+  }, []);
+
+  return (
+    <DescriptionList isHorizontal data-testid={testId}>
+      <DescriptionListGroup>
+        {propertiesMap.map(([propKey, propValue]) => {
+          const value = getPropertyValue(propValue);
+
+          return (
+            <React.Fragment key={propKey}>
+              <DescriptionListTerm>{propKey}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {!value && value !== 0 ? <NoValue /> : value}
+              </DescriptionListDescription>
+            </React.Fragment>
+          );
+        })}
+      </DescriptionListGroup>
+    </DescriptionList>
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/index.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/index.ts
@@ -1,0 +1,1 @@
+export { ArtifactDetails } from './ArtifactDetails';

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactUriLink.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactUriLink.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Flex, FlexItem, Skeleton, Truncate } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { generateGcsConsoleUri, generateMinioArtifactUrl, generateS3ArtifactUrl } from './utils';
+
+interface ArtifactUriLinkProps {
+  uri: string;
+  downloadHost: string;
+  isLoaded?: boolean;
+}
+
+export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({
+  uri,
+  downloadHost,
+  isLoaded = true,
+}) => {
+  let uriLinkTo = '';
+
+  if (!isLoaded) {
+    return <Skeleton />;
+  }
+
+  if (uri.startsWith('gs:')) {
+    uriLinkTo = generateGcsConsoleUri(uri);
+  }
+
+  if (uri.startsWith('s3:')) {
+    uriLinkTo = `${downloadHost}/${generateS3ArtifactUrl(uri)}`;
+  }
+
+  if (uri.startsWith('http:') || uri.startsWith('https:')) {
+    uriLinkTo = uri;
+  }
+
+  if (uri.startsWith('minio:')) {
+    uriLinkTo = `${downloadHost}/${generateMinioArtifactUrl(uri)}`;
+  }
+
+  return uriLinkTo ? (
+    <Link to={uriLinkTo} target="_blank">
+      <Flex
+        alignItems={{ default: 'alignItemsCenter' }}
+        spaceItems={{ default: 'spaceItemsSm' }}
+        flexWrap={{ default: 'nowrap' }}
+      >
+        <FlexItem>
+          <Truncate content={uri} />
+        </FlexItem>
+
+        <FlexItem>
+          <ExternalLinkAltIcon />
+        </FlexItem>
+      </Flex>
+    </Link>
+  ) : (
+    uri
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactDetails.spec.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactDetails.spec.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { Artifact } from '~/third_party/mlmd';
+import { artifactsBaseRoute } from '~/routes';
+import * as useGetArtifactById from '~/pages/pipelines/global/experiments/artifacts/useGetArtifactById';
+import * as usePipelinesUiRoute from '~/concepts/pipelines/context/usePipelinesUiRoute';
+import { ArtifactDetails } from '~/pages/pipelines/global/experiments/artifacts/ArtifactDetails';
+import GlobalPipelineCoreDetails from '~/pages/pipelines/global/GlobalPipelineCoreDetails';
+
+jest.mock('~/redux/selectors', () => ({
+  ...jest.requireActual('~/redux/selectors'),
+  useUser: jest.fn(() => ({ isAdmin: true })),
+}));
+
+jest.mock('~/concepts/pipelines/context/PipelinesContext', () => ({
+  usePipelinesAPI: jest.fn(() => ({
+    pipelinesServer: {
+      initializing: false,
+      installed: true,
+      compatible: true,
+      timedOut: false,
+      name: 'dspa',
+    },
+    namespace: 'Test namespace',
+    project: {
+      metadata: {
+        name: 'Test namespace',
+      },
+      kind: 'Project',
+    },
+    apiAvailable: true,
+  })),
+}));
+
+describe('ArtifactDetails', () => {
+  const useGetArtifactByIdSpy = jest.spyOn(useGetArtifactById, 'useGetArtifactById');
+  const usePipelinesUiRouteSpy = jest.spyOn(usePipelinesUiRoute, 'usePipelinesUiRoute');
+
+  beforeEach(() => {
+    useGetArtifactByIdSpy.mockReturnValue([
+      {
+        toObject: jest.fn(() => ({
+          id: 1,
+          typeId: 14,
+          type: 'system.Artifact',
+          uri: 'https://test-artifact!-aiplatform.googleapis.com/v1/12.15',
+          propertiesMap: [],
+          customPropertiesMap: [
+            [
+              'display_name',
+              {
+                stringValue: 'vertex_model',
+              },
+            ],
+            [
+              'resourceName',
+              {
+                stringValue: '12.15',
+              },
+            ],
+          ],
+          state: 2,
+          createTimeSinceEpoch: 1711113121829,
+          lastUpdateTimeSinceEpoch: 1711113121829,
+        })),
+      } as unknown as Artifact,
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+
+    usePipelinesUiRouteSpy.mockReturnValue(['dspa-pipeline-ui-route', true]);
+  });
+
+  it('renders page breadcrumbs', () => {
+    render(
+      <BrowserRouter>
+        <GlobalPipelineCoreDetails
+          pageName="Artifacts"
+          redirectPath={artifactsBaseRoute}
+          BreadcrumbDetailsComponent={ArtifactDetails}
+        />
+      </BrowserRouter>,
+    );
+
+    const breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' });
+
+    expect(
+      within(breadcrumb).getByRole('link', { name: 'Artifacts - Test namespace' }),
+    ).toBeVisible();
+    expect(within(breadcrumb).getByText('vertex_model')).toBeVisible();
+  });
+
+  it('renders artifact name as page header with the Overview tab initially selected', () => {
+    render(
+      <BrowserRouter>
+        <GlobalPipelineCoreDetails
+          pageName="Artifacts"
+          redirectPath={artifactsBaseRoute}
+          BreadcrumbDetailsComponent={ArtifactDetails}
+        />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('app-page-title')).toHaveTextContent('vertex_model');
+
+    const overviewTab = screen.getByRole('tab', { name: 'Overview' });
+    expect(overviewTab).toBeVisible();
+    expect(overviewTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('renders Overview tab metadata contents', () => {
+    render(
+      <BrowserRouter>
+        <GlobalPipelineCoreDetails
+          pageName="Artifacts"
+          redirectPath={artifactsBaseRoute}
+          BreadcrumbDetailsComponent={ArtifactDetails}
+        />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Live system dataset' })).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Custom properties' })).toBeVisible();
+
+    const datasetDescriptionList = screen.getByTestId('dataset-description-list');
+    expect(within(datasetDescriptionList).getByRole('term')).toHaveTextContent('URI');
+    expect(within(datasetDescriptionList).getByRole('definition')).toHaveTextContent(
+      'https://test-artifact!-aiplatform.googleapis.com/v1/12.15',
+    );
+
+    const customPropsDescriptionList = screen.getByTestId('custom-props-description-list');
+    const customPropsDescriptionListTerms = within(customPropsDescriptionList).getAllByRole('term');
+    const customPropsDescriptionListValues = within(customPropsDescriptionList).getAllByRole(
+      'definition',
+    );
+
+    expect(customPropsDescriptionListTerms[0]).toHaveTextContent('display_name');
+    expect(customPropsDescriptionListValues[0]).toHaveTextContent('vertex_model');
+    expect(customPropsDescriptionListTerms[1]).toHaveTextContent('resourceName');
+    expect(customPropsDescriptionListValues[1]).toHaveTextContent('12.15');
+  });
+});

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactsTable.spec.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactsTable.spec.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { Artifact } from '~/third_party/mlmd';
+import * as useGetArtifactsList from '~/pages/pipelines/global/experiments/artifacts/useGetArtifactsList';
+import * as MlmdListContext from '~/concepts/pipelines/context/MlmdListContext';
+import * as usePipelinesUiRoute from '~/concepts/pipelines/context/usePipelinesUiRoute';
+import EnsureAPIAvailability from '~/concepts/pipelines/EnsureAPIAvailability';
+import EnsureCompatiblePipelineServer from '~/concepts/pipelines/EnsureCompatiblePipelineServer';
+import { ArtifactsList } from '~/pages/pipelines/global/experiments/artifacts/ArtifactsList';
+
+jest.mock('~/redux/selectors', () => ({
+  ...jest.requireActual('~/redux/selectors'),
+  useUser: jest.fn(() => ({ isAdmin: true })),
+}));
+
+jest.mock('~/concepts/pipelines/context/PipelinesContext', () => ({
+  usePipelinesAPI: jest.fn(() => ({
+    pipelinesServer: {
+      initializing: false,
+      installed: true,
+      compatible: true,
+      timedOut: false,
+      name: 'dspa',
+    },
+    namespace: 'Test namespace',
+    project: {
+      metadata: {
+        name: 'Test namespace',
+      },
+      kind: 'Project',
+    },
+    apiAvailable: true,
+  })),
+}));
+
+describe('ArtifactsTable', () => {
+  const useGetArtifactsListSpy = jest.spyOn(useGetArtifactsList, 'useGetArtifactsList');
+  const useMlmdListContextSpy = jest.spyOn(MlmdListContext, 'useMlmdListContext');
+  const usePipelinesUiRouteSpy = jest.spyOn(usePipelinesUiRoute, 'usePipelinesUiRoute');
+
+  beforeEach(() => {
+    useMlmdListContextSpy.mockReturnValue({
+      filterQuery: '',
+      pageToken: '',
+      maxResultSize: 10,
+      orderBy: undefined,
+      setFilterQuery: jest.fn(),
+      setPageToken: jest.fn(),
+      setMaxResultSize: jest.fn(),
+      setOrderBy: jest.fn(),
+    });
+
+    useGetArtifactsListSpy.mockReturnValue([
+      {
+        artifacts: [
+          {
+            toObject: jest.fn(() => ({
+              id: 1,
+              typeId: 14,
+              type: 'system.Artifact',
+              uri: 'https://test-artifact!-aiplatform.googleapis.com/v1/12.15',
+              propertiesMap: [],
+              customPropertiesMap: [
+                [
+                  'display_name',
+                  {
+                    stringValue: 'vertex_model',
+                  },
+                ],
+                [
+                  'resourceName',
+                  {
+                    stringValue: '12.15',
+                  },
+                ],
+              ],
+              state: 2,
+              createTimeSinceEpoch: 1711113121829,
+            })),
+          },
+          {
+            toObject: jest.fn(() => ({
+              id: 2,
+              typeId: 15,
+              type: 'system.Dataset',
+              uri: 'https://test2-artifact!-aiplatform.googleapis.com/v1/12.10',
+              customPropertiesMap: [
+                [
+                  'display_name',
+                  {
+                    stringValue: 'iris_dataset',
+                  },
+                ],
+                [
+                  'resourceName',
+                  {
+                    stringValue: '12.10',
+                  },
+                ],
+              ],
+              state: 2,
+              createTimeSinceEpoch: 1611399342384,
+            })),
+          },
+        ] as unknown as Artifact[],
+        nextPageToken: '',
+      },
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+
+    usePipelinesUiRouteSpy.mockReturnValue(['dspa-pipeline-ui-route', true]);
+  });
+
+  it('renders artifacts table with data', () => {
+    render(
+      <BrowserRouter>
+        <EnsureAPIAvailability>
+          <EnsureCompatiblePipelineServer>
+            <MlmdListContext.MlmdListContextProvider>
+              <ArtifactsList />
+            </MlmdListContext.MlmdListContextProvider>
+          </EnsureCompatiblePipelineServer>
+        </EnsureAPIAvailability>
+      </BrowserRouter>,
+    );
+
+    const firstRow = screen.getByRole('row', { name: /vertex_model/ });
+    expect(firstRow).toHaveTextContent('vertex_model');
+    expect(firstRow).toHaveTextContent('1');
+    expect(firstRow).toHaveTextContent('system.Artifact');
+    expect(firstRow).toHaveTextContent('https://test-artifact!-aiplatform.googleapis.com/v1/12.15');
+    expect(firstRow).toHaveTextContent('1 month ago');
+
+    const secondRow = screen.getByRole('row', { name: /iris_dataset/ });
+    expect(secondRow).toHaveTextContent('iris_dataset');
+    expect(secondRow).toHaveTextContent('2');
+    expect(secondRow).toHaveTextContent('system.Dataset');
+    expect(secondRow).toHaveTextContent(
+      'https://test2-artifact!-aiplatform.googleapis.com/v1/12.10',
+    );
+    expect(secondRow).toHaveTextContent('23 Jan 2021');
+  });
+});

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/constants.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/constants.ts
@@ -49,3 +49,8 @@ export const columns: SortableData<MlmdArtifact.AsObject>[] = [
     width: 15,
   },
 ];
+
+export enum ArtifactDetailsTabKey {
+  Overview = 'overview',
+  LineageExplorer = 'lineage-explorer',
+}

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/useGetArtifactById.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/useGetArtifactById.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { Artifact, GetArtifactsByIDRequest } from '~/third_party/mlmd';
+import useFetchState, { FetchState } from '~/utilities/useFetchState';
+
+export const useGetArtifactById = (
+  artifactId: number,
+  refreshRate?: number,
+): FetchState<Artifact | undefined> => {
+  const { metadataStoreServiceClient } = usePipelinesAPI();
+
+  const fetchArtifact = React.useCallback(async () => {
+    const request = new GetArtifactsByIDRequest();
+    request.setArtifactIdsList([artifactId]);
+
+    const response = await metadataStoreServiceClient.getArtifactsByID(request);
+
+    return response.getArtifactsList()[0];
+  }, [artifactId, metadataStoreServiceClient]);
+
+  return useFetchState(fetchArtifact, undefined, {
+    refreshRate,
+  });
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/utils.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/utils.ts
@@ -1,0 +1,55 @@
+/** URI related utils source: https://github.com/kubeflow/pipelines/blob/master/frontend/src/lib/Utils.tsx */
+import { Artifact } from '~/third_party/mlmd';
+
+export const getArtifactName = (artifact: Artifact.AsObject | undefined): string | undefined =>
+  artifact?.name ||
+  artifact?.customPropertiesMap.find(([name]) => name === 'display_name')?.[1].stringValue;
+
+export function buildQuery(queriesMap?: { [key: string]: string | number | undefined }): string {
+  const queryContent = Object.entries(queriesMap || {})
+    .filter((entry): entry is [string, string | number] => entry[1] != null)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&');
+  if (!queryContent) {
+    return '';
+  }
+  return `?${queryContent}`;
+}
+
+/**
+ * Generates a cloud console uri from gs:// uri
+ *
+ * @param gcsUri Gcs uri that starts with gs://, like gs://bucket/path/file
+ * @returns A link user can open to visit cloud console page.
+ */
+export function generateGcsConsoleUri(uri: string): string {
+  const gcsPrefix = 'gs://';
+  return `https://console.cloud.google.com/storage/browser/${uri.substring(gcsPrefix.length)}`;
+}
+
+/**
+ * Generates an HTTPS API URL from minio:// uri
+ *
+ * @param uri Minio uri that starts with minio://, like minio://ml-pipeline/path/file
+ * @returns A URL that leads to the artifact data. Returns undefined when minioUri is not valid.
+ */
+export function generateMinioArtifactUrl(uri: string, peek?: number): string | undefined {
+  const matches = uri.match(/^minio:\/\/([^/]+)\/(.+)$/);
+
+  return matches
+    ? `artifacts/minio/${matches[1]}/${matches[2]}${buildQuery({
+        peek,
+      })}`
+    : undefined;
+}
+
+/**
+ * Generates an HTTPS API URL from s3:// uri
+ *
+ * @param uri S3 uri that starts with s3://, like s3://ml-pipeline/path/file
+ * @returns A URL that leads to the artifact data. Returns undefined when s3Uri is not valid.
+ */
+export function generateS3ArtifactUrl(uri: string): string | undefined {
+  const matches = uri.match(/^s3:\/\/([^/]+)\/(.+)$/);
+  return matches ? `artifacts/s3/${matches[1]}/${matches[2]}${buildQuery()}` : undefined;
+}

--- a/frontend/src/pages/pipelines/global/experiments/executions/details/ExecutionDetailsInputOutputSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/executions/details/ExecutionDetailsInputOutputSection.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Bullseye, Spinner, Stack, StackItem, Title } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Event } from '~/third_party/mlmd';
 import { useGetLinkedArtifactsByEvents } from '~/concepts/pipelines/apiHooks/mlmd/useGetLinkedArtifactsByEvents';
 import { getArtifactNameFromEvent } from '~/pages/pipelines/global/experiments/executions/utils';
+import { artifactsDetailsRoute } from '~/routes';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
 
 type ExecutionDetailsInputOutputSectionProps = {
   isLoaded: boolean;
@@ -18,6 +21,7 @@ const ExecutionDetailsInputOutputSection: React.FC<ExecutionDetailsInputOutputSe
   events,
   artifactTypeMap,
 }) => {
+  const { namespace } = usePipelinesAPI();
   const [linkedArtifacts, isLinkedArtifactsLoaded] = useGetLinkedArtifactsByEvents(events);
 
   if (!isLoaded || !isLinkedArtifactsLoaded) {
@@ -72,8 +76,9 @@ const ExecutionDetailsInputOutputSection: React.FC<ExecutionDetailsInputOutputSe
                 return (
                   <Tr key={id}>
                     <Td dataLabel="Artifact ID">{id}</Td>
-                    {/* TODO: add artifact details page line */}
-                    <Td dataLabel="Name">{data.name}</Td>
+                    <Td dataLabel="Name">
+                      <Link to={artifactsDetailsRoute(namespace, id)}>{data.name}</Link>
+                    </Td>
                     <Td dataLabel="Type">{type}</Td>
                     <Td dataLabel="URI">{data.uri}</Td>
                   </Tr>

--- a/frontend/src/pages/pipelines/global/experiments/executions/details/ExecutionDetailsPropertiesValue.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/executions/details/ExecutionDetailsPropertiesValue.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { CodeEditor } from '@patternfly/react-code-editor';
 import { MlmdMetadataValueType } from '~/pages/pipelines/global/experiments/executions/utils';
+import { MaxHeightCodeEditor } from '~/components/MaxHeightCodeEditor';
 
 type ExecutionDetailsPropertiesValueProps = {
   value: MlmdMetadataValueType;
 };
 
 const ExecutionDetailsPropertiesValueCode = ({ code }: { code: string }) => (
-  <CodeEditor isReadOnly code={code} height="sizeToFit" />
+  <MaxHeightCodeEditor isReadOnly code={code} maxHeight={300} />
 );
 
 const ExecutionDetailsPropertiesValue: React.FC<ExecutionDetailsPropertiesValueProps> = ({

--- a/frontend/src/routes/pipelines/artifacts.ts
+++ b/frontend/src/routes/pipelines/artifacts.ts
@@ -3,3 +3,6 @@ export const globArtifactsAll = `${artifactsRootPath}/*`;
 
 export const artifactsBaseRoute = (namespace: string | undefined): string =>
   !namespace ? artifactsRootPath : `${artifactsRootPath}/${namespace}`;
+
+export const artifactsDetailsRoute = (namespace: string, artifactId: number): string =>
+  `${artifactsBaseRoute(namespace)}/${artifactId}`;


### PR DESCRIPTION
Closes: [RHOAIENG-2987](https://issues.redhat.com/browse/RHOAIENG-2987)

## Description
Details page for artifacts accessed by clicking the table, then clicking on the name of the artifact. The page only renders the Overview tab and its data. The JIRA asked for an empty state for Lineage explorer, but since there is no design screen showing what that might look like, I've just disabled the tab for now. 

## How Has This Been Tested?
Added unit tests that verifies data being rendered on the page since Cypress does not support intercepting application/grpc-web+proto content type requests.

I've also added a simple unit test for the artifacts list table which mocks and renders some data.

## How to test
Navigate to the artifacts table from the left nav, click on an artifact name, verify you're routed to the details page, verify the visual matches the design and the data is correct.

<img width="1438" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/ade599c8-59c1-4533-9e35-5fa2b240c9c0">
(cc @yannnz)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
