### PR TITLE
Add backend routes and frontend service for admin CRUD of ModelRegistries

### DIFF
--- a/backend/src/routes/api/modelRegistries/index.ts
+++ b/backend/src/routes/api/modelRegistries/index.ts
@@ -1,0 +1,180 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { PatchUtils } from '@kubernetes/client-node';
+import { secureAdminRoute } from '../../../utils/route-security';
+import { KubeFastifyInstance, ModelRegistryKind, RecursivePartial } from '../../../types';
+import { MODEL_REGISTRY_NAMESPACE } from '../../../utils/constants';
+
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.get(
+    '/',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{ Querystring: { labelSelector: string } }>,
+        reply: FastifyReply,
+      ) => {
+        const { labelSelector } = request.query;
+        try {
+          const response = await fastify.kube.customObjectsApi.listNamespacedCustomObject(
+            'modelregistry.opendatahub.io',
+            'v1alpha1',
+            MODEL_REGISTRY_NAMESPACE,
+            'modelregistries',
+            undefined,
+            undefined,
+            undefined,
+            labelSelector,
+          );
+          return response.body;
+        } catch (e) {
+          fastify.log.error(
+            `ModelRegistries could not be listed, ${e.response?.body?.message || e.message}`,
+          );
+          reply.send(e);
+        }
+      },
+    ),
+  );
+
+  fastify.post(
+    '/',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Querystring: { dryRun?: string };
+          Body: ModelRegistryKind;
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const { dryRun } = request.query;
+        const modelRegistry = request.body;
+        try {
+          const response = await fastify.kube.customObjectsApi.createNamespacedCustomObject(
+            'modelregistry.opendatahub.io',
+            'v1alpha1',
+            MODEL_REGISTRY_NAMESPACE,
+            'modelregistries',
+            request.body,
+            undefined,
+            dryRun,
+          );
+          return response.body;
+        } catch (e) {
+          fastify.log.error(
+            `ModelRegistry ${modelRegistry.metadata.name} could not be created, ${
+              e.response?.body?.message || e.message
+            }`,
+          );
+          reply.send(e);
+        }
+      },
+    ),
+  );
+
+  fastify.get(
+    '/:modelRegistryName',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{ Params: { modelRegistryName: string } }>,
+        reply: FastifyReply,
+      ) => {
+        const { modelRegistryName } = request.params;
+        try {
+          const response = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
+            'modelregistry.opendatahub.io',
+            'v1alpha1',
+            MODEL_REGISTRY_NAMESPACE,
+            'modelregistries',
+            modelRegistryName,
+          );
+          return response.body;
+        } catch (e) {
+          fastify.log.error(
+            `ModelRegistry ${modelRegistryName} could not be read, ${
+              e.response?.body?.message || e.message
+            }`,
+          );
+          reply.send(e);
+        }
+      },
+    ),
+  );
+
+  fastify.patch(
+    '/:modelRegistryName',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Querystring: { dryRun?: string };
+          Params: { modelRegistryName: string };
+          Body: RecursivePartial<ModelRegistryKind>;
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const options = {
+          headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_PATCH },
+        };
+        const { dryRun } = request.query;
+        const { modelRegistryName } = request.params;
+        try {
+          const response = await fastify.kube.customObjectsApi.patchNamespacedCustomObject(
+            'modelregistry.opendatahub.io',
+            'v1alpha1',
+            MODEL_REGISTRY_NAMESPACE,
+            'modelregistries',
+            modelRegistryName,
+            request.body,
+            dryRun,
+            undefined,
+            undefined,
+            options,
+          );
+          return response.body;
+        } catch (e) {
+          fastify.log.error(
+            `ModelRegistry ${modelRegistryName} could not be modified, ${
+              e.response?.body?.message || e.message
+            }`,
+          );
+          reply.send(e);
+        }
+      },
+    ),
+  );
+
+  fastify.delete(
+    '/:modelRegistryName',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Querystring: { dryRun?: string };
+          Params: { modelRegistryName: string };
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const { dryRun } = request.query;
+        const { modelRegistryName } = request.params;
+        try {
+          const response = await fastify.kube.customObjectsApi.deleteNamespacedCustomObject(
+            'modelregistry.opendatahub.io',
+            'v1alpha1',
+            MODEL_REGISTRY_NAMESPACE,
+            'modelregistries',
+            modelRegistryName,
+            undefined,
+            undefined,
+            undefined,
+            dryRun,
+          );
+          return response.body;
+        } catch (e) {
+          fastify.log.error(
+            `ModelRegistry ${modelRegistryName} could not be deleted, ${
+              e.response?.body?.message || e.message
+            }`,
+          );
+          reply.send(e);
+        }
+      },
+    ),
+  );
+};

--- a/backend/src/routes/api/service/modelregistry/index.ts
+++ b/backend/src/routes/api/service/modelregistry/index.ts
@@ -1,6 +1,6 @@
 import httpProxy from '@fastify/http-proxy';
 import { KubeFastifyInstance } from '../../../../types';
-import { DEV_MODE } from '../../../../utils/constants';
+import { DEV_MODE, MODEL_REGISTRY_NAMESPACE } from '../../../../utils/constants';
 import { getParam, setParam } from '../../../../utils/proxy';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
