### PR TITLE
Support model metrics for KServe (RHOAIENG-6560) (RHOAIENG-6561)

### DIFF
--- a/frontend/src/__mocks__/mockConfigMap.ts
+++ b/frontend/src/__mocks__/mockConfigMap.ts
@@ -3,15 +3,17 @@ import { ConfigMapKind } from '~/k8sTypes';
 type MockConfigMapType = {
   data?: Record<string, string>;
   namespace?: string;
+  name?: string;
 };
 export const mockConfigMap = ({
   data = { key: 'value' },
   namespace = 'test-project',
+  name = 'config-test',
 }: MockConfigMapType): ConfigMapKind => ({
   kind: 'ConfigMap',
   apiVersion: 'v1',
   metadata: {
-    name: 'config-test',
+    name,
     labels: { 'opendatahub.io/dashboard': 'true' },
     namespace,
   },

--- a/frontend/src/__mocks__/mockKserveMetricsConfigMap.ts
+++ b/frontend/src/__mocks__/mockKserveMetricsConfigMap.ts
@@ -1,0 +1,113 @@
+import { ConfigMapKind } from '~/k8sTypes';
+import { mockConfigMap } from '~/__mocks__/mockConfigMap';
+
+type MockKserveMetricsConfigMapType = {
+  namespace?: string;
+  modelName?: string;
+  supported?: boolean;
+  config?: string;
+};
+
+export const MOCK_KSERVE_METRICS_CONFIG_1 = `
+{
+  "config": [
+    {
+      "title": "Number of incoming requests",
+      "type": "REQUEST_COUNT",
+      "queries": [
+        {
+          "title": "Successful requests",
+          "query": "sum(increase(ovms_requests_success{namespace='models',name='mnist'}[5m]))"
+        },
+        {
+          "title": "Failed requests",
+          "query": "sum(increase(ovms_requests_fail{namespace='models',name='mnist'}[5m]))"
+        }
+      ]
+    },
+    {
+      "title": "Mean Model Latency",
+      "type": "MEAN_LATENCY",
+      "queries": [
+        {
+          "title": "Mean inference latency",
+          "query": "sum by (name) (rate(ovms_inference_time_us_sum{namespace='models', name='mnist'}[1m])) / sum by (name) (rate(ovms_inference_time_us_count{namespace='models', name='mnist'}[1m]))"
+        },
+        {
+          "title": "Mean request latency",
+          "query": "sum by (name) (rate(ovms_request_time_us_sum{name='mnist'}[1m])) / sum by (name) (rate(ovms_request_time_us_count{name='mnist'}[1m]))"
+        }
+      ]
+    },
+    {
+      "title": "CPU usage",
+      "type": "CPU_USAGE",
+      "queries": [
+        {
+          "title": "CPU usage",
+          "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='models'}* on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='models', workload=~'mnist-predictor-.*', workload_type=~'deployment'}) by (pod)"
+        }
+      ]
+    },
+    {
+      "title": "Memory usage",
+      "type": "MEMORY_USAGE",
+      "queries": [
+        {
+          "title": "Memory usage",
+          "query": "sum(container_memory_working_set_bytes{namespace='models', container!='', image!=''} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster='', namespace='models', workload=~'mnist-.*', workload_type=~'deployment'}) by (pod)"
+        }
+      ]
+    }
+  ]
+}`;
+
+export const MOCK_KSERVE_METRICS_CONFIG_2 =
+  '{ I am malformed JSON and I am here to ruin your day }';
+
+export const MOCK_KSERVE_METRICS_CONFIG_3 = `
+{
+  "config": [
+    {
+      "title": "Number of incoming requests",
+      "type": "REQUEST_COUNT",
+      "queries": [
+        {
+          "title": "Successful requests",
+          "query": "sum(increase(ovms_requests_success{namespace='models',name='mnist'}[5m]))"
+        },
+        {
+          "title": "Failed requests",
+          "query": "sum(increase(ovms_requests_fail{namespace='models',name='mnist'}[5m]))"
+        }
+      ]
+    },
+    {
+      "title": "Mean Model Latency",
+      "type": "MEAN_LATENCY",
+      "queries": [
+        {
+          "title": "Mean inference latency",
+          "query": "sum by (name) (rate(ovms_inference_time_us_sum{namespace='models', name='mnist'}[1m])) / sum by (name) (rate(ovms_inference_time_us_count{namespace='models', name='mnist'}[1m]))"
+        },
+        {
+          "title": "Mean request latency",
+          "query": "sum by (name) (rate(ovms_request_time_us_sum{name='mnist'}[1m])) / sum by (name) (rate(ovms_request_time_us_count{name='mnist'}[1m]))"
+        }
+      ]
+    }
+  ]
+}`;
+
+export const mockKserveMetricsConfigMap = ({
+  namespace = 'test-project',
+  modelName = 'test-inference-service',
+  supported = true,
+  config = MOCK_KSERVE_METRICS_CONFIG_1,
+}: MockKserveMetricsConfigMapType): ConfigMapKind => {
+  const data = {
+    metrics: config,
+    supported: String(supported),
+  };
+  return mockConfigMap({ data, namespace, name: `${modelName}-metrics-dashboard` });
+};

--- a/frontend/src/__tests__/cypress/cypress/pages/modelMetrics.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelMetrics.ts
@@ -14,6 +14,10 @@ class ModelMetricsGlobal {
   getMetricsChart(title: string) {
     return new ModelMetricsChart(() => cy.findByTestId(`metrics-card-${title}`).parents());
   }
+
+  getAllMetricsCharts() {
+    return cy.findAllByTestId(/metrics-card-.*/);
+  }
 }
 
 class ModelMetricsChart extends Contextual<HTMLTableRowElement> {
@@ -32,13 +36,27 @@ class ModelMetricsPerformance extends ModelMetricsGlobal {
     this.wait();
   }
 
-  private wait() {
+  protected wait() {
     cy.findByTestId('performance-metrics-loaded');
     cy.testA11y();
   }
 
   findTab() {
     return cy.findByTestId('performance-tab');
+  }
+}
+
+class ModelMetricsKserve extends ModelMetricsPerformance {
+  findKserveAreaDisabledCard() {
+    return cy.findByTestId('kserve-metrics-disabled');
+  }
+
+  findUnsupportedRuntimeCard() {
+    return cy.findByTestId('kserve-metrics-runtime-unsupported');
+  }
+
+  findUnknownErrorCard() {
+    return cy.findByTestId('kserve-unknown-error');
   }
 }
 
@@ -181,3 +199,4 @@ export const modelMetricsBias = new ModelMetricsBias();
 export const serverMetrics = new ServerMetrics();
 export const modelMetricsConfigureSection = new ModelMetricsConfigureSection();
 export const configureBiasMetricModal = new ConfigureBiasMetricModal();
+export const modelMetricsKserve = new ModelMetricsKserve();

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,6 +34,7 @@ export * from './pipelines/k8s';
 export * from './prometheus/pvcs';
 export * from './prometheus/serving';
 export * from './prometheus/distributedWorkloads';
+export * from './prometheus/kservePerformanceMetrics';
 
 // Network error handling
 export * from './errorUtils';

--- a/frontend/src/api/k8s/__tests__/configMaps.spec.ts
+++ b/frontend/src/api/k8s/__tests__/configMaps.spec.ts
@@ -59,8 +59,11 @@ describe('getConfigMap', () => {
     expect(result).toStrictEqual(configMapMock);
     expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
     expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      fetchOptions: {
+        requestInit: {},
+      },
       model: ConfigMapModel,
-      queryOptions: { name: configMapName, ns: namespace },
+      queryOptions: { name: configMapName, ns: namespace, queryParams: {} },
     });
   });
 
@@ -70,8 +73,11 @@ describe('getConfigMap', () => {
     await expect(getConfigMap(namespace, configMapName)).rejects.toThrow('error1');
     expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
     expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      fetchOptions: {
+        requestInit: {},
+      },
       model: ConfigMapModel,
-      queryOptions: { name: configMapName, ns: namespace },
+      queryOptions: { name: configMapName, ns: namespace, queryParams: {} },
     });
   });
 });

