### PR TITLE
[WIP] useGenericObjectState: Fix types so that setPropValue function narrows value type by key

### DIFF
--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -9,12 +9,14 @@ import {
   Volume,
   VolumeMount,
 } from '~/types';
-import { ValueOf } from '~/typeHelpers';
 import { AWSSecretKind } from '~/k8sTypes';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
 import { AwsKeys } from './dataConnections/const';
 
-export type UpdateObjectAtPropAndValue<T> = (propKey: keyof T, propValue: ValueOf<T>) => void;
+export type UpdateObjectAtPropAndValue<T> = <K extends keyof T = keyof T>(
+  propKey: K,
+  propValue: T[K],
+) => void;
 
 export type NameDescType = {
   name: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

~~Standalone, semi-related to [RHOAIENG-8454](https://issues.redhat.com/browse/RHOAIENG-8454)~~
Would resolve [RHOAIENG-9748](https://issues.redhat.com/browse/RHOAIENG-9748) if completed. Closing the PR for now because fixing the errors is out of the scope of the little "sneak in a tiny change" time I budgeted.

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

I was helping @gitdallas look into using `useGenericObjectState` for [RHOAIENG-8454](https://issues.redhat.com/browse/RHOAIENG-8454) and I noticed it had this weird type quirk. I played around for a minute to see if it would be easy to fix and this very small fix worked fine, so I figured I should open a PR.

`useGenericObjectState<T>` returns a function of type `UpdateObjectAtPropAndValue<T>` which takes a key and value, and updates the value at that key in the state object `T`. The current type of the argument `propValue: ValueOf<T>` means that no matter what `propKey` is passed in, TypeScript only enforces that your value is one of any of the valid property values for any key on the object. This means potential run time type errors, as I can see playing around with the usage in `useRunFormData`:

<img width="497" alt="Screenshot 2024-07-10 at 5 55 42 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/4edbe20a-1438-4d8b-a710-ff65de95b4b7">

With this change applied, the type of `propValue` is narrowed to the actual type of the property matching the `propKey` you pass in.

Here's that same line with this change applied, correctly showing an error: 

<img width="837" alt="Screenshot 2024-07-10 at 5 56 44 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/4409bde2-3786-4c55-80b7-48f485ebb783">

And if I change the key to the one that matches the value I'm passing, the error goes away:

<img width="489" alt="Screenshot 2024-07-10 at 6 09 54 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/811963/042abb18-3954-4fc9-88a3-473888e8b0a4">

### ⚠️ Note: this reveals a handful of type errors in the repo that should be fixed before this change is merged! I thought I was tossing in a quick little fix but I opened a can of worms here. I followed up by opening [RHOAIENG-9748](https://issues.redhat.com/browse/RHOAIENG-9748).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
