### PR TITLE
[RHOAIENG-7483] Home page microcopy updates based on PM feedback

### DIFF
--- a/frontend/src/pages/home/aiFlows/ProjectsGallery.tsx
+++ b/frontend/src/pages/home/aiFlows/ProjectsGallery.tsx
@@ -49,14 +49,14 @@ const ProjectsGallery: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     <InfoGalleryItem
       key="projects"
       data-testid="ai-flows-projects-info"
-      title="Projects"
+      title="Data science projects"
       imgSrc={typedObjectImage(ProjectObjectType.project)}
       sectionType={SectionType.organize}
       description={
         <TextContent>
           <Text component="small">
-            Projects allow you and your team to organize and collaborate on resources within
-            separate namespaces.
+            Data science projects allow you and your team to organize and collaborate on resources
+            within separate namespaces.
           </Text>
           <Text component="small">
             Within a project, you can create multiple workbenches, each with their own IDE, data

--- a/frontend/src/pages/home/projects/ProjectsSection.tsx
+++ b/frontend/src/pages/home/projects/ProjectsSection.tsx
@@ -126,7 +126,7 @@ const ProjectsSection: React.FC = () => {
                 variant="link"
                 onClick={() => navigate('/projects')}
               >
-                Go to <b>Projects</b>
+                Go to <b>Data Science Projects</b>
               </Button>
             </FlexItem>
           </Flex>

--- a/frontend/src/pages/home/projects/ProjectsSectionHeader.tsx
+++ b/frontend/src/pages/home/projects/ProjectsSectionHeader.tsx
@@ -36,7 +36,7 @@ const ProjectsSectionHeader: React.FC<ProjectsSectionHeaderProps> = ({
         </FlexItem>
         <FlexItem>
           <TextContent>
-            <Text component={TextVariants.h1}>Projects</Text>
+            <Text component={TextVariants.h1}>Data Science Projects</Text>
           </TextContent>
         </FlexItem>
         {showCreate && !allowCreate ? (

--- a/frontend/src/pages/home/useEnableTeamSection.tsx
+++ b/frontend/src/pages/home/useEnableTeamSection.tsx
@@ -78,9 +78,8 @@ export const useEnableTeamSection = (): React.ReactNode => {
         description={
           <TextContent>
             <Text component="small">
-              Administrators can access notebook servers that are owned by other users to correct
-              configuration errors or help a data scientist troubleshoot problems with their
-              environment.
+              A model-serving runtime adds support for a specified set of model frameworks. You can
+              use a default serving runtime, or add and enable a custom serving runtime.
             </Text>
           </TextContent>
         }
@@ -123,7 +122,7 @@ export const useEnableTeamSection = (): React.ReactNode => {
             <Text component="small">
               If you plan to restrict access to your instance by defining specialized user groups,
               you must grant users permission access by adding user accounts to the Red Hat
-              OpenShift AI user group, administrator group, or both.
+              OpenShift AI user groups, administrator groups, or both.
             </Text>
           </TextContent>
         }


### PR DESCRIPTION
Closes: [RHOAIENG-7483](https://issues.redhat.com/browse/RHOAIENG-7483)

## Description
Updates the microcopy of the home page:
- Update the text of the `Serving runtimes` card
- Update the text for the `User management` card
- Update the references to the projects section from `Projects` to `Data Science Projects`

## Screen shots
![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/a734d8a8-c250-4b8e-abf2-d9bac9edc900)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/4d2e43c7-e163-49c9-a713-1a37f27d9b99)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/034b5849-7fbf-4b66-ad06-1cb4d9a04c7c)

## How Has This Been Tested?
Manually

## Test Impact
No test impact, textual changes only.

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

/cc @jgiardino
