### PR TITLE
[RHOAIENG-7439] Pipeline version is not visible for some runs in the run table list

### DIFF
--- a/frontend/src/concepts/pipelines/apiHooks/useAllPipelineVersions.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/useAllPipelineVersions.ts
@@ -4,7 +4,7 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import usePipelineQuery from '~/concepts/pipelines/apiHooks/usePipelineQuery';
 import { PipelineListPaged, PipelineOptions } from '~/concepts/pipelines/types';
 import { FetchState, NotReadyError } from '~/utilities/useFetchState';
-import usePipelines from '~/concepts/pipelines/apiHooks/usePipelines';
+import { useAllPipelines } from '~/concepts/pipelines/apiHooks/usePipelines';
 import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
 
 /**
@@ -15,7 +15,7 @@ export const useAllPipelineVersions = (
   refreshRate = 0,
 ): FetchState<PipelineListPaged<PipelineVersionKFv2>> => {
   const { api } = usePipelinesAPI();
-  const [{ items: pipelines }, pipelinesLoaded] = usePipelines();
+  const [{ items: pipelines }, pipelinesLoaded] = useAllPipelines();
   const pipelineIds = useDeepCompareMemoize(pipelines.map((pipeline) => pipeline.pipeline_id));
 
   return usePipelineQuery<PipelineVersionKFv2>(

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelines.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelines.ts
@@ -2,8 +2,14 @@ import * as React from 'react';
 import { FetchState, NotReadyError } from '~/utilities/useFetchState';
 import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 import usePipelineQuery from '~/concepts/pipelines/apiHooks/usePipelineQuery';
-import { PipelineListPaged, PipelineOptions } from '~/concepts/pipelines/types';
+import {
+  ListPipelines,
+  PipelineListPaged,
+  PipelineOptions,
+  PipelineParams,
+} from '~/concepts/pipelines/types';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { K8sAPIOptions } from '~/k8sTypes';
 
 const usePipelines = (
   options?: PipelineOptions,
@@ -37,6 +43,46 @@ export const useSafePipelines = (
           .then((result) => ({ ...result, items: result.pipelines }));
       },
       [api, apiAvailable, pipelinesServer.compatible],
+    ),
+    options,
+    refreshRate,
+  );
+};
+
+async function getAllPipelines(
+  opts: K8sAPIOptions,
+  params: PipelineParams | undefined,
+  listPipelines: ListPipelines,
+): Promise<PipelineKFv2[]> {
+  const result = await listPipelines(opts, params);
+  let allPipelines = result.pipelines ?? [];
+
+  if (result.next_page_token) {
+    const nextPipelines = await getAllPipelines(
+      opts,
+      { pageToken: result.next_page_token },
+      listPipelines,
+    );
+    allPipelines = allPipelines.concat(nextPipelines);
+  }
+
+  return allPipelines;
+}
+
+export const useAllPipelines = (
+  options?: PipelineOptions,
+  refreshRate?: number,
+): FetchState<PipelineListPaged<PipelineKFv2>> => {
+  const { api } = usePipelinesAPI();
+
+  return usePipelineQuery<PipelineKFv2>(
+    React.useCallback(
+      async (opts, params) => {
+        const allPipelines = await getAllPipelines(opts, params, api.listPipelines);
+
+        return { items: allPipelines };
+      },
+      [api.listPipelines],
     ),
     options,
     refreshRate,


### PR DESCRIPTION
Closes: [RHOAIENG-7439](https://issues.redhat.com/browse/RHOAIENG-7439)

## Description
Fetch all pages of pipelines whose IDs are used to fetch all versions, used to display versions in the table cells for runs and for the toolbar version filter dropdown.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
