### PR TITLE
[RHOAIENG-7499] Scheduled pipeline run tab under an experiment are not filtered by experiment

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/usePipelineRunTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/usePipelineRunTable.ts
@@ -3,16 +3,17 @@ import {
   usePipelineArchivedRuns,
 } from '~/concepts/pipelines/apiHooks/usePipelineRuns';
 import { useCreatePipelineRunTable } from '~/concepts/pipelines/content/tables/usePipelineTable';
+import { PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
 import { PipelineRunOptions } from '~/concepts/pipelines/types';
 
 export const usePipelineActiveRunsTable = (
   options?: PipelineRunOptions,
   limit?: number,
-): ReturnType<typeof useCreatePipelineRunTable> =>
-  useCreatePipelineRunTable(usePipelineActiveRuns, options, limit);
+): ReturnType<typeof useCreatePipelineRunTable<PipelineRunKFv2>> =>
+  useCreatePipelineRunTable<PipelineRunKFv2>(usePipelineActiveRuns, options, limit);
 
 export const usePipelineArchivedRunsTable = (
   options?: PipelineRunOptions,
   limit?: number,
-): ReturnType<typeof useCreatePipelineRunTable> =>
-  useCreatePipelineRunTable(usePipelineArchivedRuns, options, limit);
+): ReturnType<typeof useCreatePipelineRunTable<PipelineRunKFv2>> =>
+  useCreatePipelineRunTable<PipelineRunKFv2>(usePipelineArchivedRuns, options, limit);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobTable.ts
@@ -1,4 +1,10 @@
 import usePipelineRunJobs from '~/concepts/pipelines/apiHooks/usePipelineRunJobs';
-import createUsePipelineTable from '~/concepts/pipelines/content/tables/usePipelineTable';
+import { useCreatePipelineRunTable } from '~/concepts/pipelines/content/tables/usePipelineTable';
+import { PipelineRunJobKFv2 } from '~/concepts/pipelines/kfTypes';
+import { PipelineRunOptions } from '~/concepts/pipelines/types';
 
-export default createUsePipelineTable(usePipelineRunJobs);
+export const usePipelineScheduledRunsTable = (
+  options?: PipelineRunOptions,
+  limit?: number,
+): ReturnType<typeof useCreatePipelineRunTable<PipelineRunJobKFv2>> =>
+  useCreatePipelineRunTable<PipelineRunJobKFv2>(usePipelineRunJobs, options, limit);

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineTable.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PipelineCoreResourceKFv2, PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import { PipelineCoreResourceKFv2 } from '~/concepts/pipelines/kfTypes';
 import {
   PipelineListPaged,
   PipelineOptions,
@@ -52,18 +52,19 @@ export const getTablePagingProps = (
     setPageSize,
   }))(tableProps);
 
-export const useCreatePipelineRunTable = (
-  fetchState: (options: PipelineRunOptions) => FetchState<PipelineListPaged<PipelineRunKFv2>>,
+export function useCreatePipelineRunTable<T extends PipelineCoreResourceKFv2>(
+  fetchState: (options: PipelineRunOptions) => FetchState<PipelineListPaged<T>>,
   additionalOptions?: PipelineRunOptions,
   limit?: number,
-): [FetchState<PipelineListPaged<PipelineRunKFv2>>, TableProps] =>
-  createUsePipelineTable((options) => {
+): [FetchState<PipelineListPaged<T>>, TableProps] {
+  return createUsePipelineTable<T>((options) => {
     const experimentId = options.filter?.predicates?.find(
       (predicate) => predicate.key === 'experiment_id',
     )?.string_value;
 
     return fetchState({ ...options, experimentId, ...additionalOptions });
   })(limit);
+}
 
 const createUsePipelineTable =
   <T extends PipelineCoreResourceKFv2>(

--- a/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
@@ -15,7 +15,7 @@ import {
 import { ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import PipelineRunJobTable from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable';
-import usePipelineRunJobTable from '~/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobTable';
+import { usePipelineScheduledRunsTable } from '~/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobTable';
 import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
 import { scheduleRunRoute } from '~/routes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
@@ -25,7 +25,7 @@ const ScheduledRuns: React.FC = () => {
   const navigate = useNavigate();
   const { namespace, experimentId } = useParams();
   const [[{ items: jobs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
-    usePipelineRunJobTable();
+    usePipelineScheduledRunsTable({ experimentId });
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
   if (error) {


### PR DESCRIPTION
Closes: [RHOAIENG-7499](https://issues.redhat.com/browse/RHOAIENG-7499)

## Description
Now filtering run schedules by experiment ID when an experiment ID exists in the URL.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
