### PR TITLE
[RHOAIENG-7531] eslint rule to flag hard coded product name usage instead of variable

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -279,6 +279,23 @@
         "prettier",
         "plugin:cypress/recommended"
       ]
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "excludedFiles": ["src/__mocks__/**", "src/__tests__/**"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Literal[value=/\\bRed Hat OpenShift AI\\b/i],JSXText[value=/\\bRed Hat OpenShift AI\\b/i]",
+            "message": "Do not hard code product name `Red Hat OpenShift AI`. Use `~/utilities/const#ODH_PRODUCT_NAME` instead."
+          },
+          {
+            "selector": "Literal[value=/\\bOpen Data Hub\\b/i],JSXText[value=/\\bOpen Data Hub\\b/i]",
+            "message": "Do not hard code product name `Open Data Hub`. Use `~/utilities/const#ODH_PRODUCT_NAME` instead."
+          }
+        ]
+      }
     }
   ]
 }

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -7,6 +7,9 @@ import { interceptSnapshotFile } from '~/__tests__/cypress/cypress/utils/snapsho
 import { setup as setupWebsockets } from '~/__tests__/cypress/cypress/support/websockets';
 
 dotenv.config({
+  path: path.resolve(__dirname, '../../../.env'),
+});
+dotenv.config({
   path: path.resolve(__dirname, `../../../.env.cypress${process.env.MOCK ? '.mock' : ''}`),
 });
 dotenv.config({
@@ -28,6 +31,7 @@ export default defineConfig({
     codeCoverage: {
       exclude: [path.resolve(__dirname, '../../third_party/**')],
     },
+    ODH_PRODUCT_NAME: process.env.ODH_PRODUCT_NAME,
   },
   defaultCommandTimeout: 10000,
   e2e: {

--- a/frontend/src/__tests__/cypress/cypress/pages/administration.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/administration.ts
@@ -28,7 +28,9 @@ class AdministrationTab {
   shouldHaveManageUsersAlert() {
     cy.findByTestId('manage-users-alert').should(
       'have.text',
-      'Custom alert:Manage users in OpenShiftCreate, delete, and manage permissions for Red Hat OpenShift AI users in OpenShift. Learn more about OpenShift user management',
+      `Custom alert:Manage users in OpenShiftCreate, delete, and manage permissions for ${Cypress.env(
+        'ODH_PRODUCT_NAME',
+      )} users in OpenShift. Learn more about OpenShift user management`,
     );
     return this;
   }

--- a/frontend/src/components/OdhExploreCardTypeBadge.tsx
+++ b/frontend/src/components/OdhExploreCardTypeBadge.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { OdhApplicationCategory } from '~/types';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
 
 type OdhExploreCardTypeBadgeProps = {
   category: OdhApplicationCategory | string;
@@ -14,8 +15,7 @@ const OdhExploreCardTypeBadge: React.FC<OdhExploreCardTypeBadgeProps> = ({ categ
   } else if (category === OdhApplicationCategory.PartnerManaged) {
     content = 'Partner managed software is hosted on the ISV’s cloud service';
   } else if (category === OdhApplicationCategory.SelfManaged) {
-    content =
-      'Self-managed software is installed to a Red Hat OpenShift AI cluster, but does not support upgrade testing, alerting, or other features of externally managed software';
+    content = `Self-managed software is installed to a ${ODH_PRODUCT_NAME} cluster, but does not support upgrade testing, alerting, or other features of externally managed software`;
   }
 
   if (!content) {

--- a/frontend/src/concepts/pipelines/content/InvalidArgoDeploymentAlert.tsx
+++ b/frontend/src/concepts/pipelines/content/InvalidArgoDeploymentAlert.tsx
@@ -2,6 +2,7 @@ import { Alert, AlertActionCloseButton, AlertActionLink } from '@patternfly/reac
 import React from 'react';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
 
 const INVALID_ARGO_DEPLOYMENT_CLOUD_DOCUMENTATION_URL =
   'https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.9/html/release_notes/new-features-and-enhancements_relnotes';
@@ -55,7 +56,7 @@ export const InvalidArgoDeploymentAlert: React.FC = () => {
       title="Data Science Pipelines enablement failed"
     >
       Data Science Pipelines could not be enabled because a version of Argo Workflows that is not
-      managed by Red Hat is installed on your cluster. To learn more, view the Red Hat Openshift AI
+      managed by Red Hat is installed on your cluster. To learn more, view the {ODH_PRODUCT_NAME}
       2.9 documentation.
     </Alert>
   );

--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -6,6 +6,7 @@ import ExternalLink from '~/components/ExternalLink';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import StopServerModal from '~/pages/notebookController/screens/server/StopServerModal';
 import { Notebook } from '~/types';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
 import { columns } from './data';
 import StopAllServersButton from './StopAllServersButton';
 import UserTableCellTransform from './UserTableCellTransform';
@@ -55,7 +56,7 @@ const NotebookAdminControl: React.FC = () => {
               isInline
               data-testid="manage-users-alert"
             >
-              Create, delete, and manage permissions for Red Hat OpenShift AI users in OpenShift.{' '}
+              Create, delete, and manage permissions for {ODH_PRODUCT_NAME} users in OpenShift.{' '}
               <ExternalLink
                 text="Learn more about OpenShift user management"
                 to="https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/index"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #7531 -->

[RHOAIENG-7531](https://issues.redhat.com/browse/RHOAIENG-7531)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

I added 2 eslint rules to flag hard coded product name (e.g. Red Hat Openshift AI or Open Data Hub) usage instead of variable. These should instead reference variable name `ODH_PRODUCT_NAME` so that it could be replaced by the environment variable that was configured.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran `npm run test:lint` to run the rule checker. I also run `npm run test` to see if tests were playing well with the code changes.

Steps to reproduce code changes:

**Notebook Admin Control**
- Go to Applications > Enabled
- Click the default Jupyter application and press `Launch application`
- Navigate to the `Administration` tab. You should see the product name there.

**Odh Explore Card**
- If not done yet, create a Self-managed application.
- Go to Applications > Explore
- There is an overlay blocking this manual test (will create a ticket for this later). To go around this, right click the card and press inspect element. Delete that chunk of code (it should have the property `class="pf-v5-c-radio__label"`).
- Hover over the `Self-managed` label. You should see the product name there.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No new tests are needed; this was the test itself to check for product name usage

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
