### PR TITLE
Add character limit for pipeline run name

### DIFF
--- a/frontend/src/concepts/k8s/NameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/NameDescriptionField.tsx
@@ -22,6 +22,7 @@ type NameDescriptionFieldProps = {
   autoFocusName?: boolean;
   showK8sName?: boolean;
   disableK8sName?: boolean;
+  maxLength?: number;
 };
 
 const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
@@ -32,6 +33,7 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
   autoFocusName,
   showK8sName,
   disableK8sName,
+  maxLength,
 }) => {
   const autoSelectNameRef = React.useRef<HTMLInputElement | null>(null);
 
@@ -61,7 +63,13 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
             name={nameFieldId}
             value={data.name}
             onChange={(e, name) => setData({ ...data, name })}
+            maxLength={maxLength}
           />
+          {maxLength && (
+            <HelperText>
+              <HelperTextItem>{`Cannot exceed ${maxLength} characters`}</HelperTextItem>
+            </HelperText>
+          )}
         </FormGroup>
       </StackItem>
       {showK8sName && (

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -12,7 +12,7 @@ import { PipelineRunType } from '~/pages/pipelines/global/runs';
 import ProjectAndExperimentSection from '~/concepts/pipelines/content/createRun/contentSections/ProjectAndExperimentSection';
 import PipelineSection from './contentSections/PipelineSection';
 import { RunTypeSection } from './contentSections/RunTypeSection';
-import { CreateRunPageSections, runPageSectionTitles } from './const';
+import { CreateRunPageSections, RUN_NAME_CHARACTER_LIMIT, runPageSectionTitles } from './const';
 import { getInputDefinitionParams } from './utils';
 
 type RunFormProps = {
@@ -72,6 +72,7 @@ const RunForm: React.FC<RunFormProps> = ({ data, runType, onValueChange }) => {
           descriptionFieldId="run-description"
           data={data.nameDesc}
           setData={(nameDesc) => onValueChange('nameDesc', nameDesc)}
+          maxLength={RUN_NAME_CHARACTER_LIMIT}
         />
 
         {isSchedule && data.runType.type === RunTypeOption.SCHEDULED && (

--- a/frontend/src/concepts/pipelines/content/createRun/const.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/const.ts
@@ -34,3 +34,5 @@ export const runPageSectionTitles: Record<CreateRunPageSections, string> = {
   [CreateRunPageSections.PIPELINE]: 'Pipeline',
   [CreateRunPageSections.PARAMS]: 'Parameters',
 };
+
+export const RUN_NAME_CHARACTER_LIMIT = 255;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-2293](https://issues.redhat.com/browse/RHOAIENG-2293)

## Description
This PR aims to limit the character for pipeline run name to 255 and added help text under the name input form to explain the limitation.

![Screenshot from 2024-06-05 22-41-58](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/25e454c8-0b33-441a-8cb7-795be8005e3d)


## How Has This Been Tested?
 -  Open a create pipeline run modal.
 -  check that name in run details section has an help text.
 -  And run name will only take maximum of 255 character, check that it won't allow to add more than 255 character.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
