### PR TITLE
Add custom container size to workbenches table

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -1,4 +1,5 @@
 import { DashboardConfigKind, KnownLabels } from '~/k8sTypes';
+import { NotebookSize } from '~/types';
 
 type MockDashboardConfigType = {
   disableInfo?: boolean;
@@ -26,6 +27,7 @@ type MockDashboardConfigType = {
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
   disableNotebookController?: boolean;
+  notebookSizes?: NotebookSize[];
 };
 
 export const mockDashboardConfig = ({
@@ -54,6 +56,73 @@ export const mockDashboardConfig = ({
   disableDistributedWorkloads = false,
   disableModelRegistry = true,
   disableNotebookController = false,
+  notebookSizes = [
+    {
+      name: 'XSmall',
+      resources: {
+        limits: {
+          cpu: '0.5',
+          memory: '500Mi',
+        },
+        requests: {
+          cpu: '0.1',
+          memory: '100Mi',
+        },
+      },
+    },
+    {
+      name: 'Small',
+      resources: {
+        limits: {
+          cpu: '2',
+          memory: '8Gi',
+        },
+        requests: {
+          cpu: '1',
+          memory: '8Gi',
+        },
+      },
+    },
+    {
+      name: 'Medium',
+      resources: {
+        limits: {
+          cpu: '6',
+          memory: '24Gi',
+        },
+        requests: {
+          cpu: '3',
+          memory: '24Gi',
+        },
+      },
+    },
+    {
+      name: 'Large',
+      resources: {
+        limits: {
+          cpu: '14',
+          memory: '56Gi',
+        },
+        requests: {
+          cpu: '7',
+          memory: '56Gi',
+        },
+      },
+    },
+    {
+      name: 'X Large',
+      resources: {
+        limits: {
+          cpu: '30',
+          memory: '120Gi',
+        },
+        requests: {
+          cpu: '15',
+          memory: '120Gi',
+        },
+      },
+    },
+  ],
 }: MockDashboardConfigType): DashboardConfigKind => ({
   apiVersion: 'opendatahub.io/v1alpha',
   kind: 'OdhDashboardConfig',
@@ -147,73 +216,7 @@ export const mockDashboardConfig = ({
         },
       },
     ],
-    notebookSizes: [
-      {
-        name: 'XSmall',
-        resources: {
-          limits: {
-            cpu: '0.5',
-            memory: '500Mi',
-          },
-          requests: {
-            cpu: '0.1',
-            memory: '100Mi',
-          },
-        },
-      },
-      {
-        name: 'Small',
-        resources: {
-          limits: {
-            cpu: '2',
-            memory: '8Gi',
-          },
-          requests: {
-            cpu: '1',
-            memory: '8Gi',
-          },
-        },
-      },
-      {
-        name: 'Medium',
-        resources: {
-          limits: {
-            cpu: '6',
-            memory: '24Gi',
-          },
-          requests: {
-            cpu: '3',
-            memory: '24Gi',
-          },
-        },
-      },
-      {
-        name: 'Large',
-        resources: {
-          limits: {
-            cpu: '14',
-            memory: '56Gi',
-          },
-          requests: {
-            cpu: '7',
-            memory: '56Gi',
-          },
-        },
-      },
-      {
-        name: 'X Large',
-        resources: {
-          limits: {
-            cpu: '30',
-            memory: '120Gi',
-          },
-          requests: {
-            cpu: '15',
-            memory: '120Gi',
-          },
-        },
-      },
-    ],
+    notebookSizes,
     templateOrder: ['test-model'],
     templateDisablement: ['test-model'],
   },

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -299,6 +299,10 @@ class CreateSpawnerPage {
   findBucketInput() {
     return cy.findByTestId('field AWS_S3_BUCKET');
   }
+
+  findContainerSizeInput(name: string) {
+    return cy.findByTestId('container-size-group').contains(name);
+  }
 }
 
 class EditSpawnerPage extends CreateSpawnerPage {
@@ -325,6 +329,10 @@ class EditSpawnerPage extends CreateSpawnerPage {
   shouldHaveContainerSizeInput(name: string) {
     cy.findByTestId('container-size-group').contains(name).should('exist');
     return this;
+  }
+
+  findCancelButton() {
+    return cy.findByTestId('workbench-cancel-button');
   }
 }
 

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookList.tsx
@@ -52,6 +52,7 @@ const NotebookList: React.FC = () => {
         <Button
           key={`action-${ProjectSectionID.WORKBENCHES}`}
           onClick={() => navigate(`/projects/${projectName}/spawner`)}
+          data-testid="create-workbench-button"
           variant="primary"
         >
           Create workbench

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -1,17 +1,8 @@
 import * as React from 'react';
 import { ActionsColumn, ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
-import {
-  Button,
-  Flex,
-  FlexItem,
-  Icon,
-  Popover,
-  Split,
-  SplitItem,
-  Tooltip,
-} from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Icon, Popover, Split, SplitItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { NotebookState } from '~/pages/projects/notebook/types';
 import NotebookRouteLink from '~/pages/projects/notebook/NotebookRouteLink';
 import NotebookStatusToggle from '~/pages/projects/notebook/NotebookStatusToggle';
@@ -22,6 +13,7 @@ import { TableRowTitleDescription } from '~/components/table';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { NotebookSize } from '~/types';
 import useNotebookDeploymentSize from './useNotebookDeploymentSize';
 import useNotebookImage from './useNotebookImage';
 import NotebookSizeDetails from './NotebookSizeDetails';
@@ -51,7 +43,14 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const navigate = useNavigate();
   const [isExpanded, setExpanded] = React.useState(false);
-  const { size: notebookSize, error: sizeError } = useNotebookDeploymentSize(obj.notebook);
+  const { size: notebookSize } = useNotebookDeploymentSize(obj.notebook);
+  const lastDeployedSize: NotebookSize = {
+    name: 'Custom',
+    resources: obj.notebook.spec.template.spec.containers[0].resources ?? {
+      limits: {},
+      requests: {},
+    },
+  };
   const [notebookImage, loaded, loadError] = useNotebookImage(obj.notebook);
 
   return (
@@ -124,7 +123,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
                   }
                 >
                   <DashboardPopupIconButton
-                    aria-label="Notebook image has out of date Elrya version"
+                    aria-label="Notebook image has out of date Elyra version"
                     data-testid="outdated-elyra-info"
                     icon={
                       <Icon status="info">
@@ -143,14 +142,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
               spaceItems={{ default: 'spaceItemsXs' }}
               alignItems={{ default: 'alignItemsCenter' }}
             >
-              <FlexItem>{notebookSize?.name ?? 'Unknown'}</FlexItem>
-              {sizeError && (
-                <Tooltip content={sizeError}>
-                  <Icon aria-label="error icon" role="button" status="danger" tabIndex={0}>
-                    <ExclamationCircleIcon />
-                  </Icon>
-                </Tooltip>
-              )}
+              <FlexItem>{notebookSize?.name ?? <i>{lastDeployedSize.name}</i>}</FlexItem>
             </Flex>
           </Td>
         ) : null}
@@ -212,7 +204,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           </Td>
           <Td dataLabel="Limits">
             <ExpandableRowContent>
-              {notebookSize && <NotebookSizeDetails notebookSize={notebookSize} />}
+              <NotebookSizeDetails notebookSize={notebookSize || lastDeployedSize} />
             </ExpandableRowContent>
           </Td>
           <Td />

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize.ts
@@ -5,9 +5,7 @@ import { getNotebookSizes } from '~/pages/notebookController/screens/server/useP
 import { NotebookKind } from '~/k8sTypes';
 import { isCpuResourceEqual, isMemoryResourceEqual } from '~/utilities/valueUnits';
 
-const useNotebookDeploymentSize = (
-  notebook?: NotebookKind,
-): { size: NotebookSize | null; error: string } => {
+const useNotebookDeploymentSize = (notebook?: NotebookKind): { size: NotebookSize | null } => {
   const { dashboardConfig } = React.useContext(AppContext);
 
   const container: PodContainer | undefined = notebook?.spec.template.spec.containers.find(
@@ -15,7 +13,7 @@ const useNotebookDeploymentSize = (
   );
 
   if (!container) {
-    return { size: null, error: 'Failed to get workbench information.' };
+    return { size: null };
   }
 
   const sizes = getNotebookSizes(dashboardConfig);
@@ -25,18 +23,21 @@ const useNotebookDeploymentSize = (
       isMemoryResourceEqual(
         currentSize.resources.limits?.memory,
         container.resources?.limits?.memory,
+      ) &&
+      isCpuResourceEqual(currentSize.resources.requests?.cpu, container.resources?.requests?.cpu) &&
+      isMemoryResourceEqual(
+        currentSize.resources.requests?.memory,
+        container.resources?.requests?.memory,
       ),
   );
 
   if (!size) {
     return {
       size: null,
-      error:
-        'Workbench size is currently unavailable. Check your dashboard configuration to view size information.',
     };
   }
 
-  return { size, error: '' };
+  return { size };
 };
 
 export default useNotebookDeploymentSize;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -18,7 +18,6 @@ import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { NameDescType } from '~/pages/projects/types';
 import { NotebookKind } from '~/k8sTypes';
 import useNotebookImageData from '~/pages/projects/screens/detail/notebooks/useNotebookImageData';
-import useNotebookDeploymentSize from '~/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize';
 import NotebookRestartAlert from '~/pages/projects/components/NotebookRestartAlert';
 import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksRestart';
 import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableElyraPipelinesCheck';
@@ -31,7 +30,6 @@ import { ScrollableSelectorID, SpawnerPageSectionTitles } from './const';
 import SpawnerFooter from './SpawnerFooter';
 import ImageSelectorField from './imageSelector/ImageSelectorField';
 import ContainerSizeSelector from './deploymentSize/ContainerSizeSelector';
-import { useNotebookSize } from './useNotebookSize';
 import StorageField from './storage/StorageField';
 import EnvironmentVariables from './environmentVariables/EnvironmentVariables';
 import { useStorageDataObject } from './storage/utils';
@@ -43,6 +41,7 @@ import {
 import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVariables';
 import DataConnectionField from './dataConnection/DataConnectionField';
 import { useNotebookDataConnection } from './dataConnection/useNotebookDataConnection';
+import { useNotebookSizeState } from './useNotebookSizeState';
 
 type SpawnerPageProps = {
   existingNotebook?: NotebookKind;
@@ -61,7 +60,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     imageStream: undefined,
     imageVersion: undefined,
   });
-  const { selectedSize, setSelectedSize, sizes } = useNotebookSize();
+  const { selectedSize, setSelectedSize, sizes } = useNotebookSizeState(existingNotebook);
   const [supportedAcceleratorProfiles, setSupportedAcceleratorProfiles] = React.useState<
     string[] | undefined
   >();
@@ -94,13 +93,6 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
       }
     }
   }, [data, loaded, loadError]);
-
-  const { size: notebookSize } = useNotebookDeploymentSize(existingNotebook);
-  React.useEffect(() => {
-    if (notebookSize) {
-      setSelectedSize(notebookSize.name);
-    }
-  }, [notebookSize, setSelectedSize]);
 
   const [notebookAcceleratorProfileState, setNotebookAcceleratorProfileState] =
     useNotebookAcceleratorProfile(existingNotebook);

--- a/frontend/src/pages/projects/screens/spawner/useNotebookSizeState.ts
+++ b/frontend/src/pages/projects/screens/spawner/useNotebookSizeState.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import useNotebookDeploymentSize from '~/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize';
+import { NotebookKind } from '~/k8sTypes';
+import { NotebookSize } from '~/types';
+import { getCustomNotebookSize } from '~/pages/projects/utils';
+import { useNotebookSize } from './useNotebookSize';
+
+export const useNotebookSizeState = (
+  existingNotebook: NotebookKind | undefined,
+): {
+  selectedSize: NotebookSize;
+  setSelectedSize: (size: string) => void;
+  sizes: NotebookSize[];
+} => {
+  const { size: notebookSize } = useNotebookDeploymentSize(existingNotebook);
+  const { sizes } = useNotebookSize();
+
+  const allSizes = React.useMemo(() => {
+    if (notebookSize) {
+      return sizes;
+    }
+    const CUSTOM_NOTEBOOK_SIZE = getCustomNotebookSize(existingNotebook);
+    if (existingNotebook) {
+      return [CUSTOM_NOTEBOOK_SIZE, ...sizes];
+    }
+    return sizes;
+  }, [notebookSize, sizes, existingNotebook]);
+
+  const [selectedSize, setSelectedSize] = React.useState<NotebookSize>(
+    () => allSizes.find((size) => size.name === notebookSize?.name) || allSizes[0],
+  );
+
+  const setSelectedSizeSafe = React.useCallback(
+    (name: string) => {
+      const foundSize = allSizes.find((size) => size.name === name);
+      setSelectedSize(foundSize ?? allSizes[0]);
+    },
+    [allSizes],
+  );
+
+  return { selectedSize, setSelectedSize: setSelectedSizeSafe, sizes: allSizes };
+};

--- a/frontend/src/pages/projects/utils.ts
+++ b/frontend/src/pages/projects/utils.ts
@@ -1,4 +1,5 @@
-import { PersistentVolumeClaimKind } from '~/k8sTypes';
+import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
+import { NotebookSize } from '~/types';
 import { NotebookState } from './notebook/types';
 
 export const getNotebookStatusPriority = (notebookState: NotebookState): number =>
@@ -6,3 +7,13 @@ export const getNotebookStatusPriority = (notebookState: NotebookState): number 
 
 export const getPvcTotalSize = (pvc: PersistentVolumeClaimKind): string =>
   pvc.status?.capacity?.storage || pvc.spec.resources.requests.storage;
+
+export const getCustomNotebookSize = (
+  existingNotebook: NotebookKind | undefined,
+): NotebookSize => ({
+  name: 'Keep custom size',
+  resources: existingNotebook?.spec.template.spec.containers[0].resources ?? {
+    limits: {},
+    requests: {},
+  },
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-578

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When an administrator updates the notebook sizes, the container size now changes to `Custom` instead of `Unknown`.

<details>
  <summary>Workbenches table(not expanded):</summary>
  
<img width="986" alt="Screenshot 2024-07-09 at 11 02 41 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/7f6a3954-a5fa-4932-88e2-785fd61048a6">

</details>

<details>
  <summary>Workbenches table(expanded):</summary>
<img width="987" alt="Screenshot 2024-07-09 at 11 02 54 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/22885912/417069f0-f8b4-4de6-a1ae-fd3997400279">

</details>

</details>

<details>
  <summary>Edit workbenches for deleted notebook sizes(expanded):</summary>
<img width="663" alt="Screenshot 2024-07-16 at 6 10 24 PM" src="https://github.com/user-attachments/assets/faa1b661-a422-4689-9e67-603df6b13827">


</details>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a workbench with any container size
2. Go to console and update the `notebookSizes` in `OdhDashboardConfig`([for example](https://github.com/opendatahub-io/odh-dashboard/issues/1513#issue-1803778644))
3. Go to your Workbenches table on your dashboard and see `Custom` in the `Container size`. Expand the table row and see `limits` and `requests`.
4. Edit this workbench > now you should see a selected "Keep custom size" option in the expanded Container size dropdown, along with its `limits` and `requests`.
5. Try editing the workbench name while keeping others intact. The container size should still be "Custom" in the workbenches table after updating the workbench name.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added e2e test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`.