### PR TITLE
Restart the pods after updating configMap in workbench

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -173,6 +173,11 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
           return;
         }
 
+        const annotations = { ...editNotebook.metadata.annotations };
+        if (envFrom.length > 0) {
+          annotations['notebooks.opendatahub.io/notebook-restart'] = 'true';
+        }
+
         const { volumes, volumeMounts } = pvcDetails;
         const newStartNotebookData = {
           ...startNotebookData,
@@ -181,7 +186,12 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
           envFrom,
           tolerationSettings,
         };
-        return updateNotebook(editNotebook, newStartNotebookData, username, { dryRun });
+        return updateNotebook(
+          { ...editNotebook, metadata: { ...editNotebook.metadata, annotations } },
+          newStartNotebookData,
+          username,
+          { dryRun },
+        );
       };
 
       updateNotebookPromise(true)


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
 Closes: [RHOAIENG-1210](https://issues.redhat.com/browse/RHOAIENG-1210)

## Description
This PR will add `notebooks.opendatahub.io/notebook-restart=true` to notebook CR to restart the pod after updating config map.

## How Has This Been Tested?
1. Create a workbench with adding the Environment variables (ConfigMap Environment variables type).
2.  after creation, update the config map. You can see that the pods will restart.

## Test Impact
NA, added an annotation. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
