### PR TITLE
Fix started notebooks disappear issue

### DIFF
--- a/backend/src/routes/api/status/adminAllowedUsers.ts
+++ b/backend/src/routes/api/status/adminAllowedUsers.ts
@@ -45,7 +45,8 @@ const getUserActivityFromNotebook = async (
     .map<[string | undefined, string | undefined]>((notebook) => [
       notebook.metadata.annotations?.['opendatahub.io/username'],
       notebook.metadata.annotations?.['notebooks.kubeflow.org/last-activity'] ||
-        notebook.metadata.annotations?.['kubeflow-resource-stopped'],
+        notebook.metadata.annotations?.['kubeflow-resource-stopped'] ||
+        'Now',
     ])
     .filter(
       (arr): arr is [string, string] =>

--- a/frontend/src/__mocks__/mockAllowedUsers.ts
+++ b/frontend/src/__mocks__/mockAllowedUsers.ts
@@ -3,12 +3,14 @@ import { AllowedUser, PrivilegeState } from '~/pages/notebookController/screens/
 type MockAllowedUsersType = {
   username?: string;
   privilege?: PrivilegeState;
+  lastActivity?: string;
 };
 export const mockAllowedUsers = ({
   username = 'test-user',
   privilege = PrivilegeState.USER,
+  lastActivity = '2024-02-14T14:22:05Z',
 }: MockAllowedUsersType): AllowedUser => ({
   username,
   privilege,
-  lastActivity: '2024-02-14T14:22:05Z',
+  lastActivity,
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/administration.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/administration.ts
@@ -1,3 +1,4 @@
+import { Modal } from './components/Modal';
 import { TableRow } from './components/table';
 
 class NotebookController {
@@ -95,5 +96,16 @@ class AdministrationUsersRow extends TableRow {
   }
 }
 
+class StopNotebookModal extends Modal {
+  constructor() {
+    super('Stop server modal Stop server');
+  }
+
+  findStopNotebookServerButton() {
+    return this.find().findByTestId('stop-nb-server-button');
+  }
+}
+
 export const administration = new AdministrationTab();
 export const notebookController = new NotebookController();
+export const stopNotebookModal = new StopNotebookModal();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -6,7 +6,10 @@ import { mockNotebookImageInfo } from '~/__mocks__/mockNotebookImageInfo';
 import { mockStartNotebookData } from '~/__mocks__/mockStartNotebookData';
 import { notebookServer } from '~/__tests__/cypress/cypress/pages/notebookServer';
 import { asProductAdminUser, asProjectEditUser } from '~/__tests__/cypress/cypress/utils/users';
-import { notebookController } from '~/__tests__/cypress/cypress/pages/administration';
+import {
+  notebookController,
+  stopNotebookModal,
+} from '~/__tests__/cypress/cypress/pages/administration';
 import { homePage } from '~/__tests__/cypress/cypress/pages/home/home';
 
 const groupSubjects: RoleBindingSubject[] = [
@@ -87,8 +90,9 @@ describe('NotebookServer', () => {
         isRunning: false,
       },
     );
-    notebookServer.findStopNotebookServerButton().should('be.visible');
-    notebookServer.findStopNotebookServerButton().click();
+
+    stopNotebookModal.findStopNotebookServerButton().should('be.enabled');
+    stopNotebookModal.findStopNotebookServerButton().click();
 
     cy.wait('@stopNotebookServer').then((interception) => {
       expect(interception.request.body).to.eql({ state: 'stopped', username: 'test-user' });

--- a/frontend/src/pages/notebookController/screens/admin/__tests__/useCheckForAllowedUsers.spec.ts
+++ b/frontend/src/pages/notebookController/screens/admin/__tests__/useCheckForAllowedUsers.spec.ts
@@ -1,0 +1,54 @@
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { getAllowedUsers } from '~/redux/actions/actions';
+import { mockAllowedUsers } from '~/__mocks__/mockAllowedUsers';
+import useCheckForAllowedUsers from '~/pages/notebookController/screens/admin/useCheckForAllowedUsers';
+import { AllowedUser } from '~/pages/notebookController/screens/admin/types';
+
+jest.mock('~/redux/actions/actions', () => ({
+  getAllowedUsers: jest.fn(),
+}));
+
+jest.mock('~/pages/notebookController/useNamespaces', () => () => ({
+  notebookNamespace: 'test-project',
+  dashboardNamespace: 'opendatahub',
+}));
+
+const getAllowedUsersMock = jest.mocked(getAllowedUsers);
+
+describe('useCheckForAllowedUsers', () => {
+  it('should return list of users', async () => {
+    const mockAllowedUser: AllowedUser = mockAllowedUsers({});
+    getAllowedUsersMock.mockResolvedValue([mockAllowedUser]);
+    const renderResult = testHook(useCheckForAllowedUsers)();
+
+    expect(getAllowedUsersMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual([[], false, undefined]);
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+    expect(getAllowedUsersMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual([[mockAllowedUser], true, undefined]);
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
+  it('should handle error', async () => {
+    const error = (message: string) => ({
+      response: {
+        data: {
+          message,
+        },
+      },
+    });
+    getAllowedUsersMock.mockRejectedValue(error('error1'));
+    const renderResult = testHook(useCheckForAllowedUsers)();
+
+    expect(getAllowedUsersMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual([[], false, undefined]);
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+    expect(getAllowedUsersMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual([[], false, new Error('error1')]);
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-7660](https://issues.redhat.com/browse/RHOAIENG-7660)

## Description
This PR aims to fix the started notebook disappear problem. 

## How Has This Been Tested?
1. Make sure the notebook culling is disabled. (delete the `notebook-controller-culler-config` ConfigMap)
2. Login as a cluster-admin
3. Navigate to the Jupyter tile & select the admin tab
4. Start another user's notebook
5. Check the Administration tab, make sure the started notebook is still visible with last-activity: 'Just now' and kebab action to stop the server.

## Test Impact
Added unit test and cypress test.
![Screenshot from 2024-07-02 15-36-30](https://github.com/opendatahub-io/odh-dashboard/assets/99261071/e16db170-0c21-45ab-90ee-5acc33b8182c)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
