### PR TITLE
edited manifest to remove dot

### DIFF
--- a/frontend/src/__mocks__/mockQuickStarts.ts
+++ b/frontend/src/__mocks__/mockQuickStarts.ts
@@ -87,7 +87,7 @@ export const mockQuickStarts = (): OdhQuickStart[] => [
       appName: 'jupyter',
       conclusion: 'You are now able to deploy a sample model stored in GitHub.',
       description: 'How to deploy a Python model using Flask and OpenShift.',
-      displayName: 'Deploying a sample Python application using Flask and OpenShift.',
+      displayName: 'Deploying a sample Python application using Flask and OpenShift',
       durationMinutes: 10,
       icon: 'images/jupyterhub.svg',
       introduction:

--- a/manifests/apps/jupyter/deploy-python-model-quickstart.yaml
+++ b/manifests/apps/jupyter/deploy-python-model-quickstart.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     opendatahub.io/categories: 'Model serving,Getting started'
 spec:
-  displayName: Deploying a sample Python application using Flask and OpenShift.
+  displayName: Deploying a sample Python application using Flask and OpenShift
   appName: jupyter
   durationMinutes: 10
   icon: 'images/jupyter.svg'


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!-- Closes: #1138 -->
[RHOAIENG-1138](https://issues.redhat.com/browse/RHOAIENG-1138)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->

I removed the dot at the end of "Deploying a sample Python application using Flask and OpenShift."

<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1244" alt="Screenshot 2024-05-21 at 11 29 37 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/107655677/ba985d50-3e42-4d65-b353-45a65ef32f58">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `npm run test:cypress-ci -- --spec "**/Resources.cy.ts"`.

I also did manual testing, by running `oc apply -n opendatahub -f ./manifests/apps/jupyter/deploy-python-model-quickstart.yaml`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I edited the mock corresponding to the manifest.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
