### PR TITLE
Update references of docs.openshift.com to the latest OCP version

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -7,7 +7,7 @@ ODH requires the following to run:
 - [NodeJS and NPM](https://nodejs.org/)
   - Node recommended version -> `18.16.0`
   - NPM recommended version -> `9.6.7`
-- [OpenShift CLI](https://docs.openshift.com/container-platform/4.12/cli_reference/openshift_cli/getting-started-cli.html)
+- [OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) (if you need to do deployment)
 
 ### Additional tooling

--- a/manifests/overlays/apps/apps-onprem/starburst-enterprise/starburstenterprise-app.yaml
+++ b/manifests/overlays/apps/apps-onprem/starburst-enterprise/starburstenterprise-app.yaml
@@ -30,7 +30,7 @@ spec:
     - Previously installed and configured Kubernetes, including access to **kubectl**.
     - An editor suitable for editing YAML files.
     - Your SEP (Starburst Enterprise) license file.
-    - The latest OpenShift Container Platform (OCP) client for your platform as described in the [OpenShift documentation](https://docs.openshift.com/container-platform/4.10/cli_reference/openshift_cli/getting-started-cli.html) and the **oc** executable copied into your path, usually **/usr/local/bin.**
+    - The latest OpenShift Container Platform (OCP) client for your platform as described in the [OpenShift documentation](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) and the **oc** executable copied into your path, usually **/usr/local/bin.**
 
     
     ## Installation


### PR DESCRIPTION
## Description
The following files included docs.openshift.com reference to old Openshift versions:
- docs/dev-setup.md
- manifests/overlays/apps/apps-onprem/starburst-enterprise/starburstenterprise-app.yaml

Updated to the latest OCP versions.

## How Has This Been Tested?
The new URLs was verified to lead to docs.openshift.com of latest OCP version. 

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
