### PR TITLE
Fix inconsistency in authentication

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -171,6 +171,10 @@ class ServingRuntimeModal extends Modal {
     return this.find().findByTestId('serving-runtime-template-selection');
   }
 
+  findAuthenticationSection() {
+    return this.find().findByTestId('auth-section');
+  }
+
   findModelRouteCheckbox() {
     return this.find().findByTestId('alt-form-checkbox-route');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -931,6 +931,33 @@ describe('Serving Runtime List', () => {
       kserveModal.findLocationPathInput().type('correct-path');
       kserveModal.findSubmitButton().should('be.enabled');
     });
+
+    it('Check authentication section', () => {
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
+        servingRuntimes: [],
+        requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+      });
+      projectDetails.visitSection('test-project', 'model-server');
+
+      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+
+      kserveModal.shouldBeOpen();
+
+      kserveModal.findSubmitButton().should('be.disabled');
+
+      // Test labels are correct
+      expect(
+        kserveModal.findAuthenticationSection().findByText('Token authentication').should('exist'),
+      );
+      expect(
+        kserveModal
+          .findAuthenticationSection()
+          .findByText('Require token authentication')
+          .should('exist'),
+      );
+    });
   });
 
   describe('ModelMesh model server', () => {
@@ -1565,7 +1592,7 @@ describe('Serving Runtime List', () => {
       const kserveRow = modelServingSection.getKServeRow('Llama Caikit');
       kserveRow.findExpansion().should(be.collapsed);
       kserveRow.findToggleButton().click();
-      kserveRow.findDescriptionListItem('Token authorization').should('exist');
+      kserveRow.findDescriptionListItem('Token authentication').should('exist');
     });
 
     it('Check token section is disabled if capability is disabled', () => {
@@ -1579,7 +1606,7 @@ describe('Serving Runtime List', () => {
       const kserveRow = modelServingSection.getKServeRow('Llama Caikit');
       kserveRow.findExpansion().should(be.collapsed);
       kserveRow.findToggleButton().click();
-      kserveRow.findDescriptionListItem('Token authorization').should('not.exist');
+      kserveRow.findDescriptionListItem('Token authentication').should('not.exist');
     });
   });
 

--- a/frontend/src/pages/home/aiFlows/DeployAndMonitorGallery.tsx
+++ b/frontend/src/pages/home/aiFlows/DeployAndMonitorGallery.tsx
@@ -24,8 +24,8 @@ const DeployAndMonitorGallery: React.FC<{ onClose: () => void }> = ({ onClose })
             <Text component="small">
               Use model servers to deploy models for testing and implementing in intelligent
               applications. Configuring a model server includes specifying the number of replicas
-              being deployed, the server size, the token authorization, the serving runtime, and how
-              the project that the model server belongs to is accessed.
+              being deployed, the server size, the token authentication, the serving runtime, and
+              how the project that the model server belongs to is accessed.
             </Text>
           </TextContent>
         }

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
@@ -109,7 +109,7 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
                 <StackItem>
                   <DescriptionList>
                     <DescriptionListGroup>
-                      <DescriptionListTerm>Token authorization</DescriptionListTerm>
+                      <DescriptionListTerm>Token authentication</DescriptionListTerm>
                       <DescriptionListDescription>
                         <ServingRuntimeTokensTable
                           obj={obj}

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -99,7 +99,7 @@ const ModelServingPlatform: React.FC = () => {
           title={modelMeshEnabled ? 'Start by adding a model server' : 'Start by deploying a model'}
           description={
             modelMeshEnabled
-              ? 'Model servers are used to deploy models and to allow apps to send requests to your models. Configuring a model server includes specifying the number of replicas being deployed, the server size, the token authorization, the serving runtime, and how the project that the model server belongs to is accessed.\n'
+              ? 'Model servers are used to deploy models and to allow apps to send requests to your models. Configuring a model server includes specifying the number of replicas being deployed, the server size, the token authentication, the serving runtime, and how the project that the model server belongs to is accessed.\n'
               : 'Each model is deployed on its own model server.'
           }
           createButton={

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection.tsx
@@ -49,21 +49,21 @@ const AuthServingRuntimeSection: React.FC<AuthServingRuntimeSectionProps> = ({
   }, [data.tokens, setData]);
 
   return (
-    <Stack>
+    <Stack hasGutter>
       {!allowCreate && (
         <StackItem>
           <Popover
             showClose
             bodyContent={
               publicRoute
-                ? 'Model route and token authorization can only be changed by administrator users.'
-                : 'Token authorization can only be changed by administrator users and component Authorino needs to be installed.'
+                ? 'Model route and token authentication can only be changed by administrator users.'
+                : 'Token authentication can only be changed by administrator users and component Authorino needs to be installed.'
             }
           >
             <Button variant="link" icon={<OutlinedQuestionCircleIcon />} isInline>
               {publicRoute
-                ? "Why can't I change the model route and token authorization fields?"
-                : "Why can't I change the token authorization field?"}
+                ? "Why can't I change the model route and token authentication fields?"
+                : "Why can't I change the token authentication field?"}
             </Button>
           </Popover>
         </StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTokenSection.tsx
@@ -32,7 +32,7 @@ const ServingRuntimeTokenSection: React.FC<ServingRuntimeTokenSectionProps> = ({
   allowCreate,
   createNewToken,
 }) => (
-  <FormSection title="Token authorization">
+  <FormSection title="Token authentication" id="auth-section" data-testid="auth-section">
     <FormGroup>
       <Checkbox
         label="Require token authentication"

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -257,14 +257,14 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 isExpandable
                 isInline
                 variant="warning"
-                title="Token authorization service not installed"
+                title="Token authentication service not installed"
                 actionClose={<AlertActionCloseButton onClose={() => setAlertVisible(false)} />}
               >
                 <p>
                   The single model serving platform used by this project allows deployed models to
-                  be accessible via external routes. It is recommended that token authorization be
+                  be accessible via external routes. It is recommended that token authentication be
                   enabled to protect these routes. The serving platform requires the Authorino
-                  operator be installed on the cluster for token authorization. Contact a cluster
+                  operator be installed on the cluster for token authentication. Contact a cluster
                   administrator to install the operator.
                 </p>
               </Alert>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-382

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fix inconsistency in authentication working for model serving.

<img width="697" alt="Screenshot 2024-05-23 at 02 38 16" src="https://github.com/opendatahub-io/odh-dashboard/assets/16117276/d87e9ed5-0881-40bf-9073-a217879ecc57">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy a model through KServe
2. Select external route
3. Text should match "Token authentication"

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
