### PR TITLE
remove flaky compare runs test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/compareRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/compareRuns.cy.ts
@@ -294,18 +294,6 @@ describe('Compare runs', () => {
         .should('exist');
     });
 
-    it('displays ROC curve filter table with correct artifacts', () => {
-      compareRunsMetricsContent.findRocCurveTab().click();
-      const content = compareRunsMetricsContent.findRocCurveTabContent();
-
-      const row = content.getRocCurveRowByName('wine-classification > metrics');
-      row.findRunName().should('contain.text', 'Run 1');
-      content.findRocCurveGraph().should('include.text', '#1');
-
-      row.findRowCheckbox().uncheck();
-      content.findRocCurveGraph().should('not.include.text', '#1');
-    });
-
     it('displays ROC curve empty state when no artifacts are found', () => {
       compareRunsMetricsContent.findRocCurveTab().click();
       const content = compareRunsMetricsContent.findRocCurveTabContent();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-9665

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
remove flaky compare runs test that blocks PRs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests pass in CI

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
removed 1 test that was testing a PF graph

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
