### PR TITLE
Add no metrics state for compare runs metrics section

### DIFF
--- a/frontend/src/__mocks__/mlmd/mockGetArtifactsByContext.ts
+++ b/frontend/src/__mocks__/mlmd/mockGetArtifactsByContext.ts
@@ -1,113 +1,121 @@
 import { Artifact, GetArtifactsByContextResponse } from '~/__mocks__/third_party/mlmd';
 import createGrpcResponse, { GrpcResponse } from './utils';
 
-const mockedScalarMetricArtifact: Artifact = {
+const mockedScalarMetricArtifact = (noMetrics?: boolean): Artifact => ({
   id: 7,
   typeId: 17,
   type: 'system.Metrics',
   uri: 's3://aballant-pipelines/metrics-visualization-pipeline/f0b586ba-3e7b-4369-8d48-592e83cbbf73/digit-classification/metrics',
   properties: {},
-  customProperties: {
-    accuracy: { doubleValue: 92 },
-    displayName: { stringValue: 'metrics' },
-  },
+  customProperties: noMetrics
+    ? {}
+    : {
+        accuracy: { doubleValue: 92 },
+        displayName: { stringValue: 'metrics' },
+      },
   state: 2,
   createTimeSinceEpoch: 1711765118976,
   lastUpdateTimeSinceEpoch: 1711765118976,
-};
+});
 
