### PR TITLE
[RHOAIENG-2989] artifact node drawer details section

### DIFF
--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useArtifactsFromMlmdContext.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useArtifactsFromMlmdContext.ts
@@ -1,0 +1,32 @@
+import React from 'react';
+import { MlmdContext } from '~/concepts/pipelines/apiHooks/mlmd/types';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { Artifact } from '~/third_party/mlmd';
+import { GetArtifactsByContextRequest } from '~/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
+import useFetchState, {
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '~/utilities/useFetchState';
+
+export const useArtifactsFromMlmdContext = (
+  context: MlmdContext | null,
+  refreshRate?: number,
+): FetchState<Artifact[]> => {
+  const { metadataStoreServiceClient } = usePipelinesAPI();
+
+  const getArtifactsList = React.useCallback<FetchStateCallbackPromise<Artifact[]>>(async () => {
+    if (!context) {
+      return Promise.reject(new NotReadyError('No context'));
+    }
+
+    const request = new GetArtifactsByContextRequest();
+    request.setContextId(context.getId());
+    const res = await metadataStoreServiceClient.getArtifactsByContext(request);
+    return res.getArtifactsList();
+  }, [metadataStoreServiceClient, context]);
+
+  return useFetchState(getArtifactsList, [], {
+    refreshRate,
+  });
+};

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetArtifactsList.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetArtifactsList.ts
@@ -12,7 +12,7 @@ export interface ArtifactsListResponse {
 
 export const useGetArtifactsList = (
   refreshRate?: number,
-): FetchState<ArtifactsListResponse | null> => {
+): FetchState<ArtifactsListResponse | undefined> => {
   const { pageToken, maxResultSize, filterQuery } = useMlmdListContext();
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
@@ -39,7 +39,7 @@ export const useGetArtifactsList = (
     };
   }, [filterQuery, pageToken, maxResultSize, metadataStoreServiceClient]);
 
-  return useFetchState(fetchArtifactsList, null, {
+  return useFetchState(fetchArtifactsList, undefined, {
     refreshRate,
   });
 };

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetEventsByExecutionId.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetEventsByExecutionId.ts
@@ -8,25 +8,25 @@ import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilitie
 
 export const useGetEventsByExecutionId = (
   executionId?: string,
+): FetchState<GetEventsByExecutionIDsResponse | null> =>
+  useGetEventsByExecutionIds([Number(executionId)]);
+
+export const useGetEventsByExecutionIds = (
+  executionIds: number[],
 ): FetchState<GetEventsByExecutionIDsResponse | null> => {
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
   const call = React.useCallback<
     FetchStateCallbackPromise<GetEventsByExecutionIDsResponse | null>
   >(async () => {
-    const numberId = Number(executionId);
     const request = new GetEventsByExecutionIDsRequest();
 
-    if (!executionId || Number.isNaN(numberId)) {
-      return null;
-    }
-
-    request.setExecutionIdsList([numberId]);
+    request.setExecutionIdsList(executionIds);
 
     const response = await metadataStoreServiceClient.getEventsByExecutionIDs(request);
 
     return response;
-  }, [executionId, metadataStoreServiceClient]);
+  }, [executionIds, metadataStoreServiceClient]);
 
   return useFetchState(call, null);
 };

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent.tsx
@@ -12,16 +12,19 @@ import PipelineRunDrawerRightTabs from '~/concepts/pipelines/content/pipelinesDe
 import './PipelineRunDrawer.scss';
 import { PipelineTask } from '~/concepts/pipelines/topology';
 import { Execution } from '~/third_party/mlmd';
