### PR TITLE
[RHOAIENG-6982] About Modal in the Dashboard

### DIFF
--- a/backend/src/routes/api/operator-subscription-status/index.ts
+++ b/backend/src/routes/api/operator-subscription-status/index.ts
@@ -1,0 +1,26 @@
+import { KubeFastifyInstance } from '../../../types';
+import { secureRoute } from '../../../utils/route-security';
+import { getSubscriptions, isRHOAI } from '../../../utils/resourceUtils';
+import { createCustomError } from '../../../utils/requestUtils';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.get(
+    '/',
+    secureRoute(fastify)(async () => {
+      const subscriptions = getSubscriptions();
+      const subNamePrefix = isRHOAI(fastify) ? 'rhods-operator' : 'opendatahub-operator';
+      const operatorSubscriptionStatus = subscriptions.find((sub) =>
+        sub.installedCSV?.includes(subNamePrefix),
+      );
+      if (operatorSubscriptionStatus) {
+        return operatorSubscriptionStatus;
+      }
+      fastify.log.error(`Failed to find operator subscription, ${subNamePrefix}`);
+      throw createCustomError(
+        'Subscription unavailable',
+        'Unable to get subscription information',
+        404,
+      );
+    }),
+  );
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -222,11 +222,15 @@ export type RouteKind = {
 
 // Minimal type for Subscriptions
 export type SubscriptionKind = {
+  spec: {
+    channel?: string;
+  };
   status?: {
     installedCSV?: string;
     installPlanRef?: {
       namespace: string;
     };
+    lastUpdated?: string;
   };
 } & K8sResourceCommon;
 
@@ -1019,8 +1023,10 @@ export type DataScienceClusterInitializationList = {
 };
 
 export type SubscriptionStatusData = {
+  channel?: string;
   installedCSV?: string;
   installPlanRefNamespace?: string;
+  lastUpdated?: string;
 };
 
 export type CronJobKind = {

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -148,8 +148,10 @@ const fetchSubscriptions = (fastify: KubeFastifyInstance): Promise<SubscriptionS
           };
         };
         const subs = res?.body.items?.map((sub) => ({
+          channel: sub.spec.channel,
           installedCSV: sub.status?.installedCSV,
           installPlanRefNamespace: sub.status?.installPlanRef?.namespace,
+          lastUpdated: sub.status.lastUpdated,
         }));
         remainingItemCount = res.body?.metadata?.remainingItemCount;
         _continue = res.body?.metadata?.continue;

