### PR TITLE
Refine logic actions for runs on an archived experiment page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -959,7 +959,7 @@ describe('Pipelines', () => {
     pipelineRow.findExpandButton().click();
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
-      .findKebabAction('Schedule run')
+      .findKebabAction('Create schedule')
       .click();
 
     verifyRelativeURL(`/pipelines/${projectName}/pipelineRun/create?runType=scheduled`);
@@ -1176,7 +1176,7 @@ export const runScheduleRunPageNavTest = (visitPipelineProjects: () => void): vo
   pipelinesTable.find();
   pipelinesTable
     .getRowById(initialMockPipeline.pipeline_id)
-    .findKebabAction('Schedule run')
+    .findKebabAction('Create schedule')
     .click();
 
   verifyRelativeURL(`/pipelines/${projectName}/pipelineRun/create?runType=scheduled`);
@@ -1196,10 +1196,10 @@ export const viewPipelineServerDetailsTest = (visitPipelineProjects: () => void)
     }),
   );
   visitPipelineProjects();
-  viewPipelinelineDetails();
+  viewPipelineDetails();
 };
 
-const viewPipelinelineDetails = (
+const viewPipelineDetails = (
   accessKey = 'sdsd',
   secretKey = 'sdsd',
   endpoint = 'https://s3.amazonaws.com',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
@@ -183,7 +183,7 @@ describe('Pipeline topology', () => {
       });
 
       it('navigates to "Schedule run" page on "Schedule run" click', () => {
-        pipelineDetails.selectActionDropdownItem('Schedule run');
+        pipelineDetails.selectActionDropdownItem('Create schedule');
         verifyRelativeURL(`/pipelineRuns/${projectId}/pipelineRun/create?runType=scheduled`);
       });
 

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -57,6 +57,7 @@ const RunForm: React.FC<RunFormProps> = ({ data, runType, onValueChange }) => {
         projectName={getProjectDisplayName(data.project)}
         value={data.experiment}
         onChange={(experiment) => onValueChange('experiment', experiment)}
+        isSchedule={isSchedule}
       />
 
       <FormSection

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/ProjectAndExperimentSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/ProjectAndExperimentSection.tsx
@@ -6,20 +6,25 @@ import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
-import ExperimentSelector from '~/concepts/pipelines/content/experiment/ExperimentSelector';
+import {
+  ActiveExperimentSelector,
+  AllExperimentSelector,
+} from '~/concepts/pipelines/content/experiment/ExperimentSelector';
 import CreateExperimentButton from '~/concepts/pipelines/content/experiment/CreateExperimentButton';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
-type ExperimentSectionProps = {
+type ProjectAndExperimentSectionProps = {
   projectName: string;
   value: ExperimentKFv2 | null;
   onChange: (experiment: ExperimentKFv2) => void;
+  isSchedule: boolean;
 };
 
-const ProjectAndExperimentSection: React.FC<ExperimentSectionProps> = ({
+const ProjectAndExperimentSection: React.FC<ProjectAndExperimentSectionProps> = ({
   projectName,
   value,
   onChange,
+  isSchedule,
 }) => {
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
@@ -39,7 +44,11 @@ const ProjectAndExperimentSection: React.FC<ExperimentSectionProps> = ({
         <FormGroup label="Experiment" aria-label="Experiment" isRequired>
           <Stack hasGutter>
             <StackItem>
-              <ExperimentSelector selection={value?.display_name} onSelect={onChange} />
+              {isSchedule ? (
+                <AllExperimentSelector selection={value?.display_name} onSelect={onChange} />
+              ) : (
+                <ActiveExperimentSelector selection={value?.display_name} onSelect={onChange} />
+              )}
             </StackItem>
             <StackItem>
               <CreateExperimentButton

--- a/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
@@ -15,6 +15,7 @@ import {
   PipelineVersionKFv2,
   RecurringRunMode,
   RuntimeConfigParameters,
+  StorageStateKF,
 } from '~/concepts/pipelines/kfTypes';
 import { PipelineAPIs } from '~/concepts/pipelines/types';
 import {
@@ -97,7 +98,10 @@ const createJob = async (
           : undefined,
     },
     max_concurrency: String(formData.runType.data.maxConcurrency),
-    mode: RecurringRunMode.ENABLE,
+    mode:
+      formData.experiment?.storage_state === StorageStateKF.ARCHIVED
+        ? RecurringRunMode.DISABLE
+        : RecurringRunMode.ENABLE,
     no_catchup: !formData.runType.data.catchUp,
     service_account: '',
     experiment_id: formData.experiment?.experiment_id || '',

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -15,6 +15,7 @@ import {
   PipelineRunJobKFv2,
   PipelineRunKFv2,
   PipelineVersionKFv2,
+  StorageStateKF,
 } from '~/concepts/pipelines/kfTypes';
 
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
@@ -98,10 +99,25 @@ const useUpdateExperimentFormData = (
   const [formData, setFormValue] = formState;
 
   React.useEffect(() => {
-    if (!formData.experiment && experiment) {
+    // on create run page, we always check the experiment archived state
+    // no matter it's duplicated or carried from the create schedules pages
+    if (formData.runType.type === RunTypeOption.ONE_TRIGGER) {
+      if (formData.experiment) {
+        if (formData.experiment.storage_state === StorageStateKF.ARCHIVED) {
+          setFormValue('experiment', null);
+        }
+      } else if (experiment) {
+        if (experiment.storage_state === StorageStateKF.ARCHIVED) {
+          setFormValue('experiment', null);
+        } else {
+          setFormValue('experiment', experiment);
+        }
+      }
+    } else if (!formData.experiment && experiment) {
+      // else, on create schedules page, we do what we did before
       setFormValue('experiment', experiment);
     }
-  }, [formData.experiment, setFormValue, experiment]);
+  }, [formData.experiment, setFormValue, experiment, formData.runType.type]);
 };
 
 const useUpdatePipelineFormData = (

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -20,7 +20,10 @@ import { TableBase, getTableColumnSort } from '~/components/table';
 import { ExperimentKFv2 } from '~/concepts/pipelines/kfTypes';
 import PipelineViewMoreFooterRow from '~/concepts/pipelines/content/tables/PipelineViewMoreFooterRow';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
-import { useExperimentSelector } from '~/concepts/pipelines/content/pipelineSelector/useCreateSelectors';
+import {
+  useActiveExperimentSelector,
+  useAllExperimentSelector,
+} from '~/concepts/pipelines/content/pipelineSelector/useCreateSelectors';
 import { experimentSelectorColumns } from '~/concepts/pipelines/content/experiment/columns';
 
 type ExperimentSelectorProps = {
@@ -28,20 +31,22 @@ type ExperimentSelectorProps = {
   onSelect: (experiment: ExperimentKFv2) => void;
 };
 
-const ExperimentSelector: React.FC<ExperimentSelectorProps> = ({ selection, onSelect }) => {
+const InnerExperimentSelector: React.FC<
+  ReturnType<typeof useAllExperimentSelector> & ExperimentSelectorProps
+> = ({
+  fetchedSize,
+  totalSize,
+  searchProps,
+  onSearchClear,
+  onLoadMore,
+  sortProps,
+  loaded,
+  initialLoaded,
+  data: experiments,
+  selection,
+  onSelect,
+}) => {
   const [isOpen, setOpen] = React.useState(false);
-
-  const {
-    fetchedSize,
-    totalSize,
-    searchProps,
-    onSearchClear,
-    onLoadMore,
-    sortProps,
-    loaded,
-    initialLoaded,
-    data: experiments,
-  } = useExperimentSelector();
 
   const toggleRef = React.useRef(null);
   const menuRef = React.useRef(null);
@@ -140,4 +145,12 @@ const ExperimentSelector: React.FC<ExperimentSelectorProps> = ({ selection, onSe
   );
 };
 
-export default ExperimentSelector;
+export const AllExperimentSelector: React.FC<ExperimentSelectorProps> = (props) => {
+  const selectorProps = useAllExperimentSelector();
+  return <InnerExperimentSelector {...props} {...selectorProps} />;
+};
+
+export const ActiveExperimentSelector: React.FC<ExperimentSelectorProps> = (props) => {
+  const selectorProps = useActiveExperimentSelector();
+  return <InnerExperimentSelector {...props} {...selectorProps} />;
+};

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/useCreateSelectors.ts
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/useCreateSelectors.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { useSelectorSearch } from '~/concepts/pipelines/content/pipelineSelector/utils';
-import useExperimentTable from '~/concepts/pipelines/content/tables/experiment/useExperimentTable';
+import useExperimentTable, {
+  useActiveExperimentTable,
+} from '~/concepts/pipelines/content/tables/experiment/useExperimentTable';
 import usePipelinesTable from '~/concepts/pipelines/content/tables/pipeline/usePipelinesTable';
 import usePipelineVersionsTable from '~/concepts/pipelines/content/tables/pipelineVersion/usePipelineVersionsTable';
 import {
@@ -38,14 +40,19 @@ type UsePipelineSelectorData<DataType> = {
   };
 };
 
-export const useExperimentSelector = (): UsePipelineSelectorData<ExperimentKFv2> => {
-  const experimentsTable = useExperimentTable();
-  const [[{ items: initialData, nextPageToken: initialPageToken }, loaded]] = experimentsTable;
-  return useCreateSelector<ExperimentKFv2>(
-    experimentsTable,
-    useExperimentLoadMore({ initialData, initialPageToken, loaded }),
-  );
-};
+export const getExperimentSelector =
+  (useTable: typeof useExperimentTable) => (): UsePipelineSelectorData<ExperimentKFv2> => {
+    const experimentsTable = useTable();
+    const [[{ items: initialData, nextPageToken: initialPageToken }, loaded]] = experimentsTable;
+    return useCreateSelector<ExperimentKFv2>(
+      experimentsTable,
+      useExperimentLoadMore({ initialData, initialPageToken, loaded }),
+    );
+  };
+
+export const useAllExperimentSelector = getExperimentSelector(useExperimentTable);
+
+export const useActiveExperimentSelector = getExperimentSelector(useActiveExperimentTable);
 
 export const usePipelineSelector = (): UsePipelineSelectorData<PipelineKFv2> => {
   const pipelinesTable = usePipelinesTable();

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
@@ -76,7 +76,7 @@ const PipelineDetailsActions: React.FC<PipelineDetailsActionsProps> = ({
               )
             }
           >
-            Schedule run
+            Create schedule
           </DropdownItem>,
           <DropdownSeparator key="separator-view" />,
           <DropdownItem

--- a/frontend/src/concepts/pipelines/content/tables/experiment/useExperimentTable.ts
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/useExperimentTable.ts
@@ -1,4 +1,6 @@
-import useExperiments from '~/concepts/pipelines/apiHooks/useExperiments';
+import useExperiments, { useActiveExperiments } from '~/concepts/pipelines/apiHooks/useExperiments';
 import createUsePipelineTable from '~/concepts/pipelines/content/tables/usePipelineTable';
+
+export const useActiveExperimentTable = createUsePipelineTable(useActiveExperiments);
 
 export default createUsePipelineTable(useExperiments);

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
@@ -115,7 +115,7 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
                   },
                 },
                 {
-                  title: 'Schedule run',
+                  title: 'Create schedule',
                   onClick: () => {
                     navigate(
                       {

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -20,6 +20,7 @@ import { RestoreRunModal } from '~/pages/pipelines/global/runs/RestoreRunModal';
 import { useSetVersionFilter } from '~/concepts/pipelines/content/tables/useSetVersionFilter';
 import { createRunRoute, experimentsCompareRunsRoute } from '~/routes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { useContextExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 type PipelineRunTableProps = {
   runs: PipelineRunKFv2[];
@@ -74,17 +75,30 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
     return acc;
   }, []);
 
+  const restoreButtonTooltipRef = React.useRef(null);
+  const isExperimentArchived = useContextExperimentArchived();
+
   const primaryToolbarAction = React.useMemo(() => {
     if (runType === PipelineRunType.ARCHIVED) {
       return (
-        <Button
-          data-testid="restore-button"
-          variant="primary"
-          isDisabled={!selectedIds.length}
-          onClick={() => setIsRestoreModalOpen(true)}
-        >
-          Restore
-        </Button>
+        <>
+          {isExperimentArchived && (
+            <Tooltip
+              content="Archived runs cannot be restored until its associated experiment is restored."
+              triggerRef={restoreButtonTooltipRef}
+            />
+          )}
+          <Button
+            data-testid="restore-button"
+            variant="primary"
+            isDisabled={!selectedIds.length}
+            isAriaDisabled={isExperimentArchived}
+            onClick={() => setIsRestoreModalOpen(true)}
+            ref={restoreButtonTooltipRef}
+          >
+            Restore
+          </Button>
+        </>
       );
     }
 
@@ -100,10 +114,18 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
         Create run
       </Button>
     );
-  }, [runType, selectedIds.length, navigate, isExperimentsAvailable, experimentId, namespace]);
+  }, [
+    runType,
+    selectedIds.length,
+    navigate,
+    isExperimentsAvailable,
+    experimentId,
+    namespace,
+    isExperimentArchived,
+  ]);
 
   const compareRunsAction =
-    isExperimentsAvailable && experimentId ? (
+    isExperimentsAvailable && experimentId && !isExperimentArchived ? (
       <Tooltip content="Select up to 10 runs to compare.">
         <Button
           key="compare-runs"

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Skeleton } from '@patternfly/react-core';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { PipelineRunKFv2, RuntimeStateKF } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd } from '~/components/table';
 import {
@@ -12,16 +11,17 @@ import {
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelineRunTableRowTitle from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowTitle';
 import useNotification from '~/utilities/useNotification';
-import useExperimentById from '~/concepts/pipelines/apiHooks/useExperimentById';
 import usePipelineRunVersionInfo from '~/concepts/pipelines/content/tables/usePipelineRunVersionInfo';
 import { PipelineVersionLink } from '~/concepts/pipelines/content/PipelineVersionLink';
 import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
 import { PipelineRunType } from '~/pages/pipelines/global/runs';
 import { RestoreRunModal } from '~/pages/pipelines/global/runs/RestoreRunModal';
 import { useGetSearchParamValues } from '~/utilities/useGetSearchParamValues';
-import { cloneRunRoute, experimentRunsRoute } from '~/routes';
+import { cloneRunRoute } from '~/routes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ArchiveRunModal } from '~/pages/pipelines/global/runs/ArchiveRunModal';
+import PipelineRunTableRowExperiment from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment';
+import { useContextExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 type PipelineRunTableRowProps = {
   checkboxProps: Omit<React.ComponentProps<typeof CheckboxTd>, 'id'>;
@@ -43,11 +43,11 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
   const { namespace, api, refreshAllAPI } = usePipelinesAPI();
   const notification = useNotification();
   const navigate = useNavigate();
-  const [experiment, isExperimentLoaded] = useExperimentById(run.experiment_id);
   const { version, loaded: isVersionLoaded, error: versionError } = usePipelineRunVersionInfo(run);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
+  const isExperimentArchived = useContextExperimentArchived();
 
   const actions: IAction[] = React.useMemo(() => {
     const cloneAction: IAction = {
@@ -64,6 +64,13 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
         {
           title: 'Restore',
           onClick: () => setIsRestoreModalOpen(true),
+          isAriaDisabled: isExperimentArchived,
+          ...(isExperimentArchived && {
+            tooltipProps: {
+              content:
+                'Archived runs cannot be restored until its associated experiment is restored.',
+            },
+          }),
         },
         cloneAction,
         {
@@ -110,6 +117,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
     api,
     refreshAllAPI,
     notification,
+    isExperimentArchived,
   ]);
 
   return (
@@ -118,19 +126,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
       <Td dataLabel="Name">
         <PipelineRunTableRowTitle run={run} />
       </Td>
-      {hasExperiments && (
-        <Td dataLabel="Experiment">
-          {!isExperimentLoaded ? (
-            <Skeleton />
-          ) : isExperimentsAvailable && experimentId ? (
-            <Link to={experimentRunsRoute(namespace, experiment?.experiment_id)}>
-              {experiment?.display_name}
-            </Link>
-          ) : (
-            experiment?.display_name
-          )}
-        </Td>
-      )}
+      {hasExperiments && <PipelineRunTableRowExperiment experimentId={run.experiment_id} />}
       <Td modifier="truncate" dataLabel="Pipeline">
         <PipelineVersionLink
           displayName={version?.display_name}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Skeleton } from '@patternfly/react-core';
+import { Td } from '@patternfly/react-table';
+import { Link } from 'react-router-dom';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useExperimentById from '~/concepts/pipelines/apiHooks/useExperimentById';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { experimentRunsRoute } from '~/routes';
+
+type PipelineRunTableRowExperimentProps = {
+  experimentId: string;
+};
+
+const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps> = ({
+  experimentId,
+}) => {
+  const { namespace } = usePipelinesAPI();
+  const [experiment, isExperimentLoaded] = useExperimentById(experimentId);
+  const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
+  return (
+    <Td dataLabel="Experiment">
+      {!isExperimentLoaded ? (
+        <Skeleton />
+      ) : isExperimentsAvailable && experimentId ? (
+        <Link to={experimentRunsRoute(namespace, experiment?.experiment_id)}>
+          {experiment?.display_name}
+        </Link>
+      ) : (
+        experiment?.display_name
+      )}
+    </Td>
+  );
+};
+
+export default PipelineRunTableRowExperiment;

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
@@ -1,17 +1,10 @@
 import * as React from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-
-import { Button, TextInput, ToolbarItem } from '@patternfly/react-core';
-
+import { TextInput, ToolbarItem } from '@patternfly/react-core';
 import PipelineFilterBar from '~/concepts/pipelines/content/tables/PipelineFilterBar';
-import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 import PipelineVersionSelect from '~/concepts/pipelines/content/pipelineSelector/CustomPipelineVersionSelect';
 import { PipelineRunVersionsContext } from '~/pages/pipelines/global/runs/PipelineRunVersionsContext';
-import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
-import { PipelineRunType } from '~/pages/pipelines/global/runs';
-import { scheduleRunRoute } from '~/routes';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import CreateScheduleButton from '~/pages/pipelines/global/runs/CreateScheduleButton';
 
 const options = {
   [FilterOptions.NAME]: 'Schedule',
@@ -31,11 +24,7 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
   dropdownActions,
   ...toolbarProps
 }) => {
-  const navigate = useNavigate();
-  const { experimentId } = useParams();
-  const { namespace } = usePipelinesAPI();
   const { versions } = React.useContext(PipelineRunVersionsContext);
-  const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
   return (
     <PipelineFilterBar<keyof typeof options>
@@ -60,21 +49,7 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
       }}
     >
       <ToolbarItem>
-        <Button
-          data-testid="schedule-run-button"
-          variant="primary"
-          onClick={() =>
-            navigate({
-              pathname: scheduleRunRoute(
-                namespace,
-                isExperimentsAvailable ? experimentId : undefined,
-              ),
-              search: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.SCHEDULED}`,
-            })
-          }
-        >
-          Schedule run
-        </Button>
+        <CreateScheduleButton />
       </ToolbarItem>
       <ToolbarItem data-testid="job-table-toolbar-item">{dropdownActions}</ToolbarItem>
     </PipelineFilterBar>

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
@@ -76,7 +76,7 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
               },
             },
             {
-              title: 'Schedule run',
+              title: 'Create schedule',
               onClick: () => {
                 navigate(
                   {

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -29,6 +29,7 @@ import {
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { computeRunStatus } from '~/concepts/pipelines/content/utils';
 import PipelinesTableRowTime from '~/concepts/pipelines/content/tables/PipelinesTableRowTime';
+import { useContextExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 export const NoRunContent = (): React.JSX.Element => <>-</>;
 
@@ -147,6 +148,7 @@ export const RunJobStatus: RunJobUtil<{ onToggle: (value: boolean) => Promise<vo
 }) => {
   const [error, setError] = React.useState<Error | null>(null);
   const [isChangingFlag, setIsChangingFlag] = React.useState(false);
+  const isExperimentArchived = useContextExperimentArchived();
 
   const isEnabled = job.mode === RecurringRunMode.ENABLE;
   React.useEffect(() => {
@@ -160,7 +162,7 @@ export const RunJobStatus: RunJobUtil<{ onToggle: (value: boolean) => Promise<vo
         <Switch
           id={`${job.recurring_run_id}-toggle`}
           aria-label={`Toggle switch; ${isEnabled ? 'Enabled' : 'Disabled'}`}
-          isDisabled={isChangingFlag}
+          isDisabled={isChangingFlag || isExperimentArchived}
           onChange={(e, checked) => {
             setIsChangingFlag(true);
             setError(null);

--- a/frontend/src/pages/pipelines/GlobalPipelineExperimentsRoutes.tsx
+++ b/frontend/src/pages/pipelines/GlobalPipelineExperimentsRoutes.tsx
@@ -13,6 +13,7 @@ import PipelineRunJobDetails from '~/concepts/pipelines/content/pipelinesDetails
 import { experimentsBaseRoute } from '~/routes';
 import CreateRunPage from '~/concepts/pipelines/content/createRun/CreateRunPage';
 import CloneRunPage from '~/concepts/pipelines/content/createRun/CloneRunPage';
+import ExperimentRunsContextProvider from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 import { GlobalExperimentDetails } from './global/GlobalPipelineCoreDetails';
 import GlobalPipelineRuns from './global/runs/GlobalPipelineRuns';
 import { ExperimentRunsListBreadcrumb } from './global/experiments/ExperimentRunsListBreadcrumb';
@@ -35,52 +36,59 @@ const GlobalPipelineExperimentsRoutes: React.FC = () => (
       <Route index element={<GlobalExperiments tab={ExperimentListTabs.ACTIVE} />} />
       <Route path="active" element={<GlobalExperiments tab={ExperimentListTabs.ACTIVE} />} />
       <Route path="archived" element={<GlobalExperiments tab={ExperimentListTabs.ARCHIVED} />} />
-      <Route
-        path=":experimentId/runs"
-        element={
-          <GlobalPipelineRuns
-            breadcrumb={<ExperimentRunsListBreadcrumb />}
-            description="Manage your experiment runs and schedules."
-            getRedirectPath={experimentsBaseRoute}
-          />
-        }
-      />
-      <Route
-        path=":experimentId/runs/:runId"
-        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={PipelineRunDetails} />}
-      />
-      <Route
-        path=":experimentId/schedules/:recurringRunId"
-        element={
-          <GlobalExperimentDetails BreadcrumbDetailsComponent={PipelineRunJobDetails} isSchedule />
-        }
-      />
-      <Route
-        path=":experimentId/runs/create"
-        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CreateRunPage} />}
-      />
-      <Route
-        path=":experimentId/schedules/create"
-        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CreateRunPage} isSchedule />}
-      />
-      <Route
-        path=":experimentId/runs/clone/:runId"
-        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CloneRunPage} />}
-      />
-      <Route
-        path=":experimentId/schedules/clone/:recurringRunId"
-        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CloneRunPage} isSchedule />}
-      />
-      <Route path=":experimentId/compareRuns" element={<GlobalComparePipelineRunsLoader />}>
+      <Route path=":experimentId" element={<ExperimentRunsContextProvider />}>
         <Route
-          index
-          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CompareRunsPage} />}
+          path="runs"
+          element={
+            <GlobalPipelineRuns
+              breadcrumb={<ExperimentRunsListBreadcrumb />}
+              description="Manage your experiment runs and schedules."
+              getRedirectPath={experimentsBaseRoute}
+            />
+          }
+        />
+        <Route
+          path="runs/:runId"
+          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={PipelineRunDetails} />}
+        />
+        <Route
+          path="schedules/:recurringRunId"
+          element={
+            <GlobalExperimentDetails
+              BreadcrumbDetailsComponent={PipelineRunJobDetails}
+              isSchedule
+            />
+          }
+        />
+        <Route
+          path="runs/create"
+          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CreateRunPage} />}
+        />
+        <Route
+          path="schedules/create"
+          element={
+            <GlobalExperimentDetails BreadcrumbDetailsComponent={CreateRunPage} isSchedule />
+          }
+        />
+        <Route
+          path="runs/clone/:runId"
+          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CloneRunPage} />}
+        />
+        <Route
+          path="schedules/clone/:recurringRunId"
+          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CloneRunPage} isSchedule />}
+        />
+        <Route path="compareRuns" element={<GlobalComparePipelineRunsLoader />}>
+          <Route
+            index
+            element={<GlobalExperimentDetails BreadcrumbDetailsComponent={CompareRunsPage} />}
+          />
+        </Route>
+        <Route
+          path="compareRuns/add"
+          element={<GlobalExperimentDetails BreadcrumbDetailsComponent={ManageRunsPage} />}
         />
       </Route>
-      <Route
-        path=":experimentId/compareRuns/add"
-        element={<GlobalExperimentDetails BreadcrumbDetailsComponent={ManageRunsPage} />}
-      />
       <Route path="*" element={<Navigate to="." />} />
     </Route>
   </ProjectsRoutes>

--- a/frontend/src/pages/pipelines/global/GlobalPipelineCoreDetails.tsx
+++ b/frontend/src/pages/pipelines/global/GlobalPipelineCoreDetails.tsx
@@ -7,7 +7,7 @@ import { PipelineCoreDetailsPageComponent } from '~/concepts/pipelines/content/t
 import EnsureAPIAvailability from '~/concepts/pipelines/EnsureAPIAvailability';
 import { experimentRunsRoute, experimentSchedulesRoute, experimentsBaseRoute } from '~/routes';
 import EnsureCompatiblePipelineServer from '~/concepts/pipelines/EnsureCompatiblePipelineServer';
-import { useExperimentByParams } from './experiments/useExperimentByParams';
+import { ExperimentRunsContext } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 type GlobalPipelineCoreDetailsProps = {
   pageName: string;
@@ -48,7 +48,7 @@ export const GlobalExperimentDetails: React.FC<
     isSchedule?: boolean;
   }
 > = ({ BreadcrumbDetailsComponent, isSchedule }) => {
-  const experiment = useExperimentByParams();
+  const { experiment } = React.useContext(ExperimentRunsContext);
   const experimentId = experiment?.experiment_id;
   const { namespace, project } = usePipelinesAPI();
 

--- a/frontend/src/pages/pipelines/global/experiments/ExperimentRunsContext.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/ExperimentRunsContext.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Outlet } from 'react-router-dom';
+import { ExperimentKFv2, StorageStateKF } from '~/concepts/pipelines/kfTypes';
+import { useExperimentByParams } from '~/pages/pipelines/global/experiments/useExperimentByParams';
+
+type ExperimentRunsContextState = {
+  experiment: ExperimentKFv2 | null;
+};
+
+export const ExperimentRunsContext = React.createContext<ExperimentRunsContextState>({
+  experiment: null,
+});
+
+const ExperimentRunsContextProvider: React.FC = () => {
+  const { experiment, isExperimentLoaded } = useExperimentByParams();
+
+  const contextValue = React.useMemo(() => ({ experiment }), [experiment]);
+
+  if (!isExperimentLoaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <ExperimentRunsContext.Provider value={contextValue}>
+      <Outlet />
+    </ExperimentRunsContext.Provider>
+  );
+};
+
+export const useContextExperimentArchived = (): boolean => {
+  const { experiment } = React.useContext(ExperimentRunsContext);
+  return experiment?.storage_state === StorageStateKF.ARCHIVED;
+};
+
+export default ExperimentRunsContextProvider;

--- a/frontend/src/pages/pipelines/global/experiments/ExperimentRunsListBreadcrumb.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/ExperimentRunsListBreadcrumb.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Breadcrumb, BreadcrumbItem, Truncate } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Label, Truncate } from '@patternfly/react-core';
 
 import { experimentsRootPath } from '~/routes';
-import { useExperimentByParams } from './useExperimentByParams';
+import { StorageStateKF } from '~/concepts/pipelines/kfTypes';
+import { ExperimentRunsContext } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 export const ExperimentRunsListBreadcrumb: React.FC = () => {
-  const experiment = useExperimentByParams();
+  const { experiment } = React.useContext(ExperimentRunsContext);
 
   return (
     <Breadcrumb>
@@ -16,6 +17,7 @@ export const ExperimentRunsListBreadcrumb: React.FC = () => {
 
       <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
         <Truncate content={experiment?.display_name || 'Loading...'} />
+        {experiment?.storage_state === StorageStateKF.ARCHIVED && <Label>Archived</Label>}
       </BreadcrumbItem>
     </Breadcrumb>
   );

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsPage.tsx
@@ -25,7 +25,6 @@ import {
   experimentsCreateRunRoute,
 } from '~/routes';
 import ApplicationsPage from '~/pages/ApplicationsPage';
-import { useExperimentByParams } from '~/pages/pipelines/global/experiments/useExperimentByParams';
 import { getProjectDisplayName } from '~/concepts/projects/utils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import usePipelineFilter, {
@@ -34,6 +33,7 @@ import usePipelineFilter, {
 import { ExperimentKFv2 } from '~/concepts/pipelines/kfTypes';
 import { PipelineRunTabTitle, PipelineRunType } from '~/pages/pipelines/global/runs';
 import PipelineRunVersionsContextProvider from '~/pages/pipelines/global/runs/PipelineRunVersionsContext';
+import { ExperimentRunsContext } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 import { ManageRunsTable } from './ManageRunsTable';
 
 interface ManageRunsPageInternalProps {
@@ -165,6 +165,6 @@ export const ManageRunsPageInternal: React.FC<ManageRunsPageInternalProps> = ({ 
 };
 
 export const ManageRunsPage: React.FC = () => {
-  const experiment = useExperimentByParams();
+  const { experiment } = React.useContext(ExperimentRunsContext);
   return experiment ? <ManageRunsPageInternal experiment={experiment} /> : null;
 };

--- a/frontend/src/pages/pipelines/global/experiments/useExperimentByParams.ts
+++ b/frontend/src/pages/pipelines/global/experiments/useExperimentByParams.ts
@@ -4,7 +4,10 @@ import { experimentsRootPath } from '~/routes';
 import useExperimentById from '~/concepts/pipelines/apiHooks/useExperimentById';
 import { ExperimentKFv2 } from '~/concepts/pipelines/kfTypes';
 
-export const useExperimentByParams = (): ExperimentKFv2 | null => {
+export const useExperimentByParams = (): {
+  experiment: ExperimentKFv2 | null;
+  isExperimentLoaded: boolean;
+} => {
   const navigate = useNavigate();
   const { experimentId } = useParams();
   const [experiment, isExperimentLoaded, experimentError] = useExperimentById(experimentId);
@@ -16,5 +19,5 @@ export const useExperimentByParams = (): ExperimentKFv2 | null => {
     }
   }, [experimentError, isExperimentLoaded, navigate]);
 
-  return experiment;
+  return { experiment, isExperimentLoaded };
 };

--- a/frontend/src/pages/pipelines/global/runs/ActiveRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ActiveRuns.tsx
@@ -12,13 +12,14 @@ import {
   EmptyStateActions,
   Button,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { CubesIcon, ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import PipelineRunTable from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable';
 import { usePipelineActiveRunsTable } from '~/concepts/pipelines/content/tables/pipelineRun/usePipelineRunTable';
 import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
 import { createRunRoute } from '~/routes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { useContextExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 import { PipelineRunTabTitle, PipelineRunType } from './types';
 
 export const ActiveRuns: React.FC = () => {
@@ -27,6 +28,25 @@ export const ActiveRuns: React.FC = () => {
   const [[{ items: runs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
     usePipelineActiveRunsTable({ experimentId });
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
+  const isExperimentArchived = useContextExperimentArchived();
+
+  if (isExperimentArchived) {
+    return (
+      <Bullseye>
+        <EmptyState data-testid="experiment-archived-empty-state">
+          <EmptyStateHeader
+            titleText="Experiment archived"
+            icon={<EmptyStateIcon icon={CubesIcon} />}
+            headingLevel="h2"
+          />
+          <EmptyStateBody>
+            When an experiment is archived, its runs are moved to the {PipelineRunTabTitle.ARCHIVED}{' '}
+            tab.
+          </EmptyStateBody>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
 
   if (error) {
     return (

--- a/frontend/src/pages/pipelines/global/runs/CreateScheduleButton.tsx
+++ b/frontend/src/pages/pipelines/global/runs/CreateScheduleButton.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { useNavigate, useParams } from 'react-router-dom';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
+import { PipelineRunType } from '~/pages/pipelines/global/runs/types';
+import { scheduleRunRoute } from '~/routes';
+import { useContextExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
+
+const CreateScheduleButton: React.FC = () => {
+  const navigate = useNavigate();
+  const { namespace, experimentId } = useParams();
+  const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
+  const isExperimentArchived = useContextExperimentArchived();
+  const tooltipRef = React.useRef(null);
+
+  return (
+    <>
+      {isExperimentArchived && (
+        <Tooltip
+          content="Schedules cannot be created unless the experiment is restored."
+          triggerRef={tooltipRef}
+        />
+      )}
+      <Button
+        data-testid="schedule-run-button"
+        variant="primary"
+        onClick={() =>
+          navigate({
+            pathname: scheduleRunRoute(
+              namespace,
+              isExperimentsAvailable ? experimentId : undefined,
+            ),
+            search: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.SCHEDULED}`,
+          })
+        }
+        isAriaDisabled={isExperimentArchived}
+        ref={tooltipRef}
+      >
+        Create schedule
+      </Button>
+    </>
+  );
+};
+
+export default CreateScheduleButton;

--- a/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import {
   Bullseye,
@@ -8,7 +8,6 @@ import {
   EmptyStateIcon,
   Spinner,
   EmptyStateHeader,
-  Button,
   EmptyStateActions,
   EmptyStateFooter,
 } from '@patternfly/react-core';
@@ -16,17 +15,12 @@ import { ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import PipelineRunJobTable from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable';
 import { usePipelineScheduledRunsTable } from '~/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobTable';
-import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
-import { scheduleRunRoute } from '~/routes';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
-import { PipelineRunType } from './types';
+import CreateScheduleButton from '~/pages/pipelines/global/runs/CreateScheduleButton';
 
 const ScheduledRuns: React.FC = () => {
-  const navigate = useNavigate();
-  const { namespace, experimentId } = useParams();
+  const { experimentId } = useParams();
   const [[{ items: jobs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
     usePipelineScheduledRunsTable({ experimentId });
-  const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
   if (error) {
     return (
@@ -67,21 +61,7 @@ const ScheduledRuns: React.FC = () => {
 
         <EmptyStateFooter>
           <EmptyStateActions>
-            <Button
-              data-testid="schedule-run-button"
-              variant="primary"
-              onClick={() =>
-                navigate({
-                  pathname: scheduleRunRoute(
-                    namespace,
-                    isExperimentsAvailable ? experimentId : undefined,
-                  ),
-                  search: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.SCHEDULED}`,
-                })
-              }
-            >
-              Create schedule
-            </Button>
+            <CreateScheduleButton />
           </EmptyStateActions>
         </EmptyStateFooter>
       </EmptyState>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-7543

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When an experiment is archived, refine the login on the runs page

1. On the active runs tab, show an empty state

<img width="1728" alt="Screenshot 2024-06-03 at 12 32 42 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/02e857d9-5be1-4416-8935-1e48c187eea5">

2. On the archived runs tab, disable the restore button on both the table toolbar and the row actions

<img width="1728" alt="Screenshot 2024-06-03 at 12 33 31 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/15d66fad-8884-4e87-9c13-9a81197205df">

<img width="1728" alt="Screenshot 2024-06-03 at 12 33 46 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/22cc18c7-3d4f-48a6-9fa2-a9f64909372b">

3. On the schedules tab, disable the creation button and the status toggle, so the user cannot enable a schedule

<img width="1728" alt="Screenshot 2024-06-03 at 12 34 26 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/84e2839c-ffc0-4d1e-97a1-4512d94e08a7">

4. The user could duplicate a schedule, but the status will be disabled
5. Refine the logic on the create runs page, the experiment dropdown for a one-time triggered run will only show active experiments (even if you are under the archived experiment context). Duplicating a run with an archived experiment will not auto-fill any experiment now. Create schedules page is working as previously

<img width="1728" alt="Screenshot 2024-06-03 at 12 37 09 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/a4decc3c-66f6-453e-864c-766825981478">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create an experiment
2. Create some runs and schedules using this experiment
3. Archived this experiment
4. Verify the active tab is showing an empty state
5. Verify the restore buttons are disabled on the archived runs tab
6. Verify the create button and status is disabled on the schedules tab
7. Try to duplicate an archived run/schedule, and switch between the run/schedule creation page, make sure the experiment selection logic is working fine as mentioned in the description

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added some cypress tests to verify the buttons on the archived experiment runs page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
