### PR TITLE
Defer project kebab check and disable

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
@@ -10,10 +10,12 @@ import {
   ProjectModel,
   ProjectRequestModel,
   RouteModel,
+  SelfSubjectAccessReviewModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mock200Status } from '~/__mocks__/mockK8sStatus';
 import { mockNotebookK8sResource, mockRouteK8sResource } from '~/__mocks__';
 import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
+import { mockSelfSubjectAccessReview } from '~/__mocks__/mockSelfSubjectAccessReview';
 import { asProjectAdminUser } from '~/__tests__/cypress/cypress/utils/users';
 import { notebookConfirmModal } from '~/__tests__/cypress/cypress/pages/workbench';
 import { testPagination } from '~/__tests__/cypress/cypress/utils/pagination';
@@ -78,7 +80,16 @@ describe('Data science projects details', () => {
   it('should delete project', () => {
     initIntercepts();
     projectListPage.visit();
-    projectListPage.getProjectRow('Test Project').findKebabAction('Delete project').click();
+    cy.interceptK8s(
+      'POST',
+      SelfSubjectAccessReviewModel,
+      mockSelfSubjectAccessReview({ allowed: true }),
+    ).as('selfSubjectAccessReviewsCall');
+    const deleteProject = projectListPage
+      .getProjectRow('Test Project')
+      .findKebabAction('Delete project');
+    cy.wait('@selfSubjectAccessReviewsCall');
+    deleteProject.click();
     deleteModal.shouldBeOpen();
     deleteModal.findSubmitButton().should('be.disabled');
     deleteModal.findCancelButton().should('be.enabled').click();
@@ -152,6 +163,31 @@ describe('Data science projects details', () => {
     projectListPage.findProjectLink('DS Project 1').should('exist');
     projectListPage.findProjectLink('DS Project 2').should('not.exist');
     projectListPage.findProjectLink('renamed').should('not.exist');
+  });
+
+  it('should disable kebab actions with insufficient permissions', () => {
+    initIntercepts();
+    projectListPage.visit();
+    cy.interceptK8s(
+      'POST',
+      SelfSubjectAccessReviewModel,
+      mockSelfSubjectAccessReview({ allowed: false }),
+    ).as('selfSubjectAccessReviewsCall');
+
+    const editProject = projectListPage
+      .getProjectRow('Test Project')
+      .findKebabAction('Edit project');
+    const editPermission = projectListPage
+      .getProjectRow('Test Project')
+      .findKebabAction('Edit permissions');
+    const deleteProject = projectListPage
+      .getProjectRow('Test Project')
+      .findKebabAction('Delete project');
+    cy.wait('@selfSubjectAccessReviewsCall');
+
+    editProject.should('have.attr', 'aria-disabled', 'true');
+    editPermission.should('have.attr', 'aria-disabled', 'true');
+    deleteProject.should('have.attr', 'aria-disabled', 'true');
   });
 
   describe('Table filter', () => {

--- a/frontend/src/api/useAccessReview.ts
+++ b/frontend/src/api/useAccessReview.ts
@@ -37,6 +37,7 @@ const checkAccess = ({
 
 export const useAccessReview = (
   resourceAttributes: AccessReviewResourceAttributes,
+  shouldRunCheck = true,
 ): [boolean, boolean] => {
   const [loaded, setLoaded] = React.useState(false);
   const [isAllowed, setAllowed] = React.useState(false);
@@ -51,22 +52,24 @@ export const useAccessReview = (
   } = resourceAttributes;
 
   React.useEffect(() => {
-    checkAccess({ group, resource, subresource, verb, name, namespace })
-      .then((result) => {
-        if (result.status) {
-          setAllowed(result.status.allowed);
-        } else {
+    if (shouldRunCheck) {
+      checkAccess({ group, resource, subresource, verb, name, namespace })
+        .then((result) => {
+          if (result.status) {
+            setAllowed(result.status.allowed);
+          } else {
+            setAllowed(true);
+          }
+          setLoaded(true);
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.warn('SelfSubjectAccessReview failed', e);
           setAllowed(true);
-        }
-        setLoaded(true);
-      })
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.warn('SelfSubjectAccessReview failed', e);
-        setAllowed(true);
-        setLoaded(true);
-      });
-  }, [group, name, namespace, resource, subresource, verb]);
+          setLoaded(true);
+        });
+    }
+  }, [group, name, namespace, resource, subresource, verb, shouldRunCheck]);
 
   return [isAllowed, loaded];
 };

--- a/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
@@ -37,7 +37,12 @@ const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
   const navigate = useNavigate();
   const owner = getProjectOwner(project);
 
-  const item = useProjectTableRowItems(project, isRefreshing, setEditData, setDeleteData);
+  const [item, runAccessCheck] = useProjectTableRowItems(
+    project,
+    isRefreshing,
+    setEditData,
+    setDeleteData,
+  );
   const [notebookStates, loaded] = useProjectNotebookStates(project.metadata.name);
 
   return (
@@ -130,6 +135,8 @@ const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
                   className="odh-project-table__action-column"
                   isActionCell
                   rowSpan={notebookStates.length || 1}
+                  onMouseEnter={runAccessCheck}
+                  onClick={runAccessCheck}
                 >
                   <ActionsColumn items={item} />
                 </Td>

--- a/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
+++ b/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
@@ -1,12 +1,15 @@
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { TooltipProps } from '@patternfly/react-core';
 import { useAccessReview } from '~/api';
 import { AccessReviewResourceAttributes, ProjectKind } from '~/k8sTypes';
 
 type KebabItem = {
   title?: string;
-  isDisabled?: boolean;
+  isAriaDisabled?: boolean;
   isSeparator?: boolean;
   onClick?: () => void;
+  tooltipProps?: TooltipProps;
 };
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'rbac.authorization.k8s.io',
@@ -18,40 +21,72 @@ const useProjectTableRowItems = (
   isRefreshing: boolean,
   setEditData: (data: ProjectKind) => void,
   setDeleteData: (data: ProjectKind) => void,
-): KebabItem[] => {
-  const [allowCreate] = useAccessReview({
-    ...accessReviewResource,
-    namespace: project.metadata.name,
-  });
+): [KebabItem[], () => void] => {
   const navigate = useNavigate();
+  const [shouldRunCheck, setShouldRunCheck] = React.useState(false);
+
+  const [allowUpdate, allowUpdateLoaded] = useAccessReview(
+    {
+      ...accessReviewResource,
+      namespace: project.metadata.name,
+      verb: 'update',
+    },
+    shouldRunCheck,
+  );
+  const [allowCreate, allowCreateLoaded] = useAccessReview(
+    {
+      ...accessReviewResource,
+      namespace: project.metadata.name,
+    },
+    shouldRunCheck,
+  );
+  const [allowDelete, allowDeleteLoaded] = useAccessReview(
+    {
+      ...accessReviewResource,
+      namespace: project.metadata.name,
+      verb: 'delete',
+    },
+    shouldRunCheck,
+  );
+
+  const runAccesCheck = React.useCallback(() => {
+    setShouldRunCheck(true);
+  }, []);
+
+  const noPermissionToolTip = (allow: boolean, loaded: boolean): Partial<KebabItem> | undefined =>
+    !allow && loaded
+      ? { tooltipProps: { content: 'You do not have permissions to perform this action' } }
+      : undefined;
+
   const item: KebabItem[] = [
     {
       title: 'Edit project',
-      isDisabled: isRefreshing,
+      isAriaDisabled: isRefreshing || !allowUpdate || !allowUpdateLoaded,
       onClick: () => {
         setEditData(project);
       },
+      ...noPermissionToolTip(allowUpdate, allowUpdateLoaded),
     },
-    ...(allowCreate
-      ? [
-          {
-            title: 'Edit permissions',
-            onClick: () => {
-              navigate(`/projects/${project.metadata.name}?section=permissions`);
-            },
-          },
-        ]
-      : []),
+    {
+      title: 'Edit permissions',
+      isAriaDisabled: !allowCreate || !allowCreateLoaded,
+      onClick: () => {
+        navigate(`/projects/${project.metadata.name}?section=permissions`);
+      },
+      ...noPermissionToolTip(allowCreate, allowCreateLoaded),
+    },
     {
       isSeparator: true,
     },
     {
       title: 'Delete project',
+      isAriaDisabled: !allowDelete || !allowDeleteLoaded,
       onClick: () => {
         setDeleteData(project);
       },
+      ...noPermissionToolTip(allowDelete, allowDeleteLoaded),
     },
   ];
-  return item;
+  return [item, runAccesCheck];
 };
 export default useProjectTableRowItems;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

Closes [RHOAIENG-1163](https://issues.redhat.com/browse/RHOAIENG-1163) and https://github.com/opendatahub-io/odh-dashboard/issues/1932

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When a user doesn't have permission to Edit Project, Delete Project, or Edit Permissions, the actions will be grayed out and disabled. This prevents a user from trying to do the action and later getting an insufficient permissions error. (We decided to not hide them, because then we would have to hide the entire kebab menu if there were no permissions, which requires a check on display of the table.)

This also defers the project permission checks until the menu will be opened. This saves us from having to make 1 (or more) api calls per project being displayed on the table on page load. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with varying user permissions. Checked that projects with sufficient permissions allow actions, and without required permissions, the options will be disabled and the tooltip will show.

Added a test to check the insufficient permissions behaviour.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Mocked access review calls should be done if actions in the kebab menu are going to be used, since they are gated now. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

`aria-disabled` being used to add tooltip for a disabled item:

![image](https://github.com/user-attachments/assets/0bbcb5c8-be7a-4344-9553-ba63689728a9)

Throttled testing to show permissions disabled while network call is still loading:

https://github.com/user-attachments/assets/98a36897-830a-47bb-86d2-95acf0a07eda



After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