--- a/frontend/src/api/k8s/configMaps.ts
+++ b/frontend/src/api/k8s/configMaps.ts
@@ -27,11 +27,20 @@ export const assembleConfigMap = (
   data: configMapData,
 });
 
-export const getConfigMap = (projectName: string, configMapName: string): Promise<ConfigMapKind> =>
-  k8sGetResource<ConfigMapKind>({
-    model: ConfigMapModel,
-    queryOptions: { name: configMapName, ns: projectName },
-  });
+export const getConfigMap = (
+  projectName: string,
+  configMapName: string,
+  opts?: K8sAPIOptions,
+): Promise<ConfigMapKind> =>
+  k8sGetResource<ConfigMapKind>(
+    applyK8sAPIOptions(
+      {
+        model: ConfigMapModel,
+        queryOptions: { name: configMapName, ns: projectName },
+      },
+      opts,
+    ),
+  );
 
 export const createConfigMap = (
   data: ConfigMapKind,

--- a/frontend/src/api/prometheus/const.ts
+++ b/frontend/src/api/prometheus/const.ts
@@ -1,1 +1,8 @@
+import { DEFAULT_CONTEXT_DATA } from '~/utilities/const';
+
 export const PROMETHEUS_BIAS_PATH = '/api/prometheus/bias';
+
+export const DEFAULT_PENDING_CONTEXT_RESOURCE = {
+  ...DEFAULT_CONTEXT_DATA,
+  pending: false,
+};

--- a/frontend/src/api/prometheus/kservePerformanceMetrics.ts
+++ b/frontend/src/api/prometheus/kservePerformanceMetrics.ts
@@ -1,0 +1,209 @@
+import React from 'react';
+import { KserveMetricGraphDefinition } from '~/concepts/metrics/kserve/types';
+import { defaultResponsePredicate } from '~/api/prometheus/usePrometheusQueryRange';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { TimeframeTitle } from '~/concepts/metrics/types';
+import useQueryRangeResourceData from '~/api/prometheus/useQueryRangeResourceData';
+import { PendingContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
+import { DEFAULT_PENDING_CONTEXT_RESOURCE } from '~/api/prometheus/const';
+
+type RequestCountData = {
+  data: {
+    successCount: PendingContextResourceData<PrometheusQueryRangeResultValue>;
+    failedCount: PendingContextResourceData<PrometheusQueryRangeResultValue>;
+  };
+  refreshAll: () => void;
+};
+
+export const useFetchKserveRequestCountData = (
+  metricsDef: KserveMetricGraphDefinition,
+  timeframe: TimeframeTitle,
+  endInMs: number,
+  namespace: string,
+): RequestCountData => {
+  const active = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
+
+  const successQuery = metricsDef.queries[0].query;
+  const failedQuery = metricsDef.queries[1].query;
+
+  const successCount = useQueryRangeResourceData(
+    active,
+    successQuery,
+    endInMs,
+    timeframe,
+    defaultResponsePredicate,
+    namespace,
+  );
+
+  const failedCount = useQueryRangeResourceData(
+    active,
+    failedQuery,
+    endInMs,
+    timeframe,
+    defaultResponsePredicate,
+    namespace,
+  );
+
+  const data = React.useMemo(
+    () => ({
+      successCount,
+      failedCount,
+    }),
+    [failedCount, successCount],
+  );
+
+  return useAllSettledContextResourceData(data, {
+    successCount: DEFAULT_PENDING_CONTEXT_RESOURCE,
+    failedCount: DEFAULT_PENDING_CONTEXT_RESOURCE,
+  });
+};
+
+type MeanLatencyData = {
+  data: {
+    inferenceLatency: PendingContextResourceData<PrometheusQueryRangeResultValue>;
+    requestLatency: PendingContextResourceData<PrometheusQueryRangeResultValue>;
+  };
+  refreshAll: () => void;
+};
+
+export const useFetchKserveMeanLatencyData = (
+  metricsDef: KserveMetricGraphDefinition,
+  timeframe: TimeframeTitle,
+  endInMs: number,
+  namespace: string,
+): MeanLatencyData => {
+  const active = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
+
+  const inferenceLatency = useQueryRangeResourceData(
+    active,
+    metricsDef.queries[0].query,
+    endInMs,
+    timeframe,
+    defaultResponsePredicate,
+    namespace,
+  );
+
+  const requestLatency = useQueryRangeResourceData(
+    active,
+    metricsDef.queries[1].query,
+    endInMs,
+    timeframe,
+    defaultResponsePredicate,
+    namespace,
+  );
+
+  const data = React.useMemo(
+    () => ({
+      inferenceLatency,
+      requestLatency,
+    }),
+    [inferenceLatency, requestLatency],
+  );
+
+  return useAllSettledContextResourceData(data, {
+    inferenceLatency: DEFAULT_PENDING_CONTEXT_RESOURCE,
+    requestLatency: DEFAULT_PENDING_CONTEXT_RESOURCE,
+  });
+};
+
+type CpuUsageData = {
+  data: {
+    cpuUsage: PendingContextResourceData<PrometheusQueryRangeResultValue>;
+  };
+  refreshAll: () => void;
+};
+
+export const useFetchKserveCpuUsageData = (
+  metricsDef: KserveMetricGraphDefinition,
+  timeframe: TimeframeTitle,
+  endInMs: number,
+  namespace: string,
+): CpuUsageData => {
+  const active = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
+
+  const cpuUsage = useQueryRangeResourceData(
+    active,
+    metricsDef.queries[0].query,
+    endInMs,
+    timeframe,
+    defaultResponsePredicate,
+    namespace,
+  );
+
+  const data = React.useMemo(
+    () => ({
+      cpuUsage,
+    }),
+    [cpuUsage],
+  );
+
+  return useAllSettledContextResourceData(data, {
+    cpuUsage: DEFAULT_PENDING_CONTEXT_RESOURCE,
+  });
+};
+
+type MemoryUsageData = {
+  data: {
+    memoryUsage: PendingContextResourceData<PrometheusQueryRangeResultValue>;
+  };
+  refreshAll: () => void;
+};
+
+export const useFetchKserveMemoryUsageData = (
+  metricsDef: KserveMetricGraphDefinition,
+  timeframe: TimeframeTitle,
+  endInMs: number,
+  namespace: string,
+): MemoryUsageData => {
+  const active = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
+
+  const memoryUsage = useQueryRangeResourceData(
+    active,
+    metricsDef.queries[0].query,
+    endInMs,
+    timeframe,
+    defaultResponsePredicate,
+    namespace,
+  );
+
+  const data = React.useMemo(
+    () => ({
+      memoryUsage,
+    }),
+    [memoryUsage],
+  );
+
+  return useAllSettledContextResourceData(data, {
+    memoryUsage: DEFAULT_PENDING_CONTEXT_RESOURCE,
+  });
+};
+
+const useAllSettledContextResourceData = <
+  T,
+  U extends Record<string, PendingContextResourceData<T>>,
+>(
+  data: U,
+  defaultValue: U,
+) => {
+  const refreshAll = React.useCallback(() => {
+    Object.values(data).forEach((x) => x.refresh());
+  }, [data]);
+
+  const result = React.useMemo(
+    () => ({
+      data,
+      refreshAll,
+    }),
+    [data, refreshAll],
+  );
+
+  // store the result in a reference and only update the reference so long as there are no pending queries
+  const resultRef = React.useRef({ data: defaultValue, refreshAll });
+
+  // only update the ref when all values are settled, i.e. not pending.
+  if (!Object.values(result.data).some((x) => x.pending)) {
+    resultRef.current = result;
+  }
+
+  return resultRef.current;
+};

--- a/frontend/src/api/prometheus/useQueryRangeResourceData.ts
+++ b/frontend/src/api/prometheus/useQueryRangeResourceData.ts
@@ -1,6 +1,6 @@
 import { TimeframeTitle } from '~/concepts/metrics/types';
 import { TimeframeStep, TimeframeTimeRange } from '~/concepts/metrics/const';
-import { PrometheusQueryRangeResultValue } from '~/types';
+import { PendingContextResourceData, PrometheusQueryRangeResultValue } from '~/types';
 import useRestructureContextResourceData from '~/utilities/useRestructureContextResourceData';
 import { FetchOptions } from '~/utilities/useFetchState';
 import usePrometheusQueryRange, { ResponsePredicate } from './usePrometheusQueryRange';
@@ -15,7 +15,7 @@ const useQueryRangeResourceData = <T = PrometheusQueryRangeResultValue>(
   namespace: string,
   apiPath = '/api/prometheus/serving',
   fetchOptions?: Partial<FetchOptions>,
-): ReturnType<typeof useRestructureContextResourceData<T>> =>
+): PendingContextResourceData<T> =>
   useRestructureContextResourceData<T>(
     usePrometheusQueryRange<T>(
       active,

--- a/frontend/src/concepts/metrics/kserve/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/metrics/kserve/__tests__/utils.spec.ts
@@ -1,0 +1,120 @@
+import { KserveMetricsGraphTypes } from '~/concepts/metrics/kserve/const';
+import {
+  isKserveMetricsConfigMapKind,
+  isValidKserveMetricsDataObject,
+} from '~/concepts/metrics/kserve/utils';
+import { mockConfigMap } from '~/__mocks__/mockConfigMap';
+
+describe('isKserveMetricsConfigMapKind', () => {
+  it('should return true when given a valid value', () => {
+    const configMap1 = mockConfigMap({
+      data: {
+        supported: 'true',
+        metrics: '{}',
+      },
+    });
+
+    const configMap2 = mockConfigMap({
+      data: {
+        supported: 'false',
+      },
+    });
+
+    const configMap3 = mockConfigMap({
+      data: {
+        supported: 'false',
+        unknownExtraProp: 'hello',
+      },
+    });
+
+    expect(isKserveMetricsConfigMapKind(configMap1)).toBe(true);
+    expect(isKserveMetricsConfigMapKind(configMap2)).toBe(true);
+    expect(isKserveMetricsConfigMapKind(configMap3)).toBe(true);
+  });
+
+  it('should return false when given an invalid value', () => {
+    const configMap1 = mockConfigMap({
+      data: {
+        supported: 'true',
+      },
+    });
+
+    const configMap2 = mockConfigMap({
+      data: {
+        supported: 'no sir!',
+      },
+    });
+
+    expect(isKserveMetricsConfigMapKind(configMap1)).toBe(false);
+    expect(isKserveMetricsConfigMapKind(configMap2)).toBe(false);
+  });
+
+  it('should return false when given an insane value', () => {
+    const configMap1 = mockConfigMap({ data: undefined });
+    expect(isKserveMetricsConfigMapKind(configMap1)).toBe(false);
+  });
+});
+
+describe('isValidKserveMetricsDataObject', () => {
+  it('should return true when given a valid value', () => {
+    expect(
+      isValidKserveMetricsDataObject({
+        config: [
+          {
+            title: 'Requests',
+            type: KserveMetricsGraphTypes.MEAN_LATENCY,
+            queries: [
+              {
+                title: 'success',
+                query: 'prometheus query',
+              },
+              {
+                title: 'failed',
+                query: 'prometheus query',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when given an invalid value', () => {
+    expect(
+      isValidKserveMetricsDataObject({
+        cats: [
+          {
+            title: 'Requests',
+            type: KserveMetricsGraphTypes.MEAN_LATENCY,
+            queries: [
+              {
+                title: 'success',
+                query: 'prometheus query',
+              },
+              {
+                title: 'failed',
+                query: 'prometheus query',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+
+    expect(
+      isValidKserveMetricsDataObject({
+        config: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when given an insane value', () => {
+    expect(isValidKserveMetricsDataObject(null)).toBe(false);
+    expect(isValidKserveMetricsDataObject(undefined)).toBe(false);
+    expect(isValidKserveMetricsDataObject({})).toBe(false);
+    expect(isValidKserveMetricsDataObject([])).toBe(false);
+    expect(isValidKserveMetricsDataObject(true)).toBe(false);
+    expect(isValidKserveMetricsDataObject(false)).toBe(false);
+    expect(isValidKserveMetricsDataObject(1)).toBe(false);
+  });
+});

--- a/frontend/src/concepts/metrics/kserve/const.ts
+++ b/frontend/src/concepts/metrics/kserve/const.ts
@@ -1,0 +1,8 @@
+export const KSERVE_METRICS_CONFIG_MAP_NAME_SUFFIX = '-metrics-dashboard';
+
+export enum KserveMetricsGraphTypes {
+  CPU_USAGE = 'CPU_USAGE',
+  MEMORY_USAGE = 'MEMORY_USAGE',
+  REQUEST_COUNT = 'REQUEST_COUNT',
+  MEAN_LATENCY = 'MEAN_LATENCY',
+}

--- a/frontend/src/concepts/metrics/kserve/content/KserveCpuUsageGraph.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KserveCpuUsageGraph.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { KserveMetricGraphDefinition } from '~/concepts/metrics/kserve/types';
+import { TimeframeTitle } from '~/concepts/metrics/types';
+import { useFetchKserveCpuUsageData } from '~/api';
+import MetricsChart from '~/pages/modelServing/screens/metrics/MetricsChart';
+import { toPercentage } from '~/pages/modelServing/screens/metrics/utils';
+
+type KserveCpuUsageGraphProps = {
+  graphDefinition: KserveMetricGraphDefinition;
+  timeframe: TimeframeTitle;
+  end: number;
+  namespace: string;
+};
+
+const KserveCpuUsageGraph: React.FC<KserveCpuUsageGraphProps> = ({
+  graphDefinition,
+  timeframe,
+  end,
+  namespace,
+}) => {
+  const {
+    data: { cpuUsage },
+  } = useFetchKserveCpuUsageData(graphDefinition, timeframe, end, namespace);
+
+  return (
+    <MetricsChart
+      title={graphDefinition.title}
+      metrics={{ metric: cpuUsage, translatePoint: toPercentage }}
+      color="purple"
+      domain={() => ({
+        y: [0, 100],
+      })}
+    />
+  );
+};
+
+export default KserveCpuUsageGraph;

--- a/frontend/src/concepts/metrics/kserve/content/KserveMeanLatencyGraph.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KserveMeanLatencyGraph.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { KserveMetricGraphDefinition } from '~/concepts/metrics/kserve/types';
+import { TimeframeTitle } from '~/concepts/metrics/types';
+import MetricsChart from '~/pages/modelServing/screens/metrics/MetricsChart';
+import { useFetchKserveMeanLatencyData } from '~/api';
+import { convertPrometheusNaNToZero } from '~/pages/modelServing/screens/metrics/utils';
+
+type KserveMeanLatencyGraphProps = {
+  graphDefinition: KserveMetricGraphDefinition;
+  timeframe: TimeframeTitle;
+  end: number;
+  namespace: string;
+};
+
+const KserveMeanLatencyGraph: React.FC<KserveMeanLatencyGraphProps> = ({
+  graphDefinition,
+  timeframe,
+  end,
+  namespace,
+}) => {
+  const {
+    data: { requestLatency, inferenceLatency },
+  } = useFetchKserveMeanLatencyData(graphDefinition, timeframe, end, namespace);
+
+  return (
+    <MetricsChart
+      metrics={[
+        {
+          name: graphDefinition.queries[0].title,
+          metric: {
+            ...inferenceLatency,
+            data: convertPrometheusNaNToZero(inferenceLatency.data),
+          },
+        },
+        {
+          name: graphDefinition.queries[1].title,
+          metric: {
+            ...requestLatency,
+            data: convertPrometheusNaNToZero(requestLatency.data),
+          },
+        },
+      ]}
+      color="green"
+      title={graphDefinition.title}
+    />
+  );
+};
+
+export default KserveMeanLatencyGraph;

--- a/frontend/src/concepts/metrics/kserve/content/KserveMemoryUsageGraph.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KserveMemoryUsageGraph.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { KserveMetricGraphDefinition } from '~/concepts/metrics/kserve/types';
+import { TimeframeTitle } from '~/concepts/metrics/types';
+
+import { useFetchKserveMemoryUsageData } from '~/api';
+import MetricsChart from '~/pages/modelServing/screens/metrics/MetricsChart';
+import { toPercentage } from '~/pages/modelServing/screens/metrics/utils';
+
+type KserveMemoryUsageGraphProps = {
+  graphDefinition: KserveMetricGraphDefinition;
+  timeframe: TimeframeTitle;
+  end: number;
+  namespace: string;
+};
+
+const KserveMemoryUsageGraph: React.FC<KserveMemoryUsageGraphProps> = ({
+  graphDefinition,
+  timeframe,
+  end,
+  namespace,
+}) => {
+  const {
+    data: { memoryUsage },
+  } = useFetchKserveMemoryUsageData(graphDefinition, timeframe, end, namespace);
+
+  return (
+    <MetricsChart
+      title={graphDefinition.title}
+      metrics={{
+        metric: memoryUsage,
+        translatePoint: toPercentage,
+      }}
+      color="orange"
+      domain={() => ({
+        y: [0, 100],
+      })}
+    />
+  );
+};
+
+export default KserveMemoryUsageGraph;

--- a/frontend/src/concepts/metrics/kserve/content/KserveMetricsContent.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KserveMetricsContent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import KservePerformanceGraphs from '~/concepts/metrics/kserve/content/KservePerformanceGraphs';
+import { KserveMetricsContext } from '~/concepts/metrics/kserve/KserveMetricsContext';
+
+const KserveMetricsContent: React.FC = () => {
+  const { namespace, graphDefinitions, timeframe, lastUpdateTime } =
+    React.useContext(KserveMetricsContext);
+
+  return (
+    <KservePerformanceGraphs
+      namespace={namespace}
+      graphDefinitions={graphDefinitions}
+      timeframe={timeframe}
+      end={lastUpdateTime}
+    />
+  );
+};
+
+export default KserveMetricsContent;

--- a/frontend/src/concepts/metrics/kserve/content/KservePerformanceGraphs.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KservePerformanceGraphs.tsx
@@ -1,0 +1,85 @@
+import { Stack, StackItem } from '@patternfly/react-core/dist/esm';
+import React from 'react';
+import { KserveMetricGraphDefinition } from '~/concepts/metrics/kserve/types';
+import { KserveMetricsGraphTypes } from '~/concepts/metrics/kserve/const';
+import KserveRequestCountGraph from '~/concepts/metrics/kserve/content/KserveRequestCountGraph';
+import { TimeframeTitle } from '~/concepts/metrics/types';
+import KserveMeanLatencyGraph from '~/concepts/metrics/kserve/content/KserveMeanLatencyGraph';
+import KserveCpuUsageGraph from '~/concepts/metrics/kserve/content/KserveCpuUsageGraph';
+import KserveMemoryUsageGraph from '~/concepts/metrics/kserve/content/KserveMemoryUsageGraph';
+
+type KservePerformanceGraphsProps = {
+  namespace: string;
+  graphDefinitions: KserveMetricGraphDefinition[];
+  timeframe: TimeframeTitle;
+  end: number;
+};
+
+const KservePerformanceGraphs: React.FC<KservePerformanceGraphsProps> = ({
+  namespace,
+  graphDefinitions,
+  timeframe,
+  end,
+}) => {
+  const renderGraph = (graphDefinition: KserveMetricGraphDefinition) => {
+    if (graphDefinition.type === KserveMetricsGraphTypes.REQUEST_COUNT) {
+      return (
+        <KserveRequestCountGraph
+          graphDefinition={graphDefinition}
+          timeframe={timeframe}
+          end={end}
+          namespace={namespace}
+        />
+      );
+    }
+
+    if (graphDefinition.type === KserveMetricsGraphTypes.MEAN_LATENCY) {
+      return (
+        <KserveMeanLatencyGraph
+          graphDefinition={graphDefinition}
+          timeframe={timeframe}
+          end={end}
+          namespace={namespace}
+        />
+      );
+    }
+
+    if (graphDefinition.type === KserveMetricsGraphTypes.CPU_USAGE) {
+      return (
+        <KserveCpuUsageGraph
+          graphDefinition={graphDefinition}
+          timeframe={timeframe}
+          end={end}
+          namespace={namespace}
+        />
+      );
+    }
+
+    // Condition IS necessary as graph types are provided by the backend.
+    // We need to guard against receiving an unknown value at runtime and fail gracefully.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (graphDefinition.type === KserveMetricsGraphTypes.MEMORY_USAGE) {
+      return (
+        <KserveMemoryUsageGraph
+          graphDefinition={graphDefinition}
+          timeframe={timeframe}
+          end={end}
+          namespace={namespace}
+        />
+      );
+    }
+
+    // TODO: add an unsupported graph type error state.
+    return null;
+  };
+
+  return (
+    <Stack hasGutter>
+      {graphDefinitions.map((x) => (
+        <StackItem key={x.title}>{renderGraph(x)}</StackItem>
+      ))}
+    </Stack>
+  );
+};
+
+export default KservePerformanceGraphs;

--- a/frontend/src/concepts/metrics/kserve/content/KserveRequestCountGraph.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KserveRequestCountGraph.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { KserveMetricGraphDefinition } from '~/concepts/metrics/kserve/types';
+import { useFetchKserveRequestCountData } from '~/api';
+import MetricsChart from '~/pages/modelServing/screens/metrics/MetricsChart';
+import { TimeframeTitle } from '~/concepts/metrics/types';
+
+type KserveRequestCountGraphProps = {
+  graphDefinition: KserveMetricGraphDefinition;
+  timeframe: TimeframeTitle;
+  end: number;
+  namespace: string;
+};
+
+const KserveRequestCountGraph: React.FC<KserveRequestCountGraphProps> = ({
+  graphDefinition,
+  timeframe,
+  end,
+  namespace,
+}) => {
+  const {
+    data: { successCount, failedCount },
+  } = useFetchKserveRequestCountData(graphDefinition, timeframe, end, namespace);
+
+  return (
+    <MetricsChart
+      metrics={[
+        {
+          name: 'Successful',
+          metric: successCount,
+        },
+        {
+          name: 'Failed',
+          metric: failedCount,
+        },
+      ]}
+      color="blue"
+      title={graphDefinition.title}
+      isStack
+    />
+  );
+};
+
+export default KserveRequestCountGraph;

--- a/frontend/src/concepts/metrics/kserve/types.ts
+++ b/frontend/src/concepts/metrics/kserve/types.ts
@@ -1,0 +1,31 @@
+import { ConfigMapKind } from '~/k8sTypes';
+import { KserveMetricsGraphTypes } from '~/concepts/metrics/kserve/const';
+
+export type KserveMetricsConfigMapKind = ConfigMapKind & {
+  data: {
+    supported: 'true' | 'false';
+    metrics: string;
+  };
+};
+
+export type KserveMetricGraphDefinition = {
+  title: string;
+  type: KserveMetricsGraphTypes;
+  queries: KserveMetricQueryDefinition[];
+};
+
+export type KserveMetricQueryDefinition = {
+  title: string;
+  query: string;
+};
+
+export type KserveMetricsDataObject = {
+  config: KserveMetricGraphDefinition[];
+};
+
+export type KserveMetricsDefinition = {
+  supported: boolean;
+  loaded: boolean;
+  error?: Error;
+  graphDefinitions: KserveMetricGraphDefinition[];
+};

--- a/frontend/src/concepts/metrics/kserve/useKserveMetricsConfigMap.ts
+++ b/frontend/src/concepts/metrics/kserve/useKserveMetricsConfigMap.ts
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+import { getConfigMap } from '~/api';
+import { KSERVE_METRICS_CONFIG_MAP_NAME_SUFFIX } from '~/concepts/metrics/kserve/const';
+import { KserveMetricsConfigMapKind } from '~/concepts/metrics/kserve/types';
+import { isKserveMetricsConfigMapKind } from '~/concepts/metrics/kserve/utils';
+
+const useKserveMetricsConfigMap = (
+  namespace: string,
+  modelName: string,
+): FetchState<KserveMetricsConfigMapKind | null> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<KserveMetricsConfigMapKind | null>>(
+    (opts) =>
+      getConfigMap(namespace, `${modelName}${KSERVE_METRICS_CONFIG_MAP_NAME_SUFFIX}`, opts)
+        .then((c) => {
+          if (!isKserveMetricsConfigMapKind(c)) {
+            return Promise.reject(
+              'Received invalid ConfigMap format for kserve metrics definition',
+            );
+          }
+          return c;
+        })
+        .catch((e) => {
+          throw e;
+        }),
+    [modelName, namespace],
+  );
+
+  return useFetchState(callback, null);
+};
+
+export default useKserveMetricsConfigMap;

--- a/frontend/src/concepts/metrics/kserve/useKserveMetricsGraphDefinitions.ts
+++ b/frontend/src/concepts/metrics/kserve/useKserveMetricsGraphDefinitions.ts
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+  KserveMetricsConfigMapKind,
+  KserveMetricsDefinition,
+} from '~/concepts/metrics/kserve/types';
+import { isValidKserveMetricsDataObject } from '~/concepts/metrics/kserve/utils';
+
+const useKserveMetricsGraphDefinitions = (
+  kserveMetricsConfigMap: KserveMetricsConfigMapKind | null,
+): KserveMetricsDefinition =>
+  React.useMemo(() => {
+    const result: KserveMetricsDefinition = {
+      supported: false,
+      loaded: !!kserveMetricsConfigMap,
+      graphDefinitions: [],
+    };
+
+    if (kserveMetricsConfigMap) {
+      result.supported = kserveMetricsConfigMap.data.supported === 'true';
+
+      let parsed: unknown;
+      if (result.supported) {
+        try {
+          parsed = JSON.parse(kserveMetricsConfigMap.data.metrics);
+        } catch (e) {
+          result.error = new Error('Error reading metrics configuration: malformed JSON');
+          result.loaded = true;
+        }
+
+        if (!result.error) {
+          if (isValidKserveMetricsDataObject(parsed)) {
+            result.graphDefinitions = parsed.config;
+          } else {
+            result.error = new Error('Error reading metrics configuration: schema mismatch');
+            result.loaded = true;
+          }
+        }
+      }
+    }
+    return result;
+  }, [kserveMetricsConfigMap]);
+
+export default useKserveMetricsGraphDefinitions;

--- a/frontend/src/concepts/metrics/kserve/utils.ts
+++ b/frontend/src/concepts/metrics/kserve/utils.ts
@@ -1,0 +1,23 @@
+import { ConfigMapKind } from '~/k8sTypes';
+import {
+  KserveMetricsConfigMapKind,
+  KserveMetricsDataObject,
+} from '~/concepts/metrics/kserve/types';
+
+export const isKserveMetricsConfigMapKind = (
+  configMapKind: ConfigMapKind,
+): configMapKind is KserveMetricsConfigMapKind => {
+  if (configMapKind.data?.supported === 'true' && typeof configMapKind.data.metrics === 'string') {
+    return true;
+  }
+
+  return configMapKind.data?.supported === 'false';
+};
+
+export const isValidKserveMetricsDataObject = (obj: unknown): obj is KserveMetricsDataObject => {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  return 'config' in obj && Array.isArray(obj.config) && obj.config.length > 0;
+};

--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -109,7 +109,7 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
   );
 
   const error = metrics.find((line) => line.metric.error)?.metric.error;
-  const isAllLoaded = metrics.every((line) => line.metric.loaded);
+  const isAllLoaded = error || metrics.every((line) => line.metric.loaded);
   const hasSomeData = graphLines.some((line) => line.points.length > 0);
 
   const ChartGroupWrapper = React.useMemo(() => (isStack ? ChartStack : ChartGroup), [isStack]);

--- a/frontend/src/pages/modelServing/screens/metrics/performance/KserveMetrics.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/performance/KserveMetrics.tsx
@@ -1,22 +1,20 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
-import MetricsPlaceHolder from '~/pages/modelServing/screens/metrics/performance/MetricsPlaceHolder';
+import { ModelServingMetricsContext } from '~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
+import { KserveMetricsContextProvider } from '~/concepts/metrics/kserve/KserveMetricsContext';
+import KserveMetricsContent from '~/concepts/metrics/kserve/content/KserveMetricsContent';
 
-const KserveMetrics: React.FC = () => (
-  <Stack hasGutter>
-    <StackItem>
-      <MetricsPlaceHolder title="HTTP requests per 5 minutes" />
-    </StackItem>
-    <StackItem>
-      <MetricsPlaceHolder title="Average response time (ms)" />
-    </StackItem>
-    <StackItem>
-      <MetricsPlaceHolder title="CPU utilization %" />
-    </StackItem>
-    <StackItem>
-      <MetricsPlaceHolder title="Memory utilization %" />
-    </StackItem>
-  </Stack>
-);
+type KserveMetricsProps = {
+  modelName: string;
+};
+
+const KserveMetrics: React.FC<KserveMetricsProps> = ({ modelName }) => {
+  const { namespace } = React.useContext(ModelServingMetricsContext);
+
+  return (
+    <KserveMetricsContextProvider namespace={namespace} modelName={modelName}>
+      <KserveMetricsContent />
+    </KserveMetricsContextProvider>
+  );
+};
 
 export default KserveMetrics;

--- a/frontend/src/pages/modelServing/screens/metrics/performance/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/performance/ModelGraphs.tsx
@@ -9,6 +9,6 @@ type ModelGraphProps = {
 };
 
 const ModelGraphs: React.FC<ModelGraphProps> = ({ model }) =>
-  isModelMesh(model) ? <ModelMeshMetrics /> : <KserveMetrics />;
+  isModelMesh(model) ? <ModelMeshMetrics /> : <KserveMetrics modelName={model.metadata.name} />;
 
 export default ModelGraphs;

--- a/frontend/src/pages/modelServing/screens/metrics/performance/PerformanceTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/performance/PerformanceTab.tsx
@@ -10,8 +10,8 @@ import {
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { InferenceServiceKind } from '~/k8sTypes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
-import MetricsPageToolbar from '~/concepts/metrics/MetricsPageToolbar';
 import { isModelMesh } from '~/pages/modelServing/utils';
+import MetricsPageToolbar from '~/concepts/metrics/MetricsPageToolbar';
 import ModelGraphs from '~/pages/modelServing/screens/metrics/performance/ModelGraphs';
 
 type PerformanceTabsProps = {
@@ -24,14 +24,19 @@ const PerformanceTab: React.FC<PerformanceTabsProps> = ({ model }) => {
 
   if (!modelMesh && !kserveMetricsEnabled) {
     return (
-      <EmptyState variant="full">
-        <EmptyStateHeader
-          titleText="Single-model serving platform model metrics are not enabled."
-          headingLevel="h4"
-          icon={<EmptyStateIcon icon={WarningTriangleIcon} />}
-          alt=""
-        />
-      </EmptyState>
+      <Stack data-testid="performance-metrics-loaded">
+        <StackItem>
+          <EmptyState variant="full">
+            <EmptyStateHeader
+              titleText="Single-model serving platform model metrics are not enabled."
+              headingLevel="h4"
+              icon={<EmptyStateIcon icon={WarningTriangleIcon} />}
+              alt=""
+              data-testid="kserve-metrics-disabled"
+            />
+          </EmptyState>
+        </StackItem>
+      </Stack>
     );
   }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -644,6 +644,7 @@ export type FetchStateObject<T, E = Error> = {
 
 // TODO this and useContextResourceData should probably be removed in favor of useMakeFetchObject
 export type ContextResourceData<T> = FetchStateObject<T[], Error | AxiosError>;
+export type PendingContextResourceData<T> = ContextResourceData<T> & { pending: boolean };
 
 export type BreadcrumbItemType = {
   label: string;

--- a/frontend/src/utilities/useRestructureContextResourceData.tsx
+++ b/frontend/src/utilities/useRestructureContextResourceData.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { FetchState } from '~/utilities/useFetchState';
-import { ContextResourceData } from '~/types';
+import { PendingContextResourceData } from '~/types';
 
 const useRestructureContextResourceData = <T,>(
   resourceData: [...FetchState<T[]>, boolean],
-): ContextResourceData<T> & { pending: boolean } => {
+): PendingContextResourceData<T> => {
   const [data, loaded, error, refresh, pending] = resourceData;
   return React.useMemo(
     () => ({


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: [RHOAIENG-6560](https://issues.redhat.com//browse/RHOAIENG-6560) [RHOAIENG-6561](https://issues.redhat.com//browse/RHOAIENG-6561)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Implements metrics graphs for supported Kserve runtimes. Implements empty state for when a specific serving runtime is not supported.

Graphs and queries are now defined by a config map created by the KServe operator.

![odh-dashboard-opendatahub apps rosa vedant-metrics chbf p3 openshiftapps com_projects_models_metrics_model_mnist_performance (1)](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/047c272a-2052-48d2-940c-c653f2a2cdb6)

![odh-dashboard-opendatahub apps rosa vedant-metrics chbf p3 openshiftapps com_projects_models_metrics_model_mnist_performance (2)](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/4f804ba0-3670-4295-b67f-758b81ade68b)

![odh-dashboard-opendatahub apps rosa vedant-metrics chbf p3 openshiftapps com_projects_models_metrics_model_mnist_performance (3)](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/2cfd7ec5-3001-426c-bbdf-d71c11406f17)

![odh-dashboard-opendatahub apps rosa vedant-metrics chbf p3 openshiftapps com_projects_models_metrics_model_mnist_performance](https://github.com/opendatahub-io/odh-dashboard/assets/4092230/2d180f9b-66e7-4a41-a7a7-2718dfbf3c5e)

NOTE: There are some outstanding bugs in the backend:
- The definition provided for the requests chart is invalid, right now we can only verify the dashboard handles this gracefully
- Graph titles are defined on the backend, these need updating to fix case / match modelmesh charts.
- There is an error in the Memory Usage query that returns an absolute value, instead of a percentage. As such you won't see any data on that chart.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Environment setup:
- Install latest ODH/RHOAI
- Use the following [DSC](https://gist.github.com/VedantMahabaleshwarkar/634b4e1b4e434280775c477135d81454#file-gistfile1-txt-L2-L18)
- Add the following [SR ](https://gist.github.com/VedantMahabaleshwarkar/634b4e1b4e434280775c477135d81454#file-gistfile1-txt-L20-L69)for single model serving
- Use the serving runtime to create a mnist model. Can use the [rhods-public s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/rhods-public/?region=us-east-1&tab=objects) with your access+secret key
model path is : kserve-samples/mnist/
(can keep the require service account box unchecked for easier curls..)
To perform requests against the model
curl --insecure {isvc_url}/v2/models/mnist/infer -d @./input-onnx.json 
where,
isvc_url=$(oc get isvc -n <your_project> mnist -o jsonpath='{.status.url}') 
and
you can find input-onnx.json [here](https://github.com/opendatahub-io/modelmesh-serving/blob/main/opendatahub/quickstart/common_manifests/input-onnx.json)

Instructions:
- Navigate to kserve model `mnist`
- Hit the model with some data (spam a number of requests as directed above)
- Validate charts function correctly (use the timeframe / refresh interval controls.
- Navigate to model `sklearn-v2-iris metrics`
- Validate the unsupported runtime state is visible.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Cypress tests added
- Unit tests of utility functions
- Tests of new hooks to follow after.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
