### PR TITLE
add taskName parameter to parseRuntimeInfoFromExecutions function

### DIFF
--- a/frontend/src/concepts/pipelines/topology/__tests__/parseUtils.spec.ts
+++ b/frontend/src/concepts/pipelines/topology/__tests__/parseUtils.spec.ts
@@ -166,23 +166,23 @@ describe('pipeline topology parseUtils', () => {
     const testTaskId = 'test-task-id';
 
     it('returns undefined when executions are not provided', () => {
-      const result = parseRuntimeInfoFromExecutions(testTaskId);
+      const result = parseRuntimeInfoFromExecutions(testTaskId, testTaskId);
       expect(result).toBeUndefined();
     });
 
     it('returns undefined when executions is null', () => {
-      const result = parseRuntimeInfoFromExecutions(testTaskId, null);
+      const result = parseRuntimeInfoFromExecutions(testTaskId, testTaskId, null);
       expect(result).toBeUndefined();
     });
 
     it('returns undefined when executions are empty', () => {
-      const result = parseRuntimeInfoFromExecutions(testTaskId, []);
+      const result = parseRuntimeInfoFromExecutions(testTaskId, testTaskId, []);
       expect(result).toBeUndefined();
     });
 
     it('returns undefined when there are no match executions', () => {
       const mockExecution = new Execution();
-      const result = parseRuntimeInfoFromExecutions(testTaskId, [mockExecution]);
+      const result = parseRuntimeInfoFromExecutions(testTaskId, testTaskId, [mockExecution]);
       expect(result).toBeUndefined();
     });
 
@@ -193,7 +193,7 @@ describe('pipeline topology parseUtils', () => {
       mockExecution.setCreateTimeSinceEpoch(1713285296322);
       mockExecution.setLastUpdateTimeSinceEpoch(1713285296524);
       mockExecution.setLastKnownState(Execution.State.COMPLETE);
-      const result = parseRuntimeInfoFromExecutions(testTaskId, [mockExecution]);
+      const result = parseRuntimeInfoFromExecutions(testTaskId, testTaskId, [mockExecution]);
       expect(result).toStrictEqual({
         completeTime: '2024-04-16T16:34:56.524Z',
         podName: undefined,

--- a/frontend/src/concepts/pipelines/topology/parseUtils.ts
+++ b/frontend/src/concepts/pipelines/topology/parseUtils.ts
@@ -182,6 +182,7 @@ export const parseRuntimeInfoFromRunDetails = (
 
 export const parseRuntimeInfoFromExecutions = (
   taskId: string,
+  taskName: string,
   executions?: Execution[] | null,
 ): PipelineTaskRunStatus | undefined => {
   if (!executions) {
@@ -189,7 +190,7 @@ export const parseRuntimeInfoFromExecutions = (
   }
 
   const execution = executions.find(
-    (e) => e.getCustomPropertiesMap().get('task_name')?.getStringValue() === taskId,
+    (e) => e.getCustomPropertiesMap().get('task_name')?.getStringValue() === (taskName || taskId),
   );
 
   if (!execution) {

--- a/frontend/src/concepts/pipelines/topology/usePipelineTaskTopology.tsx
+++ b/frontend/src/concepts/pipelines/topology/usePipelineTaskTopology.tsx
@@ -115,7 +115,7 @@ const getNodesForTasks = (
     const taskName = details.taskInfo.name;
 
     const status =
-      parseRuntimeInfoFromExecutions(taskId, executions) ||
+      parseRuntimeInfoFromExecutions(taskId, taskName, executions) ||
       parseRuntimeInfoFromRunDetails(taskId, runDetails);
     const runStatus = translateStatusForNode(status?.state);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

closes: https://issues.redhat.com/browse/RHOAIENG-7079

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- run details now uses the task name first to match an execution to a task in the dag
- if no name exists, we fall back to using the key to match the execution
- and if nothing exists at all in terms of matching an execution, we fall back to the pipeline spec

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- check that logs are equal from our UI to KF

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none, small mlmd fix in for backend

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
