### PR TITLE
[RHOAIENG-4385] DSPA - Add back the Folder Info

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   FormSection,
   Title,
@@ -7,14 +8,17 @@ import {
   InputGroup,
   Tooltip,
   InputGroupItem,
+  Alert,
+  Popover,
 } from '@patternfly/react-core';
-import React from 'react';
 import { DataConnection } from '~/pages/projects/types';
-import { PIPELINE_AWS_FIELDS } from '~/pages/projects/dataConnections/const';
+import { AwsKeys, PIPELINE_AWS_FIELDS } from '~/pages/projects/dataConnections/const';
 import { FieldListField } from '~/components/FieldList';
+import ExternalLink from '~/components/ExternalLink';
+import { PipelineDropdown } from './PipelineDropdown';
 import { PipelineServerConfigType } from './types';
 import './ConfigurePipelinesServerModal.scss';
-import { PipelineDropdown } from './PipelineDropdown';
+import { storingDataHelpLink } from './const';
 
 export type FieldOptions = {
   key: string;
@@ -85,14 +89,42 @@ export const ObjectStorageSection = ({
             </InputGroup>
           </FormGroup>
         ) : (
-          <FieldListField
-            key={field.key}
-            value={
-              config.objectStorage.newValue.find((data) => data.key === field.key)?.value || ''
-            }
-            options={field}
-            onChange={onChange}
-          />
+          <>
+            <FieldListField
+              key={field.key}
+              value={
+                config.objectStorage.newValue.find((data) => data.key === field.key)?.value || ''
+              }
+              options={field}
+              onChange={onChange}
+            />
+
+            {field.key === AwsKeys.AWS_S3_BUCKET && (
+              <Popover
+                aria-label="bucket tooltip"
+                headerContent="Where is my data stored within the bucket?"
+                position="right"
+                hasAutoWidth
+                bodyContent={
+                  <div className="pf-v5-u-mt-md">
+                    Uploaded pipelines will be stored in the <b>/pipelines</b> directory.
+                    <br />
+                    When running a pipeline, artifacts will be stored in dedicated folders at the{' '}
+                    <b>/root</b> directory.
+                  </div>
+                }
+                footerContent={<ExternalLink text="Learn more" to={storingDataHelpLink} />}
+              >
+                <Alert
+                  variant="info"
+                  isInline
+                  isPlain
+                  title="Where is my data stored within the bucket?"
+                  style={{ width: 'fit-content' }}
+                />
+              </Popover>
+            )}
+          </>
         ),
       )}
     </FormSection>

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/const.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/const.ts
@@ -70,3 +70,6 @@ export const EMPTY_DATABASE_CONNECTION: EnvVariableDataEntry[] = [
     value: '',
   },
 ];
+
+export const storingDataHelpLink =
+  'https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud_service/1/html/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#storing-data-with-data-science-pipelines_ds-pipelines';


### PR DESCRIPTION
Closes: [RHOAIENG-4385](https://issues.redhat.com/browse/RHOAIENG-4385)

## Description
Added info alert with popover for Bucket field in the Configure Pipeline modal

<img width="1011" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/a5650feb-4882-473d-bb5f-7bd48a217862">
(cc @yannnz)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
