### PR TITLE
[RHOAIENG-4702] Improve unique naming for runs and versions in pipelines

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -144,11 +144,11 @@ export class CreateRunPage {
   }
 
   fillName(value: string): void {
-    this.findNameInput().type(value);
+    this.findNameInput().clear().type(value);
   }
 
   fillDescription(value: string): void {
-    this.findDescriptionInput().type(value);
+    this.findDescriptionInput().clear().type(value);
   }
 
   selectExperimentByName(name: string): void {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -389,7 +389,10 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: `GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions`,
-          options: { path: { namespace: string; serviceName: string; pipelineId: string } },
+          options: {
+            path: { namespace: string; serviceName: string; pipelineId: string };
+            times?: number;
+          },
           response: OdhResponse<ListPipelineVersionsKF | GoogleRpcStatusKF>,
         ) => Cypress.Chainable<null>) &
         ((
@@ -397,6 +400,7 @@ declare global {
           options: {
             path: { namespace: string; serviceName: string };
             query?: { sort_by: string };
+            times?: number;
           },
           response: OdhResponse<ListPipelinesResponseKF | GoogleRpcStatusKF>,
         ) => Cypress.Chainable<null>) &

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
@@ -131,6 +131,8 @@ describe('Pipeline create runs', () => {
       createRunPage.find();
 
       // Fill out the form without a schedule and submit
+      createRunPage.fillName(initialMockRuns[0].display_name);
+      cy.findByTestId('duplicate-name-help-text').should('be.visible');
       createRunPage.fillName('New run');
       createRunPage.fillDescription('New run description');
       createRunPage.findExperimentSelect().should('not.be.disabled').click();
@@ -561,6 +563,8 @@ describe('Pipeline create runs', () => {
       createSchedulePage.find();
 
       // Fill out the form with a schedule and submit
+      createRunPage.fillName(initialMockRecurringRuns[0].display_name);
+      cy.findByTestId('duplicate-name-help-text').should('be.visible');
       createSchedulePage.fillName('New recurring run');
       createSchedulePage.fillDescription('New recurring run description');
       createSchedulePage.findExperimentSelect().should('not.be.disabled').click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -18,7 +18,6 @@ import {
   viewPipelineServerModal,
   PipelineSort,
 } from '~/__tests__/cypress/cypress/pages/pipelines';
-import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import {
   DataSciencePipelineApplicationModel,
@@ -364,8 +363,28 @@ describe('Pipelines', () => {
   });
 
   it('View pipeline server', () => {
-    const visitPipelineProjects = () => pipelinesGlobal.visit(projectName);
-    viewPipelineServerDetailsTest(visitPipelineProjects);
+    initIntercepts({});
+    cy.interceptK8s(
+      {
+        model: SecretModel,
+        ns: projectName,
+      },
+      mockSecretK8sResource({
+        s3Bucket: 'c2RzZA==',
+        namespace: projectName,
+        name: 'aws-connection-test',
+      }),
+    );
+    pipelinesGlobal.visit(projectName);
+
+    pipelinesGlobal.selectPipelineServerAction('View pipeline server configuration');
+    viewPipelineServerModal.shouldHaveAccessKey('sdsd');
+    viewPipelineServerModal.findPasswordHiddenButton().click();
+    viewPipelineServerModal.shouldHaveSecretKey('sdsd');
+    viewPipelineServerModal.shouldHaveEndPoint('https://s3.amazonaws.com');
+    viewPipelineServerModal.shouldHaveBucketName('test-pipelines-bucket');
+
+    viewPipelineServerModal.findCloseButton().click();
   });
 
   it('renders the page with pipelines table data', () => {
@@ -523,10 +542,10 @@ describe('Pipelines', () => {
   it('selects a different project', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
-    verifyRelativeURL('/pipelines/test-project-name');
+    cy.url().should('include', '/pipelines/test-project-name');
 
     pipelinesGlobal.selectProjectByName('Test Project 2');
-    verifyRelativeURL('/pipelines/test-project-name-2');
+    cy.url().should('include', '/pipelines/test-project-name-2');
   });
 
   it('imports a new pipeline', () => {
@@ -540,9 +559,7 @@ describe('Pipelines', () => {
 
     // Intercept upload/re-fetch of pipelines
     pipelineImportModal.mockUploadPipeline(uploadPipelineParams, projectName).as('uploadPipeline');
-    pipelinesTable
-      .mockGetPipelines([initialMockPipeline, uploadedMockPipeline], projectName)
-      .as('refreshPipelines');
+    pipelinesTable.mockGetPipelines([initialMockPipeline], projectName);
 
     // Wait for the pipelines table to load
     pipelinesTable.find();
@@ -552,9 +569,14 @@ describe('Pipelines', () => {
 
     // Fill out the "Import pipeline" modal and submit
     pipelineImportModal.shouldBeOpen();
+    pipelineImportModal.fillPipelineName(initialMockPipeline.display_name);
+    cy.findByTestId('duplicate-name-help-text').should('be.visible');
     pipelineImportModal.fillPipelineName('New pipeline');
     pipelineImportModal.fillPipelineDescription('New pipeline description');
     pipelineImportModal.uploadPipelineYaml(pipelineYamlPath);
+    pipelinesTable
+      .mockGetPipelines([initialMockPipeline, uploadedMockPipeline], projectName)
+      .as('refreshPipelines');
     pipelineImportModal.submit();
 
     // Wait for upload/fetch requests
@@ -574,7 +596,9 @@ describe('Pipelines', () => {
     });
 
     cy.wait('@refreshPipelines').then((interception) => {
-      expect(interception.request.query).to.eql({ sort_by: 'created_at desc', page_size: '10' });
+      expect(interception.request.query).to.include({
+        sort_by: 'created_at desc',
+      });
     });
 
     // Verify the uploaded pipeline is in the table
@@ -587,6 +611,7 @@ describe('Pipelines', () => {
     pipelinesGlobal.findImportPipelineButton().click();
 
     pipelineImportModal.shouldBeOpen();
+    pipelinesTable.mockGetPipelines([initialMockPipeline], projectName, 1);
     pipelineImportModal.fillPipelineName('New pipeline');
     pipelineImportModal.findUploadError().should('not.exist');
     pipelineImportModal.findSubmitButton().should('be.disabled');
@@ -617,12 +642,10 @@ describe('Pipelines', () => {
     pipelineImportModal
       .mockCreatePipelineAndVersion(createPipelineAndVersionParams, projectName)
       .as('createPipelineAndVersion');
-    pipelinesTable
-      .mockGetPipelines([initialMockPipeline, createdMockPipeline], projectName)
-      .as('refreshPipelines');
+    pipelinesTable.mockGetPipelines([initialMockPipeline], projectName);
     pipelinesTable.mockGetPipelineVersions(
       [buildMockPipelineVersionV2(createPipelineAndVersionParams.pipeline_version)],
-      'new-pipeline',
+      initialMockPipeline.pipeline_id,
       projectName,
     );
 
@@ -637,6 +660,9 @@ describe('Pipelines', () => {
     pipelineImportModal.fillPipelineName('New pipeline');
     pipelineImportModal.findImportPipelineRadio().check();
     pipelineImportModal.findPipelineUrlInput().type('https://example.com/pipeline.yaml');
+    pipelinesTable
+      .mockGetPipelines([initialMockPipeline, createdMockPipeline], projectName)
+      .as('refreshPipelines');
     pipelineImportModal.submit();
 
     // Wait for upload/fetch requests
@@ -668,13 +694,6 @@ describe('Pipelines', () => {
     pipelineVersionImportModal
       .mockUploadVersion(uploadVersionParams, projectName)
       .as('uploadVersion');
-    pipelinesTable
-      .mockGetPipelineVersions(
-        [initialMockPipelineVersion, uploadedMockPipelineVersion],
-        initialMockPipeline.pipeline_id,
-        projectName,
-      )
-      .as('refreshVersions');
 
     // Fill out the "Upload new version" modal and submit
     pipelineVersionImportModal.shouldBeOpen();
@@ -682,6 +701,13 @@ describe('Pipelines', () => {
     pipelineVersionImportModal.fillVersionName('New pipeline version');
     pipelineVersionImportModal.fillVersionDescription('New pipeline version description');
     pipelineVersionImportModal.uploadPipelineYaml(pipelineYamlPath);
+    pipelinesTable
+      .mockGetPipelineVersions(
+        [initialMockPipelineVersion, uploadedMockPipelineVersion],
+        initialMockPipeline.pipeline_id,
+        projectName,
+      )
+      .as('refreshVersions');
     pipelineVersionImportModal.submit();
 
     // Wait for upload/fetch requests
@@ -702,9 +728,8 @@ describe('Pipelines', () => {
     });
 
     cy.wait('@refreshVersions').then((interception) => {
-      expect(interception.request.query).to.eql({
+      expect(interception.request.query).to.include({
         sort_by: 'created_at desc',
-        page_size: '1',
         pipeline_id: 'test-pipeline',
       });
     });
@@ -729,6 +754,7 @@ describe('Pipelines', () => {
         pipeline_url: 'https://example.com/pipeline.yaml',
       },
     };
+
     // Wait for the pipelines table to load
     pipelinesTable.find();
 
@@ -745,7 +771,6 @@ describe('Pipelines', () => {
         projectName,
       )
       .as('refreshVersions');
-
     pipelineVersionImportModal
       .mockCreatePipelineVersion(createPipelineVersionParams, projectName)
       .as('createVersion');
@@ -753,6 +778,14 @@ describe('Pipelines', () => {
     // Fill out the "Upload new version" modal and submit
     pipelineVersionImportModal.shouldBeOpen();
     pipelineVersionImportModal.selectPipelineByName('Test pipeline');
+    pipelinesTable.mockGetPipelineVersions(
+      [initialMockPipelineVersion],
+      initialMockPipeline.pipeline_id,
+      projectName,
+      2,
+    );
+    pipelineVersionImportModal.fillVersionName(initialMockPipelineVersion.display_name);
+    cy.findByTestId('duplicate-name-help-text').should('be.visible');
     pipelineVersionImportModal.fillVersionName('New pipeline version');
     pipelineVersionImportModal.findImportPipelineRadio().check();
     pipelineVersionImportModal.findPipelineUrlInput().type('https://example.com/pipeline.yaml');
@@ -852,7 +885,6 @@ describe('Pipelines', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
 
-    // Wait for the pipelines table to load
     pipelinesTable.find();
     const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
     pipelineRow.findExpandButton().click();
@@ -861,7 +893,9 @@ describe('Pipelines', () => {
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
       .findPipelineVersionLink()
       .click();
-    verifyRelativeURL(
+
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/view`,
     );
   });
@@ -874,7 +908,8 @@ describe('Pipelines', () => {
     const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
     pipelineRow.findPipelineNameLink(initialMockPipeline.display_name).click();
 
-    verifyRelativeURL(
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/view`,
     );
   });
@@ -956,13 +991,25 @@ describe('Pipelines', () => {
   });
 
   it('navigate to create run page from pipeline row', () => {
-    const visitPipelineProjects = () => pipelinesGlobal.visit(projectName);
-    runCreateRunPageNavTest(visitPipelineProjects);
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
+
+    pipelinesTable.find();
+    pipelinesTable
+      .getRowById(initialMockPipeline.pipeline_id)
+      .findKebabAction('Create run')
+      .click();
+
+    cy.url().should(
+      'include',
+      `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/runs/create`,
+    );
   });
 
   it('run and schedule dropdown action should be disabeld when pipeline has no versions', () => {
     initIntercepts({ hasNoPipelineVersions: true });
     pipelinesGlobal.visit(projectName);
+
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
       .findKebabAction('Create schedule')
@@ -974,23 +1021,36 @@ describe('Pipelines', () => {
   });
 
   it('navigates to "Schedule run" page from pipeline row', () => {
-    const visitPipelineProjects = () => pipelinesGlobal.visit(projectName);
-    runScheduleRunPageNavTest(visitPipelineProjects);
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
+
+    pipelinesTable.find();
+    pipelinesTable
+      .getRowById(initialMockPipeline.pipeline_id)
+      .findKebabAction('Create schedule')
+      .click();
+
+    cy.url().should(
+      'include',
+      `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/schedules/create`,
+    );
   });
 
   it('navigate to create run page from pipeline version row', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
 
-    // Wait for the pipelines table to load
     pipelinesTable.find();
+
     const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
     pipelineRow.findExpandButton().click();
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
       .findKebabAction('Create run')
       .click();
-    verifyRelativeURL(
+
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/runs/create`,
     );
   });
@@ -1007,7 +1067,8 @@ describe('Pipelines', () => {
       .findKebabAction('Create schedule')
       .click();
 
-    verifyRelativeURL(
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/schedules/create`,
     );
   });
@@ -1016,15 +1077,17 @@ describe('Pipelines', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
 
-    // Wait for the pipelines table to load
     pipelinesTable.find();
+
     const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
     pipelineRow.findExpandButton().click();
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
       .findKebabAction('View runs')
       .click();
-    verifyRelativeURL(
+
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/runs`,
     );
   });
@@ -1040,7 +1103,9 @@ describe('Pipelines', () => {
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
       .findKebabAction('View schedules')
       .click();
-    verifyRelativeURL(
+
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/schedules`,
     );
   });
@@ -1083,9 +1148,8 @@ describe('Pipelines', () => {
     pagination.findNextButton().click();
 
     cy.wait('@refreshPipelines').then((interception) => {
-      expect(interception.request.query).to.eql({
+      expect(interception.request.query).to.include({
         sort_by: 'created_at desc',
-        page_size: '10',
         page_token: 'page-2-token',
       });
     });
@@ -1136,7 +1200,7 @@ type HandlersProps = {
   nextPageToken?: string | undefined;
 };
 
-export const initIntercepts = ({
+const initIntercepts = ({
   isEmpty = false,
   mockPipelines = [initialMockPipeline],
   hasNoPipelineVersions = false,
@@ -1234,63 +1298,3 @@ const createDeletePipelineIntercept = (pipelineId: string) =>
     },
     mockSuccessGoogleRpcStatus({}),
   );
-
-export const runCreateRunPageNavTest = (visitPipelineProjects: () => void): void => {
-  initIntercepts({});
-  visitPipelineProjects();
-
-  // Wait for the pipelines table to load
-  pipelinesTable.find();
-  pipelinesTable.getRowById(initialMockPipeline.pipeline_id).findKebabAction('Create run').click();
-  verifyRelativeURL(
-    `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/runs/create`,
-  );
-};
-
-export const runScheduleRunPageNavTest = (visitPipelineProjects: () => void): void => {
-  initIntercepts({});
-  visitPipelineProjects();
-
-  pipelinesTable.find();
-  pipelinesTable
-    .getRowById(initialMockPipeline.pipeline_id)
-    .findKebabAction('Create schedule')
-    .click();
-
-  verifyRelativeURL(
-    `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/schedules/create`,
-  );
-};
-
-export const viewPipelineServerDetailsTest = (visitPipelineProjects: () => void): void => {
-  initIntercepts({});
-  cy.interceptK8s(
-    {
-      model: SecretModel,
-      ns: projectName,
-    },
-    mockSecretK8sResource({
-      s3Bucket: 'c2RzZA==',
-      namespace: projectName,
-      name: 'aws-connection-test',
-    }),
-  );
-  visitPipelineProjects();
-  viewPipelineDetails();
-};
-
-const viewPipelineDetails = (
-  accessKey = 'sdsd',
-  secretKey = 'sdsd',
-  endpoint = 'https://s3.amazonaws.com',
-  bucketName = 'test-pipelines-bucket',
-) => {
-  pipelinesGlobal.selectPipelineServerAction('View pipeline server configuration');
-  viewPipelineServerModal.shouldHaveAccessKey(accessKey);
-  viewPipelineServerModal.findPasswordHiddenButton().click();
-  viewPipelineServerModal.shouldHaveSecretKey(secretKey);
-  viewPipelineServerModal.shouldHaveEndPoint(endpoint);
-  viewPipelineServerModal.shouldHaveBucketName(bucketName);
-
-  viewPipelineServerModal.findCloseButton().click();
-};

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesList.cy.ts
@@ -1,5 +1,11 @@
 /* eslint-disable camelcase */
-import { buildMockPipelineVersionV2 } from '~/__mocks__';
+import {
+  buildMockPipelineVersionV2,
+  buildMockPipelineVersionsV2,
+  mockProjectK8sResource,
+  mockRouteK8sResource,
+  mockSecretK8sResource,
+} from '~/__mocks__';
 import { mockDataSciencePipelineApplicationK8sResource } from '~/__mocks__/mockDataSciencePipelinesApplicationK8sResource';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
 import { mock404Error } from '~/__mocks__/mockK8sStatus';
@@ -9,18 +15,18 @@ import {
   configurePipelineServerModal,
   pipelineVersionImportModal,
   PipelineSort,
+  pipelinesGlobal,
+  viewPipelineServerModal,
 } from '~/__tests__/cypress/cypress/pages/pipelines';
 import { pipelinesSection } from '~/__tests__/cypress/cypress/pages/pipelines/pipelinesSection';
 import { projectDetails } from '~/__tests__/cypress/cypress/pages/projects';
-import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
-import { DataSciencePipelineApplicationModel } from '~/__tests__/cypress/cypress/utils/models';
-import type { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 import {
-  initIntercepts,
-  runCreateRunPageNavTest,
-  runScheduleRunPageNavTest,
-  viewPipelineServerDetailsTest,
-} from './pipelines.cy';
+  DataSciencePipelineApplicationModel,
+  ProjectModel,
+  RouteModel,
+  SecretModel,
+} from '~/__tests__/cypress/cypress/utils/models';
+import type { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 
 const projectName = 'test-project-name';
 const initialMockPipeline = buildMockPipelineV2({ display_name: 'Test pipeline' });
@@ -44,7 +50,7 @@ const mockPipelines: PipelineKFv2[] = [
 
 describe('PipelinesList', () => {
   it('should show the configure pipeline server button when the server is not configured', () => {
-    initIntercepts({ isEmpty: true });
+    initIntercepts({ isEmptyProject: true });
     cy.interceptK8s(
       {
         model: DataSciencePipelineApplicationModel,
@@ -63,7 +69,7 @@ describe('PipelinesList', () => {
   });
 
   it('should verify that clicking on Configure pipeline server button will open a modal', () => {
-    initIntercepts({ isEmpty: true });
+    initIntercepts({ isEmptyProject: true });
     projectDetails.visitSection(projectName, 'pipelines-projects');
     pipelinesSection.findCreatePipelineButton().should('be.enabled');
     pipelinesSection.findCreatePipelineButton().click();
@@ -71,13 +77,32 @@ describe('PipelinesList', () => {
   });
 
   it('should view pipeline server', () => {
-    const visitPipelineProjects = () =>
-      projectDetails.visitSection(projectName, 'pipelines-projects');
-    viewPipelineServerDetailsTest(visitPipelineProjects);
+    initIntercepts();
+    cy.interceptK8s(
+      {
+        model: SecretModel,
+        ns: projectName,
+      },
+      mockSecretK8sResource({
+        s3Bucket: 'c2RzZA==',
+        namespace: projectName,
+        name: 'aws-connection-test',
+      }),
+    );
+    projectDetails.visitSection(projectName, 'pipelines-projects');
+
+    pipelinesGlobal.selectPipelineServerAction('View pipeline server configuration');
+    viewPipelineServerModal.shouldHaveAccessKey('sdsd');
+    viewPipelineServerModal.findPasswordHiddenButton().click();
+    viewPipelineServerModal.shouldHaveSecretKey('sdsd');
+    viewPipelineServerModal.shouldHaveEndPoint('https://s3.amazonaws.com');
+    viewPipelineServerModal.shouldHaveBucketName('test-pipelines-bucket');
+
+    viewPipelineServerModal.findCloseButton().click();
   });
 
   it('should disable the upload version button when the list is empty', () => {
-    initIntercepts({});
+    initIntercepts();
     cy.interceptK8sList(
       DataSciencePipelineApplicationModel,
       mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({})]),
@@ -95,7 +120,6 @@ describe('PipelinesList', () => {
     ).as('pipelines');
 
     projectDetails.visitSection(projectName, 'pipelines-projects');
-
     pipelinesSection.findImportPipelineSplitButton().should('be.enabled').click();
 
     cy.wait('@pipelines').then((interception) => {
@@ -109,7 +133,7 @@ describe('PipelinesList', () => {
   });
 
   it('should show the ability to delete the pipeline server kebab option', () => {
-    initIntercepts({});
+    initIntercepts();
 
     projectDetails.visitSection(projectName, 'pipelines-projects');
 
@@ -118,9 +142,9 @@ describe('PipelinesList', () => {
   });
 
   it('should show the ability to upload new version when clicking the pipeline server kebab option', () => {
-    initIntercepts({});
-
+    initIntercepts();
     projectDetails.visitSection(projectName, 'pipelines-projects');
+
     pipelinesTable.find();
     const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
     pipelineRow.findKebabAction('Upload new version').should('be.visible').click();
@@ -128,7 +152,7 @@ describe('PipelinesList', () => {
   });
 
   it('should navigate to details page when clicking on the version name', () => {
-    initIntercepts({});
+    initIntercepts();
     projectDetails.visitSection(projectName, 'pipelines-projects');
 
     pipelinesTable.find();
@@ -138,27 +162,18 @@ describe('PipelinesList', () => {
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
       .findPipelineVersionLink()
       .click();
-    verifyRelativeURL(
+
+    cy.url().should(
+      'include',
       `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/view`,
     );
   });
 
   it('clicking on upload a new pipeline version should show a modal', () => {
-    initIntercepts({});
-    cy.intercept(
-      {
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
-      },
-      buildMockPipelines([initialMockPipelineVersion]),
-    );
+    initIntercepts();
     projectDetails.visitSection(projectName, 'pipelines-projects');
-    cy.intercept(
-      {
-        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines`,
-      },
-      buildMockPipelines(mockPipelines),
-    );
 
+    pipelinesTable.find();
     pipelinesSection.findImportPipelineSplitButton().click();
     pipelinesSection.findUploadVersionButton().click();
     pipelineVersionImportModal.shouldBeOpen();
@@ -173,19 +188,117 @@ describe('PipelinesList', () => {
   });
 
   it('navigates to create run page from pipeline row', () => {
-    const visitPipelineProjects = () =>
-      projectDetails.visitSection(projectName, 'pipelines-projects');
-    runCreateRunPageNavTest(visitPipelineProjects);
+    initIntercepts();
+    projectDetails.visitSection(projectName, 'pipelines-projects');
+
+    // Wait for the pipelines table to load
+    pipelinesTable.find();
+    pipelinesTable
+      .getRowById(initialMockPipeline.pipeline_id)
+      .findKebabAction('Create run')
+      .click();
+
+    cy.url().should(
+      'include',
+      `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/runs/create`,
+    );
   });
 
   it('navigates to "Schedule run" page from pipeline row', () => {
-    const visitPipelineProjects = () =>
-      projectDetails.visitSection(projectName, 'pipelines-projects');
-    runScheduleRunPageNavTest(visitPipelineProjects);
+    initIntercepts();
+    projectDetails.visitSection(projectName, 'pipelines-projects');
+
+    pipelinesTable.find();
+    pipelinesTable
+      .getRowById(initialMockPipeline.pipeline_id)
+      .findKebabAction('Create schedule')
+      .click();
+
+    cy.url().should(
+      'include',
+      `/pipelines/${projectName}/${initialMockPipeline.pipeline_id}/${initialMockPipelineVersion.pipeline_version_id}/schedules/create`,
+    );
   });
 });
 
 const pipelineTableSetup = () => {
-  initIntercepts({ mockPipelines });
+  initIntercepts();
   projectDetails.visitSection(projectName, 'pipelines-projects');
+};
+
+export const initIntercepts = (
+  { isEmptyProject }: { isEmptyProject?: boolean } = { isEmptyProject: false },
+): void => {
+  cy.interceptK8sList(
+    DataSciencePipelineApplicationModel,
+    mockK8sResourceList(
+      isEmptyProject
+        ? []
+        : [mockDataSciencePipelineApplicationK8sResource({ namespace: projectName })],
+    ),
+  );
+  cy.interceptK8s(
+    DataSciencePipelineApplicationModel,
+    mockDataSciencePipelineApplicationK8sResource({
+      namespace: projectName,
+      dspaSecretName: 'aws-connection-test',
+    }),
+  );
+  cy.interceptK8s(
+    RouteModel,
+    mockRouteK8sResource({
+      notebookName: 'ds-pipeline-dspa',
+      namespace: projectName,
+    }),
+  );
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([
+      mockProjectK8sResource({ k8sName: projectName }),
+      mockProjectK8sResource({ k8sName: `${projectName}-2`, displayName: 'Test Project 2' }),
+    ]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines',
+    {
+      path: { namespace: projectName, serviceName: 'dspa' },
+    },
+    buildMockPipelines([initialMockPipeline]),
+  ).as('getPipelines');
+
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+    {
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        pipelineId: initialMockPipeline.pipeline_id,
+      },
+    },
+    buildMockPipelineVersionsV2([initialMockPipelineVersion]),
+  );
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
+    {
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        pipelineId: initialMockPipeline.pipeline_id,
+      },
+    },
+    initialMockPipeline,
+  );
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+    {
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        pipelineId: initialMockPipeline.pipeline_id,
+        pipelineVersionId: initialMockPipelineVersion.pipeline_version_id,
+      },
+    },
+    initialMockPipelineVersion,
+  );
 };

--- a/frontend/src/concepts/k8s/NameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/NameDescriptionField.tsx
@@ -23,6 +23,8 @@ type NameDescriptionFieldProps = {
   showK8sName?: boolean;
   disableK8sName?: boolean;
   maxLength?: number;
+  nameHelperText?: React.ReactNode;
+  onNameChange?: (value: string) => void;
 };
 
 const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
@@ -34,6 +36,8 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
   showK8sName,
   disableK8sName,
   maxLength,
+  nameHelperText,
+  onNameChange,
 }) => {
   const autoSelectNameRef = React.useRef<HTMLInputElement | null>(null);
 
@@ -62,14 +66,20 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
             data-testid={nameFieldId}
             name={nameFieldId}
             value={data.name}
-            onChange={(e, name) => setData({ ...data, name })}
+            onChange={(_e, value) => {
+              setData({ ...data, name: value });
+              onNameChange?.(value);
+            }}
             maxLength={maxLength}
           />
+
           {maxLength && (
             <HelperText>
               <HelperTextItem>{`Cannot exceed ${maxLength} characters`}</HelperTextItem>
             </HelperText>
           )}
+
+          {nameHelperText}
         </FormGroup>
       </StackItem>
       {showK8sName && (

--- a/frontend/src/concepts/pipelines/apiHooks/useAllPipelineVersions.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/useAllPipelineVersions.ts
@@ -2,10 +2,41 @@ import React from 'react';
 import { PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import usePipelineQuery from '~/concepts/pipelines/apiHooks/usePipelineQuery';
-import { PipelineListPaged, PipelineOptions } from '~/concepts/pipelines/types';
+import {
+  ListPipelineVersions,
+  PipelineListPaged,
+  PipelineOptions,
+  PipelineParams,
+} from '~/concepts/pipelines/types';
 import { FetchState, NotReadyError } from '~/utilities/useFetchState';
 import { useAllPipelines } from '~/concepts/pipelines/apiHooks/usePipelines';
 import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
+import { K8sAPIOptions } from '~/k8sTypes';
+
+/**
+ * Recursively fetch each pipeline version page when a next_page_token exists.
+ */
+async function getAllVersions(
+  opts: K8sAPIOptions,
+  pipelineId: string,
+  params: PipelineParams | undefined,
+  listPipelineVersions: ListPipelineVersions,
+): Promise<PipelineVersionKFv2[]> {
+  const result = await listPipelineVersions(opts, pipelineId, params);
+  let allVersions = result.pipeline_versions ?? [];
+
+  if (result.next_page_token) {
+    const nextVersions = await getAllVersions(
+      opts,
+      pipelineId,
+      { pageSize: result.pipeline_versions?.length, pageToken: result.next_page_token },
+      listPipelineVersions,
+    );
+    allVersions = allVersions.concat(nextVersions);
+  }
+
+  return allVersions;
+}
 
 /**
  * Fetch all pipelines, then use those pipeline IDs to accumulate a list of pipeline versions.
@@ -26,15 +57,15 @@ export const useAllPipelineVersions = (
         }
 
         const pipelineVersionRequests = pipelineIds.map((pipelineId) =>
-          api.listPipelineVersions(opts, pipelineId, params),
+          getAllVersions(opts, pipelineId, params, api.listPipelineVersions),
         );
         const results = await Promise.all(pipelineVersionRequests);
 
         return results.reduce(
-          (acc: { total_size: number; items: PipelineVersionKFv2[] }, result) => {
+          (acc: { total_size: number; items: PipelineVersionKFv2[] }, versions) => {
             // eslint-disable-next-line camelcase
-            acc.total_size += result.total_size || 0;
-            acc.items = acc.items.concat(result.pipeline_versions || []);
+            acc.total_size += versions.length || 0;
+            acc.items = acc.items.concat(versions);
 
             return acc;
           },

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelines.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelines.ts
@@ -60,7 +60,7 @@ async function getAllPipelines(
   if (result.next_page_token) {
     const nextPipelines = await getAllPipelines(
       opts,
-      { pageToken: result.next_page_token },
+      { ...params, pageToken: result.next_page_token },
       listPipelines,
     );
     allPipelines = allPipelines.concat(nextPipelines);

--- a/frontend/src/concepts/pipelines/content/DuplicateNameHelperText.tsx
+++ b/frontend/src/concepts/pipelines/content/DuplicateNameHelperText.tsx
@@ -1,0 +1,31 @@
+import { HelperText, HelperTextItem, HelperTextItemProps, Icon } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+interface DuplicateNameHelperTextProps {
+  name: string;
+  isError?: boolean;
+}
+
+export const DuplicateNameHelperText: React.FC<DuplicateNameHelperTextProps> = ({
+  name,
+  isError,
+}) => {
+  const helperTextItemProps: HelperTextItemProps = isError
+    ? { variant: 'error', hasIcon: true }
+    : {
+        icon: (
+          <Icon status="info">
+            <InfoCircleIcon />
+          </Icon>
+        ),
+      };
+
+  return (
+    <HelperText data-testid="duplicate-name-help-text">
+      <HelperTextItem {...helperTextItemProps}>
+        <b>{name}</b> already exists. Try a different name.
+      </HelperTextItem>
+    </HelperText>
+  );
+};

--- a/frontend/src/concepts/pipelines/utils.ts
+++ b/frontend/src/concepts/pipelines/utils.ts
@@ -5,7 +5,8 @@ import {
 } from '~/concepts/pipelines/content/configurePipelinesServer/const';
 import { ELYRA_SECRET_NAME } from '~/concepts/pipelines/elyra/const';
 import { allSettledPromises } from '~/utilities/allSettledPromises';
-import { PipelineRecurringRunKFv2, PipelineRunKFv2 } from './kfTypes';
+import { PipelineRecurringRunKFv2, PipelineRunKFv2, PipelinesFilterOp } from './kfTypes';
+import { PipelineParams } from './types';
 
 export const deleteServer = async (namespace: string, crName: string): Promise<void> => {
   const dspa = await getPipelinesCR(namespace, crName);
@@ -33,3 +34,16 @@ export const isGeneratedDSPAExternalStorageSecret = (name: string): boolean =>
 export const isRunSchedule = (
   resource: PipelineRunKFv2 | PipelineRecurringRunKFv2,
 ): resource is PipelineRecurringRunKFv2 => 'trigger' in resource;
+
+export const getNameEqualsFilter = (name: string): Pick<PipelineParams, 'filter'> => ({
+  filter: {
+    predicates: [
+      {
+        key: 'name',
+        operation: PipelinesFilterOp.EQUALS,
+        // eslint-disable-next-line camelcase
+        string_value: name,
+      },
+    ],
+  },
+});


### PR DESCRIPTION
Closes: [RHOAIENG-4702](https://issues.redhat.com/browse/RHOAIENG-4702)

## Description
- Added duplicate name info helper text when uploading a pipeline, version or creating a run or schedule.
- Fixed issue where if > 20 versions existed within a particular pipeline, only the latest 20 were being used in the list of versions used on every runs table - this would result in pipeline versions not rendered in the table - instead just a hyphen, and consequently effected the list of pipeline versions available for the table filter toolbar dropdown.
- Fixed duplicate running of ~30 tests that was leading to an unnecessary additional ~2.5 minutes of CI cypress test runtime.

<img width="630" alt="image" src="https://github.com/user-attachments/assets/f074631d-2efc-4260-ae73-01d9c3cc3b1f">

## How Has This Been Tested?
Manual testing, and updated existing tests to verify the existence of the duplicate name helper text.

## Test Impact
Creation of runs, schedules, and importing of pipelines and versions.

## How to test
1. When creating a new run, specify a "Name" of a run that already exists within the project you're in, verify Info helper text exists, with the ability to still create the run, since this is not an API limitation for runs or recurring runs.
2. Perform step 1, but instead use the "Create schedule" page/form.
3. Open the import pipeline modal from the pipelines list page, specify a "Name" of a pipeline that already exists within the project you're in, verify helper text exists.
4. Perform step 3 except from the "Create run" page (accessed from below the Pipeline form dropdown).
5. Open the import pipeline version modal from the pipelines list page, specify a "Version name" of a pipeline version that already exists within the project you're in and the pipeline specified above it, verify helper text exists.
6. Perform step 5 except from the "Create run" page (accessed from below the Pipeline version form dropdown).

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
