### PR TITLE
[WIP] Add a low profile overlay

### DIFF
--- a/manifests/overlays/lowProfile/deployment.yaml
+++ b/manifests/overlays/lowProfile/deployment.yaml
@@ -1,0 +1,30 @@
+# dashboard container smaller
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: 100m
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: 250Mi
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: 200m
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: 500Mi
+# oauth proxy container smaller
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/cpu
+  value: 100m
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/memory
+  value: 250Mi
+- op: replace
+  path: /spec/template/spec/containers/1/resources/limits/cpu
+  value: 200m
+- op: replace
+  path: /spec/template/spec/containers/1/resources/limits/memory
+  value: 500Mi
+# 1 replica
+- op: replace
+  path: /spec/replicas
+  value: 1

--- a/manifests/overlays/lowProfile/kustomization.yaml
+++ b/manifests/overlays/lowProfile/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesJson6902:
+  - path: deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: odh-dashboard


### PR DESCRIPTION
Add a standard low profile mode for the Dashboard. This way we can be run with minimal items

DSC Status:
```
spec:
  dashboard:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: overlays/lowProfile
            uri: >-
              https://github.com/andrewballantyne/odh-dashboard/tarball/lowProfile
    managementState: Managed
```

Testing...
* Currently the network requests are awfully slow, takes a few seconds to get the loaded state of anything. Likely will end up queuing hard behind the requests if polling ie excessive.