### PR TITLE
remove isAdmin logic for EnsureCompatiblePipelineServer empty state

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -479,7 +479,7 @@ describe('Pipelines', () => {
     });
   });
 
-  it('incompatible dpsa version shows error', () => {
+  it('incompatible dpsa version shows error with delete option for regular user', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
     cy.interceptK8sList(
@@ -496,10 +496,10 @@ describe('Pipelines', () => {
     pipelinesGlobal.visit(projectName);
     pipelinesGlobal.isApiAvailable();
     pipelinesGlobal.findIsServerIncompatible().should('exist');
-    pipelinesGlobal.findDeletePipelineServerButton().should('not.exist');
+    pipelinesGlobal.findDeletePipelineServerButton().should('exist');
   });
 
-  it('incompatible dpsa version shows error with delete option for admins', () => {
+  it('incompatible dpsa version shows error with delete option for admin', () => {
     asProductAdminUser();
     initIntercepts({});
     pipelinesGlobal.visit(projectName);

--- a/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
@@ -14,7 +14,6 @@ import {
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import ExternalLink from '~/components/ExternalLink';
 import NoPipelineServer from '~/concepts/pipelines/NoPipelineServer';
-import { useUser } from '~/redux/selectors';
 import { DeleteServerModal, usePipelinesAPI } from './context';
 
 // TODO: Fix doc link to go to more docs on v2
@@ -29,12 +28,7 @@ const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerPro
   children,
 }) => {
   const { pipelinesServer } = usePipelinesAPI();
-  const { isAdmin } = useUser();
   const [isDeleting, setIsDeleting] = React.useState(false);
-
-  const bodyText = isAdmin
-    ? "Rendering of this pipeline version in the UI is no longer supported, but it can still be accessed via the API or OpenShift Console. To remove unsupported versions, delete this project's pipeline server and create a new one."
-    : 'Rendering of this pipeline version in the UI is no longer supported. To access this pipeline, contact your administrator.';
 
   if (pipelinesServer.initializing) {
     return (
@@ -63,25 +57,28 @@ const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerPro
               }
             />
             <EmptyStateBody>
-              <p>{bodyText}</p>
+              <p>
+                Rendering of this pipeline version in the UI is no longer supported, but it can
+                still be accessed via the API or OpenShift Console. To remove unsupported versions,
+                delete this project&apos;s pipeline server and create a new one.
+              </p>
               <ExternalLink
                 text="Learn more about supported versions and data recovery"
                 to={DOCS_LINK}
               />
             </EmptyStateBody>
-            {isAdmin && (
-              <EmptyStateFooter>
-                <EmptyStateActions>
-                  <Button
-                    data-testid="delete-pipeline-server-button"
-                    variant="primary"
-                    onClick={() => setIsDeleting(true)}
-                  >
-                    Delete pipeline server
-                  </Button>
-                </EmptyStateActions>
-              </EmptyStateFooter>
-            )}
+
+            <EmptyStateFooter>
+              <EmptyStateActions>
+                <Button
+                  data-testid="delete-pipeline-server-button"
+                  variant="primary"
+                  onClick={() => setIsDeleting(true)}
+                >
+                  Delete pipeline server
+                </Button>
+              </EmptyStateActions>
+            </EmptyStateFooter>
           </EmptyState>
         </Bullseye>
         <DeleteServerModal isOpen={isDeleting} onClose={() => setIsDeleting(false)} />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-8635

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
removes the non admin state for incompatible pipeline version view

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a pipeline server and change its version to v1 (will need to manually update the DSPA yaml)
2. go to UI and go to this project with the v1 server
3. make sure you are a non odh admin user
4. should see a button to delete in the empty state error view

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated tests for admin user to expect the button

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

No UI change, just logic

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
