### PR TITLE
fix info popover for pipeline overview card

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesOverviewCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesOverviewCard.tsx
@@ -16,12 +16,8 @@ const PipelinesOverviewCard: React.FC<PipelinesOverviewCardProps> = ({
     objectType={ProjectObjectType.pipeline}
     sectionType={pipelinesCount ? SectionType.training : SectionType.organize}
     title="Pipelines"
-    popoverHeaderContent={pipelinesCount ? 'About pipelines' : undefined}
-    popoverBodyContent={
-      !pipelinesCount
-        ? 'Pipelines are platforms for building and deploying portable and scalable machine-learning (ML) workflows. You can import a pipeline or create one in a workbench.'
-        : undefined
-    }
+    popoverHeaderContent="About pipelines"
+    popoverBodyContent="Pipelines are platforms for building and deploying portable and scalable machine-learning (ML) workflows. You can import a pipeline or create one in a workbench."
     data-testid="section-pipelines"
   >
     {children}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-6654

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Removed logic that attempted to show the info icon + tooltip under certain conditions. Instead, as per UX guidance, always show the the icon + tooltip.

![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/d9baa8bb-50c1-4ea1-ba46-74e250316829)

![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/311bfa97-3a8c-4d59-9826-6d6a77801593)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a project
- add a pipeline server
- go to the project details and observe the info popover is present
- add a pipeline
- go to the project details and observe the info popover is present

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @jgiardino