### PR TITLE
feat(mr): routes etc and empty state for registered deployments

### DIFF
--- a/frontend/src/pages/modelRegistry/ModelRegistryRoutes.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryRoutes.tsx
@@ -36,6 +36,15 @@ const ModelRegistryRoutes: React.FC = () => (
               path={ModelVersionDetailsTab.DETAILS}
               element={<ModelVersionsDetails tab={ModelVersionDetailsTab.DETAILS} empty={false} />}
             />
+            <Route
+              path={ModelVersionDetailsTab.REGISTERED_DEPLOYMENTS}
+              element={
+                <ModelVersionsDetails
+                  tab={ModelVersionDetailsTab.REGISTERED_DEPLOYMENTS}
+                  empty={false}
+                />
+              }
+            />
             <Route path="*" element={<Navigate to="." />} />
           </Route>
           <Route path="*" element={<Navigate to="." />} />

--- a/frontend/src/pages/modelRegistry/screens/EmptyModelRegistryState.tsx
+++ b/frontend/src/pages/modelRegistry/screens/EmptyModelRegistryState.tsx
@@ -16,8 +16,8 @@ type EmptyModelRegistryStateType = {
   testid?: string;
   title: string;
   description: string;
-  primaryActionText: string;
-  primaryActionOnClick: () => void;
+  primaryActionText?: string;
+  primaryActionOnClick?: () => void;
   secondaryActionText?: string;
   secondaryActionOnClick?: () => void;
 };
@@ -36,23 +36,25 @@ const EmptyModelRegistryState: React.FC<EmptyModelRegistryStateType> = ({
     <EmptyStateBody>{description}</EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>
-        <Button
-          data-testid="empty-model-registry-primary-action"
-          variant={ButtonVariant.primary}
-          onClick={primaryActionOnClick}
-        >
-          {primaryActionText}
-        </Button>
+        {primaryActionText && (
+          <Button
+            data-testid="empty-model-registry-primary-action"
+            variant={ButtonVariant.primary}
+            onClick={primaryActionOnClick}
+          >
+            {primaryActionText}
+          </Button>
+        )}
+        {secondaryActionText && (
+          <Button
+            data-testid="empty-model-registry-secondary-action"
+            variant="link"
+            onClick={secondaryActionOnClick}
+          >
+            {secondaryActionText}
+          </Button>
+        )}
       </EmptyStateActions>
-      {secondaryActionText && (
-        <Button
-          data-testid="empty-model-registry-secondary-action"
-          variant="link"
-          onClick={secondaryActionOnClick}
-        >
-          {secondaryActionText}
-        </Button>
-      )}
     </EmptyStateFooter>
   </EmptyState>
 );

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import '~/pages/pipelines/global/runs/GlobalPipelineRunsTabs.scss';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import { ModelVersionDetailsTabTitle, ModelVersionDetailsTab } from './const';
 import ModelVersionDetailsView from './ModelVersionDetailsView';
+import ModelVersionRegisteredDeploymentsView from './ModelVersionRegisteredDeploymentsView';
 
 type ModelVersionDetailTabsProps = {
   tab: ModelVersionDetailsTab;
@@ -15,34 +17,38 @@ const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
   tab,
   modelVersion: mv,
   refresh,
-}) => (
-  <Tabs
-    activeKey={tab}
-    aria-label="Model versions details page tabs"
-    role="region"
-    data-testid="model-versions-details-page-tabs"
-  >
-    <Tab
-      eventKey={ModelVersionDetailsTab.DETAILS}
-      title={<TabTitleText>{ModelVersionDetailsTabTitle.DETAILS}</TabTitleText>}
-      aria-label="Model versions details tab"
-      data-testid="model-versions-details-tab"
+}) => {
+  const navigate = useNavigate();
+  return (
+    <Tabs
+      activeKey={tab}
+      aria-label="Model versions details page tabs"
+      role="region"
+      data-testid="model-versions-details-page-tabs"
+      onSelect={(_event, eventKey) => navigate(`../${eventKey}`, { relative: 'path' })}
     >
-      <PageSection isFilled variant="light" data-testid="model-versions-details-tab-content">
-        <ModelVersionDetailsView modelVersion={mv} refresh={refresh} />
-      </PageSection>
-    </Tab>
-    <Tab
-      eventKey={ModelVersionDetailsTab.REGISTERED_DEPLOYMENTS}
-      title={<TabTitleText>{ModelVersionDetailsTabTitle.REGISTERED_DEPLOYMENTS}</TabTitleText>}
-      aria-label="Registered deployments tab"
-      data-testid="registered-deployments-tab"
-    >
-      <PageSection isFilled variant="light" data-testid="registered-deployments-tab-content">
-        {/* TODO: Fill Model Details Page Component here */}
-      </PageSection>
-    </Tab>
-  </Tabs>
-);
+      <Tab
+        eventKey={ModelVersionDetailsTab.DETAILS}
+        title={<TabTitleText>{ModelVersionDetailsTabTitle.DETAILS}</TabTitleText>}
+        aria-label="Model versions details tab"
+        data-testid="model-versions-details-tab"
+      >
+        <PageSection isFilled variant="light" data-testid="model-versions-details-tab-content">
+          <ModelVersionDetailsView modelVersion={mv} refresh={refresh} />
+        </PageSection>
+      </Tab>
+      <Tab
+        eventKey={ModelVersionDetailsTab.REGISTERED_DEPLOYMENTS}
+        title={<TabTitleText>{ModelVersionDetailsTabTitle.REGISTERED_DEPLOYMENTS}</TabTitleText>}
+        aria-label="Registered deployments tab"
+        data-testid="registered-deployments-tab"
+      >
+        <PageSection isFilled variant="light" data-testid="registered-deployments-tab-content">
+          <ModelVersionRegisteredDeploymentsView modelVersion={mv} />
+        </PageSection>
+      </Tab>
+    </Tabs>
+  );
+};
 
 export default ModelVersionDetailsTabs;

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ModelVersion } from '~/concepts/modelRegistry/types';
+import EmptyModelRegistryState from '~/pages/modelRegistry/screens/EmptyModelRegistryState';
+
+type ModelVersionRegisteredDeploymentsViewProps = {
+  modelVersion: ModelVersion;
+};
+
+const ModelVersionRegisteredDeploymentsView: React.FC<
+  ModelVersionRegisteredDeploymentsViewProps
+> = ({ modelVersion: mv }) => {
+  // eslint-disable-next-line no-console
+  console.log({ mv });
+  //TODO: implement component
+  return (
+    <EmptyModelRegistryState
+      title="No registered deployments"
+      description="You can deploy this version using Actions dropdown in the header"
+    />
+  );
+};
+export default ModelVersionRegisteredDeploymentsView;


### PR DESCRIPTION
initial progress towards https://issues.redhat.com/browse/RHOAIENG-6636

## Description
includes setting up the tab, routes, and the component with the empty state
![image](https://github.com/opendatahub-io/odh-dashboard/assets/5322142/289e308a-43f5-4e3e-a9e3-7ba3764dcaea)


## How Has This Been Tested?
na, just setting up a skeleton with empty state for now

## Test Impact
none

## Request review criteria:
can access tab with route and see empty state

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
