### PR TITLE
[RHOAIENG-2989] artifact node drawer visualization

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,6 +55,7 @@
         "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^6.3.0",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/chai-subset": "^1.3.5",
         "@types/dompurify": "^2.2.6",
         "@types/google-protobuf": "^3.7.2",
@@ -4217,6 +4218,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,6 +98,7 @@
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/chai-subset": "^1.3.5",
     "@types/dompurify": "^2.2.6",
     "@types/google-protobuf": "^3.7.2",

--- a/frontend/src/__tests__/unit/jest.setup.ts
+++ b/frontend/src/__tests__/unit/jest.setup.ts
@@ -1,9 +1,12 @@
+import { TextEncoder } from 'util';
 import { JestAssertionError } from 'expect';
 import {
   BooleanValues,
   RenderHookResultExt,
   createComparativeValue,
 } from '~/__tests__/unit/testUtils/hooks';
+
+global.TextEncoder = TextEncoder;
 
 const tryExpect = (expectFn: () => void) => {
   try {

--- a/frontend/src/concepts/pipelines/content/artifacts/charts/ROCCurve.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/charts/ROCCurve.tsx
@@ -46,15 +46,14 @@ export const RocCurveChartColorScale = [
 type ROCCurveProps = {
   configs: ROCCurveConfig[];
   maxDimension?: number;
+  maxContainerWidth?: number;
 };
 
-const ROCCurve: React.FC<ROCCurveProps> = ({ configs, maxDimension }) => {
-  const width = Math.min(maxDimension || 800, 500);
-  const height = width;
+const ROCCurve: React.FC<ROCCurveProps> = ({ configs, maxContainerWidth, maxDimension = 800 }) => {
   const baseLineData = Array.from(Array(100).keys()).map((x) => ({ x: x / 100, y: x / 100 }));
 
   return (
-    <div style={{ width }}>
+    <div style={{ width: maxContainerWidth || maxDimension }}>
       <Chart
         ariaDesc="ROC Curve"
         ariaTitle="ROC Curve"
@@ -65,8 +64,8 @@ const ROCCurve: React.FC<ROCCurveProps> = ({ configs, maxDimension }) => {
             labels={({ datum }) => `threshold (Series #${datum.index + 1}): ${datum.name}`}
           />
         }
-        height={height}
-        width={width}
+        height={maxDimension}
+        width={maxDimension}
         padding={{ bottom: 100, left: 100, right: 50, top: 50 }}
         legendAllowWrap
         legendPosition="bottom-left"

--- a/frontend/src/concepts/pipelines/content/artifacts/charts/confusionMatrix/ConfusionMatrix.scss
+++ b/frontend/src/concepts/pipelines/content/artifacts/charts/confusionMatrix/ConfusionMatrix.scss
@@ -1,70 +1,69 @@
 .confusionMatrix {
-	margin: 20px;
-	margin-right: 75px;
-	display: flex;
-  }
-  
-  .confusionMatrix-table {
-	border-collapse: collapse;
-  }
-  
-  .confusionMatrix-cell {
-	border: solid 1px white;
-	position: relative;
-	text-align: center;
-	vertical-align: middle;
-  }
-  
-  .confusionMatrix-labelCell {
-	text-align: right;
-	white-space: nowrap;
-	padding-right: 10px;
-  }
+  margin: 20px;
+  margin-right: 75px;
+  display: flex;
+}
 
-  .confusionMatrix-gradientLegendOuter {
-	display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-  
-  .confusionMatrix-gradientLegend {
-	border-right: solid 1px #777;
-	margin-left: 30px;
-	min-width: 10px;
-	position: relative;
-	width: 10px;
-  }
-  
-  .confusionMatrix-gradientLegendMaxOuter {
-	top: 0;
-	border-top: solid 1px #777;
-	left: 100%;
-	padding-left: 5px;
-	position: absolute;
-	width: 5px;
-  }
+.confusionMatrix-table {
+  border-collapse: collapse;
+}
 
-  .confusionMatrix-gradientLegendMaxLabel {
-	left: 15px;
-	position: absolute;
-	top: -7px;
-  }
+.confusionMatrix-cell {
+  border: solid 1px white;
+  position: relative;
+  text-align: center;
+  vertical-align: middle;
+}
 
-  .confusionMatrix-verticalMarker {
-	writing-mode: vertical-lr;
-	white-space: nowrap;
-  }
-  
-  .confusionMatrix-markerLabel {
-	border-top: solid 1px #777;
-	left: 100%;
-	padding-left: 5px;
-	position: absolute;
-	width: 5px;
-  }
-  
-  .confusionMatrix-trueLabel {
-	font-weight: bold;
-	padding-left: 20px;
-  }
-  
+.confusionMatrix-labelCell {
+  text-align: right;
+  white-space: nowrap;
+  padding-right: 10px;
+}
+
+.confusionMatrix-gradientLegendOuter {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.confusionMatrix-gradientLegend {
+  border-right: solid 1px #777;
+  margin-left: 30px;
+  min-width: 10px;
+  position: relative;
+  width: 10px;
+}
+
+.confusionMatrix-gradientLegendMaxOuter {
+  top: 0;
+  border-top: solid 1px #777;
+  left: 100%;
+  padding-left: 5px;
+  position: absolute;
+  width: 5px;
+}
+
+.confusionMatrix-gradientLegendMaxLabel {
+  left: 15px;
+  position: absolute;
+  top: -7px;
+}
+
+.confusionMatrix-verticalMarker {
+  writing-mode: vertical-lr;
+  white-space: nowrap;
+}
+
+.confusionMatrix-markerLabel {
+  border-top: solid 1px #777;
+  left: 100%;
+  padding-left: 5px;
+  position: absolute;
+  width: 5px;
+}
+
+.confusionMatrix-trueLabel {
+  font-weight: bold;
+  padding-left: 20px;
+}

--- a/frontend/src/concepts/pipelines/content/artifacts/charts/confusionMatrix/ConfusionMatrix.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/charts/confusionMatrix/ConfusionMatrix.tsx
@@ -14,15 +14,6 @@ export interface ConfusionMatrixConfig {
   labels: string[];
 }
 
-export function buildConfusionMatrixConfig(
-  confusionMatrix: ConfusionMatrixInput,
-): ConfusionMatrixConfig {
-  return {
-    labels: confusionMatrix.annotationSpecs.map((annotation) => annotation.displayName),
-    data: confusionMatrix.rows.map((x) => x.row),
-  };
-}
-
 type ConfusionMatrixProps = {
   config: ConfusionMatrixConfig;
   size?: number;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+import { Drawer } from '@patternfly/react-core';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
+import { PipelineTask } from '~/concepts/pipelines/topology';
+import { Artifact } from '~/third_party/mlmd';
+
+const artifactTask: PipelineTask = {
+  type: 'artifact',
+  name: 'metrics',
+  metadata: new Artifact(),
+  inputs: { artifacts: [{ label: 'metrics', type: 'system.Metrics (0.0.1)' }] },
+};
+
+const task: PipelineTask = {
+  type: 'task',
+  name: 'digit-classification',
+  steps: [],
+  outputs: { artifacts: [{ label: 'metrics', type: 'system.Metrics (0.0.1)' }] },
+  status: {
+    startTime: '2024-05-13T11:45:21.508Z',
+    completeTime: '2024-05-13T11:45:22.317Z',
+    taskId: 'task.digit-classification',
+    podName: '',
+  },
+  volumeMounts: [],
+};
+
+describe('PipelineRunDrawerRightContent', () => {
+  it('renders artifact drawer tabs when the task prop is of type "artifact"', () => {
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <PipelineRunDrawerRightContent task={artifactTask} executions={[]} onClose={jest.fn()} />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+
+    expect(tabs).toHaveLength(2);
+    expect(screen.getByRole('tab', { name: 'Artifact details' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Visualization' })).toBeVisible();
+  });
+
+  it('renders task drawer tabs when the task prop is of type "groupTask"', () => {
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <PipelineRunDrawerRightContent
+            task={{ ...task, type: 'groupTask' }}
+            executions={[]}
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+
+    expect(tabs).toHaveLength(4);
+    expect(screen.getByRole('tab', { name: 'Input/Output' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Task details' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Volumes' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Logs' })).toBeVisible();
+  });
+
+  it('renders task drawer tabs when the task prop is of type "task"', () => {
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <PipelineRunDrawerRightContent task={task} executions={[]} onClose={jest.fn()} />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+
+    expect(tabs).toHaveLength(4);
+    expect(screen.getByRole('tab', { name: 'Input/Output' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Task details' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Volumes' })).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Logs' })).toBeVisible();
+  });
+});

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent.tsx
@@ -17,6 +17,7 @@ import {
 
 import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
 import { ArtifactNodeDetails } from './ArtifactNodeDetails';
+import { ArtifactVisualization } from './ArtifactVisualization';
 
 type ArtifactNodeDrawerContentProps = Omit<
   React.ComponentProps<typeof PipelineRunDrawerRightContent>,
@@ -34,7 +35,7 @@ export const ArtifactNodeDrawerContent: React.FC<ArtifactNodeDrawerContentProps>
   onClose,
 }) => {
   const [activeTab, setActiveTab] = React.useState<string | number>(ArtifactNodeDrawerTab.Details);
-  const artifact = task?.metadata?.toObject();
+  const artifact = task?.metadata;
 
   return task ? (
     <>
@@ -57,15 +58,20 @@ export const ArtifactNodeDrawerContent: React.FC<ArtifactNodeDrawerContentProps>
             <Tab
               eventKey={ArtifactNodeDrawerTab.Details}
               title={<TabTitleText>Artifact details</TabTitleText>}
-              aria-label="Overview"
+              aria-label="Artifact details"
             >
-              <ArtifactNodeDetails artifact={artifact} upstreamTaskName={upstreamTaskName} />
+              <ArtifactNodeDetails
+                artifact={artifact.toObject()}
+                upstreamTaskName={upstreamTaskName}
+              />
             </Tab>
             <Tab
               eventKey={ArtifactNodeDrawerTab.Visualization}
               title={<TabTitleText>Visualization</TabTitleText>}
               aria-label="Visualization"
-            />
+            >
+              <ArtifactVisualization artifact={artifact} />
+            </Tab>
           </Tabs>
         ) : (
           <EmptyState variant={EmptyStateVariant.xs}>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateVariant,
+  Flex,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import { TableVariant, Td, Tr } from '@patternfly/react-table';
+
+import { Artifact } from '~/third_party/mlmd';
+import { Table } from '~/components/table';
+import { ArtifactType } from '~/concepts/pipelines/kfTypes';
+import {
+  buildRocCurveConfig,
+  isConfidenceMetric,
+} from '~/concepts/pipelines/content/compareRuns/metricsSection/roc/utils';
+import ROCCurve from '~/concepts/pipelines/content/artifacts/charts/ROCCurve';
+import ConfusionMatrix from '~/concepts/pipelines/content/artifacts/charts/confusionMatrix/ConfusionMatrix';
+import { buildConfusionMatrixConfig } from '~/concepts/pipelines/content/artifacts/charts/confusionMatrix/utils';
+import { isConfusionMatrix } from '~/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/utils';
+
+interface ArtifactVisualizationProps {
+  artifact: Artifact;
+}
+
+export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ artifact }) => {
+  const artifactType = artifact.getType();
+
+  if (artifactType === ArtifactType.CLASSIFICATION_METRICS) {
+    const confusionMatrix = artifact.getCustomPropertiesMap().get('confusionMatrix');
+    const confidenceMetrics = artifact.getCustomPropertiesMap().get('confidenceMetrics');
+
+    if (confusionMatrix) {
+      const confusionMatrixValue = confusionMatrix.getStructValue()?.toJavaScript().struct;
+
+      return isConfusionMatrix(confusionMatrixValue) ? (
+        <Stack className="pf-v5-u-pt-lg pf-v5-u-pb-lg" hasGutter>
+          <Title headingLevel="h3">Confusion matrix metrics</Title>
+
+          <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+            <ConfusionMatrix config={buildConfusionMatrixConfig(confusionMatrixValue)} />
+          </Flex>
+        </Stack>
+      ) : null;
+    }
+
+    if (confidenceMetrics) {
+      const confidenceMetricsList = confidenceMetrics.getStructValue()?.toJavaScript().list;
+
+      return Array.isArray(confidenceMetricsList) &&
+        confidenceMetricsList.every(isConfidenceMetric) ? (
+        <Stack className="pf-v5-u-pt-lg pf-v5-u-pb-lg">
+          <Title headingLevel="h3">ROC curve</Title>
+
+          <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+            <ROCCurve
+              maxContainerWidth={650}
+              configs={[buildRocCurveConfig(confidenceMetricsList, 0)]}
+            />
+          </Flex>
+        </Stack>
+      ) : null;
+    }
+  }
+
+  if (artifactType === ArtifactType.METRICS) {
+    const scalarMetrics = artifact
+      .toObject()
+      .customPropertiesMap.reduce(
+        (
+          acc: { name: string; value: string }[],
+          [customPropKey, { stringValue, intValue, doubleValue, boolValue }],
+        ) => {
+          if (customPropKey !== 'display_name') {
+            acc.push({
+              name: customPropKey,
+              value: stringValue || (intValue || doubleValue || boolValue).toString(),
+            });
+          }
+
+          return acc;
+        },
+        [],
+      );
+
+    return (
+      <Stack className="pf-v5-u-pt-lg pf-v5-u-pb-lg">
+        <Title headingLevel="h3">Scalar metrics</Title>
+
+        <StackItem>
+          <Table
+            data={scalarMetrics}
+            columns={[
+              {
+                label: 'Name',
+                field: 'name',
+                sortable: (a, b) => a.name.localeCompare(b.name),
+              },
+              {
+                label: 'Value',
+                field: 'value',
+                sortable: (a, b) => a.value.localeCompare(b.value),
+              },
+            ]}
+            enablePagination="compact"
+            emptyTableView={
+              <EmptyState
+                variant={EmptyStateVariant.sm}
+                data-testid="artifact-scalar-metrics-empty-state"
+              >
+                <EmptyStateHeader titleText="No scalar metrics" headingLevel="h4" />
+                <EmptyStateBody>No scalar metrics found.</EmptyStateBody>
+              </EmptyState>
+            }
+            rowRenderer={(scalarMetric) => (
+              <Tr>
+                <Td dataLabel="name">{scalarMetric.name}</Td>
+                <Td dataLabel="value">{scalarMetric.value}</Td>
+              </Tr>
+            )}
+            variant={TableVariant.compact}
+            data-testid="artifact-scalar-metrics-table"
+            id="artifact-scalar-metrics-table"
+          />
+        </StackItem>
+      </Stack>
+    );
+  }
+
+  if (artifactType === ArtifactType.HTML || artifactType === ArtifactType.MARKDOWN) {
+    return (
+      <EmptyState variant={EmptyStateVariant.xs}>
+        <EmptyStateHeader titleText="Content is not available yet." headingLevel="h4" />
+      </EmptyState>
+    );
+  }
+
+  return null;
+};

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+
+import { Drawer } from '@patternfly/react-core';
+import { render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { PipelineTask } from '~/concepts/pipelines/topology';
+import { Artifact, Value } from '~/third_party/mlmd';
+import { ArtifactNodeDrawerContent } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent';
+
+const task: PipelineTask = {
+  type: 'artifact',
+  name: 'metrics',
+  metadata: createArtifact('system.Metrics'),
+  inputs: { artifacts: [{ label: 'metrics', type: 'system.Metrics (0.0.1)' }] },
+};
+
+jest.mock('~/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/utils', () => ({
+  isConfusionMatrix: jest.fn(() => true),
+}));
+
+jest.mock('~/concepts/pipelines/content/compareRuns/metricsSection/roc/utils', () => ({
+  buildRocCurveConfig: jest.fn(() => ({})),
+  isConfidenceMetric: jest.fn(() => true),
+}));
+
+jest.mock('~/concepts/pipelines/content/artifacts/charts/confusionMatrix/utils', () => ({
+  buildConfusionMatrixConfig: jest.fn(() => ({
+    labels: ['Some label'],
+    data: [[0]],
+  })),
+}));
+
+describe('ArtifactNodeDrawerContent', () => {
+  it('renders artifact drawer content', () => {
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={task}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Artifact details' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    const artifactDetailsList = screen.getByTestId('artifact-details-description-list');
+    expect(within(artifactDetailsList).getByText('some-upstream-task')).toBeVisible();
+    expect(within(artifactDetailsList).getByText('metrics')).toBeVisible();
+    expect(within(artifactDetailsList).getByText('system.Metrics')).toBeVisible();
+    expect(within(artifactDetailsList).getByText('1 Jan 2023')).toBeVisible();
+
+    const artifactUriList = screen.getByTestId('artifact-uri-description-list');
+    expect(within(artifactUriList).getByText('some.uri')).toBeVisible();
+  });
+
+  it('renders "Scalar metrics" visualization drawer content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={task}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    expect(screen.getByRole('heading', { name: 'Scalar metrics' })).toBeVisible();
+  });
+
+  it('renders "ROC curve" visualization drawer content', async () => {
+    const confidenceMetricsStruct = Struct.fromJavaScript({
+      list: [
+        {
+          confidenceThreshold: 0,
+          falsePositiveRate: 0,
+          recall: 0,
+        },
+      ],
+    });
+
+    const user = userEvent.setup();
+    const confidenceMetricsValue = new Value();
+    confidenceMetricsValue.setStructValue(confidenceMetricsStruct);
+
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.ClassificationMetrics', {
+                key: 'confidenceMetrics',
+                value: confidenceMetricsValue,
+              }),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    expect(screen.getByRole('heading', { name: 'ROC curve' })).toBeVisible();
+  });
+
+  it('renders "Confusion matrix metrics" visualization drawer content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.ClassificationMetrics', {
+                key: 'confusionMatrix',
+                value: new Value(),
+              }),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Visualization' }));
+    expect(screen.getByRole('heading', { name: 'Confusion matrix metrics' })).toBeVisible();
+  });
+});
+
+function createArtifact(type: string, customProperty?: { key: string; value: Value }) {
+  const artifact = new Artifact();
+
+  artifact.setUri('some.uri');
+  artifact.setType(type);
+  artifact.setName('metrics');
+  artifact.setCreateTimeSinceEpoch(1672585200000);
+
+  if (customProperty) {
+    artifact.getCustomPropertiesMap().set(customProperty.key, customProperty.value);
+  }
+
+  return artifact;
+}

--- a/frontend/src/pages/pipelines/global/experiments/MlmdPropertyValue.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/MlmdPropertyValue.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Value } from '~/third_party/mlmd';
+import { MaxHeightCodeEditor } from '~/components/MaxHeightCodeEditor';
+import { NoValue } from '~/components/NoValue';
+
+interface MlmdPropertyValueProps {
+  values: Value.AsObject;
+  testId?: string;
+}
+
+export const MlmdPropertyDetailsValue: React.FC<MlmdPropertyValueProps> = ({ values, testId }) => {
+  let value: React.ReactNode =
+    values.stringValue || values.intValue || values.doubleValue || values.boolValue || '';
+
+  if (values.structValue || values.protoValue) {
+    value = (
+      <MaxHeightCodeEditor
+        isReadOnly
+        code={JSON.stringify(values.structValue || values.protoValue, null, 2)}
+        maxHeight={300}
+        data-testid={testId}
+      />
+    );
+  }
+
+  if (!value && value !== 0) {
+    return <NoValue />;
+  }
+
+  return value;
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactPropertyDescriptionList.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactPropertyDescriptionList.tsx
@@ -8,8 +8,7 @@ import {
 } from '@patternfly/react-core';
 
 import { Value } from '~/third_party/mlmd';
-import { NoValue } from '~/components/NoValue';
-import { ExecutionDetailsPropertiesValueCode } from '~/pages/pipelines/global/experiments/executions/details/ExecutionDetailsPropertiesValue';
+import { MlmdPropertyDetailsValue } from '~/pages/pipelines/global/experiments/MlmdPropertyValue';
 
 interface ArtifactPropertyDescriptionListProps {
   testId?: string;
@@ -19,38 +18,17 @@ interface ArtifactPropertyDescriptionListProps {
 export const ArtifactPropertyDescriptionList: React.FC<ArtifactPropertyDescriptionListProps> = ({
   propertiesMap,
   testId,
-}) => {
-  const getPropertyValue = React.useCallback((property: Value.AsObject): React.ReactNode => {
-    let propValue: React.ReactNode =
-      property.stringValue || property.intValue || property.doubleValue || property.boolValue || '';
-
-    if (property.structValue || property.protoValue) {
-      propValue = (
-        <ExecutionDetailsPropertiesValueCode
-          code={JSON.stringify(property.structValue || property.protoValue, null, 2)}
-        />
-      );
-    }
-
-    return propValue;
-  }, []);
-
-  return (
-    <DescriptionList isHorizontal data-testid={testId}>
-      <DescriptionListGroup>
-        {propertiesMap.map(([propKey, propValue]) => {
-          const value = getPropertyValue(propValue);
-
-          return (
-            <React.Fragment key={propKey}>
-              <DescriptionListTerm>{propKey}</DescriptionListTerm>
-              <DescriptionListDescription>
-                {!value && value !== 0 ? <NoValue /> : value}
-              </DescriptionListDescription>
-            </React.Fragment>
-          );
-        })}
-      </DescriptionListGroup>
-    </DescriptionList>
-  );
-};
+}) => (
+  <DescriptionList isHorizontal data-testid={testId}>
+    <DescriptionListGroup>
+      {propertiesMap.map(([propKey, propValues]) => (
+        <React.Fragment key={propKey}>
+          <DescriptionListTerm>{propKey}</DescriptionListTerm>
+          <DescriptionListDescription>
+            <MlmdPropertyDetailsValue values={propValues} />
+          </DescriptionListDescription>
+        </React.Fragment>
+      ))}
+    </DescriptionListGroup>
+  </DescriptionList>
+);


### PR DESCRIPTION
Closes: [RHOAIENG-2989](https://issues.redhat.com/browse/RHOAIENG-2989)

## Description
Added visualization content (ROC curve, scalar metrics table, confusion matrix) for run artifact node drawers.

NOTE: Since we have yet to setup requests to allow for HTML and Markdown visualization data, those artifact types have placeholder text in the drawer content space for now.

### How to test
Create and/or navigate to a run that has artifact nodes of type `system.Metrics` and `system.ClassificationMetrics` (confusion matrix and ROC curves fit under this category), click on those respective topology graph nodes, and within the drawer for each, click the "Visualization" tab and verify the content is correct. 

**Scalar metrics:**
<img width="829" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/96b508fd-fb6a-4cfa-a0bf-185b3bb82812">

**ROC curve:**
<img width="923" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/f2e6fd1c-b3d5-41d2-b9e4-9163d556b32d">

**Confusion matrix:**
<img width="834" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/340ef127-dab6-408d-a425-60ef7d9e6f44">
(@yannnz)

## How Has This Been Tested?
Added unit tests

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
