### PR TITLE
[RHOAIENG-6851] Fix for Edit and Delete actions in Model tab

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -11,14 +11,14 @@ const KServeInferenceServiceTable: React.FC = () => {
   const [editKserveResources, setEditKServeResources] = React.useState<
     | {
         inferenceService: InferenceServiceKind;
-        servingRuntime: ServingRuntimeKind;
+        servingRuntime?: ServingRuntimeKind;
       }
     | undefined
   >(undefined);
   const [deleteKserveResources, setDeleteKServeResources] = React.useState<
     | {
         inferenceService: InferenceServiceKind;
-        servingRuntime: ServingRuntimeKind;
+        servingRuntime?: ServingRuntimeKind;
       }
     | undefined
   >(undefined);

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
@@ -21,11 +21,11 @@ type KServeInferenceServiceTableRowProps = {
   obj: InferenceServiceKind;
   onEditKServe: (obj: {
     inferenceService: InferenceServiceKind;
-    servingRuntime: ServingRuntimeKind;
+    servingRuntime?: ServingRuntimeKind;
   }) => void;
   onDeleteKServe: (obj: {
     inferenceService: InferenceServiceKind;
-    servingRuntime: ServingRuntimeKind;
+    servingRuntime?: ServingRuntimeKind;
   }) => void;
   rowIndex: number;
 };
@@ -67,22 +67,8 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
           isGlobal={false}
           showServingRuntime
           servingRuntime={servingRuntime}
-          onDeleteInferenceService={() => {
-            if (servingRuntime) {
-              onDeleteKServe({
-                inferenceService: obj,
-                servingRuntime,
-              });
-            }
-          }}
-          onEditInferenceService={() => {
-            if (servingRuntime) {
-              onEditKServe({
-                inferenceService: obj,
-                servingRuntime,
-              });
-            }
-          }}
+          onDeleteInferenceService={() => onDeleteKServe({ inferenceService: obj, servingRuntime })}
+          onEditInferenceService={() => onEditKServe({ inferenceService: obj, servingRuntime })}
         />
       </ResourceTr>
       <ResourceTr isExpanded={isExpanded} resource={obj}>


### PR DESCRIPTION
Closes: [RHOAIENG-6851](https://issues.redhat.com/browse/RHOAIENG-6851)

## Description
The edit and delete buttons did not perform their actions if the serving runtime was not found. Both the edit and delete modals handle the action when the serving runtime is not passed so the modals can still be launched.

## How Has This Been Tested?
Manually tested

## Test Impact
None

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

