### PR TITLE
fixed workbench image number dep

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
@@ -2,7 +2,8 @@ import { AwsKeys } from '~/pages/projects/dataConnections/const';
 import {
   getExistingVersionsForImageStream,
   isAWSValid,
-  checkVersionRecommended, // Added import for the new function
+  checkVersionRecommended,
+  getVersion,
 } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { EnvVariableDataEntry } from '~/pages/projects/types';
 import { mockImageStreamK8sResource } from '~/__mocks__/mockImageStreamK8sResource';
@@ -173,5 +174,18 @@ describe('checkVersionRecommended', () => {
       },
     };
     expect(checkVersionRecommended(imageVersion)).toBe(false);
+  });
+
+  it('should get version with a prefix and string parameter', () => {
+    expect(getVersion('v3.9', 'v')).toEqual('v3.9');
+    expect(getVersion('4.9', 'V')).toEqual('V4.9');
+    expect(getVersion('3.1', 'Randomprefix')).toEqual('Randomprefix3.1');
+    expect(getVersion('0.1')).toEqual('0.1');
+  });
+
+  it('should get version with a number as the parameter', () => {
+    expect(getVersion(0.1)).toEqual('0.1');
+    expect(getVersion(3.1, 'v')).toEqual('v3.1');
+    expect(getVersion(1000.5, 'V')).toEqual('V1000.5');
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -52,9 +52,12 @@ export const useMergeDefaultPVCName = (
   };
 };
 
-export const getVersion = (version?: string, prefix?: string): string => {
+export const getVersion = (version?: string | number, prefix?: string): string => {
   if (!version) {
     return '';
+  }
+  if (typeof version === 'number') {
+    return `${prefix || ''}${version}`;
   }
   const versionString =
     version.startsWith('v') || version.startsWith('V') ? version.slice(1) : version;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-5531](https://issues.redhat.com/browse/RHOAIENG-5531)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Before, when using a dependency with a number (non-string) dependency, it will crash due to a type error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create a custom ImageStream with the Python dependency as 3.9 instead of "3.9". It should work with the fix. More detailed reproduction of the error is nicely laid out in the jira ticket

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added tests to `spawnerUtils.spec.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


CC @lucferbux 