### PR TITLE
added method-style rule for eslint

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -77,6 +77,7 @@
       "always",
       { "exceptAfterSingleLine": false }
     ],
+    "@typescript-eslint/method-signature-style": "error",
     "@typescript-eslint/naming-convention": [
       "error",
       {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -11,17 +11,17 @@ declare global {
        * @param url the URL to visit
        * @param credentials login credentials
        */
-      visitWithLogin(
+      visitWithLogin: (
         url: string,
         credentials?: { username: string; password: string; provider?: string },
-      ): Cypress.Chainable<void>;
+      ) => Cypress.Chainable<void>;
 
       /**
        * Find a patternfly kebab toggle button.
        *
        * @param isDropdownToggle - True to indicate that it is a dropdown toggle instead of table kebab actions
        */
-      findKebab(isDropdownToggle?: boolean): Cypress.Chainable<JQuery>;
+      findKebab: (isDropdownToggle?: boolean) => Cypress.Chainable<JQuery>;
 
       /**
        * Finds a patternfly kebab toggle button, opens the menu, and finds the action.
@@ -29,51 +29,61 @@ declare global {
        * @param name the name of the action in the kebeb menu
        * @param isDropdownToggle - True to indicate that it is a dropdown toggle instead of table kebab actions
        */
-      findKebabAction(name: string | RegExp, isDropdownToggle?: boolean): Cypress.Chainable<JQuery>;
+      findKebabAction: (
+        name: string | RegExp,
+        isDropdownToggle?: boolean,
+      ) => Cypress.Chainable<JQuery>;
 
       /**
        * Finds a patternfly dropdown item by first opening the dropdown if not already opened.
        *
        * @param name the name of the item
        */
-      findDropdownItem(name: string | RegExp): Cypress.Chainable<JQuery>;
+      findDropdownItem: (name: string | RegExp) => Cypress.Chainable<JQuery>;
 
       /**
        * Finds a patternfly dropdown item by data-testid, first opening the dropdown if not already opened.
        *
        * @param testId the name of the item
        */
-      findDropdownItemByTestId(testId: string): Cypress.Chainable<JQuery>;
+      findDropdownItemByTestId: (testId: string) => Cypress.Chainable<JQuery>;
       /**
        * Finds a patternfly select option by first opening the select menu if not already opened.
        *
        * @param name the name of the option
        */
-      findSelectOption(name: string | RegExp): Cypress.Chainable<JQuery>;
+      findSelectOption: (name: string | RegExp) => Cypress.Chainable<JQuery>;
 
       /**
        * Shortcut to first clear the previous value and then type text into DOM element.
        *
        * @see https://on.cypress.io/type
        */
-      fill(
+      fill: (
         text: string,
         options?: Partial<Cypress.TypeOptions> | undefined,
-      ): Cypress.Chainable<unknown>;
+      ) => Cypress.Chainable<unknown>;
 
       /**
        * Returns a PF Switch label for clickable actions.
        *
        * @param dataId - the data test id you provided to the PF Switch
        */
-      pfSwitch(dataId: string): Cypress.Chainable<JQuery>;
+      pfSwitch: (dataId: string) => Cypress.Chainable<JQuery>;
 
       /**
        * Returns a PF Switch input behind the checkbox to compare .should('be.checked') like ops
        *
        * @param dataId
        */
-      pfSwitchValue(dataId: string): Cypress.Chainable<JQuery>;
+      pfSwitchValue: (dataId: string) => Cypress.Chainable<JQuery>;
+
+      /**
+       * The bottom two functions, findByTestId and findAllByTestId have the disabled rule
+       * method-signature-style because they are overwrites.
+       * Thus, we cannot change it to use the property signature for functions.
+       * https://typescript-eslint.io/rules/method-signature-style/
+       */
 
       /**
        * Overwrite `findByTestId` to support an array of Matchers.
@@ -85,6 +95,7 @@ declare global {
        * cy.findByTestId(['card', 'my-id']);
        * cy.findByTestId('card my-id');
        */
+      // eslint-disable-next-line @typescript-eslint/method-signature-style
       findByTestId(id: Matcher | Matcher[], options?: MatcherOptions): Chainable<JQuery>;
 
       /**
@@ -97,6 +108,7 @@ declare global {
        * cy.findAllByTestId(['card']);
        * cy.findAllByTestId('card my-id');
        */
+      // eslint-disable-next-line @typescript-eslint/method-signature-style
       findAllByTestId(id: Matcher | Matcher[], options?: MatcherOptions): Chainable<JQuery>;
     }
   }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/axe.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/axe.ts
@@ -4,7 +4,7 @@ import 'cypress-axe';
 declare global {
   namespace Cypress {
     interface Chainable {
-      testA11y(context?: Parameters<cy['checkA11y']>[0]): void;
+      testA11y: (context?: Parameters<cy['checkA11y']>[0]) => void;
     }
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/intercept-snapshots.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/intercept-snapshots.ts
@@ -7,8 +7,8 @@ declare global {
   namespace Cypress {
     interface Chainable {
       interceptSnapshot: InterceptSnapshot;
-      waitSnapshot(alias: string): Chainable<Interception>;
-      readSnapshot(path: string): Cypress.Chainable<{ [key: string]: Snapshot }>;
+      waitSnapshot: (alias: string) => Chainable<Interception>;
+      readSnapshot: (path: string) => Cypress.Chainable<{ [key: string]: Snapshot }>;
     }
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/k8s.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/k8s.ts
@@ -35,16 +35,16 @@ declare global {
        * By default all the URL will include the namespace but not the name of the provided resource.
        * This results in the default behavior tailored to listing resources.
        */
-      wsK8s<K extends K8sResourceCommon>(
+      wsK8s: <K extends K8sResourceCommon>(
         type: 'ADDED' | 'DELETED' | 'MODIFIED',
         modelOrOptions: K8sModelCommon | WsOptions,
         resource: K,
-      ): Cypress.Chainable<undefined>;
+      ) => Cypress.Chainable<undefined>;
 
       /**
        * Simplified variant of equivalent function for GET method.
        */
-      interceptK8s<K extends K8sResourceCommon>(
+      interceptK8s: (<K extends K8sResourceCommon>(
         modelOrOptions: K8sModelCommon | K8sOptions,
         response?:
           | K
@@ -53,29 +53,28 @@ declare global {
           | string
           | GenericStaticResponse<string, K | K8sStatus | Patch[] | string>
           | RouteHandlerController,
-      ): Chainable<null>;
-
-      /**
-       * Intercept command for K8s resource.
-       * Provides equivalent functionality to `cy.intercept` where the URL is constructed from the given model and options.
-       *
-       * The default URL will include the name and namespace extracted from the supplied resource.
-       * This can be overridden by supplying options.
-       *
-       * If a payload other than a K8s resource is supplied, ensure that the appropriate options include the resource
-       * name and namespace, if required.
-       */
-      interceptK8s<K extends K8sResourceCommon>(
-        method: 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT',
-        modelOrOptions: K8sModelCommon | K8sOptions,
-        response?:
-          | K
-          | K8sStatus
-          | Patch[]
-          | string
-          | GenericStaticResponse<string, K | K8sStatus | Patch[] | string>
-          | RouteHandlerController,
-      ): Chainable<null>;
+      ) => Chainable<null>) &
+        /**
+         * Intercept command for K8s resource.
+         * Provides equivalent functionality to `cy.intercept` where the URL is constructed from the given model and options.
+         *
+         * The default URL will include the name and namespace extracted from the supplied resource.
+         * This can be overridden by supplying options.
+         *
+         * If a payload other than a K8s resource is supplied, ensure that the appropriate options include the resource
+         * name and namespace, if required.
+         */
+        (<K extends K8sResourceCommon>(
+          method: 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT',
+          modelOrOptions: K8sModelCommon | K8sOptions,
+          response?:
+            | K
+            | K8sStatus
+            | Patch[]
+            | string
+            | GenericStaticResponse<string, K | K8sStatus | Patch[] | string>
+            | RouteHandlerController,
+        ) => Chainable<null>);
 
       /**
        * Intercept command for listing K8s resources.
@@ -87,13 +86,13 @@ declare global {
        * If a payload other than a list containing at least one K8s resource is supplied, ensure that the appropriate
        * options include the resource name and namespace, if required.
        */
-      interceptK8sList<K extends K8sResourceCommon>(
+      interceptK8sList: <K extends K8sResourceCommon>(
         modelOrOptions: K8sModelCommon | K8sOptions,
         resource:
           | K8sResourceListResult<K>
           | GenericStaticResponse<string, K8sResourceListResult<K> | K8sStatus>
           | RouteHandlerController,
-      ): Chainable<null>;
+      ) => Chainable<null>;
     }
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -65,489 +65,404 @@ type Options = { path?: Replacement; query?: Query; times?: number } | null;
 declare global {
   namespace Cypress {
     interface Chainable {
-      interceptOdh(
+      interceptOdh: ((
         type: 'POST /api/accelerator-profiles',
         response?: OdhResponse,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'DELETE /api/accelerator-profiles/:name',
-        options: { path: { name: string } },
-        response?: OdhResponse,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PUT /api/accelerator-profiles/:name',
-        options: { path: { name: string } },
-        response: OdhResponse,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/groups-config',
-        response: OdhResponse<GroupsConfig>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PUT /api/groups-config',
-        response: OdhResponse<GroupsConfig>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/components',
-        options: {
-          query?: {
-            installed: 'true' | 'false';
-          };
-        } | null,
-        response: OdhResponse<OdhApplication[]>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/docs',
-        response: OdhResponse<OdhDocument[]>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/quickstarts',
-        response: OdhResponse<OdhQuickStart[]>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/dsc/status',
-        response: OdhResponse<DataScienceClusterKindStatus>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/status',
-        response: OdhResponse<StatusResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',
-        response: OdhResponse<AllowedUser[]>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',
-        response: OdhResponse<AllowedUser>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
-        response: OdhResponse<K8sResourceListResult<RoleBindingKind>>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/config',
-        response: OdhResponse<DashboardConfigKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/dsci/status',
-        response: OdhResponse<DataScienceClusterInitializationKindStatus>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/dashboardConfig/opendatahub/odh-dashboard-config',
-        response: OdhResponse<DashboardConfigKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/cluster-settings',
-        response: OdhResponse<ClusterSettingsType>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PUT /api/cluster-settings',
-        response: OdhResponse,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/namespaces/:namespace/:context',
-        options: {
-          path: {
-            namespace: string;
-            context: '0' | '1' | '2' | '*';
-          };
-        },
-        response: OdhResponse<{ applied: boolean }>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/templates/:namespace',
-        options: { path: { namespace: string }; query?: { labelSelector: string } },
-        response: OdhResponse<K8sResourceListResult<TemplateKind>>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/templates/:namespace/:name',
-        options: { path: { namespace: string; name: string } },
-        response: OdhResponse<TemplateKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/templates/',
-        response: OdhResponse<TemplateKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'DELETE /api/templates/:namespace/:name',
-        options: { path: { namespace: string; name: string } },
-        response: OdhResponse<TemplateKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PATCH /api/templates/:namespace/:name',
-        options: { path: { namespace: string; name: string } },
-        response: OdhResponse<TemplateKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/servingRuntimes/',
-        options: { query: { dryRun: 'All' } } | null,
-        response: OdhResponse<ServingRuntimeKind>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/images/byon',
-        response: OdhResponse<BYONImage[]>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/images/:type',
-        options: { path: { type: string } },
-        response: OdhResponse<ImageInfo[]>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'DELETE /api/images/:image',
-        options: { path: { image: string } },
-        response: OdhResponse<SuccessErrorResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PUT /api/images/:image',
-        options: { path: { image: string } },
-        response: OdhResponse<SuccessErrorResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/images',
-        response: OdhResponse<SuccessErrorResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/notebooks',
-        response: OdhResponse<StartNotebookData>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PATCH /api/notebooks',
-        response: OdhResponse<StartNotebookData>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/notebooks/openshift-ai-notebooks/:username/status',
-        options: {
-          path: { username: string };
-        },
-        response: OdhResponse<NotebookKind>,
-      ): Cypress.Chainable<null>;
-      interceptOdh(
-        type: 'POST /api/prometheus/pvc',
-        response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/prometheus/query',
-        response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/prometheus/serving',
-        response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/prometheus/bias',
-        response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/all/requests',
-        options: {
-          path: { namespace: string };
-          query?: { type: string };
-        },
-        response: OdhResponse<BaseMetricListResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/spd/requests',
-        options: {
-          path: { namespace: string };
-        },
-        response: OdhResponse<BaseMetricListResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/service/trustyai/:namespace/trustyai-service/metrics/spd/request',
-        options: {
-          path: { namespace: string };
-        },
-        response: OdhResponse<BaseMetricListResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'DELETE /api/service/trustyai/:namespace/trustyai-service/metrics/spd/request',
-        options: {
-          path: { namespace: string };
-        },
-        response: OdhResponse<undefined>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/dir/requests',
-        options: {
-          path: { namespace: string };
-        },
-        response: OdhResponse<BaseMetricListResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'POST /api/service/trustyai/:namespace/trustyai-service/metrics/dir/request',
-        options: {
-          path: { namespace: string };
-        },
-        response: OdhResponse<BaseMetricCreationResponse>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'DELETE /api/service/trustyai/:namespace/trustyai-service/metrics/dir/request',
-        options: {
-          path: { namespace: string };
-        },
-        response: OdhResponse<undefined>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models',
-        options: { path: { serviceName: string; apiVersion: string } },
-        response: OdhResponse<RegisteredModelList>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
-        options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
-        response: OdhResponse<ModelVersionList>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId',
-        options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
-        response: OdhResponse<RegisteredModel>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',
-        options: {
-          path: { serviceName: string; apiVersion: string; modelVersionId: number };
-        },
-        response: OdhResponse<ModelVersion>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
-        options: { path: { serviceName: string; apiVersion: string; modelVersionId: number } },
-        response: OdhResponse<ModelArtifactList>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PATCH /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',
-        options: { path: { serviceName: string; apiVersion: string; modelVersionId: number } },
-        response: OdhResponse<ModelVersion | undefined>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'PATCH /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId',
-        options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
-        response: OdhResponse<RegisteredModel | undefined>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId`,
-        options: {
-          path: {
-            namespace: string;
-            serviceName: string;
-            pipelineId: string;
-            pipelineVersionId: string;
-          };
-        },
-        response: OdhResponse<PipelineVersionKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId`,
-        options: {
-          path: {
-            namespace: string;
-            serviceName: string;
-            pipelineId: string;
-            pipelineVersionId: string;
-          };
-          times?: number;
-        },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId`,
-        options: { path: { namespace: string; serviceName: string; pipelineId: string } },
-        response: OdhResponse<PipelineKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId`,
-        options: {
-          path: { namespace: string; serviceName: string; pipelineId: string };
-          times?: number;
-        },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload_version`,
-        options: { path: { namespace: string; serviceName: string }; times?: number },
-        response: OdhResponse<PipelineVersionKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions`,
-        options: {
-          path: { namespace: string; serviceName: string; pipelineId: string };
-          times?: number;
-        },
-        response: OdhResponse<PipelineVersionKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions`,
-        options: { path: { namespace: string; serviceName: string; pipelineId: string } },
-        response: OdhResponse<ListPipelineVersionsKF | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines`,
-        options: {
-          path: { namespace: string; serviceName: string };
-          query?: { sort_by: string };
-        },
-        response: OdhResponse<ListPipelinesResponseKF | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
-        options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
-        options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
-        response: OdhResponse<PipelineRunJobKFv2>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
-        options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/create`,
-        options: { path: { namespace: string; serviceName: string }; times?: number },
-        response: OdhResponse<PipelineKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload`,
-        options: { path: { namespace: string; serviceName: string }; times?: number },
-        response: OdhResponse<PipelineKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs`,
-        options: { path: { namespace: string; serviceName: string } },
-        response: OdhResponse<ListPipelineRunsResourceKF | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs`,
-        options: { path: { namespace: string; serviceName: string }; times?: number },
-        response: OdhResponse<PipelineRunKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId`,
-        options: { path: { namespace: string; serviceName: string; runId: string } },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId`,
-        options: { path: { namespace: string; serviceName: string; runId: string } },
-        response: OdhResponse<PipelineRunKFv2 | GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId`,
-        options: { path: { namespace: string; serviceName: string; runId: string } },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments`,
-        options: { path: { namespace: string; serviceName: string } },
-        response: OdhResponse<ListExperimentsResponseKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId`,
-        options: { path: { namespace: string; serviceName: string; experimentId: string } },
-        response: OdhResponse<GoogleRpcStatusKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId`,
-        options: { path: { namespace: string; serviceName: string; experimentId: string } },
-        response: OdhResponse<ExperimentKFv2>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns`,
-        options: { path: { namespace: string; serviceName: string }; times?: number },
-        response: OdhResponse<PipelineRunJobKFv2>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns`,
-        options: { path: { namespace: string; serviceName: string } },
-        response: OdhResponse<ListPipelineRunJobsResourceKF>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
-        response: OdhResponse<K8sResourceListResult<RoleBindingKind>>,
-      ): Cypress.Chainable<null>;
-
-      interceptOdh(
-        type: 'GET /api/notebooks/openshift-ai-notebooks/:username/status',
-        options: {
-          path: { username: string };
-        },
-        response: OdhResponse<{ notebook: NotebookKind; isRunning: boolean }>,
-      ): Cypress.Chainable<null>;
+      ) => Cypress.Chainable<null>) &
+        ((
+          type: 'DELETE /api/accelerator-profiles/:name',
+          options: { path: { name: string } },
+          response?: OdhResponse,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PUT /api/accelerator-profiles/:name',
+          options: { path: { name: string } },
+          response: OdhResponse,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/groups-config',
+          response: OdhResponse<GroupsConfig>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PUT /api/groups-config',
+          response: OdhResponse<GroupsConfig>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/components',
+          options: {
+            query?: {
+              installed: 'true' | 'false';
+            };
+          } | null,
+          response: OdhResponse<OdhApplication[]>,
+        ) => Cypress.Chainable<null>) &
+        ((type: 'GET /api/docs', response: OdhResponse<OdhDocument[]>) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/quickstarts',
+          response: OdhResponse<OdhQuickStart[]>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/dsc/status',
+          response: OdhResponse<DataScienceClusterKindStatus>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/status',
+          response: OdhResponse<StatusResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',
+          response: OdhResponse<AllowedUser[]>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',
+          response: OdhResponse<AllowedUser>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
+          response: OdhResponse<K8sResourceListResult<RoleBindingKind>>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/config',
+          response: OdhResponse<DashboardConfigKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/dsci/status',
+          response: OdhResponse<DataScienceClusterInitializationKindStatus>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/dashboardConfig/opendatahub/odh-dashboard-config',
+          response: OdhResponse<DashboardConfigKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/cluster-settings',
+          response: OdhResponse<ClusterSettingsType>,
+        ) => Cypress.Chainable<null>) &
+        ((type: 'PUT /api/cluster-settings', response: OdhResponse) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/namespaces/:namespace/:context',
+          options: {
+            path: {
+              namespace: string;
+              context: '0' | '1' | '2' | '*';
+            };
+          },
+          response: OdhResponse<{ applied: boolean }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/templates/:namespace',
+          options: { path: { namespace: string }; query?: { labelSelector: string } },
+          response: OdhResponse<K8sResourceListResult<TemplateKind>>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/templates/:namespace/:name',
+          options: { path: { namespace: string; name: string } },
+          response: OdhResponse<TemplateKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/templates/',
+          response: OdhResponse<TemplateKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'DELETE /api/templates/:namespace/:name',
+          options: { path: { namespace: string; name: string } },
+          response: OdhResponse<TemplateKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PATCH /api/templates/:namespace/:name',
+          options: { path: { namespace: string; name: string } },
+          response: OdhResponse<TemplateKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/servingRuntimes/',
+          options: { query: { dryRun: 'All' } } | null,
+          response: OdhResponse<ServingRuntimeKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/images/byon',
+          response: OdhResponse<BYONImage[]>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/images/:type',
+          options: { path: { type: string } },
+          response: OdhResponse<ImageInfo[]>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'DELETE /api/images/:image',
+          options: { path: { image: string } },
+          response: OdhResponse<SuccessErrorResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PUT /api/images/:image',
+          options: { path: { image: string } },
+          response: OdhResponse<SuccessErrorResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/images',
+          response: OdhResponse<SuccessErrorResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/notebooks',
+          response: OdhResponse<StartNotebookData>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PATCH /api/notebooks',
+          response: OdhResponse<StartNotebookData>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+          options: {
+            path: { username: string };
+          },
+          response: OdhResponse<NotebookKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/prometheus/pvc',
+          response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/prometheus/query',
+          response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/prometheus/serving',
+          response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/prometheus/bias',
+          response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/all/requests',
+          options: {
+            path: { namespace: string };
+            query?: { type: string };
+          },
+          response: OdhResponse<BaseMetricListResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/spd/requests',
+          options: {
+            path: { namespace: string };
+          },
+          response: OdhResponse<BaseMetricListResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/service/trustyai/:namespace/trustyai-service/metrics/spd/request',
+          options: {
+            path: { namespace: string };
+          },
+          response: OdhResponse<BaseMetricListResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'DELETE /api/service/trustyai/:namespace/trustyai-service/metrics/spd/request',
+          options: {
+            path: { namespace: string };
+          },
+          response: OdhResponse<undefined>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/dir/requests',
+          options: {
+            path: { namespace: string };
+          },
+          response: OdhResponse<BaseMetricListResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/service/trustyai/:namespace/trustyai-service/metrics/dir/request',
+          options: {
+            path: { namespace: string };
+          },
+          response: OdhResponse<BaseMetricCreationResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'DELETE /api/service/trustyai/:namespace/trustyai-service/metrics/dir/request',
+          options: {
+            path: { namespace: string };
+          },
+          response: OdhResponse<undefined>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models',
+          options: { path: { serviceName: string; apiVersion: string } },
+          response: OdhResponse<RegisteredModelList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
+          options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
+          response: OdhResponse<ModelVersionList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId',
+          options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
+          response: OdhResponse<RegisteredModel>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',
+          options: {
+            path: { serviceName: string; apiVersion: string; modelVersionId: number };
+          },
+          response: OdhResponse<ModelVersion>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
+          options: { path: { serviceName: string; apiVersion: string; modelVersionId: number } },
+          response: OdhResponse<ModelArtifactList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PATCH /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',
+          options: { path: { serviceName: string; apiVersion: string; modelVersionId: number } },
+          response: OdhResponse<ModelVersion | undefined>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId`,
+          options: {
+            path: {
+              namespace: string;
+              serviceName: string;
+              pipelineId: string;
+              pipelineVersionId: string;
+            };
+          },
+          response: OdhResponse<PipelineVersionKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId`,
+          options: {
+            path: {
+              namespace: string;
+              serviceName: string;
+              pipelineId: string;
+              pipelineVersionId: string;
+            };
+            times?: number;
+          },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId`,
+          options: { path: { namespace: string; serviceName: string; pipelineId: string } },
+          response: OdhResponse<PipelineKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId`,
+          options: {
+            path: { namespace: string; serviceName: string; pipelineId: string };
+            times?: number;
+          },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload_version`,
+          options: { path: { namespace: string; serviceName: string }; times?: number },
+          response: OdhResponse<PipelineVersionKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions`,
+          options: {
+            path: { namespace: string; serviceName: string; pipelineId: string };
+            times?: number;
+          },
+          response: OdhResponse<PipelineVersionKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions`,
+          options: { path: { namespace: string; serviceName: string; pipelineId: string } },
+          response: OdhResponse<ListPipelineVersionsKF | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines`,
+          options: {
+            path: { namespace: string; serviceName: string };
+            query?: { sort_by: string };
+          },
+          response: OdhResponse<ListPipelinesResponseKF | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
+          options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
+          options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
+          response: OdhResponse<PipelineRunJobKFv2>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
+          options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/create`,
+          options: { path: { namespace: string; serviceName: string }; times?: number },
+          response: OdhResponse<PipelineKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload`,
+          options: { path: { namespace: string; serviceName: string }; times?: number },
+          response: OdhResponse<PipelineKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs`,
+          options: { path: { namespace: string; serviceName: string } },
+          response: OdhResponse<ListPipelineRunsResourceKF | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs`,
+          options: { path: { namespace: string; serviceName: string }; times?: number },
+          response: OdhResponse<PipelineRunKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `DELETE /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId`,
+          options: { path: { namespace: string; serviceName: string; runId: string } },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId`,
+          options: { path: { namespace: string; serviceName: string; runId: string } },
+          response: OdhResponse<PipelineRunKFv2 | GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId`,
+          options: { path: { namespace: string; serviceName: string; runId: string } },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments`,
+          options: { path: { namespace: string; serviceName: string } },
+          response: OdhResponse<ListExperimentsResponseKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId`,
+          options: { path: { namespace: string; serviceName: string; experimentId: string } },
+          response: OdhResponse<GoogleRpcStatusKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/experiments/:experimentId`,
+          options: { path: { namespace: string; serviceName: string; experimentId: string } },
+          response: OdhResponse<ExperimentKFv2>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns`,
+          options: { path: { namespace: string; serviceName: string }; times?: number },
+          response: OdhResponse<PipelineRunJobKFv2>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns`,
+          options: { path: { namespace: string; serviceName: string } },
+          response: OdhResponse<ListPipelineRunJobsResourceKF>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
+          response: OdhResponse<K8sResourceListResult<RoleBindingKind>>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+          options: {
+            path: { username: string };
+          },
+          response: OdhResponse<{ notebook: NotebookKind; isRunning: boolean }>,
+        ) => Cypress.Chainable<null>);
     }
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/support/websockets.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/websockets.ts
@@ -7,10 +7,10 @@ declare global {
       /**
        * Send data to through websockets to all matching connections.
        */
-      wsSend(
+      wsSend: (
         matcher: string | { pathname: string; searchParams?: URLSearchParams },
         data: string | object,
-      ): void;
+      ) => void;
     }
   }
 }

--- a/frontend/src/__tests__/unit/jest.d.ts
+++ b/frontend/src/__tests__/unit/jest.d.ts
@@ -1,13 +1,13 @@
 declare namespace jest {
   interface Expect {
-    isIdentityEqual<T>(expected: T): T;
+    isIdentityEqual: <T>(expected: T) => T;
   }
 
   interface Matchers<R, T> {
-    hookToBe(expected: unknown): R;
-    hookToStrictEqual(expected: unknown): R;
-    hookToHaveUpdateCount(expected: number): R;
-    hookToBeStable<
+    hookToBe: (expected: unknown) => R;
+    hookToStrictEqual: (expected: unknown) => R;
+    hookToHaveUpdateCount: (expected: number) => R;
+    hookToBeStable: <
       V extends T extends Pick<
         import('~/__tests__/unit/testUtils/hooks').RenderHookResultExt<
           infer Result,
@@ -20,10 +20,10 @@ declare namespace jest {
         : never,
     >(
       expected?: V,
-    ): R;
+    ) => R;
   }
 
   interface Expect {
-    isIdentityEqual(expected: unknown): AsymmetricMatcher;
+    isIdentityEqual: (expected: unknown) => AsymmetricMatcher;
   }
 }

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection/types.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection/types.ts
@@ -3,5 +3,5 @@ import { RuntimeConfigParamValue } from '~/concepts/pipelines/kfTypes';
 export type InputParamProps = {
   id: string;
   value: RuntimeConfigParamValue;
-  onChange(event: React.ChangeEvent<unknown> | null, value: RuntimeConfigParamValue): void;
+  onChange: (event: React.ChangeEvent<unknown> | null, value: string | number | boolean) => void;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-4721](https://issues.redhat.com/browse/RHOAIENG-4721)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Set this eslint rule: `"@typescript-eslint/method-signature-style": "error"` to have consistency for interface functions. The standard we're trying to achieve is `func: (arg: type) => type;`

details: https://issues.redhat.com/browse/RHOAIENG-4721

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npm run test:lint`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
