### PR TITLE
added core interceptor for pipeline

### DIFF
--- a/frontend/src/__mocks__/mockGoogleRpcStatusKF.ts
+++ b/frontend/src/__mocks__/mockGoogleRpcStatusKF.ts
@@ -1,0 +1,19 @@
+import { GoogleRpcStatusKF } from '~/concepts/pipelines/kfTypes';
+
+type MockGoogleRpcStatusKF = { message?: string };
+
+export const mockSuccessGoogleRpcStatus = ({
+  message = '',
+}: MockGoogleRpcStatusKF): GoogleRpcStatusKF => ({
+  code: 0,
+  message,
+  details: [],
+});
+
+export const mockCancelledGoogleRpcStatus = ({
+  message = '',
+}: MockGoogleRpcStatusKF): GoogleRpcStatusKF => ({
+  code: 1,
+  message,
+  details: [],
+});

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelRegistry/ModelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelRegistry/ModelRegistry.cy.ts
@@ -50,12 +50,22 @@ const initIntercepts = ({
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models`,
+    {
+      path: { serviceName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION },
+    },
     mockRegisteredModelList({ size: registeredModelsSize }),
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/1/versions`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
     mockModelVersionList({ items: modelVersions }),
   );
 };

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelRegistry/ModelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelRegistry/ModelVersionDetails.cy.ts
@@ -38,12 +38,27 @@ const initIntercepts = () => {
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/1`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
+
     mockRegisteredModel({}),
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/1/versions`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
     mockModelVersionList({
       items: [
         mockModelVersion({ name: 'Version 1', author: 'Author 1', registeredModelId: '1' }),
@@ -58,8 +73,14 @@ const initIntercepts = () => {
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions/:id`,
-    { path: { id: '1' } },
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 1,
+      },
+    },
     mockModelVersion({
       id: '1',
       name: 'Version 1',
@@ -110,13 +131,26 @@ const initIntercepts = () => {
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions/:id`,
-    { path: { id: '2' } },
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 2,
+      },
+    },
     mockModelVersion({ id: '2', name: 'Version 2' }),
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions/1/artifacts`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 1,
+      },
+    },
     mockModelArtifactList(),
   );
 };

--- a/frontend/src/__tests__/cypress/cypress/e2e/modelRegistry/ModelVersions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/modelRegistry/ModelVersions.cy.ts
@@ -83,17 +83,32 @@ const initIntercepts = ({
   cy.interceptK8s(ModelRegistryModel, mockModelRegistry({}));
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models`,
+    { path: { serviceName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION } },
     mockRegisteredModelList({ size: registeredModelsSize }),
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/1/versions`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
     mockModelVersionList({ items: modelVersions }),
   );
 
   cy.interceptOdh(
-    `GET /api/service/modelregistry/modelregistry-sample/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/1`,
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
     mockRegisteredModel({}),
   );
 };

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Experiments.cy.ts
@@ -6,8 +6,6 @@ import {
   mockK8sResourceList,
   buildMockPipelineV2,
   buildMockPipelines,
-  buildMockPipelineVersionV2,
-  buildMockPipelineVersionsV2,
   mockProjectK8sResource,
   mockRouteK8sResource,
 } from '~/__mocks__';
@@ -28,9 +26,6 @@ import {
 
 const projectName = 'test-project-name';
 const initialMockPipeline = buildMockPipelineV2({ display_name: 'Test pipeline' });
-const initialMockPipelineVersion = buildMockPipelineVersionV2({
-  pipeline_id: initialMockPipeline.pipeline_id,
-});
 const mockExperiments = [
   buildMockExperimentKF({
     display_name: 'Test experiment 1',
@@ -270,39 +265,38 @@ const initIntercepts = () => {
       mockProjectK8sResource({ k8sName: projectName, displayName: projectName }),
     ]),
   );
-
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
     {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     buildMockPipelines([initialMockPipeline]),
   );
 
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
     {
-      method: 'POST',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipeline_versions`,
-    },
-    buildMockPipelineVersionsV2([initialMockPipelineVersion]),
-  );
-  cy.intercept(
-    {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     { runs: [] },
   );
-  cy.intercept(
+
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
-    {
-      recurringRuns: [],
-    },
+    { recurringRuns: [] },
   );
-  cy.intercept(
+
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId',
     {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/experiments/${mockExperiments[0].experiment_id}`,
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        experimentId: mockExperiments[0].experiment_id,
+      },
     },
     mockExperiments[0],
   );

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/ManageRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/ManageRuns.cy.ts
@@ -22,7 +22,7 @@ const initialRunIds = ['test-run-1', 'test-run-2'];
 
 const mockRuns = Array(11)
   .fill(buildMockRunKF())
-  .map((mockRun: Partial<PipelineRunKFv2>, index) => ({
+  .map((mockRun: PipelineRunKFv2, index) => ({
     ...mockRun,
     display_name: `Test run ${index + 1}`,
     run_id: `test-run-${index + 1}`,
@@ -95,10 +95,10 @@ describe('Manage runs', () => {
   });
 
   it('navigates to "Compare runs" page with updated run IDs when "Update" toolbar action is clicked', () => {
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs/test-run-3`,
+        path: { namespace: projectName, serviceName: 'dspa', runId: 'test-run-3' },
       },
       mockRuns[2],
     );
@@ -117,10 +117,10 @@ const initIntercepts = () => {
   configIntercept();
   dspaIntercepts(projectName);
   projectsIntercept([{ k8sName: projectName, displayName: 'Test project' }]);
-
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
     {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     buildMockPipelines([buildMockPipelineV2({ pipeline_id: pipelineId })]),
   );
@@ -130,37 +130,32 @@ const initIntercepts = () => {
     pipeline_id: pipelineId,
   });
 
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${pipelineId}/versions`,
+      path: { namespace: projectName, serviceName: 'dspa', pipelineId },
     },
     buildMockPipelineVersionsV2([mockPipelineVersion]),
   );
 
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/experiments/${experimentId}`,
-    },
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId',
+    { path: { namespace: projectName, serviceName: 'dspa', experimentId } },
     buildMockExperimentKF({ experiment_id: experimentId }),
   );
 
   initialRunIds.forEach((selectedRunId) => {
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs/${selectedRunId}`,
+        path: { namespace: projectName, serviceName: 'dspa', runId: selectedRunId },
       },
-      mockRuns.find((mockRun) => mockRun.run_id === selectedRunId),
+      mockRuns.find((mockRun) => mockRun.run_id === selectedRunId) as PipelineRunKFv2,
     );
   });
-
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
-    },
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
+    { path: { namespace: projectName, serviceName: 'dspa' } },
     {
       runs: mockRuns,
       total_size: mockRuns.length,

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineCreateRuns.cy.ts
@@ -69,18 +69,6 @@ describe('Pipeline create runs', () => {
   });
 
   describe('Runs', () => {
-    beforeEach(() => {
-      mockExperiments.forEach((experiment) => {
-        cy.intercept(
-          {
-            method: 'POST',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/experiments/${experiment.experiment_id}`,
-          },
-          experiment,
-        );
-      });
-    });
-
     it('switches to scheduled runs from triggered', () => {
       // Mock experiments, pipelines & versions for form select dropdowns
       createRunPage.mockGetExperiments(projectName, mockExperiments);
@@ -471,10 +459,14 @@ describe('Pipeline create runs', () => {
   describe('Schedules', () => {
     beforeEach(() => {
       mockExperiments.forEach((experiment) => {
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/experiments/${experiment.experiment_id}`,
+            path: {
+              namespace: projectName,
+              serviceName: 'dspa',
+              experimentId: experiment.experiment_id,
+            },
           },
           experiment,
         );
@@ -725,19 +717,17 @@ const initIntercepts = () => {
   configIntercept();
   dspaIntercepts(projectName);
   projectsIntercept([{ k8sName: projectName, displayName: 'Test project' }]);
-
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     { recurringRuns: initialMockRecurringRuns, total_size: initialMockRecurringRuns.length },
   );
-
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     { runs: initialMockRuns, total_size: initialMockRuns.length },
   );

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelineRuns.cy.ts
@@ -186,11 +186,10 @@ describe('Pipeline runs', () => {
             state: RuntimeStateKF.SUCCEEDED,
           }),
         );
-
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             runs: mockRuns.slice(0, 10),
@@ -216,10 +215,10 @@ describe('Pipeline runs', () => {
 
         // test Next button
         pagination.findPreviousButton().should('be.disabled');
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             runs: mockRuns.slice(10, 15),
@@ -242,10 +241,10 @@ describe('Pipeline runs', () => {
 
         // test Previous button
         pagination.findNextButton().should('be.disabled');
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             runs: mockRuns.slice(0, 10),
@@ -257,10 +256,10 @@ describe('Pipeline runs', () => {
         activeRunsTable.findRows().should('have.length', 10);
 
         // 20 per page
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/runs`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             runs: mockRuns.slice(0, 15),
@@ -834,10 +833,10 @@ describe('Pipeline runs', () => {
           }),
         );
 
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             recurringRuns: mockJobRuns.slice(0, 10),
@@ -862,10 +861,10 @@ describe('Pipeline runs', () => {
         // test Next button
         pagination.findFirstButton().should('be.disabled');
         pagination.findPreviousButton().should('be.disabled');
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             recurringRuns: mockJobRuns.slice(10, 15),
@@ -889,10 +888,10 @@ describe('Pipeline runs', () => {
         //test first button
         pagination.findLastButton().should('be.disabled');
         pagination.findNextButton().should('be.disabled');
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             recurringRuns: mockJobRuns.slice(0, 10),
@@ -908,10 +907,10 @@ describe('Pipeline runs', () => {
         //test last button
         pagination.findFirstButton().should('be.disabled');
         pagination.findPreviousButton().should('be.disabled');
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             recurringRuns: mockJobRuns.slice(10, 15),
@@ -935,10 +934,10 @@ describe('Pipeline runs', () => {
         // test Previous button
         pagination.findLastButton().should('be.disabled');
         pagination.findNextButton().should('be.disabled');
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             recurringRuns: mockJobRuns.slice(0, 10),
@@ -951,16 +950,17 @@ describe('Pipeline runs', () => {
         pipelineRunJobTable.findRows().should('have.length', 10);
 
         // 20 per page
-        cy.intercept(
+        cy.interceptOdh(
+          'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
           {
-            method: 'GET',
-            pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/recurringruns`,
+            path: { namespace: projectName, serviceName: 'dspa' },
           },
           {
             recurringRuns: mockJobRuns.slice(0, 15),
             total_size: 15,
           },
         );
+
         pagination.selectToggleOption('20 per page');
 
         pipelineRunJobTable.getRowByName('another-pipeline-0').find().should('exist');
@@ -1062,19 +1062,17 @@ const initIntercepts = () => {
     ]),
   );
 
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     buildMockPipelines([buildMockPipelineV2({ pipeline_id: pipelineId })]),
   );
 
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${pipelineId}/versions`,
-    },
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+    { path: { namespace: projectName, serviceName: 'dspa', pipelineId } },
     buildMockPipelineVersionsV2(mockVersions),
   );
 };

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/Pipelines.cy.ts
@@ -30,6 +30,7 @@ import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
 import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 import { be } from '~/__tests__/cypress/cypress/utils/should';
 import { tablePagination } from '~/__tests__/cypress/cypress/pages/components/Pagination';
+import { mockSuccessGoogleRpcStatus } from '~/__mocks__/mockGoogleRpcStatusKF';
 
 const projectName = 'test-project-name';
 const initialMockPipeline = buildMockPipelineV2({ display_name: 'Test pipeline' });
@@ -774,13 +775,14 @@ describe('Pipelines', () => {
       .click();
     pipelineDeleteModal.shouldBeOpen();
     pipelineDeleteModal.findInput().type(initialMockPipeline.display_name);
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+        path: { namespace: projectName, serviceName: 'dspa' },
       },
       buildMockPipelines([]),
     ).as('refreshPipelines');
+
     pipelineDeleteModal.findSubmitButton().click();
 
     cy.wait('@deletePipeline');
@@ -808,13 +810,18 @@ describe('Pipelines', () => {
       .click();
     pipelineDeleteModal.shouldBeOpen();
     pipelineDeleteModal.findInput().type(initialMockPipelineVersion.display_name);
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${initialMockPipeline.pipeline_id}/versions`,
+        path: {
+          namespace: projectName,
+          serviceName: 'dspa',
+          pipelineId: initialMockPipeline.pipeline_id,
+        },
       },
       buildMockPipelineVersionsV2([]),
     ).as('refreshVersions');
+
     pipelineDeleteModal.findSubmitButton().click();
 
     cy.wait('@deleteVersion');
@@ -1020,13 +1027,14 @@ describe('Pipelines', () => {
 
     // test Next button
     pagination.findPreviousButton().should('be.disabled');
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+        path: { namespace: projectName, serviceName: 'dspa' },
       },
       buildMockPipelines(mockPipelinesv2.slice(10, 20), 25),
     ).as('refreshPipelines');
+
     pagination.findNextButton().click();
 
     cy.wait('@refreshPipelines').then((interception) => {
@@ -1041,10 +1049,10 @@ describe('Pipelines', () => {
     pipelinesTable.findRows().should('have.length', '10');
 
     // test Previous button
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+        path: { namespace: projectName, serviceName: 'dspa' },
       },
       buildMockPipelines(mockPipelinesv2.slice(0, 10), 25),
     ).as('getFirstTenPipelines');
@@ -1061,10 +1069,10 @@ describe('Pipelines', () => {
     pipelinesTable.getRowByName('Test pipeline-0').find().should('exist');
 
     // 20 per page
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+        path: { namespace: projectName, serviceName: 'dspa' },
       },
       buildMockPipelines(mockPipelinesv2.slice(0, 20), 22),
     );
@@ -1116,42 +1124,43 @@ const initIntercepts = ({
     ]),
   );
 
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
     {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
+      path: { namespace: projectName, serviceName: 'dspa' },
     },
     buildMockPipelines(mockPipelines, totalSize, nextPageToken),
   ).as('getPipelines');
 
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${initialMockPipeline.pipeline_id}/versions`,
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        pipelineId: initialMockPipeline.pipeline_id,
+      },
     },
     buildMockPipelineVersionsV2([initialMockPipelineVersion]),
   );
 };
 
 const createDeleteVersionIntercept = (pipelineId: string, pipelineVersionId: string) =>
-  cy.intercept(
+  cy.interceptOdh(
+    'DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
     {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${pipelineId}/versions/${pipelineVersionId}`,
-      method: 'DELETE',
+      path: { namespace: projectName, serviceName: 'dspa', pipelineId, pipelineVersionId },
       times: 1,
     },
-    {
-      body: {},
-    },
+    mockSuccessGoogleRpcStatus({}),
   );
 
 const createDeletePipelineIntercept = (pipelineId: string) =>
-  cy.intercept(
+  cy.interceptOdh(
+    'DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
     {
-      pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${pipelineId}`,
-      method: 'DELETE',
+      path: { namespace: projectName, serviceName: 'dspa', pipelineId },
       times: 1,
     },
-    {
-      body: {},
-    },
+    mockSuccessGoogleRpcStatus({}),
   );

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesList.cy.ts
@@ -81,13 +81,14 @@ describe('PipelinesList', () => {
       DataSciencePipelineApplicationModel,
       mockDataSciencePipelineApplicationK8sResource({}),
     );
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        method: 'GET',
-        pathname: '/api/service/pipelines/test-project/dspa/apis/v2beta1/pipelines',
+        path: { namespace: 'test-project', serviceName: 'dspa' },
       },
       buildMockPipelines([]),
     ).as('pipelines');
+
     projectDetails.visitSection('test-project', 'pipelines-projects');
 
     pipelinesSection.findImportPipelineSplitButton().should('be.enabled').click();
@@ -130,17 +131,21 @@ describe('PipelinesList', () => {
       DataSciencePipelineApplicationModel,
       mockDataSciencePipelineApplicationK8sResource({}),
     );
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        pathname: '/api/service/pipelines/test-project/dspa/apis/v2beta1/pipelines',
+        path: { namespace: 'test-project', serviceName: 'dspa' },
       },
       buildMockPipelines([initialMockPipeline]),
     );
-
-    cy.intercept(
+    cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/test-project/dspa/apis/v2beta1/pipelines/${initialMockPipeline.pipeline_id}/versions`,
+        path: {
+          namespace: 'test-project',
+          serviceName: 'dspa',
+          pipelineId: initialMockPipeline.pipeline_id,
+        },
       },
       buildMockPipelineVersionsV2([initialMockPipelineVersion]),
     );

--- a/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/pipelines/PipelinesTopology.cy.ts
@@ -28,7 +28,6 @@ import {
   RouteModel,
   SecretModel,
 } from '~/__tests__/cypress/cypress/utils/models';
-import { mock200Status } from '~/__mocks__/mockK8sStatus';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 
 const projectId = 'test-project';
@@ -106,67 +105,41 @@ const initIntercepts = () => {
       namespace: projectId,
     }),
   );
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
     {
-      method: 'POST',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines`,
-    },
-    { pipelines: [mockPipeline] },
-  );
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}`,
+      path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
     },
     mockPipeline,
   );
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions`,
-    },
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+    { path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id } },
     buildMockPipelineVersionsV2([mockVersion, mockVersion2]),
   );
-
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId',
     {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/recurringruns/${mockJob.recurring_run_id}`,
+      path: { namespace: projectId, serviceName: 'dspa', recurringRunId: mockJob.recurring_run_id },
     },
     mockJob,
   );
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
     {
-      method: 'POST',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/recurringruns`,
-    },
-    { recurringRuns: [mockJob] },
-  );
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/runs/${mockRun.run_id}`,
+      path: { namespace: projectId, serviceName: 'dspa', runId: mockRun.run_id },
     },
     mockRun,
   );
-  cy.intercept(
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
     {
-      method: 'POST',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/runs`,
-    },
-    { runs: [mockRun] },
-  );
-  cy.intercept(
-    {
-      method: 'POST',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions`,
-    },
-    [mockVersion],
-  );
-  cy.intercept(
-    {
-      method: 'GET',
-      pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions/${mockVersion.pipeline_version_id}`,
+      path: {
+        namespace: projectId,
+        serviceName: 'dspa',
+        pipelineId: mockPipeline.pipeline_id,
+        pipelineVersionId: mockVersion.pipeline_version_id,
+      },
     },
     mockVersion,
   );
@@ -247,12 +220,17 @@ describe('Pipeline topology', () => {
       pipelineDetails.selectActionDropdownItem('Delete pipeline version');
       deleteModal.shouldBeOpen();
       deleteModal.findInput().type(mockVersion.display_name);
-      cy.intercept(
+      cy.interceptOdh(
+        'DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
         {
-          method: 'DELETE',
-          pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions/${mockVersion.pipeline_version_id}`,
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockVersion.pipeline_version_id,
+          },
         },
-        mock200Status({}),
+        {},
       ).as('deletePipelineVersion');
 
       deleteModal.findSubmitButton().click();
@@ -260,10 +238,15 @@ describe('Pipeline topology', () => {
     });
 
     it('page details are updated when a new pipeline version is selected', () => {
-      cy.intercept(
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
         {
-          method: 'GET',
-          pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions/${mockVersion2.pipeline_version_id}`,
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockVersion2.pipeline_version_id,
+          },
         },
         mockVersion2,
       );
@@ -275,10 +258,15 @@ describe('Pipeline topology', () => {
     });
 
     it('page details are updated after uploading a new version', () => {
-      cy.intercept(
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
         {
-          method: 'GET',
-          pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions/${mockVersion2.pipeline_version_id}`,
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockVersion2.pipeline_version_id,
+          },
         },
         mockVersion2,
       );
@@ -286,10 +274,10 @@ describe('Pipeline topology', () => {
       pipelineDetails.selectActionDropdownItem('Upload new version');
       pipelineVersionImportModal.findImportPipelineRadio().check();
       pipelineVersionImportModal.findPipelineUrlInput().type('https://example.com/pipeline.yaml');
-      cy.intercept(
+      cy.interceptOdh(
+        'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
         {
-          method: 'POST',
-          pathname: `/api/service/pipelines/${projectId}/dspa/apis/v2beta1/pipelines/${mockPipeline.pipeline_id}/versions`,
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
         },
         mockVersion2,
       ).as('uploadNewPipelineVersion');
@@ -342,9 +330,15 @@ describe('Pipeline topology', () => {
         deleteModal.findInput().type(mockPipeline.display_name);
 
         cy.interceptOdh(
-          'DELETE /api/service/pipelines/:projectId/dspa/apis/v2beta1/recurringruns/:pipeline_id',
-          { path: { projectId, pipeline_id: mockPipeline.pipeline_id } },
-          mock200Status({}),
+          'DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId',
+          {
+            path: {
+              namespace: projectId,
+              serviceName: 'dspa',
+              recurringRunId: mockPipeline.pipeline_id,
+            },
+          },
+          {},
         ).as('deletepipelineRunJob');
 
         deleteModal.findSubmitButton().click();

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/cloneRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/cloneRunPage.ts
@@ -15,21 +15,19 @@ class CloneRunPage extends CreateRunPage {
   }
 
   mockGetRun(namespace: string, run: PipelineRunKFv2) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/runs/${run.run_id}`,
+        path: { namespace, serviceName: 'dspa', runId: run.run_id },
       },
       run,
     );
   }
 
   mockGetRecurringRun(namespace: string, recurringRun: PipelineRunJobKFv2) {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/recurringruns/${recurringRun.recurring_run_id}`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId',
+      { path: { namespace, serviceName: 'dspa', recurringRunId: recurringRun.recurring_run_id } },
       recurringRun,
     );
   }
@@ -38,31 +36,32 @@ class CloneRunPage extends CreateRunPage {
     namespace: string,
     pipelineVersion: PipelineVersionKFv2,
   ): Cypress.Chainable<null> {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${pipelineVersion.pipeline_id}/versions/${pipelineVersion.pipeline_version_id}`,
+        path: {
+          namespace,
+          serviceName: 'dspa',
+          pipelineId: pipelineVersion.pipeline_id,
+          pipelineVersionId: pipelineVersion.pipeline_version_id,
+        },
       },
       pipelineVersion,
     );
   }
 
   mockGetPipeline(namespace: string, pipeline: PipelineKFv2): Cypress.Chainable<null> {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${pipeline.pipeline_id}`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
+      { path: { namespace, serviceName: 'dspa', pipelineId: pipeline.pipeline_id } },
       pipeline,
     );
   }
 
   mockGetExperiment(namespace: string, experiment: ExperimentKFv2): Cypress.Chainable<null> {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/experiments/${experiment.experiment_id}`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId',
+      { path: { namespace, serviceName: 'dspa', experimentId: experiment.experiment_id } },
       experiment,
     );
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -159,16 +159,20 @@ export class CreateRunPage {
   }
 
   mockGetExperiments(namespace: string, experiments?: ExperimentKFv2[]): Cypress.Chainable<null> {
-    return cy.intercept(
-      { pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/experiments` },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments',
+      {
+        path: { namespace, serviceName: 'dspa' },
+      },
       buildMockExperiments(experiments),
     );
   }
 
   mockGetPipelines(namespace: string, pipelines: PipelineKFv2[]): Cypress.Chainable<null> {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines`,
+        path: { namespace, serviceName: 'dspa' },
       },
       buildMockPipelines(pipelines),
     );
@@ -179,11 +183,9 @@ export class CreateRunPage {
     versions: PipelineVersionKFv2[],
     pipelineId: string,
   ): Cypress.Chainable<null> {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${pipelineId}/versions`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+      { path: { namespace, serviceName: 'dspa', pipelineId } },
       buildMockPipelineVersionsV2(versions),
     );
   }
@@ -193,10 +195,10 @@ export class CreateRunPage {
     pipelineVersion: PipelineVersionKFv2,
     { run_id, ...run }: Partial<PipelineRunKFv2>,
   ): Cypress.Chainable<null> {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
       {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/runs`,
+        path: { namespace, serviceName: 'dspa' },
         times: 1,
       },
       (req) => {
@@ -222,12 +224,9 @@ export class CreateRunPage {
     pipelineVersion: PipelineVersionKFv2,
     { recurring_run_id, ...recurringRun }: Partial<PipelineRunJobKFv2>,
   ): Cypress.Chainable<null> {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/recurringruns`,
-        times: 1,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
+      { path: { namespace, serviceName: 'dspa' }, times: 1 },
       (req) => {
         const data = {
           display_name: recurringRun.display_name,

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
@@ -35,10 +35,10 @@ class ExperimentsTabs {
     activeExperiments: ExperimentKFv2[],
     archivedExperiments: ExperimentKFv2[] = [],
   ) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/experiments`,
+        path: { namespace, serviceName: 'dspa' },
       },
       (req) => {
         const { predicates } = JSON.parse(req.query.filter.toString());
@@ -72,11 +72,9 @@ class ExperimentsTable {
   }
 
   mockArchiveExperiment(experimentId: string, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/experiments/${experimentId}:archive`,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId',
+      { path: { namespace, serviceName: 'dspa', experimentId: `${experimentId}:archive` } },
       (req) => {
         req.reply({ body: {} });
       },
@@ -84,11 +82,9 @@ class ExperimentsTable {
   }
 
   mockRestoreExperiment(experimentId: string, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/experiments/${experimentId}:unarchive`,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId',
+      { path: { namespace, serviceName: 'dspa', experimentId: `${experimentId}:unarchive` } },
       (req) => {
         req.reply({ body: {} });
       },

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
@@ -70,10 +70,10 @@ class PipelineRunFilterBar extends PipelineFilterBar {
   }
 
   mockExperiments(experiments: ExperimentKFv2[], namespace: string) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/experiments`,
+        path: { namespace, serviceName: 'dspa' },
       },
       {
         experiments,

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -52,10 +52,10 @@ class PipelineImportModal extends Modal {
   }
 
   mockCreatePipelineAndVersion(params: CreatePipelineAndVersionKFData, namespace: string) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/create',
       {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/create`,
+        path: { namespace, serviceName: 'dspa' },
         times: 1,
       },
       buildMockPipelineV2(params.pipeline),
@@ -63,12 +63,9 @@ class PipelineImportModal extends Modal {
   }
 
   mockUploadPipeline(params: Partial<PipelineKFv2>, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/upload`,
-        times: 1,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload',
+      { path: { namespace, serviceName: 'dspa' }, times: 1 },
       buildMockPipelineV2(params),
     );
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
@@ -66,11 +66,9 @@ class PipelineRunsTable {
   }
 
   mockRestoreRun(runId: string, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/runs/${runId}:unarchive`,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
+      { path: { namespace, serviceName: 'dspa', runId: `${runId}:unarchive` } },
       (req) => {
         req.reply({ body: {} });
       },
@@ -78,11 +76,9 @@ class PipelineRunsTable {
   }
 
   mockArchiveRun(runId: string, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/runs/${runId}:archive`,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
+      { path: { namespace, serviceName: 'dspa', runId: `${runId}:archive` } },
       (req) => {
         req.reply({ body: {} });
       },
@@ -95,10 +91,10 @@ class PipelineRunsTable {
     namespace: string,
     times?: number,
   ) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/runs`,
+        path: { namespace, serviceName: 'dspa' },
         ...(times && { times }),
       },
       (req) => {
@@ -160,40 +156,40 @@ class PipelineRunJobTable extends PipelineRunsTable {
   }
 
   mockGetJobs(jobs: PipelineRunJobKFv2[], namespace: string) {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/recurringruns`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns',
+      { path: { namespace, serviceName: 'dspa' } },
       { recurringRuns: jobs, total_size: jobs.length },
     );
   }
 
   mockGetJob(job: PipelineRunJobKFv2, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/recurringruns/${job.recurring_run_id}`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId',
+      { path: { namespace, serviceName: 'dspa', recurringRunId: job.recurring_run_id } },
       job,
     );
   }
 
   mockEnableJob(job: PipelineRunJobKFv2, namespace: string) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId',
       {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/recurringruns/${job.recurring_run_id}:enable`,
+        path: {
+          namespace,
+          serviceName: 'dspa',
+          recurringRunId: `${job.recurring_run_id}:'enable'`,
+        },
       },
       {},
     );
   }
 
   mockDisableJob(job: PipelineRunJobKFv2, namespace: string) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId',
       {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/recurringruns/${job.recurring_run_id}:disable`,
+        path: { namespace, serviceName: 'dspa', recurringRunId: `${job.recurring_run_id}:disable` },
       },
       {},
     );

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
@@ -74,23 +74,17 @@ class PipelineImportModal extends Modal {
   }
 
   mockCreatePipelineVersion(params: CreatePipelineVersionKFData, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${params.pipeline_id}/versions`,
-        times: 1,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+      { path: { namespace, serviceName: 'dspa', pipelineId: params.pipeline_id }, times: 1 },
       buildMockPipelineVersionV2(params),
     );
   }
 
   mockUploadVersion(params: Partial<PipelineVersionKFv2>, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'POST',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/upload_version`,
-        times: 1,
-      },
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload_version',
+      { path: { namespace, serviceName: 'dspa' }, times: 1 },
       buildMockPipelineVersionV2(params),
     );
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
@@ -69,41 +69,42 @@ class PipelinesTable {
   }
 
   mockDeletePipeline(pipeline: PipelineKFv2, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'DELETE',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${pipeline.pipeline_id}`,
-      },
+    return cy.interceptOdh(
+      'DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
+      { path: { namespace, serviceName: 'dspa', pipelineId: pipeline.pipeline_id } },
       {},
     );
   }
 
   mockDeletePipelineVersion(version: PipelineVersionKFv2, namespace: string) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
       {
-        method: 'DELETE',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${version.pipeline_id}/versions/${version.pipeline_version_id}`,
+        path: {
+          namespace,
+          serviceName: 'dspa',
+          pipelineId: version.pipeline_id,
+          pipelineVersionId: version.pipeline_version_id,
+        },
       },
       {},
     );
   }
 
   mockGetPipelines(pipelines: PipelineKFv2[], namespace: string) {
-    return cy.intercept(
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
       {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines`,
+        path: { namespace, serviceName: 'dspa' },
       },
       buildMockPipelines(pipelines),
     );
   }
 
   mockGetPipelineVersions(versions: PipelineVersionKFv2[], pipelineId: string, namespace: string) {
-    return cy.intercept(
-      {
-        method: 'GET',
-        pathname: `/api/service/pipelines/${namespace}/dspa/apis/v2beta1/pipelines/${pipelineId}/versions`,
-      },
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+      { path: { namespace, serviceName: 'dspa', pipelineId } },
       buildMockPipelineVersionsV2(versions),
     );
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-5329

## Description
continuation for updating interceptOdh for pipeline intercepts
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
