### PR TITLE
Allow experiments table to sort by last run started

### DIFF
--- a/frontend/src/__mocks__/mockExperimentKF.ts
+++ b/frontend/src/__mocks__/mockExperimentKF.ts
@@ -7,6 +7,7 @@ export const buildMockExperimentKF = (experiment?: Partial<ExperimentKFv2>): Exp
   description: 'All runs created without specifying an experiment will be grouped here.',
   created_at: '2024-01-31T15:46:33Z',
   storage_state: StorageStateKF.AVAILABLE,
+  last_run_created_at: '2024-01-31T15:46:33Z',
   ...experiment,
 });
 

--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -77,6 +77,11 @@ export const experimentColumns: SortableData<ExperimentKFv2>[] = [
     sortable: true,
   },
   {
+    label: 'Last run started',
+    field: 'last_run_created_at',
+    sortable: true,
+  },
+  {
     label: 'Last 5 runs',
     field: 'last_5_runs',
     sortable: false,

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
@@ -7,7 +7,7 @@ import { ExperimentKFv2, StorageStateKF } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd } from '~/components/table';
 import { experimentRunsRoute } from '~/routes';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { ExperimentCreated, LastExperimentRuns } from './renderUtils';
+import { ExperimentCreated, LastExperimentRuns, LastExperimentRunsStarted } from './renderUtils';
 
 type ExperimentTableRowProps = {
   isChecked: boolean;
@@ -42,6 +42,9 @@ const ExperimentTableRow: React.FC<ExperimentTableRowProps> = ({
       <Td dataLabel="Description">{experiment.description}</Td>
       <Td dataLabel="Created">
         <ExperimentCreated experiment={experiment} />
+      </Td>
+      <Td dataLabel="Last run started">
+        <LastExperimentRunsStarted experiment={experiment} />
       </Td>
       <Td dataLabel="Last 5 runs">
         <LastExperimentRuns experiment={experiment} />

--- a/frontend/src/concepts/pipelines/content/tables/experiment/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/renderUtils.tsx
@@ -12,6 +12,18 @@ export const ExperimentCreated: ExperimentUtil = ({ experiment }) => {
   return <PipelinesTableRowTime date={createdDate} />;
 };
 
+export const LastExperimentRunsStarted: ExperimentUtil = ({ experiment }) => {
+  const lastRunCreatedAt = experiment.last_run_created_at;
+
+  // Check if last_run_created_at is not set or has a default invalid date
+  if (!lastRunCreatedAt || lastRunCreatedAt === '1970-01-01T00:00:00Z') {
+    return '-';
+  }
+
+  const lastRunStarted = new Date(lastRunCreatedAt);
+  return Number.isNaN(lastRunStarted) ? '-' : <PipelinesTableRowTime date={lastRunStarted} />;
+};
+
 export const LastExperimentRuns: ExperimentUtil = ({ experiment }) => {
   const [runs] = usePipelineRunsByExperiment(experiment.experiment_id, {
     sortDirection: 'desc',

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -664,6 +664,7 @@ export type ExperimentKFv2 = {
   created_at: string;
   namespace?: string;
   storage_state: StorageStateKF;
+  last_run_created_at: string;
 };
 
 export type ListExperimentsResponseKF = PipelineKFCallCommon<{
@@ -697,7 +698,7 @@ export type CreatePipelineVersionKFData = Omit<
 
 export type CreateExperimentKFData = Omit<
   ExperimentKFv2,
-  'experiment_id' | 'created_at' | 'namespace' | 'storage_state'
+  'experiment_id' | 'created_at' | 'namespace' | 'storage_state' | 'last_run_created_at'
 >;
 export type CreatePipelineRunKFData = Omit<
   PipelineRunKFv2,


### PR DESCRIPTION
Closes: [RHOAIENG-7715](https://issues.redhat.com/browse/RHOAIENG-7715)

## Description
Added new column in Experiments table for last run started.

![Screenshot 2024-06-12 at 4 51 50 PM](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/5b4c1003-bd1d-40ce-950b-c103a0cd6123)


## How Has This Been Tested?
Go to Experiments page and you can find the new column added.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@yannnz 