### PR TITLE
RHOAIENG-7791:Add test configuration template file for cypress tests

### DIFF
--- a/frontend/src/__tests__/cypress/test-variables.yml.example
+++ b/frontend/src/__tests__/cypress/test-variables.yml.example
@@ -1,0 +1,9 @@
+ODH_DASHBOARD_URL: "http://odh-dashboard-opendatahub.apps.my-cluster.test.redhat.com"
+TEST_USER:
+  AUTH_TYPE: foo-auth
+  USERNAME: foo-user
+  PASSWORD: foo-passwd
+OCP_ADMIN_USER:
+  AUTH_TYPE: adm-auth
+  USERNAME: adminuser
+  PASSWORD: adminuser-passwd


### PR DESCRIPTION

Closes: [RHOAIENG-7791](https://issues.redhat.com/browse/RHOAIENG-7791)

## Description
This  is the template file which holds the structure of the configuration file and the default values for test.
  The values are being generated dynamically during runtime and populate fields of template file data and generates the final content for the actual configuration file.

## How Has This Been Tested?
Need to run the jenkins pipeline job for cypress tests
