### PR TITLE
update codecov status checks to informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,15 +6,15 @@ coverage:
   round: down
   range: "70...100"
   status:
-    project: true
-    patch: true
-    # project:
-    #   frontend:
-    #     target: auto
-    #     threshold: 1%
-    # patch:
-    #   default:
-    #     target: 70%
+    project:
+      default:
+        informational: true
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true
+        target: 70%
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-5313

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Force codecov status checks to be informational only so that they will always succeed.

Turns out that the default behavior of codecov without thresholds is causing PR checks to fail.