### PR TITLE
fix storage mount location

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -210,7 +210,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                 variant="info"
                 isPlain
                 isInline
-                title="Cluster storage will mount to /"
+                title="Cluster storage will mount to /opt/app-root/src"
               />
               <StorageField
                 storageData={storageData}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
Created bug report here:
https://issues.redhat.com/browse/RHOAIRFE-174

This updates the message on the "Edit Workbench" page to fix what path the message indicates where the volume is mounted.

Currently it says:

```
Cluster storage will mount to /
```

But the volume is not mounted at root, it is mounted at /opt/app-root/src.  See the following snippet from a notebook:

```yaml
          volumeMounts:
            - mountPath: /opt/app-root/src
              name: test
```

And the df results from inside the notebook:

```sh
$ df -h /opt/app-root/src
Filesystem      Size  Used Avail Use% Mounted on
/dev/sdc         20G   45M   20G   1% /opt/app-root/src
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
