### PR TITLE
Fix markdown tab render delay when toggling selected compared runs

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/compareRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/compareRuns.cy.ts
@@ -300,10 +300,10 @@ describe('Compare runs', () => {
 
       const row = content.getRocCurveRowByName('wine-classification > metrics');
       row.findRunName().should('contain.text', 'Run 1');
-      content.findRocCurveGraph().should('contain.text', 'Series #1');
+      content.findRocCurveGraph().should('include.text', '#1');
 
       row.findRowCheckbox().uncheck();
-      content.findRocCurveGraph().should('not.contain.text', 'Series #1');
+      content.findRocCurveGraph().should('not.include.text', '#1');
     });
 
     it('displays ROC curve empty state when no artifacts are found', () => {
@@ -311,24 +311,6 @@ describe('Compare runs', () => {
       const content = compareRunsMetricsContent.findRocCurveTabContent();
       content.findRocCruveSearchBar().type('invalid');
       content.findRocCurveEmptyState().should('exist');
-    });
-
-    it('displays markdown fetched from S3 based on selected runs', () => {
-      cy.wait('@s3Loaded', {
-        timeout: 15000,
-      });
-
-      compareRunsMetricsContent.findMarkdownTab().click();
-      const markdownCompare = compareRunsMetricsContent
-        .findMarkdownTabContent()
-        .findMarkdownSelect(mockRun.run_id);
-
-      // check markdown content
-      markdownCompare.findArtifactContent().should('contain.text', 'This is a markdown file');
-
-      // check expanded graph
-      markdownCompare.findExpandButton().click();
-      compareRunsMetricsContent.findMarkdownTabContent().findExpandedMarkdown().should('exist');
     });
   });
 });
@@ -397,32 +379,4 @@ const initIntercepts = () => {
   );
 
   initMlmdIntercepts(projectName);
-
-  cy.interceptOdh(
-    'GET /api/storage/:namespace',
-    {
-      path: {
-        namespace: projectName,
-      },
-      query: {
-        key: 'metrics-visualization-pipeline/16dbff18-a3d5-4684-90ac-4e6198a9da0f/markdown-visualization/markdown_artifact',
-      },
-    },
-    { body: 'This is a markdown file' },
-  ).as('s3Loaded');
-
-  cy.interceptOdh(
-    'GET /api/storage/:namespace/size',
-    {
-      path: {
-        namespace: projectName,
-      },
-      query: {
-        key: 'metrics-visualization-pipeline/16dbff18-a3d5-4684-90ac-4e6198a9da0f/markdown-visualization/markdown_artifact',
-      },
-    },
-    {
-      body: 100,
-    },
-  );
 };

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps.ts
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps.ts
@@ -1,0 +1,90 @@
+import React from 'react';
+import { RunArtifact } from '~/concepts/pipelines/apiHooks/mlmd/types';
+import { extractS3UriComponents } from '~/concepts/pipelines/content/artifacts/utils';
+import { MarkdownAndTitle } from '~/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare';
+import {
+  getFullArtifactPathLabel,
+  getFullArtifactPaths,
+} from '~/concepts/pipelines/content/compareRuns/metricsSection/utils';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import { fetchStorageObject, fetchStorageObjectSize } from '~/services/storageService';
+import { allSettledPromises } from '~/utilities/allSettledPromises';
+
+const useFetchMarkdownMaps = (
+  markdownArtifacts?: RunArtifact[],
+): {
+  configMap: Record<string, MarkdownAndTitle[]>;
+  runMap: Record<string, PipelineRunKFv2>;
+  configsLoaded: boolean;
+} => {
+  const { namespace } = usePipelinesAPI();
+  const [configsLoaded, setConfigsLoaded] = React.useState(false);
+  const [configMapBuilder, setConfigMapBuilder] = React.useState<
+    Record<string, MarkdownAndTitle[]>
+  >({});
+  const [runMapBuilder, setRunMapBuilder] = React.useState<Record<string, PipelineRunKFv2>>({});
+
+  const fullArtifactPaths = React.useMemo(() => {
+    if (!markdownArtifacts) {
+      return [];
+    }
+
+    return getFullArtifactPaths(markdownArtifacts);
+  }, [markdownArtifacts]);
+
+  const fetchStorageObjectPromises = React.useMemo(
+    () =>
+      fullArtifactPaths
+        .filter((path) => !!path.linkedArtifact.artifact.getUri())
+        .map(async (path) => {
+          const { run } = path;
+          const uriComponents = extractS3UriComponents(path.linkedArtifact.artifact.getUri());
+          if (!uriComponents) {
+            return null;
+          }
+          const sizeBytes = await fetchStorageObjectSize(namespace, uriComponents.path).catch(
+            () => undefined,
+          );
+          const text = await fetchStorageObject(namespace, uriComponents.path).catch(() => null);
+
+          if (text === null) {
+            return null;
+          }
+
+          return { run, sizeBytes, text, path };
+        }),
+    [fullArtifactPaths, namespace],
+  );
+
+  React.useEffect(() => {
+    setConfigsLoaded(false);
+    setConfigMapBuilder({});
+    setRunMapBuilder({});
+
+    allSettledPromises(fetchStorageObjectPromises).then(([successes]) => {
+      successes.forEach((result) => {
+        if (result.value) {
+          const { text, sizeBytes, run, path } = result.value;
+          setRunMapBuilder((runMap) => ({ ...runMap, [run.run_id]: run }));
+
+          const config = {
+            title: getFullArtifactPathLabel(path),
+            config: text,
+            fileSize: sizeBytes,
+          };
+
+          setConfigMapBuilder((configMap) => ({
+            ...configMap,
+            [run.run_id]: run.run_id in configMap ? [...configMap[run.run_id], config] : [config],
+          }));
+        }
+      });
+      setConfigsLoaded(true);
+    });
+  }, [fetchStorageObjectPromises]);
+
+  return { configMap: configMapBuilder, runMap: runMapBuilder, configsLoaded };
+};
+
+export default useFetchMarkdownMaps;

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import _ from 'lodash-es';
 import { ExpandableSection, Tab, TabContentBody, TabTitleText, Tabs } from '@patternfly/react-core';
 import { useCompareRuns } from '~/concepts/pipelines/content/compareRuns/CompareRunsContext';
 import { useGetArtifactTypes } from '~/concepts/pipelines/apiHooks/mlmd/useGetArtifactTypes';
