### PR TITLE
[RHOAIENG-6314] Add tracking for new Homepage.

### DIFF
--- a/frontend/src/pages/home/projects/ProjectCard.tsx
+++ b/frontend/src/pages/home/projects/ProjectCard.tsx
@@ -23,6 +23,7 @@ import {
   getProjectDisplayName,
   getProjectOwner,
 } from '~/concepts/projects/utils';
+import { fireTrackingEventRaw } from '~/utilities/segmentIOUtils';
 
 interface ProjectCardProps {
   project: ProjectKind;
@@ -38,7 +39,13 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
           data-testid={`project-link-${project.metadata.name}`}
           variant="link"
           isInline
-          onClick={() => navigate(`/projects/${project.metadata.name}`)}
+          onClick={() => {
+            navigate(`/projects/${project.metadata.name}`);
+            fireTrackingEventRaw('HomeCardClicked', {
+              to: `/projects/${project.metadata.name}`,
+              type: 'project',
+            });
+          }}
           style={{ fontSize: 'var(--pf-v5-global--FontSize--md)' }}
         >
           <Truncate content={getProjectDisplayName(project)} />

--- a/frontend/src/pages/home/useEnableTeamSection.tsx
+++ b/frontend/src/pages/home/useEnableTeamSection.tsx
@@ -13,6 +13,7 @@ import InfoGalleryItem from '~/concepts/design/InfoGalleryItem';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { SupportedArea } from '~/concepts/areas';
 import useIsAreaAvailable from '~/concepts/areas/useIsAreaAvailable';
+import { fireTrackingEventRaw } from '~/utilities/segmentIOUtils';
 
 export const useEnableTeamSection = (): React.ReactNode => {
   const navigate = useNavigate();
@@ -32,6 +33,15 @@ export const useEnableTeamSection = (): React.ReactNode => {
     return null;
   }
 
+  const trackAndNavigate = (section: string, to: string): void => {
+    fireTrackingEventRaw('HomeCardClicked', {
+      to: `${to}`,
+      type: 'enableTeam',
+      section: `${section}`,
+    });
+    navigate(to);
+  };
+
   const infoItems = [];
 
   if (notebooksAvailable) {
@@ -41,7 +51,7 @@ export const useEnableTeamSection = (): React.ReactNode => {
         testId="landing-page-admin--notebook-images"
         isOpen={resourcesOpen}
         title="Notebook images"
-        onClick={() => navigate('/notebookImages')}
+        onClick={() => trackAndNavigate('notebook-images', '/notebookImages')}
         imgSrc={notebookImagesImage}
         sectionType={SectionType.setup}
         description={
@@ -62,7 +72,7 @@ export const useEnableTeamSection = (): React.ReactNode => {
         testId="landing-page-admin--serving-runtimes"
         isOpen={resourcesOpen}
         title="Serving runtimes"
-        onClick={() => navigate('/servingRuntimes')}
+        onClick={() => trackAndNavigate('serving-runtimes', '/servingRuntimes')}
         imgSrc={servingRuntimesImage}
         sectionType={SectionType.setup}
         description={
@@ -84,7 +94,7 @@ export const useEnableTeamSection = (): React.ReactNode => {
         testId="landing-page-admin--cluster-settings"
         isOpen={resourcesOpen}
         title="Cluster settings"
-        onClick={() => navigate('/clusterSettings')}
+        onClick={() => trackAndNavigate('cluster-settings', '/clusterSettings')}
         imgSrc={clusterSettingsImage}
         sectionType={SectionType.setup}
         description={
@@ -105,7 +115,7 @@ export const useEnableTeamSection = (): React.ReactNode => {
         testId="landing-page-admin--user-management"
         isOpen={resourcesOpen}
         title="User management"
-        onClick={() => navigate('/groupSettings')}
+        onClick={() => trackAndNavigate('user-management', '/groupSettings')}
         imgSrc={userImage}
         sectionType={SectionType.setup}
         description={

--- a/frontend/src/pages/projects/screens/projects/NewProjectButton.tsx
+++ b/frontend/src/pages/projects/screens/projects/NewProjectButton.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
-import { fireTrackingEvent } from '~/utilities/segmentIOUtils';
-import { TrackingOutcome } from '~/types';
 import ManageProjectModal from './ManageProjectModal';
 
 type NewProjectButtonProps = {
@@ -24,11 +22,6 @@ const NewProjectButton: React.FC<NewProjectButtonProps> = ({ closeOnCreate, onPr
       <ManageProjectModal
         open={open}
         onClose={(newProjectName) => {
-          fireTrackingEvent('NewProject Created', {
-            outcome: newProjectName ? TrackingOutcome.submit : TrackingOutcome.cancel,
-            success: onProjectCreated != null,
-            projectName: newProjectName || '',
-          });
           if (newProjectName) {
             if (onProjectCreated) {
               onProjectCreated(newProjectName);


### PR DESCRIPTION
## Description

This adds tracking for the new home page. As part of this, trackign of the new project
button has moved from the NewProjectButton to the ManageProjectsModal.
[RHOAIENG-6314] 

## How Has This Been Tested?
By hand and by watching the browser console.

## Test Impact
Functionality of the UI has not changed.

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