@@ -20,7 +20,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
           // kubectl port-forward -n <namespace> svc/<service-name> <local.port>:<service.port>
           `http://${process.env.MODEL_REGISTRY_SERVICE_HOST}:${process.env.MODEL_REGISTRY_SERVICE_PORT}`
         : // Construct service URL
-          `http://${name}.odh-model-registries.svc.cluster.local:8080`;
+          `http://${name}.${MODEL_REGISTRY_NAMESPACE}.svc.cluster.local:8080`;
 
       // assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
       setParam(request, 'upstream', upstream);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1029,6 +1029,36 @@ export type TrustyAIKind = K8sResourceCommon & {
 };
 
 export type ModelRegistryKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  spec: {
+    grpc: {
+      port: number;
+    };
+    rest: {
+      port: number;
+      serviceRoute: string;
+    };
+    mysql?: {
+      database: string;
+      host: string;
+      port?: number;
+    };
+    postgres: {
+      database: string;
+      host?: string;
+      passwordSecret?: {
+        key: string;
+        name: string;
+      };
+      port: number;
+      skipDBCreation?: boolean;
+      sslMode?: string;
+      username?: string;
+    };
+  };
   status?: {
     conditions?: K8sCondition[];
   };

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -141,3 +141,5 @@ export const THANOS_RBAC_PORT = '9092';
 export const THANOS_INSTANCE_NAME = 'thanos-querier';
 export const THANOS_NAMESPACE = 'openshift-monitoring';
 export const LABEL_SELECTOR_DASHBOARD_RESOURCE = `${KnownLabels.DASHBOARD_RESOURCE}=true`;
+
+export const MODEL_REGISTRY_NAMESPACE = 'odh-model-registries';

--- a/frontend/src/services/modelRegistryService.ts
+++ b/frontend/src/services/modelRegistryService.ts
@@ -1,0 +1,60 @@
+import axios from 'axios';
+import { ModelRegistryKind } from '~/k8sTypes';
+import { RecursivePartial } from '~/typeHelpers';
+
+export const listModelRegistriesBackend = (
+  labelSelector?: string,
+): Promise<ModelRegistryKind[]> => {
+  const url = '/api/modelRegistries';
+  return axios
+    .get(url, { params: { labelSelector } })
+    .then((response) => response.data.items)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};
+
+export const createModelRegistryBackend = (data: ModelRegistryKind): Promise<ModelRegistryKind> => {
+  const url = '/api/modelRegistries';
+  return axios
+    .post(url, data)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};
+
+export const getModelRegistryBackend = (modelRegistryName: string): Promise<ModelRegistryKind> => {
+  const url = `/api/modelRegistries/${modelRegistryName}`;
+  return axios
+    .get(url)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};
+
+export const updateModelRegistryBackend = (
+  modelRegistryName: string,
+  patch: RecursivePartial<ModelRegistryKind>,
+): Promise<ModelRegistryKind> => {
+  const url = `/api/modelRegistries/${modelRegistryName}`;
+  return axios
+    .patch(url, patch)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};
+
+export const deleteModelRegistryBackend = (
+  modelRegistryName: string,
+): Promise<ModelRegistryKind> => {
+  const url = `/api/modelRegistries/${modelRegistryName}`;
+  return axios
+    .delete(url)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -180,3 +180,15 @@ rules:
       - get
     resources:
       - dscinitializations
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    resources:
+      - modelregistries


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-7058

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds the following admin-only backend API routes:
* `GET /api/modelRegistries` - lists ModelRegistries
* `POST /api/modelRegistries` - creates a ModelRegistry
* `GET /api/modelRegistries/:modelRegistryName` - gets a ModelRegistry
* `PATCH /api/modelRegistries/:modelRegistryName` - updates a ModelRegistry
* `DELETE /api/modelRegistries/:modelRegistryName` - deletes a ModelRegistry 

And adds the new `frontend/src/services/modelRegistryService.ts` with functions to call these routes using axios.

Also adds a new constant `MODEL_REGISTRY_NAMESPACE` to `backend/src/utils/constants.ts` since there are some places where we were hard-coding the use of the `odh-model-registries` namespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The admin page where this will be used does not exist yet (it is being created in https://github.com/opendatahub-io/odh-dashboard/pull/2810). I tested the two GET routes by inserting this temporary code into another existing page:

```ts
  React.useEffect(() => {
    const fetchData = async () => {
      const registries = await listModelRegistriesBackend();
      console.log('Registries!', registries);
      const registry = await getModelRegistryBackend('internal-registry');
      console.log('Registry!', registry);
    };
    fetchData();
  }, []);
```

This worked as expected. I did not yet test the POST, PATCH or DELETE routes because I don't want to mess with what's currently set up on the shared cluster. Those will be tested as part of upcoming PRs to consume these routes, and any issues we find at that time can be addressed in those PRs.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No tests here currently. There are no existing tests for any of these backend routes or corresponding services. They are also a temporary workaround to be removed when we access these services via a passthrough API (per @lucferbux) so tests here would be removed soon anyway.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
