### PR TITLE
Update TrustyAI APIs to use new endpoint (RHOAINENG-6620)

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelServing/ModelMetrics.cy.ts
@@ -111,7 +111,7 @@ const initIntercepts = ({
   });
   cy.interceptOdh(
     'GET /api/service/trustyai/:namespace/trustyai-service/metrics/all/requests',
-    { path: { namespace: 'test-project' } },
+    { path: { namespace: 'test-project' }, query: { type: 'fairness' } },
     mockMetricsRequest({ modelName: 'test-inference-service' }),
   );
   cy.interceptK8sList(

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -258,6 +258,7 @@ declare global {
         type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/all/requests',
         options: {
           path: { namespace: string };
+          query?: { type: string };
         },
         response: OdhResponse<BaseMetricListResponse>,
       ): Cypress.Chainable<null>;

--- a/frontend/src/api/trustyai/custom.ts
+++ b/frontend/src/api/trustyai/custom.ts
@@ -3,10 +3,10 @@ import { K8sAPIOptions } from '~/k8sTypes';
 import { BaseMetricCreationResponse, BaseMetricListResponse, BaseMetricRequest } from '~/api';
 import { handleTrustyAIFailures } from './errorUtils';
 
-export const getAllRequests =
+export const getAllBiasRequests =
   (hostPath: string) =>
   (opts: K8sAPIOptions): Promise<BaseMetricListResponse> =>
-    handleTrustyAIFailures(proxyGET(hostPath, '/metrics/all/requests', {}, opts));
+    handleTrustyAIFailures(proxyGET(hostPath, '/metrics/all/requests', { type: 'fairness' }, opts));
 
 export const getSpdRequests =
   (hostPath: string) =>

--- a/frontend/src/concepts/trustyai/useTrustyAIAPIState.ts
+++ b/frontend/src/concepts/trustyai/useTrustyAIAPIState.ts
@@ -7,7 +7,7 @@ import {
   createSpdRequest,
   deleteDirRequest,
   deleteSpdRequest,
-  getAllRequests,
+  getAllBiasRequests,
   getDirRequests,
   getSpdRequests,
 } from '~/api';
@@ -24,7 +24,7 @@ const useTrustyAIAPIState = (
       deleteDirRequest: deleteDirRequest(path),
       deleteSpdRequest: deleteSpdRequest(path),
       listDirRequests: getDirRequests(path),
-      listRequests: getAllRequests(path),
+      listRequests: getAllBiasRequests(path),
       listSpdRequests: getSpdRequests(path),
     }),
     [],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-6620](https://issues.redhat.com//browse/RHOAIENG-6620)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updates trusty ai API client to filter only for bias metrics when querying for the list of all Bias Metric Configs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Prerequisites:
* Deploy on a cluster with the following TrustyAI section in your DSC:
```
trustyai:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/ruivieira/trustyai-service-operator/tarball/RHOAIENG-6622-dev'
```
* Create a new project, enable trustyai and deploy demo models.
* Train demo models and hit them with real world data
* Create a few Bias Metric Configs
* Create an Identity metric via the CLI

Testing:
* Visit the bias metrics page, make sure the charts all work
* Goto the configure screen
* Verify in the network tab of your browser that the call to endpoint: `api/service/trustyai/model-namespace/trustyai-service/metrics/all/requests` now contains the query parameter `?type=fairness`. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
