### PR TITLE
Create NPM Cache directories for CI and run `npm ci` in Dockerfile build

### DIFF
--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -3,11 +3,11 @@ FROM quay.io/fedora/fedora:40
 ARG USER=cypress
 ARG USER_HOME=/home/$USER
 ARG NPM_CACHE=/opt/app-root/src/.npm-global
-ARG CYPRESS_CACHE=/home/jenkins/.cypress-cache
+ARG CYPRESS_CACHE=$USER_HOME/.cypress-cache
 ARG CHROME=https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 ARG OCP_CLI=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
 ARG NVM_INSTALLER=https://raw.githubusercontent.com/creationix/nvm/v0.39.7/install.sh
-ARG NODE_VERSION=v20.10.0
+ARG NODE_VERSION=v20.15.0
 
 USER root
 
@@ -16,9 +16,16 @@ RUN mkdir -p "$USER_HOME"
 RUN useradd -m -g root "$USER" -d "$USER_HOME" --uid 1000
 RUN chgrp -R 0 "$USER_HOME"
 RUN chmod -R g=u "$USER_HOME"
-RUN mkdir -p $NPM_CACHE
+
+# Create global NPM cache directory
+RUN mkdir -p "$NPM_CACHE"
 RUN chgrp -R 0 "$NPM_CACHE"
-RUN chmod -R 777 $NPM_CACHE
+RUN chmod -R 777 "$NPM_CACHE"
+
+# Create local Cypress cache directory
+RUN mkdir -p "$CYPRESS_CACHE"
+RUN chgrp -R 0 "$CYPRESS_CACHE"
+RUN chmod -R 777 "$CYPRESS_CACHE"
 
 # Install tools including Xvfb and Chrome
 RUN dnf update -y
@@ -41,7 +48,7 @@ RUN rm -rf /var/cache/yum
 # Set capability to adjust OOM score for Node
 RUN echo CAP_SYS_NICE >> /etc/security/limits.conf
 
-# Copy NodeJS package.json from "frontend" directory 
+# Copy NodeJS packages lists (json files) from "frontend" directory 
 WORKDIR $USER_HOME
 COPY ./frontend/package*.json ./
 RUN chown $USER:0 ./*
@@ -55,7 +62,7 @@ ENV NODE_PATH "$NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules"
 ENV PATH "$NVM_DIR/versions/node/$NODE_VERSION/bin:/bin:$HOME/.local/bin:/root/.local/bin:$PATH"
 RUN mkdir -p $NVM_DIR
 
-# Install Node Version Manager, Node Package Manager, and the "frontend" packages
+# Install Node Version Manager, NodeJS and the packages for CI (package-lock.json) 
 RUN curl -o- $NVM_INSTALLER | bash
 RUN /bin/bash -c "source $NVM_DIR/nvm.sh && \
     nvm install $NODE_VERSION && \
@@ -63,8 +70,8 @@ RUN /bin/bash -c "source $NVM_DIR/nvm.sh && \
     npm config set prefix '$NPM_CACHE' && \
     echo 'export PATH=$PATH' >> '$USER_HOME/.profile' && \
     source $USER_HOME/.profile && \
-    npm install -g npm@latest && \
-    npm cache -g clean --force"
+    npm cache -g clean --force && \
+    npm ci --cache=$NPM_CACHE"
 
 # Export NPM and Cypress Cache directories (to be accesible by rootless user)
 ENV NPM_CONFIG_CACHE $NPM_CACHE


### PR DESCRIPTION
## Description
This reduces the cypress job duration in the CI (Jenkins) container runtime, by using preexisting npm packages that were installed during `scripts/ci/Dockerfile` build.
In addition updated to the latest minor release of NPM 20 (v20.15.0).

## How Has This Been Tested?
Running the CI Job that uses an image built from this Dockerfile, takes ~10 minutes instead of ~16 previously:
![image](https://github.com/opendatahub-io/odh-dashboard/assets/9913945/ca39e630-2054-459c-842c-cc6385904b5d)

In the job output we can see that the `npm ci` command did not pull new packages, since all required Node packages were already available:
```
14:03:50  + git clone -b main --single-branch https://github.com/opendatahub-io/odh-dashboard odh-dashboard
14:03:50  Cloning into 'odh-dashboard'...
[Pipeline] dir
14:03:56  Running in /home/jenkins/workspace/cypress/cypress-tests/odh-dashboard
[Pipeline] {
[Pipeline] echo
14:03:56  Installing NodeJS dependencies (package-lock.json) for Cypress 'frontend' tests
[Pipeline] sh
14:03:58  + whoami
14:03:58  cypress
[Pipeline] sh
14:04:01  + npm --verbose --prefix frontend ci
14:04:01  npm verbose cli /home/cypress/nvm/versions/node/v20.15.0/bin/node /home/cypress/nvm/versions/node/v20.15.0/bin/npm
14:04:01  npm info using npm@10.7.0
14:04:01  npm info using node@v20.15.0
14:04:01  npm verbose title npm ci
14:04:01  npm verbose argv "--loglevel" "verbose" "--prefix" "frontend" "ci"
14:04:01  npm verbose logfile logs-max:10 dir:/opt/app-root/src/.npm-global/_logs/2024-06-27T11_04_01_288Z-
14:04:01  npm verbose logfile /opt/app-root/src/.npm-global/_logs/2024-06-27T11_04_01_288Z-debug-0.log
...
14:05:56  npm info run cypress@13.10.0 postinstall { code: 0, signal: null }
14:05:56  added 1954 packages, and audited 1955 packages in 2m
14:05:56  found 0 vulnerabilities
14:05:56  npm verbose exit 0
14:05:56  npm info ok
```

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
