### PR TITLE
Update PipelineRun details test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
@@ -499,6 +499,68 @@ describe('Pipeline topology', () => {
         .findValue()
         .contains('False');
     });
+
+    it('Test pipeline triggered run bottom drawer output', () => {
+      initIntercepts();
+      pipelineRunDetails.visit(projectId, mockRun.run_id);
+
+      pipelineRunDetails.findBottomDrawer().findBottomDrawerYamlTab().click();
+      pipelineRunDetails.findYamlOutput().click();
+      const pipelineDashboardCodeEditor = pipelineDetails.getPipelineDashboardCodeEditor();
+      pipelineDashboardCodeEditor.findInput().should('not.be.empty');
+    });
+  });
+
+  describe('Pipeline run Input/Output', () => {
+    beforeEach(() => {
+      initIntercepts();
+      pipelineRunDetails.visit(projectId, mockRun.run_id);
+    });
+
+    it('Test with input/output artifacts', () => {
+      pipelineRunDetails.findTaskNode('create-dataset').click();
+      const rightDrawer = pipelineRunDetails.findRightDrawer();
+      rightDrawer.findRightDrawerInputOutputTab().should('be.visible');
+      rightDrawer.findRightDrawerInputOutputTab().click();
+      pipelineDetails.findRunTaskRightDrawer();
+      pipelineRunDetails
+        .findOutputArtifacts()
+        .should('contain', 'Output artifacts')
+        .should('contain', 'iris_dataset');
+
+      pipelineRunDetails.findTaskNode('normalize-dataset').click();
+      rightDrawer.findRightDrawerInputOutputTab().should('be.visible');
+      pipelineDetails.findRunTaskRightDrawer();
+      pipelineRunDetails
+        .findInputArtifacts()
+        .should('contain', 'Input artifacts')
+        .should('contain', 'input_iris_dataset');
+    });
+  });
+
+  describe('Pipeline run Details', () => {
+    beforeEach(() => {
+      initIntercepts();
+      pipelineRunDetails.visit(projectId, mockRun.run_id);
+    });
+
+    it('Test with the details', () => {
+      pipelineRunDetails.findTaskNode('create-dataset').click();
+      const rightDrawer = pipelineRunDetails.findRightDrawer();
+      rightDrawer.findRightDrawerDetailsTab().should('be.visible');
+      rightDrawer.findRightDrawerDetailsTab().click();
+      rightDrawer
+        .findRightDrawerDetailItem('Task ID')
+        .findValue()
+        .should('contain', 'task.create-dataset');
+
+      pipelineRunDetails.findTaskNode('normalize-dataset').click();
+      pipelineRunDetails.findRightDrawer().findRightDrawerDetailsTab().should('be.visible');
+      rightDrawer
+        .findRightDrawerDetailItem('Task ID')
+        .findValue()
+        .should('contain', 'task.normalize-dataset');
+    });
   });
 
   describe('Pipeline run volume mounts', () => {
@@ -509,29 +571,26 @@ describe('Pipeline topology', () => {
 
     it('Test node with no volume mounts', () => {
       pipelineRunDetails.findTaskNode('create-dataset').click();
-      pipelineRunDetails.findRightDrawer().findRightDrawerVolumesTab().should('be.visible');
-      pipelineRunDetails.findRightDrawer().findRightDrawerVolumesTab().click();
-      pipelineRunDetails
-        .findRightDrawer()
-        .findRightDrawerVolumesSection()
-        .should('contain.text', 'No content');
+      const rightDrawer = pipelineRunDetails.findRightDrawer();
+      rightDrawer.findRightDrawerVolumesTab().should('be.visible');
+      rightDrawer.findRightDrawerVolumesTab().click();
+      rightDrawer.findRightDrawerVolumesSection().should('contain.text', 'No content');
     });
 
     it('Test node with volume mounts', () => {
       pipelineRunDetails.findTaskNode('normalize-dataset').click();
-      pipelineRunDetails.findRightDrawer().findRightDrawerVolumesTab().should('be.visible');
-      pipelineRunDetails.findRightDrawer().findRightDrawerVolumesTab().click();
-      pipelineRunDetails
-        .findRightDrawer()
+      const rightDrawer = pipelineRunDetails.findRightDrawer();
+      rightDrawer.findRightDrawerVolumesTab().should('be.visible');
+      rightDrawer.findRightDrawerVolumesTab().click();
+      rightDrawer
         .findRightDrawerDetailItem('/data/1')
         .findValue()
         .should('contain', 'create-dataset');
       // Close the side drawer to uncover the 'train-model' node
       pipelineRunDetails.findTaskNode('normalize-dataset').click();
       pipelineRunDetails.findTaskNode('train-model').click();
-      pipelineRunDetails.findRightDrawer().findRightDrawerVolumesTab().click();
-      pipelineRunDetails
-        .findRightDrawer()
+      rightDrawer.findRightDrawerVolumesTab().click();
+      rightDrawer
         .findRightDrawerDetailItem('/data/2')
         .findValue()
         .should('contain', 'normalize-dataset');
@@ -543,9 +602,10 @@ describe('Pipeline topology', () => {
       initIntercepts();
       pipelineRunDetails.visit(projectId, mockRun.run_id);
       pipelineRunDetails.findTaskNode('create-dataset').click();
-      pipelineRunDetails.findRightDrawer().findRightDrawerDetailsTab().should('be.visible');
-      pipelineRunDetails.findRightDrawer().findRightDrawerLogsTab().should('be.visible');
-      pipelineRunDetails.findRightDrawer().findRightDrawerLogsTab().click();
+      const rightDrawer = pipelineRunDetails.findRightDrawer();
+      rightDrawer.findRightDrawerDetailsTab().should('be.visible');
+      rightDrawer.findRightDrawerLogsTab().should('be.visible');
+      rightDrawer.findRightDrawerLogsTab().click();
       pipelineRunDetails.findLogsSuccessAlert().should('be.visible');
     });
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -72,7 +72,7 @@ class PipelineRunRightDrawer extends Contextual<HTMLDivElement> {
   }
 
   findRightDrawerDetailItem(key: string) {
-    return new DetailsItem(() => this.find().findByTestId(`detail-item-${key}`).parent());
+    return new DetailsItem(() => this.find().findByTestId(`detail-item-${key}`));
   }
 }
 
@@ -232,6 +232,18 @@ class PipelineRunDetails extends RunDetails {
 
   selectActionDropdownItem(label: string) {
     this.findActionsDropdown().findDropdownItem(label).click();
+  }
+
+  findYamlOutput() {
+    return cy.findByTestId('pipeline-dashboard-code-editor');
+  }
+
+  findInputArtifacts() {
+    return cy.findByTestId('Input-artifacts');
+  }
+
+  findOutputArtifacts() {
+    return cy.findByTestId('Output-artifacts');
   }
 }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-4729](https://issues.redhat.com/browse/RHOAIENG-4729)

## Description
This PR validates that pipelineRun details right drawer (Input/output, details) have tabs with data, and that the bottom drawer (run output) has tabs with data. Action drop down tests covered in separate PR [2746](https://github.com/opendatahub-io/odh-dashboard/pull/2746)

## How Has This Been Tested?
`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
