### PR TITLE
update codecov color range

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "50...70"
   status:
     project:
       default:


### PR DESCRIPTION
Change the codecov color [range](https://docs.codecov.com/docs/coverage-configuration#range).

> This value is used to customize the visible color range in Codecov. The first number represents the cutover from red to yellow, and the second represents the cutover from yellow to green. You can change the range of colors by adjusting this configuration.

Since our coverage target is 70%, any coverage >= 70% should be green.
The range from 50-70 will become yellow.
The range < 50 will become red.
