### PR TITLE
[RHOAIENG-8583] Remove the disabled 'Create schedule' button when in an archived experiment

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
@@ -325,10 +325,10 @@ describe('Runs page for archived experiment', () => {
     pipelineRunsGlobal.findRestoreRunButton().should('have.class', 'pf-m-aria-disabled');
   });
 
-  it('has create schedule button disabled on schedules tab', () => {
+  it('has no create schedule button on schedules tab', () => {
     pipelineRunsGlobal.findSchedulesTab().click();
     pipelineRunJobTable.getRowByName('Test job').findCheckbox().click();
-    pipelineRunsGlobal.findScheduleRunButton().should('have.class', 'pf-m-aria-disabled');
+    pipelineRunsGlobal.findScheduleRunButton().should('not.exist');
   });
 });
 

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableToolbar.tsx
@@ -6,6 +6,7 @@ import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFi
 import PipelineVersionSelect from '~/concepts/pipelines/content/pipelineSelector/CustomPipelineVersionSelect';
 import { PipelineRunVersionsContext } from '~/pages/pipelines/global/runs/PipelineRunVersionsContext';
 import CreateScheduleButton from '~/pages/pipelines/global/runs/CreateScheduleButton';
+import { useContextExperimentArchived as useIsExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 export type FilterProps = Pick<
   React.ComponentProps<typeof PipelineFilterBar>,
@@ -21,6 +22,7 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
   ...toolbarProps
 }) => {
   const { versions } = React.useContext(PipelineRunVersionsContext);
+  const isExperimentArchived = useIsExperimentArchived();
   const { pipelineVersionId } = useParams();
 
   const options = {
@@ -53,9 +55,12 @@ const PipelineRunJobTableToolbar: React.FC<PipelineRunJobTableToolbarProps> = ({
         ),
       }}
     >
-      <ToolbarItem>
-        <CreateScheduleButton />
-      </ToolbarItem>
+      {!isExperimentArchived && (
+        <ToolbarItem>
+          <CreateScheduleButton />
+        </ToolbarItem>
+      )}
+
       <ToolbarItem data-testid="job-table-toolbar-item">{dropdownActions}</ToolbarItem>
     </PipelineFilterBar>
   );

--- a/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ScheduledRuns.tsx
@@ -16,12 +16,13 @@ import { ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import PipelineRunJobTable from '~/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTable';
 import { usePipelineScheduledRunsTable } from '~/concepts/pipelines/content/tables/pipelineRunJob/usePipelineRunJobTable';
 import CreateScheduleButton from '~/pages/pipelines/global/runs/CreateScheduleButton';
+import { useContextExperimentArchived as useIsExperimentArchived } from '~/pages/pipelines/global/experiments/ExperimentRunsContext';
 
 const ScheduledRuns: React.FC = () => {
   const { experimentId, pipelineVersionId } = useParams();
-
   const [[{ items: jobs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
     usePipelineScheduledRunsTable({ experimentId, pipelineVersionId });
+  const isExperimentArchived = useIsExperimentArchived();
 
   if (error) {
     return (
@@ -56,15 +57,17 @@ const ScheduledRuns: React.FC = () => {
         />
 
         <EmptyStateBody>
-          Schedules dictate when and how many times a run is executed. To get started, create a
-          schedule.
+          Schedules dictate when and how many times a run is executed.{' '}
+          {!isExperimentArchived && 'To get started, create a schedule.'}
         </EmptyStateBody>
 
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            <CreateScheduleButton />
-          </EmptyStateActions>
-        </EmptyStateFooter>
+        {!isExperimentArchived && (
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <CreateScheduleButton />
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        )}
       </EmptyState>
     );
   }


### PR DESCRIPTION
Closes: [RHOAIENG-8583](https://issues.redhat.com/browse/RHOAIENG-8583)

## Description
Removed 2 "Create schedule" buttons when the experiment is archived

**Archived experiment schedules list with data:**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/0f2f78f2-e114-4698-9185-d16013137158">

**Archived experiment schedules list empty state:**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/9eb7416d-8980-4c4a-b5af-211844c593a6">

## How Has This Been Tested?
Manually tested

## Test impact
Updated cypress test verifying the create button is not present in the schedule list table's toolbar.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
