### PR TITLE
[RHOAIENG-6867] Tracking of dashboard version and users's capabilities

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -58,7 +58,7 @@ Run the tests.
 
 For in-depth testing guidance review the [testing guidelines](./testing.md)
 
-## Deploying the ODH Dashbard
+## Deploying the ODH Dashboard
 
 ### Official Image Builds
 

--- a/frontend/src/utilities/useSegmentTracking.ts
+++ b/frontend/src/utilities/useSegmentTracking.ts
@@ -2,6 +2,9 @@ import React from 'react';
 import { useAppContext } from '~/app/AppContext';
 import { initSegment } from '~/utilities/segmentIOUtils';
 import { useAppSelector } from '~/redux/hooks';
+import { AccessReviewResourceAttributes } from '~/k8sTypes';
+import { useAccessReview } from '~/api';
+import { useUser } from '~/redux/selectors';
 import { useWatchSegmentKey } from './useWatchSegmentKey';
 
 export const useSegmentTracking = (): void => {
@@ -10,14 +13,66 @@ export const useSegmentTracking = (): void => {
   const username = useAppSelector((state) => state.user);
   const clusterID = useAppSelector((state) => state.clusterID);
 
+  // TODO this should go to a helper, as it is called from multiple places
+  const createReviewResource: AccessReviewResourceAttributes = {
+    group: 'project.openshift.io',
+    resource: 'projectrequests',
+    verb: 'create',
+  };
+  const [allowCreate, createLoaded] = useAccessReview(createReviewResource);
+
+  // TODO this should go to a helper, as it is called from multiple places
+  const deleteReviewResource: AccessReviewResourceAttributes = {
+    group: 'project.openshift.io',
+    resource: 'projectrequests',
+    verb: 'delete',
+  };
+  const [allowDelete, deleteLoaded] = useAccessReview(deleteReviewResource);
+
+  const updateReviewResource: AccessReviewResourceAttributes = {
+    group: 'datasciencecluster.opendatahub.io/v1',
+    resource: 'DataScienceCluster',
+    verb: 'update',
+  };
+  const [allowUpdate, updateLoaded] = useAccessReview(updateReviewResource);
+
+  const { isAdmin } = useUser();
+
   React.useEffect(() => {
-    if (segmentKey && loaded && !loadError && username && clusterID) {
+    if (
+      segmentKey &&
+      loaded &&
+      !loadError &&
+      createLoaded &&
+      deleteLoaded &&
+      updateLoaded &&
+      username &&
+      clusterID
+    ) {
       window.clusterID = clusterID;
       initSegment({
         segmentKey,
         username,
         enabled: !dashboardConfig.spec.dashboardConfig.disableTracking,
+        canCreate: allowCreate,
+        canDelete: allowDelete,
+        canUpdate: allowUpdate,
+        isAdmin,
       });
     }
-  }, [clusterID, loadError, loaded, segmentKey, username, dashboardConfig]);
+  }, [
+    clusterID,
+    loadError,
+    loaded,
+    segmentKey,
+    username,
+    dashboardConfig,
+    allowCreate,
+    allowDelete,
+    isAdmin,
+    createLoaded,
+    deleteLoaded,
+    updateLoaded,
+    allowUpdate,
+  ]);
 };


### PR DESCRIPTION
## Description

This is related to [RHOAIENG-6867](https://issues.redhat.com/browse/RHOAIENG-6867)

* Add dashboard version to track events / page views
* On user init record the capabilities of the user 

## How Has This Been Tested?
Manually be looking at the data that arrived in Segment / by looking at request in the Browsers network tab

## Test Impact
No change on functionality of the visible UI

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)


After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
