### PR TITLE
 Refactor useMetricColumnNames to handle empty experimentId

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/useMetricColumnNames.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/useMetricColumnNames.ts
@@ -17,7 +17,9 @@ export const useMetricColumnNames = (experimentId: string, metricsNames: Set<str
     ],
     [firstDefaultMetricColumn, secondDefaultMetricColumn],
   );
-  const metricsColumnNames = storedMetricsColumnNames ?? defaultMetricsColumnNames;
+  const metricsColumnNames = experimentId
+    ? storedMetricsColumnNames ?? defaultMetricsColumnNames
+    : [];
 
   // Set default metric columns in localStorage when no prior stored
   // columns exist and at least 1 metric exists to use as a default.


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-8585

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
makes fetching the metrics dependent on if a experiment id is in the params

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. navigate to viewing the runs of a version and verify no custom columns are added

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none - covered by existing tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
