### PR TITLE
Set experiment as Default on create run/schedule page

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
@@ -30,6 +30,7 @@ import { useGetSearchParamValues } from '~/utilities/useGetSearchParamValues';
 import { PipelineRunSearchParam } from '~/concepts/pipelines/content/types';
 import { asEnumMember } from '~/utilities/utils';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import useDefaultExperiment from '~/pages/pipelines/global/experiments/useDefaultExperiment';
 
 type RunPageProps = {
   cloneRun?: PipelineRunKFv2 | PipelineRecurringRunKFv2 | null;
@@ -64,6 +65,7 @@ const RunPage: React.FC<RunPageProps> = ({
   const isSchedule = runType === RunTypeOption.SCHEDULED;
 
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
+  const [defaultExperiment] = useDefaultExperiment();
 
   const jumpToSections = Object.values(CreateRunPageSections).filter(
     (section) =>
@@ -94,7 +96,7 @@ const RunPage: React.FC<RunPageProps> = ({
     runType: runTypeData,
     pipeline: locationPipeline || contextPipeline,
     version: locationVersion || contextPipelineVersion,
-    experiment: locationExperiment || contextExperiment,
+    experiment: locationExperiment || contextExperiment || defaultExperiment,
   });
 
   const onValueChange = React.useCallback(

--- a/frontend/src/pages/pipelines/global/experiments/useDefaultExperiment.ts
+++ b/frontend/src/pages/pipelines/global/experiments/useDefaultExperiment.ts
@@ -1,0 +1,34 @@
+import React from 'react';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { ExperimentKFv2, PipelinesFilterOp } from '~/concepts/pipelines/kfTypes';
+import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+
+/**
+ * Fetch the first created experiment and check it's name to make sure it's default experiment
+ */
+const useDefaultExperiment = (): FetchState<ExperimentKFv2 | null> => {
+  const { api } = usePipelinesAPI();
+
+  const getDefaultExperiment = React.useCallback<
+    FetchStateCallbackPromise<ExperimentKFv2 | null>
+  >(async () => {
+    const response = await api.listExperiments(
+      {},
+      {
+        filter: {
+          predicates: [
+            // eslint-disable-next-line camelcase
+            { key: 'name', operation: PipelinesFilterOp.EQUALS, string_value: 'Default' },
+          ],
+        },
+        pageSize: 1,
+      },
+    );
+
+    return response.experiments?.[0] || null;
+  }, [api]);
+
+  return useFetchState(getDefaultExperiment, null);
+};
+
+export default useDefaultExperiment;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
JIRA: [RHOAIENG-9429](https://issues.redhat.com/browse/RHOAIENG-9429)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a run/schedule from the pipelines page, it will auto-fill the experiment field as `Default` if the `Default` experiment is in the selector (not archived on the create run page).

<img width="1510" alt="Screenshot 2024-07-11 at 12 44 33 PM" src="https://github.com/opendatahub-io/odh-dashboard/assets/37624318/b72bb8f6-3090-4c6b-8c9d-4fbc3ec59e5a">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a run from the pipeline version row or details page
2. See if the `Default` experiment is auto-filled
3. Archive the `Default` experiment
4. When creating a run, the experiment field should be empty
5. When creating a schedule, the experiment field should still be set to `Default`
6. Try to duplicate a run/schedule, make sure this change doesn't have an impact on the field
7. Try to create a run/schedule from the experiment runs page, make sure this change doesn't have an impact on the field
8. Try to switch between create run/schedule page, make sure this change doesn't have an impact on the field

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add a cypress test to verify the auto-filled experiment.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
