### PR TITLE
[RHOAIENG-7717] Make pipeline table name cell be a clickable link to the latest pipeline version details

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesTable.ts
@@ -24,6 +24,10 @@ class PipelinesTableRow extends TableRow {
         ]) as unknown as Cypress.Chainable<JQuery<HTMLTableRowElement>>,
     );
   }
+
+  findPipelineNameLink(value: string) {
+    return this.find().findByTestId('table-row-title').contains(value);
+  }
 }
 
 class PipelineVersionsTableRow extends TableRow {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -866,6 +866,19 @@ describe('Pipelines', () => {
     );
   });
 
+  it('navigates to pipeline version details page via pipeline name', () => {
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
+    pipelinesTable.find();
+
+    const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
+    pipelineRow.findPipelineNameLink(initialMockPipeline.display_name).click();
+
+    verifyRelativeURL(
+      `/pipelines/${projectName}/pipeline/view/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}`,
+    );
+  });
+
   it('delete pipeline and versions', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Td, Tbody, Tr, ActionsColumn, TableText } from '@patternfly/react-table';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Skeleton } from '@patternfly/react-core';
 import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd, TableRowTitleDescription } from '~/components/table';
@@ -43,6 +43,7 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
   const [isExpanded, setExpanded] = React.useState(false);
   const [importTarget, setImportTarget] = React.useState<PipelineKFv2 | null>(null);
   const {
+    version,
     totalSize,
     updatedDate,
     loading,
@@ -84,7 +85,23 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
           />
           <Td>
             <TableRowTitleDescription
-              title={<TableText wrapModifier="truncate">{pipeline.display_name}</TableText>}
+              title={
+                loading ? (
+                  <Skeleton />
+                ) : version?.pipeline_version_id ? (
+                  <Link
+                    to={pipelineDetailsPath(
+                      namespace,
+                      pipeline.pipeline_id,
+                      version.pipeline_version_id,
+                    )}
+                  >
+                    <TableText wrapModifier="truncate">{pipeline.display_name}</TableText>
+                  </Link>
+                ) : (
+                  <TableText wrapModifier="truncate">{pipeline.display_name}</TableText>
+                )
+              }
               description={pipeline.description}
               descriptionAsMarkdown
             />

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/usePipelineTableRowData.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/usePipelineTableRowData.ts
@@ -6,6 +6,7 @@ import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
 const usePipelineTableRowData = (
   pipeline: PipelineKFv2,
 ): {
+  version: PipelineVersionKFv2 | undefined;
   updatedDate: Date;
   totalSize: number;
   loading: boolean;
@@ -19,10 +20,10 @@ const usePipelineTableRowData = (
       sortDirection: 'desc',
     },
   );
+  const latestVersion = isLoaded ? items[0] : undefined;
+  const updatedDate = new Date(latestVersion?.created_at || pipeline.created_at);
 
-  const updatedDate = new Date(items[0]?.created_at || pipeline.created_at);
-
-  return { updatedDate, totalSize, loading: !isLoaded, refresh };
+  return { version: latestVersion, updatedDate, totalSize, loading: !isLoaded, refresh };
 };
 
 export default usePipelineTableRowData;


### PR DESCRIPTION
Closes: 

## Description
Added link for pipeline names in the pipelines list table to navigate to the latest pipeline version's details.


https://github.com/opendatahub-io/odh-dashboard/assets/96431149/64027921-8d14-4230-9e04-dcb21e425a4f


## Test Impact
Added cypress test

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
