### PR TITLE
add always() condition to upload cypress artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           directory: ./frontend/coverage
           verbose: true
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: cypress-results
           path: ./frontend/src/__tests__/cypress/results/


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Cypress artifact upload was only done on success but not when test failed.
According to the [github documentation](https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions), the default conditional for actions is `success()`. Added the condition of `always()` to the artifact upload step.

