### PR TITLE
add env var to support rhods-dashboard for dev:start:ext

### DIFF
--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -39,6 +39,7 @@ module.exports = merge(
       proxy: (() => {
         if (process.env.EXT_CLUSTER) {
           const odhProject = process.env.OC_PROJECT || 'opendatahub';
+          const app = process.env.ODH_APP || 'odh-dashboard';
           console.info('Using project:', odhProject);
 
           let dashboardHost;
@@ -46,7 +47,7 @@ module.exports = merge(
           try {
             try {
               dashboardHost = execSync(
-                `oc get routes -n ${odhProject} odh-dashboard -o jsonpath='{.spec.host}'`,
+                `oc get routes -n ${odhProject} ${app} -o jsonpath='{.spec.host}'`,
               )
                 .toString()
                 .trim();
@@ -54,7 +55,7 @@ module.exports = merge(
               console.info('Failed to GET dashboard route, constructing host manually.');
               dashboardHost = new URL(execSync(`oc whoami --show-server`).toString()).host
                 .replace(/:\d+$/, '')
-                .replace(/^api./, `odh-dashboard-${odhProject}.apps.`);
+                .replace(/^api./, `${app}-${odhProject}.apps.`);
             }
             console.info('Dashboard host:', dashboardHost);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-6597

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When using `npm run start:dev:ext`, it was not possible to target an external cluster running RHOAI.

This change simply adds support for the `ODH_APP` env variable which can be supplied in the `.env.local` file. The default value remains `odh-dashbaord` but can be overridden to `rhods-dashboard`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Update `.env.local` to include:
```
OC_PROJECT=redhat-ods-applications
ODH_APP=rhods-dashboard
```

`oc login ...` to your cluster running RHOAI (use a cluster admin)
`npm run start:dev:ext`

Visit `http://localhost:4010` to check the UI is running as expected.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
