### PR TITLE
Fix types for ServingRuntimes and InferenceService

### DIFF
--- a/backend/src/routes/api/servingRuntimes/index.ts
+++ b/backend/src/routes/api/servingRuntimes/index.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { KubeFastifyInstance, ServingRuntime } from '../../../types';
+import { KubeFastifyInstance, ServingRuntimeKind } from '../../../types';
 import { secureAdminRoute } from '../../../utils/route-security';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
@@ -9,7 +9,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       async (
         request: FastifyRequest<{
           Querystring: { dryRun?: string };
-          Body: ServingRuntime;
+          Body: ServingRuntimeKind;
         }>,
         reply: FastifyReply,
       ) => {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -876,7 +876,20 @@ export type ContainerResources = {
   } & Record<string, unknown>;
 };
 
-export type ServingRuntime = K8sResourceCommon & {
+export type PodAffinity = {
+  nodeAffinity?: { [key: string]: unknown };
+};
+
+export type ServingContainer = {
+  name: string;
+  args?: string[];
+  image?: string;
+  affinity?: PodAffinity;
+  resources?: ContainerResources;
+  volumeMounts?: VolumeMount[];
+};
+
+export type ServingRuntimeKind = K8sResourceCommon & {
   metadata: {
     annotations?: DisplayNameAnnotations & ServingRuntimeAnnotations;
     name: string;
@@ -884,20 +897,15 @@ export type ServingRuntime = K8sResourceCommon & {
   };
   spec: {
     builtInAdapter?: {
-      serverType: string;
-      runtimeManagementPort: number;
+      serverType?: string;
+      runtimeManagementPort?: number;
       memBufferBytes?: number;
       modelLoadingTimeoutMillis?: number;
     };
-    containers: {
-      args: string[];
-      image: string;
-      name: string;
-      resources?: ContainerResources;
-      volumeMounts?: VolumeMount[];
-    }[];
-    supportedModelFormats: SupportedModelFormats[];
+    containers: ServingContainer[];
+    supportedModelFormats?: SupportedModelFormats[];
     replicas?: number;
+    tolerations?: Toleration[];
     volumes?: Volume[];
   };
 };

--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -19,6 +19,7 @@ type MockResourceConfigType = {
   maxReplicas?: number;
   lastFailureInfoMessage?: string;
   resources?: ContainerResources;
+  statusPredictor?: Record<string, string>;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -74,6 +75,7 @@ export const mockInferenceServiceK8sResource = ({
   maxReplicas = 1,
   lastFailureInfoMessage = 'Waiting for runtime Pod to become available',
   resources,
+  statusPredictor = undefined,
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',
@@ -131,7 +133,9 @@ export const mockInferenceServiceK8sResource = ({
     },
   },
   status: {
-    components: {},
+    components: {
+      ...(statusPredictor && { predictor: statusPredictor }),
+    },
     url,
     conditions: [
       {

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -276,6 +276,14 @@ class InferenceServiceRow extends TableRow {
   findAPIProtocol() {
     return this.find().find(`[data-label="API protocol"]`);
   }
+
+  findInternalServiceButton() {
+    return this.find().findByTestId('internal-service-button');
+  }
+
+  findInternalServicePopover() {
+    return cy.findByTestId('internal-service-popover');
+  }
 }
 class ServingPlatformCard extends Contextual<HTMLElement> {
   findDeployModelButton() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -1713,154 +1713,213 @@ describe('Serving Runtime List', () => {
     });
   });
 
-  it('Check model size rendered with ServingRuntime size and no InferenceServiceSize', () => {
-    initIntercepts({
-      projectEnableModelMesh: false,
-      disableKServeConfig: true,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          modelName: 'llama-service',
-          isModelMesh: false,
-          resources: undefined,
-        }),
-      ],
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          namespace: 'test-project',
-          resources: {
-            limits: {
-              cpu: '2',
-              memory: '8Gi',
+  describe('Model size', () => {
+    it('Check model size rendered with ServingRuntime size and no InferenceServiceSize', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: true,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            modelName: 'llama-service',
+            isModelMesh: false,
+            resources: undefined,
+          }),
+        ],
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            namespace: 'test-project',
+            resources: {
+              limits: {
+                cpu: '2',
+                memory: '8Gi',
+              },
+              requests: {
+                cpu: '1',
+                memory: '4Gi',
+              },
             },
-            requests: {
-              cpu: '1',
-              memory: '4Gi',
-            },
-          },
-        }),
-      ],
+          }),
+        ],
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+      const kserveRow = modelServingSection.getKServeRow('Llama Service');
+      kserveRow.findExpansion().should(be.collapsed);
+      kserveRow.findToggleButton().click();
+      kserveRow
+        .findDescriptionListItem('Model server size')
+        .next('dd')
+        .should('contain.text', 'Small');
+
+      // click on the toggle button and open edit model server
+      kserveRow.find().findKebabAction('Edit').click();
+
+      kserveModal.shouldBeOpen();
+
+      kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Small');
     });
 
-    projectDetails.visitSection('test-project', 'model-server');
-    const kserveRow = modelServingSection.getKServeRow('Llama Service');
-    kserveRow.findExpansion().should(be.collapsed);
-    kserveRow.findToggleButton().click();
-    kserveRow
-      .findDescriptionListItem('Model server size')
-      .next('dd')
-      .should('contain.text', 'Small');
+    it('Check model size rendered with InferenceService size', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: true,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            modelName: 'llama-service',
+            isModelMesh: false,
+            resources: {
+              limits: {
+                cpu: '2',
+                memory: '8Gi',
+              },
+              requests: {
+                cpu: '1',
+                memory: '4Gi',
+              },
+            },
+          }),
+        ],
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            namespace: 'test-project',
+            resources: undefined,
+          }),
+        ],
+      });
 
