### PR TITLE
[RHOAIENG-8521] Enable home page in manifest file

### DIFF
--- a/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
@@ -13,7 +13,7 @@ spec:
     disableSupport: false
     disableTracking: false
     enablement: true
-    disableHome: true
+    disableHome: false
     disableProjects: false
     disablePipelines: false
     disableModelServing: false


### PR DESCRIPTION
Closes: [RHOAIENG-8521](https://issues.redhat.com/browse/RHOAIENG-8521)

## Description
Updates the dashboard config manifest file to enable the home page by default.

## How Has This Been Tested?
Needs to be tested on an install

## Test Impact
Install and verify the home page is shown.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
