### PR TITLE
[RHOAIENG-8568] Remove 'Learn more' link from pipeline server bucket form field popover

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -14,11 +14,9 @@ import {
 import { DataConnection } from '~/pages/projects/types';
 import { AwsKeys, PIPELINE_AWS_FIELDS } from '~/pages/projects/dataConnections/const';
 import { FieldListField } from '~/components/FieldList';
-import ExternalLink from '~/components/ExternalLink';
 import { PipelineDropdown } from './PipelineDropdown';
 import { PipelineServerConfigType } from './types';
 import './ConfigurePipelinesServerModal.scss';
-import { storingDataHelpLink } from './const';
 
 export type FieldOptions = {
   key: string;
@@ -113,7 +111,6 @@ export const ObjectStorageSection = ({
                     <b>/root</b> directory.
                   </div>
                 }
-                footerContent={<ExternalLink text="Learn more" to={storingDataHelpLink} />}
               >
                 <Alert
                   variant="info"

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/const.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/const.ts
@@ -70,6 +70,3 @@ export const EMPTY_DATABASE_CONNECTION: EnvVariableDataEntry[] = [
     value: '',
   },
 ];
-
-export const storingDataHelpLink =
-  'https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud_service/1/html/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#storing-data-with-data-science-pipelines_ds-pipelines';


### PR DESCRIPTION
Closes: [RHOAIENG-8568](https://issues.redhat.com/browse/RHOAIENG-8568)

## Description
Removing link for now since the destination doc link is still in question.

<img width="1130" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/0b8ca36d-5df4-4de7-841a-19783d6939d4">

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
