### PR TITLE
[RHOAIENG-7794]: Use different colors for the ROC curve legend

### DIFF
--- a/frontend/src/concepts/pipelines/content/artifacts/charts/ROCCurve.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/charts/ROCCurve.tsx
@@ -7,17 +7,17 @@ import {
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import {
-  chart_color_blue_100 as chartColorBlue100,
-  chart_color_blue_200 as chartColorBlue200,
-  chart_color_blue_300 as chartColorBlue300,
-  chart_color_blue_400 as chartColorBlue400,
-  chart_color_blue_500 as chartColorBlue500,
-  chart_color_cyan_100 as chartColorCyan100,
-  chart_color_cyan_200 as chartColorCyan200,
-  chart_color_cyan_300 as chartColorCyan300,
-  chart_color_cyan_400 as chartColorCyan400,
-  chart_color_cyan_500 as chartColorCyan500,
   chart_color_black_100 as chartColorBlack100,
+  chart_theme_multi_color_ordered_ColorScale_100 as chartThemeMultiColorOrderedColorScale100,
+  chart_theme_multi_color_ordered_ColorScale_200 as chartThemeMultiColorOrderedColorScale200,
+  chart_theme_multi_color_ordered_ColorScale_300 as chartThemeMultiColorOrderedColorScale300,
+  chart_theme_multi_color_ordered_ColorScale_400 as chartThemeMultiColorOrderedColorScale400,
+  chart_theme_multi_color_ordered_ColorScale_500 as chartThemeMultiColorOrderedColorScale500,
+  chart_theme_multi_color_ordered_ColorScale_600 as chartThemeMultiColorOrderedColorScale600,
+  chart_theme_multi_color_ordered_ColorScale_700 as chartThemeMultiColorOrderedColorScale700,
+  chart_theme_multi_color_ordered_ColorScale_800 as chartThemeMultiColorOrderedColorScale800,
+  chart_theme_multi_color_ordered_ColorScale_900 as chartThemeMultiColorOrderedColorScale900,
+  chart_theme_multi_color_ordered_ColorScale_1000 as chartThemeMultiColorOrderedColorScale1000,
 } from '@patternfly/react-tokens';
 
 export type ROCCurveConfig = {
@@ -31,16 +31,16 @@ export type ROCCurveConfig = {
 };
 
 export const RocCurveChartColorScale = [
-  chartColorBlue100.value,
-  chartColorBlue200.value,
-  chartColorBlue300.value,
-  chartColorBlue400.value,
-  chartColorBlue500.value,
-  chartColorCyan100.value,
-  chartColorCyan200.value,
-  chartColorCyan300.value,
-  chartColorCyan400.value,
-  chartColorCyan500.value,
+  chartThemeMultiColorOrderedColorScale100.value,
+  chartThemeMultiColorOrderedColorScale200.value,
+  chartThemeMultiColorOrderedColorScale300.value,
+  chartThemeMultiColorOrderedColorScale400.value,
+  chartThemeMultiColorOrderedColorScale500.value,
+  chartThemeMultiColorOrderedColorScale600.value,
+  chartThemeMultiColorOrderedColorScale700.value,
+  chartThemeMultiColorOrderedColorScale800.value,
+  chartThemeMultiColorOrderedColorScale900.value,
+  chartThemeMultiColorOrderedColorScale1000.value,
 ];
 
 type ROCCurveProps = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
https://issues.redhat.com/browse/RHOAIENG-7794
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Previously in pipelines compare runs we would compare many ROC curves in one graph by using different shades of blue, but per the PF recommendation we should instead be[ corresponding each run with one of the available base colors](https://www.patternfly.org/charts/colors-for-charts/#use-cases).

Before
<img width="350" alt="Screenshot 2024-06-26 at 2 07 56 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/cb091b62-c686-46e7-969d-39bd203b34e8">
<img width="250" alt="Screenshot 2024-06-26 at 2 08 01 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/54d6eb6a-5b4d-4f9c-b148-5fc3856168b6">

After
<img width="350" alt="Screenshot 2024-06-26 at 1 41 29 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/a24cfd3a-ee58-40ad-968e-8f4f420acd0c">
<img width="250" alt="Screenshot 2024-06-26 at 1 41 35 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/d160d918-a5ec-4501-8341-5c3eab79e439">
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Compare runs that have all metrics. Use the following pipeline
[Pipeline metrics-visualization-pipeline.yaml.zip](https://github.com/opendatahub-io/odh-dashboard/files/15268325/Pipeline.metrics-visualization-pipeline.yaml.zip)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, color change only

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
