### PR TITLE
[RHOAIENG-8502]: Change pipeline URI truncate to middle instead of end

### DIFF
--- a/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-  Button,
-  Flex,
-  FlexItem,
-  Icon,
-  Popover,
-  Split,
-  SplitItem,
-  Truncate,
-} from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Icon, Popover, Truncate } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
@@ -78,18 +69,15 @@ export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri, type }) =
         <Button
           variant="link"
           isInline
+          icon={<ExternalLinkAltIcon />}
+          iconPosition="end"
+          // TODO: remove this style override after upgrading to PFv6
+          style={{ display: 'inline-flex' }}
           onClick={() => {
             window.open(url);
           }}
         >
-          <Split>
-            <SplitItem>
-              <Truncate content={uri} />
-            </SplitItem>
-            <SplitItem>
-              <ExternalLinkAltIcon />
-            </SplitItem>
-          </Split>
+          <Truncate content={uri} position="middle" trailingNumChars={30} />
         </Button>
       </FlexItem>
     </Flex>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

https://issues.redhat.com/browse/RHOAIENG-8502
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

### Before
<img width="717" alt="Screenshot 2024-06-28 at 2 37 56 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/98788c80-b82b-4fa2-8d2f-28fc97a15703">

<img width="500" alt="Screenshot 2024-06-28 at 3 42 45 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/c765281c-b352-4b9c-a9e9-093530697ca6">
<img width="717" alt="Screenshot 2024-06-28 at 3 43 54 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/3d40b0e0-9f6f-4fb8-9cc7-5198e7b28505">
<img width="717" alt="Screenshot 2024-06-28 at 3 44 30 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/9107996a-174c-4cc8-97fc-858e1d9b99d7">



### After
<img width="700" alt="Screenshot 2024-07-01 at 1 23 25 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/3d7c37f1-c96e-4f81-81ac-8141e9fccf83">
<img width="700" alt="Screenshot 2024-07-01 at 1 59 50 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/18da266c-af63-4c29-9d71-6c353974e8f0">
<img width="700" alt="Screenshot 2024-07-01 at 1 53 08 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/06bab844-c59e-45e0-8693-506693e0e18f">

<img width="700" alt="Screenshot 2024-07-01 at 1 25 16 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/32821331/4d7da6b3-2d07-4c7b-b830-cbe56f6ac2cb">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Navigate to the Artifacts page from the left nav. Using a project with multiple artifacts, verify that any truncated artifact URI  truncates in the middle. 

To test URIs within artifact node details, navigate to artifact node details in runs for the following pipelines:
[Pipeline.metrics-visualization-pipeline.yaml.zip](https://github.com/user-attachments/files/16057492/Pipeline.metrics-visualization-pipeline.yaml.zip)
[Pipeline iris-training-pipeline.yaml.zip](https://github.com/user-attachments/files/16057516/Pipeline.iris-training-pipeline.2.1.yaml.zip)


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
