### PR TITLE
[RHOAIENG-8837] Truncate min width issue

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -23,7 +23,8 @@ const PipelineDetailsTitle: React.FC<RunJobTitleProps> = ({
     <>
       <Split hasGutter>
         <SplitItem>
-          <Truncate content={run.display_name} />
+          {/* TODO: Remove the custom className after upgrading to PFv6 */}
+          <Truncate content={run.display_name} className="truncate-no-min-width" />
         </SplitItem>
         {pipelineRunLabel && (
           <SplitItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -99,14 +99,28 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
                 <Breadcrumb>
                   {breadcrumbPath}
                   <BreadcrumbItem style={{ maxWidth: 300 }}>
-                    <Truncate content={pipeline?.display_name || 'Loading...'} />
+                    {/* TODO: Remove the custom className after upgrading to PFv6 */}
+                    <Truncate
+                      content={pipeline?.display_name || 'Loading...'}
+                      className="truncate-no-min-width"
+                    />
                   </BreadcrumbItem>
                   <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
-                    <Truncate content={pipelineVersion?.display_name || 'Loading...'} />
+                    {/* TODO: Remove the custom className after upgrading to PFv6 */}
+                    <Truncate
+                      content={pipelineVersion?.display_name || 'Loading...'}
+                      className="truncate-no-min-width"
+                    />
                   </BreadcrumbItem>
                 </Breadcrumb>
               }
-              title={<Truncate content={pipelineVersion?.display_name || 'Loading...'} />}
+              title={
+                <Truncate
+                  content={pipelineVersion?.display_name || 'Loading...'}
+                  // TODO: Remove the custom className after upgrading to PFv6
+                  className="truncate-no-min-width"
+                />
+              }
               {...(pipelineVersion && {
                 description: (
                   <MarkdownView

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -138,14 +138,19 @@ const PipelineRunDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath, 
                         version.pipeline_version_id,
                       )}
                     >
-                      <Truncate content={version.display_name} />
+                      {/* TODO: Remove the custom className after upgrading to PFv6 */}
+                      <Truncate content={version.display_name} className="truncate-no-min-width" />
                     </Link>
                   ) : (
                     'Loading...'
                   )}
                 </BreadcrumbItem>
                 <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
-                  <Truncate content={run?.display_name ?? 'Loading...'} />
+                  {/* TODO: Remove the custom className after upgrading to PFv6 */}
+                  <Truncate
+                    content={run?.display_name ?? 'Loading...'}
+                    className="truncate-no-min-width"
+                  />
                 </BreadcrumbItem>
               </Breadcrumb>
             }

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
@@ -35,7 +35,8 @@ const ExperimentTableRow: React.FC<ExperimentTableRowProps> = ({
           }`}
           state={{ experiment }}
         >
-          <Truncate content={experiment.display_name} />
+          {/* TODO: Remove the custom className after upgrading to PFv6 */}
+          <Truncate content={experiment.display_name} className="truncate-no-min-width" />
         </Link>
       </Td>
       <Td dataLabel="Description">{experiment.description}</Td>

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineVersionRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineVersionRuns.tsx
@@ -49,7 +49,11 @@ const GlobalPipelineVersionRuns: PipelineCoreDetailsPageComponent = ({ breadcrum
           {breadcrumbPath}
           <BreadcrumbItem isActive style={{ maxWidth: 300 }}>
             <Link to={routePipelineDetailsNamespace(namespace, pipelineId, pipelineVersionId)}>
-              <Truncate content={pipelineVersion?.display_name || 'Loading...'} />
+              {/* TODO: Remove the custom className after upgrading to PFv6 */}
+              <Truncate
+                content={pipelineVersion?.display_name || 'Loading...'}
+                className="truncate-no-min-width"
+              />
             </Link>
           </BreadcrumbItem>
           <BreadcrumbItem isActive>Runs</BreadcrumbItem>


### PR DESCRIPTION
Closes: [RHOAIENG-8837](https://issues.redhat.com/browse/RHOAIENG-8837)

## Description
Added inline styling for solve truncate min width issue. 

![Screenshot 2024-06-20 at 7 59 32 PM](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/b13f92ae-67b0-4890-9bd0-3a16161faac8)
![Screenshot 2024-06-20 at 7 59 51 PM](https://github.com/opendatahub-io/odh-dashboard/assets/97534722/a6988a30-295e-4cc9-9e64-3d16923d6849)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check page title and breadcrumbs in pipeline pages.

## Test Impact
None, just a css change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@yannnz 