### PR TITLE
Cypress test for experiments table time

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
@@ -62,6 +62,14 @@ class ExperimentsRow extends TableRow {
   findCheckbox() {
     return this.find().find(`[data-label=Checkbox]`).find('input');
   }
+
+  findExperimentCreatedTime() {
+    return this.find().find(`[data-label="Created"]`);
+  }
+
+  findExperimentLastRunTime() {
+    return this.find().find(`[data-label="Last run started"]`);
+  }
 }
 
 class ExperimentsTable {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
@@ -35,14 +35,17 @@ const mockExperiments = [
   buildMockExperimentKF({
     display_name: 'Test experiment 1',
     experiment_id: '1',
+    last_run_created_at: '2024-02-31T15:46:33Z',
   }),
   buildMockExperimentKF({
     display_name: 'Test experiment 2',
     experiment_id: '2',
+    last_run_created_at: '1970-01-01T00:00:00Z',
   }),
   buildMockExperimentKF({
     display_name: 'Test experiment 3',
     experiment_id: '3',
+    last_run_created_at: '',
   }),
 ];
 
@@ -61,6 +64,27 @@ describe('Experiments', () => {
       experimentsTabs.getActiveExperimentsTable().findEmptyState().should('exist');
       experimentsTabs.findArchivedTab().click();
       experimentsTabs.getArchivedExperimentsTable().findEmptyState().should('exist');
+    });
+
+    it('experiments table time', () => {
+      experimentsTabs.findActiveTab().click();
+      const activeExperimentsTable = experimentsTabs.getActiveExperimentsTable();
+      activeExperimentsTable
+        .getRowByName('Test experiment 1')
+        .findExperimentLastRunTime()
+        .contains('3 months ago');
+
+      // Last run time when experiment is just created
+      activeExperimentsTable
+        .getRowByName('Test experiment 2')
+        .findExperimentLastRunTime()
+        .contains('-');
+
+      // Last run time when empty
+      activeExperimentsTable
+        .getRowByName('Test experiment 3')
+        .findExperimentLastRunTime()
+        .contains('-');
     });
 
     it('filters by experiment name', () => {


### PR DESCRIPTION
[RHOAIENG-8493](https://issues.redhat.com/browse/RHOAIENG-8493)

## Description
Added cypress tests for experiments table which was missed in [RHOAIENG-7715](https://issues.redhat.com/browse/RHOAIENG-7715).

## How Has This Been Tested?
Just a cypress test

## Test Impact
Added cypress test to check last run time in experiments table.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
