### PR TITLE
Reloads the page after deleting DSPv1 pipeline server

### DIFF
--- a/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
@@ -12,11 +12,10 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import DeletePipelineServerModal from '~/concepts/pipelines/content/DeletePipelineServerModal';
 import ExternalLink from '~/components/ExternalLink';
 import NoPipelineServer from '~/concepts/pipelines/NoPipelineServer';
 import { useUser } from '~/redux/selectors';
-import { usePipelinesAPI } from './context';
+import { DeleteServerModal, usePipelinesAPI } from './context';
 
 // TODO: Fix doc link to go to more docs on v2
 const DOCS_LINK =
@@ -85,7 +84,7 @@ const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerPro
             )}
           </EmptyState>
         </Bullseye>
-        <DeletePipelineServerModal isOpen={isDeleting} onClose={() => setIsDeleting(false)} />
+        <DeleteServerModal isOpen={isDeleting} onClose={() => setIsDeleting(false)} />
       </>
     );
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes: https://issues.redhat.com/browse/RHOAIENG-5325

## Description
The UI page reloads/refreshed  when DSPv1 pipeline server is deleted

[Screencast from 2024-05-30 15-45-06.webm](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/bb046e47-c439-4880-8dca-ac3a7c463e8c)
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Needed DSPV1 pipeline version 
(to do this In the openshift console ->navigate to DataSciencePipelinesApplication  within your project/namespace, search for `dspVersion: v2`  change v2 to v1 and save

2. Check for the warning in the dashboard UI 
3. click on Delete pipeline server button and delete the version
4. once deleted, check whether the UI is refreshed 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
