### PR TITLE
Fix label for runs produces by a deleted recurring run

### DIFF
--- a/frontend/src/concepts/pipelines/context/useJobRelatedInformation.ts
+++ b/frontend/src/concepts/pipelines/context/useJobRelatedInformation.ts
@@ -46,6 +46,10 @@ const useJobRelatedInformation = (
           .catch((e) => {
             // eslint-disable-next-line no-console
             console.error('Could not fetch job reference', e);
+            setJobStorage((jobState) => ({
+              ...jobState,
+              [jobId]: { loading: false, data: null },
+            }));
             loadedIds.current = loadedIds.current.filter((i) => i !== jobId);
             return null;
           });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-7375

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Simply set the loading state to `false` when there is an error fetching the recurring run. This could help fix the forever loading state when showing the label of a run.

<img width="1728" alt="Screenshot 2024-06-07 at 2 29 04 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/8c50b2ce-6ea8-4c79-835d-d329b5c38d2e">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a schedule
2. Wait until the schedule create one or more runs
3. Delete the schedule
4. Go to the runs tab, make sure there is no `Loading...` text under the runs

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
