### PR TITLE
fixed end date issue and issues scheduling pipelines in Firefox

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/RunTypeSectionScheduled.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/RunTypeSectionScheduled.tsx
@@ -6,6 +6,7 @@ import EndDateBeforeStartDateError from '~/concepts/pipelines/content/createRun/
 import CatchUp from '~/concepts/pipelines/content/createRun/contentSections/CatchUp';
 import MaxConcurrencyField from '~/concepts/pipelines/content/createRun/contentSections/MaxConcurrencyField';
 import TriggerTypeField from '~/concepts/pipelines/content/createRun/contentSections/TriggerTypeField';
+import { convertToDate } from '~/utilities/time';
 
 type RunTypeSectionScheduledProps = {
   data: RunTypeScheduledData;
@@ -39,7 +40,7 @@ const RunTypeSectionScheduled: React.FC<RunTypeSectionScheduledProps> = ({ data,
         onChange={(end) => onChange({ ...data, end })}
         adjustNow={(now) => {
           if (data.start) {
-            const start = new Date(`${data.start.date} ${data.start.time}`);
+            const start = convertToDate(data.start);
             start.setDate(start.getDate() + 7);
             return start;
           }

--- a/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
@@ -21,7 +21,7 @@ import {
   getInputDefinitionParams,
   isFilledRunFormData,
 } from '~/concepts/pipelines/content/createRun/utils';
-import { convertPeriodicTimeToSeconds } from '~/utilities/time';
+import { convertPeriodicTimeToSeconds, convertToDate } from '~/utilities/time';
 
 const createRun = async (
   formData: SafeRunFormData,
@@ -46,12 +46,11 @@ const createRun = async (
   return createPipelineRun({}, data);
 };
 
-const convertDateDataToKFDateTime = (dateData?: RunDateTime): DateTimeKF | null => {
+export const convertDateDataToKFDateTime = (dateData?: RunDateTime): DateTimeKF | null => {
   if (!dateData) {
     return null;
   }
-
-  const date = new Date(`${dateData.date} ${dateData.time}`);
+  const date = convertToDate(dateData);
   return date.toISOString();
 };
 

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -6,8 +6,8 @@ import {
   ScheduledType,
 } from '~/concepts/pipelines/content/createRun/types';
 import { ParametersKF, PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
-
 import { getCorePipelineSpec } from '~/concepts/pipelines/getCorePipelineSpec';
+import { convertToDate } from '~/utilities/time';
 
 const runTypeSafeData = (runType: RunFormData['runType']): boolean =>
   runType.type !== RunTypeOption.SCHEDULED ||
@@ -18,10 +18,8 @@ export const isStartBeforeEnd = (start?: RunDateTime, end?: RunDateTime): boolea
   if (!start || !end) {
     return true;
   }
-
-  const startDate = new Date(`${start.date} ${start.time}`);
-  const endDate = new Date(`${end.date} ${end.time}`);
-
+  const startDate = convertToDate(start);
+  const endDate = convertToDate(end);
   return endDate.getTime() - startDate.getTime() > 0;
 };
 
@@ -29,8 +27,7 @@ const isValidDate = (value?: RunDateTime): boolean => {
   if (!value) {
     return true;
   }
-
-  const date = new Date(`${value.date} ${value.time}`);
+  const date = convertToDate(value);
   return date.toString() !== 'Invalid Date';
 };
 

--- a/frontend/src/utilities/__tests__/time.spec.ts
+++ b/frontend/src/utilities/__tests__/time.spec.ts
@@ -1,3 +1,4 @@
+import { RunDateTime } from '~/concepts/pipelines/content/createRun/types';
 import {
   convertPeriodicTimeToSeconds,
   convertSecondsToPeriodicTime,
@@ -7,6 +8,8 @@ import {
   ensureTimeFormat,
   printSeconds,
   relativeTime,
+  convertToTwentyFourHourTime,
+  convertToDate,
 } from '~/utilities/time';
 
 describe('relativeDuration', () => {
@@ -48,6 +51,53 @@ describe('convertDateToTimeString', () => {
   it('should convert to 12:00 AM if time entered on date is 0', () => {
     const date = new Date('2021-01-01T00:00:00');
     expect(convertDateToTimeString(date)).toBe('12:00 AM');
+  });
+});
+
+describe('convertToDate', () => {
+  it('should convert to local date', () => {
+    const value: RunDateTime = {
+      date: '2024-01-04',
+      time: '11:55 PM',
+    };
+    expect(convertToDate(value)).toStrictEqual(new Date('2024-01-04T23:55:00.000'));
+  });
+
+  it('should convert to local date using convertToTwentyFourHourTime function', () => {
+    const value: RunDateTime = {
+      date: '2024-01-04',
+      time: '12:30 PM',
+    };
+    expect(convertToDate(value)).toStrictEqual(
+      new Date(`${value.date}T${convertToTwentyFourHourTime(value.time)}:00.000`),
+    );
+  });
+});
+
+describe('convertToTwentyFourHourTime', () => {
+  it('should convert 12 hour time to 24 hour time', () => {
+    const time = '1:30 AM';
+    expect(convertToTwentyFourHourTime(time)).toBe('01:30');
+  });
+
+  it('should convert past 12', () => {
+    const time = '2:55 PM';
+    expect(convertToTwentyFourHourTime(time)).toBe('14:55');
+  });
+
+  it('should convert from 10 AM <= x < 12PM to 24 hour time', () => {
+    const time = '11:24 AM';
+    expect(convertToTwentyFourHourTime(time)).toBe('11:24');
+  });
+
+  it('should convert from 12:30 PM to 12:30', () => {
+    const time = '12:30 PM';
+    expect(convertToTwentyFourHourTime(time)).toBe('12:30');
+  });
+
+  it('should convert from 12:30 AM to 00:30', () => {
+    const time = '12:30 AM';
+    expect(convertToTwentyFourHourTime(time)).toBe('00:30');
   });
 });
 

--- a/frontend/src/utilities/time.ts
+++ b/frontend/src/utilities/time.ts
@@ -1,5 +1,6 @@
 import {
   PeriodicOptions,
+  RunDateTime,
   periodicOptionAsSeconds,
 } from '~/concepts/pipelines/content/createRun/types';
 
@@ -40,6 +41,21 @@ export const convertDateToTimeString = (date?: Date): string | null => {
   const hoursIn12 = (hours >= 12 ? hours - 12 : hours) || 12;
 
   return `${hoursIn12}:${leadZero(date.getMinutes())} ${hours >= 12 ? 'PM' : 'AM'}`;
+};
+
+export const convertToDate = ({ date, time }: RunDateTime): Date =>
+  new Date(`${date}T${convertToTwentyFourHourTime(time)}:00.000`);
+
+/* Return HH:MM from HH:MM *M */
+export const convertToTwentyFourHourTime = (time: string): string => {
+  const timeArray = time.trim().split(' ');
+  const hourMinutesArray = timeArray[0].trim().split(':');
+  const hour = Number(hourMinutesArray[0]);
+  const minutes = hourMinutesArray[1];
+  if (timeArray[1] === 'AM') {
+    return `${hour === 12 ? 0 : hour}:${minutes}`.padStart(5, '0');
+  }
+  return `${hour === 12 ? hour : hour + 12}:${minutes}`;
 };
 
 /** The TimeField component can sometimes cause '6:00PM' instead of '6:00 PM' if the user edits directly */


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-1197](https://issues.redhat.com/browse/RHOAIENG-1197)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The issue at hand was that in Firefox, when trying to schedule a pipeline run, returned incoherent values for the end date. This was because of the usage of the Date() constructor, which is inconsistent at runtime if the parameter isn't an `ISO 8601 formatted` string. Here is the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#several_ways_to_create_a_date_object) if you are interested.

Unfortunately, it seemed that I could not schedule any pipelines in Firefox, due to this runtime issue, which is a larger issue. Although this is now fixed, I need guidance on whether or not the testing I have done is adequate, or if it needs more.

Reproducible for Firefox on Mac

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run `npm run test`.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I added a test for my newly created function in `frontend/src/utilities/__tests__/time.spec.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