-const mockedConfusionMatrixArtifact: Artifact = {
+const mockedConfusionMatrixArtifact = (noMetrics?: boolean): Artifact => ({
   id: 8,
   typeId: 18,
   type: 'system.ClassificationMetrics',
   uri: 's3://aballant-pipelines/metrics-visualization-pipeline/ccdfe85e-06cc-4a63-b10d-a12d688d2ec3/iris-sgdclassifier/metrics',
   properties: {},
-  customProperties: {
-    confusionMatrix: {
-      structValue: {
-        struct: {
-          annotationSpecs: [
-            { displayName: 'Setosa' },
-            { displayName: 'Versicolour' },
-            { displayName: 'Virginica' },
-          ],
-          rows: [
-            {
-              row: [38, 0, 0],
+  customProperties: noMetrics
+    ? {}
+    : {
+        confusionMatrix: {
+          structValue: {
+            struct: {
+              annotationSpecs: [
+                { displayName: 'Setosa' },
+                { displayName: 'Versicolour' },
+                { displayName: 'Virginica' },
+              ],
+              rows: [
+                {
+                  row: [38, 0, 0],
+                },
+                {
+                  row: [2, 19, 9],
+                },
+                {
+                  row: [1, 17, 19],
+                },
+              ],
             },
-            {
-              row: [2, 19, 9],
-            },
-            {
-              row: [1, 17, 19],
-            },
-          ],
+          },
+        },
+        displayName: {
+          stringValue: 'metrics',
         },
       },
-    },
-    displayName: {
-      stringValue: 'metrics',
-    },
-  },
   state: 2,
   createTimeSinceEpoch: 1711765608345,
   lastUpdateTimeSinceEpoch: 1711765608345,
-};
+});
 
-const mockedRocCurveArtifact: Artifact = {
+const mockedRocCurveArtifact = (noMetrics?: boolean): Artifact => ({
   id: 9,
   typeId: 18,
   type: 'system.ClassificationMetrics',
   uri: 's3://aballant-pipelines/metrics-visualization-pipeline/aa61378c-d507-4bde-aa18-9f8678b2beb6/wine-classification/metrics',
   properties: {},
-  customProperties: {
-    confidenceMetrics: {
-      structValue: {
-        list: [
-          { confidenceThreshold: 2, falsePositiveRate: 0, recall: 0 },
-          { confidenceThreshold: 1, falsePositiveRate: 0, recall: 0.33962264150943394 },
-          { confidenceThreshold: 0, falsePositiveRate: 0, recall: 0.6037735849056604 },
-          { confidenceThreshold: 0.8, falsePositiveRate: 0, recall: 0.8490566037735849 },
-          { confidenceThreshold: 0.6, falsePositiveRate: 0, recall: 0.8867924528301887 },
-          { confidenceThreshold: 0.5, falsePositiveRate: 0.0125, recall: 0.9245283018867925 },
-          { confidenceThreshold: 0.4, falsePositiveRate: 0.075, recall: 0.9622641509433962 },
-          { confidenceThreshold: 0.3, falsePositiveRate: 0.0875, recall: 1 },
-          { confidenceThreshold: 0.2, falsePositiveRate: 0.2375, recall: 1 },
-          { confidenceThreshold: 0.1, falsePositiveRate: 0.475, recall: 1 },
-          { confidenceThreshold: 0, falsePositiveRate: 1, recall: 1 },
-        ],
+  customProperties: noMetrics
+    ? {}
+    : {
+        confidenceMetrics: {
+          structValue: {
+            list: [
+              { confidenceThreshold: 2, falsePositiveRate: 0, recall: 0 },
+              { confidenceThreshold: 1, falsePositiveRate: 0, recall: 0.33962264150943394 },
+              { confidenceThreshold: 0, falsePositiveRate: 0, recall: 0.6037735849056604 },
+              { confidenceThreshold: 0.8, falsePositiveRate: 0, recall: 0.8490566037735849 },
+              { confidenceThreshold: 0.6, falsePositiveRate: 0, recall: 0.8867924528301887 },
+              { confidenceThreshold: 0.5, falsePositiveRate: 0.0125, recall: 0.9245283018867925 },
+              { confidenceThreshold: 0.4, falsePositiveRate: 0.075, recall: 0.9622641509433962 },
+              { confidenceThreshold: 0.3, falsePositiveRate: 0.0875, recall: 1 },
+              { confidenceThreshold: 0.2, falsePositiveRate: 0.2375, recall: 1 },
+              { confidenceThreshold: 0.1, falsePositiveRate: 0.475, recall: 1 },
+              { confidenceThreshold: 0, falsePositiveRate: 1, recall: 1 },
+            ],
+          },
+        },
+        displayName: {
+          stringValue: 'metrics',
+        },
       },
-    },
-    displayName: {
-      stringValue: 'metrics',
-    },
-  },
   state: 2,
   createTimeSinceEpoch: 1711766424068,
   lastUpdateTimeSinceEpoch: 1711766424068,
-};
+});
 
-const mockedMarkdownArtifact: Artifact = {
+const mockedMarkdownArtifact = (noMetrics?: boolean): Artifact => ({
   id: 16,
   typeId: 19,
   type: 'system.Markdown',
   uri: 's3://aballant-pipelines/metrics-visualization-pipeline/16dbff18-a3d5-4684-90ac-4e6198a9da0f/markdown-visualization/markdown_artifact',
   properties: {},
-  customProperties: {
-    displayName: { stringValue: 'markdown_artifact' },
-  },
+  customProperties: noMetrics
+    ? {}
+    : {
+        displayName: { stringValue: 'markdown_artifact' },
+      },
   state: 2,
   createTimeSinceEpoch: 1712841455267,
   lastUpdateTimeSinceEpoch: 1712841455267,
-};
+});
 
-export const mockGetArtifactsByContext = (): GrpcResponse => {
+export const mockGetArtifactsByContext = (noMetrics?: boolean): GrpcResponse => {
   const binary = GetArtifactsByContextResponse.encode({
     artifacts: [
-      mockedScalarMetricArtifact,
-      mockedConfusionMatrixArtifact,
-      mockedRocCurveArtifact,
-      mockedMarkdownArtifact,
+      mockedScalarMetricArtifact(noMetrics),
+      mockedConfusionMatrixArtifact(noMetrics),
+      mockedRocCurveArtifact(noMetrics),
+      mockedMarkdownArtifact(noMetrics),
     ],
   }).finish();
   return createGrpcResponse(binary);

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/compareRuns.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/compareRuns.ts
@@ -111,6 +111,10 @@ class RocCurveFilterTableRow extends TableRow {
 
 class CompareRunsRocCurve extends Contextual<HTMLElement> {
   findRocCurveEmptyState() {
+    return this.find().findByTestId('compare-runs-roc-curve-empty-state');
+  }
+
+  findRocCurveTableEmptyState() {
     return this.find().findByTestId('no-result-found-title');
   }
 
@@ -123,12 +127,16 @@ class CompareRunsRocCurve extends Contextual<HTMLElement> {
     );
   }
 
-  findRocCruveSearchBar() {
+  findRocCurveSearchBar() {
     return this.find().findByTestId('roc-curve-search');
   }
 
   findRocCurveGraph() {
     return this.find().findByTestId('roc-curve-graph');
+  }
+
+  findRocCurveNoMetricsState() {
+    return this.find().findByTestId('compare-runs-roc-curve-no-data-state');
   }
 }
 
@@ -151,6 +159,10 @@ class CompareRunsScalarMetrics extends Contextual<HTMLDivElement> {
 
   findScalarMetricsEmptyState() {
     return this.find().findByTestId('compare-runs-scalar-metrics-empty-state');
+  }
+
+  findScalarMetricsNoMetricsState() {
+    return this.find().findByTestId('compare-runs-scalar-metrics-no-data-state');
   }
 }
 
@@ -188,6 +200,10 @@ class CompareRunsMarkdown extends Contextual<HTMLElement> {
       this.find().findByTestId(`compare-runs-markdown-${runId}`),
     );
   }
+
+  findMarkdownNoMetricsState() {
+    return this.find().findByTestId('compare-runs-markdown-no-data-state');
+  }
 }
 
 class CompareRunsConfusionMatrix extends Contextual<HTMLElement> {
@@ -205,6 +221,10 @@ class CompareRunsConfusionMatrix extends Contextual<HTMLElement> {
     return new ConfusionMatrixArtifactSelect(() =>
       this.find().findByTestId(`compare-runs-confusion-matrix-${runId}`),
     );
+  }
+
+  findConfusionMatrixNoMetricsState() {
+    return this.find().findByTestId('compare-runs-confusion-matrix-no-data-state');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/executions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/executions.cy.ts
@@ -188,10 +188,6 @@ const initIntercepts = (interceptMlmd: boolean, isExecutionsEmpty?: boolean) => 
   );
 
   if (interceptMlmd) {
-    if (isExecutionsEmpty) {
-      initMlmdIntercepts(projectName, true);
-    } else {
-      initMlmdIntercepts(projectName, false);
-    }
+    initMlmdIntercepts(projectName, { isExecutionsEmpty });
   }
 };

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/mlmdUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/mlmdUtils.ts
@@ -6,7 +6,11 @@ import { mockGetExecutions, mockGetNoExecutions } from '~/__mocks__/mlmd/mockGet
 import { mockGetExecutionsByContext } from '~/__mocks__/mlmd/mockGetExecutionsByContext';
 import { mockGetExecutionsByID } from '~/__mocks__/mlmd/mockGetExecutionsByID';
 
-export const initMlmdIntercepts = (projectName: string, isExecutionsEmpty?: boolean): void => {
+export const initMlmdIntercepts = (
+  projectName: string,
+  options: { isExecutionsEmpty?: boolean; noMetrics?: boolean } = {},
+): void => {
+  const { isExecutionsEmpty, noMetrics } = options;
   cy.interceptOdh(
     'POST /api/service/mlmd/:namespace/:serviceName/ml_metadata.MetadataStoreService/GetArtifactTypes',
     { path: { namespace: projectName, serviceName: 'dspa' } },
@@ -20,7 +24,7 @@ export const initMlmdIntercepts = (projectName: string, isExecutionsEmpty?: bool
   cy.interceptOdh(
     'POST /api/service/mlmd/:namespace/:serviceName/ml_metadata.MetadataStoreService/GetArtifactsByContext',
     { path: { namespace: projectName, serviceName: 'dspa' } },
-    mockGetArtifactsByContext(),
+    mockGetArtifactsByContext(noMetrics),
   );
   cy.interceptOdh(
     'POST /api/service/mlmd/:namespace/:serviceName/ml_metadata.MetadataStoreService/GetExecutionsByContext',

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics.tsx
@@ -1,0 +1,23 @@
+import {
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateHeader,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import React from 'react';
+
+type CompareRunsNoMetricsProps = Omit<React.ComponentProps<typeof EmptyState>, 'children'> & {
+  title?: string;
+};
+
+export const CompareRunsNoMetrics: React.FC<CompareRunsNoMetricsProps> = ({
+  title = 'No metrics to compare',
+  ...props
+}) => (
+  <EmptyState variant={EmptyStateVariant.xs} {...props}>
+    <EmptyStateHeader titleText={title} headingLevel="h4" />
+    <EmptyStateBody>
+      The selected runs do not contain relevant metrics. Select different runs to compare.
+    </EmptyStateBody>
+  </EmptyState>
+);

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/ConfusionMatrixCompare.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/ConfusionMatrixCompare.tsx
@@ -1,15 +1,5 @@
 import * as React from 'react';
-import {
-  Bullseye,
-  Divider,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader,
-  EmptyStateVariant,
-  Flex,
-  FlexItem,
-  Spinner,
-} from '@patternfly/react-core';
+import { Bullseye, Divider, Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import { PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
 import { RunArtifact } from '~/concepts/pipelines/apiHooks/mlmd/types';
 
@@ -23,17 +13,20 @@ import { PipelineRunArtifactSelect } from '~/concepts/pipelines/content/compareR
 import { ConfusionMatrixConfig } from '~/concepts/pipelines/content/artifacts/charts/confusionMatrix/types';
 import { buildConfusionMatrixConfig } from '~/concepts/pipelines/content/artifacts/charts/confusionMatrix/utils';
 import ConfusionMatrix from '~/concepts/pipelines/content/artifacts/charts/confusionMatrix/ConfusionMatrix';
+import { CompareRunsNoMetrics } from '~/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics';
 import { isConfusionMatrix } from './utils';
 import { ConfusionMatrixConfigAndTitle } from './types';
 
 type ConfusionMatrixCompareProps = {
   runArtifacts?: RunArtifact[];
   isLoaded: boolean;
+  isEmpty: boolean;
 };
 
 const ConfusionMatrixCompare: React.FC<ConfusionMatrixCompareProps> = ({
   runArtifacts,
   isLoaded,
+  isEmpty,
 }) => {
   const [expandedGraph, setExpandedGraph] = React.useState<
     ConfusionMatrixConfigAndTitle | undefined
@@ -94,21 +87,11 @@ const ConfusionMatrixCompare: React.FC<ConfusionMatrixCompareProps> = ({
     );
   }
 
-  if (!runArtifacts || runArtifacts.length === 0) {
-    return <CompareRunsEmptyState />;
+  if (isEmpty) {
+    return <CompareRunsEmptyState data-testid="compare-runs-confusion-matrix-empty-state" />;
   }
   if (Object.keys(configMap).length === 0) {
-    return (
-      <EmptyState
-        variant={EmptyStateVariant.xs}
-        data-testid="compare-runs-confusion-matrix-empty-state"
-      >
-        <EmptyStateHeader titleText="No confusion matrix artifacts" headingLevel="h4" />
-        <EmptyStateBody>
-          There are no confusion matrix artifacts available on the selected runs.
-        </EmptyStateBody>
-      </EmptyState>
-    );
+    return <CompareRunsNoMetrics data-testid="compare-runs-confusion-matrix-no-data-state" />;
   }
 
   return (

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare.tsx
@@ -3,10 +3,6 @@ import {
   Alert,
   Bullseye,
   Divider,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader,
-  EmptyStateVariant,
   Flex,
   FlexItem,
   Spinner,
@@ -19,6 +15,7 @@ import MarkdownView from '~/components/MarkdownView';
 import { MAX_STORAGE_OBJECT_SIZE } from '~/services/storageService';
 import { bytesAsRoundedGiB } from '~/utilities/number';
 import { PipelineRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import { CompareRunsNoMetrics } from '~/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics';
 
 type MarkdownCompareProps = {
   configMap: Record<string, MarkdownAndTitle[]>;
@@ -50,18 +47,11 @@ const MarkdownCompare: React.FC<MarkdownCompareProps> = ({
   }
 
   if (isEmpty) {
-    return <CompareRunsEmptyState />;
+    return <CompareRunsEmptyState data-testid="compare-runs-markdown-empty-state" />;
   }
 
   if (Object.keys(configMap).length === 0) {
-    return (
-      <EmptyState variant={EmptyStateVariant.xs} data-testid="compare-runs-markdown-empty-state">
-        <EmptyStateHeader titleText="No markdown artifacts" headingLevel="h4" />
-        <EmptyStateBody>
-          There are no markdown artifacts available on the selected runs.
-        </EmptyStateBody>
-      </EmptyState>
-    );
+    return <CompareRunsNoMetrics data-testid="compare-runs-markdown-no-data-state" />;
   }
 
   const renderMarkdownWithSize = (config: MarkdownAndTitle) => (

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/roc/RocCurveCompare.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/roc/RocCurveCompare.tsx
@@ -1,16 +1,5 @@
 import * as React from 'react';
-import {
-  Bullseye,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader,
-  EmptyStateVariant,
-  Flex,
-  Spinner,
-  Split,
-  SplitItem,
-  Text,
-} from '@patternfly/react-core';
+import { Bullseye, Flex, Spinner, Split, SplitItem, Text } from '@patternfly/react-core';
 import DashboardHelpTooltip from '~/concepts/dashboard/DashboardHelpTooltip';
 import { useCheckboxTableBase } from '~/components/table';
 import ROCCurve from '~/concepts/pipelines/content/artifacts/charts/ROCCurve';
@@ -21,6 +10,7 @@ import {
   getLinkedArtifactId,
 } from '~/concepts/pipelines/content/compareRuns/metricsSection/utils';
 import { CompareRunsEmptyState } from '~/concepts/pipelines/content/compareRuns/CompareRunsEmptyState';
+import { CompareRunsNoMetrics } from '~/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics';
 import RocCurveTable from './RocCurveTable';
 import { FullArtifactPathsAndConfig } from './types';
 import { isConfidenceMetric, buildRocCurveConfig } from './utils';
@@ -28,9 +18,10 @@ import { isConfidenceMetric, buildRocCurveConfig } from './utils';
 type RocCurveCompareProps = {
   runArtifacts?: RunArtifact[];
   isLoaded: boolean;
+  isEmpty: boolean;
 };
 
-const RocCurveCompare: React.FC<RocCurveCompareProps> = ({ runArtifacts, isLoaded }) => {
+const RocCurveCompare: React.FC<RocCurveCompareProps> = ({ runArtifacts, isLoaded, isEmpty }) => {
   const [search, setSearch] = React.useState<string>('');
   const [selected, setSelected] = React.useState<FullArtifactPathsAndConfig[]>([]);
 
@@ -93,18 +84,11 @@ const RocCurveCompare: React.FC<RocCurveCompareProps> = ({ runArtifacts, isLoade
     );
   }
 
-  if (!runArtifacts || runArtifacts.length === 0) {
-    return <CompareRunsEmptyState />;
+  if (isEmpty) {
+    return <CompareRunsEmptyState data-testid="compare-runs-roc-curve-empty-state" />;
   }
   if (Object.keys(configs).length === 0) {
-    return (
-      <EmptyState variant={EmptyStateVariant.xs}>
-        <EmptyStateHeader titleText="No ROC curve artifacts" headingLevel="h4" />
-        <EmptyStateBody>
-          There are no ROC curve artifacts available on the selected runs.
-        </EmptyStateBody>
-      </EmptyState>
-    );
+    return <CompareRunsNoMetrics data-testid="compare-runs-roc-curve-no-data-state" />;
   }
 
   return (

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/scalar/ScalarMetricTable.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/scalar/ScalarMetricTable.tsx
@@ -1,27 +1,24 @@
 import * as React from 'react';
 import { InnerScrollContainer, TableVariant, Td, Tr } from '@patternfly/react-table';
-import {
-  Bullseye,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader,
-  EmptyStateVariant,
-  Flex,
-  Spinner,
-  Switch,
-} from '@patternfly/react-core';
+import { Bullseye, Flex, Spinner, Switch } from '@patternfly/react-core';
 import { Table } from '~/components/table';
 import { RunArtifact } from '~/concepts/pipelines/apiHooks/mlmd/types';
 import { CompareRunsEmptyState } from '~/concepts/pipelines/content/compareRuns/CompareRunsEmptyState';
+import { CompareRunsNoMetrics } from '~/concepts/pipelines/content/compareRuns/CompareRunsNoMetrics';
 import { ScalarTableData } from './types';
 import { generateTableStructure } from './utils';
 
 type ScalarMetricTableProps = {
   runArtifacts?: RunArtifact[];
   isLoaded: boolean;
+  isEmpty: boolean;
 };
 
-const ScalarMetricTable: React.FC<ScalarMetricTableProps> = ({ runArtifacts, isLoaded }) => {
+const ScalarMetricTable: React.FC<ScalarMetricTableProps> = ({
+  runArtifacts,
+  isLoaded,
+  isEmpty,
+}) => {
   const { columns, data, subColumns } = generateTableStructure(runArtifacts ?? []);
 
   const [isHideSameRowsChecked, setIsHideSameRowsChecked] = React.useState<boolean>(false);
@@ -69,18 +66,11 @@ const ScalarMetricTable: React.FC<ScalarMetricTableProps> = ({ runArtifacts, isL
     );
   }
 
-  if (!runArtifacts || runArtifacts.length === 0) {
+  if (isEmpty) {
     return <CompareRunsEmptyState data-testid="compare-runs-scalar-metrics-empty-state" />;
   }
   if (!hasScalarMetrics) {
-    return (
-      <EmptyState variant={EmptyStateVariant.xs}>
-        <EmptyStateHeader titleText="No scalar metric artifacts" headingLevel="h4" />
-        <EmptyStateBody>
-          There are no scalar metric artifacts available on the selected runs.
-        </EmptyStateBody>
-      </EmptyState>
-    );
+    return <CompareRunsNoMetrics data-testid="compare-runs-scalar-metrics-no-data-state" />;
   }
 
   return (

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
@@ -56,6 +56,8 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
     return [_.pick(configMap, selectedIds), _.pick(runMap, selectedIds)];
   }, [configMap, runMap, selectedRuns]);
 
+  const isEmpty = selectedRuns.length === 0;
+
   const filterSelected = React.useCallback(
     (runArtifact: RunArtifact) => selectedRuns.some((run) => run.run_id === runArtifact.run.run_id),
     [selectedRuns],
@@ -82,7 +84,11 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
           data-testid="compare-runs-scalar-metrics-tab"
         >
           <TabContentBody hasPadding data-testid="compare-runs-scalar-metrics-tab-content">
-            <ScalarMetricTable runArtifacts={scalarMetricsArtifactData} isLoaded={isLoaded} />
+            <ScalarMetricTable
+              runArtifacts={scalarMetricsArtifactData}
+              isEmpty={isEmpty}
+              isLoaded={isLoaded}
+            />
           </TabContentBody>
         </Tab>
         <Tab
@@ -93,6 +99,7 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
           <TabContentBody hasPadding data-testid="compare-runs-confusion-matrix-tab-content">
             <ConfusionMatrixCompare
               runArtifacts={confusionMatrixArtifactData}
+              isEmpty={isEmpty}
               isLoaded={isLoaded}
             />
           </TabContentBody>
@@ -103,7 +110,11 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
           data-testid="compare-runs-roc-curve-tab"
         >
           <TabContentBody hasPadding data-testid="compare-runs-roc-curve-tab-content">
-            <RocCurveCompare runArtifacts={rocCurveArtifactData} isLoaded={isLoaded} />
+            <RocCurveCompare
+              runArtifacts={rocCurveArtifactData}
+              isEmpty={isEmpty}
+              isLoaded={isLoaded}
+            />
           </TabContentBody>
         </Tab>
         {isS3EndpointAvailable && (
@@ -116,7 +127,7 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
               <MarkdownCompare
                 configMap={selectedConfigMap}
                 runMap={selectedRunMap}
-                isEmpty={selectedRuns.length === 0}
+                isEmpty={isEmpty}
                 isLoaded={isLoaded && configsLoaded}
               />
             </TabContentBody>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: [RHOAIENG-8406](https://issues.redhat.com/browse/RHOAIENG-8406)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add an empty state when there are runs selected but no metrics to compare for all the tabs in compare run metrics section.

<img width="1510" alt="Screenshot 2024-07-10 at 4 53 04 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/6c70c53a-b005-48d4-9512-c367ca6d65a1">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create some runs with a pipeline that will not generate metrics
2. Go to compare runs page
3. See the metrics section, check and uncheck the runs
4. Make sure the empty state is shown as described

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added some cypress tests to verify the empty state

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
