### PR TITLE
[RHOAIENG-7752] Add disable pipeline schedule in the job detail page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -1,5 +1,6 @@
 import { Contextual } from '~/__tests__/cypress/cypress/pages/components/Contextual';
 import { DashboardCodeEditor } from '~/__tests__/cypress/cypress/pages/components/DashboardCodeEditor';
+import type { PipelineRecurringRunKFv2 } from '~/concepts/pipelines/kfTypes';
 
 class TaskDrawer extends Contextual<HTMLElement> {
   findInputArtifacts() {
@@ -193,6 +194,36 @@ class PipelineRecurringRunDetails extends RunDetails {
 
   selectActionDropdownItem(label: string) {
     this.findActionsDropdown().click().findByRole('menuitem', { name: label }).click();
+  }
+
+  mockEnableRecurringRun(recurringRun: PipelineRecurringRunKFv2, namespace: string) {
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId:mode',
+      {
+        path: {
+          namespace,
+          serviceName: 'dspa',
+          recurringRunId: recurringRun.recurring_run_id,
+          mode: ':enable',
+        },
+      },
+      { data: {} },
+    );
+  }
+
+  mockDisableRecurringRun(recurringRun: PipelineRecurringRunKFv2, namespace: string) {
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId:mode',
+      {
+        path: {
+          namespace,
+          serviceName: 'dspa',
+          recurringRunId: recurringRun.recurring_run_id,
+          mode: ':disable',
+        },
+      },
+      { data: {} },
+    );
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -401,6 +401,18 @@ declare global {
           response: OdhResponse<GoogleRpcStatusKF>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId:mode`,
+          options: {
+            path: {
+              namespace: string;
+              serviceName: string;
+              recurringRunId: string;
+              mode: string;
+            };
+          },
+          response: OdhResponse<{ data: object }>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/recurringruns/:recurringRunId`,
           options: { path: { namespace: string; serviceName: string; recurringRunId: string } },
           response: OdhResponse<PipelineRecurringRunKFv2>,

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -17,7 +17,7 @@ import {
   PipelineRunKFv2,
   runtimeStateLabels,
   PipelineRecurringRunKFv2,
-  RecurringRunMode,
+  RecurringRunStatus as RecurringRunStatusType,
 } from '~/concepts/pipelines/kfTypes';
 import {
   getRunDuration,
@@ -136,7 +136,7 @@ export const RecurringRunStatus: RecurringRunUtil<{
   const [isChangingFlag, setIsChangingFlag] = React.useState(false);
   const isExperimentArchived = useContextExperimentArchived();
 
-  const isEnabled = recurringRun.mode === RecurringRunMode.ENABLE;
+  const isEnabled = recurringRun.status === RecurringRunStatusType.ENABLED;
   React.useEffect(() => {
     // When the network updates, if we are currently locked fetching, disable it so we can accept the change
     setIsChangingFlag((v) => (v ? false : v));

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -126,8 +126,8 @@ export enum RecurringRunMode {
 
 export enum RecurringRunStatus {
   STATUS_UNSPECIFIED = 'STATUS_UNSPECIFIED',
-  ENABLED = 'ENABLE',
-  DISABLED = 'DISABLE',
+  ENABLED = 'ENABLED',
+  DISABLED = 'DISABLED',
 }
 
 export enum StorageStateKF {


### PR DESCRIPTION
Closes: [RHOAIENG-7752](https://issues.redhat.com/browse/RHOAIENG-7752)

## Description
Added ability to Enable or Disable the status of schedules from their respective schedule details pages via the top right actions dropdown.

**Enable**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/71fbdd3d-e650-414c-84a6-6ebd43d2f8e0">
<img width="1423" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/9dc3ac63-191f-4ba4-8413-f2a7f8b5394a">

**Disable**
<img width="1436" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/ace2f014-6d91-4da8-81c8-792c76d2baf0">
<img width="1423" alt="image" src="https://github.com/opendatahub-io/odh-dashboard/assets/96431149/39b26a20-84ab-426a-b05d-274166e0b6a4">
(cc @yannnz)

## How Has This Been Tested?
Manual and cypress tests

## Test Impact
Added cypress tests for enabling and disabling from the schedule details page

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
