### PR TITLE
[RHOAIENG-8566] Duplicate run is not useful when its pipeline is disabled

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
@@ -24,6 +24,8 @@ import {
   bulkRestoreRunModal,
   archiveRunModal,
   bulkArchiveRunModal,
+  cloneRunPage,
+  cloneSchedulePage,
 } from '~/__tests__/cypress/cypress/pages/pipelines';
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 import { be } from '~/__tests__/cypress/cypress/utils/should';
@@ -280,14 +282,15 @@ describe('Pipeline runs', () => {
     describe('with data', () => {
       beforeEach(() => {
         activeRunsTable.mockGetActiveRuns(mockActiveRuns, projectName);
-        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
       });
 
       it('renders the page with table data', () => {
+        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
         activeRunsTable.getRowByName('Test active run 1').find().should('exist');
       });
 
       it('archive a single run', () => {
+        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
         const [runToArchive] = mockActiveRuns;
 
         activeRunsTable.mockArchiveRun(runToArchive.run_id, projectName);
@@ -303,6 +306,7 @@ describe('Pipeline runs', () => {
       });
 
       it('archive multiple runs', () => {
+        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
         mockActiveRuns.forEach((activeRun) => {
           activeRunsTable.mockArchiveRun(activeRun.run_id, projectName);
           activeRunsTable.getRowByName(activeRun.display_name).findCheckbox().click();
@@ -322,19 +326,28 @@ describe('Pipeline runs', () => {
 
       describe('Navigation', () => {
         it('navigate to create run page', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
           pipelineRunsGlobal.findCreateRunButton().click();
           verifyRelativeURL(`/pipelines/${projectName}/pipelineRun/create`);
         });
+
         it('navigate to clone run page', () => {
+          cloneRunPage.mockGetExperiments(projectName, mockExperiments);
+          cloneRunPage.mockGetExperiment(projectName, mockExperiments[0]);
+          cy.visitWithLogin(`/experiments/${projectName}/test-experiment-1/runs`);
+
           activeRunsTable
             .getRowByName(mockActiveRuns[0].display_name)
             .findKebabAction('Duplicate')
             .click();
+
           verifyRelativeURL(
-            `/pipelines/${projectName}/pipelineRun/clone/${mockActiveRuns[0].run_id}`,
+            `/experiments/${projectName}/test-experiment-1/runs/clone/${mockActiveRuns[0].run_id}`,
           );
         });
+
         it('navigate between tabs', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
           pipelineRunsGlobal.findArchivedRunsTab().click();
           verifyRelativeURL(
             `/pipelines/${projectName}/pipeline/runs/${pipelineId}/${pipelineVersionId}?runType=archived`,
@@ -348,7 +361,9 @@ describe('Pipeline runs', () => {
             `/pipelines/${projectName}/pipeline/runs/${pipelineId}/${pipelineVersionId}?runType=scheduled`,
           );
         });
+
         it('navigate to run details page', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
           activeRunsTable
             .getRowByName(mockActiveRuns[0].display_name)
             .findColumnName(mockActiveRuns[0].display_name)
@@ -362,6 +377,8 @@ describe('Pipeline runs', () => {
 
       describe('Table filter', () => {
         it('filter by name', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
+
           // Verify initial run rows exist
           activeRunsTable.findRows().should('have.length', 3);
 
@@ -386,6 +403,8 @@ describe('Pipeline runs', () => {
         });
 
         it('filter by experiment', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
+
           // Mock initial list of experiments
           pipelineRunFilterBar.mockExperiments(mockExperiments, projectName);
 
@@ -417,6 +436,8 @@ describe('Pipeline runs', () => {
         });
 
         it('filter by started', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
+
           // Verify initial run rows exist
           activeRunsTable.findRows().should('have.length', 3);
 
@@ -460,6 +481,8 @@ describe('Pipeline runs', () => {
         });
 
         it('filter by status', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
+
           // Verify initial run rows exist
           activeRunsTable.findRows().should('have.length', 3);
 
@@ -521,6 +544,8 @@ describe('Pipeline runs', () => {
         });
 
         it('Sort by Name', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'active');
+
           pipelineRunFilterBar.findSortButtonForActive('Run').click();
           pipelineRunFilterBar.findSortButtonForActive('Run').should(be.sortAscending);
           pipelineRunFilterBar.findSortButtonForActive('Run').click();
@@ -919,10 +944,10 @@ describe('Pipeline runs', () => {
     describe('with data', () => {
       beforeEach(() => {
         pipelineRunJobTable.mockGetJobs(mockJobs, projectName);
-        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
       });
 
       it('renders the page with table rows', () => {
+        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
         pipelineRunJobTable.find().should('exist');
         pipelineRunJobTable.getRowByName('test-pipeline').find().should('exist');
         pipelineRunJobTable.getRowByName('other-pipeline').find().should('exist');
@@ -930,6 +955,7 @@ describe('Pipeline runs', () => {
       });
 
       it('can disable a job', () => {
+        pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
         pipelineRunJobTable.mockDisableJob(mockJobs[0], projectName).as('disableJob');
         pipelineRunJobTable
           .getRowByName(mockJobs[0].display_name)
@@ -940,19 +966,30 @@ describe('Pipeline runs', () => {
 
       describe('Navigation', () => {
         it('navigate to create scheduled run page', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
           pipelineRunsGlobal.findScheduleRunButton().click();
           verifyRelativeURL(`/pipelines/${projectName}/pipelineRun/create?runType=scheduled`);
         });
+
         it('navigate to clone scheduled run page', () => {
+          cloneSchedulePage.mockGetExperiments(projectName, mockExperiments);
+          cloneSchedulePage.mockGetExperiment(projectName, mockExperiments[0]);
+          cy.visitWithLogin(`/experiments/${projectName}/test-experiment-1/runs`);
+
+          pipelineRunsGlobal.findSchedulesTab().click();
           pipelineRunJobTable
             .getRowByName(mockJobs[0].display_name)
             .findKebabAction('Duplicate')
             .click();
+
           verifyRelativeURL(
-            `/pipelines/${projectName}/pipelineRun/cloneJob/${mockJobs[0].recurring_run_id}?runType=scheduled`,
+            `/experiments/${projectName}/test-experiment-1/schedules/clone/${mockJobs[0].recurring_run_id}?runType=scheduled`,
           );
         });
+
         it('navigate to scheduled run details page', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
+          pipelineRunsGlobal.findSchedulesTab().click();
           pipelineRunJobTable
             .getRowByName(mockJobs[0].display_name)
             .findColumnName(mockJobs[0].display_name)
@@ -965,6 +1002,9 @@ describe('Pipeline runs', () => {
 
       describe('Table filter', () => {
         it('filter by name', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
+          pipelineRunsGlobal.findSchedulesTab().click();
+
           // Verify initial job rows exist
           pipelineRunJobTable.findRows().should('have.length', 3);
 
@@ -984,6 +1024,9 @@ describe('Pipeline runs', () => {
         });
 
         it('Sort by Name', () => {
+          pipelineRunsGlobal.visit(projectName, pipelineId, pipelineVersionId, 'scheduled');
+          pipelineRunsGlobal.findSchedulesTab().click();
+
           pipelineRunFilterBar.findSortButtonforSchedules('Schedule').click();
           pipelineRunFilterBar.findSortButtonforSchedules('Schedule').should(be.sortAscending);
           pipelineRunFilterBar.findSortButtonforSchedules('Schedule').click();

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -75,7 +75,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
             },
           }),
         },
-        cloneAction,
+        ...(version ? [cloneAction] : []),
         {
           isSeparator: true,
         },
@@ -99,7 +99,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
             .catch((e) => notification.error('Unable to stop the pipeline run.', e.message));
         },
       },
-      cloneAction,
+      ...(version ? [cloneAction] : []),
       {
         isSeparator: true,
       },
@@ -112,15 +112,16 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
     runType,
     run.state,
     run.run_id,
-    navigate,
-    isExperimentsAvailable,
-    experimentId,
-    namespace,
+    version,
+    isExperimentArchived,
     onDelete,
     api,
     refreshAllAPI,
     notification,
-    isExperimentArchived,
+    navigate,
+    namespace,
+    isExperimentsAvailable,
+    experimentId,
   ]);
 
   return (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRunJob/PipelineRunJobTableRow.tsx
@@ -86,22 +86,26 @@ const PipelineRunJobTableRow: React.FC<PipelineRunJobTableRowProps> = ({
       <Td isActionCell dataLabel="Kebab">
         <ActionsColumn
           items={[
-            {
-              title: 'Duplicate',
-              onClick: () => {
-                navigate({
-                  pathname: cloneScheduleRoute(
-                    namespace,
-                    job.recurring_run_id,
-                    isExperimentsAvailable ? experimentId : undefined,
-                  ),
-                  search: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.SCHEDULED}`,
-                });
-              },
-            },
-            {
-              isSeparator: true,
-            },
+            ...(version
+              ? [
+                  {
+                    title: 'Duplicate',
+                    onClick: () => {
+                      navigate({
+                        pathname: cloneScheduleRoute(
+                          namespace,
+                          job.recurring_run_id,
+                          isExperimentsAvailable ? experimentId : undefined,
+                        ),
+                        search: `?${PipelineRunSearchParam.RunType}=${PipelineRunType.SCHEDULED}`,
+                      });
+                    },
+                  },
+                  {
+                    isSeparator: true,
+                  },
+                ]
+              : []),
             {
               title: 'Delete',
               onClick: () => {


### PR DESCRIPTION
Closes: [RHOAIENG-8566](https://issues.redhat.com/browse/RHOAIENG-8566)

## Description
Hiding run/schedule "Duplicate" actions when the associated pipeline version is not found.

**Active run with a deleted pipeline version:**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/84843477-3d10-4068-bc14-33536b5ec79d">

**Active run with a pipeline version:**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/231909f3-b4a3-488f-9e4f-b3bee2a20f6a">

**Schedule with a deleted pipeline version:**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/dc311d48-0f5c-4b4c-85be-baba5d16b4f3">

**Schedule with a pipeline version:**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/b3368d1e-673c-47a1-ac7e-98fa7fcb7b8b">

## How Has This Been Tested?
Manually tested

## Test impact
Updated duplicate action related cypress tests to point to the experiment runs page vs the legacy runs page. The rest will eventually need updating as well, but that will require many more line changes and was out of scope.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
