### PR TITLE
Fix unit test date - Artifacts table

### DIFF
--- a/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactsTable.spec.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactsTable.spec.tsx
@@ -79,7 +79,7 @@ describe('ArtifactsTable', () => {
                 ],
               ],
               state: 2,
-              createTimeSinceEpoch: 1711113121829,
+              createTimeSinceEpoch: new Date(),
             })),
           },
           {
@@ -135,7 +135,7 @@ describe('ArtifactsTable', () => {
     expect(firstRow).toHaveTextContent('1');
     expect(firstRow).toHaveTextContent('system.Artifact');
     expect(firstRow).toHaveTextContent('https://test-artifact!-aiplatform.googleapis.com/v1/12.15');
-    expect(firstRow).toHaveTextContent('1 month ago');
+    expect(firstRow).toHaveTextContent('Just now');
 
     const secondRow = screen.getByRole('row', { name: /iris_dataset/ });
     expect(secondRow).toHaveTextContent('iris_dataset');


### PR DESCRIPTION
Relates to: [RHOAIENG-2977](https://issues.redhat.com/browse/RHOAIENG-2977)
Fixing Artifacts table unit test to always the use current date to compare against.