### PR TITLE
[RHOAIENG-8788]: Update loading state for project section in home page

### DIFF
--- a/frontend/src/pages/home/projects/ProjectsLoading.tsx
+++ b/frontend/src/pages/home/projects/ProjectsLoading.tsx
@@ -1,9 +1,20 @@
+import {
+  EmptyState,
+  EmptyStateVariant,
+  Spinner,
+  EmptyStateHeader,
+  Bullseye,
+} from '@patternfly/react-core';
 import * as React from 'react';
-import { Skeleton } from '@patternfly/react-core';
 
 const ProjectsLoading: React.FC = () => (
   <div style={{ height: '230px' }}>
-    <Skeleton height="75%" width="100%" screenreaderText="Loading projects" />
+    <Bullseye>
+      <EmptyState variant={EmptyStateVariant.lg} data-id="loading-empty-state">
+        <Spinner size="xl" />
+        <EmptyStateHeader titleText="Loading" headingLevel="h1" />
+      </EmptyState>
+    </Bullseye>
   </div>
 );
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

https://issues.redhat.com/browse/RHOAIENG-8788

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Update loading state for project section in home page. 

Before
<img width="500" alt="Screenshot 2024-07-15 at 11 41 57 AM" src="https://github.com/user-attachments/assets/3455c3ea-0f1a-49bf-beaa-97371c549a6c">

After
<img width="500" alt="Screenshot 2024-07-15 at 12 01 13 PM" src="https://github.com/user-attachments/assets/0afc6350-6b16-40ae-92c1-d9ab2505abc5">





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually. Reload home screen to test Projects loading state. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A - no changes to functionality 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
