### PR TITLE
Fix breadcrumb navigation to correct tabs for pipeline run and jobs details page

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/CloneRunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/CloneRunPage.tsx
@@ -21,7 +21,7 @@ const CloneRunPage: React.FC<PathProps> = ({ breadcrumbPath, contextPath }) => {
       title={title}
       breadcrumb={
         <Breadcrumb>
-          {breadcrumbPath}
+          {breadcrumbPath(runType)}
           <BreadcrumbItem isActive>
             {run ? `Duplicate of ${run.display_name}` : 'Duplicate'}
           </BreadcrumbItem>

--- a/frontend/src/concepts/pipelines/content/createRun/CreateRunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/CreateRunPage.tsx
@@ -16,7 +16,9 @@ const CreateRunPage: React.FC<PathProps> = ({ breadcrumbPath, contextPath }) => 
       title={title}
       breadcrumb={
         <Breadcrumb>
-          {breadcrumbPath}
+          {breadcrumbPath(
+            runType === PipelineRunType.SCHEDULED ? PipelineRunType.SCHEDULED : undefined,
+          )}
           <BreadcrumbItem isActive>{title}</BreadcrumbItem>
         </Breadcrumb>
       }

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -69,7 +69,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
       <ApplicationsPage
         breadcrumb={
           <Breadcrumb>
-            {breadcrumbPath}
+            {breadcrumbPath()}
             <BreadcrumbItem isActive>{title}</BreadcrumbItem>
           </Breadcrumb>
         }
@@ -97,7 +97,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
             <ApplicationsPage
               breadcrumb={
                 <Breadcrumb>
-                  {breadcrumbPath}
+                  {breadcrumbPath()}
                   <BreadcrumbItem style={{ maxWidth: 300 }}>
                     <Truncate content={pipeline?.display_name || 'Loading...'} />
                   </BreadcrumbItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -33,6 +33,7 @@ import PipelineJobReferenceName from '~/concepts/pipelines/content/PipelineJobRe
 import useExecutionsForPipelineRun from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/useExecutionsForPipelineRun';
 import { useGetEventsByExecutionIds } from '~/concepts/pipelines/apiHooks/mlmd/useGetEventsByExecutionId';
 import { PipelineTopology } from '~/concepts/topology';
+import { StorageStateKF } from '~/concepts/pipelines/kfTypes';
 import { usePipelineRunArtifacts } from './artifacts';
 import { PipelineRunDetailsTabs } from './PipelineRunDetailsTabs';
 
@@ -136,6 +137,9 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
                         namespace,
                         version.pipeline_id,
                         version.pipeline_version_id,
+                        run?.storage_state === StorageStateKF.ARCHIVED
+                          ? PipelineRunType.ARCHIVED
+                          : undefined,
                       )}
                     >
                       <Truncate content={version.display_name} />

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -93,6 +93,9 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
     );
   }
 
