### PR TITLE
disable access to notebook from other users

### DIFF
--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -8,7 +8,7 @@ import { K8sStatus, KubeFastifyInstance, OauthFastifyRequest } from '../../../ty
 import { createCustomError } from '../../../utils/requestUtils';
 import { isK8sStatus, passThroughResource } from '../k8s/pass-through';
 
-const createSelfSubjectAccessReview = (
+export const createSelfSubjectAccessReview = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   resourceAttributes: V1ResourceAttributes,

--- a/backend/src/routes/api/nb-events/eventUtils.ts
+++ b/backend/src/routes/api/nb-events/eventUtils.ts
@@ -1,5 +1,7 @@
-import { V1Event, V1EventList } from '@kubernetes/client-node';
-import { KubeFastifyInstance } from '../../../types';
+import { V1Event, V1SelfSubjectAccessReview } from '@kubernetes/client-node';
+import { K8sStatus, KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
+import { createSelfSubjectAccessReview } from '../namespaces/namespaceUtils';
+import { createCustomError } from '../../../utils/requestUtils';
 
 export const getNotebookEvents = async (
   fastify: KubeFastifyInstance,
@@ -7,18 +9,57 @@ export const getNotebookEvents = async (
   notebookName: string,
   podUID: string | undefined,
 ): Promise<V1Event[]> => {
-  return fastify.kube.coreV1Api
-    .listNamespacedEvent(
+  if (podUID) {
+    const response = await fastify.kube.coreV1Api.listNamespacedPod(
       namespace,
       undefined,
       undefined,
       undefined,
-      podUID
-        ? `involvedObject.kind=Pod,involvedObject.uid=${podUID}`
-        : `involvedObject.kind=StatefulSet,involvedObject.name=${notebookName}`,
-    )
-    .then((res) => {
-      const body = res.body as V1EventList;
-      return body.items;
-    });
+      undefined,
+      `notebook-name=${notebookName}`,
+    );
+    for (const pod of response.body.items) {
+      if (pod.metadata.uid === podUID) {
+        return fastify.kube.coreV1Api
+          .listNamespacedEvent(
+            namespace,
+            undefined,
+            undefined,
+            undefined,
+            `involvedObject.kind=Pod,involvedObject.uid=${podUID}`,
+          )
+          .then((res) => res.body.items);
+      }
+    }
+    throw createCustomError(
+      '404 Referenced pod not found for the notebook',
+      'Referenced pod not found for the notebook',
+      404,
+    );
+  } else {
+    return fastify.kube.coreV1Api
+      .listNamespacedEvent(
+        namespace,
+        undefined,
+        undefined,
+        undefined,
+        `involvedObject.kind=StatefulSet,involvedObject.name=${notebookName}`,
+      )
+      .then((res) => res.body.items);
+  }
 };
+
+export const checkUserNotebookPermissions = (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  name: string,
+  namespace: string,
+): Promise<V1SelfSubjectAccessReview | K8sStatus> =>
+  createSelfSubjectAccessReview(fastify, request, {
+    group: 'kubeflow.org',
+    resource: 'notebooks',
+    subresource: '',
+    verb: 'get',
+    name,
+    namespace,
+  });

--- a/backend/src/routes/api/nb-events/index.ts
+++ b/backend/src/routes/api/nb-events/index.ts
@@ -1,7 +1,9 @@
 import { FastifyRequest } from 'fastify';
-import { getNotebookEvents } from './eventUtils';
 import { secureRoute } from '../../../utils/route-security';
 import { KubeFastifyInstance } from '../../../types';
+import { checkUserNotebookPermissions, getNotebookEvents } from './eventUtils';
+import { createCustomError } from '../../../utils/requestUtils';
+import { isK8sStatus } from '../k8s/pass-through';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   const routeHandler = secureRoute(fastify)(
@@ -15,7 +17,27 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       }>,
     ) => {
       const { namespace, notebookName, podUID } = request.params;
-      return getNotebookEvents(fastify, namespace, notebookName, podUID);
+      const selfSubjectAccessReview = await checkUserNotebookPermissions(
+        fastify,
+        request,
+        notebookName,
+        namespace,
+      );
+      if (isK8sStatus(selfSubjectAccessReview)) {
+        throw createCustomError(
+          selfSubjectAccessReview.reason,
+          selfSubjectAccessReview.message,
+          selfSubjectAccessReview.code,
+        );
+      }
+      if (selfSubjectAccessReview.status.allowed === true) {
+        return getNotebookEvents(fastify, namespace, notebookName, podUID);
+      }
+      throw createCustomError(
+        '404 Referenced pod not found for the notebook',
+        'Referenced pod not found for the notebook',
+        404,
+      );
     },
   );
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-536](https://issues.redhat.com/browse/RHOAIENG-536)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Previously, a user without 'get' permissions for notebooks could access the API url for notebook events. Now, they are unable to, and they would be greeted with a `403` status code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Steps to test:
1. Create a new notebook server (`Applications` -> `Enabled` ->  `Jupyter`)
2. That itself should be an event. If time has elapsed since then, just open up the notebook server, make a file, and type in `print("hello world")` or anything else that would constitute an event.
3. Create a user with no permissions
4. Change the URL in `dev_impersonate` to:
```
 const url = `https://oauth.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`; 
```
We are changing the URL because currently it doesn't work in ROSA clusters. This issue has already been [raised](https://issues.redhat.com/browse/RHOAIENG-9996)
5. Follow the steps [ here ](https://github.com/opendatahub-io/odh-dashboard/blob/279d95daa575379ca4fb27e86877ffd6a9a9edb7/docs/SDK.md#pass-through-impersonate-user-dev-mode) to impersonate said user with no permissions.
6. Create a role for that user which gives it access to view notebooks. Then, make a rolebinding to that user for that role.
```
rules:
  - verbs:
      - get
    apiGroups:
      - kubeflow.org
    resources:
      - notebooks
    resourceName:
      - <notebook name>
```
7. Access through this link  `/api/nb-events/:namespace/:notebookName/:podUID`
8. Get the notebookName and podUID from the terminal with this command:

```
oc get pods -n opendatahub -o custom-columns=notebookName:.metadata.labels.notebook-name,podUID:.metadata.uid
```
9. This should work. However, when you go back to the role you just created previously and remove the 'get' verb OR set the <notebook name> to literally anything else, you should be greeted with a 403 status code.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

SSAR is hard to test in test suites.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
