### PR TITLE
Add error state when pipeline version is deleted

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -257,6 +257,10 @@ class PipelineRunDetails extends RunDetails {
   findOutputArtifacts() {
     return cy.findByTestId('Output-artifacts');
   }
+
+  findErrorState(id: string) {
+    return cy.findByTestId(id);
+  }
 }
 
 export const pipelineDetails = new PipelineDetails();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
@@ -12,10 +12,12 @@ import {
   buildMockRecurringRunKF,
 } from '~/__mocks__';
 import {
+  activeRunsTable,
   archivedRunsTable,
   archiveExperimentModal,
   bulkArchiveExperimentModal,
   bulkRestoreExperimentModal,
+  pipelineRunDetails,
   pipelineRecurringRunTable,
   pipelineRunsGlobal,
   restoreExperimentModal,
@@ -27,7 +29,7 @@ import {
   ProjectModel,
   RouteModel,
 } from '~/__tests__/cypress/cypress/utils/models';
-import { RecurringRunStatus, StorageStateKF } from '~/concepts/pipelines/kfTypes';
+import { RecurringRunStatus, RuntimeStateKF, StorageStateKF } from '~/concepts/pipelines/kfTypes';
 
 const projectName = 'test-project-name';
 const initialMockPipeline = buildMockPipelineV2({ display_name: 'Test pipeline' });
@@ -50,6 +52,14 @@ const mockExperiments = [
     last_run_created_at: '',
   }),
 ];
