### PR TITLE
refactored k8 second pass

### DIFF
--- a/frontend/src/__mocks__/mockServiceAccountK8sResource.ts
+++ b/frontend/src/__mocks__/mockServiceAccountK8sResource.ts
@@ -1,5 +1,5 @@
 import { genUID } from '~/__mocks__/mockUtils';
-import { ServiceAccountKind } from '~/k8sTypes';
+import { K8sModelCommonMetadata, ServiceAccountKind } from '~/k8sTypes';
 
 type MockResourceConfigType = {
   name?: string;
@@ -19,3 +19,9 @@ export const mockServiceAccountK8sResource = ({
     creationTimestamp: '2023-02-14T21:43:59Z',
   },
 });
+
+export const ServiceAccountModelTest: K8sModelCommonMetadata = {
+  apiVersion: 'v1',
+  kind: 'ServiceAccount',
+  metadata: { name: 'test-name-sa', namespace: 'test-project', ownerReferences: [] },
+};

--- a/frontend/src/__mocks__/mockTrustyAIServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockTrustyAIServiceK8sResource.ts
@@ -68,3 +68,26 @@ export const mockTrustyAIServiceK8sResource = ({
     replicas: 0,
   },
 });
+
+export const TrustyAITest: TrustyAIKind = {
+  apiVersion: 'trustyai.opendatahub.io/v1alpha1',
+  kind: 'TrustyAIService',
+  metadata: {
+    name: 'trustyai-service',
+    namespace: 'test-project',
+  },
+  spec: {
+    storage: {
+      format: 'PVC',
+      folder: '/inputs',
+      size: '1Gi',
+    },
+    data: {
+      filename: 'data.csv',
+      format: 'CSV',
+    },
+    metrics: {
+      schedule: '5s',
+    },
+  },
+};

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
@@ -16,7 +16,10 @@ import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { mockPrometheusServing } from '~/__mocks__/mockPrometheusServing';
 import { mockPrometheusBias } from '~/__mocks__/mockPrometheusBias';
 import { mockMetricsRequest } from '~/__mocks__/mockMetricsRequests';
-import { mockTrustyAIServiceK8sResource } from '~/__mocks__/mockTrustyAIServiceK8sResource';
+import {
+  TrustyAITest,
+  mockTrustyAIServiceK8sResource,
+} from '~/__mocks__/mockTrustyAIServiceK8sResource';
 import { mockRouteK8sResource } from '~/__mocks__/mockRouteK8sResource';
 import { projectDetailsSettingsTab } from '~/__tests__/cypress/cypress/pages/projects';
 import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
