### PR TITLE
refactor model registry proxy onto proxy util

### DIFF
--- a/backend/src/routes/api/service/modelregistry/index.ts
+++ b/backend/src/routes/api/service/modelregistry/index.ts
@@ -1,32 +1,18 @@
-import httpProxy from '@fastify/http-proxy';
-import { KubeFastifyInstance } from '../../../../types';
-import { DEV_MODE, MODEL_REGISTRY_NAMESPACE } from '../../../../utils/constants';
-import { getParam, setParam } from '../../../../utils/proxy';
+import { MODEL_REGISTRY_NAMESPACE } from '../../../../utils/constants';
+import { proxyService } from '../../../../utils/proxy';
 
-export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  fastify.register(httpProxy, {
-    upstream: '',
-    prefix: '/:name',
-    rewritePrefix: '',
-    replyOptions: {
-      // preHandler must set the `upstream` param
-      getUpstream: (request) => getParam(request, 'upstream'),
-    },
-    preHandler: (request, _, done) => {
-      const name = getParam(request, 'name');
-
-      const upstream = DEV_MODE
-        ? // Use port forwarding for local development:
-          // kubectl port-forward -n <namespace> svc/<service-name> <local.port>:<service.port>
-          `http://${process.env.MODEL_REGISTRY_SERVICE_HOST}:${process.env.MODEL_REGISTRY_SERVICE_PORT}`
-        : // Construct service URL
-          `http://${name}.${MODEL_REGISTRY_NAMESPACE}.svc.cluster.local:8080`;
-
-      // assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
-      setParam(request, 'upstream', upstream);
-
-      fastify.log.info(`Proxy ${request.method} request ${request.url} to ${upstream}`);
-      done();
-    },
-  });
-};
+export default proxyService(
+  null,
+  {
+    port: 8080,
+    namespace: MODEL_REGISTRY_NAMESPACE,
+  },
+  {
+    // Use port forwarding for local development:
+    // kubectl port-forward -n odh-model-registries svc/<service-name> 8085:8080
+    host: process.env.MODEL_REGISTRY_SERVICE_HOST,
+    port: process.env.MODEL_REGISTRY_SERVICE_PORT,
+  },
+  null,
+  false,
+);

--- a/backend/src/utils/proxy.ts
+++ b/backend/src/utils/proxy.ts
@@ -27,12 +27,13 @@ const notFoundError = (kind: string, name: string, e?: any, overrideMessage?: st
 };
 
 export const proxyService =