+  const runType =
+    run?.storage_state === StorageStateKF.ARCHIVED ? PipelineRunType.ARCHIVED : undefined;
+
   return (
     <>
       <Drawer isExpanded={!!selectedNode}>
@@ -129,7 +132,7 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
             loadError={error}
             breadcrumb={
               <Breadcrumb>
-                {breadcrumbPath}
+                {breadcrumbPath(runType)}
                 <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
                   {version ? (
                     <Link
@@ -137,9 +140,7 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
                         namespace,
                         version.pipeline_id,
                         version.pipeline_version_id,
-                        run?.storage_state === StorageStateKF.ARCHIVED
-                          ? PipelineRunType.ARCHIVED
-                          : undefined,
+                        runType,
                       )}
                     >
                       <Truncate content={version.display_name} />

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRunJob/PipelineRunJobDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRunJob/PipelineRunJobDetails.tsx
@@ -102,6 +102,7 @@ const PipelineRunJobDetails: PipelineCoreDetailsPageComponent = ({
                         namespace,
                         version.pipeline_id,
                         version.pipeline_version_id,
+                        PipelineRunType.SCHEDULED,
                       )}
                     >
                       {version.display_name}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRunJob/PipelineRunJobDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRunJob/PipelineRunJobDetails.tsx
@@ -94,7 +94,7 @@ const PipelineRunJobDetails: PipelineCoreDetailsPageComponent = ({
             loadError={error}
             breadcrumb={
               <Breadcrumb>
-                {breadcrumbPath}
+                {breadcrumbPath(PipelineRunType.SCHEDULED)}
                 <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
                   {version ? (
                     <Link

--- a/frontend/src/concepts/pipelines/content/types.ts
+++ b/frontend/src/concepts/pipelines/content/types.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { BreadcrumbItem } from '@patternfly/react-core';
+import { PipelineRunType } from '~/pages/pipelines/global/runs';
 
 export type PathProps = {
-  breadcrumbPath: React.ReactElement<typeof BreadcrumbItem>[];
+  breadcrumbPath: (runType?: PipelineRunType | null) => React.ReactElement<typeof BreadcrumbItem>[];
   contextPath?: string;
 };
 

--- a/frontend/src/pages/pipelines/global/GlobalPipelineCoreDetails.tsx
+++ b/frontend/src/pages/pipelines/global/GlobalPipelineCoreDetails.tsx
@@ -8,6 +8,7 @@ import EnsureAPIAvailability from '~/concepts/pipelines/EnsureAPIAvailability';
 import { experimentRunsRoute, experimentSchedulesRoute, experimentsBaseRoute } from '~/routes';
 import EnsureCompatiblePipelineServer from '~/concepts/pipelines/EnsureCompatiblePipelineServer';
 import { ExperimentRunsContext } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
+import { PipelineRunType } from '~/pages/pipelines/global/runs';
 
 type GlobalPipelineCoreDetailsProps = {
   pageName: string;
@@ -64,7 +65,13 @@ export const GlobalExperimentDetails: React.FC<
             </BreadcrumbItem>,
             <BreadcrumbItem key="experiment">
               {experiment?.display_name ? (
-                <Link to={experimentRunsRoute(namespace, experimentId)}>
+                <Link
+                  to={experimentRunsRoute(
+                    namespace,
+                    experimentId,
+                    isSchedule ? PipelineRunType.SCHEDULED : undefined,
+                  )}
+                >
                   {experiment.display_name}
                 </Link>
               ) : (

--- a/frontend/src/pages/pipelines/global/GlobalPipelineCoreDetails.tsx
+++ b/frontend/src/pages/pipelines/global/GlobalPipelineCoreDetails.tsx
@@ -8,7 +8,6 @@ import EnsureAPIAvailability from '~/concepts/pipelines/EnsureAPIAvailability';
 import { experimentRunsRoute, experimentSchedulesRoute, experimentsBaseRoute } from '~/routes';
 import EnsureCompatiblePipelineServer from '~/concepts/pipelines/EnsureCompatiblePipelineServer';
 import { ExperimentRunsContext } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
-import { PipelineRunType } from '~/pages/pipelines/global/runs';
 
 type GlobalPipelineCoreDetailsProps = {
   pageName: string;
@@ -27,7 +26,7 @@ const GlobalPipelineCoreDetails: React.FC<GlobalPipelineCoreDetailsProps> = ({
     <EnsureAPIAvailability>
       <EnsureCompatiblePipelineServer>
         <BreadcrumbDetailsComponent
-          breadcrumbPath={[
+          breadcrumbPath={() => [
             <BreadcrumbItem
               key="home"
               render={() => (
@@ -57,7 +56,7 @@ export const GlobalExperimentDetails: React.FC<
     <EnsureAPIAvailability>
       <EnsureCompatiblePipelineServer>
         <BreadcrumbDetailsComponent
-          breadcrumbPath={[
+          breadcrumbPath={(runType) => [
             <BreadcrumbItem key="experiments">
               <Link to={experimentsBaseRoute(namespace)}>
                 Experiments - {getProjectDisplayName(project)}
@@ -65,13 +64,7 @@ export const GlobalExperimentDetails: React.FC<
             </BreadcrumbItem>,
             <BreadcrumbItem key="experiment">
               {experiment?.display_name ? (
-                <Link
-                  to={experimentRunsRoute(
-                    namespace,
-                    experimentId,
-                    isSchedule ? PipelineRunType.SCHEDULED : undefined,
-                  )}
-                >
+                <Link to={experimentRunsRoute(namespace, experimentId, runType)}>
                   {experiment.display_name}
                 </Link>
               ) : (

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetails.tsx
@@ -61,7 +61,7 @@ export const ArtifactDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPa
       loadError={artifactError}
       breadcrumb={
         <Breadcrumb>
-          {breadcrumbPath}
+          {breadcrumbPath()}
           <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
             <Truncate content={artifactName} />
           </BreadcrumbItem>

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsPage.tsx
@@ -21,7 +21,7 @@ const CompareRunsPage: React.FC<PathProps> = ({ breadcrumbPath }) => {
       title=""
       breadcrumb={
         <Breadcrumb>
-          {breadcrumbPath}
+          {breadcrumbPath()}
           <BreadcrumbItem isActive>Compare runs</BreadcrumbItem>
         </Breadcrumb>
       }

--- a/frontend/src/pages/pipelines/global/experiments/executions/details/ExecutionDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/executions/details/ExecutionDetails.tsx
@@ -96,7 +96,7 @@ const ExecutionDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, co
       loaded
       breadcrumb={
         <Breadcrumb>
-          {breadcrumbPath}
+          {breadcrumbPath()}
           <BreadcrumbItem isActive>{displayName}</BreadcrumbItem>
         </Breadcrumb>
       }

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineVersionRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineVersionRuns.tsx
@@ -29,7 +29,7 @@ const GlobalPipelineVersionRuns: PipelineCoreDetailsPageComponent = ({ breadcrum
       <ApplicationsPage
         breadcrumb={
           <Breadcrumb>
-            {breadcrumbPath}
+            {breadcrumbPath()}
             <BreadcrumbItem isActive>{title}</BreadcrumbItem>
           </Breadcrumb>
         }
@@ -46,7 +46,7 @@ const GlobalPipelineVersionRuns: PipelineCoreDetailsPageComponent = ({ breadcrum
     <ApplicationsPage
       breadcrumb={
         <Breadcrumb>
-          {breadcrumbPath}
+          {breadcrumbPath()}
           <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
             <Link to={routePipelineDetailsNamespace(namespace, pipelineId, pipelineVersionId)}>
               <Truncate content={pipelineVersion?.display_name || 'Loading...'} />

--- a/frontend/src/pages/projects/screens/detail/pipelines/ProjectPipelineBreadcrumbPage.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/ProjectPipelineBreadcrumbPage.tsx
@@ -19,7 +19,7 @@ const ProjectPipelineBreadcrumbPage: React.FC<ProjectPipelineDetailsProps> = ({
   return (
     <EnsureAPIAvailability>
       <BreadcrumbDetailsComponent
-        breadcrumbPath={[
+        breadcrumbPath={() => [
           <BreadcrumbItem
             key="project-home"
             render={() => <Link to="/projects">Data Science Projects</Link>}

--- a/frontend/src/routes/pipelines/experiments.ts
+++ b/frontend/src/routes/pipelines/experiments.ts
@@ -1,3 +1,5 @@
+import { PipelineRunType } from '~/pages/pipelines/global/runs';
+
 export const experimentsRootPath = '/experiments';
 export const globExperimentsAll = `${experimentsRootPath}/*`;
 
@@ -34,10 +36,13 @@ export const experimentsCloneScheduleRoute = (
 export const experimentRunsRoute = (
   namespace: string | undefined,
   experimentId: string | undefined,
+  runType?: PipelineRunType,
 ): string =>
   !experimentId
     ? experimentsBaseRoute(namespace)
-    : `${experimentsBaseRoute(namespace)}/${experimentId}/runs`;
+    : `${experimentsBaseRoute(namespace)}/${experimentId}/runs${
+        runType ? `?runType=${runType}` : ''
+      }`;
 
 export const experimentSchedulesRoute = (
   namespace: string | undefined,

--- a/frontend/src/routes/pipelines/experiments.ts
+++ b/frontend/src/routes/pipelines/experiments.ts
@@ -36,7 +36,7 @@ export const experimentsCloneScheduleRoute = (
 export const experimentRunsRoute = (
   namespace: string | undefined,
   experimentId: string | undefined,
-  runType?: PipelineRunType,
+  runType?: PipelineRunType | null,
 ): string =>
   !experimentId
     ? experimentsBaseRoute(namespace)

--- a/frontend/src/routes/pipelines/global.ts
+++ b/frontend/src/routes/pipelines/global.ts
@@ -1,3 +1,5 @@
+import { PipelineRunType } from '~/pages/pipelines/global/runs';
+
 const globNamespace = ':namespace';
 export const globNamespaceAll = `/${globNamespace}?/*`;
 
@@ -31,8 +33,11 @@ export const routePipelineVersionRunsNamespace = (
   namespace: string,
   pipelineId: string,
   versionId: string,
+  runType?: PipelineRunType,
 ): string =>
-  `${routePipelinesNamespace(namespace)}/${routePipelineVersionRuns(pipelineId, versionId)}`;
+  `${routePipelinesNamespace(namespace)}/${routePipelineVersionRuns(pipelineId, versionId)}${
+    runType ? `?runType=${runType}` : ''
+  }`;
 export const routePipelineRunCreateNamespacePipelinesPage = (namespace?: string): string =>
   `${routePipelinesNamespace(namespace)}/${globPipelineRunCreate}`;
 export const routePipelineRunCloneNamespacePipelinesPage = (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-7751

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When you are on a run details page and navigate back to the pipeline runs page or experiment runs page, it will navigate you back to the correct tab now based on whether the run is archived or is a schedule.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a run
2. Archive a run
3. Go to the run details page from the pipeline version runs page
4. Click on the breadcrumb to go back to the pipeline version runs page
5. Make sure it lands on the archived tab
6. Go to the experiment runs page
7. Go to the same run details page
8. Click on the breadcrumb to go back to the experiment runs page
9. Make sure it lands on the archived tab
10. Create a schedule
11. Repeat step 3-9, but make sure it lands on the schedules page on each page

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, we don't have the breadcrumb test yet. Might need it from [RHOAIENG-4324](https://issues.redhat.com/browse/RHOAIENG-4324).

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
