### PR TITLE
[RHOAIENG-7403] Pipeline system.ClassificationMetrics artifacts provide a uri but have no source in storage

### DIFF
--- a/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
@@ -14,16 +14,19 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
 import { MAX_STORAGE_OBJECT_SIZE, fetchStorageObjectSize } from '~/services/storageService';
 import { bytesAsRoundedGiB } from '~/utilities/number';
+import { ArtifactType } from '~/concepts/pipelines/kfTypes';
 import { extractS3UriComponents, getArtifactUrlFromUri } from './utils';
 
 interface ArtifactUriLinkProps {
   uri: string;
+  type: string;
 }
 
-export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri }) => {
+export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri, type }) => {
   const { namespace } = usePipelinesAPI();
   const isS3EndpointAvailable = useIsAreaAvailable(SupportedArea.S3_ENDPOINT).status;
   const [size, setSize] = React.useState<number | null>(null);
+  const isClassificationMetrics = type === ArtifactType.CLASSIFICATION_METRICS;
 
   const url = React.useMemo(() => {
     if (!uri || !isS3EndpointAvailable) {
@@ -41,7 +44,7 @@ export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri }) => {
     return getArtifactUrlFromUri(uri, namespace);
   }, [isS3EndpointAvailable, namespace, uri]);
 
-  if (!url) {
+  if (!url || isClassificationMetrics) {
     return uri;
   }
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
@@ -88,7 +88,7 @@ export const ArtifactNodeDetails: React.FC<ArtifactNodeDetailsProps> = ({
             <DescriptionListGroup>
               <DescriptionListTerm>{artifactName}</DescriptionListTerm>
               <DescriptionListDescription>
-                <ArtifactUriLink uri={artifact.getUri()} />
+                <ArtifactUriLink uri={artifact.getUri()} type={artifact.getType()} />
               </DescriptionListDescription>
             </DescriptionListGroup>
           </DescriptionList>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsInputOutput.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsInputOutput.tsx
@@ -27,7 +27,7 @@ const TaskDetailsInputOutput: React.FC<TaskDetailsInputOutputProps> = ({
       if (artifact) {
         return {
           label: artifactInputOutput.label,
-          value: <ArtifactUriLink uri={artifact.getUri()} />,
+          value: <ArtifactUriLink uri={artifact.getUri()} type={artifact.getType()} />,
         };
       }
 

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactOverviewDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactOverviewDetails.tsx
@@ -34,7 +34,7 @@ export const ArtifactOverviewDetails: React.FC<ArtifactOverviewDetailsProps> = (
               <>
                 <DescriptionListTerm>URI</DescriptionListTerm>
                 <DescriptionListDescription>
-                  <ArtifactUriLink uri={artifact.uri} />
+                  <ArtifactUriLink uri={artifact.uri} type={artifact.type} />
                 </DescriptionListDescription>
               </>
             )}

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTable.tsx
@@ -151,7 +151,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
         <Td>{artifact.id}</Td>
         <Td>{artifact.type}</Td>
         <Td>
-          <ArtifactUriLink uri={artifact.uri} />
+          <ArtifactUriLink uri={artifact.uri} type={artifact.type} />
         </Td>
         <Td>
           <PipelinesTableRowTime date={new Date(artifact.createTimeSinceEpoch)} />


### PR DESCRIPTION
Closes: [RHOAIENG-7403](https://issues.redhat.com/browse/RHOAIENG-7403)

## Description
For system.ClassificationMetrics artifacts the download link is removed.

https://github.com/opendatahub-io/odh-dashboard/assets/97534722/d4b6e22b-b57c-4e8d-a184-a9caf3bb25df

## How Has This Been Tested?
1. Enable S3 feature flag.
2. Create a pipeline run containing a classification metrics artifact, and ensure that the artifact URL is not clickable.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x]  Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@yannnz 