### PR TITLE
[RHOAIENG-7073] Fix for cancel on spawn a notebook server page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/e2e/applications/NotebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/e2e/applications/NotebookServer.cy.ts
@@ -7,6 +7,7 @@ import { mockStartNotebookData } from '~/__mocks__/mockStartNotebookData';
 import { notebookServer } from '~/__tests__/cypress/cypress/pages/notebookServer';
 import { asProductAdminUser, asProjectEditUser } from '~/__tests__/cypress/cypress/utils/users';
 import { notebookController } from '~/__tests__/cypress/cypress/pages/administration';
+import { homePage } from '~/__tests__/cypress/cypress/pages/home';
 
 const groupSubjects: RoleBindingSubject[] = [
   {
@@ -31,7 +32,7 @@ const initIntercepts = () => {
   cy.interceptOdh('GET /api/status/openshift-ai-notebooks/allowedUsers', mockAllowedUsers({}));
 };
 
-it('Administartion tab should not be accessible for non-project admins', () => {
+it('Administration tab should not be accessible for non-project admins', () => {
   initIntercepts();
   asProjectEditUser();
   notebookServer.visit();
@@ -92,5 +93,21 @@ describe('NotebookServer', () => {
     cy.wait('@stopNotebookServer').then((interception) => {
       expect(interception.request.body).to.eql({ state: 'stopped', username: 'test-user' });
     });
+  });
+
+  it('should return to the enabled page on cancel', () => {
+    homePage.initHomeIntercepts({ disableHome: false });
+    notebookServer.visit();
+    notebookServer.findCancelStartServerButton().should('be.visible');
+    notebookServer.findCancelStartServerButton().click();
+
+    cy.findByTestId('app-page-title').should('have.text', 'Enabled');
+
+    homePage.initHomeIntercepts({ disableHome: true });
+    notebookServer.visit();
+    notebookServer.findCancelStartServerButton().should('be.visible');
+    notebookServer.findCancelStartServerButton().click();
+
+    cy.findByTestId('app-page-title').should('have.text', 'Enabled');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
@@ -25,6 +25,10 @@ class NotebookServer {
     return cy.findByTestId('start-server-button');
   }
 
+  findCancelStartServerButton() {
+    return cy.findByTestId('cancel-start-server-button');
+  }
+
   findEventlog() {
     return cy.findByTestId('expand-logs').findByRole('button');
   }

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -40,6 +40,7 @@ import useNamespaces from '~/pages/notebookController/useNamespaces';
 import { fireTrackingEvent } from '~/utilities/segmentIOUtils';
 import { getEnvConfigMap, getEnvSecret } from '~/services/envService';
 import useNotebookAcceleratorProfile from '~/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfile';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import SizeSelectField from './SizeSelectField';
 import useSpawnerNotebookModalState from './useSpawnerNotebookModalState';
 import BrowserTabPreferenceCheckbox from './BrowserTabPreferenceCheckbox';
@@ -47,13 +48,14 @@ import EnvironmentVariablesRow from './EnvironmentVariablesRow';
 import ImageSelector from './ImageSelector';
 import { usePreferredNotebookSize } from './usePreferredNotebookSize';
 import StartServerModal from './StartServerModal';
+import AcceleratorProfileSelectField from './AcceleratorProfileSelectField';
 
 import '~/pages/notebookController/NotebookController.scss';
-import AcceleratorProfileSelectField from './AcceleratorProfileSelectField';
 
 const SpawnerPage: React.FC = () => {
   const navigate = useNavigate();
   const notification = useNotification();
+  const isHomeAvailable = useIsAreaAvailable(SupportedArea.HOME).status;
   const { images, loaded, loadError } = useWatchImages();
   const { buildStatuses } = useAppContext();
   const { currentUserNotebook, requestNotebookRefresh, impersonatedUsername, setImpersonating } =
@@ -358,12 +360,13 @@ const SpawnerPage: React.FC = () => {
               </Button>
               <Button
                 data-id="cancel-button"
+                data-testid="cancel-start-server-button"
                 variant="secondary"
                 onClick={() => {
                   if (impersonatedUsername) {
                     setImpersonating();
                   } else {
-                    navigate('/');
+                    navigate(isHomeAvailable ? '/enabled' : '/');
                   }
                 }}
               >


### PR DESCRIPTION
Closes: [RHOAIENG-7073](https://issues.redhat.com/browse/RHOAIENG-7073)

## Description
Cancel on the spawner page sends the user to `/` which, when the home page is enabled, is incorrect. It should send the user to '/enabled' when the home page is enabled.

## How Has This Been Tested?
Tested locally and added an e2e test.

## Test Impact
Should test cancel from the spawner page with and without the home page enabled.

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
