### PR TITLE
[RHOAIENG-7428]: update pipelineRunLabel to apply correct colors

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -15,7 +15,7 @@ const PipelineDetailsTitle: React.FC<RunJobTitleProps> = ({
   statusIcon,
   pipelineRunLabel,
 }) => {
-  const { icon, label } = computeRunStatus(run);
+  const { icon, label, color } = computeRunStatus(run);
 
   const isArchived = run.storage_state === StorageStateKF.ARCHIVED;
 
@@ -30,7 +30,9 @@ const PipelineDetailsTitle: React.FC<RunJobTitleProps> = ({
         )}
         {statusIcon && (
           <SplitItem>
-            <Label icon={icon}>{label}</Label>
+            <Label color={color} icon={icon}>
+              {label}
+            </Label>
           </SplitItem>
         )}
         {isArchived && (

--- a/frontend/src/concepts/pipelines/content/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/utils.tsx
@@ -7,7 +7,7 @@ import {
   QuestionCircleIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
-import { Icon } from '@patternfly/react-core';
+import { Icon, LabelProps } from '@patternfly/react-core';
 import {
   PipelineCoreResourceKFv2,
   PipelineRunJobKFv2,
@@ -20,6 +20,7 @@ import { relativeTime } from '~/utilities/time';
 export type RunStatusDetails = {
   icon: React.ReactNode;
   label: PipelineRunKFv2['state'] | string;
+  color?: LabelProps['color'];
   status?: React.ComponentProps<typeof Icon>['status'];
   details?: string;
   createdAt?: string;
@@ -36,6 +37,7 @@ export const computeRunStatus = (run?: PipelineRunKFv2 | null): RunStatusDetails
   let status: React.ComponentProps<typeof Icon>['status'];
   let details: string | undefined;
   let label: string;
+  let color: LabelProps['color'];
   const createdAt = relativeTime(Date.now(), new Date(run.created_at).getTime());
 
   switch (run.state) {
@@ -56,11 +58,13 @@ export const computeRunStatus = (run?: PipelineRunKFv2 | null): RunStatusDetails
     case RuntimeStateKF.SUCCEEDED:
       icon = <CheckCircleIcon />;
       status = 'success';
+      color = 'green';
       label = runtimeStateLabels[RuntimeStateKF.SUCCEEDED];
       break;
     case RuntimeStateKF.FAILED:
       icon = <ExclamationCircleIcon />;
       status = 'danger';
+      color = 'red';
       label = runtimeStateLabels[RuntimeStateKF.FAILED];
       details = run.error?.message;
       break;
@@ -83,7 +87,7 @@ export const computeRunStatus = (run?: PipelineRunKFv2 | null): RunStatusDetails
       details = run.state;
   }
 
-  return { icon, label, status, details, createdAt };
+  return { icon, label, color, status, details, createdAt };
 };
 
 export const getPipelineAndVersionDeleteString = (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

JIRA: https://issues.redhat.com/browse/RHOAIENG-7428

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates the label colors for the PipelineDetailsTitle header to reflect status of Pipeline Run. 

<img width="469" alt="Screenshot 2024-06-11 at 11 54 32 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/c7bb4f55-4f1b-48fc-8756-daac3595d4b1">
<img width="400" alt="Screenshot 2024-06-11 at 11 54 54 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/10ae5b5f-bb77-4b86-9cf9-0a2a3bce6588">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Navigate to a succeeded pipeline run and verify the label in the header is green. 
2. Navigate to a failed pipeline run and verify the label in the header is red. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
