### PR TITLE
[RHOAIENG-7421] pipeline run artifact detail drawer link to artifact details not behind flag

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -30,6 +30,15 @@ const task: PipelineTask = {
   volumeMounts: [],
 };
 
+jest.mock('~/concepts/areas/useIsAreaAvailable', () => () => ({
+  status: true,
+  featureFlags: {},
+  reliantAreas: {},
+  requiredComponents: {},
+  requiredCapabilities: {},
+  customCondition: jest.fn(),
+}));
+
 describe('PipelineRunDrawerRightContent', () => {
   it('renders artifact drawer tabs when the task prop is of type "artifact"', () => {
     render(

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
@@ -18,6 +18,7 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { getArtifactName } from '~/pages/pipelines/global/experiments/artifacts/utils';
 import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
 import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 type ArtifactNodeDetailsProps = Pick<
   React.ComponentProps<typeof PipelineRunDrawerRightContent>,
@@ -32,6 +33,7 @@ export const ArtifactNodeDetails: React.FC<ArtifactNodeDetailsProps> = ({
 }) => {
   const { namespace } = usePipelinesAPI();
   const artifactName = getArtifactName(artifact);
+  const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
   return (
     <Flex
@@ -53,7 +55,11 @@ export const ArtifactNodeDetails: React.FC<ArtifactNodeDetailsProps> = ({
 
               <DescriptionListTerm>Artifact name</DescriptionListTerm>
               <DescriptionListDescription>
-                <Link to={artifactsDetailsRoute(namespace, artifact.id)}>{artifactName}</Link>
+                {isExperimentsAvailable ? (
+                  <Link to={artifactsDetailsRoute(namespace, artifact.id)}>{artifactName}</Link>
+                ) : (
+                  artifactName
+                )}
               </DescriptionListDescription>
 
               <DescriptionListTerm>Artifact type</DescriptionListTerm>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -34,6 +34,15 @@ jest.mock('~/concepts/pipelines/content/artifacts/charts/confusionMatrix/utils',
   })),
 }));
 
+jest.mock('~/concepts/areas/useIsAreaAvailable', () => () => ({
+  status: true,
+  featureFlags: {},
+  reliantAreas: {},
+  requiredComponents: {},
+  requiredCapabilities: {},
+  customCondition: jest.fn(),
+}));
+
 describe('ArtifactNodeDrawerContent', () => {
   it('renders artifact drawer content', () => {
     render(


### PR DESCRIPTION
Closes: [RHOAIENG-7421](https://issues.redhat.com/browse/RHOAIENG-7421)

## Description
Just rendering the string of the artifact name instead of the link which takes users to the new artifact details page behind the experiments feature flag.

<img width="923" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/ef67e221-f621-4b7d-9d30-c978bdad1864">

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