-    // click on the toggle button and open edit model server
-    kserveRow.find().findKebabAction('Edit').click();
+      projectDetails.visitSection('test-project', 'model-server');
+      const kserveRow = modelServingSection.getKServeRow('Llama Service');
+      kserveRow.findExpansion().should(be.collapsed);
+      kserveRow.findToggleButton().click();
+      kserveRow
+        .findDescriptionListItem('Model server size')
+        .next('dd')
+        .should('contain.text', 'Small');
 
-    kserveModal.shouldBeOpen();
+      // click on the toggle button and open edit model server
+      kserveRow.find().findKebabAction('Edit').click();
 
-    kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Small');
+      kserveModal.shouldBeOpen();
+
+      kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Small');
+    });
+
+    it('Check model size rendered with InferenceService custom size', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: true,
+        disableModelMeshConfig: true,
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            modelName: 'llama-service',
+            isModelMesh: false,
+            resources: {
+              limits: {
+                cpu: '1',
+                memory: '10Gi',
+              },
+              requests: {
+                cpu: '1',
+                memory: '4Gi',
+              },
+            },
+          }),
+        ],
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'llama-service',
+            displayName: 'Llama Service',
+            namespace: 'test-project',
+            resources: undefined,
+            disableResources: true,
+          }),
+        ],
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+      const kserveRow = modelServingSection.getKServeRow('Llama Service');
+      kserveRow.findExpansion().should(be.collapsed);
+      kserveRow.findToggleButton().click();
+      kserveRow
+        .findDescriptionListItem('Model server size')
+        .next('dd')
+        .should('contain.text', 'Custom');
+
+      // click on the toggle button and open edit model server
+      modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
+
+      kserveModal.shouldBeOpen();
+
+      kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Custom');
+    });
   });
 
