### PR TITLE
update double params to be fixed at 1

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
@@ -267,7 +267,7 @@ describe('Pipeline create runs', () => {
                     },
                     double_param: {
                       parameterType: InputDefinitionParameterType.DOUBLE,
-                      defaultValue: 0.1,
+                      defaultValue: 7.0,
                       description: 'Some double helper text',
                       isOptional: true,
                     },
@@ -313,7 +313,7 @@ describe('Pipeline create runs', () => {
       paramsSection.findParamById('string_param').should('have.value', 'String default value');
       cy.findByTestId('string_param-helper-text').should('have.text', 'Some string helper text');
 
-      paramsSection.findParamById('double_param').should('have.value', '0.1');
+      paramsSection.findParamById('double_param').should('have.value', '7.0');
       cy.findByTestId('double_param-form-group').should('not.have.text', '*', { exact: false });
       cy.findByTestId('double_param-helper-text').should('have.text', 'Some double helper text');
 

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection/NumberInputParam.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/ParamsSection/NumberInputParam.tsx
@@ -1,5 +1,5 @@
 import { TextInput } from '@patternfly/react-core';
-import React from 'react';
+import React, { useRef } from 'react';
 import NumberInputWrapper from '~/components/NumberInputWrapper';
 import { InputParamProps } from './types';
 
@@ -15,16 +15,24 @@ export const NumberInputParam: React.FC<NumberInputParamProps> = ({
   const [value, setValue] = React.useState<number | ''>(
     inputProps.value !== '' ? Number(inputProps.value) : '',
   );
+  const isDefault = useRef(true);
 
   if (isFloat) {
+    // if the default value is a whole number, display it as x.0
+    const displayValue =
+      typeof value === 'number' && Number.isInteger(value) && isDefault.current
+        ? value.toFixed(1)
+        : value;
+
     return (
       <TextInput
         {...inputProps}
         data-testid={inputProps.id}
         type="number"
         step={0.1}
-        value={value}
+        value={displayValue}
         onChange={(event, newValue) => {
+          isDefault.current = false;
           setValue(typeof newValue === 'string' ? parseFloat(newValue) : newValue);
           onChange(event, newValue);
         }}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeInputOutputTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeInputOutputTab.tsx
@@ -48,6 +48,9 @@ const SelectedNodeInputOutputTab: React.FC<SelectedNodeInputOutputTabProps> = ({
 
       switch (type) {
         case InputDefinitionParameterType.DOUBLE:
+          return numberValue && Number.isInteger(numberValue)
+            ? numberValue.toFixed(1)
+            : numberValue;
         case InputDefinitionParameterType.INTEGER:
           return numberValue;
         case InputDefinitionParameterType.BOOLEAN:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-7678

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- makes the doubles render with at least one decimal place even when they have no decimal value
   - this is done in the input params and the task detail input params
![Screenshot 2024-06-18 at 2 44 12 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/d5222007-7f09-42f3-9d63-39862d79a265)
![Screenshot 2024-06-18 at 2 43 39 PM](https://github.com/opendatahub-io/odh-dashboard/assets/12587674/7e7035c4-512b-4dd8-980e-e1f2d5dd480d)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. use the provided pipeline which has a default float value of `7.0`: [pipeline-float-input.yaml.zip](https://github.com/user-attachments/files/15891912/pipeline-float-input.yaml.zip)
2. it should show the default as `7.0`
3. the run details input should also show `7.0` instead of `7`


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated test to reflect this case

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).
@yannnz 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
