### PR TITLE
[RHOAIENG-8414] Tracking of dashboard version in Segment.

### DIFF
--- a/frontend/src/utilities/segmentIOUtils.tsx
+++ b/frontend/src/utilities/segmentIOUtils.tsx
@@ -15,7 +15,15 @@ export const fireTrackingEventRaw = (eventType: string, properties?: any): void 
       }`,
     );
   } else if (window.analytics) {
-    window.analytics.track(eventType, { ...properties, clusterID });
+    window.analytics.track(
+      eventType,
+      { ...properties, clusterID },
+      {
+        app: {
+          version: INTERNAL_DASHBOARD_VERSION,
+        },
+      },
+    );
   }
 };
 
@@ -39,10 +47,26 @@ export const fireTrackingEvent = (
         window.analytics.identify(properties?.anonymousID, { clusterID });
         break;
       case 'page':
-        window.analytics.page(undefined, { clusterID });
+        window.analytics.page(
+          undefined,
+          { clusterID },
+          {
+            app: {
+              version: INTERNAL_DASHBOARD_VERSION,
+            },
+          },
+        );
         break;
       default:
-        window.analytics.track(eventType, { ...properties, clusterID });
+        window.analytics.track(
+          eventType,
+          { ...properties, clusterID },
+          {
+            app: {
+              version: INTERNAL_DASHBOARD_VERSION,
+            },
+          },
+        );
     }
   }
 };


### PR DESCRIPTION
## Description
Now that we have the dashboard version in the Frontend, we can send it to Segment as context.app.version
See [RHOAIENG-8414](https://issues.redhat.com/browse/RHOAIENG-8414)

## How Has This Been Tested?
Manual testing by looking at the network tab of the browser.

## Test Impact
No functionality change of the UI code.

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
