### PR TITLE
support feature flag overrides via query string

### DIFF
--- a/backend/src/routes/api/cluster-settings/clusterSettingsUtils.ts
+++ b/backend/src/routes/api/cluster-settings/clusterSettingsUtils.ts
@@ -38,7 +38,7 @@ export const updateClusterSettings = async (
     notebookTolerationSettings,
     modelServingPlatformEnabled,
   } = request.body;
-  const dashConfig = getDashboardConfig();
+  const dashConfig = getDashboardConfig(request);
   const isJupyterEnabled = checkJupyterEnabled();
   try {
     if (
@@ -124,10 +124,11 @@ export const updateClusterSettings = async (
 
 export const getClusterSettings = async (
   fastify: KubeFastifyInstance,
+  request: FastifyRequest,
 ): Promise<ClusterSettings | string> => {
   const coreV1Api = fastify.kube.coreV1Api;
   const namespace = fastify.kube.namespace;
-  const dashConfig = getDashboardConfig();
+  const dashConfig = getDashboardConfig(request);
   const isJupyterEnabled = checkJupyterEnabled();
   const clusterSettings: ClusterSettings = {
     ...DEFAULT_CLUSTER_SETTINGS,

--- a/backend/src/routes/api/cluster-settings/index.ts
+++ b/backend/src/routes/api/cluster-settings/index.ts
@@ -7,7 +7,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
     '/',
     secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
-      return getClusterSettings(fastify)
+      return getClusterSettings(fastify, request)
         .then((res) => {
           return res;
         })

--- a/backend/src/routes/api/storage/index.ts
+++ b/backend/src/routes/api/storage/index.ts
@@ -14,7 +14,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
       reply: FastifyReply,
     ) => {
       try {
-        const dashConfig = getDashboardConfig();
+        const dashConfig = getDashboardConfig(request);
         if (dashConfig?.spec.dashboardConfig.disableS3Endpoint !== false) {
           reply.code(404).send('Not found');
           return reply;
@@ -49,7 +49,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
       reply: FastifyReply,
     ) => {
       try {
-        const dashConfig = getDashboardConfig();
+        const dashConfig = getDashboardConfig(request);
         if (dashConfig?.spec.dashboardConfig.disableS3Endpoint !== false) {
           reply.code(404).send('Not found');
           return reply;

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -111,18 +111,25 @@
     "no-restricted-imports": [
       "error",
       {
+        "paths": [
+          {
+            "name": "^axios$",
+            "importNames": ["default"],
+            "message": "Import from `~/utilities/axios` instead."
+          }
+        ],
         "patterns": [
           {
             "group": ["~/api/**"],
-            "message": "Read from '~/api' instead."
+            "message": "Import from '~/api' instead."
           },
           {
             "group": ["~/components/table/**", "!~/components/table/useTableColumnSort"],
-            "message": "Read from '~/components/table' instead."
+            "message": "Import from '~/components/table' instead."
           },
           {
             "group": ["~/concepts/area/**"],
-            "message": "Read from '~/concepts/area' instead."
+            "message": "Import from '~/concepts/area' instead."
           },
           {
             "group": ["~/components/table/useTableColumnSort"],
@@ -286,7 +293,10 @@
       ],
       "overrides": [
         {
-          "files": ["./src/__tests__/cypress/cypress/pages/*.ts", "./src/__tests__/cypress/cypress/tests/e2e/*.ts"],
+          "files": [
+            "./src/__tests__/cypress/cypress/pages/*.ts",
+            "./src/__tests__/cypress/cypress/tests/e2e/*.ts"
+          ],
           "rules": {
             "no-restricted-syntax": [
               "error",

--- a/frontend/src/api/k8s/__tests__/projects.spec.ts
+++ b/frontend/src/api/k8s/__tests__/projects.spec.ts
@@ -4,7 +4,7 @@ import {
   k8sUpdateResource,
   k8sDeleteResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mockAxiosError } from '~/__mocks__/mockAxiosError';
@@ -40,7 +40,7 @@ jest.mock('~/api/k8s/servingRuntimes.ts', () => ({
   listServingRuntimes: jest.fn(),
 }));
 
-jest.mock('axios');
+jest.mock('~/utilities/axios');
 
 const mockedAxios = jest.mocked(axios);
 const k8sListResourceMock = jest.mocked(k8sListResource<ProjectKind>);

--- a/frontend/src/api/k8s/projects.ts
+++ b/frontend/src/api/k8s/projects.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import {
   k8sCreateResource,
   k8sDeleteResource,
@@ -6,6 +5,7 @@ import {
   K8sResourceCommon,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import axios from '~/utilities/axios';
 import { CustomWatchK8sResult } from '~/types';
 import { K8sAPIOptions, ProjectKind } from '~/k8sTypes';
 import { ProjectModel, ProjectRequestModel } from '~/api/models';

--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { mockPrometheusQueryVectorResponse } from '~/__mocks__/mockPrometheusQueryVectorResponse';
 import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';
 import { WorkloadKind, WorkloadOwnerType } from '~/k8sTypes';
@@ -310,7 +310,7 @@ describe('getTopResourceConsumingWorkloads', () => {
   });
 });
 
-jest.mock('axios', () => ({
+jest.mock('~/utilities/axios', () => ({
   post: jest.fn(),
 }));
 

--- a/frontend/src/api/prometheus/__tests__/pvcs.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/pvcs.spec.ts
@@ -1,12 +1,12 @@
 import { act } from '@testing-library/react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { usePVCFreeAmount } from '~/api/prometheus/pvcs';
 import { POLL_INTERVAL } from '~/utilities/const';
 
-jest.mock('axios', () => ({
+jest.mock('~/utilities/axios', () => ({
   post: jest.fn(),
 }));
 

--- a/frontend/src/api/prometheus/__tests__/usePrometheusQuery.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/usePrometheusQuery.spec.ts
@@ -1,10 +1,10 @@
 import { act } from '@testing-library/react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import usePrometheusQuery from '~/api/prometheus/usePrometheusQuery';
 
-jest.mock('axios', () => ({
+jest.mock('~/utilities/axios', () => ({
   post: jest.fn(),
 }));
 

--- a/frontend/src/api/prometheus/__tests__/usePrometheusQueryRange.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/usePrometheusQueryRange.spec.ts
@@ -1,11 +1,11 @@
-import axios from 'axios';
 import { act } from '@testing-library/react';
+import axios from '~/utilities/axios';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockPrometheusServing } from '~/__mocks__/mockPrometheusServing';
 import usePrometheusQueryRange from '~/api/prometheus/usePrometheusQueryRange';
 import { PrometheusQueryRangeResponseData } from '~/types';
 
-jest.mock('axios', () => ({
+jest.mock('~/utilities/axios', () => ({
   post: jest.fn(),
 }));
 

--- a/frontend/src/api/prometheus/usePrometheusQuery.ts
+++ b/frontend/src/api/prometheus/usePrometheusQuery.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { PrometheusQueryResponse } from '~/types';
 import useFetchState, { FetchOptions, FetchState, NotReadyError } from '~/utilities/useFetchState';
 

--- a/frontend/src/api/prometheus/usePrometheusQueryRange.ts
+++ b/frontend/src/api/prometheus/usePrometheusQueryRange.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 
 import useFetchState, {
   FetchOptions,

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -20,6 +20,7 @@ import useDetectUser from '~/utilities/useDetectUser';
 import ProjectsContextProvider from '~/concepts/projects/ProjectsContext';
 import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import AreaContextProvider from '~/concepts/areas/AreaContext';
+import useDevFeatureFlags from './useDevFeatureFlags';
 import Header from './Header';
 import AppRoutes from './AppRoutes';
 import NavSidebar from './NavSidebar';
@@ -29,6 +30,7 @@ import { useApplicationSettings } from './useApplicationSettings';
 import TelemetrySetup from './TelemetrySetup';
 import { logout } from './appUtils';
 import QuickStarts from './QuickStarts';
+import DevFeatureFlagsBanner from './DevFeatureFlagsBanner';
 
 import './App.scss';
 
@@ -38,10 +40,13 @@ const App: React.FC = () => {
 
   const buildStatuses = useWatchBuildStatus();
   const {
-    dashboardConfig,
+    dashboardConfig: dashboardConfigFromServer,
     loaded: configLoaded,
     loadError: fetchConfigError,
   } = useApplicationSettings();
+
+  const { dashboardConfig, ...devFeatureFlagsProps } =
+    useDevFeatureFlags(dashboardConfigFromServer);
 
   const [storageClasses] = useStorageClasses();
 
@@ -115,6 +120,10 @@ const App: React.FC = () => {
             data-testid={DASHBOARD_MAIN_CONTAINER_ID}
           >
             <ErrorBoundary>
+              <DevFeatureFlagsBanner
+                dashboardConfig={dashboardConfig.spec.dashboardConfig}
+                {...devFeatureFlagsProps}
+              />
               <ProjectsContextProvider>
                 <QuickStarts>
                   <AppRoutes />

--- a/frontend/src/app/DevFeatureFlagsBanner.tsx
+++ b/frontend/src/app/DevFeatureFlagsBanner.tsx
@@ -1,0 +1,131 @@
+import {
+  Banner,
+  Button,
+  Checkbox,
+  Grid,
+  GridItem,
+  Modal,
+  Split,
+  SplitItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import { CloseIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { allFeatureFlags } from '~/concepts/areas/const';
+import { isFeatureFlag } from '~/concepts/areas/utils';
+import { DashboardCommonConfig } from '~/k8sTypes';
+import { DevFeatureFlags } from '~/types';
+
+type Props = { dashboardConfig: Partial<DashboardCommonConfig> } & DevFeatureFlags;
+
+const DevFeatureFlagsBanner: React.FC<Props> = ({
+  dashboardConfig,
+  devFeatureFlags,
+  setDevFeatureFlag,
+  resetDevFeatureFlags,
+  setDevFeatureFlagQueryVisible,
+}) => {
+  const [isBannerHidden, setBannerHidden] = React.useState(false);
+  const [isModalOpen, setModalOpen] = React.useState(false);
+
+  if (!devFeatureFlags || isBannerHidden) {
+    return null;
+  }
+
+  const renderDevFeatureFlags = () => (
+    <Grid hasGutter span={6} md={3}>
+      {allFeatureFlags
+        .filter(isFeatureFlag)
+        .toSorted()
+        .map((key) => {
+          const value = devFeatureFlags[key] ?? dashboardConfig[key];
+          return (
+            <React.Fragment key={key}>
+              <GridItem>
+                <Checkbox
+                  id={key}
+                  data-testid={`${key}-checkbox`}
+                  label={key}
+                  isChecked={value ?? null}
+                  onChange={(_, checked) => {
+                    setDevFeatureFlag(key, checked);
+                  }}
+                />
+              </GridItem>
+              <GridItem data-testid={`${key}-value`}>{`${value ?? ''}${
+                key in devFeatureFlags ? ' (overridden)' : ''
+              }`}</GridItem>
+            </React.Fragment>
+          );
+        })}
+    </Grid>
+  );
+  return (
+    <>
+      <Banner variant="blue">
+        <Split>
+          <SplitItem isFilled>
+            Feature flags are{' '}
+            <Button
+              data-testid="override-feature-flags-button"
+              variant="link"
+              isInline
+              onClick={() => {
+                setModalOpen(true);
+                setDevFeatureFlagQueryVisible(true);
+              }}
+            >
+              overridden
+            </Button>{' '}
+            in the current session.{' '}
+            <Button
+              data-testid="reset-feature-flags-button"
+              variant="link"
+              isInline
+              onClick={resetDevFeatureFlags}
+            >
+              Click here
+            </Button>{' '}
+            to reset back to defaults.
+          </SplitItem>
+          <SplitItem>
+            <Tooltip content="Close the banner and keep feature flag overrides active. Refresh the page to reveal the banner.">
+              <Button
+                data-testid="hide-banner-button"
+                variant="link"
+                isInline
+                onClick={() => setBannerHidden(true)}
+                icon={<CloseIcon />}
+                aria-label="hide banner"
+              />
+            </Tooltip>
+          </SplitItem>
+        </Split>
+      </Banner>
+      <Modal
+        data-testid="dev-feature-flags-modal"
+        variant="large"
+        title="Feature flags"
+        isOpen={isModalOpen}
+        onClose={() => {
+          setModalOpen(false);
+          setDevFeatureFlagQueryVisible(false);
+        }}
+        actions={[
+          <Button
+            data-testid="reset-feature-flags-modal-button"
+            key="confirm"
+            variant="link"
+            onClick={() => resetDevFeatureFlags()}
+          >
+            Reset to defaults
+          </Button>,
+        ]}
+      >
+        {renderDevFeatureFlags()}
+      </Modal>
+    </>
+  );
+};
+
+export default DevFeatureFlagsBanner;

--- a/frontend/src/app/__tests__/DevFeatureFlagsBanner.spec.tsx
+++ b/frontend/src/app/__tests__/DevFeatureFlagsBanner.spec.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DevFeatureFlagsBanner from '~/app/DevFeatureFlagsBanner';
+
+describe('DevFeatureFlagsBanner', () => {
+  it('should not render if no feature flags are overridden', () => {
+    const result = render(
+      <DevFeatureFlagsBanner
+        dashboardConfig={{}}
+        setDevFeatureFlag={() => undefined}
+        resetDevFeatureFlags={() => undefined}
+        devFeatureFlags={null}
+        setDevFeatureFlagQueryVisible={() => undefined}
+      />,
+    );
+    expect(result.container).toBeEmptyDOMElement();
+  });
+
+  it('should render banner and open modal', () => {
+    const resetFn = jest.fn();
+    const visibleFn = jest.fn();
+    const result = render(
+      <DevFeatureFlagsBanner
+        dashboardConfig={{}}
+        setDevFeatureFlag={() => undefined}
+        resetDevFeatureFlags={resetFn}
+        setDevFeatureFlagQueryVisible={visibleFn}
+        devFeatureFlags={{}}
+      />,
+    );
+    expect(result.container).not.toBeEmptyDOMElement();
+    act(() => result.getByTestId('override-feature-flags-button').click());
+    result.getByTestId('dev-feature-flags-modal');
+
+    act(() => result.getByTestId('reset-feature-flags-button').click());
+    expect(resetFn).toHaveBeenCalled();
+    expect(visibleFn).toHaveBeenLastCalledWith(true);
+    act(() => result.getByRole('button', { name: 'Close' }).click());
+    expect(visibleFn).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should render and set feature flags', () => {
+    const setFeatureFlagFn = jest.fn();
+    const resetFn = jest.fn();
+    const result = render(
+      <DevFeatureFlagsBanner
+        dashboardConfig={{
+          disableAcceleratorProfiles: false,
+        }}
+        setDevFeatureFlag={setFeatureFlagFn}
+        resetDevFeatureFlags={resetFn}
+        setDevFeatureFlagQueryVisible={() => undefined}
+        devFeatureFlags={{
+          disableHome: true,
+        }}
+      />,
+    );
+    expect(result.container).not.toBeEmptyDOMElement();
+    act(() => result.getByTestId('override-feature-flags-button').click());
+    screen.getByTestId('dev-feature-flags-modal');
+
+    act(() => result.getByTestId('reset-feature-flags-button').click());
+    expect(resetFn).toHaveBeenCalled();
+
+    expect(result.getByTestId('disableHome-checkbox')).toBeChecked();
+    expect(result.getByTestId('disableAcceleratorProfiles-checkbox')).not.toBeChecked();
+    expect(result.getByTestId('enablement-checkbox')).toBePartiallyChecked();
+
+    expect(result.getByTestId('disableHome-value').textContent).toBe('true (overridden)');
+    expect(result.getByTestId('disableAcceleratorProfiles-value').textContent).toBe('false');
+    expect(result.getByTestId('enablement-value').textContent).toBe('');
+
+    act(() => {
+      result.getByTestId('disableHome-checkbox').click();
+      result.getByTestId('disableAcceleratorProfiles-checkbox').click();
+      result.getByTestId('enablement-checkbox').click();
+    });
+
+    expect(setFeatureFlagFn).toHaveBeenCalledTimes(3);
+    expect(setFeatureFlagFn.mock.calls).toEqual([
+      ['disableHome', false],
+      ['disableAcceleratorProfiles', true],
+      ['enablement', true],
+    ]);
+  });
+});

--- a/frontend/src/app/__tests__/useDevFeatureFlags.spec.ts
+++ b/frontend/src/app/__tests__/useDevFeatureFlags.spec.ts
@@ -1,0 +1,157 @@
+import { merge } from 'lodash-es';
+import { act } from '@testing-library/react';
+import { useSearchParams } from 'react-router-dom';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import useDevFeatureFlags from '~/app/useDevFeatureFlags';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { DashboardCommonConfig, DashboardConfigKind } from '~/k8sTypes';
+import axios from '~/utilities/axios';
+
+jest.mock('react-router-dom', () => ({
+  useSearchParams: jest.fn(() => [
+    { get: jest.fn(() => null), has: jest.fn(() => false), delete: jest.fn() },
+    jest.fn(),
+  ]),
+}));
+jest.mock('~/components/browserStorage', () => ({
+  useBrowserStorage: jest.fn(() => [null, jest.fn()]),
+}));
+jest.mock('~/utilities/axios', () => ({
+  __esModule: true,
+  default: {
+    defaults: {
+      headers: {
+        common: [],
+      },
+    },
+  },
+}));
+
+const axiosMock = jest.mocked(axios);
+const useSearchParamsMock = jest.mocked(useSearchParams);
+const useBrowserStorageMock = jest.mocked(useBrowserStorage);
+
+const mockSession = (sessionFlags: Partial<DashboardCommonConfig> | null) => {
+  const setSessionFn = jest.fn();
+  useBrowserStorageMock.mockReturnValue([sessionFlags, setSessionFn]);
+  return { sessionFlags, setSessionFn };
+};
+
+const mockUseSearchParams = (queryFlags: { [key in string]: boolean } | null) => {
+  const backing = new URLSearchParams({
+    foo: 'bar',
+    ...(queryFlags
+      ? {
+          devFeatureFlags: Object.entries(queryFlags)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(','),
+        }
+      : {}),
+  });
+  const getFn = jest.fn((name: string) => backing.get(name));
+  const hasFn = jest.fn((name: string) => backing.has(name));
+  const deleteFn = jest.fn((name: string) => backing.delete(name));
+  const searchParams = {
+    get: getFn,
+    has: hasFn,
+    delete: deleteFn,
+    toString: () => backing.toString(),
+  } as unknown as ReturnType<typeof useSearchParams>[0];
+  const setSearchParamsFn = jest.fn();
+  useSearchParamsMock.mockReturnValue([searchParams, setSearchParamsFn]);
+  return { queryFlags, searchParams, setSearchParamsFn };
+};
+
+describe('useDevFeatureFlags', () => {
+  it('should pass through dashboardConfig if no dev feature flags set', () => {
+    const dashboardConfig = {} as DashboardConfigKind;
+    const renderResult = testHook(useDevFeatureFlags)(dashboardConfig);
+    expect(renderResult.result.current.dashboardConfig).toBe(dashboardConfig);
+    expect(renderResult.result.current).toEqual({
+      dashboardConfig,
+      devFeatureFlags: null,
+      resetDevFeatureFlags: expect.any(Function),
+      setDevFeatureFlag: expect.any(Function),
+      setDevFeatureFlagQueryVisible: expect.any(Function),
+    });
+  });
+
+  it('should load flags from session', () => {
+    const { sessionFlags, setSessionFn } = mockSession({
+      disableHome: true,
+      disableAppLauncher: false,
+    });
+    const dashboardConfig = {
+      spec: { dashboardConfig: { enablement: true } },
+    } as DashboardConfigKind;
+    const renderResult = testHook(useDevFeatureFlags)(dashboardConfig);
+    expect(renderResult.result.current).toEqual({
+      dashboardConfig: merge(dashboardConfig, { spec: { dashboardConfig: sessionFlags } }),
+      devFeatureFlags: sessionFlags,
+      resetDevFeatureFlags: expect.any(Function),
+      setDevFeatureFlag: expect.any(Function),
+      setDevFeatureFlagQueryVisible: expect.any(Function),
+    });
+
+    expect(axiosMock.defaults.headers.common['x-odh-feature-flags']).toEqual(
+      JSON.stringify({
+        disableHome: true,
+        disableAppLauncher: false,
+      }),
+    );
+
+    act(() => renderResult.result.current.resetDevFeatureFlags());
+    expect(setSessionFn).toHaveBeenCalledWith(null);
+    act(() => renderResult.result.current.setDevFeatureFlag('disableInfo', false));
+    expect(setSessionFn).toHaveBeenLastCalledWith({
+      disableAppLauncher: false,
+      disableHome: true,
+      disableInfo: false,
+    });
+  });
+
+  it('should load flags from query string', () => {
+    const { setSessionFn } = mockSession(null);
+    const { searchParams, setSearchParamsFn } = mockUseSearchParams({
+      disableHome: true,
+      enablement: true,
+      info: false,
+      invalid: true,
+    });
+    const dashboardConfig = {
+      spec: { dashboardConfig: { disableAppLauncher: true } },
+    } as DashboardConfigKind;
+    const renderResult = testHook(useDevFeatureFlags)(dashboardConfig);
+    expect(renderResult.result.current).toEqual({
+      dashboardConfig: merge(dashboardConfig, {
+        spec: {
+          dashboardConfig: {
+            disableAppLauncher: true,
+            disableHome: true,
+            enablement: true,
+            disableInfo: true,
+          },
+        },
+      }),
+      devFeatureFlags: {
+        disableHome: true,
+        enablement: true,
+        disableInfo: true,
+      },
+      resetDevFeatureFlags: expect.any(Function),
+      setDevFeatureFlag: expect.any(Function),
+      setDevFeatureFlagQueryVisible: expect.any(Function),
+    });
+
+    expect(searchParams.delete).toHaveBeenCalledWith('devFeatureFlags');
+    expect(setSearchParamsFn.mock.calls[0][0].toString()).toEqual(
+      new URLSearchParams({ foo: 'bar' }).toString(),
+    );
+
+    expect(setSessionFn).toHaveBeenCalledWith({
+      disableHome: true,
+      enablement: true,
+      disableInfo: true,
+    });
+  });
+});

--- a/frontend/src/app/useDevFeatureFlags.ts
+++ b/frontend/src/app/useDevFeatureFlags.ts
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useBrowserStorage } from '~/components/browserStorage';
+import { isFeatureFlag } from '~/concepts/areas/utils';
+import { DashboardCommonConfig, DashboardConfigKind } from '~/k8sTypes';
+import { DevFeatureFlags } from '~/types';
+import axios from '~/utilities/axios';
+
+const PARAM_NAME = 'devFeatureFlags';
+const SESSION_KEY = 'odh-feature-flags';
+const HEADER_NAME = 'x-odh-feature-flags';
+
+const capitalize = (v: string) => v.charAt(0).toUpperCase() + v.slice(1);
+
+/**
+ * Override dashboard config feature flags in the query string: eg.
+ * `devFeatureFlags=disableHome=false,appLauncher,support=true`
+ * Results in:
+ *  - disableHome = false
+ *  - disableAppLauncher = false
+ *  - disableSupport = false
+ */
+const useDevFeatureFlags = (
+  dashboardConfig?: DashboardConfigKind | null,
+): {
+  dashboardConfig: DashboardConfigKind | null;
+} & DevFeatureFlags => {
+  const [isDevFeatureFlagQueryVisible, setDevFeatureFlagQueryVisible] = React.useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [sessionFlags, setSessionFlags] = useBrowserStorage<Partial<DashboardCommonConfig> | null>(
+    SESSION_KEY,
+    null,
+    true,
+    true,
+  );
+
+  // only keep valid feature flags
+  const sanitizedSessionFlags = React.useMemo<Partial<DashboardCommonConfig> | null>(() => {
+    if (sessionFlags) {
+      const entries = Object.entries(sessionFlags);
+      const filteredEntries = entries.filter(
+        ([key, value]) => isFeatureFlag(key) && typeof value === 'boolean',
+      );
+      if (entries.length === filteredEntries.length) {
+        // return the original object if valid
+        // keep stable reference
+        return sessionFlags;
+      }
+      // return the sanitized object
+      return filteredEntries.reduce<Partial<DashboardCommonConfig>>((acc, [key, v]) => {
+        if (isFeatureFlag(key)) {
+          acc[key] = v;
+        }
+        return acc;
+      }, {});
+    }
+    return null;
+  }, [sessionFlags]);
+
+  // read from query string at first then fallback to session
+  const firstLoad = React.useRef(true);
+  const devFeatureFlags =
+    (firstLoad.current
+      ? (() => {
+          const devFlagsParam = searchParams.get(PARAM_NAME);
+          if (devFlagsParam != null) {
+            return devFlagsParam.split(',').reduce<Partial<DashboardCommonConfig>>((acc, v) => {
+              const [name, bool] = v.split('=');
+              if (isFeatureFlag(name)) {
+                acc[name] = bool === 'true';
+              } else {
+                const fullName = `disable${capitalize(name)}`;
+                if (isFeatureFlag(fullName)) {
+                  acc[fullName] = bool === 'false';
+                }
+              }
+              return acc;
+            }, {});
+          }
+          return null;
+        })()
+      : null) ?? sanitizedSessionFlags;
+  firstLoad.current = false;
+
+  React.useEffect(() => {
+    if (isDevFeatureFlagQueryVisible) {
+      searchParams.set(
+        PARAM_NAME,
+        devFeatureFlags
+          ? Object.entries(devFeatureFlags)
+              .map(([key, value]) => `${key}=${value}`)
+              .join(',')
+          : '',
+      );
+      setSearchParams(searchParams, { replace: true });
+    } else if (searchParams.has(PARAM_NAME)) {
+      // clean up query string
+      searchParams.delete(PARAM_NAME);
+      setSearchParams(searchParams, { replace: true });
+    }
+    // do not react to changes in searchParams or setSearchParams
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDevFeatureFlagQueryVisible, devFeatureFlags]);
+
+  // update session
+  React.useEffect(() => {
+    // assign axios default header
+    if (devFeatureFlags) {
+      axios.defaults.headers.common[HEADER_NAME] = JSON.stringify(devFeatureFlags);
+    } else {
+      delete axios.defaults.headers.common[HEADER_NAME];
+    }
+
+    // update session storage
+    // compares against original sessionFlags object on purpose and not the sanitizedSessionFlags
+    if (devFeatureFlags !== sessionFlags) {
+      setSessionFlags(devFeatureFlags);
+    }
+  }, [devFeatureFlags, sessionFlags, setSessionFlags]);
+
+  // construct the new dashbaord config by merging in the dev feature flags
+  const newDashboardConfig = React.useMemo<DashboardConfigKind | null>(() => {
+    if (dashboardConfig && devFeatureFlags) {
+      return {
+        ...dashboardConfig,
+        spec: {
+          ...dashboardConfig.spec,
+          dashboardConfig: {
+            ...dashboardConfig.spec.dashboardConfig,
+            ...devFeatureFlags,
+          },
+        },
+      };
+    }
+    return dashboardConfig ?? null;
+  }, [devFeatureFlags, dashboardConfig]);
+
+  // api functions
+  const resetDevFeatureFlags = React.useCallback(() => {
+    setDevFeatureFlagQueryVisible(false);
+    setSessionFlags(null);
+  }, [setSessionFlags]);
+
+  const setDevFeatureFlag = React.useCallback(
+    (flag: keyof DashboardCommonConfig, value: boolean) => {
+      setSessionFlags({ ...sessionFlags, [flag]: value });
+    },
+    [sessionFlags, setSessionFlags],
+  );
+
+  return {
+    dashboardConfig: newDashboardConfig,
+    devFeatureFlags,
+    setDevFeatureFlag,
+    resetDevFeatureFlags,
+    setDevFeatureFlagQueryVisible,
+  };
+};
+
+export default useDevFeatureFlags;

--- a/frontend/src/components/browserStorage/BrowserStorageContext.tsx
+++ b/frontend/src/components/browserStorage/BrowserStorageContext.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
 import { useEventListener } from '~/utilities/useEventListener';
 
 type ValueMap = { [storageKey: string]: unknown };
@@ -48,8 +49,11 @@ export const useBrowserStorage = <T,>(
     [isSessionStorage, jsonify, setJSONValue, setStringValue, storageKey],
   );
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  return [(getValue(storageKey, jsonify, isSessionStorage) as T) ?? defaultValue, setValue];
+  const value = useDeepCompareMemoize(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (getValue(storageKey, jsonify, isSessionStorage) as T) ?? defaultValue,
+  );
+  return [value, setValue];
 };
 
 type BrowserStorageContextProviderProps = {

--- a/frontend/src/concepts/areas/__tests__/useFetchDscStatus.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/useFetchDscStatus.spec.ts
@@ -1,10 +1,10 @@
 import { act } from '@testing-library/react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import useFetchDscStatus from '~/concepts/areas/useFetchDscStatus';
 
-jest.mock('axios', () => ({
+jest.mock('~/utilities/axios', () => ({
   get: jest.fn(),
 }));
 

--- a/frontend/src/concepts/areas/__tests__/useFetchDsciStatus.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/useFetchDsciStatus.spec.ts
@@ -1,10 +1,10 @@
 import { act } from '@testing-library/react';
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';
 import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
 
-jest.mock('axios', () => ({
+jest.mock('~/utilities/axios', () => ({
   get: jest.fn(),
 }));
 

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -1,4 +1,34 @@
+import { DashboardCommonConfig } from '~/k8sTypes';
 import { StackCapability, StackComponent, SupportedArea, SupportedAreasState } from './types';
+
+export const allFeatureFlags: string[] = Object.keys({
+  enablement: false,
+  disableInfo: false,
+  disableSupport: false,
+  disableClusterManager: false,
+  disableTracking: false,
+  disableBYONImageStream: false,
+  disableISVBadges: false,
+  disableAppLauncher: false,
+  disableUserManagement: false,
+  disableHome: false,
+  disableProjects: false,
+  disableModelServing: false,
+  disableProjectSharing: false,
+  disableCustomServingRuntimes: false,
+  disablePipelines: false,
+  disableBiasMetrics: false,
+  disablePerformanceMetrics: false,
+  disableKServe: false,
+  disableKServeAuth: false,
+  disableKServeMetrics: false,
+  disableModelMesh: false,
+  disableAcceleratorProfiles: false,
+  disablePipelineExperiments: false,
+  disableS3Endpoint: false,
+  disableDistributedWorkloads: false,
+  disableModelRegistry: false,
+} satisfies DashboardCommonConfig);
 
 export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.BYON]: {

--- a/frontend/src/concepts/areas/useFetchDscStatus.ts
+++ b/frontend/src/concepts/areas/useFetchDscStatus.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import useFetchState, { FetchState } from '~/utilities/useFetchState';
 import { DataScienceClusterKindStatus } from '~/k8sTypes';
 

--- a/frontend/src/concepts/areas/useFetchDsciStatus.ts
+++ b/frontend/src/concepts/areas/useFetchDsciStatus.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import useFetchState, { FetchState } from '~/utilities/useFetchState';
 import { DataScienceClusterInitializationKindStatus } from '~/k8sTypes';
 

--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -4,19 +4,17 @@ import {
   DataScienceClusterKindStatus,
 } from '~/k8sTypes';
 import { IsAreaAvailableStatus, FeatureFlag, SupportedArea } from './types';
-import { SupportedAreasStateMap } from './const';
+import { SupportedAreasStateMap, allFeatureFlags } from './const';
+
+export const isFeatureFlag = (key: string): key is FeatureFlag => allFeatureFlags.includes(key);
 
 type FlagState = { [flag in FeatureFlag]?: boolean };
 const getFlags = (dashboardConfigSpec: DashboardConfigKind['spec']): FlagState => {
   const flags = dashboardConfigSpec.dashboardConfig;
 
-  // TODO: Improve to be a list of items
-  const isFeatureFlag = (key: string, value: unknown): key is FeatureFlag =>
-    typeof value === 'boolean';
-
   return {
     ...Object.entries(flags).reduce<FlagState>((acc, [key, value]) => {
-      if (isFeatureFlag(key, value)) {
+      if (isFeatureFlag(key)) {
         acc[key] = key.startsWith('disable') ? !value : value;
       }
       return acc;

--- a/frontend/src/redux/actions/actions.ts
+++ b/frontend/src/redux/actions/actions.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
 import { ThunkAction } from 'redux-thunk';
 import { Action } from 'redux';
+import axios from '~/utilities/axios';
 import { Actions, AppNotification, AppState, GetUserAction, StatusResponse } from '~/redux/types';
 import { AllowedUser } from '~/pages/notebookController/screens/admin/types';
 

--- a/frontend/src/services/acceleratorProfileService.ts
+++ b/frontend/src/services/acceleratorProfileService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import { ResponseStatus } from '~/types';
 

--- a/frontend/src/services/acceleratorService.ts
+++ b/frontend/src/services/acceleratorService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { DetectedAccelerators } from '~/types';
 
 export const getDetectedAccelerators = (): Promise<DetectedAccelerators> => {

--- a/frontend/src/services/buildsService.ts
+++ b/frontend/src/services/buildsService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { BuildStatus } from '~/types';
 
 export const fetchBuildStatuses = (): Promise<BuildStatus[]> => {

--- a/frontend/src/services/clusterSettingsService.ts
+++ b/frontend/src/services/clusterSettingsService.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { ClusterSettingsType } from '~/types';
+import axios from '~/utilities/axios';
 
 export const fetchClusterSettings = (): Promise<ClusterSettingsType> => {
   const url = '/api/cluster-settings';

--- a/frontend/src/services/componentsServices.ts
+++ b/frontend/src/services/componentsServices.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { OdhApplication } from '~/types';
 
 export const fetchComponents = (installed: boolean): Promise<OdhApplication[]> => {

--- a/frontend/src/services/consoleLinksService.ts
+++ b/frontend/src/services/consoleLinksService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { ConsoleLinkKind } from '~/k8sTypes';
 
 export const fetchConsoleLinks = (): Promise<ConsoleLinkKind[]> => {

--- a/frontend/src/services/dashboardConfigService.ts
+++ b/frontend/src/services/dashboardConfigService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { DashboardConfigKind } from '~/k8sTypes';
 
 export const fetchDashboardConfig = (): Promise<DashboardConfigKind> => {

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -1,5 +1,5 @@
 // TODO: Delete once we refactor Admin panel to support Passthrough API
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { DashboardConfigKind } from '~/k8sTypes';
 import { DASHBOARD_CONFIG } from '~/utilities/const';
 

--- a/frontend/src/services/docsService.ts
+++ b/frontend/src/services/docsService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { OdhDocument } from '~/types';
 
 export const fetchDocs = (docType?: string): Promise<OdhDocument[]> => {

--- a/frontend/src/services/envService.ts
+++ b/frontend/src/services/envService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { ConfigMap, Secret } from '~/types';
 
 export const getEnvSecret = (namespace: string, name: string): Promise<Secret> => {

--- a/frontend/src/services/groupSettingsService.ts
+++ b/frontend/src/services/groupSettingsService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { GroupsConfig } from '~/pages/groupSettings/groupTypes';
 
 export const fetchGroupsSettings = (): Promise<GroupsConfig> => {

--- a/frontend/src/services/imagesService.ts
+++ b/frontend/src/services/imagesService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { BYONImage, ImageInfo, ResponseStatus } from '~/types';
 
 export const fetchImages = (): Promise<ImageInfo[]> => {

--- a/frontend/src/services/impersonateService.ts
+++ b/frontend/src/services/impersonateService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 
 export const updateImpersonateSettings = (impersonate: boolean): Promise<void> => {
   const url = '/api/dev-impersonate';

--- a/frontend/src/services/modelRegistrySettingsService.ts
+++ b/frontend/src/services/modelRegistrySettingsService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { ModelRegistryKind } from '~/k8sTypes';
 import { RecursivePartial } from '~/typeHelpers';
 

--- a/frontend/src/services/notebookEventsService.ts
+++ b/frontend/src/services/notebookEventsService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { K8sEvent } from '~/types';
 
 export const getNotebookEvents = (

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { RecursivePartial } from '~/typeHelpers';
 import { Notebook, NotebookState, NotebookData, NotebookRunningState } from '~/types';
 

--- a/frontend/src/services/quickStartsService.ts
+++ b/frontend/src/services/quickStartsService.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { QuickStart } from '@patternfly/quickstarts';
+import axios from '~/utilities/axios';
 
 export const fetchQuickStarts = (): Promise<QuickStart[]> => {
   const url = '/api/quickstarts';

--- a/frontend/src/services/roleBindingService.ts
+++ b/frontend/src/services/roleBindingService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { RoleBinding } from '~/types';
 
 export const getRoleBinding = (projectName: string, rbName: string): Promise<RoleBinding> => {

--- a/frontend/src/services/routeService.ts
+++ b/frontend/src/services/routeService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { Route } from '~/types';
 
 export const getRoute = (namespace: string, routeName: string): Promise<Route> => {

--- a/frontend/src/services/segmentKeyService.ts
+++ b/frontend/src/services/segmentKeyService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 import { ODHSegmentKey } from '~/types';
 
 export const fetchSegmentKey = (): Promise<ODHSegmentKey> => {

--- a/frontend/src/services/storageService.ts
+++ b/frontend/src/services/storageService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 
 export const MAX_STORAGE_OBJECT_SIZE = 1e8;
 

--- a/frontend/src/services/templateService.ts
+++ b/frontend/src/services/templateService.ts
@@ -1,6 +1,6 @@
 // TODO: Delete once we refactor Admin panel to support Passthrough API
-import axios from 'axios';
 import YAML from 'yaml';
+import axios from '~/utilities/axios';
 import { assembleServingRuntimeTemplate } from '~/api';
 import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';

--- a/frontend/src/services/validateIsvService.ts
+++ b/frontend/src/services/validateIsvService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from '~/utilities/axios';
 
 export const postValidateIsv = (
   appName: string,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,8 +8,20 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { AxiosError } from 'axios';
 import { EnvironmentFromVariable } from '~/pages/projects/types';
-import { AcceleratorProfileKind, ImageStreamKind, ImageStreamSpecTagType } from './k8sTypes';
+import {
+  AcceleratorProfileKind,
+  DashboardCommonConfig,
+  ImageStreamKind,
+  ImageStreamSpecTagType,
+} from './k8sTypes';
 import { EitherNotBoth } from './typeHelpers';
+
+export type DevFeatureFlags = {
+  devFeatureFlags: Partial<DashboardCommonConfig> | null;
+  setDevFeatureFlag: (flag: keyof DashboardCommonConfig, value: boolean) => void;
+  resetDevFeatureFlags: () => void;
+  setDevFeatureFlagQueryVisible: (visible: boolean) => void;
+};
 
 export type PrometheusQueryResponse<TResultExtraProps extends object = object> = {
   data: {

--- a/frontend/src/utilities/__tests__/useDetectUser.spec.ts
+++ b/frontend/src/utilities/__tests__/useDetectUser.spec.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { act, waitFor, renderHook } from '@testing-library/react';
+import axios from '~/utilities/axios';
 import { StatusResponse } from '~/redux/types';
 import { useAppDispatch } from '~/redux/hooks';
 import useDetectUser from '~/utilities/useDetectUser';
@@ -7,7 +7,7 @@ import { getUserFulfilled, getUserPending, getUserRejected } from '~/redux/actio
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 
 // Mock Axios
-jest.mock('axios');
+jest.mock('~/utilities/axios');
 
 // Mock the useDispatch hook
 jest.mock('~/redux/hooks', () => ({

--- a/frontend/src/utilities/axios.ts
+++ b/frontend/src/utilities/axios.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
+import axios from 'axios';
+
+export default axios.create();

--- a/frontend/src/utilities/useDetectUser.ts
+++ b/frontend/src/utilities/useDetectUser.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import * as React from 'react';
+import axios from '~/utilities/axios';
 import { getUserFulfilled, getUserPending, getUserRejected } from '~/redux/actions/actions';
 import { useAppDispatch } from '~/redux/hooks';
 import { POLL_INTERVAL } from './const';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-7894

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Once feature flags are overridden in the current session a banner is displayed at the top of the page. From the banner the user can restore their session without the need for closing their browser window. They can also open a modal to more easily adjust the feature flags for the current session.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/3b909643-70c8-4f6f-986f-0c94a7d2006a)

The modal lists all available feature flags and their current state. Flags that have been overridden in the session via query string or through this model are annotated as `(overridden)`. If the current dashboard config doesn't contain a valid entry (likely only a dev issue with a mismatched frontend and backend), the checkbox will be in the partially checked state.
![image](https://github.com/opendatahub-io/odh-dashboard/assets/14068621/e15d4f2e-1ef3-49ef-899b-f9363d7e5b79)

Changes to feature flags are immediately reflected in the UI.

While the modal is open, the query string is updated for the purpose of constructing a shareable URL that can also be bookmarked for future use.

Restoring defaults will immediately remove the banner.

To enable this feature, set the query string param to `?devFeatureFlags`.
To adjust the feature flags via the query string, assign a value: `?devFeatureFlags=home,disableInfo,disableAppLauncher=false,enablement=true`
Note that the query string accepts both variants of a flag which has the `disable` prefix or not. eg. `disableHome=true` is the same as `home=false`, or `disableHome=false` is the same as `home` or `home=true`

Some backend end points such as `/api/cluster-settings` reads from the dashboard config cached on the backend. In order to get around this caching, if feature flags are overridden in the front end, a new header is sent along with all requests. See `x-odh-feature-flags`.

The new header is supplied by setting the default headers for axios. As such all usage of axios must use our new singleton instance from `~/utilities/axios`. To ensure compliance a new eslint rule is provided that errors if the node_modules axios instance is imported.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Open any page and then change the query string to be `?devFeatureFlags=...` where `...` is either empty or a feature flag of your choice. eg `home`

Play around with the banner and feature flag modal.

As an admin navigate to `Settings => Cluster settings` and inspect the network tab. Look for the `/api/cluster-settings` call and inspect the response such that the enablement matches the front end feature flag settings:
```
    "modelServingPlatformEnabled": {
        "kServe": true,
        "modelMesh": true
    }
```

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