+import { ArtifactNodeDrawerContent } from './artifacts';
 
 type PipelineRunDrawerRightContentProps = {
   task?: PipelineTask;
   executions: Execution[];
+  upstreamTaskName?: string;
   onClose: () => void;
 };
 
 const PipelineRunDrawerRightContent: React.FC<PipelineRunDrawerRightContentProps> = ({
   task,
   executions,
+  upstreamTaskName,
   onClose,
 }) => {
   if (!task) {
@@ -35,18 +38,28 @@ const PipelineRunDrawerRightContent: React.FC<PipelineRunDrawerRightContentProps
       minSize="500px"
       data-testid="pipeline-run-drawer-right-content"
     >
-      <DrawerHead>
-        <Title headingLevel="h2" size="xl">
-          {task.name} {task.type === 'artifact' ? 'Artifact details' : ''}
-        </Title>
-        {task.status?.podName && <Text component="small">{task.status.podName}</Text>}
-        <DrawerActions>
-          <DrawerCloseButton onClick={onClose} />
-        </DrawerActions>
-      </DrawerHead>
-      <DrawerPanelBody className="pipeline-run__drawer-panel-body pf-v5-u-pr-sm">
-        <PipelineRunDrawerRightTabs task={task} executions={executions} />
-      </DrawerPanelBody>
+      {task.type === 'artifact' ? (
+        <ArtifactNodeDrawerContent
+          upstreamTaskName={upstreamTaskName}
+          task={task}
+          onClose={onClose}
+        />
+      ) : (
+        <>
+          <DrawerHead>
+            <Title headingLevel="h2" size="xl">
+              {task.name}
+            </Title>
+            {task.status?.podName && <Text component="small">{task.status.podName}</Text>}
+            <DrawerActions>
+              <DrawerCloseButton onClick={onClose} />
+            </DrawerActions>
+          </DrawerHead>
+          <DrawerPanelBody className="pipeline-run__drawer-panel-body pf-v5-u-pr-sm">
+            <PipelineRunDrawerRightTabs task={task} executions={executions} />
+          </DrawerPanelBody>
+        </>
+      )}
     </DrawerPanelContent>
   );
 };

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import {
+  Title,
+  Flex,
+  FlexItem,
+  Stack,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
+
+import { Artifact } from '~/third_party/mlmd';
+import { artifactsDetailsRoute } from '~/routes';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { getArtifactName } from '~/pages/pipelines/global/experiments/artifacts/utils';
+import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
+import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
+
+type ArtifactNodeDetailsProps = Pick<
+  React.ComponentProps<typeof PipelineRunDrawerRightContent>,
+  'upstreamTaskName'
+> & {
+  artifact: Artifact.AsObject;
+};
+
+export const ArtifactNodeDetails: React.FC<ArtifactNodeDetailsProps> = ({
+  artifact,
+  upstreamTaskName,
+}) => {
+  const { namespace } = usePipelinesAPI();
+  const artifactName = getArtifactName(artifact);
+
+  return (
+    <Flex
+      spaceItems={{ default: 'spaceItems2xl' }}
+      direction={{ default: 'column' }}
+      className="pf-v5-u-pt-lg pf-v5-u-pb-lg"
+    >
+      <FlexItem>
+        <Stack hasGutter>
+          <Title headingLevel="h3">Artifact details</Title>
+          <DescriptionList
+            isHorizontal
+            horizontalTermWidthModifier={{ default: '15ch' }}
+            data-testid="artifact-details-description-list"
+          >
+            <DescriptionListGroup>
+              <DescriptionListTerm>Upstream task</DescriptionListTerm>
+              <DescriptionListDescription>{upstreamTaskName}</DescriptionListDescription>
+
+              <DescriptionListTerm>Artifact name</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Link to={artifactsDetailsRoute(namespace, artifact.id)}>{artifactName}</Link>
+              </DescriptionListDescription>
+
+              <DescriptionListTerm>Artifact type</DescriptionListTerm>
+              <DescriptionListDescription>{artifact.type}</DescriptionListDescription>
+
+              <DescriptionListTerm>Created at</DescriptionListTerm>
+              <DescriptionListDescription>
+                <PipelinesTableRowTime date={new Date(artifact.createTimeSinceEpoch)} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </Stack>
+      </FlexItem>
+
+      <FlexItem>
+        <Stack hasGutter>
+          <Title headingLevel="h3">Artifact URI</Title>
+          <DescriptionList
+            isHorizontal
+            horizontalTermWidthModifier={{ default: '15ch' }}
+            data-testid="artifact-uri-description-list"
+          >
+            <DescriptionListGroup>
+              <DescriptionListTerm>{artifactName}</DescriptionListTerm>
+              <DescriptionListDescription>{artifact.uri}</DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </Stack>
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import {
+  DrawerHead,
+  Title,
+  Text,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerPanelBody,
+  Tabs,
+  Tab,
+  TabTitleText,
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+
+import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
+import { ArtifactNodeDetails } from './ArtifactNodeDetails';
+
+type ArtifactNodeDrawerContentProps = Omit<
+  React.ComponentProps<typeof PipelineRunDrawerRightContent>,
+  'executions'
+>;
+
+enum ArtifactNodeDrawerTab {
+  Details = 'details',
+  Visualization = 'visualization',
+}
+
+export const ArtifactNodeDrawerContent: React.FC<ArtifactNodeDrawerContentProps> = ({
+  task,
+  upstreamTaskName,
+  onClose,
+}) => {
+  const [activeTab, setActiveTab] = React.useState<string | number>(ArtifactNodeDrawerTab.Details);
+  const artifact = task?.metadata?.toObject();
+
+  return task ? (
+    <>
+      <DrawerHead>
+        <Title headingLevel="h2" size="xl">
+          {task.name}
+        </Title>
+        {task.status?.podName && <Text component="small">{task.status.podName}</Text>}
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody className="pipeline-run__drawer-panel-body pf-v5-u-pr-sm">
+        {artifact ? (
+          <Tabs
+            aria-label="Artifact node detail tabs"
+            activeKey={activeTab}
+            onSelect={(_, tabName: string | number) => setActiveTab(tabName)}
+          >
+            <Tab
+              eventKey={ArtifactNodeDrawerTab.Details}
+              title={<TabTitleText>Artifact details</TabTitleText>}
+              aria-label="Overview"
+            >
+              <ArtifactNodeDetails artifact={artifact} upstreamTaskName={upstreamTaskName} />
+            </Tab>
+            <Tab
+              eventKey={ArtifactNodeDrawerTab.Visualization}
+              title={<TabTitleText>Visualization</TabTitleText>}
+              aria-label="Visualization"
+            />
+          </Tabs>
+        ) : (
+          <EmptyState variant={EmptyStateVariant.xs}>
+            <EmptyStateHeader titleText="Content is not available yet." headingLevel="h4" />
+          </EmptyState>
+        )}
+      </DrawerPanelBody>
+    </>
+  ) : null;
+};

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/index.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/index.ts
@@ -1,0 +1,3 @@
+export * from './ArtifactNodeDetails';
+export * from './ArtifactNodeDrawerContent';
+export * from './usePipelineRunArtifacts';

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/usePipelineRunArtifacts.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/usePipelineRunArtifacts.tsx
@@ -1,0 +1,17 @@
+import { useArtifactsFromMlmdContext } from '~/concepts/pipelines/apiHooks/mlmd/useArtifactsFromMlmdContext';
+import { usePipelineRunMlmdContext } from '~/concepts/pipelines/apiHooks/mlmd/usePipelineRunMlmdContext';
+import { isPipelineRunFinished } from '~/concepts/pipelines/apiHooks/usePipelineRunById';
+import { PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import { Artifact } from '~/third_party/mlmd';
+import { FAST_POLL_INTERVAL } from '~/utilities/const';
+
+export const usePipelineRunArtifacts = (
+  run: PipelineRunKFv2 | null,
+): [artifacts: Artifact[], loaded: boolean, error?: Error] => {
+  const isFinished = isPipelineRunFinished(run);
+  const refreshRate = isFinished ? 0 : FAST_POLL_INTERVAL;
+  const [context, , contextError] = usePipelineRunMlmdContext(run?.run_id, refreshRate);
+  const [artifacts, artifactsLoaded] = useArtifactsFromMlmdContext(context, refreshRate);
+
+  return [artifacts, artifactsLoaded, contextError];
+};

--- a/frontend/src/concepts/pipelines/topology/pipelineTaskTypes.ts
+++ b/frontend/src/concepts/pipelines/topology/pipelineTaskTypes.ts
@@ -5,6 +5,7 @@ import {
   InputDefinitionParameterType,
   RuntimeStateKF,
 } from '~/concepts/pipelines/kfTypes';
+import { Artifact } from '~/third_party/mlmd';
 import { VolumeMount } from '~/types';
 
 export type PipelineTaskParam = {
@@ -46,6 +47,7 @@ export type PipelineTask = {
   steps?: PipelineTaskStep[];
   inputs?: PipelineTaskInputOutput;
   outputs?: PipelineTaskInputOutput;
+  metadata?: Artifact | undefined;
   /** Run Status */
   status?: PipelineTaskRunStatus;
   /** Volume Mounts */


### PR DESCRIPTION
Starts: [RHOAIENG-2989](https://issues.redhat.com/browse/RHOAIENG-2989)

## Description
Fetches the artifact context for the run, now displaying those MLMD artifact details. Virtualization will be a follow-up PR.

<img width="1007" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/4bf3635a-169e-4261-bf73-e0920a8c9184">

<img width="1007" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/207c361d-c169-4548-89fd-e61243517e9d">
(cc yannnz)

## Test Impact
Will include tests in follow-up PR if applicable.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
