### PR TITLE
show special error state for ChunkLoadError

### DIFF
--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Button, Split, SplitItem, Title } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import ErrorDetails from './ErrorDetails';
+import UpdateState from './UpdateState';
 
 type ErrorBoundaryProps = {
   children?: React.ReactNode;
@@ -13,6 +14,7 @@ type ErrorBoundaryState =
       hasError: true;
       error: Error;
       errorInfo: React.ErrorInfo;
+      isUpdateState: boolean;
     };
 
 class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
@@ -28,6 +30,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       hasError: true,
       error,
       errorInfo,
+      isUpdateState: error.name === 'ChunkLoadError',
     });
     // eslint-disable-next-line no-console
     console.error('Caught error:', error, errorInfo);
@@ -38,17 +41,37 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     const { hasError } = this.state;
 
     if (hasError) {
-      const { error, errorInfo } = this.state;
+      const { error, errorInfo, isUpdateState } = this.state;
+      if (isUpdateState) {
+        return (
+          <UpdateState
+            onClose={() => this.setState((prevState) => ({ ...prevState, isUpdateState: false }))}
+          />
+        );
+      }
       return (
-        <div className="pf-v5-u-p-lg">
+        <div className="pf-v5-u-p-lg" data-testid="error-boundary">
           <Split>
             <SplitItem isFilled>
-              <Title headingLevel="h1" className="pf-v5-u-mb-lg">
-                An error occurred.
+              <Title headingLevel="h1" className="pf-v5-u-mb-sm">
+                An error occurred
               </Title>
+              <p className="pf-v5-u-mb-md">
+                Try{' '}
+                <Button
+                  data-testid="reload-link"
+                  variant="link"
+                  isInline
+                  onClick={() => window.location.reload()}
+                >
+                  reloading
+                </Button>{' '}
+                the page if there was a recent update.
+              </p>
             </SplitItem>
             <SplitItem>
               <Button
+                data-testid="close-error-button"
                 variant="plain"
                 aria-label="Close"
                 onClick={() => {

--- a/frontend/src/components/error/ErrorDetails.tsx
+++ b/frontend/src/components/error/ErrorDetails.tsx
@@ -23,7 +23,7 @@ const ErrorDetails: React.FC<ErrorDetailsProps> = ({
   stack,
 }) => (
   <>
-    <Title headingLevel="h2" className="pf-v5-u-mb-lg">
+    <Title headingLevel="h2" className="pf-v5-u-mb-md">
       {title}
     </Title>
     <DescriptionList>

--- a/frontend/src/components/error/UpdateState.tsx
+++ b/frontend/src/components/error/UpdateState.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  PageSectionVariants,
+} from '@patternfly/react-core';
+import { PathMissingIcon } from '@patternfly/react-icons';
+
+type Props = {
+  onClose: () => void;
+};
+
+const UpdateState: React.FC<Props> = ({ onClose }) => (
+  <PageSection variant={PageSectionVariants.light} data-testid="error-update-state">
+    <EmptyState variant={EmptyStateVariant.full}>
+      <EmptyStateHeader
+        titleText="An error occurred"
+        icon={<EmptyStateIcon icon={PathMissingIcon} />}
+        headingLevel="h2"
+      />
+      <EmptyStateBody>This is likely the result of a recent update.</EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button
+            variant="primary"
+            onClick={() => window.location.reload()}
+            data-testid="reload-button"
+          >
+            Reload this page
+          </Button>
+        </EmptyStateActions>
+        <EmptyStateActions>
+          <Button variant="link" onClick={onClose} data-testid="show-error-button">
+            Show error
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  </PageSection>
+);
+
+export default UpdateState;

--- a/frontend/src/components/error/__tests__/ErrorBoundary.spec.tsx
+++ b/frontend/src/components/error/__tests__/ErrorBoundary.spec.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import ErrorBoundary from '~/components/error/ErrorBoundary';
+
+class ChunkLoadError extends Error {
+  name = 'ChunkLoadError';
+}
+
+describe('ErrorBoundary', () => {
+  it('should handle regular error', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: jest.fn() },
+    });
+
+    let showError = true;
+    const TestComponent = () => {
+      if (showError) {
+        throw new Error('regular error');
+      }
+      return <div data-testid="testing-123">testing</div>;
+    };
+    render(
+      <ErrorBoundary>
+        <TestComponent />
+      </ErrorBoundary>,
+    );
+    await screen.findByTestId('error-boundary');
+    await screen.findByText('regular error');
+
+    // reload link
+    const reloadButton = await screen.findByTestId('reload-link');
+    act(() => reloadButton.click());
+    expect(window.location.reload).toHaveBeenCalled();
+
+    // close error
+    showError = false;
+    const closeButton = await screen.findByTestId('close-error-button');
+    act(() => closeButton.click());
+    expect(await screen.queryByTestId('error-boundary')).not.toBeInTheDocument();
+    await screen.findByTestId('testing-123');
+  });
+
+  it('should handle ChunkLoadError', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: jest.fn() },
+    });
+
+    const ErrorComponent = () => {
+      throw new ChunkLoadError('a chunk load error');
+    };
+    render(
+      <ErrorBoundary>
+        <ErrorComponent />
+      </ErrorBoundary>,
+    );
+    await screen.findByTestId('error-update-state');
+    expect(await screen.queryByTestId('error-boundary')).not.toBeInTheDocument();
+
+    // reload button
+    const reloadButton = await screen.findByTestId('reload-button');
+    act(() => reloadButton.click());
+    expect(window.location.reload).toHaveBeenCalled();
+
+    // show error
+    const showErrorButton = await screen.findByTestId('show-error-button');
+    act(() => showErrorButton.click());
+    expect(await screen.queryByTestId('error-update-state')).not.toBeInTheDocument();
+    await screen.findByTestId('error-boundary');
+    await screen.findByText('ChunkLoadError');
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-2690

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

_@ UX please suggest icon and text_

The times in which this screen may be shown is very very small. A possible way to encounter this issue in production is to have the web app opened while the dashboard updates behind the scene. Then the user attempts to navigate the already opened application.

A `ChunkLoadError` is a special case that indicates a failure to load a build artifact. This generally occurs because the web page was opened on a previous version of the application and the build artifacts have changed on the server. It _may_ also occur as a result of cache not getting the latest version although this case hasn't been proven in our environment where it's expected that we do not cache such files.

Whenever a `ChunkLoadError` is detected, the best course of action for the user is to simply refresh the page. As such this change will provide the user with a clear action button for how to proceed. Furthermore in case the error persists for some reason, we give the option to display the error as is done with all other errors. Since it's a possibility that other errors may also be resolved by reloading the page, a general message and reload action is provided in the header of the standard error page. eg. if after an update, the endpoint of an action on longer exists and throws an error.

![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/2d15ad12-b67b-4596-87d9-51c60b1d0f22)

Clicking the `Show error` button will display the standard error screen for data collection purposes:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/2b1a59a1-afce-420d-8f14-9a6cb75ff88a)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests.
This has been tested locally.

1. Build the frontend `npm run build`
2. Start the backend `npm run start:dev`
3. Open your web browser to `localhost:4000`
4. Open web inspector.
5. Navigate to the `Explore` page.
6. From the network tab web inspector look, for `###.js` javascript file request. This is the chunk related to the explore page.
7. Rename `frontend/public/###.js` to anything else. eg `###.js.bak`
8. Reload the page or first go to `localhost:4000` and then click on the `Explore` page link.
9. Observe the new error state.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @andrewballantyne @kywalker-rh @kaedward @vconzola  