### PR TITLE
feat(MR): 8454 add namedesc fields

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
@@ -2,6 +2,7 @@ import { appChrome } from './appChrome';
 
 export enum FormFieldSelector {
   NAME = '#mr-name',
+  RESOURCENAME = '#resource-mr-name',
   HOST = '#mr-host',
   PORT = '#mr-port',
   USERNAME = '#mr-username',
@@ -10,7 +11,6 @@ export enum FormFieldSelector {
 }
 
 export enum FormErrorTestId {
-  NAME = 'mr-name-error',
   HOST = 'mr-host-error',
   PORT = 'mr-port-error',
   USERNAME = 'mr-username-error',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -3,7 +3,6 @@ import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';
 import { StackCapability, StackComponent } from '~/concepts/areas/types';
 import {
   FormFieldSelector,
-  FormErrorTestId,
   modelRegistrySettings,
   DatabaseDetailsTestId,
 } from '~/__tests__/cypress/cypress/pages/modelRegistrySettings';
@@ -104,14 +103,6 @@ describe('CreateModal', () => {
     modelRegistrySettings.clearFormFields();
     modelRegistrySettings.findSubmitButton().should('be.disabled');
     modelRegistrySettings.shouldHaveAllErrors();
-  });
-
-  it('should display error when name is not empty but is invalid', () => {
-    modelRegistrySettings.visit(true);
-    modelRegistrySettings.findCreateButton().click();
-    modelRegistrySettings.findFormField(FormFieldSelector.NAME).type('Invalid Name');
-    modelRegistrySettings.findFormField(FormFieldSelector.NAME).blur();
-    modelRegistrySettings.findFormError(FormErrorTestId.NAME).should('exist');
   });
 
   it('should enable submit button if fields are valid', () => {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1302,6 +1302,7 @@ export type ModelRegistryKind = K8sResourceCommon & {
   metadata: {
     name: string;
     namespace: string;
+    annotations?: DisplayNameAnnotations;
   };
   spec: {
     grpc: {

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import { ModelRegistryKind } from '~/k8sTypes';
+import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import ViewDatabaseConfigModal from './ViewDatabaseConfigModal';
 import DeleteModelRegistryModal from './DeleteModelRegistryModal';
 
@@ -19,7 +20,16 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
   return (
     <>
       <Tr>
-        <Td dataLabel="Model registry name">{mr.metadata.name}</Td>
+        <Td dataLabel="Model registry name">
+          <ResourceNameTooltip resource={mr}>
+            <strong>
+              {mr.metadata.annotations?.['openshift.io/display-name'] || mr.metadata.name}
+            </strong>
+          </ResourceNameTooltip>
+          {mr.metadata.annotations?.['openshift.io/description'] && (
+            <p>{mr.metadata.annotations['openshift.io/description']}</p>
+          )}
+        </Td>
         <Td modifier="fitContent">
           <Link
             aria-label={`Manage permissions for model registry ${mr.metadata.name}`}


### PR DESCRIPTION
Closes: 8454

## Description

- add display name, resource name, description fields to MR.
- use the namedescriptionfield component for creation form.
- use resourcenametooltip for table name, add description underneath

<img width="823" alt="image" src="https://github.com/user-attachments/assets/780fec97-71b6-4994-a42f-3caaa7a5cb52">


<img width="965" alt="image" src="https://github.com/user-attachments/assets/99143a73-71bb-4680-b16b-d7d4bc862637">


## How Has This Been Tested?
ran tests, updated where necessary, tested manually by creating MRs and viewing on the table.

## Test Impact
minor updates

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
