### PR TITLE
Fix LogViewerSearch styling issue and improve functionality

### DIFF
--- a/frontend/src/__mocks__/mockPipelinePodK8sResource.ts
+++ b/frontend/src/__mocks__/mockPipelinePodK8sResource.ts
@@ -13,6 +13,7 @@ export const mockPipelinePodK8sResource = ({
   user = 'test-user',
   name = 'test-pod',
   namespace = 'test-project',
+  isPending = false,
 }: MockResourceConfigType): PodKind => ({
   kind: 'Pod',
   apiVersion: 'project.openshift.io/v1',
@@ -545,21 +546,24 @@ export const mockPipelinePodK8sResource = ({
       {
         name: 'step-copy-artifacts',
         state: {
-          terminated: true,
+          terminated: !isPending,
+          running: isPending,
         },
         ready: false,
       },
       {
         name: 'step-main',
         state: {
-          terminated: true,
+          terminated: !isPending,
+          running: isPending,
         },
         ready: false,
       },
       {
         name: 'step-move-all-results-to-tekton-home',
         state: {
-          terminated: true,
+          terminated: !isPending,
+          running: isPending,
         },
         ready: false,
       },

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -176,7 +176,8 @@ class PipelineDetails extends PipelinesTopology {
   }
 
   selectActionDropdownItem(label: string) {
-    this.findActionsDropdown().click().findByRole('menuitem', { name: label }).click();
+    this.findActionsDropdown().click();
+    cy.findByRole('menuitem', { name: label }).click();
   }
 }
 
@@ -193,7 +194,8 @@ class PipelineRecurringRunDetails extends RunDetails {
   }
 
   selectActionDropdownItem(label: string) {
-    this.findActionsDropdown().click().findByRole('menuitem', { name: label }).click();
+    this.findActionsDropdown().click();
+    cy.findByRole('menuitem', { name: label }).click();
   }
 
   mockEnableRecurringRun(recurringRun: PipelineRecurringRunKFv2, namespace: string) {
@@ -269,12 +271,17 @@ class PipelineRunDetails extends RunDetails {
     return cy.findByTestId('logs-step-select');
   }
 
+  findLogsPauseButton() {
+    return cy.findByTestId('logs-pause-refresh-button');
+  }
+
   selectStepByName(name: string): void {
     this.findStepSelect().findDropdownItem(name).click();
   }
 
   selectActionDropdownItem(label: string) {
-    this.findActionsDropdown().findDropdownItem(label).click();
+    this.findActionsDropdown().click();
+    cy.findByRole('menuitem', { name: label }).click();
   }
 
   findYamlOutput() {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
@@ -18,6 +18,7 @@ import {
   pipelineVersionRecurringRunsRoute,
   pipelineVersionRunsRoute,
 } from '~/routes';
+import { getDashboardMainContainer } from '~/utilities/utils';
 
 type PipelineDetailsActionsProps = {
   onDelete: () => void;
@@ -40,6 +41,7 @@ const PipelineDetailsActions: React.FC<PipelineDetailsActionsProps> = ({
       <Dropdown
         data-testid="pipeline-version-details-actions"
         onSelect={() => setOpen(false)}
+        menuAppendTo={getDashboardMainContainer}
         toggle={
           <DropdownToggle toggleVariant="primary" onToggle={() => setOpen(!open)}>
             Actions

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRecurringRun/PipelineRecurringRunDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRecurringRun/PipelineRecurringRunDetailsActions.tsx
@@ -13,6 +13,7 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineRecurringRunKFv2, RecurringRunStatus } from '~/concepts/pipelines/kfTypes';
 import { cloneRecurringRunRoute } from '~/routes';
 import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
+import { getDashboardMainContainer } from '~/utilities/utils';
 
 type PipelineRecurringRunDetailsActionsProps = {
   recurringRun?: PipelineRecurringRunKFv2;
@@ -69,6 +70,7 @@ const PipelineRecurringRunDetailsActions: React.FC<PipelineRecurringRunDetailsAc
     <Dropdown
       data-testid="pipeline-recurring-run-details-actions"
       onSelect={() => setOpen(false)}
+      menuAppendTo={getDashboardMainContainer}
       toggle={
         <DropdownToggle toggleVariant="primary" onToggle={() => setOpen(!open)}>
           Actions

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsActions.tsx
@@ -13,6 +13,7 @@ import { PipelineRunKFv2, RuntimeStateKF, StorageStateKF } from '~/concepts/pipe
 import { cloneRunRoute, experimentsCompareRunsRoute } from '~/routes';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import useExperimentById from '~/concepts/pipelines/apiHooks/useExperimentById';
+import { getDashboardMainContainer } from '~/utilities/utils';
 
 type PipelineRunDetailsActionsProps = {
   run?: PipelineRunKFv2 | null;
@@ -55,6 +56,7 @@ const PipelineRunDetailsActions: React.FC<PipelineRunDetailsActionsProps> = ({
     <Dropdown
       data-testid="pipeline-run-details-actions"
       onSelect={() => setOpen(false)}
+      menuAppendTo={getDashboardMainContainer}
       toggle={
         <DropdownToggle toggleVariant="primary" onToggle={() => setOpen(!open)}>
           Actions

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -108,7 +108,7 @@ const LogsTab: React.FC<LogsTabProps> = ({ task }) => {
     scrollOffsetToBottom,
     scrollUpdateWasRequested,
   }) => {
-    if (!scrollUpdateWasRequested) {
+    if (!podStatus?.completed && logsLoaded && !scrollUpdateWasRequested) {
       if (scrollOffsetToBottom > 0) {
         setIsPaused(true);
       } else {
@@ -296,33 +296,36 @@ const LogsTab: React.FC<LogsTabProps> = ({ task }) => {
                         </ToolbarItem>
                       )}
                       <ToolbarItem spacer={{ default: 'spacerNone' }} style={{ maxWidth: '300px' }}>
-                        <Tooltip content="Search">
-                          <LogViewerSearch
-                            onFocus={() => setIsPaused(true)}
-                            placeholder="Search"
-                            minSearchChars={0}
-                            expandableInput={{
-                              isExpanded: showSearchbar,
-                              onToggleExpand,
-                              toggleAriaLabel: 'Expandable search input toggle',
-                            }}
-                          />
-                        </Tooltip>
+                        <LogViewerSearch
+                          onFocus={() => {
+                            if (!podStatus?.completed && logsLoaded) {
+                              setIsPaused(true);
+                            }
+                          }}
+                          placeholder="Search"
+                          minSearchChars={0}
+                          expandableInput={{
+                            isExpanded: showSearchbar,
+                            onToggleExpand,
+                            toggleAriaLabel: 'Expandable search input toggle',
+                          }}
+                        />
                       </ToolbarItem>
-                      {!podStatus?.completed && (
+                      {(!podStatus?.completed || isPaused) && (
                         <ToolbarItem spacer={{ default: 'spacerNone' }}>
                           <Button
                             variant={!logsLoaded ? 'plain' : isPaused ? 'plain' : 'link'}
                             onClick={() => setIsPaused(!isPaused)}
                             isDisabled={!!error}
+                            data-testid="logs-pause-refresh-button"
                           >
-                            {!logsLoaded || podStatus?.podInitializing ? (
-                              <Tooltip content="Loading log">
-                                <Spinner size="sm" />
-                              </Tooltip>
-                            ) : isPaused ? (
+                            {isPaused ? (
                               <Tooltip content="Resume refreshing">
                                 <PlayIcon />
+                              </Tooltip>
+                            ) : !logsLoaded || podStatus?.podInitializing ? (
+                              <Tooltip content="Loading log">
+                                <Spinner size="sm" />
                               </Tooltip>
                             ) : (
                               <Tooltip content="Pause refreshing">


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
closes: https://issues.redhat.com/browse/RHOAIENG-4705

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
1. removes tooltip on logs search icon
2. fixed logs tab overflowing action dropdown
3. Now when you pause a running a pipeline log, if the task completes while still paused, it will remain paused. When you unpause the logs, it will fetch the rest of the logs and the pause icon will be hidden due to the task completing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. run a pipeline
2. go to one of the nodes pods tab
4. verify tooltip doesn't exist on pod search icon
5. pause the logs before the finish
6. wait for the node to complete
7. verify pod is still paused
8. unpause
9. verify it fetches the rest and the pause icon disappears
 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added test for pausing logs

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

not really any ux changes, just removing a tooltip and logic for pausing

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