@@ -414,28 +417,7 @@ describe('Model Metrics', () => {
     projectDetailsSettingsTab.findTrustyAIInstallCheckbox().check();
 
     cy.wait('@installTrustyAI').then((interception) => {
-      expect(interception.request.body).to.be.eql({
-        apiVersion: 'trustyai.opendatahub.io/v1alpha1',
-        kind: 'TrustyAIService',
-        metadata: {
-          name: 'trustyai-service',
-          namespace: 'test-project',
-        },
-        spec: {
-          storage: {
-            format: 'PVC',
-            folder: '/inputs',
-            size: '1Gi',
-          },
-          data: {
-            filename: 'data.csv',
-            format: 'CSV',
-          },
-          metrics: {
-            schedule: '5s',
-          },
-        },
-      });
+      expect(interception.request.body).to.be.eql(TrustyAITest);
     });
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -14,7 +14,10 @@ import {
   mockRouteK8sResourceModelServing,
 } from '~/__mocks__/mockRouteK8sResource';
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
-import { mockServiceAccountK8sResource } from '~/__mocks__/mockServiceAccountK8sResource';
+import {
+  ServiceAccountModelTest,
+  mockServiceAccountK8sResource,
+} from '~/__mocks__/mockServiceAccountK8sResource';
 import {
   mockServingRuntimeK8sResource,
   mockServingRuntimeK8sResourceLegacy,
@@ -1021,11 +1024,7 @@ describe('Serving Runtime List', () => {
       //dry run request
       cy.wait('@createServiceAccount').then((interception) => {
         expect(interception.request.url).to.include('?dryRun=All');
-        expect(interception.request.body).to.eql({
-          apiVersion: 'v1',
-          kind: 'ServiceAccount',
-          metadata: { name: 'test-name-sa', namespace: 'test-project', ownerReferences: [] },
-        });
+        expect(interception.request.body).to.eql(ServiceAccountModelTest);
       });
 
       //Actual request
@@ -1343,11 +1342,7 @@ describe('Serving Runtime List', () => {
       //dry run request
       cy.wait('@createServiceAccount').then((interception) => {
         expect(interception.request.url).to.include('?dryRun=All');
-        expect(interception.request.body).to.eql({
-          apiVersion: 'v1',
-          kind: 'ServiceAccount',
-          metadata: { name: 'test-name-sa', namespace: 'test-project', ownerReferences: [] },
-        });
+        expect(interception.request.body).to.eql(ServiceAccountModelTest);
       });
 
       // Actual request

--- a/frontend/src/api/k8s/acceleratorProfiles.ts
+++ b/frontend/src/api/k8s/acceleratorProfiles.ts
@@ -1,6 +1,7 @@
 import { k8sGetResource, k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import { AcceleratorProfileModel } from '~/api/models';
+import { TolerationEffect, TolerationOperator } from '~/types';
 
 export const listAcceleratorProfiles = async (
   namespace: string,
@@ -20,3 +21,23 @@ export const getAcceleratorProfile = (
     model: AcceleratorProfileModel,
     queryOptions: { name, ns: namespace },
   });
+
+export const fakeAcceleratorProfile: AcceleratorProfileKind = {
+  apiVersion: 'dashboard.opendatahub.io/v1',
+  kind: 'AcceleratorProfile',
+  metadata: {
+    name: 'migrated-gpu',
+  },
+  spec: {
+    identifier: 'nvidia.com/gpu',
+    displayName: 'NVIDIA GPU',
+    enabled: true,
+    tolerations: [
+      {
+        key: 'nvidia.com/gpu',
+        operator: TolerationOperator.EXISTS,
+        effect: TolerationEffect.NO_SCHEDULE,
+      },
+    ],
+  },
+};

--- a/frontend/src/api/k8sUtils.ts
+++ b/frontend/src/api/k8sUtils.ts
@@ -3,6 +3,10 @@ import {
   K8sModelCommon,
   K8sResourceCommon,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import { genUID } from '~/__mocks__/mockUtils';
+import { KnownLabels } from '~/k8sTypes';
+import { AwsKeys } from '~/pages/projects/dataConnections/const';
+import { DataConnection } from '~/pages/projects/types';
 
 export const addOwnerReference = <R extends K8sResourceCommon>(
   resource: R,
@@ -40,3 +44,35 @@ export const groupVersionKind = (model: K8sModelCommon): K8sGroupVersionKind => 
   version: model.apiVersion,
   kind: model.kind,
 });
+
+export const dataConnection: DataConnection = {
+  type: 0,
+  data: {
+    kind: 'Secret',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'test-secret',
+      namespace: 'test-project',
+      uid: genUID('secret'),
+      resourceVersion: '5985371',
+      creationTimestamp: '2023-03-22T16:18:56Z',
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        [KnownLabels.DATA_CONNECTION_AWS]: 'true',
+      },
+      annotations: {
+        'opendatahub.io/connection-type': 's3',
+        'openshift.io/display-name': 'Test Secret',
+      },
+    },
+    data: {
+      [AwsKeys.NAME]: 'test-secret',
+      AWS_ACCESS_KEY_ID: 'test',
+      AWS_DEFAULT_REGION: 'region',
+      AWS_S3_BUCKET: 'bucket',
+      AWS_S3_ENDPOINT: 'endpoint',
+      AWS_SECRET_ACCESS_KEY: 'test',
+    },
+    type: 'Opaque',
+  },
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1329,3 +1329,13 @@ export type ModelRegistryKind = K8sResourceCommon & {
     conditions?: K8sCondition[];
   };
 };
+
+export type K8sModelCommonMetadata = {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    ownerReferences: string[];
+  };
+};

--- a/frontend/src/pages/projects/screens/detail/data-connections/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/data-connections/__tests__/utils.spec.ts
@@ -1,5 +1,4 @@
-import { KnownLabels } from '~/k8sTypes';
-import { DataConnection, DataConnectionType } from '~/pages/projects/types';
+import { DataConnectionType } from '~/pages/projects/types';
 import {
   convertAWSSecretData,
   deleteDataConnection,
@@ -12,49 +11,15 @@ import {
   isSecretAWSSecretKind,
 } from '~/pages/projects/screens/detail/data-connections/utils';
 import { AwsKeys } from '~/pages/projects/dataConnections/const';
-import { deleteSecret } from '~/api';
 import { mockSecretK8sResource } from '~/__mocks__/mockSecretK8sResource';
-
-import { genUID } from '~/__mocks__/mockUtils';
 import { mock200Status, mock404Error } from '~/__mocks__/mockK8sStatus';
+import { dataConnection, deleteSecret } from '~/api';
 
 jest.mock('~/api', () => ({
   deleteSecret: jest.fn(),
 }));
 
 const deletesecretMock = jest.mocked(deleteSecret);
-
-const dataConnection: DataConnection = {
-  type: 0,
-  data: {
-    kind: 'Secret',
-    apiVersion: 'v1',
-    metadata: {
-      name: 'test-secret',
-      namespace: 'test-project',
-      uid: genUID('secret'),
-      resourceVersion: '5985371',
-      creationTimestamp: '2023-03-22T16:18:56Z',
-      labels: {
-        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
-        [KnownLabels.DATA_CONNECTION_AWS]: 'true',
-      },
-      annotations: {
-        'opendatahub.io/connection-type': 's3',
-        'openshift.io/display-name': 'Test Secret',
-      },
-    },
-    data: {
-      [AwsKeys.NAME]: 'test-secret',
-      AWS_ACCESS_KEY_ID: 'test',
-      AWS_DEFAULT_REGION: 'region',
-      AWS_S3_BUCKET: 'bucket',
-      AWS_S3_ENDPOINT: 'endpoint',
-      AWS_SECRET_ACCESS_KEY: 'test',
-    },
-    type: 'Opaque',
-  },
-};
 
 const createDataConnection = (type: DataConnectionType) => ({
   ...dataConnection,

--- a/frontend/src/utilities/__tests__/addTypesToK8sListedResources.spec.ts
+++ b/frontend/src/utilities/__tests__/addTypesToK8sListedResources.spec.ts
@@ -1,27 +1,6 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { servingRuntimeTemplate } from '~/__mocks__/mockServingRuntimeK8sResource';
 import { addTypesToK8sListedResources } from '~/utilities/addTypesToK8sListedResources';
-
-const servingRuntimeTemplate = {
-  apiVersion: 'template.openshift.io/v1',
-  kind: 'TemplateList',
-  items: [
-    {
-      metadata: {
-        name: 'test-model',
-        annotations: {
-          'openshift.io/display-name': 'New OVMS Server',
-        },
-        labels: {
-          'opendatahub.io/dashboard': 'true',
-        },
-      },
-    },
-  ],
-  metadata: {
-    resourceVersion: '24348645',
-    continue: '',
-  },
-};
 
 describe('addTypesToK8sListedResources', () => {
   it('should have apiVersion and kind as Template', () => {

--- a/frontend/src/utilities/useAcceleratorProfileState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileState.ts
@@ -1,14 +1,9 @@
 import React from 'react';
+import { fakeAcceleratorProfile } from '~/api';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import useAcceleratorProfiles from '~/pages/notebookController/screens/server/useAcceleratorProfiles';
 import { useDashboardNamespace } from '~/redux/selectors';
-import {
-  ContainerResourceAttributes,
-  ContainerResources,
-  Toleration,
-  TolerationEffect,
-  TolerationOperator,
-} from '~/types';
+import { ContainerResourceAttributes, ContainerResources, Toleration } from '~/types';
 import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
 import { getAcceleratorProfileCount, isEnumMember } from '~/utilities/utils';
 
@@ -96,27 +91,6 @@ const useAcceleratorProfileState = (
                 setData('additionalOptions', { useDisabled: acceleratorProfile });
               }
             } else {
-              // create a fake accelerator to use
-              const fakeAcceleratorProfile: AcceleratorProfileKind = {
-                apiVersion: 'dashboard.opendatahub.io/v1',
-                kind: 'AcceleratorProfile',
-                metadata: {
-                  name: 'migrated-gpu',
-                },
-                spec: {
-                  identifier: 'nvidia.com/gpu',
-                  displayName: 'NVIDIA GPU',
-                  enabled: true,
-                  tolerations: [
-                    {
-                      key: 'nvidia.com/gpu',
-                      operator: TolerationOperator.EXISTS,
-                      effect: TolerationEffect.NO_SCHEDULE,
-                    },
-                  ],
-                },
-              };
-
               setData('acceleratorProfile', fakeAcceleratorProfile);
               setData('acceleratorProfiles', [fakeAcceleratorProfile, ...acceleratorProfiles]);
               setData('initialAcceleratorProfile', fakeAcceleratorProfile);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-2733](https://issues.redhat.com/browse/RHOAIENG-2733)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Refactored k8 resources.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npm run test`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Only refactored, no need for tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
