### PR TITLE
disable create run/schedule dropdown action when pipeline has no vers…

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -960,6 +960,19 @@ describe('Pipelines', () => {
     runCreateRunPageNavTest(visitPipelineProjects);
   });
 
+  it('run and schedule dropdown action should be disabeld when pipeline has no versions', () => {
+    initIntercepts({ hasNoPipelineVersions: true });
+    pipelinesGlobal.visit(projectName);
+    pipelinesTable
+      .getRowById(initialMockPipeline.pipeline_id)
+      .findKebabAction('Create schedule')
+      .should('have.attr', 'aria-disabled');
+    pipelinesTable
+      .getRowById(initialMockPipeline.pipeline_id)
+      .findKebabAction('Create run')
+      .should('have.attr', 'aria-disabled');
+  });
+
   it('navigates to "Schedule run" page from pipeline row', () => {
     const visitPipelineProjects = () => pipelinesGlobal.visit(projectName);
     runScheduleRunPageNavTest(visitPipelineProjects);
@@ -1114,6 +1127,7 @@ describe('Pipelines', () => {
 type HandlersProps = {
   isEmpty?: boolean;
   mockPipelines?: PipelineKFv2[];
+  hasNoPipelineVersions?: boolean;
   totalSize?: number;
   nextPageToken?: string | undefined;
 };
@@ -1121,6 +1135,7 @@ type HandlersProps = {
 export const initIntercepts = ({
   isEmpty = false,
   mockPipelines = [initialMockPipeline],
+  hasNoPipelineVersions = false,
   totalSize = mockPipelines.length,
   nextPageToken,
 }: HandlersProps): void => {
@@ -1169,7 +1184,7 @@ export const initIntercepts = ({
         pipelineId: initialMockPipeline.pipeline_id,
       },
     },
-    buildMockPipelineVersionsV2([initialMockPipelineVersion]),
+    hasNoPipelineVersions ? {} : buildMockPipelineVersionsV2([initialMockPipelineVersion]),
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
@@ -60,6 +60,7 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
 
   // disable the checkbox if the pipeline has pipeline versions
   const disableDelete = totalSize > 0;
+  const hasNoPipelineVersions = totalSize === 0;
   React.useEffect(() => {
     disableCheck(pipelineRef.current, disableDelete || loading);
   }, [disableDelete, loading, disableCheck]);
@@ -125,6 +126,7 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
                 },
                 {
                   title: 'Create run',
+                  isAriaDisabled: hasNoPipelineVersions,
                   onClick: () => {
                     navigate(routePipelineRunCreateNamespacePipelinesPage(namespace), {
                       state: { lastPipeline: pipeline },
@@ -133,6 +135,7 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
                 },
                 {
                   title: 'Create schedule',
+                  isAriaDisabled: hasNoPipelineVersions,
                   onClick: () => {
                     navigate(
                       {


### PR DESCRIPTION
…ions

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: https://issues.redhat.com/browse/RHOAIENG-9013

## Description
The Create run and Create Schedule is disabled when pipeline has no pipeline version

![Screenshot 2024-07-09 at 2 48 57 PM](https://github.com/opendatahub-io/odh-dashboard/assets/99238909/d742fca6-1681-4a0f-9834-97d329bd285e)



<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Import a pipeline
2. Delete all the versions inside it
3. Click on the pipeline row kebab action
4. Check whether the Create run and Create schedule dropdown action is disabled

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added Cypress test
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

