### PR TITLE
added cluster-admins to administration tab

### DIFF
--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -26,6 +26,7 @@ export const getAdminUserList = async (fastify: KubeFastifyInstance): Promise<st
   const adminGroupsList = adminGroups
     .split(',')
     .filter((groupName) => groupName && !groupName.startsWith('system:')); // Handle edge-cases and ignore k8s defaults
+  adminGroupsList.push('cluster-admins');
   return getGroupUserList(fastify, adminGroupsList);
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-7659](https://issues.redhat.com/browse/RHOAIENG-7659)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Users in the group `cluster-admins` but not in `odh-admins` showed up as `users` in the administration tab. I added this group so that they would instead show as `admin`

This fix will also show `cluster-admin` users with no previous activity in the tab.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Comment out the one-liner
2. Add a `cluster-admin` to your cluster, but do not add them to the `odh-admins` group.
3. Create a notebook server (Applications -> Enabled -> Jupyter -> Notebooks Server) logged in with the credentials of the NEW USER you just created.
4. Go to `Applications` -> `Enabled` -> `Jupyter` -> `Administration`. They should show up as a `user` since it just had recent activity.
5. Repeat step 2.
6. Uncomment the one-line fix
7. After reloading, you will be able to see that the users in steps 1 and 5 show up as 'admins', even though 5 had no previous activity.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A... Small fix, and code changes are unlikely to break this functionality since it is a one-liner.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
