### PR TITLE
[RHOAIENG-6880] Disable homePage feature flag for RHOAI deployments

### DIFF
--- a/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
@@ -13,7 +13,7 @@ spec:
     disableSupport: false
     disableTracking: false
     enablement: true
-    disableHome: false
+    disableHome: true
     disableProjects: false
     disablePipelines: false
     disableModelServing: false


### PR DESCRIPTION
Closes: [RHOAIENG-6880](https://issues.redhat.com/browse/RHOAIENG-6880)

## Description
The `disableHome` flag was inadvertently set to false for the RHOAI `odhDashbardConfig` spec.
 
## Test Impact
On the nightly build of a RHOAI deployment, verify the home page is not show and the initial page is the enabled application page.

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
