### PR TITLE
Render pipeline topology correctly, add missing nodes

### DIFF
--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -175,14 +175,16 @@ export type InputOutputArtifactType = {
 };
 
 export type InputOutputDefinition = {
-  artifacts?: Record<
-    string,
-    {
-      artifactType: InputOutputArtifactType;
-    }
-  >;
+  artifacts?: InputOutputDefinitionArtifacts;
   parameters?: ParametersKF;
 };
+
+export type InputOutputDefinitionArtifacts = Record<
+  string,
+  {
+    artifactType: InputOutputArtifactType;
+  }
+>;
 
 type GroupNodeComponent = {
   dag: DAG;
@@ -234,17 +236,22 @@ export type TaskKF = {
   inputs?: {
     artifacts?: Record<
       string,
-      {
-        taskOutputArtifact?: {
-          /** Artifact node name */
-          outputArtifactKey: string;
-          /**
-           * The task string for runAfter
-           * @see DAG.tasks
-           */
-          producerTask: string;
-        };
-      }
+      EitherNotBoth<
+        {
+          taskOutputArtifact?: {
+            /** Artifact node name */
+            outputArtifactKey: string;
+            /**
+             * The task string for runAfter
+             * @see DAG.tasks
+             */
+            producerTask: string;
+          };
+        },
+        {
+          componentInputArtifact: string;
+        }
+      >
     >;
     parameters?: Record<
       string,
@@ -326,9 +333,7 @@ export type PipelineSpec = {
   };
   root: {
     dag: DAG;
-    inputDefinitions?: {
-      parameters: ParametersKF;
-    };
+    inputDefinitions?: InputOutputDefinition;
   };
   schemaVersion: string;
   sdkVersion: string;

--- a/frontend/src/concepts/pipelines/topology/__tests__/usePipelineTaskTopology.spec.ts
+++ b/frontend/src/concepts/pipelines/topology/__tests__/usePipelineTaskTopology.spec.ts
@@ -6,6 +6,9 @@ import { ICON_TASK_NODE_TYPE } from '~/concepts/topology/utils';
 import { EXECUTION_TASK_NODE_TYPE } from '~/concepts/topology/const';
 
 describe('usePipelineTaskTopology', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+  });
   it('returns the correct number of nodes', () => {
     const renderResult = testHook(usePipelineTaskTopology)(mockLargePipelineSpec);
     const nodes = renderResult.result.current;
@@ -14,9 +17,9 @@ describe('usePipelineTaskTopology', () => {
     const groups = nodes.filter((n) => n.type === EXECUTION_TASK_NODE_TYPE);
     const artifactNodes = nodes.filter((n) => n.type === ICON_TASK_NODE_TYPE);
 
-    expect(nodes).toHaveLength(86);
+    expect(nodes).toHaveLength(107);
     expect(tasks).toHaveLength(35);
     expect(groups).toHaveLength(5);
-    expect(artifactNodes).toHaveLength(46);
+    expect(artifactNodes).toHaveLength(67);
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Resolves:
[RHOAIENG-6319](https://issues.redhat.com/browse/RHOAIENG-6319)
[RHOAIENG-6572](https://issues.redhat.com/browse/RHOAIENG-6572)
[RHOAIENG-6671](https://issues.redhat.com/browse/RHOAIENG-6671)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR is resolving several issues when rendering the pipeline topology. Now it can find all the edges and nodes correctly. More details will be explained in the comments below.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compare the topology with the KF UI to see if it renders the same, and make sure there are no missing nodes and edges for any pipelines.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated some jest test cases.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