-  it('Check model size rendered with InferenceService size', () => {
-    initIntercepts({
-      projectEnableModelMesh: false,
-      disableKServeConfig: true,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          modelName: 'llama-service',
-          isModelMesh: false,
-          resources: {
-            limits: {
-              cpu: '2',
-              memory: '8Gi',
+  describe('Internal service', () => {
+    it('Check internal service is rendered when the model is loaded', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+        disableKServeConfig: false,
+        disableModelMeshConfig: true,
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'test-model',
+            auth: true,
+            route: false,
+          }),
+        ],
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'model-loaded',
+            displayName: 'Loaded model',
+            isModelMesh: true,
+            statusPredictor: {
+              grpcUrl: 'grpc://modelmesh-serving.modelmesh:8033',
+              restUrl: 'http://modelmesh-serving.modelmesh:8008',
+              url: 'grpc://modelmesh-serving.modelmesh:8033',
             },
-            requests: {
-              cpu: '1',
-              memory: '4Gi',
-            },
-          },
-        }),
-      ],
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          namespace: 'test-project',
-          resources: undefined,
-        }),
-      ],
+          }),
+          mockInferenceServiceK8sResource({
+            name: 'model-not-loaded',
+            displayName: 'Model not loaded',
+            isModelMesh: true,
+          }),
+        ],
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+
+      // Expand the model serving section
+      modelServingSection
+        .getModelMeshRow('OVMS Model Serving')
+        .findDeployedModelExpansionButton()
+        .click();
+      modelServingSection.findInferenceServiceTable().should('exist');
+
+      // Get modal of inference service when is loaded
+      const loadedInferenceServiceRow = modelServingSection.getInferenceServiceRow('Loaded model');
+      loadedInferenceServiceRow.findInternalServiceButton().click();
+      loadedInferenceServiceRow.findInternalServicePopover().findByText('grpcUrl').should('exist');
+
+      // Get modal of inference service when is not loaded
+      const notLoadedInferenceServiceRow =
+        modelServingSection.getInferenceServiceRow('Model not loaded');
+      notLoadedInferenceServiceRow.findInternalServiceButton().click();
+      notLoadedInferenceServiceRow
+        .findInternalServicePopover()
+        .findByText('Could not find any internal service enabled')
+        .should('exist');
     });
