### PR TITLE
[RHOAIENG-7970] Very long pipeline names make pipelines list view scroll columns off …

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { Label, Split, SplitItem, Truncate } from '@patternfly/react-core';
 import { PipelineRunKFv2, StorageStateKF } from '~/concepts/pipelines/kfTypes';
 import { computeRunStatus } from '~/concepts/pipelines/content/utils';
 import PipelineRunTypeLabel from '~/concepts/pipelines/content/PipelineRunTypeLabel';
@@ -22,7 +22,9 @@ const PipelineDetailsTitle: React.FC<RunJobTitleProps> = ({
   return (
     <>
       <Split hasGutter>
-        <SplitItem>{run.display_name}</SplitItem>
+        <SplitItem>
+          <Truncate content={run.display_name} />
+        </SplitItem>
         {pipelineRunLabel && (
           <SplitItem>
             <PipelineRunTypeLabel run={run} />

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -98,7 +98,9 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
               breadcrumb={
                 <Breadcrumb>
                   {breadcrumbPath}
-                  <BreadcrumbItem>{pipeline?.display_name || 'Loading...'}</BreadcrumbItem>
+                  <BreadcrumbItem style={{ maxWidth: 300 }}>
+                    <Truncate content={pipeline?.display_name || 'Loading...'} />
+                  </BreadcrumbItem>
                   <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
                     <Truncate content={pipelineVersion?.display_name || 'Loading...'} />
                   </BreadcrumbItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -138,7 +138,7 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
                         version.pipeline_version_id,
                       )}
                     >
-                      {version.display_name}
+                      <Truncate content={version.display_name} />
                     </Link>
                   ) : (
                     'Loading...'

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
-
+import { Truncate } from '@patternfly/react-core';
 import { ExperimentKFv2, StorageStateKF } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd } from '~/components/table';
 import { experimentRunsRoute } from '~/routes';
@@ -36,7 +35,7 @@ const ExperimentTableRow: React.FC<ExperimentTableRowProps> = ({
           }`}
           state={{ experiment }}
         >
-          {experiment.display_name}
+          <Truncate content={experiment.display_name} />
         </Link>
       </Td>
       <Td dataLabel="Description">{experiment.description}</Td>

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Td, Tbody, Tr, ActionsColumn } from '@patternfly/react-table';
+import { Td, Tbody, Tr, ActionsColumn, TableText } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { Skeleton } from '@patternfly/react-core';
 import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
@@ -84,7 +84,7 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
           />
           <Td>
             <TableRowTitleDescription
-              title={pipeline.display_name}
+              title={<TableText wrapModifier="truncate">{pipeline.display_name}</TableText>}
               description={pipeline.description}
               descriptionAsMarkdown
             />

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, TableText, Td, Tr } from '@patternfly/react-table';
 import { Link, useNavigate } from 'react-router-dom';
 import { PipelineKFv2, PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
 import { CheckboxTd, TableRowTitleDescription } from '~/components/table';
@@ -53,15 +53,17 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
       <Td>
         <TableRowTitleDescription
           title={
-            <Link
-              to={pipelineVersionDetailsPath(
-                namespace,
-                version.pipeline_id,
-                version.pipeline_version_id,
-              )}
-            >
-              {version.display_name}
-            </Link>
+            <TableText wrapModifier="truncate">
+              <Link
+                to={pipelineVersionDetailsPath(
+                  namespace,
+                  version.pipeline_id,
+                  version.pipeline_version_id,
+                )}
+              >
+                {version.display_name}
+              </Link>
+            </TableText>
           }
           description={version.description}
           descriptionAsMarkdown

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineVersionRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineVersionRuns.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Truncate } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineCoreDetailsPageComponent } from '~/concepts/pipelines/content/types';
@@ -49,7 +49,7 @@ const GlobalPipelineVersionRuns: PipelineCoreDetailsPageComponent = ({ breadcrum
           {breadcrumbPath}
           <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
             <Link to={routePipelineDetailsNamespace(namespace, pipelineId, pipelineVersionId)}>
-              {pipelineVersion?.display_name || 'Loading...'}
+              <Truncate content={pipelineVersion?.display_name || 'Loading...'} />
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem isActive>Runs</BreadcrumbItem>


### PR DESCRIPTION
Closes [RHOAIENG-7970](https://issues.redhat.com/browse/RHOAIENG-7970)

## Description
Added Truncate to Pipeline and expirement name in table and breadcrumbs.

![Screenshot 2024-06-18 at 4 16 52 PM](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/7789279b-dd8b-4776-b61d-bfc918d83545)

![Screenshot 2024-06-18 at 4 17 18 PM](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/37027d3b-4ac9-43cb-8483-5016430e9bda)


## How Has This Been Tested?
Create a pipeline and experiment with long name.

## Test Impact
No tests, just added truncate to table column.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@yannnz 