### PR TITLE
Merge smarter jupyter values

### DIFF
--- a/backend/src/__tests__/objUtils.spec.ts
+++ b/backend/src/__tests__/objUtils.spec.ts
@@ -1,0 +1,69 @@
+import { smartMergeArraysWithNameObjects } from '../utils/objUtils';
+
+describe('objUtils', () => {
+  describe('smartMergeArraysWithNameObjects', () => {
+    /** we only use the first two params of the customization utility, so ignore the last 3 */
+    const smartMergeArraysWithNameObjectsWithUsedParams = (v1: any, v2: any) =>
+      smartMergeArraysWithNameObjects(v1, v2, undefined, undefined, undefined);
+
+    it('should do nothing with nulls', () => {
+      expect(smartMergeArraysWithNameObjectsWithUsedParams(null, null)).toBe(undefined);
+    });
+
+    it('should do nothing with objects', () => {
+      expect(
+        smartMergeArraysWithNameObjectsWithUsedParams({ a: true }, { a: false, b: true }),
+      ).toBe(undefined);
+    });
+
+    it('should do nothing with string[]', () => {
+      expect(smartMergeArraysWithNameObjectsWithUsedParams(['test'], ['test2'])).toBe(undefined);
+    });
+
+    it('should do nothing with invalid object arrays', () => {
+      expect(
+        smartMergeArraysWithNameObjectsWithUsedParams([{ id: 'test' }], [{ id: 'test2' }]),
+      ).toBe(undefined);
+    });
+
+    it('should replace 2nd object if given two same correct objects arrays', () => {
+      expect(
+        smartMergeArraysWithNameObjectsWithUsedParams(
+          [{ name: 'test', value: '1' }],
+          [{ name: 'test', value: '2' }],
+        ),
+      ).toEqual([{ name: 'test', value: '2' }]);
+    });
+
+    it('should add 2nd object if given two different correct object arrays', () => {
+      expect(
+        smartMergeArraysWithNameObjectsWithUsedParams(
+          [{ name: 'test', value: '1' }],
+          [{ name: 'test2', value: '2' }],
+        ),
+      ).toEqual([
+        { name: 'test', value: '1' },
+        { name: 'test2', value: '2' },
+      ]);
+    });
+
+    it('should replace and add as appropriate if given two correct object arrays', () => {
+      expect(
+        smartMergeArraysWithNameObjectsWithUsedParams(
+          [
+            { name: 'test', value: '1' },
+            { name: 'test3', value: '3' },
+          ],
+          [
+            { name: 'test', value: '1b' },
+            { name: 'test2', value: '2' },
+          ],
+        ),
+      ).toEqual([
+        { name: 'test', value: '1b' },
+        { name: 'test3', value: '3' },
+        { name: 'test2', value: '2' },
+      ]);
+    });
+  });
+});

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -739,7 +739,12 @@ export type DetectedAccelerators = {
 
 export type EnvironmentVariable = EitherNotBoth<
   { value: string | number },
-  { valueFrom: Record<string, unknown> }
+  {
+    valueFrom: Record<string, unknown> & {
+      configMapKeyRef?: { key: string; name: string };
+      secretKeyRef?: { key: string; name: string };
+    };
+  }
 > & {
   name: string;
 };

--- a/backend/src/utils/objUtils.ts
+++ b/backend/src/utils/objUtils.ts
@@ -1,0 +1,30 @@
+import { MergeWithCustomizer } from 'lodash';
+
+/**
+ * When given two object arrays that have "name" keys, replace when keys are the same, or add to
+ * the end when new key.
+ *
+ * Note: returns `undefined` if invalid data is provided.
+ *
+ * @see mergeWith -- lodash mergeWith customizer
+ */
+export const smartMergeArraysWithNameObjects: MergeWithCustomizer = (objValue, srcValue) => {
+  type GoodArray = { name: string }[];
+  const isGoodArray = (v: any): v is GoodArray => Array.isArray(v) && v.length > 0 && v[0].name;
+  if (isGoodArray(objValue) && isGoodArray(srcValue)) {
+    // Arrays with objects that have a .name property, sync on merge for the name
+    return srcValue.reduce<GoodArray>((newArray, elm) => {
+      const key = elm.name;
+      const index = newArray.findIndex(({ name }) => name === key);
+      if (index >= 0) {
+        // existing value, replace
+        newArray[index] = elm;
+      } else {
+        // didn't find existing name, add to end
+        newArray.push(elm);
+      }
+
+      return newArray;
+    }, objValue);
+  }
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-7070

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Improves the merging of env values provided as part of the Jupyter Tile.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Don't have a Jupyter Tile Notebook
    * delete Notebook, PVC, and configmap under your name
    * Find the namespace these are in by checking the OdhDashboardConfig -- if a notebookNamespace is set, go there, if not it's in the Dashboard's namespace
3. Create a Jupyter Tile Notebook
4. Stop the Notebook after it creates (this flow is not part of this fix)
5. Add an env var and start the Notebook again

It failed after the 2nd start (no4 above) with an error in the modal -- if it continues to deploy, the fix is successful.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Wrote tests for the customizer function used in lodash `mergeWith`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
