### PR TITLE
[RHOAIENG-7946]: Hide Status Icon on Hovered Artifact Nodes

### DIFF
--- a/frontend/src/concepts/topology/customNodes/ArtifactTaskNode.tsx
+++ b/frontend/src/concepts/topology/customNodes/ArtifactTaskNode.tsx
@@ -68,6 +68,15 @@ const IconTaskNode: React.FC<IconTaskNodeProps> = observer(({ element, selected,
         rx={bounds.height / 2}
       />
       <g
+        className={
+          data?.runStatus
+            ? css(
+                'pf-topology-pipelines__pill-status',
+                selected && 'pf-m-selected',
+                runStatusModifier,
+              )
+            : undefined
+        }
         transform={`translate(${(bounds.width - iconSize) / 2}, ${ICON_PADDING})`}
         color={
           selected
@@ -120,6 +129,9 @@ const ArtifactTaskNodeInner: React.FC<ArtifactTaskNodeInnerProps> = observer(
             <TaskNode
               nameLabelClass="artifact-node-label"
               hideDetailsAtMedium
+              customStatusIcon={
+                data?.artifactType === 'system.Metrics' ? <MonitoringIcon /> : <ListIcon />
+              }
               truncateLength={30}
               element={element}
               hover


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-7946

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Hides status icon on hovered artifact nodes as per UX feedback of artifact node rendering.

Before  - default artifact node: 
<img width="98" alt="Screenshot 2024-06-12 at 2 26 41 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/88b3d427-bfd9-4a14-8591-1e4f2fb417c8">
Before  - hovered artifact node: 
<img width="290" alt="Screenshot 2024-06-12 at 2 26 46 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/19281326-efe9-4956-b0ef-773589bb352d">

After  - default artifact node: 
<img width="98" alt="Screenshot 2024-06-12 at 2 28 12 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/1c0c93cc-ed1c-4cff-88f0-15572101be0d">
After  - hovered artifact node: 
<img width="290" alt="Screenshot 2024-06-12 at 2 22 53 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/3e258c78-333f-4553-92f9-3d567e6d865a">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Navigate to a pipeline run with artifacts (e.g. iris pipeline)
2. Verify the artifact nodes render the artifact icon beside the text when hovered

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
