### PR TITLE
update oauth-proxy openshift-delegate-urls

### DIFF
--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -53,9 +53,8 @@ module.exports = merge(
                 .trim();
             } catch (e) {
               console.info('Failed to GET dashboard route, constructing host manually.');
-              dashboardHost = new URL(execSync(`oc whoami --show-server`).toString()).host
-                .replace(/:\d+$/, '')
-                .replace(/^api./, `${app}-${odhProject}.apps.`);
+              dashboardHost = new URL(execSync(`oc whoami --show-console`).toString()).host
+                .replace(/^[^.]+\./, `${app}-${odhProject}.`);
             }
             console.info('Dashboard host:', dashboardHost);
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -70,12 +70,6 @@ spec:
             name: odh-ca-cert
             subPath: odh-ca-bundle.crt
       - name: oauth-proxy
-        env:
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
         args:
           - --https-address=:8443
           - --provider=openshift
@@ -88,7 +82,7 @@ spec:
           - --cookie-secret-file=/etc/oauth/config/cookie_secret
           - --cookie-expire=23h0m0s
           - --pass-access-token
-          - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "odh-dashboard", "namespace": "$(NAMESPACE)"}}'
+          - '--openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
           - --skip-auth-regex=^/metrics
         image: oauth-proxy
         ports:

--- a/manifests/overlays/rhoai/deployment.yaml
+++ b/manifests/overlays/rhoai/deployment.yaml
@@ -20,9 +20,6 @@
   path: /spec/template/spec/containers/0/image
   value: $(odh-dashboard-image)
 - op: replace
-  path: /spec/template/spec/containers/1/args/11
-  value: '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "rhods-dashboard", "namespace": "$(NAMESPACE)"}}'
-- op: replace
   path: /spec/template/spec/serviceAccount
   value: rhods-dashboard
 - op: replace


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-6479

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The oauth-proxy `openshift-delegate-urls` option grants access to the underlying service via `Authorization: Bearer` header. The current access check is restricted to users with access to the namespace in which the dashboard is deployed. This limits access to privileged users and restricts other users, such as self-provisioners.

When running a local frontend dev server, developers want to target external clusters and test with users of varying access. Currently this method of development only works for cluster admin users. The change in this PR will loosen the access check so that any user with the ability to list projects can get through.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Apply the deployment changes for the oauth-proxy configuration.

Create a self-provisioner user on the cluster
In a terminal, `oc login` ... to your cluster with the unprivileged user
Now start the dev server: `npm run start:dev:ext`

Visit http://localhost:4010 to check the UI is running as expected.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @andrewballantyne 