### PR TITLE
Cleanup S3 endpoint host in configurePipelinesServer utils

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -126,7 +126,7 @@ describe('Pipelines', () => {
           dspVersion: 'v2',
           objectStorage: {
             externalStorage: {
-              host: 's3.amazonaws.com/',
+              host: 's3.amazonaws.com',
               scheme: 'https',
               bucket: 'sdsd',
               region: 'us-east-1',

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
@@ -71,6 +71,16 @@ describe('configure pipeline server utils', () => {
       expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
     });
 
+    it('should cleanup S3 endpoint host', () => {
+      const secretsResponse = createSecretsResponse();
+      const config = createPipelineServerConfig();
+      config.objectStorage.newValue = [
+        { key: AwsKeys.S3_ENDPOINT, value: 'https://s3.amazonaws.com/' },
+      ];
+      const spec = createDSPipelineResourceSpec(config, secretsResponse);
+      expect(spec.objectStorage.externalStorage?.host).toBe('s3.amazonaws.com');
+    });
+
     it('should parse S3 endpoint without scheme', () => {
       const secretsResponse = createSecretsResponse();
       const config = createPipelineServerConfig();

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/utils.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/utils.ts
@@ -108,7 +108,7 @@ export const createDSPipelineResourceSpec = (
     dspVersion: 'v2',
     objectStorage: {
       externalStorage: {
-        host: externalStorageHost,
+        host: cleanupEndpointHost(externalStorageHost),
         scheme: externalStorageScheme || 'https',
         bucket: awsRecord.AWS_S3_BUCKET || '',
         region: externalStorageRegion,
@@ -157,3 +157,5 @@ export const getLabelName = (index: string): string => {
   const field = PIPELINE_AWS_FIELDS.find((currentField) => currentField.key === index);
   return field ? field.label : '';
 };
+
+const cleanupEndpointHost = (endpoint: string): string => endpoint.replace(/\/$/, '') || '';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-8836

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds a cleanup step for pipeline server install to remove trailing slash from the host

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a pipeline server with a host that has a trailing slash
2. verify that the resulting dspa has the same host but with the trailing slash removed

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added test to cover the trailing slash removal

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
