### PR TITLE
edited manifest to remove dot

### DIFF
--- a/frontend/src/__mocks__/mockQuickStarts.ts
+++ b/frontend/src/__mocks__/mockQuickStarts.ts
@@ -87,7 +87,7 @@ export const mockQuickStarts = (): OdhQuickStart[] => [
       appName: 'jupyter',
       conclusion: 'You are now able to deploy a sample model stored in GitHub.',
       description: 'How to deploy a Python model using Flask and OpenShift.',
-      displayName: 'Deploying a sample Python application using Flask and OpenShift.',
+      displayName: 'Deploying a sample Python application using Flask and OpenShift',
       durationMinutes: 10,
       icon: 'images/jupyterhub.svg',
       introduction:

--- a/manifests/apps/jupyter/deploy-python-model-quickstart.yaml
+++ b/manifests/apps/jupyter/deploy-python-model-quickstart.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     opendatahub.io/categories: 'Model serving,Getting started'
 spec:
-  displayName: Deploying a sample Python application using Flask and OpenShift.
+  displayName: Deploying a sample Python application using Flask and OpenShift
   appName: jupyter
   durationMinutes: 10
   icon: 'images/jupyter.svg'


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
