### PR TITLE
set experimentalMemoryManagement=true for cypress

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -27,6 +27,7 @@ import { setup as setupWebsockets } from '~/__tests__/cypress/cypress/support/we
 const resultsDir = `results/${process.env.MOCK ? 'mocked' : 'e2e'}`;
 
 export default defineConfig({
+  experimentalMemoryManagement: true,
   // Use relative path as a workaround to https://github.com/cypress-io/cypress/issues/6406
   reporter: '../../../node_modules/cypress-multi-reporters',
   reporterOptions: {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
cc @manosnoam 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Set `experimentalMemoryManagement=true` to enable support for improved memory management within Chromium-based browsers.
https://docs.cypress.io/guides/references/experiments#Configuration

> This feature helps prevent out-of-memory errors and improves test stability and performance by:
>  - Actively managing memory usage
>  - Clearing caches and performing garbage collection more aggressively

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test:cypress-ci`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
