### PR TITLE
Fix issue that fetch the wrong Notebook Image if two Imagestream Version shared the same sha

### DIFF
--- a/frontend/src/__mocks__/mockImageStreamK8sResource.ts
+++ b/frontend/src/__mocks__/mockImageStreamK8sResource.ts
@@ -7,6 +7,7 @@ type MockResourceConfigType = {
   namespace?: string;
   displayName?: string;
   imageTag?: string;
+  tagName?: string;
   opts?: RecursivePartial<ImageStreamKind>;
 };
 
@@ -15,6 +16,7 @@ export const mockImageStreamK8sResource = ({
   namespace = 'test-project',
   displayName = 'Test Image',
   imageTag = 'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+  tagName = '1.2',
   opts = {},
 }: MockResourceConfigType): ImageStreamKind =>
   _.mergeWith(
@@ -50,7 +52,7 @@ export const mockImageStreamK8sResource = ({
         },
         tags: [
           {
-            name: '1.2',
+            name: tagName,
             annotations: {
               'opendatahub.io/notebook-python-dependencies':
                 '[{"name":"JupyterLab","version": "3.2"}, {"name": "Notebook","version": "6.4"}]',

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -14,6 +14,7 @@ type MockResourceConfigType = {
   envFromName?: string;
   resources?: ContainerResources;
   image?: string;
+  lastImageSelection?: string;
   opts?: RecursivePartial<NotebookKind>;
   uid?: string;
 };
@@ -27,6 +28,7 @@ export const mockNotebookK8sResource = ({
   description = '',
   resources = DEFAULT_NOTEBOOK_SIZES[0].resources,
   image = 'test-imagestream:1.2',
+  lastImageSelection = 's2i-minimal-notebook:py3.8-v1',
   opts = {},
   uid = genUID('notebook'),
 }: MockResourceConfigType): NotebookKind =>
@@ -38,7 +40,7 @@ export const mockNotebookK8sResource = ({
         annotations: {
           'notebooks.kubeflow.org/last-activity': '2023-02-14T21:45:14Z',
           'notebooks.opendatahub.io/inject-oauth': 'true',
-          'notebooks.opendatahub.io/last-image-selection': 's2i-minimal-notebook:py3.8-v1',
+          'notebooks.opendatahub.io/last-image-selection': lastImageSelection,
           'notebooks.opendatahub.io/last-size-selection': 'Small',
           'notebooks.opendatahub.io/oauth-logout-url':
             'http://localhost:4010/projects/project?notebookLogout=workbench',

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/useNotebookImageData.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/useNotebookImageData.spec.ts
@@ -4,19 +4,93 @@ import { getNotebookImageData } from '~/pages/projects/screens/detail/notebooks/
 import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
 
 describe('getNotebookImageData', () => {
-  it('should return image data when image stream exists and image version exists', () => {
+  it('should return image data when image stream exists and image version exists with internal registry', () => {
     const notebook = mockNotebookK8sResource({
       image:
         'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+      lastImageSelection: 'jupyter-datascience-notebook',
     });
     const images = [
       mockImageStreamK8sResource({
         imageTag:
           'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+        name: 'jupyter-datascience-notebook',
       }),
     ];
     const result = getNotebookImageData(notebook, images);
     expect(result?.imageAvailability).toBe(NotebookImageAvailability.ENABLED);
+  });
+
+  it('should return image data when image stream exists and image version exists without internal registry', () => {
+    const imageName = 'jupyter-datascience-notebook';
+    const tagName = '2024.1';
+    const notebook = mockNotebookK8sResource({
+      image: `image-registry.openshift-image-registry.svc:5000/opendatahub/${imageName}:${tagName}`,
+      lastImageSelection: 'jupyter-datascience-notebook',
+    });
+    const images = [
+      mockImageStreamK8sResource({
+        imageTag:
+          'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+        tagName,
+        name: imageName,
+      }),
+    ];
+    const result = getNotebookImageData(notebook, images);
+    expect(result?.imageAvailability).toBe(NotebookImageAvailability.ENABLED);
+  });
+
+  it('should return the right image if multiple ImageStreams have the same image with internal registry', () => {
+    const displayName = 'Jupyter Data Science Notebook';
+    const notebook = mockNotebookK8sResource({
+      image:
+        'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+      lastImageSelection: 'jupyter-datascience-notebook',
+    });
+    const images = [
+      mockImageStreamK8sResource({
+        imageTag:
+          'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+        name: 'jupyter-datascience-notebook',
+        displayName,
+      }),
+      mockImageStreamK8sResource({
+        imageTag:
+          'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+        name: 'custom-notebook',
+        displayName: 'Custom Notebook',
+      }),
+    ];
+    const result = getNotebookImageData(notebook, images);
+    expect(result?.imageDisplayName).toBe(displayName);
+  });
+
+  it('should return the right image if multiple ImageStreams have the same tag without internal registry', () => {
+    const imageName = 'jupyter-datascience-notebook';
+    const tagName = '2024.1';
+    const displayName = 'Jupyter Data Science Notebook';
+    const notebook = mockNotebookK8sResource({
+      image: `image-registry.openshift-image-registry.svc:5000/opendatahub/${imageName}:${tagName}`,
+      lastImageSelection: 'jupyter-datascience-notebook',
+    });
+    const images = [
+      mockImageStreamK8sResource({
+        imageTag:
+          'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+        tagName,
+        name: 'code-server',
+        displayName: 'Code Server',
+      }),
+      mockImageStreamK8sResource({
+        imageTag:
+          'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+        tagName,
+        name: imageName,
+        displayName,
+      }),
+    ];
+    const result = getNotebookImageData(notebook, images);
+    expect(result?.imageDisplayName).toBe(displayName);
   });
 
   it('should return image data when image stream exists and image version does not exist', () => {

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -23,14 +23,23 @@ export const getNotebookImageData = (
     };
   }
 
-  const [, versionName] = imageTag;
-  const imageStream = images.find((image) =>
-    image.spec.tags
-      ? image.spec.tags.find(
-          (version) => version.name === versionName || version.from?.name === container.image,
-        )
-      : false,
-  );
+  const [imageName, versionName] = imageTag;
+  const [lastImageSelectionName] =
+    notebook.metadata.annotations?.['notebooks.opendatahub.io/last-image-selection']?.split(':') ??
+    [];
+
+  // Fallback for non internal registry clusters
+  const imageStream =
+    images.find((image) => image.metadata.name === imageName) ||
+    images.find((image) =>
+      image.spec.tags
+        ? image.spec.tags.find(
+            (version) =>
+              version.from?.name === container.image &&
+              image.metadata.name === lastImageSelectionName,
+          )
+        : false,
+    );
 
   // if the image stream is not found, consider it deleted
   if (!imageStream) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-7917

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix issue that fetch the wrong Notebook Image if two Imagestream Version shared the same sha

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### In a cluster without Internal Registry

1. Create a workbench with jupyter-minimal-notebook imagestream
2. Notebook image value is shown properly on Dashboard as Minimal Python
3. Then import a custom image (same as is used in this jupyter-minimal-notebook imagestream) and name it as custom-minimal
4. The Notebook image should keep the same image

### In a cluster with Internal Registry

1. Deploy an image
2. It should display the correct image version

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Expanded the testing coverage of the function to account for that edge case

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