-  <K extends K8sResourceCommon>(
-    model: { apiGroup: string; apiVersion: string; plural: string; kind: string },
+  <K extends K8sResourceCommon = never>(
+    model: { apiGroup: string; apiVersion: string; plural: string; kind: string } | null,
     service: {
       port: number | string;
       prefix?: string;
       suffix?: string;
+      namespace?: string;
     },
     local: {
       host: string;
@@ -44,7 +45,7 @@ export const proxyService =
   async (fastify: KubeFastifyInstance): Promise<void> => {
     fastify.register(httpProxy, {
       upstream: '',
-      prefix: '/:namespace/:name',
+      prefix: service.namespace ? ':name' : '/:namespace/:name',
       rewritePrefix: '',
       replyOptions: {
         // preHandler must set the `upstream` param
@@ -65,52 +66,60 @@ export const proxyService =
           );
           return;
         }
-        const kc = fastify.kube.config;
-        const cluster = kc.getCurrentCluster();
-
         // see `prefix` for named params
-        const namespace = getParam(request, 'namespace');
+        const namespace = service.namespace ?? getParam(request, 'namespace');
         const name = getParam(request, 'name');
 
-        // retreive the gating resource by name and namespace
-        passThroughResource<K>(fastify, request, {
-          url: `${cluster.server}/apis/${model.apiGroup}/${model.apiVersion}/namespaces/${namespace}/${model.plural}/${name}`,
-          method: 'GET',
-        })
-          .then((resource) => {
-            return getDirectCallOptions(fastify, request, request.url).then((requestOptions) => {
-              if (isK8sStatus(resource)) {
-                done(notFoundError(model.kind, name));
-              } else if (!statusCheck || statusCheck(resource)) {
-                if (tls) {
-                  const token = getAccessToken(requestOptions);
-                  request.headers.authorization = `Bearer ${token}`;
-                }
+        const doServiceRequest = () => {
+          const scheme = tls ? 'https' : 'http';
 
-                const scheme = tls ? 'https' : 'http';
+          const upstream = DEV_MODE
+            ? // Use port forwarding for local development:
+              // kubectl port-forward -n <namespace> svc/<service-name> <local.port>:<service.port>
+              `${scheme}://${local.host}:${local.port}`
+            : // Construct service URL
+              `${scheme}://${service.prefix || ''}${name}${
+                service.suffix ?? ''
+              }.${namespace}.svc.cluster.local:${service.port}`;
 
-                const upstream = DEV_MODE
-                  ? // Use port forwarding for local development:
-                    // kubectl port-forward -n <namespace> svc/<service-name> <local.port>:<service.port>
-                    `${scheme}://${local.host}:${local.port}`
-                  : // Construct service URL
-                    `${scheme}://${service?.prefix || ''}${resource.metadata.name}${
-                      service?.suffix ?? ''
-                    }.${resource.metadata.namespace}.svc.cluster.local:${service.port}`;
+          // assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
+          setParam(request, 'upstream', upstream);
 
-                // assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
-                setParam(request, 'upstream', upstream);
+          fastify.log.info(`Proxy ${request.method} request ${request.url} to ${upstream}`);
+          done();
+        };
 
-                fastify.log.info(`Proxy ${request.method} request ${request.url} to ${upstream}`);
-                done();
-              } else {
-                done(notFoundError(model.kind, name, undefined, 'service unavailable'));
-              }
-            });
+        if (model) {
+          const kc = fastify.kube.config;
+          const cluster = kc.getCurrentCluster();
+
+          // retreive the gating resource by name and namespace
+          passThroughResource<K>(fastify, request, {
+            url: `${cluster.server}/apis/${model.apiGroup}/${model.apiVersion}/namespaces/${namespace}/${model.plural}/${name}`,
+            method: 'GET',
           })
-          .catch((e) => {
-            done(notFoundError(model.kind, name, e));
-          });
+            .then((resource) => {
+              return getDirectCallOptions(fastify, request, request.url).then((requestOptions) => {
+                if (isK8sStatus(resource)) {
+                  done(notFoundError(model.kind, name));
+                } else if (!statusCheck || statusCheck(resource)) {
+                  if (tls) {
+                    const token = getAccessToken(requestOptions);
+                    request.headers.authorization = `Bearer ${token}`;
+                  }
+
+                  doServiceRequest();
+                } else {
+                  done(notFoundError(model.kind, name, undefined, 'service unavailable'));
+                }
+              });
+            })
+            .catch((e) => {
+              done(notFoundError(model.kind, name, e));
+            });
+        } else {
+          doServiceRequest();
+        }
       },
     });
   };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

https://issues.redhat.com/browse/RHOAIENG-8891

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Model registry had a slight variation in requires for their backend proxy than the other proxy services and therefore the common proxy util was not usable without being refactored.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Find a cluster with model-registry setup or perform the setup on your cluster.
Login to the cluster on the terminal.
- run a local backend: `npm run start:dev`
- run a local frontend: `npm run start:dev`
- from the root dir, `NAMESPACE=default make port-forward`
  - make sure the env var `MODEL_REGISTRY_NAME` in the `.env.development` is correct for your cluster
- visit `http://localhost:4010/modelRegistry`

Make sure the page loads and functions as expected

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None, unfortunately backend doesn't have tests at this time.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