+
+const mockActiveRuns = buildMockRunKF({
+  display_name: 'Test active run 4',
+  run_id: 'run-4',
+  experiment_id: 'test-experiment-1',
+  created_at: '2024-02-10T00:00:00Z',
+  state: RuntimeStateKF.SUCCEEDED,
+});
 
 describe('Experiments', () => {
   describe('Active experiments', () => {
@@ -251,6 +261,41 @@ describe('Experiments', () => {
       cy.findByLabelText('Experiment').contains(mockExperiment.display_name);
     });
 
+    it('should display error state when the pipeline version deleted', () => {
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
+        {
+          path: {
+            namespace: projectName,
+            serviceName: 'dspa',
+            runId: mockActiveRuns.run_id,
+          },
+        },
+        mockActiveRuns,
+      );
+      activeRunsTable.getRowByName('Test active run 4').findColumnName('Test active run 4').click();
+      pipelineRunDetails
+        .findErrorState('run-graph-error-state')
+        .should('have.text', 'Pipeline run graph unavailable');
+
+      pipelineRunDetails.findDetailsTab().click();
+      pipelineRunDetails.findDetailItem('Name').findValue().contains(mockActiveRuns.display_name);
+      pipelineRunDetails
+        .findDetailItem('Pipeline version')
+        .findValue()
+        .contains('No pipeline version');
+      pipelineRunDetails.findDetailItem('Project').findValue().contains(projectName);
+      pipelineRunDetails.findDetailItem('Run ID').findValue().contains(mockActiveRuns.run_id);
+      pipelineRunDetails
+        .findDetailItem('Workflow name')
+        .findValue()
+        .contains(mockActiveRuns.display_name);
+      pipelineRunDetails.findPipelineSpecTab().click();
+      pipelineRunDetails
+        .findErrorState('pipeline-spec-error-state')
+        .should('have.text', 'Pipeline spec unavailable');
+    });
+
     it('navigates back to experiments from "Create run" page breadcrumb', () => {
       pipelineRunsGlobal.findCreateRunButton().click();
       cy.findByLabelText('Breadcrumb').findByText(`Experiments - ${projectName}`).click();
@@ -370,7 +415,7 @@ const initIntercepts = () => {
     {
       path: { namespace: projectName, serviceName: 'dspa' },
     },
-    { runs: [] },
+    { runs: [mockActiveRuns] },
   );
 
   cy.interceptOdh(

--- a/frontend/src/concepts/dashboard/codeEditor/DashboardCodeEditor.tsx
+++ b/frontend/src/concepts/dashboard/codeEditor/DashboardCodeEditor.tsx
@@ -17,7 +17,7 @@ const DashboardCodeEditor: React.FC<Partial<DashboardCodeEditorProps>> = ({
   height = 'calc(100% - 38px)',
   ...props
 }) => (
-  <div data-testid={props.testId} style={{ height }}>
+  <div data-testid={props.testId} style={{ height, padding: '14px' }}>
     <CodeEditor height="100%" className="odh-dashboard__code-editor" {...props} />
   </div>
 );

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsYAML.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsYAML.tsx
@@ -9,13 +9,29 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import DashboardCodeEditor from '~/concepts/dashboard/codeEditor/DashboardCodeEditor';
+import PipelineVersionError from './PipelineVersionError';
 
 type PipelineDetailsYAMLProps = {
   filename?: string;
   content?: Record<string, unknown> | null;
+  versionError?: Error;
 };
 
-const PipelineDetailsYAML: React.FC<PipelineDetailsYAMLProps> = ({ filename, content }) => {
+const PipelineDetailsYAML: React.FC<PipelineDetailsYAMLProps> = ({
+  versionError,
+  filename,
+  content,
+}) => {
+  if (versionError) {
+    return (
+      <PipelineVersionError
+        title="Pipeline spec unavailable"
+        description="The pipeline version that this pipeline spec belongs to has been deleted."
+        testId="pipeline-spec-error-state"
+      />
+    );
+  }
+
   if (!content) {
     return (
       <EmptyState>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineVersionError.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineVersionError.tsx
@@ -1,0 +1,41 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+type PipelineVersionErrorProps = {
+  title?: string;
+  description?: string;
+  testId?: string;
+};
+
+const PipelineVersionError: React.FC<PipelineVersionErrorProps> = ({
+  title,
+  description,
+  testId,
+}) => (
+  <PageSection className="pf-v5-u-h-100">
+    <EmptyState variant={EmptyStateVariant.lg} isFullHeight>
+      <EmptyStateHeader
+        data-testid={testId}
+        titleText={title}
+        icon={
+          <EmptyStateIcon
+            color="var(--pf-v5-global--warning-color--100)"
+            icon={ExclamationTriangleIcon}
+          />
+        }
+        headingLevel="h2"
+      />
+      <EmptyStateBody>{description}</EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default PipelineVersionError;

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -234,7 +234,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
                   hidden={PipelineDetailsTab.YAML !== activeTabKey}
                   className="pf-v5-u-h-100"
                 >
-                  <TabContentBody hasPadding className="pf-v5-u-h-100">
+                  <TabContentBody className="pf-v5-u-h-100">
                     <PipelineDetailsYAML
                       filename={`Pipeline ${
                         getCorePipelineSpec(pipelineVersion?.pipeline_spec)?.pipelineInfo.name ??

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -69,8 +69,8 @@ const PipelineRunDetails: React.FC<
     [selectedId, nodes],
   );
 
-  const loaded = runLoaded && (versionLoaded || !!run?.pipeline_spec);
-  const error = versionError || runError;
+  const loaded = runLoaded && (versionLoaded || !!run?.pipeline_spec || !!versionError);
+  const error = runError;
 
   if (error) {
     return (
@@ -150,10 +150,12 @@ const PipelineRunDetails: React.FC<
           >
             <PipelineRunDetailsTabs
               run={run}
+              versionError={versionError}
               pipelineSpec={version?.pipeline_spec}
               graphContent={
                 <PipelineTopology
                   nodes={nodes}
+                  versionError={versionError}
                   selectedIds={selectedId ? [selectedId] : []}
                   onSelectionChange={(ids) => {
                     const firstId = ids[0];

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsTabs.tsx
@@ -21,12 +21,14 @@ interface PipelineRunDetailsTabsProps {
   run: PipelineRunKFv2 | PipelineRecurringRunKFv2 | null;
   pipelineSpec: PipelineSpecVariable | undefined;
   graphContent: React.ReactNode;
+  versionError?: Error;
 }
 
 export const PipelineRunDetailsTabs: React.FC<PipelineRunDetailsTabsProps> = ({
   run,
   pipelineSpec,
   graphContent,
+  versionError,
 }) => {
   const [activeKey, setActiveKey] = React.useState<string | number>(DetailsTabKey.Graph);
   const isRecurringRun = run && isPipelineRecurringRun(run);
@@ -57,7 +59,7 @@ export const PipelineRunDetailsTabs: React.FC<PipelineRunDetailsTabsProps> = ({
           </TabContentBody>
         </Tab>
 
-        {!isRecurringRun && pipelineSpec && (
+        {!isRecurringRun && (
           <Tab
             eventKey={DetailsTabKey.Spec}
             tabContentId={DetailsTabKey.Spec}
@@ -73,6 +75,7 @@ export const PipelineRunDetailsTabs: React.FC<PipelineRunDetailsTabsProps> = ({
           id={DetailsTabKey.Graph}
           eventKey={DetailsTabKey.Graph}
           className="pf-v5-u-h-100"
+          data-testid="pipeline-graph-tab"
         >
           <TabContentBody className="pf-v5-u-h-100">{graphContent}</TabContentBody>
         </TabContent>
@@ -83,9 +86,14 @@ export const PipelineRunDetailsTabs: React.FC<PipelineRunDetailsTabsProps> = ({
         eventKey={DetailsTabKey.Spec}
         hidden={activeKey !== DetailsTabKey.Spec}
         style={{ flex: 1 }}
+        data-testid="pipeline-spec-tab"
       >
-        <TabContentBody className="pf-v5-u-h-100" hasPadding>
-          <PipelineDetailsYAML filename={run?.display_name} content={pipelineSpec} />
+        <TabContentBody className="pf-v5-u-h-100">
+          <PipelineDetailsYAML
+            filename={run?.display_name}
+            content={pipelineSpec}
+            versionError={versionError}
+          />
         </TabContentBody>
       </TabContent>
     </>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabDetails.tsx
@@ -73,6 +73,8 @@ const PipelineRunTabDetails: React.FC<PipelineRunTabDetailsProps> = ({ run, work
             ),
           },
         ]
+      : versionError
+      ? [{ key: 'Pipeline version', value: 'No pipeline version' }]
       : []),
     ...(pipeline
       ? [

--- a/frontend/src/concepts/topology/PipelineTopology.tsx
+++ b/frontend/src/concepts/topology/PipelineTopology.tsx
@@ -5,20 +5,23 @@ import {
   VisualizationProvider,
 } from '@patternfly/react-topology';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import PipelineVersionError from '~/concepts/pipelines/content/pipelinesDetails/PipelineVersionError';
+import PipelineTopologyEmpty from './PipelineTopologyEmpty';
 import useTopologyController from './useTopologyController';
 import PipelineVisualizationSurface from './PipelineVisualizationSurface';
-import PipelineTopologyEmpty from './PipelineTopologyEmpty';
 
 type PipelineTopologyProps = {
   selectedIds?: string[];
   onSelectionChange?: (selectionIds: string[]) => void;
   nodes: PipelineNodeModel[];
+  versionError?: Error;
 };
 
 const PipelineTopology: React.FC<PipelineTopologyProps> = ({
   nodes,
   selectedIds,
   onSelectionChange,
+  versionError,
 }) => {
   const controller = useTopologyController('g1');
 
@@ -36,6 +39,16 @@ const PipelineTopology: React.FC<PipelineTopologyProps> = ({
 
     return undefined;
   }, [controller, onSelectionChange]);
+
+  if (versionError) {
+    return (
+      <PipelineVersionError
+        title="Pipeline run graph unavailable"
+        description="The pipeline version that this run graph belongs to has been deleted."
+        testId="run-graph-error-state"
+      />
+    );
+  }
 
   if (!nodes.length) {
     return <PipelineTopologyEmpty />;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes: [RHOAIENG-6683](https://issues.redhat.com/browse/RHOAIENG-6683)

## Description
This PR aims to add error state in pipeline run details page when pipeline version is deleted.

![Screenshot from 2024-07-03 21-14-05](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/80e222fe-2de5-4ac8-8a94-858b0247f92f)


![Screenshot from 2024-07-02 12-43-39](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/d80c0c3e-5ddd-4c6d-bd7b-c1b703825d40)


![Screenshot from 2024-07-03 21-14-12](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/9d59c536-d41e-430e-be59-b592c1a7726f)



## How Has This Been Tested?
1. create a pipeline
2. create a run for that.
3. delete pipeline version of that run.
4. From Experiments and run page open pipeline run details page.
5. It will show the error state on run graph and pipeline spec tab. Also in details tab, "No pipeline version" will be mentioned for pipeline version property.

## Test Impact
Added cypress test.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