@@ -18,6 +18,7 @@ import RocCurveCompare from '~/concepts/pipelines/content/compareRuns/metricsSec
 import ConfusionMatrixCompare from '~/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/ConfusionMatrixCompare';
 import MarkdownCompare from '~/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useFetchMarkdownMaps from '~/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps';
 
 export const CompareRunMetricsSection: React.FunctionComponent = () => {
   const { runs, selectedRuns } = useCompareRuns();
@@ -29,39 +30,47 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
   );
   const isS3EndpointAvailable = useIsAreaAvailable(SupportedArea.S3_ENDPOINT).status;
 
-  const selectedMlmdPackages = React.useMemo(
-    () =>
-      mlmdPackages.filter((mlmdPackage) =>
-        selectedRuns.some((run) => run.run_id === mlmdPackage.run.run_id),
-      ),
-    [mlmdPackages, selectedRuns],
+  const runArtifacts: RunArtifact[] = React.useMemo(
+    () => getRunArtifacts(mlmdPackages),
+    [mlmdPackages],
   );
 
   const isLoaded = mlmdPackagesLoaded && artifactTypesLoaded;
 
-  const [
-    scalarMetricsArtifactData,
-    confusionMatrixArtifactData,
-    rocCurveArtifactData,
-    markdownArtifactData,
-  ] = React.useMemo(() => {
+  const [markdownArtifacts, ...allArtifacts] = React.useMemo(() => {
     if (!isLoaded) {
       return [[], [], [], []];
     }
 
-    const runArtifacts: RunArtifact[] = getRunArtifacts(selectedMlmdPackages);
     return [
+      filterRunArtifactsByType(runArtifacts, artifactTypes, MetricsType.MARKDOWN),
       filterRunArtifactsByType(runArtifacts, artifactTypes, MetricsType.SCALAR_METRICS),
       filterRunArtifactsByType(runArtifacts, artifactTypes, MetricsType.CONFUSION_MATRIX),
       filterRunArtifactsByType(runArtifacts, artifactTypes, MetricsType.ROC_CURVE),
-      filterRunArtifactsByType(runArtifacts, artifactTypes, MetricsType.MARKDOWN),
     ];
-  }, [artifactTypes, isLoaded, selectedMlmdPackages]);
+  }, [artifactTypes, isLoaded, runArtifacts]);
+
+  const { configMap, configsLoaded, runMap } = useFetchMarkdownMaps(markdownArtifacts);
+  const [selectedConfigMap, selectedRunMap] = React.useMemo(() => {
+    const selectedIds = selectedRuns.map((run) => run.run_id);
+    return [_.pick(configMap, selectedIds), _.pick(runMap, selectedIds)];
+  }, [configMap, runMap, selectedRuns]);
+
+  const filterSelected = React.useCallback(
+    (runArtifact: RunArtifact) => selectedRuns.some((run) => run.run_id === runArtifact.run.run_id),
+    [selectedRuns],
+  );
+
+  const [scalarMetricsArtifactData, confusionMatrixArtifactData, rocCurveArtifactData] =
+    React.useMemo(
+      () => allArtifacts.map((artifacts) => artifacts.filter(filterSelected)),
+      [allArtifacts, filterSelected],
+    );
 
   return (
     <ExpandableSection
       toggleText="Metrics"
-      onToggle={(_, isOpen) => setIsSectionOpen(isOpen)}
+      onToggle={(_event, isOpen) => setIsSectionOpen(isOpen)}
       isExpanded={isSectionOpen}
       isIndented
       data-testid="compare-runs-metrics-content"
@@ -104,7 +113,12 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
             data-testid="compare-runs-markdown-tab"
           >
             <TabContentBody hasPadding data-testid="compare-runs-markdown-tab-content">
-              <MarkdownCompare runArtifacts={markdownArtifactData} isLoaded={isLoaded} />
+              <MarkdownCompare
+                configMap={selectedConfigMap}
+                runMap={selectedRunMap}
+                isEmpty={selectedRuns.length === 0}
+                isLoaded={isLoaded && configsLoaded}
+              />
             </TabContentBody>
           </Tab>
         )}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-8360

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This issue is because we have 2 additional S3 API calls for fetching the markdown content. In that way, we have a delay when selecting/unselecting the compared runs. The solution is to fetch all the markdown data on the first render and record it as a map. Then we only need to filter the map based on the run selection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Turn S3 feature flag on
2. Create 2 runs with the pipeline provided in the ticket
3. Go to compare runs page
4. Select/Unselect the runs to see if the markdown tab is rendering seamlessly and correctly

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
