### PR TITLE
Add support for public routes in kserve

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -19,7 +19,9 @@ type MockResourceConfigType = {
   maxReplicas?: number;
   lastFailureInfoMessage?: string;
   resources?: ContainerResources;
+  kserveInternalUrl?: string;
   statusPredictor?: Record<string, string>;
+  kserveInternalLabel?: boolean;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -76,6 +78,8 @@ export const mockInferenceServiceK8sResource = ({
   lastFailureInfoMessage = 'Waiting for runtime Pod to become available',
   resources,
   statusPredictor = undefined,
+  kserveInternalUrl = '',
+  kserveInternalLabel = false,
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',
@@ -96,6 +100,7 @@ export const mockInferenceServiceK8sResource = ({
     labels: {
       name,
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+      ...(kserveInternalLabel && { 'networking.knative.dev/visibility': 'cluster-local' }),
     },
     name,
     namespace,
@@ -167,5 +172,10 @@ export const mockInferenceServiceK8sResource = ({
       },
       transitionStatus: '',
     },
+    ...(kserveInternalUrl && {
+      address: {
+        url: kserveInternalUrl,
+      },
+    }),
   },
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -228,6 +228,14 @@ class ModelServingRow extends TableRow {
       .should(enabled ? 'not.exist' : 'exist');
     return this;
   }
+
+  findInternalServiceButton() {
+    return this.find().findByTestId('internal-service-button');
+  }
+
+  findInternalServicePopover() {
+    return cy.findByTestId('internal-service-popover');
+  }
 }
 
 class ModelMeshRow extends ModelServingRow {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -1894,7 +1894,7 @@ describe('Serving Runtime List', () => {
   });
 
   describe('Internal service', () => {
-    it('Check internal service is rendered when the model is loaded', () => {
+    it('Check internal service is rendered when the model is loaded in Modelmesh', () => {
       initIntercepts({
         projectEnableModelMesh: true,
         disableKServeConfig: false,
@@ -1944,6 +1944,58 @@ describe('Serving Runtime List', () => {
         modelServingSection.getInferenceServiceRow('Model not loaded');
       notLoadedInferenceServiceRow.findInternalServiceButton().click();
       notLoadedInferenceServiceRow
+        .findInternalServicePopover()
+        .findByText('Could not find any internal service enabled')
+        .should('exist');
+    });
+
+    it('Check internal service is rendered when the model is loaded in Kserve', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: true,
+        disableModelMeshConfig: false,
+        servingRuntimes: [
+          mockServingRuntimeK8sResource({
+            name: 'test-model',
+            auth: true,
+            route: false,
+          }),
+          mockServingRuntimeK8sResource({
+            name: 'test-model-not-loaded',
+            auth: true,
+            route: false,
+          }),
+        ],
+        inferenceServices: [
+          mockInferenceServiceK8sResource({
+            name: 'model-loaded',
+            modelName: 'test-model',
+            displayName: 'Loaded model',
+            isModelMesh: false,
+            kserveInternalUrl: 'http://test.kserve.svc.cluster.local',
+            kserveInternalLabel: true,
+          }),
+          mockInferenceServiceK8sResource({
+            name: 'model-not-loaded',
+            modelName: 'est-model-not-loaded',
+            displayName: 'Model Not loaded',
+            isModelMesh: false,
+            kserveInternalLabel: true,
+          }),
+        ],
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+
+      // Get modal of inference service when is loaded
+      const kserveRowModelLoaded = modelServingSection.getKServeRow('Loaded model');
+      kserveRowModelLoaded.findInternalServiceButton().click();
+      kserveRowModelLoaded.findInternalServicePopover().findByText('url').should('exist');
+
+      // Get modal of inference service when is not loaded
+      const kserveRowModelNotLoaded = modelServingSection.getKServeRow('Model Not loaded');
+      kserveRowModelNotLoaded.findInternalServiceButton().click();
+      kserveRowModelLoaded
         .findInternalServicePopover()
         .findByText('Could not find any internal service enabled')
         .should('exist');

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -107,6 +107,37 @@ describe('assembleInferenceService', () => {
     );
   });
 
+  it('should have the right labels when creating for Kserve with public route', async () => {
+    const inferenceService = assembleInferenceService(
+      mockInferenceServiceModalData({ externalRoute: false }),
+    );
+
+    expect(inferenceService.metadata.labels?.['networking.knative.dev/visibility']).toBe(
+      'cluster-local',
+    );
+
+    const missingExternalRoute = assembleInferenceService(
+      mockInferenceServiceModalData({ externalRoute: true }),
+    );
+
+    expect(missingExternalRoute.metadata.labels?.['networking.knative.dev/visibility']).toBe(
+      undefined,
+    );
+  });
+
+  it('should have the right labels when creating for Modelmesh with public route', async () => {
+    const missingExternalRoute = assembleInferenceService(
+      mockInferenceServiceModalData({ externalRoute: true }),
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(missingExternalRoute.metadata.labels?.['networking.knative.dev/visibility']).toBe(
+      undefined,
+    );
+  });
+
   it('should handle name and display name', async () => {
     const displayName = 'Llama model';
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -424,6 +424,10 @@ export type InferenceServiceAnnotations = Partial<{
   'security.opendatahub.io/enable-auth': string;
 }>;
 
+export type InferenceServiceLabels = Partial<{
+  'networking.knative.dev/visibility': string;
+}>;
+
 export type InferenceServiceKind = K8sResourceCommon & {
   metadata: {
     name: string;
@@ -495,6 +499,12 @@ export type InferenceServiceKind = K8sResourceCommon & {
       transitionStatus: string;
     };
     url: string;
+    address?: {
+      CACerts?: string;
+      audience?: string;
+      name?: string;
+      url?: string;
+    };
   };
 };
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceEndpoint.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceEndpoint.tsx
@@ -8,7 +8,10 @@ import {
   Skeleton,
 } from '@patternfly/react-core';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
-import { isServingRuntimeRouteEnabled } from '~/pages/modelServing/screens/projects/utils';
+import {
+  isServingRuntimeRouteEnabled,
+  isInferenceServiceRouteEnabled,
+} from '~/pages/modelServing/screens/projects/utils';
 import useRouteForInferenceService from './useRouteForInferenceService';
 import InternalServicePopoverContent from './InternalServicePopoverContent';
 
@@ -23,8 +26,9 @@ const InferenceServiceEndpoint: React.FC<InferenceServiceEndpointProps> = ({
   servingRuntime,
   isKserve,
 }) => {
-  const isRouteEnabled =
-    servingRuntime !== undefined && isServingRuntimeRouteEnabled(servingRuntime);
+  const isRouteEnabled = !isKserve
+    ? servingRuntime !== undefined && isServingRuntimeRouteEnabled(servingRuntime)
+    : isInferenceServiceRouteEnabled(inferenceService);
 
   const [routeLink, loaded, loadError] = useRouteForInferenceService(
     inferenceService,
@@ -32,23 +36,21 @@ const InferenceServiceEndpoint: React.FC<InferenceServiceEndpointProps> = ({
     isKserve,
   );
 
-  if (!isKserve && !isRouteEnabled) {
+  if (!isRouteEnabled) {
     return (
       <Popover
         data-testid="internal-service-popover"
         headerContent="Internal Service can be accessed inside the cluster"
         aria-label="Internal Service Info"
-        bodyContent={<InternalServicePopoverContent inferenceService={inferenceService} />}
+        bodyContent={
+          <InternalServicePopoverContent inferenceService={inferenceService} isKserve={isKserve} />
+        }
       >
         <Button data-testid="internal-service-button" isInline variant="link">
           Internal Service
         </Button>
       </Popover>
     );
-  }
-
-  if (!loaded) {
-    return <Skeleton />;
   }
 
   if (loadError) {
@@ -59,6 +61,10 @@ const InferenceServiceEndpoint: React.FC<InferenceServiceEndpointProps> = ({
         </HelperTextItem>
       </HelperText>
     );
+  }
+
+  if (!loaded || !routeLink) {
+    return <Skeleton />;
   }
 
   return (

--- a/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {
+  ClipboardCopy,
+  ClipboardCopyVariant,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -9,15 +11,38 @@ import { InferenceServiceKind } from '~/k8sTypes';
 
 type InternalServicePopoverContentProps = {
   inferenceService: InferenceServiceKind;
+  isKserve?: boolean;
 };
 
 const InternalServicePopoverContent: React.FC<InternalServicePopoverContentProps> = ({
   inferenceService,
+  isKserve,
 }) => {
-  const isInternalServiceEnabled = inferenceService.status?.components?.predictor;
+  const isInternalServiceEnabled = !isKserve
+    ? inferenceService.status?.components?.predictor
+    : inferenceService.status?.address?.url;
 
   if (!isInternalServiceEnabled) {
     return <>Could not find any internal service enabled</>;
+  }
+
+  if (isKserve) {
+    return (
+      <DescriptionList isCompact>
+        <DescriptionListGroup>
+          <DescriptionListTerm>url</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant={ClipboardCopyVariant.inlineCompact}
+            >
+              {inferenceService.status?.address?.url}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    );
   }
 
   return (
@@ -25,7 +50,15 @@ const InternalServicePopoverContent: React.FC<InternalServicePopoverContentProps
       {Object.entries(isInternalServiceEnabled).map(([route, value]) => (
         <DescriptionListGroup key={route}>
           <DescriptionListTerm>{route}</DescriptionListTerm>
-          <DescriptionListDescription>{value}</DescriptionListDescription>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant={ClipboardCopyVariant.inlineCompact}
+            >
+              {value}
+            </ClipboardCopy>
+          </DescriptionListDescription>
         </DescriptionListGroup>
       ))}
     </DescriptionList>

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -3,10 +3,12 @@ import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import {
   filterOutConnectionsWithoutBucket,
   getProjectModelServingPlatform,
+  getUrlFromKserveInferenceService,
 } from '~/pages/modelServing/screens/projects/utils';
 import { DataConnection } from '~/pages/projects/types';
 import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
+import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
 
 describe('filterOutConnectionsWithoutBucket', () => {
   it('should return an empty array if input connections array is empty', () => {
@@ -123,5 +125,29 @@ describe('getProjectModelServingPlatform', () => {
         getMockServingPlatformStatuses({ kServeEnabled: false }),
       ),
     ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI });
+  });
+});
+
+describe('getUrlsFromKserveInferenceService', () => {
+  it('should return the url from the inference service status', () => {
+    const url = 'https://test-kserve.apps.kserve-pm.dev.com';
+    const inferenceService = mockInferenceServiceK8sResource({
+      url,
+    });
+    expect(getUrlFromKserveInferenceService(inferenceService)).toBe(url);
+  });
+  it('should return undefined if the inference service status does not have an address', () => {
+    const url = '';
+    const inferenceService = mockInferenceServiceK8sResource({
+      url,
+    });
+    expect(getUrlFromKserveInferenceService(inferenceService)).toBeUndefined();
+  });
+  it('should return undefined if the inference service status is an internal service', () => {
+    const url = 'http://test.kserve.svc.cluster.local';
+    const inferenceService = mockInferenceServiceK8sResource({
+      url,
+    });
+    expect(getUrlFromKserveInferenceService(inferenceService)).toBeUndefined();
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -329,6 +329,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 data={createDataInferenceService}
                 setData={setCreateDataInferenceService}
                 allowCreate={allowCreate}
+                publicRoute
               />
             </StackItem>
           )}

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -64,6 +64,9 @@ export const isServingRuntimeRouteEnabled = (servingRuntime: ServingRuntimeKind)
 export const isInferenceServiceTokenEnabled = (inferenceService: InferenceServiceKind): boolean =>
   inferenceService.metadata.annotations?.['security.opendatahub.io/enable-auth'] === 'true';
 
+export const isInferenceServiceRouteEnabled = (inferenceService: InferenceServiceKind): boolean =>
+  inferenceService.metadata.labels?.['networking.knative.dev/visibility'] !== 'cluster-local';
+
 export const isGpuDisabled = (servingRuntime: ServingRuntimeKind): boolean =>
   servingRuntime.metadata.annotations?.['opendatahub.io/disable-gpu'] === 'true';
 
@@ -206,7 +209,8 @@ export const useCreateInferenceServiceObject = (
   const existingMaxReplicas =
     existingData?.spec.predictor.maxReplicas || existingServingRuntimeData?.spec.replicas || 1;
 
-  const existingExternalRoute = false; // TODO: Change this in the future in case we have an External Route
+  const existingExternalRoute =
+    existingData?.metadata.labels?.['networking.knative.dev/visibility'] !== 'cluster-local';
   const existingTokenAuth =
     existingData?.metadata.annotations?.['security.opendatahub.io/enable-auth'] === 'true';
 
@@ -523,7 +527,13 @@ export const submitServingRuntimeResourcesWithDryRun = async (
 
 export const getUrlFromKserveInferenceService = (
   inferenceService: InferenceServiceKind,
-): string | undefined => inferenceService.status?.url;
+): string | undefined =>
+  isUrlInternalService(inferenceService.status?.url) || !inferenceService.status?.url
+    ? undefined
+    : inferenceService.status.url;
+
+export const isUrlInternalService = (url: string | undefined): boolean =>
+  url !== undefined && url.endsWith('.svc.cluster.local');
 
 export const filterOutConnectionsWithoutBucket = (
   connections: DataConnection[],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes https://issues.redhat.com/browse/RHOAIENG-6651

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add support for public/private routes in kserve

<img width="2293" alt="Screenshot 2024-07-17 at 16 07 27" src="https://github.com/user-attachments/assets/e0361f59-417b-4698-bebe-bf217d9bd8ef">
<img width="2285" alt="Screenshot 2024-07-17 at 16 07 14" src="https://github.com/user-attachments/assets/3086f978-b291-4a61-953d-6d95be176119">



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Install ODH Operator 2.14 (needed for the changes in kserve controller)
2. Create a new project
3. Deploy a single model server without a public route
4. Check that the internal route points to the right service
5. Now edit the deployment and make it public
6. Check that you end up getting a url

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added integration tests and unit test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