--- a/frontend/src/__tests__/cypress/cypress/pages/aboutDialog.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/aboutDialog.ts
@@ -1,0 +1,50 @@
+import Chainable = Cypress.Chainable;
+
+export class AboutDialog {
+  show(wait = true): void {
+    cy.get('#help-icon-toggle').click();
+    cy.findByTestId('help-about-item').click();
+    if (wait) {
+      this.wait();
+    }
+  }
+
+  private wait() {
+    cy.findByTestId('home-page').should('be.visible');
+    cy.testA11y();
+  }
+
+  findText(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('about-text');
+  }
+
+  findProductName(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('about-product-name');
+  }
+
+  findProductVersion(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('about-version');
+  }
+
+  findChannel(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('about-channel');
+  }
+
+  findAccessLevel(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('about-access-level');
+  }
+
+  findLastUpdate(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('about-last-update');
+  }
+
+  isAdminAccessLevel(): Chainable<JQuery<HTMLElement>> {
+    return this.findAccessLevel().should('contain.text', 'Administrator');
+  }
+
+  isUserAccessLevel(): Chainable<JQuery<HTMLElement>> {
+    return this.findAccessLevel().should('contain.text', 'Non-administrator');
+  }
+}
+
+export const aboutDialog = new AboutDialog();

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -32,6 +32,7 @@ import type {
   OdhDocument,
   PrometheusQueryRangeResponse,
   PrometheusQueryResponse,
+  SubscriptionStatusData,
 } from '~/types';
 import type {
   ExperimentKFv2,
@@ -110,6 +111,10 @@ declare global {
         ((
           type: 'GET /api/status',
           response: OdhResponse<StatusResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/operator-subscription-status',
+          response: OdhResponse<SubscriptionStatusData>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/status/openshift-ai-notebooks/allowedUsers',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/application.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/application.cy.ts
@@ -4,6 +4,8 @@ import {
   asProductAdminUser,
   asProjectAdminUser,
 } from '~/__tests__/cypress/cypress/utils/users';
+import { mockDashboardConfig } from '~/__mocks__';
+import { aboutDialog } from '~/__tests__/cypress/cypress/pages/aboutDialog';
 
 describe('Application', () => {
   it('should disallow access to the dashboard', () => {
@@ -34,5 +36,70 @@ describe('Application', () => {
     );
     applicationLauncherMenuGroup.shouldHaveApplicationLauncherItem('OpenShift Cluster Manager');
     applicationLauncher.toggleAppLauncherButton();
+  });
+
+  it('should show the about modal for ODH application', () => {
+    cy.interceptOdh('GET /api/operator-subscription-status', {
+      channel: 'fast',
+      lastUpdated: '2024-06-25T05:36:37Z',
+    });
+    cy.interceptOdh('GET /api/dsci/status', {
+      conditions: [],
+      release: {
+        name: 'test application',
+        version: '1.0.1',
+      },
+    });
+
+    appChrome.visit();
+    aboutDialog.show();
+
+    aboutDialog.findText().should('contain.text', 'Open Data Hub');
+    aboutDialog.findProductName().should('contain.text', 'test application');
+    aboutDialog.findProductVersion().should('contain.text', '1.0.1');
+    aboutDialog.findChannel().should('contain.text', 'fast');
+    aboutDialog.isUserAccessLevel();
+    aboutDialog.findLastUpdate().should('contain.text', 'June 25, 2024');
+  });
+
+  it('should show the about modal correctly when release name is not available', () => {
+    cy.interceptOdh('GET /api/operator-subscription-status', {
+      channel: 'fast',
+      lastUpdated: '2024-06-25T05:36:37Z',
+    });
+    // Handle no release name returned
+    cy.interceptOdh('GET /api/dsci/status', {
+      conditions: [],
+      release: {
+        version: '1.0.1',
+      },
+    });
+    appChrome.visit();
+    aboutDialog.show();
+
+    aboutDialog.findProductName().should('contain.text', 'Open Data Hub');
+  });
+
+  it('should show the about modal for RHOAI application', () => {
+    // Validate RHOAI about settings
+    const mockConfig = mockDashboardConfig({});
+    mockConfig.metadata!.namespace = 'redhat-ods-applications';
+    cy.interceptOdh('GET /api/config', mockConfig);
+    cy.interceptOdh('GET /api/operator-subscription-status', {
+      channel: 'fast',
+      lastUpdated: '2024-06-25T05:36:37Z',
+    });
+    cy.interceptOdh('GET /api/dsci/status', {
+      conditions: [],
+      release: {
+        version: '1.0.1',
+      },
+    });
+
+    appChrome.visit();
+    aboutDialog.show();
+
+    aboutDialog.findText().should('contain.text', 'OpenShift');
+    aboutDialog.findProductName().should('contain.text', 'OpenShift AI');
   });
 });

--- a/frontend/src/app/AboutDialog.scss
+++ b/frontend/src/app/AboutDialog.scss
@@ -1,0 +1,9 @@
+// TODO: Remove when PF provides a fix for https://github.com/patternfly/patternfly/issues/6871
+// Override for about box height, reduce to fit the content instead of a fixed height
+// Override to use the full width of the dialog rather than wrapping early
+.odh-about-dialog {
+  height: fit-content;
+  .pf-v5-c-about-modal-box__content {
+    grid-column-end: -1;
+  }
+}

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  AboutModal,
+  Alert,
+  Bullseye,
+  Spinner,
+  TextContent,
+  TextList,
+  TextListItem,
+} from '@patternfly/react-core';
+import { ODH_LOGO, ODH_PRODUCT_NAME } from '~/utilities/const';
+import { useUser, useClusterInfo } from '~/redux/selectors';
+import { useAppContext } from '~/app/AppContext';
+import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
+import { useWatchOperatorSubscriptionStatus } from '~/utilities/useWatchOperatorSubscriptionStatus';
+
+import './AboutDialog.scss';
+
+const RhoaiAboutText = `Red Hat® OpenShift® AI (formerly Red Hat OpenShift Data Science) is a flexible, scalable MLOps platform for data scientists and developers of artificial intelligence and machine learning (AI/ML) applications. Built using open source technologies, OpenShift AI supports the full lifecycle of AI/ML experiments and models, on premise and in the public cloud.`;
+const RhoaiDefaultReleaseName = `OpenShift AI`;
+
+const OdhAboutText = `Open Data Hub is an open source AI platform designed for the hybrid cloud. The community seeks to bridge the gap between application developers, data stewards, and data scientists by blending the leading open source AI tools with a unifying and intuitive user experience. Open Data Hub supports the full lifecycle of AI/ML experiments and models.`;
+const OdhDefaultReleaseName = `Open Data Hub`;
+
+interface AboutDialogProps {
+  onClose: () => void;
+}
+
+const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
+  const { isAdmin } = useUser();
+  const { isRHOAI } = useAppContext();
+  const { serverURL } = useClusterInfo();
+  const [dsciStatus, loadedDsci, errorDsci] = useFetchDsciStatus();
+  const [subStatus, loadedSubStatus, errorSubStatus] = useWatchOperatorSubscriptionStatus();
+  const error = errorDsci || errorSubStatus;
+  const loading = (!errorDsci && !loadedDsci) || (!errorSubStatus && !loadedSubStatus);
+
+  return (
+    <AboutModal
+      className="odh-about-dialog"
+      isOpen
+      onClose={onClose}
+      brandImageSrc={`${window.location.origin}/images/${ODH_LOGO}`}
+      brandImageAlt={`${ODH_PRODUCT_NAME} logo`}
+      productName={ODH_PRODUCT_NAME}
+      aria-label={ODH_PRODUCT_NAME}
+      data-testid="odh-about-dialog"
+    >
+      <TextContent style={{ paddingBottom: 48 }}>
+        <h4>About</h4>
+        <p data-testid="about-text">{isRHOAI ? RhoaiAboutText : OdhAboutText}</p>
+      </TextContent>
+      <TextContent>
+        <div style={{ position: 'relative' }}>
+          {loading ? (
+            <Bullseye style={{ position: 'absolute', width: '100%' }}>
+              <Spinner size="xl" />
+            </Bullseye>
+          ) : null}
+          <TextList component="dl" style={{ visibility: loading ? 'hidden' : 'visible' }}>
+            <TextListItem component="dt" data-testid="about-product-name">
+              {dsciStatus?.release?.name ||
+                (isRHOAI ? RhoaiDefaultReleaseName : OdhDefaultReleaseName)}{' '}
+              version
+            </TextListItem>
+            <TextListItem component="dd" data-testid="about-version">
+              {dsciStatus?.release?.version || 'Unknown'}
+            </TextListItem>
+            <TextListItem component="dt">Channel</TextListItem>
+            <TextListItem component="dd" data-testid="about-channel">
+              {subStatus?.channel || 'Unknown'}
+            </TextListItem>
+            <TextListItem component="dt">API server</TextListItem>
+            <TextListItem component="dd" data-testid="about-server-url">
+              {serverURL}
+            </TextListItem>
+            <TextListItem component="dt">User type</TextListItem>
+            <TextListItem component="dd" data-testid="about-access-level">
+              {isAdmin ? 'Administrator' : 'Non-administrator'}
+            </TextListItem>
+            <TextListItem component="dt">Last updated</TextListItem>
+            <TextListItem component="dd" data-testid="about-last-update">
+              {subStatus?.lastUpdated
+                ? new Date(subStatus.lastUpdated).toLocaleString(undefined, {
+                    dateStyle: 'long',
+                  })
+                : 'Unknown'}
+            </TextListItem>
+          </TextList>
+        </div>
+        {error ? (
+          <Alert
+            style={{ marginTop: 'var(--pf-v5-global--spacer--lg)' }}
+            variant="danger"
+            title="Problem loading product information"
+          >
+            {error.message}
+          </Alert>
+        ) : null}
+      </TextContent>
+    </AboutModal>
+  );
+};
+
+export default AboutDialog;

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -60,6 +60,7 @@ const App: React.FC = () => {
             buildStatuses,
             dashboardConfig,
             storageClasses,
+            isRHOAI: dashboardConfig.metadata?.namespace === 'redhat-ods-applications',
           }
         : null,
     [buildStatuses, dashboardConfig, storageClasses],

--- a/frontend/src/app/AppContext.ts
+++ b/frontend/src/app/AppContext.ts
@@ -6,6 +6,7 @@ type AppContextProps = {
   buildStatuses: BuildStatus[];
   dashboardConfig: DashboardConfigKind;
   storageClasses: StorageClassKind[];
+  isRHOAI: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -19,6 +19,7 @@ import useNotification from '~/utilities/useNotification';
 import { updateImpersonateSettings } from '~/services/impersonateService';
 import { AppNotification } from '~/redux/types';
 import { useAppSelector } from '~/redux/hooks';
+import AboutDialog from '~/app/AboutDialog';
 import AppLauncher from './AppLauncher';
 import { useAppContext } from './AppContext';
 import { logout } from './appUtils';
@@ -30,6 +31,7 @@ interface HeaderToolsProps {
 const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
   const [userMenuOpen, setUserMenuOpen] = React.useState(false);
   const [helpMenuOpen, setHelpMenuOpen] = React.useState(false);
+  const [aboutShown, setAboutShown] = React.useState(false);
   const notifications: AppNotification[] = useAppSelector((state) => state.notifications);
   const userName: string = useAppSelector((state) => state.user || '');
   const isImpersonating: boolean = useAppSelector((state) => state.isImpersonating || false);
@@ -116,6 +118,19 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
     );
   }
 
+  helpMenuItems.push(
+    <DropdownItem
+      key="about"
+      data-testid="help-about-item"
+      onClick={() => {
+        handleHelpClick();
+        setAboutShown(true);
+      }}
+    >
+      About
+    </DropdownItem>,
+  );
+
   return (
     <Toolbar isFullHeight>
       <ToolbarContent>
@@ -133,29 +148,27 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
               onClick={onNotificationsClick}
             />
           </ToolbarItem>
-          {helpMenuItems.length > 0 ? (
-            <ToolbarItem>
-              <Dropdown
-                popperProps={{ position: 'right' }}
-                onOpenChange={(isOpen) => setHelpMenuOpen(isOpen)}
-                toggle={(toggleRef) => (
-                  <MenuToggle
-                    variant="plain"
-                    aria-label="Help items"
-                    id="help-icon-toggle"
-                    ref={toggleRef}
-                    onClick={() => setHelpMenuOpen(!helpMenuOpen)}
-                    isExpanded={helpMenuOpen}
-                  >
-                    <QuestionCircleIcon />
-                  </MenuToggle>
-                )}
-                isOpen={helpMenuOpen}
-              >
-                <DropdownList>{helpMenuItems}</DropdownList>
-              </Dropdown>
-            </ToolbarItem>
-          ) : null}
+          <ToolbarItem>
+            <Dropdown
+              popperProps={{ position: 'right' }}
+              onOpenChange={(isOpen) => setHelpMenuOpen(isOpen)}
+              toggle={(toggleRef) => (
+                <MenuToggle
+                  variant="plain"
+                  aria-label="Help items"
+                  id="help-icon-toggle"
+                  ref={toggleRef}
+                  onClick={() => setHelpMenuOpen(!helpMenuOpen)}
+                  isExpanded={helpMenuOpen}
+                >
+                  <QuestionCircleIcon />
+                </MenuToggle>
+              )}
+              isOpen={helpMenuOpen}
+            >
+              <DropdownList>{helpMenuItems}</DropdownList>
+            </Dropdown>
+          </ToolbarItem>
         </ToolbarGroup>
         {DEV_MODE && isImpersonating && (
           <ToolbarItem>
@@ -197,6 +210,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
           </Dropdown>
         </ToolbarItem>
       </ToolbarContent>
+      {aboutShown ? <AboutDialog onClose={() => setAboutShown(false)} /> : null}
     </Toolbar>
   );
 };

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ClusterState, UserState } from '~/redux/selectors/types';
+import { useUser, useClusterInfo } from '~/redux/selectors';
+import { useAppContext } from '~/app/AppContext';
+import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
+import { mockDashboardConfig } from '~/__mocks__';
+import { BuildStatus, SubscriptionStatusData } from '~/types';
+import {
+  DashboardConfigKind,
+  DataScienceClusterInitializationKindStatus,
+  StorageClassKind,
+} from '~/k8sTypes';
+import { FetchState } from '~/utilities/useFetchState';
+import AboutDialog from '~/app/AboutDialog';
+import { useWatchOperatorSubscriptionStatus } from '~/utilities/useWatchOperatorSubscriptionStatus';
+
+jest.mock('~/app/AppContext', () => ({
+  __esModule: true,
+  useAppContext: jest.fn(),
+}));
+
+jest.mock('~/redux/selectors', () => ({
+  ...jest.requireActual('~/redux/selectors'),
+  useUser: jest.fn(),
+  useClusterInfo: jest.fn(),
+}));
+
+jest.mock('~/concepts/areas/useFetchDsciStatus', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('~/utilities/useWatchOperatorSubscriptionStatus', () => ({
+  __esModule: true,
+  useWatchOperatorSubscriptionStatus: jest.fn(),
+}));
+
+const useUserMock = jest.mocked(useUser);
+const useAppContextMock = jest.mocked(useAppContext);
+const useClusterInfoMock = jest.mocked(useClusterInfo);
+const useFetchDsciStatusMock = jest.mocked(useFetchDsciStatus);
+const useWatchOperatorSubscriptionStatusMock = jest.mocked(useWatchOperatorSubscriptionStatus);
+
+describe('AboutDialog', () => {
+  let dashboardConfig: DashboardConfigKind;
+  let appContext: {
+    buildStatuses: BuildStatus[];
+    dashboardConfig: DashboardConfigKind;
+    storageClasses: StorageClassKind[];
+    isRHOAI: boolean;
+  };
+  let userInfo: UserState;
+  const clusterInfo: ClusterState = { serverURL: 'https://test-server.com' };
+  let dsciStatus: DataScienceClusterInitializationKindStatus;
+  let dsciFetchStatus: FetchState<DataScienceClusterInitializationKindStatus>;
+  let operatorSubscriptionStatus: SubscriptionStatusData;
+  let operatorSubscriptionFetchStatus: FetchState<SubscriptionStatusData>;
+
+  beforeEach(() => {
+    dashboardConfig = mockDashboardConfig({});
+    dashboardConfig.metadata!.namespace = 'odh-dashboard';
+    appContext = {
+      buildStatuses: [],
+      dashboardConfig,
+      storageClasses: [],
+      isRHOAI: false,
+    };
+    dsciStatus = {
+      conditions: [],
+      release: {
+        // eslint-disable-next-line no-restricted-syntax
+        name: 'Open Data Hub Operator',
+        version: '1.0.1',
+      },
+    };
+    dsciFetchStatus = [dsciStatus, true, undefined, () => Promise.resolve(dsciStatus)];
+    userInfo = {
+      username: 'test-user',
+      isAdmin: false,
+      isAllowed: true,
+      userLoading: false,
+      userError: null,
+    };
+    operatorSubscriptionStatus = {
+      channel: 'fast',
+      lastUpdated: '2024-06-25T05:36:37Z',
+    };
+    operatorSubscriptionFetchStatus = [
+      operatorSubscriptionStatus,
+      true,
+      undefined,
+      () => Promise.resolve(operatorSubscriptionStatus),
+    ];
+  });
+
+  it('should show the appropriate odh values', async () => {
+    useAppContextMock.mockReturnValue(appContext);
+    useUserMock.mockReturnValue(userInfo);
+    useClusterInfoMock.mockReturnValue(clusterInfo);
+    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
+    useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
+
+    // eslint-disable-next-line no-restricted-syntax
+    render(<AboutDialog onClose={jest.fn()} />);
+
+    const aboutText = await screen.findByTestId('about-text');
+    const name = await screen.findByTestId('about-product-name');
+    const version = await screen.findByTestId('about-version');
+    const channel = await screen.findByTestId('about-channel');
+    const accessLevel = await screen.findByTestId('about-access-level');
+    const lastUpdate = await screen.findByTestId('about-last-update');
+
+    // eslint-disable-next-line no-restricted-syntax
+    expect(aboutText.textContent).toContain('Open Data Hub');
+    // eslint-disable-next-line no-restricted-syntax
+    expect(name.textContent).toContain('Open Data Hub');
+    expect(version.textContent).toContain('1.0.1');
+    expect(channel.textContent).toContain('fast');
+    expect(accessLevel.textContent).toContain('Non-administrator');
+    expect(lastUpdate.textContent).toContain('June 25, 2024');
+  });
+
+  it('should show the appropriate RHOAI values', async () => {
+    dashboardConfig.metadata!.namespace = 'redhat-ods-applications';
+    appContext.isRHOAI = true;
+    userInfo.isAdmin = true;
+    dsciStatus.release!.name = 'OpenShift AI Self-Managed version';
+
+    useAppContextMock.mockReturnValue(appContext);
+    useUserMock.mockReturnValue(userInfo);
+    useClusterInfoMock.mockReturnValue(clusterInfo);
+    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
+    useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
+
+    // eslint-disable-next-line no-restricted-syntax
+    render(<AboutDialog onClose={jest.fn()} />);
+
+    const aboutText = await screen.findByTestId('about-text');
+    const name = await screen.findByTestId('about-product-name');
+    const version = await screen.findByTestId('about-version');
+    const channel = await screen.findByTestId('about-channel');
+    const accessLevel = await screen.findByTestId('about-access-level');
+    const lastUpdate = await screen.findByTestId('about-last-update');
+
+    // eslint-disable-next-line no-restricted-syntax
+    expect(aboutText.textContent).toContain('OpenShift');
+    expect(name.textContent).toContain('OpenShift AI');
+    expect(version.textContent).toContain('1.0.1');
+    expect(channel.textContent).toContain('fast');
+    expect(accessLevel.textContent).toContain('Administrator');
+    expect(lastUpdate.textContent).toContain('June 25, 2024');
+  });
+});

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1283,10 +1283,18 @@ export type DataScienceClusterKindStatus = {
   conditions: K8sCondition[];
   installedComponents: { [key in StackComponent]?: boolean };
   phase?: string;
+  release?: {
+    name: string;
+    version: string;
+  };
 };
 
 export type DataScienceClusterInitializationKindStatus = {
   conditions: K8sCondition[];
+  release?: {
+    name?: string;
+    version?: string;
+  };
   phase?: string;
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -36,6 +36,7 @@ describe('ManageInferenceServiceModal', () => {
       buildStatuses: [],
       dashboardConfig: mockDashboardConfig({}),
       storageClasses: [],
+      isRHOAI: false,
     });
 
     const currentProject = mockProjectK8sResource({});

--- a/frontend/src/redux/selectors/index.ts
+++ b/frontend/src/redux/selectors/index.ts
@@ -1,3 +1,4 @@
 export * from './project';
 export * from './types';
 export * from './user';
+export * from './clusterInfo';

--- a/frontend/src/services/operatorSubscriptionStatusService.ts
+++ b/frontend/src/services/operatorSubscriptionStatusService.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { SubscriptionStatusData } from '~/types';
+
+export const fetchOperatorSubscriptionStatus = (): Promise<SubscriptionStatusData> => {
+  const url = '/api/operator-subscription-status';
+  return axios
+    .get(url)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -236,6 +236,13 @@ export type BuildStatus = {
   timestamp: string;
 };
 
+export type SubscriptionStatusData = {
+  channel?: string;
+  installedCSV?: string;
+  installPlanRefNamespace?: string;
+  lastUpdated?: string;
+};
+
 type K8sMetadata = {
   name: string;
   namespace?: string;

--- a/frontend/src/utilities/useWatchOperatorSubscriptionStatus.tsx
+++ b/frontend/src/utilities/useWatchOperatorSubscriptionStatus.tsx
@@ -1,0 +1,6 @@
+import { fetchOperatorSubscriptionStatus } from '~/services/operatorSubscriptionStatusService';
+import { SubscriptionStatusData } from '~/types';
+import useFetchState, { FetchState } from '~/utilities/useFetchState';
+
+export const useWatchOperatorSubscriptionStatus = (): FetchState<SubscriptionStatusData | null> =>
+  useFetchState<SubscriptionStatusData | null>(fetchOperatorSubscriptionStatus, null);


### PR DESCRIPTION
Closes: [RHOAIENG-4220](https://issues.redhat.com/browse/RHOAIENG-4220)

## Description
Add an About dialog to the Dashboard UI using existing PatternFLy component.
https://www.patternfly.org/components/about-modal

This provides a place for UI users to see the current product version they are using, which can be useful for support and analytics use cases. 

## Screen shots
![image](https://github.com/opendatahub-io/odh-dashboard/assets/11633780/453112c0-38dd-4cbe-80f1-d7665bbf808e)

## How Has This Been Tested?
Tested locally

## Test Impact
Added e2e mock tests
Added jest test

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

/cc @simrandhaliw