-
-    projectDetails.visitSection('test-project', 'model-server');
-    const kserveRow = modelServingSection.getKServeRow('Llama Service');
-    kserveRow.findExpansion().should(be.collapsed);
-    kserveRow.findToggleButton().click();
-    kserveRow
-      .findDescriptionListItem('Model server size')
-      .next('dd')
-      .should('contain.text', 'Small');
-
-    // click on the toggle button and open edit model server
-    kserveRow.find().findKebabAction('Edit').click();
-
-    kserveModal.shouldBeOpen();
-
-    kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Small');
-  });
-
-  it('Check model size rendered with InferenceService custom size', () => {
-    initIntercepts({
-      projectEnableModelMesh: false,
-      disableKServeConfig: true,
-      disableModelMeshConfig: true,
-      inferenceServices: [
-        mockInferenceServiceK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          modelName: 'llama-service',
-          isModelMesh: false,
-          resources: {
-            limits: {
-              cpu: '1',
-              memory: '10Gi',
-            },
-            requests: {
-              cpu: '1',
-              memory: '4Gi',
-            },
-          },
-        }),
-      ],
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
-          name: 'llama-service',
-          displayName: 'Llama Service',
-          namespace: 'test-project',
-          resources: undefined,
-          disableResources: true,
-        }),
-      ],
-    });
-
-    projectDetails.visitSection('test-project', 'model-server');
-    const kserveRow = modelServingSection.getKServeRow('Llama Service');
-    kserveRow.findExpansion().should(be.collapsed);
-    kserveRow.findToggleButton().click();
-    kserveRow
-      .findDescriptionListItem('Model server size')
-      .next('dd')
-      .should('contain.text', 'Custom');
-
-    // click on the toggle button and open edit model server
-    modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
-
-    kserveModal.shouldBeOpen();
-
-    kserveModal.findModelServerSizeSelect().invoke('text').should('equal', 'Custom');
   });
 });

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -157,8 +157,8 @@ describe('assembleInferenceService', () => {
     expect(inferenceService.spec.predictor.tolerations?.[0].key).toBe(
       mockAcceleratorProfile({}).spec.tolerations?.[0].key,
     );
-    expect(inferenceService.spec.predictor.model.resources?.limits?.['nvidia.com/gpu']).toBe(1);
-    expect(inferenceService.spec.predictor.model.resources?.requests?.['nvidia.com/gpu']).toBe(1);
+    expect(inferenceService.spec.predictor.model?.resources?.limits?.['nvidia.com/gpu']).toBe(1);
+    expect(inferenceService.spec.predictor.model?.resources?.requests?.['nvidia.com/gpu']).toBe(1);
   });
 
   it('should not add accelerator if modelmesh and accelerator found', async () => {
@@ -181,7 +181,7 @@ describe('assembleInferenceService', () => {
     );
 
     expect(inferenceService.spec.predictor.tolerations).toBeUndefined();
-    expect(inferenceService.spec.predictor.model.resources).toBeUndefined();
+    expect(inferenceService.spec.predictor.model?.resources).toBeUndefined();
   });
 
   it('should provide max and min replicas if provided', async () => {
@@ -268,16 +268,16 @@ describe('assembleInferenceService', () => {
       acceleratorProfileState,
     );
 
-    expect(inferenceService.spec.predictor.model.resources?.requests?.cpu).toBe(
+    expect(inferenceService.spec.predictor.model?.resources?.requests?.cpu).toBe(
       modelSize.resources.requests?.cpu,
     );
-    expect(inferenceService.spec.predictor.model.resources?.requests?.memory).toBe(
+    expect(inferenceService.spec.predictor.model?.resources?.requests?.memory).toBe(
       modelSize.resources.requests?.memory,
     );
-    expect(inferenceService.spec.predictor.model.resources?.limits?.cpu).toBe(
+    expect(inferenceService.spec.predictor.model?.resources?.limits?.cpu).toBe(
       modelSize.resources.limits?.cpu,
     );
-    expect(inferenceService.spec.predictor.model.resources?.limits?.memory).toBe(
+    expect(inferenceService.spec.predictor.model?.resources?.limits?.memory).toBe(
       modelSize.resources.limits?.memory,
     );
   });
@@ -315,7 +315,7 @@ describe('assembleInferenceService', () => {
       acceleratorProfileState,
     );
 
-    expect(inferenceService.spec.predictor.model.resources).toBeUndefined();
+    expect(inferenceService.spec.predictor.model?.resources).toBeUndefined();
   });
 });
 

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -137,7 +137,10 @@ export const assembleInferenceService = (
       updateInferenceService.spec.predictor.tolerations = tolerations;
     }
 
-    updateInferenceService.spec.predictor.model.resources = resources;
+    updateInferenceService.spec.predictor.model = {
+      ...updateInferenceService.spec.predictor.model,
+      resources,
+    };
   }
 
   return updateInferenceService;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -378,9 +378,9 @@ export type ServiceAccountKind = K8sResourceCommon & {
 };
 
 export type ServingContainer = {
-  args: string[];
-  image: string;
   name: string;
+  args?: string[];
+  image?: string;
   affinity?: PodAffinity;
   resources?: ContainerResources;
   volumeMounts?: VolumeMount[];
@@ -394,13 +394,13 @@ export type ServingRuntimeKind = K8sResourceCommon & {
   };
   spec: {
     builtInAdapter?: {
-      serverType: string;
-      runtimeManagementPort: number;
+      serverType?: string;
+      runtimeManagementPort?: number;
       memBufferBytes?: number;
       modelLoadingTimeoutMillis?: number;
     };
     containers: ServingContainer[];
-    supportedModelFormats: SupportedModelFormats[];
+    supportedModelFormats?: SupportedModelFormats[];
     replicas?: number;
     tolerations?: Toleration[];
     volumes?: Volume[];
@@ -437,8 +437,8 @@ export type InferenceServiceKind = K8sResourceCommon & {
   spec: {
     predictor: {
       tolerations?: Toleration[];
-      model: {
-        modelFormat: {
+      model?: {
+        modelFormat?: {
           name: string;
           version?: string;
         };
@@ -446,9 +446,9 @@ export type InferenceServiceKind = K8sResourceCommon & {
         runtime?: string;
         storageUri?: string;
         storage?: {
-          key: string;
+          key?: string;
           parameters?: Record<string, string>;
-          path: string;
+          path?: string;
           schemaPath?: string;
         };
       };
@@ -457,33 +457,33 @@ export type InferenceServiceKind = K8sResourceCommon & {
     };
   };
   status?: {
-    components: {
+    components?: {
       predictor?: {
-        grpcUrl: string;
-        restUrl: string;
-        url: string;
+        grpcUrl?: string;
+        restUrl?: string;
+        url?: string;
       };
     };
-    conditions: {
-      lastTransitionTime: string;
+    conditions?: {
+      lastTransitionTime?: string;
       status: string;
       type: string;
     }[];
-    modelStatus: {
-      copies: {
-        failedCopies: number;
-        totalCopies: number;
+    modelStatus?: {
+      copies?: {
+        failedCopies?: number;
+        totalCopies?: number;
       };
       lastFailureInfo?: {
-        location: string;
-        message: string;
-        modelRevisionName: string;
-        reason: string;
-        time: string;
+        location?: string;
+        message?: string;
+        modelRevisionName?: string;
+        reason?: string;
+        time?: string;
       };
-      states: {
+      states?: {
         activeModelState: string;
-        targetModelState: string;
+        targetModelState?: string;
       };
       transitionStatus: string;
     };

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceEndpoint.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceEndpoint.tsx
@@ -35,11 +35,12 @@ const InferenceServiceEndpoint: React.FC<InferenceServiceEndpointProps> = ({
   if (!isKserve && !isRouteEnabled) {
     return (
       <Popover
+        data-testid="internal-service-popover"
         headerContent="Internal Service can be accessed inside the cluster"
         aria-label="Internal Service Info"
         bodyContent={<InternalServicePopoverContent inferenceService={inferenceService} />}
       >
-        <Button isInline variant="link">
+        <Button data-testid="internal-service-button" isInline variant="link">
           Internal Service
         </Button>
       </Popover>

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -24,7 +24,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
 }) => {
   const [modelStatus] = useModelStatus(
     inferenceService.metadata.namespace,
-    inferenceService.spec.predictor.model.runtime ?? '',
+    inferenceService.spec.predictor.model?.runtime ?? '',
     isKserve,
   );
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -54,7 +54,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
             <InferenceServiceTableRow
               obj={is}
               servingRuntime={servingRuntimes.find(
-                (sr) => sr.metadata.name === is.spec.predictor.model.runtime,
+                (sr) => sr.metadata.name === is.spec.predictor.model?.runtime,
               )}
               isGlobal={isGlobal}
               showServingRuntime={isGlobal}
@@ -70,7 +70,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
         servingRuntime={
           deleteInferenceService && !isModelMesh(deleteInferenceService)
             ? servingRuntimes.find(
-                (sr) => sr.metadata.name === deleteInferenceService.spec.predictor.model.runtime,
+                (sr) => sr.metadata.name === deleteInferenceService.spec.predictor.model?.runtime,
               )
             : undefined
         }
@@ -98,7 +98,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
           servingRuntimeEditInfo: {
             servingRuntime: editInferenceService
               ? servingRuntimes.find(
-                  (sr) => sr.metadata.name === editInferenceService.spec.predictor.model.runtime,
+                  (sr) => sr.metadata.name === editInferenceService.spec.predictor.model?.runtime,
                 )
               : undefined,
             secrets: [],

--- a/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
@@ -14,7 +14,7 @@ type InternalServicePopoverContentProps = {
 const InternalServicePopoverContent: React.FC<InternalServicePopoverContentProps> = ({
   inferenceService,
 }) => {
-  const isInternalServiceEnabled = inferenceService.status?.components.predictor;
+  const isInternalServiceEnabled = inferenceService.status?.components?.predictor;
 
   if (!isInternalServiceEnabled) {
     return <>Could not find any internal service enabled</>;

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -12,18 +12,18 @@ export const getTokenDisplayName = (secret: SecretKind): string =>
 export const getInferenceServiceActiveModelState = (
   is: InferenceServiceKind,
 ): InferenceServiceModelState =>
-  <InferenceServiceModelState | undefined>is.status?.modelStatus.states.activeModelState ||
-  <InferenceServiceModelState | undefined>is.status?.modelStatus.states.targetModelState ||
+  <InferenceServiceModelState | undefined>is.status?.modelStatus?.states?.activeModelState ||
+  <InferenceServiceModelState | undefined>is.status?.modelStatus?.states?.targetModelState ||
   InferenceServiceModelState.UNKNOWN;
 
 export const getInferenceServiceStatusMessage = (is: InferenceServiceKind): string => {
-  const activeModelState = is.status?.modelStatus.states.activeModelState;
-  const targetModelState = is.status?.modelStatus.states.targetModelState;
+  const activeModelState = is.status?.modelStatus?.states?.activeModelState;
+  const targetModelState = is.status?.modelStatus?.states?.targetModelState;
 
   const failedToLoad = InferenceServiceModelState.FAILED_TO_LOAD;
   const isFailedToLoad = activeModelState === failedToLoad || targetModelState === failedToLoad;
 
-  const lastFailureMessage = is.status?.modelStatus.lastFailureInfo?.message;
+  const lastFailureMessage = is.status?.modelStatus?.lastFailureInfo?.message;
   const stateMessage = activeModelState ?? targetModelState ?? 'Unknown';
 
   return isFailedToLoad ? lastFailureMessage ?? stateMessage : stateMessage;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
@@ -18,7 +18,7 @@ const useModelFramework = (
     setLoaded(false);
     getServingRuntime(name, namespace)
       .then((servingRuntime) => {
-        setModels(servingRuntime.spec.supportedModelFormats);
+        setModels(servingRuntime.spec.supportedModelFormats || []);
         setLoaded(true);
       })
       .catch((e) => {

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
@@ -43,11 +43,11 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
     servingRuntimes: { data: servingRuntimes },
   } = React.useContext(ProjectDetailsContext);
 
-  const frameworkName = obj.spec.predictor.model.modelFormat.name;
-  const frameworkVersion = obj.spec.predictor.model.modelFormat.version;
+  const frameworkName = obj.spec.predictor.model?.modelFormat?.name;
+  const frameworkVersion = obj.spec.predictor.model?.modelFormat?.version;
 
   const servingRuntime = servingRuntimes.find(
-    (sr) => sr.metadata.name === obj.spec.predictor.model.runtime,
+    (sr) => sr.metadata.name === obj.spec.predictor.model?.runtime,
   );
 
   return (

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -25,7 +25,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc
   const enabledAcceleratorProfiles = acceleratorProfile.acceleratorProfiles.filter(
     (ac) => ac.spec.enabled,
   );
-  const resources = obj.spec.containers[0].resources || isvc?.spec.predictor.model.resources;
+  const resources = obj.spec.containers[0].resources || isvc?.spec.predictor.model?.resources;
   const sizes = getServingRuntimeSizes(dashboardConfig);
   const size = sizes.find(
     (currentSize) => getResourceSize(sizes, resources || {}).name === currentSize.name,

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal.tsx
@@ -51,7 +51,7 @@ const DeleteServingRuntimeModal: React.FC<DeleteServingRuntimeModalProps> = ({
             ...inferenceServices
               .filter(
                 (inferenceService) =>
-                  inferenceService.spec.predictor.model.runtime === servingRuntime.metadata.name,
+                  inferenceService.spec.predictor.model?.runtime === servingRuntime.metadata.name,
               )
               .map((inferenceService) =>
                 deleteInferenceService(

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -180,7 +180,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     setActionInProgress(true);
 
     const servingRuntimeName =
-      editInfo?.inferenceServiceEditInfo?.spec.predictor.model.runtime ||
+      editInfo?.inferenceServiceEditInfo?.spec.predictor.model?.runtime ||
       translateDisplayNameForK8s(createDataInferenceService.name);
 
     const submitServingRuntimeResources = getSubmitServingRuntimeResourcesFn(

--- a/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfile.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfile.ts
@@ -11,7 +11,7 @@ const useServingAcceleratorProfile = (
   const acceleratorProfileName =
     servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-name'];
   const resources =
-    inferenceService?.spec.predictor.model.resources ||
+    inferenceService?.spec.predictor.model?.resources ||
     servingRuntime?.spec.containers[0].resources;
   const tolerations =
     inferenceService?.spec.predictor.tolerations || servingRuntime?.spec.tolerations;

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -73,7 +73,7 @@ export const getInferenceServiceFromServingRuntime = (
 ): InferenceServiceKind[] =>
   inferenceServices.filter(
     (inferenceService) =>
-      inferenceService.spec.predictor.model.runtime === servingRuntime.metadata.name,
+      inferenceService.spec.predictor.model?.runtime === servingRuntime.metadata.name,
   );
 
 export const useCreateServingRuntimeObject = (existingData?: {
@@ -196,11 +196,11 @@ export const useCreateInferenceServiceObject = (
     existingData?.metadata.name ||
     '';
   const existingStorage =
-    useDeepCompareMemoize(existingData?.spec.predictor.model.storage) || undefined;
-  const existingServingRuntime = existingData?.spec.predictor.model.runtime || '';
+    useDeepCompareMemoize(existingData?.spec.predictor.model?.storage) || undefined;
+  const existingServingRuntime = existingData?.spec.predictor.model?.runtime || '';
   const existingProject = existingData?.metadata.namespace || '';
   const existingFormat =
-    useDeepCompareMemoize(existingData?.spec.predictor.model.modelFormat) || undefined;
+    useDeepCompareMemoize(existingData?.spec.predictor.model?.modelFormat) || undefined;
   const existingMinReplicas =
     existingData?.spec.predictor.minReplicas || existingServingRuntimeData?.spec.replicas || 1;
   const existingMaxReplicas =

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -192,13 +192,13 @@ export const getInferenceServiceSizeOrReturnEmpty = (
   inferenceService?: InferenceServiceKind,
 ): ContainerResources | undefined => {
   if (
-    inferenceService?.spec.predictor.model.resources &&
+    inferenceService?.spec.predictor.model?.resources &&
     Object.keys(inferenceService.spec.predictor.model.resources).length === 0
   ) {
     return undefined;
   }
 
-  return inferenceService?.spec.predictor.model.resources;
+  return inferenceService?.spec.predictor.model?.resources;
 };
 
 export const getServingRuntimeOrReturnEmpty = (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
@@ -72,7 +72,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
         try {
           const modelPods = await (!isModelMesh(deployedModel)
             ? getPodsForKserve
-            : getPodsForModelMesh)(namespace, deployedModel.spec.predictor.model.runtime ?? '');
+            : getPodsForModelMesh)(namespace, deployedModel.spec.predictor.model?.runtime ?? '');
           if (!canceled) {
             updateServiceState(deployedModel, checkModelStatus(modelPods[0]));
           }
@@ -133,7 +133,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
             key={model.metadata.uid}
             inferenceService={model}
             servingRuntime={servingRuntimes.find(
-              (sr) => sr.metadata.name === model.spec.predictor.model.runtime,
+              (sr) => sr.metadata.name === model.spec.predictor.model?.runtime,
             )}
           />
         ))}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-6794, https://issues.redhat.com/browse/RHOAIENG-6649

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes types for both `InferenceService` and `ServingRuntime` CR objects, fixing an existing bug that made the UI crash by clicking the internal service popup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Internal Service popup fix

1. Create a new modelmesh server
2. Unselect public route
3. Deploy a new model
4. Click the Internal Service section in the row before the model is deployed

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
