### PR TITLE
remove the length check for the loaded state of customize metric columns

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -381,7 +381,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({ runs, page, ...prop
       runs={runsWithMetrics}
       page={page}
       metricsNames={metricsNames}
-      artifactsLoaded={runArtifactsLoaded && !!runArtifacts.length}
+      artifactsLoaded={runArtifactsLoaded}
       artifactsError={runArtifactsError}
       {...props}
     />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-8581

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
for pages of pipeline runs that have no metrics but the experiment as a whole has saved selected metrics, the icon button does not remain disabled with the tooltip saying it is loading. instead now it allows you to customize the metric columns when on these specific pages

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a new experiment
2. create 1 run that has scalar metrics
3. create 10 more runs that dont have a scalar metric output
4. confirm there are selected runs by seeing them in the table columns
5. go to the page that does **not** have the run with the metric output
6. confirm the customize button in the toolbar is enabled

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no tests in this area because the the cypress tests for the experiment run page dont yet support mlmd mocks. this work is being done this sprint to support mlmd in cypress

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
