### PR TITLE
[RHOAIENG-6985] Create kserve metrics feature flag

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -33,6 +33,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disablePerformanceMetrics: boolean;
       disableKServe: boolean;
       disableKServeAuth: boolean;
+      disableKServeMetrics: boolean;
       disableModelMesh: boolean;
       disableAcceleratorProfiles: boolean;
       disablePipelineExperiments: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -58,6 +58,7 @@ export const blankDashboardCR: DashboardConfig = {
       disablePipelines: false,
       disableKServe: false,
       disableKServeAuth: false,
+      disableKServeMetrics: true,
       disableModelMesh: false,
       disableAcceleratorProfiles: false,
       disablePipelineExperiments: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -27,6 +27,7 @@ The following are a list of features that are supported, along with there defaul
 | disableCustomServingRuntimes | false   | Disables Custom Serving Runtimes from the Admin Panel.                                               |
 | disableKServe                | false   | Disables the ability to select KServe as a Serving Platform.                                         |
 | disableKServeAuth            | false   | Disables the ability to use auth in KServe.                                                          |
+| disableKServeMetrics         | true    | Disables the ability to see KServe Metrics.                                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
 | disableBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
@@ -57,6 +58,7 @@ spec:
     disableProjectSharing: false
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: false
+    disableKServeMetrics: true
     disableBiasMetrics: false
     disablePerformanceMetrics: false
     disablePipelineExperiments: false
@@ -151,6 +153,7 @@ spec:
     disableProjectSharing: true
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: true
+    disableKServeMetrics: true
     disableBiasMetrics: false
     disablePerformanceMetrics: false
     disablePipelineExperiments: true

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -16,6 +16,7 @@ type MockDashboardConfigType = {
   disableCustomServingRuntimes?: boolean;
   disableKServe?: boolean;
   disableKServeAuth?: boolean;
+  disableKServeMetrics?: boolean;
   disableModelMesh?: boolean;
   disableAcceleratorProfiles?: boolean;
   disablePerformanceMetrics?: boolean;
@@ -42,6 +43,7 @@ export const mockDashboardConfig = ({
   disablePipelines = false,
   disableKServe = false,
   disableKServeAuth = false,
+  disableKServeMetrics = true,
   disableModelMesh = false,
   disableAcceleratorProfiles = false,
   disablePerformanceMetrics = false,
@@ -81,6 +83,7 @@ export const mockDashboardConfig = ({
       disablePerformanceMetrics,
       disableKServe,
       disableKServeAuth,
+      disableKServeMetrics,
       disableModelMesh,
       disableAcceleratorProfiles,
       disablePipelineExperiments,

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -61,6 +61,10 @@ class ModelServingGlobal {
     return this.findModelsTable().find(`[data-label=Name]`).contains(name).parents('tr');
   }
 
+  getModelMetricLink(name: string) {
+    return this.findModelsTable().findByTestId(`metrics-link-${name}`);
+  }
+
   findEmptyResults() {
     return cy.findByTestId('no-result-found-title');
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -221,6 +221,14 @@ class ProjectDetails {
   findUnsupportedPipelineVersionAlert() {
     return cy.findByTestId('unsupported-pipeline-version-alert');
   }
+
+  private findKserveModelsTable() {
+    return cy.findByTestId('kserve-inference-service-table');
+  }
+
+  getKserveModelMetricLink(name: string) {
+    return this.findKserveModelsTable().findByTestId(`metrics-link-${name}`);
+  }
 }
 
 class ProjectDetailsSettingsTab extends ProjectDetails {

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -37,6 +37,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.K_SERVE],
     requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
   },
+  [SupportedArea.K_SERVE_METRICS]: {
+    featureFlags: ['disableKServeMetrics'],
+    reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
+  },
   [SupportedArea.MODEL_MESH]: {
     featureFlags: ['disableModelMesh'],
     requiredComponents: [StackComponent.MODEL_MESH],
@@ -59,7 +63,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.PERFORMANCE_METRICS]: {
     featureFlags: ['disablePerformanceMetrics'],
-    requiredComponents: [StackComponent.MODEL_MESH], // TODO: remove when KServe support is added
     reliantAreas: [SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.TRUSTY_AI]: {

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -45,6 +45,7 @@ export enum SupportedArea {
   CUSTOM_RUNTIMES = 'custom-serving-runtimes',
   K_SERVE = 'kserve',
   K_SERVE_AUTH = 'kserve-auth',
+  K_SERVE_METRICS = 'kserve-metrics',
   MODEL_MESH = 'model-mesh',
   BIAS_METRICS = 'bias-metrics',
   PERFORMANCE_METRICS = 'performance-metrics',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1211,6 +1211,7 @@ export type DashboardCommonConfig = {
   disablePerformanceMetrics: boolean;
   disableKServe: boolean;
   disableKServeAuth: boolean;
+  disableKServeMetrics: boolean;
   disableModelMesh: boolean;
   disableAcceleratorProfiles: boolean;
   // TODO Temp feature flag - remove with https://issues.redhat.com/browse/RHOAIENG-3826

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -6,6 +6,8 @@ import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import useModelMetricsEnabled from '~/pages/modelServing/useModelMetricsEnabled';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { isModelMesh } from '~/pages/modelServing/utils';
+import { SupportedArea } from '~/concepts/areas';
+import useIsAreaAvailable from '~/concepts/areas/useIsAreaAvailable';
 import { getInferenceServiceDisplayName } from './utils';
 import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
@@ -31,28 +33,42 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
   showServingRuntime,
 }) => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
+  const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
 
-  const modelMetricsSupported = (modelMetricsInferenceService: InferenceServiceKind) =>
-    modelMetricsEnabled &&
-    modelMetricsInferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode'] ===
-      'ModelMesh';
+  const modelMesh = isModelMesh(inferenceService);
+  const modelMeshMetricsSupported = modelMetricsEnabled && modelMesh;
+  const kserveMetricsSupported = modelMetricsEnabled && kserveMetricsEnabled && !modelMesh;
+
+  const displayName = getInferenceServiceDisplayName(inferenceService);
 
   return (
     <>
       <Td dataLabel="Name">
         <ResourceNameTooltip resource={inferenceService}>
-          {modelMetricsSupported(inferenceService) ? (
+          {modelMeshMetricsSupported ? (
             <Link
+              data-testid={`metrics-link-${displayName}`}
               to={
                 isGlobal
                   ? `/modelServing/${inferenceService.metadata.namespace}/metrics/${inferenceService.metadata.name}`
                   : `/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`
               }
             >
-              {getInferenceServiceDisplayName(inferenceService)}
+              {displayName}
+            </Link>
+          ) : kserveMetricsSupported ? (
+            <Link
+              data-testid={`metrics-link-${displayName}`}
+              to={
+                isGlobal
+                  ? `/modelServing/${inferenceService.metadata.namespace}/metrics/${inferenceService.metadata.name}`
+                  : `/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`
+              }
+            >
+              {displayName}
             </Link>
           ) : (
-            getInferenceServiceDisplayName(inferenceService)
+            displayName
           )}
         </ResourceNameTooltip>
       </Td>
@@ -70,20 +86,17 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
         <InferenceServiceEndpoint
           inferenceService={inferenceService}
           servingRuntime={servingRuntime}
-          isKserve={!isModelMesh(inferenceService)}
+          isKserve={!modelMesh}
         />
       </Td>
       <Td dataLabel="API protocol">
         <InferenceServiceAPIProtocol
           servingRuntime={servingRuntime}
-          isMultiModel={modelMetricsSupported(inferenceService)}
+          isMultiModel={modelMeshMetricsSupported}
         />
       </Td>
       <Td dataLabel="Status">
-        <InferenceServiceStatus
-          inferenceService={inferenceService}
-          isKserve={!isModelMesh(inferenceService)}
-        />
+        <InferenceServiceStatus inferenceService={inferenceService} isKserve={!modelMesh} />
       </Td>
       <Td isActionCell>
         <ResourceActionsColumn

--- a/frontend/src/pages/modelServing/screens/metrics/GlobalModelMetricsPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/GlobalModelMetricsPage.tsx
@@ -18,6 +18,7 @@ const GlobalModelMetricsPage: React.FC = () => {
           isActive: true,
         },
       ]}
+      model={model}
       type={PerformanceMetricType.MODEL}
     />
   );

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPage.tsx
@@ -9,15 +9,17 @@ import { MetricsTabKeys } from '~/pages/modelServing/screens/metrics/types';
 import { PerformanceMetricType } from '~/pages/modelServing/screens/types';
 import { TrustyAIContext } from '~/concepts/trustyai/context/TrustyAIContext';
 import ServerMetricsPage from '~/pages/modelServing/screens/metrics/performance/ServerMetricsPage';
+import { InferenceServiceKind } from '~/k8sTypes';
 import { getBreadcrumbItemComponents } from './utils';
 
 type MetricsPageProps = {
   title: string;
   breadcrumbItems: BreadcrumbItemType[];
   type: PerformanceMetricType;
+  model?: InferenceServiceKind;
 };
 
-const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems, type }) => {
+const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems, type, model }) => {
   const { tab } = useParams();
   const navigate = useNavigate();
 
@@ -46,7 +48,11 @@ const MetricsPage: React.FC<MetricsPageProps> = ({ title, breadcrumbItems, type 
         )
       }
     >
-      {type === PerformanceMetricType.SERVER ? <ServerMetricsPage /> : <MetricsPageTabs />}
+      {type === PerformanceMetricType.SERVER ? (
+        <ServerMetricsPage />
+      ) : model ? (
+        <MetricsPageTabs model={model} />
+      ) : null}
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsPageTabs.tsx
@@ -6,6 +6,7 @@ import { useModelBiasData } from '~/concepts/trustyai/context/useModelBiasData';
 import NotFound from '~/pages/NotFound';
 import useDoesTrustyAICRExist from '~/concepts/trustyai/context/useDoesTrustyAICRExist';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { InferenceServiceKind } from '~/k8sTypes';
 import PerformanceTab from './performance/PerformanceTab';
 import BiasTab from './bias/BiasTab';
 import BiasConfigurationAlertPopover from './bias/BiasConfigurationPage/BiasConfigurationAlertPopover';
@@ -13,7 +14,11 @@ import useMetricsPageEnabledTabs from './useMetricsPageEnabledTabs';
 
 import './MetricsPageTabs.scss';
 
-const MetricsPageTabs: React.FC = () => {
+type MetricsPageTabsProps = {
+  model: InferenceServiceKind;
+};
+
+const MetricsPageTabs: React.FC<MetricsPageTabsProps> = ({ model }) => {
   const enabledTabs = useMetricsPageEnabledTabs();
   const { biasMetricConfigs, loaded } = useModelBiasData();
   const [biasMetricsInstalled] = useDoesTrustyAICRExist();
@@ -33,6 +38,10 @@ const MetricsPageTabs: React.FC = () => {
 
   if (enabledTabs.length === 0) {
     return <NotFound />;
+  }
+
+  if (enabledTabs.length === 1) {
+    return performanceMetricsAreaAvailable ? <PerformanceTab model={model} /> : <BiasTab />;
   }
 
   return (
@@ -57,7 +66,7 @@ const MetricsPageTabs: React.FC = () => {
           className="odh-metrics-page-tabs__content"
           data-testid="performance-tab"
         >
-          <PerformanceTab />
+          <PerformanceTab model={model} />
         </Tab>
       )}
       {biasMetricsInstalled && (

--- a/frontend/src/pages/modelServing/screens/metrics/performance/PerformanceTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/performance/PerformanceTab.tsx
@@ -1,23 +1,57 @@
-import React, { ReactElement } from 'react';
-import { PageSection, Stack, StackItem } from '@patternfly/react-core';
-import ModelGraphs from '~/pages/modelServing/screens/metrics/performance/ModelGraphs';
+import React from 'react';
+import {
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  PageSection,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { PendingIcon } from '@patternfly/react-icons';
+import { InferenceServiceKind } from '~/k8sTypes';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import MetricsPageToolbar from '~/concepts/metrics/MetricsPageToolbar';
+import { isModelMesh } from '~/pages/modelServing/utils';
+import ModelGraphs from '~/pages/modelServing/screens/metrics/performance/ModelGraphs';
 import { ModelMetricType } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import EnsureMetricsAvailable from '~/pages/modelServing/screens/metrics/EnsureMetricsAvailable';
 
-const PerformanceTab = (): ReactElement => (
-  <EnsureMetricsAvailable
-    metrics={[ModelMetricType.REQUEST_COUNT_SUCCESS, ModelMetricType.REQUEST_COUNT_FAILED]}
-    accessDomain="model metrics"
-  >
-    <Stack data-testid="performance-metrics-loaded">
-      <StackItem>
-        <MetricsPageToolbar />
-      </StackItem>
-      <PageSection isFilled>
-        <ModelGraphs />
-      </PageSection>
-    </Stack>
-  </EnsureMetricsAvailable>
-);
+type PerformanceTabsProps = {
+  model: InferenceServiceKind;
+};
+
+const PerformanceTab: React.FC<PerformanceTabsProps> = ({ model }) => {
+  const kserve = !isModelMesh(model);
+  const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
+
+  if (kserve && kserveMetricsEnabled) {
+    return (
+      <EmptyState variant="full" data-testid="kserve-metrics-page">
+        <EmptyStateHeader
+          titleText="Single-model serving platform model metrics coming soon."
+          headingLevel="h4"
+          icon={<EmptyStateIcon icon={PendingIcon} />}
+          alt=""
+        />
+      </EmptyState>
+    );
+  }
+
+  return (
+    <EnsureMetricsAvailable
+      metrics={[ModelMetricType.REQUEST_COUNT_SUCCESS, ModelMetricType.REQUEST_COUNT_FAILED]}
+      accessDomain="model metrics"
+    >
+      <Stack data-testid="performance-metrics-loaded">
+        <StackItem>
+          <MetricsPageToolbar />
+        </StackItem>
+        <PageSection isFilled>
+          <ModelGraphs />
+        </PageSection>
+      </Stack>
+    </EnsureMetricsAvailable>
+  );
+};
+
 export default PerformanceTab;

--- a/frontend/src/pages/modelServing/screens/projects/ProjectModelMetricsPage.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectModelMetricsPage.tsx
@@ -26,6 +26,7 @@ const ProjectModelMetricsPage: React.FC = () => {
         },
       ]}
       type={PerformanceMetricType.MODEL}
+      model={model}
     />
   );
 };

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
@@ -23,6 +23,7 @@ import useModelMetricsEnabled from '~/pages/modelServing/useModelMetricsEnabled'
 import InferenceServiceServingRuntime from '~/pages/modelServing/screens/global/InferenceServiceServingRuntime';
 import InferenceServiceEndpoint from '~/pages/modelServing/screens/global/InferenceServiceEndpoint';
 import TypeBorderedCard from '~/concepts/design/TypeBorderedCard';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas/';
 
 interface DeployedModelCardProps {
   inferenceService: InferenceServiceKind;
@@ -33,10 +34,11 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
   servingRuntime,
 }) => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
+  const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
+  const modelMesh = isModelMesh(inferenceService);
 
-  const modelMetricsSupported =
-    modelMetricsEnabled &&
-    inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode'] === 'ModelMesh';
+  const modelMetricsSupported = modelMetricsEnabled && (modelMesh || kserveMetricsEnabled);
+
   const inferenceServiceDisplayName = getInferenceServiceDisplayName(inferenceService);
 
   return (

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -61,6 +61,8 @@ spec:
                       type: boolean
                     disableKServeAuth:
                       type: boolean
+                    disableKServeMetrics:
+                      type: boolean
                     disableModelMesh:
                       type: boolean
                     disableAcceleratorProfiles:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -25,6 +25,7 @@ spec:
     disableAcceleratorProfiles: true
     disableKServe: false
     disableKServeAuth: false
+    disableKServeMetrics: true
     disableModelMesh: false
     disableDistributedWorkloads: false
   notebookController:

--- a/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
@@ -24,6 +24,7 @@ spec:
     disableAcceleratorProfiles: false
     disableKServe: false
     disableKServeAuth: false
+    disableKServeMetrics: true
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: true


### PR DESCRIPTION
Closes: [RHOAIENG-6985](https://issues.redhat.com/browse/RHOAIENG-6985)

## Description
Initial creation fo the kserve metric feature, disabled by default. Includes a simple `Coming soon` page.

## How Has This Been Tested?
Tested locally and added e2e tests

## Test Impact
Verify that the user can navigate to the kserve metrics page from the model list view by clicking on the model name ONLY if the feature flag is enabled.

## Screen shots
![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/3f53beea-6bc1-4214-ac91-25505eaef1c6)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/b7fc7961-7009-4f62-8936-17c1ca9626e3)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/91210a43-d6ed-4a09-9c82-f3ecccf05524)

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
