### PR TITLE
Model Details and Model Version Details: add editable properties section, set up API patches for description, labels and properties

### DIFF
--- a/frontend/src/__mocks__/mockRegisteredModelsList.ts
+++ b/frontend/src/__mocks__/mockRegisteredModelsList.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { RegisteredModelList } from '~/concepts/modelRegistry/types';
+import { ModelRegistryMetadataType, RegisteredModelList } from '~/concepts/modelRegistry/types';
 import { mockRegisteredModel } from './mockRegisteredModel';
 
 export const mockRegisteredModelList = ({
@@ -14,27 +14,27 @@ export const mockRegisteredModelList = ({
         'A machine learning model trained to detect fraudulent transactions in financial data',
       customProperties: {
         Financial: {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: 'non-empty',
         },
         'Financial data': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Fraud detection': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Test label': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Machine learning': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Next data to be overflow': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
       },
@@ -43,23 +43,23 @@ export const mockRegisteredModelList = ({
       name: 'Credit Scoring',
       customProperties: {
         'Credit Score Predictor': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Creditworthiness scoring system': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Default Risk Analyzer': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Portfolio Management': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Risk Assessment': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
       },
@@ -70,44 +70,44 @@ export const mockRegisteredModelList = ({
         'A machine learning model trained to detect fraudulent transactions in financial data',
       customProperties: {
         'Testing label': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         Financial: {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: 'non-empty',
         },
         'Financial data': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Fraud detection': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Long label data to be truncated abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc':
           {
-            metadataType: 'MetadataStringValue',
+            metadataType: ModelRegistryMetadataType.STRING,
             string_value: '',
           },
         'Machine learning': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Next data to be overflow': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Label x': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Label y': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
         'Label z': {
-          metadataType: 'MetadataStringValue',
+          metadataType: ModelRegistryMetadataType.STRING,
           string_value: '',
         },
       },

--- a/frontend/src/components/DashboardDescriptionListGroup.tsx
+++ b/frontend/src/components/DashboardDescriptionListGroup.tsx
@@ -8,7 +8,6 @@ import {
   DescriptionListTerm,
   Split,
   SplitItem,
-  Text,
 } from '@patternfly/react-core';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { CheckIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
@@ -70,7 +69,7 @@ const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps
                     </ActionListItem>
                     <ActionListItem>
                       <Button
-                        data-testid={`discard-edit-button-${title} `}
+                        data-testid={`discard-edit-button-${title}`}
                         aria-label={`Discard edits to ${title} `}
                         variant="plain"
                         onClick={onDiscardEditsClick}
@@ -100,13 +99,7 @@ const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps
         <DescriptionListTerm>{title}</DescriptionListTerm>
       )}
       <DescriptionListDescription className={isEmpty && !isEditing ? text.disabledColor_100 : ''}>
-        {isEditing ? (
-          contentWhenEditing
-        ) : isEmpty ? (
-          <Text style={{ color: '--pf-v5-global--Color--200' }}>{contentWhenEmpty}</Text>
-        ) : (
-          children
-        )}
+        {isEditing ? contentWhenEditing : isEmpty ? contentWhenEmpty : children}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/frontend/src/components/EditableTextDescriptionListGroup.tsx
+++ b/frontend/src/components/EditableTextDescriptionListGroup.tsx
@@ -9,7 +9,7 @@ type EditableTextDescriptionListGroupProps = Pick<
   'title' | 'contentWhenEmpty'
 > & {
   value: string;
-  saveEditedValue: (value: string) => Promise<void>;
+  saveEditedValue: (value: string) => Promise<unknown>;
 };
 
 const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGroupProps> = ({
@@ -37,6 +37,8 @@ const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGrou
           value={unsavedValue}
           onChange={(_event, v) => setUnsavedValue(v)}
           isDisabled={isSavingEdits}
+          rows={24}
+          resizeOrientation="vertical"
         />
       }
       onEditClick={() => {

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -35,6 +35,57 @@ export enum ModelArtifactState {
   REFERENCE = 'REFERENCE',
 }
 
+export enum ModelRegistryMetadataType {
+  INT = 'MetadataIntValue',
+  DOUBLE = 'MetadataDoubleValue',
+  STRING = 'MetadataStringValue',
+  STRUCT = 'MetadataStructValue',
+  PROTO = 'MetadataProtoValue',
+  BOOL = 'MetadataBoolValue',
+}
+
+export type ModelRegistryCustomPropertyInt = {
+  metadataType: ModelRegistryMetadataType.INT;
+  int_value: string; // int64-formatted string
+};
+
+export type ModelRegistryCustomPropertyDouble = {
+  metadataType: ModelRegistryMetadataType.DOUBLE;
+  double_value: number;
+};
+
+export type ModelRegistryCustomPropertyString = {
+  metadataType: ModelRegistryMetadataType.STRING;
+  string_value: string;
+};
+
+export type ModelRegistryCustomPropertyStruct = {
+  metadataType: ModelRegistryMetadataType.STRUCT;
+  struct_value: string; // Base64 encoded bytes for struct value
+};
+
+export type ModelRegistryCustomPropertyProto = {
+  metadataType: ModelRegistryMetadataType.PROTO;
+  type: string; // url describing proto value
+  proto_value: string; // Base64 encoded bytes for proto value
+};
+
+export type ModelRegistryCustomPropertyBool = {
+  metadataType: ModelRegistryMetadataType.BOOL;
+  bool_value: boolean;
+};
+
+export type ModelRegistryCustomProperty =
+  | ModelRegistryCustomPropertyInt
+  | ModelRegistryCustomPropertyDouble
+  | ModelRegistryCustomPropertyString
+  | ModelRegistryCustomPropertyStruct
+  | ModelRegistryCustomPropertyProto
+  | ModelRegistryCustomPropertyBool;
+
+export type ModelRegistryCustomProperties = Record<string, ModelRegistryCustomProperty>;
+export type ModelRegistryStringCustomProperties = Record<string, ModelRegistryCustomPropertyString>;
+
 export type ModelRegistryBase = {
   id: string;
   name: string;
@@ -42,7 +93,7 @@ export type ModelRegistryBase = {
   description?: string;
   createTimeSinceEpoch?: string;
   lastUpdateTimeSinceEpoch: string;
-  customProperties: Record<string, Record<string, string>>;
+  customProperties: ModelRegistryCustomProperties;
 };
 
 export type ModelArtifact = ModelRegistryBase & {

--- a/frontend/src/pages/modelRegistry/screens/GlobalModelVersionsTabs.tsx
+++ b/frontend/src/pages/modelRegistry/screens/GlobalModelVersionsTabs.tsx
@@ -11,12 +11,14 @@ type GlobalModelVersionsTabProps = {
   tab: ModelVersionsTabs;
   registeredModel: RegisteredModel;
   modelVersions: ModelVersion[];
+  refresh: () => void;
 };
 
 const GlobalModelVersionsTabs: React.FC<GlobalModelVersionsTabProps> = ({
   tab,
   registeredModel: rm,
   modelVersions,
+  refresh,
 }) => {
   const navigate = useNavigate();
   return (
@@ -44,7 +46,7 @@ const GlobalModelVersionsTabs: React.FC<GlobalModelVersionsTabProps> = ({
         data-testid="model-details-tab"
       >
         <PageSection isFilled variant="light" data-testid="model-details-tab-content">
-          <ModelDetailsView registeredModel={rm} />
+          <ModelDetailsView registeredModel={rm} refresh={refresh} />
         </PageSection>
       </Tab>
     </Tabs>

--- a/frontend/src/pages/modelRegistry/screens/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelDetailsView.tsx
@@ -1,97 +1,104 @@
 import * as React from 'react';
-import { Button, ClipboardCopy, DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { ClipboardCopy, DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
 import { RegisteredModel } from '~/concepts/modelRegistry/types';
+import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
 import EditableLabelsDescriptionListGroup from '~/components/EditableLabelsDescriptionListGroup';
+import ModelPropertiesDescriptionListGroup from './ModelPropertiesDescriptionListGroup';
 import RegisteredModelOwner from './RegisteredModelOwner';
 import ModelTimestamp from './ModelTimestamp';
-import { getLabels } from './utils';
+import { getLabels, getPatchBodyForRegisteredModel, mergeUpdatedLabels } from './utils';
 
 type ModelDetailsViewProps = {
   registeredModel: RegisteredModel;
+  refresh: () => void;
 };
 
-const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm }) => (
-  <Flex
-    direction={{ default: 'column', md: 'row' }}
-    columnGap={{ default: 'columnGap4xl' }}
-    rowGap={{ default: 'rowGapLg' }}
-  >
-    <FlexItem flex={{ default: 'flex_1' }}>
-      <DescriptionList isFillColumns>
-        <EditableTextDescriptionListGroup
-          title="Description"
-          contentWhenEmpty="No description"
-          value={rm.description || ''}
-          saveEditedValue={(value) => {
-            // eslint-disable-next-line no-console
-            console.log('TODO: save description', value); // TODO API patch and refetch
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                resolve();
-              }, 2000);
-            });
-          }}
-        />
-        <EditableLabelsDescriptionListGroup
-          labels={getLabels(rm.customProperties)}
-          saveEditedLabels={(editedLabels) => {
-            // eslint-disable-next-line no-console
-            console.log('TODO: save labels', editedLabels); // TODO API patch and refetch
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                resolve();
-              }, 2000);
-            });
-          }}
-        />
-        <DashboardDescriptionListGroup
-          title="Properties"
-          action={
-            <Button isInline variant="link" icon={<PlusCircleIcon />} iconPosition="start">
-              Add property
-            </Button>
-          }
-          isEmpty // TODO
-          contentWhenEmpty="No properties"
-        >
-          TODO properties here
-        </DashboardDescriptionListGroup>
-      </DescriptionList>
-    </FlexItem>
-    <FlexItem flex={{ default: 'flex_1' }}>
-      <DescriptionList isFillColumns>
-        <DashboardDescriptionListGroup
-          title="Model ID"
-          isEmpty={!rm.externalID}
-          contentWhenEmpty="No model ID"
-        >
-          <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
-            {rm.externalID}
-          </ClipboardCopy>
-        </DashboardDescriptionListGroup>
-        <DashboardDescriptionListGroup title="Owner">
-          <RegisteredModelOwner registeredModelId={rm.id} />
-        </DashboardDescriptionListGroup>
-        <DashboardDescriptionListGroup
-          title="Last modified at"
-          isEmpty={!rm.lastUpdateTimeSinceEpoch}
-          contentWhenEmpty="Unknown"
-        >
-          <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
-        </DashboardDescriptionListGroup>
-        <DashboardDescriptionListGroup
-          title="Created at"
-          isEmpty={!rm.createTimeSinceEpoch}
-          contentWhenEmpty="Unknown"
-        >
-          <ModelTimestamp timeSinceEpoch={rm.createTimeSinceEpoch} />
-        </DashboardDescriptionListGroup>
-      </DescriptionList>
-    </FlexItem>
-  </Flex>
-);
+const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm, refresh }) => {
+  const { apiState } = React.useContext(ModelRegistryContext);
+  return (
+    <Flex
+      direction={{ default: 'column', md: 'row' }}
+      columnGap={{ default: 'columnGap4xl' }}
+      rowGap={{ default: 'rowGapLg' }}
+    >
+      <FlexItem flex={{ default: 'flex_1' }}>
+        <DescriptionList isFillColumns>
+          <EditableTextDescriptionListGroup
+            title="Description"
+            contentWhenEmpty="No description"
+            value={rm.description || ''}
+            saveEditedValue={(value) =>
+              apiState.api
+                .patchRegisteredModel(
+                  {},
+                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
+                  getPatchBodyForRegisteredModel(rm, { description: value }),
+                  rm.id,
+                )
+                .then(refresh)
+            }
+          />
+          <EditableLabelsDescriptionListGroup
+            labels={getLabels(rm.customProperties)}
+            allExistingKeys={Object.keys(rm.customProperties)}
+            saveEditedLabels={(editedLabels) =>
+              apiState.api
+                .patchRegisteredModel(
+                  {},
+                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
+                  getPatchBodyForRegisteredModel(rm, {
+                    customProperties: mergeUpdatedLabels(rm.customProperties, editedLabels),
+                  }),
+                  rm.id,
+                )
+                .then(refresh)
+            }
+          />
+          <ModelPropertiesDescriptionListGroup
+            customProperties={rm.customProperties}
+            saveEditedCustomProperties={(editedProperties) =>
+              apiState.api
+                .patchRegisteredModel(
+                  {},
+                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
+                  getPatchBodyForRegisteredModel(rm, { customProperties: editedProperties }),
+                  rm.id,
+                )
+                .then(refresh)
+            }
+          />
+        </DescriptionList>
+      </FlexItem>
+      <FlexItem flex={{ default: 'flex_1' }}>
+        <DescriptionList isFillColumns>
+          <DashboardDescriptionListGroup title="Model ID">
+            <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
+              {rm.id}
+            </ClipboardCopy>
+          </DashboardDescriptionListGroup>
+          <DashboardDescriptionListGroup title="Owner">
+            <RegisteredModelOwner registeredModelId={rm.id} />
+          </DashboardDescriptionListGroup>
+          <DashboardDescriptionListGroup
+            title="Last modified at"
+            isEmpty={!rm.lastUpdateTimeSinceEpoch}
+            contentWhenEmpty="Unknown"
+          >
+            <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
+          </DashboardDescriptionListGroup>
+          <DashboardDescriptionListGroup
+            title="Created at"
+            isEmpty={!rm.createTimeSinceEpoch}
+            contentWhenEmpty="Unknown"
+          >
+            <ModelTimestamp timeSinceEpoch={rm.createTimeSinceEpoch} />
+          </DashboardDescriptionListGroup>
+        </DescriptionList>
+      </FlexItem>
+    </Flex>
+  );
+};
 
 export default ModelDetailsView;

--- a/frontend/src/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
+import { ModelRegistryCustomProperties } from '~/concepts/modelRegistry/types';
+import ModelPropertiesTableRow from './ModelPropertiesTableRow';
+import { getProperties, mergeUpdatedProperty } from './utils';
+
+type ModelPropertiesDescriptionListGroupProps = {
+  customProperties: ModelRegistryCustomProperties;
+  saveEditedCustomProperties: (properties: ModelRegistryCustomProperties) => Promise<unknown>;
+};
+
+const ModelPropertiesDescriptionListGroup: React.FC<ModelPropertiesDescriptionListGroupProps> = ({
+  customProperties = {},
+  saveEditedCustomProperties,
+}) => {
+  const [editingPropertyKeys, setEditingPropertyKeys] = React.useState<string[]>([]);
+  const setIsEditingKey = (key: string, isEditing: boolean) =>
+    setEditingPropertyKeys([
+      ...editingPropertyKeys.filter((k) => k !== key),
+      ...(isEditing ? [key] : []),
+    ]);
+  const [isAdding, setIsAdding] = React.useState(false);
+  const isEditingSomeRow = isAdding || editingPropertyKeys.length > 0;
+
+  const [isSavingEdits, setIsSavingEdits] = React.useState(false);
+
+  // We only show string properties with a defined value (no labels or other property types)
+  const filteredProperties = getProperties(customProperties);
+
+  const [isShowingMoreProperties, setIsShowingMoreProperties] = React.useState(false);
+  const keys = Object.keys(filteredProperties);
+  const needExpandControl = keys.length > 5;
+  const shownKeys = isShowingMoreProperties ? keys : keys.slice(0, 5);
+  const numHiddenKeys = keys.length - shownKeys.length;
+
+  // Includes keys reserved by non-string properties and labels
+  const allExistingKeys = Object.keys(customProperties);
+
+  const requiredAsterisk = (
+    <span aria-hidden="true" className={text.dangerColor_100}>
+      {' *'}
+    </span>
+  );
+
+  return (
+    <DashboardDescriptionListGroup
+      title="Properties"
+      action={
+        <Button
+          isInline
+          variant="link"
+          icon={<PlusCircleIcon />}
+          iconPosition="start"
+          isDisabled={isAdding || isSavingEdits}
+          onClick={() => setIsAdding(true)}
+        >
+          Add property
+        </Button>
+      }
+      isEmpty={!isAdding && keys.length === 0}
+      contentWhenEmpty="No properties"
+    >
+      <Table aria-label="Properties table" data-testid="properties-table" variant="compact">
+        <Thead>
+          <Tr>
+            <Th>Key {isEditingSomeRow && requiredAsterisk}</Th>
+            <Th>Value {isEditingSomeRow && requiredAsterisk}</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>
+          {shownKeys.map((key) => (
+            <ModelPropertiesTableRow
+              key={key}
+              keyValuePair={{ key, value: filteredProperties[key].string_value }}
+              allExistingKeys={allExistingKeys}
+              isEditing={editingPropertyKeys.includes(key)}
+              setIsEditing={(isEditing) => setIsEditingKey(key, isEditing)}
+              isSavingEdits={isSavingEdits}
+              setIsSavingEdits={setIsSavingEdits}
+              saveEditedProperty={(oldKey, newPair) =>
+                saveEditedCustomProperties(
+                  mergeUpdatedProperty({ customProperties, op: 'update', oldKey, newPair }),
+                )
+              }
+              deleteProperty={(oldKey) =>
+                saveEditedCustomProperties(
+                  mergeUpdatedProperty({ customProperties, op: 'delete', oldKey }),
+                )
+              }
+            />
+          ))}
+          {isAdding && (
+            <ModelPropertiesTableRow
+              isAddRow
+              allExistingKeys={allExistingKeys}
+              setIsEditing={setIsAdding}
+              isSavingEdits={isSavingEdits}
+              setIsSavingEdits={setIsSavingEdits}
+              saveEditedProperty={(_oldKey, newPair) =>
+                saveEditedCustomProperties(
+                  mergeUpdatedProperty({ customProperties, op: 'create', newPair }),
+                )
+              }
+            />
+          )}
+        </Tbody>
+      </Table>
+      {needExpandControl && (
+        <Button
+          variant="link"
+          className={spacing.mtSm}
+          onClick={() => setIsShowingMoreProperties(!isShowingMoreProperties)}
+        >
+          {isShowingMoreProperties
+            ? 'Show fewer properties'
+            : `Show ${numHiddenKeys} more ${numHiddenKeys === 1 ? 'property' : 'properties'}`}
+        </Button>
+      )}
+    </DashboardDescriptionListGroup>
+  );
+};
+
+export default ModelPropertiesDescriptionListGroup;

--- a/frontend/src/pages/modelRegistry/screens/ModelPropertiesTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelPropertiesTableRow.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import {
+  ActionList,
+  ActionListItem,
+  Button,
+  ExpandableSection,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import { KeyValuePair } from '~/types';
+import { EitherNotBoth } from '~/typeHelpers';
+
+type ModelPropertiesTableRowProps = {
+  allExistingKeys: string[];
+  setIsEditing: (isEditing: boolean) => void;
+  isSavingEdits: boolean;
+  setIsSavingEdits: (isSaving: boolean) => void;
+  saveEditedProperty: (oldKey: string, newPair: KeyValuePair) => Promise<unknown>;
+} & EitherNotBoth<
+  { isAddRow: true },
+  {
+    isEditing: boolean;
+    keyValuePair: KeyValuePair;
+    deleteProperty: (key: string) => Promise<unknown>;
+  }
+>;
+
+const ModelPropertiesTableRow: React.FC<ModelPropertiesTableRowProps> = ({
+  isAddRow,
+  isEditing = isAddRow,
+  keyValuePair = { key: '', value: '' },
+  deleteProperty = () => Promise.resolve(),
+  allExistingKeys,
+  setIsEditing,
+  isSavingEdits,
+  setIsSavingEdits,
+  saveEditedProperty,
+}) => {
+  const { key, value } = keyValuePair;
+  const [unsavedKey, setUnsavedKey] = React.useState(key);
+  const [unsavedValue, setUnsavedValue] = React.useState(value);
+
+  const [isValueExpanded, setIsValueExpanded] = React.useState(false);
+
+  let keyValidationError: string | null = null;
+  if (unsavedKey !== key && allExistingKeys.includes(unsavedKey)) {
+    keyValidationError = 'Key must not match an existing property key or label';
+  } else if (unsavedKey.length > 63) {
+    keyValidationError = "Key text can't exceed 63 characters";
+  }
+
+  const clearUnsavedInputs = () => {
+    setUnsavedKey(key);
+    setUnsavedValue(value);
+  };
+
+  const onEditClick = () => {
+    clearUnsavedInputs();
+    setIsEditing(true);
+  };
+
+  const onDeleteClick = async () => {
+    setIsSavingEdits(true);
+    try {
+      await deleteProperty(key);
+    } finally {
+      setIsSavingEdits(false);
+    }
+  };
+
+  const onSaveEditsClick = async () => {
+    setIsSavingEdits(true);
+    try {
+      await saveEditedProperty(key, { key: unsavedKey, value: unsavedValue });
+    } finally {
+      setIsSavingEdits(false);
+    }
+    setIsEditing(false);
+  };
+
+  const onDiscardEditsClick = () => {
+    clearUnsavedInputs();
+    setIsEditing(false);
+  };
+
+  return (
+    <Tr>
+      <Td dataLabel="Key" width={45} modifier="breakWord">
+        {isEditing ? (
+          <>
+            <TextInput
+              data-testid={isAddRow ? `add-property-key-input` : `edit-property-${key}-key-input`}
+              aria-label={
+                isAddRow
+                  ? 'Key input for new property'
+                  : `Key input for editing property with key ${key}`
+              }
+              isRequired
+              type="text"
+              value={unsavedKey}
+              onChange={(_event, str) => setUnsavedKey(str)}
+              validated={keyValidationError ? 'error' : 'default'}
+            />
+            {keyValidationError && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">{keyValidationError}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </>
+        ) : (
+          key
+        )}
+      </Td>
+      <Td dataLabel="Value" width={45} modifier="breakWord">
+        {isEditing ? (
+          <TextInput
+            data-testid={isAddRow ? `add-property-value-input` : `edit-property-${key}-value-input`}
+            aria-label={
+              isAddRow
+                ? 'Value input for new property'
+                : `Value input for editing property with key ${key}`
+            }
+            isRequired
+            type="text"
+            value={unsavedValue}
+            onChange={(_event, str) => setUnsavedValue(str)}
+          />
+        ) : (
+          <ExpandableSection
+            variant="truncate"
+            truncateMaxLines={3}
+            toggleText={isValueExpanded ? 'Show less' : 'Show more'}
+            onToggle={(_event, isExpanded) => setIsValueExpanded(isExpanded)}
+            isExpanded={isValueExpanded}
+          >
+            {value}
+          </ExpandableSection>
+        )}
+      </Td>
+      <Td isActionCell width={10}>
+        {isEditing ? (
+          <ActionList isIconList>
+            <ActionListItem>
+              <Button
+                data-testid={`save-edit-button-property-${key}`}
+                aria-label={`Save edits to property with key ${key}`}
+                variant="link"
+                onClick={onSaveEditsClick}
+                isDisabled={isSavingEdits || !unsavedKey || !unsavedValue || !!keyValidationError}
+              >
+                <CheckIcon />
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button
+                data-testid={`discard-edit-button-property-${key}`}
+                aria-label={`Discard edits to property with key ${key}`}
+                variant="plain"
+                onClick={onDiscardEditsClick}
+                isDisabled={isSavingEdits}
+              >
+                <TimesIcon />
+              </Button>
+            </ActionListItem>
+          </ActionList>
+        ) : (
+          <ActionsColumn
+            isDisabled={isSavingEdits}
+            popperProps={{ direction: 'up' }}
+            items={[
+              { title: 'Edit', onClick: onEditClick, isDisabled: isSavingEdits },
+              { title: 'Delete', onClick: onDeleteClick, isDisabled: isSavingEdits },
+            ]}
+          />
+        )}
+      </Td>
+    </Tr>
+  );
+};
+
+export default ModelPropertiesTableRow;

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
@@ -26,7 +26,7 @@ const ModelVersionsDetails: React.FC<ModelVersionsDetailProps> = ({ tab, ...page
 
   const { modelVersionId: mvId, registeredModelId: rmId } = useParams();
   const [rm] = useRegisteredModelById(rmId);
-  const [mv, mvLoaded, mvLoadError] = useModelVersionById(mvId);
+  const [mv, mvLoaded, mvLoadError, refresh] = useModelVersionById(mvId);
 
   return (
     <ApplicationsPage
@@ -80,7 +80,7 @@ const ModelVersionsDetails: React.FC<ModelVersionsDetailProps> = ({ tab, ...page
       loaded={mvLoaded}
       provideChildrenPadding
     >
-      {mv !== null && <ModelVersionDetailsTabs tab={tab} modelVersion={mv} />}
+      {mv !== null && <ModelVersionDetailsTabs tab={tab} modelVersion={mv} refresh={refresh} />}
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
@@ -8,11 +8,13 @@ import ModelVersionDetailsView from './ModelVersionDetailsView';
 type ModelVersionDetailTabsProps = {
   tab: ModelVersionDetailsTab;
   modelVersion: ModelVersion;
+  refresh: () => void;
 };
 
 const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
   tab,
   modelVersion: mv,
+  refresh,
 }) => (
   <Tabs
     activeKey={tab}
@@ -27,7 +29,7 @@ const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
       data-testid="model-versions-details-tab"
     >
       <PageSection isFilled variant="light" data-testid="model-versions-details-tab-content">
-        <ModelVersionDetailsView modelVersion={mv} />
+        <ModelVersionDetailsView modelVersion={mv} refresh={refresh} />
       </PageSection>
     </Tab>
     <Tab

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions.tsx
@@ -21,7 +21,7 @@ const ModelVersions: React.FC<ModelVersionsProps> = ({ tab, ...pageProps }) => {
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const { registeredModelId: rmId } = useParams();
   const [modelVersions, mvLoaded, mvLoadError] = useModelVersionsByRegisteredModel(rmId);
-  const [rm, rmLoaded, rmLoadError] = useRegisteredModelById(rmId);
+  const [rm, rmLoaded, rmLoadError, rmRefresh] = useRegisteredModelById(rmId);
   const loadError = mvLoadError || rmLoadError;
   const loaded = mvLoaded && rmLoaded;
 
@@ -52,6 +52,7 @@ const ModelVersions: React.FC<ModelVersionsProps> = ({ tab, ...pageProps }) => {
           tab={tab}
           registeredModel={rm}
           modelVersions={modelVersions.items}
+          refresh={rmRefresh}
         />
       )}
     </ApplicationsPage>

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -1,30 +1,321 @@
 /* eslint-disable camelcase */
-import { RegisteredModel } from '~/concepts/modelRegistry/types';
-import { getLabels } from '~/pages/modelRegistry/screens/utils';
+import { mockModelVersion } from '~/__mocks__/mockModelVersion';
+import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
+import {
+  ModelRegistryCustomProperties,
+  ModelRegistryStringCustomProperties,
+  ModelRegistryMetadataType,
+  RegisteredModel,
+  ModelVersion,
+  RegisteredModelState,
+  ModelVersionState,
+} from '~/concepts/modelRegistry/types';
+import {
+  getLabels,
+  getProperties,
+  mergeUpdatedProperty,
+  mergeUpdatedLabels,
+  getPatchBody,
+} from '~/pages/modelRegistry/screens/utils';
 
 describe('getLabels', () => {
   it('should return an empty array when customProperties is empty', () => {
-    const customProperties: RegisteredModel['customProperties'] = {};
+    const customProperties: ModelRegistryCustomProperties = {};
     const result = getLabels(customProperties);
     expect(result).toEqual([]);
   });
 
   it('should return an array of keys with empty string values in customProperties', () => {
-    const customProperties: RegisteredModel['customProperties'] = {
-      label1: { string_value: '' },
-      label2: { string_value: 'non-empty' },
-      label3: { string_value: '' },
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      label2: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      label3: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
     };
     const result = getLabels(customProperties);
     expect(result).toEqual(['label1', 'label3']);
   });
 
   it('should return an empty array when all values in customProperties are non-empty strings', () => {
-    const customProperties: RegisteredModel['customProperties'] = {
-      label1: { string_value: 'non-empty' },
-      label2: { string_value: 'another-non-empty' },
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      label2: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'another-non-empty' },
     };
     const result = getLabels(customProperties);
     expect(result).toEqual([]);
+  });
+});
+
+describe('mergeUpdatedLabels', () => {
+  it('should return an empty object when customProperties and updatedLabels are empty', () => {
+    const customProperties: ModelRegistryCustomProperties = {};
+    const result = mergeUpdatedLabels(customProperties, []);
+    expect(result).toEqual({});
+  });
+
+  it('should return an unmodified object if updatedLabels match existing labels', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      someUnrelatedProp: { string_value: 'foo', metadataType: ModelRegistryMetadataType.STRING },
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedLabels(customProperties, ['label1']);
+    expect(result).toEqual(customProperties);
+  });
+
+  it('should return an object with labels added', () => {
+    const customProperties: ModelRegistryCustomProperties = {};
+    const result = mergeUpdatedLabels(customProperties, ['label1', 'label2']);
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label2: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should return an object with labels removed', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label2: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label3: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label4: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedLabels(customProperties, ['label2', 'label4']);
+    expect(result).toEqual({
+      label2: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label4: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should return an object with labels both added and removed', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label2: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label3: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedLabels(customProperties, ['label1', 'label3', 'label4']);
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label3: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label4: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should not affect non-label properties on the object', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      someUnrelatedStrProp: { string_value: 'foo', metadataType: ModelRegistryMetadataType.STRING },
+      someUnrelatedIntProp: { int_value: '3', metadataType: ModelRegistryMetadataType.INT },
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label2: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedLabels(customProperties, ['label2', 'label3']);
+    expect(result).toEqual({
+      someUnrelatedStrProp: { string_value: 'foo', metadataType: ModelRegistryMetadataType.STRING },
+      someUnrelatedIntProp: { int_value: '3', metadataType: ModelRegistryMetadataType.INT },
+      label2: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      label3: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+});
+
+describe('getProperties', () => {
+  it('should return an empty object when customProperties is empty', () => {
+    const customProperties: ModelRegistryCustomProperties = {};
+    const result = getProperties(customProperties);
+    expect(result).toEqual({});
+  });
+
+  it('should return a filtered object including only string properties with a non-empty value', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      property2: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'another-non-empty',
+      },
+      label1: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      label2: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      int1: { metadataType: ModelRegistryMetadataType.INT, int_value: '1' },
+      int2: { metadataType: ModelRegistryMetadataType.INT, int_value: '2' },
+    };
+    const result = getProperties(customProperties);
+    expect(result).toEqual({
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      property2: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'another-non-empty',
+      },
+    } satisfies ModelRegistryStringCustomProperties);
+  });
+
+  it('should return an empty object when all values in customProperties are empty strings or non-string values', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      label2: { metadataType: ModelRegistryMetadataType.STRING, string_value: '' },
+      int1: { metadataType: ModelRegistryMetadataType.INT, int_value: '1' },
+      int2: { metadataType: ModelRegistryMetadataType.INT, int_value: '2' },
+    };
+    const result = getProperties(customProperties);
+    expect(result).toEqual({});
+  });
+});
+
+describe('mergeUpdatedProperty', () => {
+  it('should handle the create operation', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedProperty({
+      customProperties,
+      op: 'create',
+      newPair: { key: 'prop2', value: 'val2' },
+    });
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+      prop2: { string_value: 'val2', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should handle the update operation without a key change', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedProperty({
+      customProperties,
+      op: 'update',
+      oldKey: 'prop1',
+      newPair: { key: 'prop1', value: 'updatedVal1' },
+    });
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'updatedVal1', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should handle the update operation with a key change', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedProperty({
+      customProperties,
+      op: 'update',
+      oldKey: 'prop1',
+      newPair: { key: 'prop2', value: 'val2' },
+    });
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop2: { string_value: 'val2', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should perform a create if using the update operation with an invalid oldKey', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedProperty({
+      customProperties,
+      op: 'update',
+      oldKey: 'prop2',
+      newPair: { key: 'prop3', value: 'val3' },
+    });
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+      prop3: { string_value: 'val3', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should handle the delete operation', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+      prop2: { string_value: 'val2', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedProperty({
+      customProperties,
+      op: 'delete',
+      oldKey: 'prop2',
+    });
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+
+  it('should do nothing if using the delete operation with an invalid oldKey', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    };
+    const result = mergeUpdatedProperty({
+      customProperties,
+      op: 'delete',
+      oldKey: 'prop2',
+    });
+    expect(result).toEqual({
+      label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
+    } satisfies ModelRegistryCustomProperties);
+  });
+});
+
+describe('getPatchBody', () => {
+  it('returns a given RegisteredModel with id/name/timestamps removed, customProperties updated and other values unchanged', () => {
+    const registeredModel = mockRegisteredModel({
+      id: '1',
+      name: 'test-model',
+      description: 'Description here',
+      customProperties: {},
+      state: RegisteredModelState.LIVE,
+    });
+    const result = getPatchBody(
+      registeredModel,
+      {
+        customProperties: {
+          label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+        },
+      },
+      [],
+    );
+    expect(result).toEqual({
+      description: 'Description here',
+      customProperties: {
+        label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
+      },
+      state: RegisteredModelState.LIVE,
+      externalID: '1234132asdfasdf',
+    } satisfies Partial<RegisteredModel>);
+  });
+
+  it('returns a given ModelVersion with id/name/timestamps removed, description updated and other values unchanged', () => {
+    const modelVersion = mockModelVersion({
+      author: 'Test author',
+      registeredModelId: '1',
+    });
+    const result = getPatchBody(modelVersion, { description: 'New description' }, []);
+    expect(result).toEqual({
+      author: 'Test author',
+      registeredModelId: '1',
+      description: 'New description',
+      customProperties: {},
+      state: ModelVersionState.ARCHIVED,
+    } satisfies Partial<ModelVersion>);
+  });
+
+  it('excludes given additional properties', () => {
+    const modelVersion = mockModelVersion({
+      author: 'Test author',
+      registeredModelId: '1',
+    });
+    const result = getPatchBody(modelVersion, { description: 'New description' }, [
+      'registeredModelId',
+    ]);
+    expect(result).toEqual({
+      author: 'Test author',
+      description: 'New description',
+      customProperties: {},
+      state: ModelVersionState.ARCHIVED,
+    } satisfies Partial<ModelVersion>);
   });
 });

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -1,11 +1,111 @@
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
-import { ModelRegistryBase, ModelVersion } from '~/concepts/modelRegistry/types';
+import {
+  ModelRegistryBase,
+  ModelRegistryCustomProperties,
+  ModelRegistryMetadataType,
+  ModelRegistryStringCustomProperties,
+  ModelVersion,
+  RegisteredModel,
+} from '~/concepts/modelRegistry/types';
+import { KeyValuePair } from '~/types';
 
-//Retrieves the labels from customProperties that have non-empty string_value.
-export const getLabels = <T extends ModelRegistryBase['customProperties']>(
+// Retrieves the labels from customProperties that have non-empty string_value.
+export const getLabels = <T extends ModelRegistryCustomProperties>(customProperties: T): string[] =>
+  Object.keys(customProperties).filter((key) => {
+    const prop = customProperties[key];
+    return prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value === '';
+  });
+
+// Returns the customProperties object with an updated set of labels (non-empty string_value) without affecting other properties.
+export const mergeUpdatedLabels = (
+  customProperties: ModelRegistryCustomProperties,
+  updatedLabels: string[],
+): ModelRegistryCustomProperties => {
+  const existingLabels = getLabels(customProperties);
+  const addedLabels = updatedLabels.filter((label) => !existingLabels.includes(label));
+  const removedLabels = existingLabels.filter((label) => !updatedLabels.includes(label));
+  const customPropertiesCopy = { ...customProperties };
+  removedLabels.forEach((label) => {
+    delete customPropertiesCopy[label];
+  });
+  addedLabels.forEach((label) => {
+    customPropertiesCopy[label] = {
+      // eslint-disable-next-line camelcase
+      string_value: '',
+      metadataType: ModelRegistryMetadataType.STRING,
+    };
+  });
+  return customPropertiesCopy;
+};
+
+// Retrives the customProperties that are not labels (they have a defined string_value).
+export const getProperties = <T extends ModelRegistryCustomProperties>(
   customProperties: T,
-): string[] =>
-  Object.keys(customProperties).filter((key) => customProperties[key].string_value === '');
+): ModelRegistryStringCustomProperties => {
+  const initial: ModelRegistryStringCustomProperties = {};
+  return Object.keys(customProperties).reduce((acc, key) => {
+    const prop = customProperties[key];
+    if (prop.metadataType === ModelRegistryMetadataType.STRING && prop.string_value !== '') {
+      return { ...acc, [key]: prop };
+    }
+    return acc;
+  }, initial);
+};
+
+// Returns the customProperties object with a single string property added, updated or deleted
+export const mergeUpdatedProperty = (
+  args: { customProperties: ModelRegistryCustomProperties } & (
+    | { op: 'create'; newPair: KeyValuePair }
+    | { op: 'update'; oldKey: string; newPair: KeyValuePair }
+    | { op: 'delete'; oldKey: string }
+  ),
+): ModelRegistryCustomProperties => {
+  const { op } = args;
+  const customPropertiesCopy = { ...args.customProperties };
+  if (op === 'delete' || (op === 'update' && args.oldKey !== args.newPair.key)) {
+    delete customPropertiesCopy[args.oldKey];
+  }
+  if (op === 'create' || op === 'update') {
+    const { key, value } = args.newPair;
+    customPropertiesCopy[key] = {
+      // eslint-disable-next-line camelcase
+      string_value: value,
+      metadataType: ModelRegistryMetadataType.STRING,
+    };
+  }
+  return customPropertiesCopy;
+};
+
+// Returns a patch payload for a Model Registry object, retaining all mutable fields but excluding internal fields to prevent errors
+// TODO this will not be necessary if the backend eventually merges objects on PATCH requests. See https://issues.redhat.com/browse/RHOAIENG-6652
+export const getPatchBody = <T extends ModelRegistryBase>(
+  existingObj: T,
+  updates: Partial<T>,
+  otherExcludedKeys: (keyof T)[],
+): Partial<T> => {
+  const objCopy = { ...existingObj };
+  const excludedKeys: (keyof T)[] = [
+    'id',
+    'name',
+    'createTimeSinceEpoch',
+    'lastUpdateTimeSinceEpoch',
+    ...otherExcludedKeys,
+  ];
+  excludedKeys.forEach((key) => {
+    delete objCopy[key];
+  });
+  return { ...objCopy, ...updates };
+};
+
+export const getPatchBodyForRegisteredModel = (
+  existing: RegisteredModel,
+  updates: Partial<RegisteredModel>,
+): Partial<RegisteredModel> => getPatchBody(existing, updates, []);
+
+export const getPatchBodyForModelVersion = (
+  existing: ModelVersion,
+  updates: Partial<ModelVersion>,
+): Partial<ModelVersion> => getPatchBody(existing, updates, ['registeredModelId']);
 
 export const filteredmodelVersions = (
   unfilteredmodelVersions: ModelVersion[],

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -2,6 +2,7 @@ import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   ContainerResources,
   ImageStreamAndVersion,
+  KeyValuePair,
   NotebookSize,
   Toleration,
   TolerationSettings,
@@ -121,10 +122,7 @@ export type DataConnection =
 
 export type AWSDataEntry = { key: AwsKeys; value: string }[];
 
-export type EnvVariableDataEntry = {
-  key: string;
-  value: string;
-};
+export type EnvVariableDataEntry = KeyValuePair;
 
 export type EnvVariableData = {
   category: SecretCategory | ConfigMapCategory | null;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -719,3 +719,8 @@ export enum ServingRuntimeAPIProtocol {
   REST = 'REST',
   GRPC = 'gRPC',
 }
+
+export type KeyValuePair = {
+  key: string;
+  value: string;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes [RHOAIENG-2235](https://issues.redhat.com/browse/RHOAIENG-2235) and [RHOAIENG-2238](https://issues.redhat.com/browse/RHOAIENG-2238)
Followup to https://github.com/opendatahub-io/odh-dashboard/pull/2760

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

* Implements the contents of the Properties section using a new `ModelPropertiesDescriptionListGroup` component which provides view/add/edit/delete controls
* Implements API patch requests when saving edits to Description, Labels and Properties (replacing the stub Promise for the former two)
* Adds input validation to ensure labels and property keys are unique. See **"Input validation screencaps"** below.
* None of these components/utils are specific to `RegisteredModel`, they work with `ModelRegistryCustomProperties` objects and generic `T extends ModelRegistryBase` objects, so it should be easy to reuse these for the ModelVersion detail page.
* Note that the patch requests must use the new `getPatchBody` utility in order to make sure the request isn't clearing other fields due to the way patches are performed in the API. We must supply all editable fields when patching an object even if we aren't modifying them all, but we can't supply some fields like the create/edit timestamps or we'll get 400 errors.

### Demo screencaps

* Editing the Description of a RegisteredModel

  https://github.com/opendatahub-io/odh-dashboard/assets/811963/08721aae-5897-4fa3-a00e-a7e7bee78ecb

* Editing the Labels of a RegisteredModel

  https://github.com/opendatahub-io/odh-dashboard/assets/811963/6bed2da9-99cc-4880-942b-e5e981cc4609

* Editing the Properties of a RegisteredModel

  https://github.com/opendatahub-io/odh-dashboard/assets/811963/4aba24ad-f97e-42b5-a49b-4be3432fc6cf

### Input validation screencaps
* When adding a new label, in addition to the existing validation that the label text must be no longer than 63 characters, we also now validate that a newly added label is unique (does not match any existing key in `customProperties`, whether that is a label or the key of a property in the table below). If the label is not unique, the modal submission is blocked and an error message appears:
  
  <img width="584" alt="Screenshot 2024-05-02 at 3 44 56 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/5ebb0b79-fce6-4a57-ae02-9c456a9a58d5">
    
* When editing an existing label, the same validation is applied. However, with the [current beta version of PF editable labels](https://www.patternfly.org/components/label#editable-labels), there is no way to express input validation errors while editing a label's text. As a workaround for now, if the user attempts to use an invalid label (either longer than 63 characters or matching an existing label/property), when they click away the change is not applied and the label remains as it was before they clicked it:
  
  https://github.com/opendatahub-io/odh-dashboard/assets/811963/d88261bf-0743-4f36-9c41-2fe9a43964cc

* When adding or editing a property, the same validation is applied to the property key. Errors in this case appear inline below the key input field:
  
  <img width="725" alt="Screenshot 2024-05-02 at 3 53 40 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/16c2b375-db95-49a1-abb3-fa0766404cf6">
  <img width="749" alt="Screenshot 2024-05-02 at 3 52 26 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/d25af2c4-8da6-423f-a3e8-181dbfca95f3">

cc @yih-wang @vconzola 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to `Model Registry` in the nav, click a registered model and click the Details tab. Play around with the edit controls on the Description, Labels and Properties sections. (see the screen recordings above)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Unit tests have been added for the new utility functions `mergeUpdatedLabels`, `getProperties`, `mergeUpdatedProperty` and `getPatchBody`. Cypress tests for all these views are to come soon.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
