### PR TITLE
Rename Edit Permission to Contributor

### DIFF
--- a/frontend/src/pages/projects/projectSharing/utils.ts
+++ b/frontend/src/pages/projects/projectSharing/utils.ts
@@ -15,4 +15,4 @@ export const firstSubject = (roleBinding: RoleBindingKind): string =>
   roleBinding.subjects[0]?.name || '';
 
 export const roleLabel = (value: ProjectSharingRoleType): string =>
-  value === ProjectSharingRoleType.ADMIN ? 'Admin' : 'Edit';
+  value === ProjectSharingRoleType.ADMIN ? 'Admin' : 'Contributor';


### PR DESCRIPTION
Closes: [RHOAIENG-582](https://issues.redhat.com/browse/RHOAIENG-582)

## Description
Updates the wording to use 'Contributor' instead of 'Edit'

## How Has This Been Tested?
This has been tested using the Cypress tests in `permissions.cy.ts`

## Test Impact
No new tests were added as this is only a label change and there is no functionality change. Screenshots of that change in Cypress are included below. 
<img width="674" alt="Screenshot 2024-06-25 at 10 05 52 AM" src="https://github.com/opendatahub-io/odh-dashboard/assets/123661468/67ebb523-7acd-43f0-9cf6-1fb18780cfb3">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
