### PR TITLE
[RHOAIENG-9754] Use npm-Version of the Segment client

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@patternfly/react-tokens": "^5.3.1",
         "@patternfly/react-topology": "^5.4.0-prerelease.10",
         "@patternfly/react-virtualized-extension": "^5.1.0",
+        "@segment/analytics-next": "^1.72.0",
         "@types/classnames": "^2.3.1",
         "axios": "^1.6.4",
         "classnames": "^2.2.6",
@@ -3717,6 +3718,27 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
@@ -4210,6 +4232,87 @@
       "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.6.0.tgz",
+      "integrity": "sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-next": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.72.0.tgz",
+      "integrity": "sha512-NqJ8819q1DJ2nWo71XnJhkdBYIh0oYOP8yBqJhcyqsQYiSo3Eg4NGLm+7ubMcFzB/1YRM005medyvokEmDocuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.6.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "@segment/analytics.js-video-plugins": "^0.2.1",
+        "@segment/facade": "^3.4.9",
+        "dset": "^3.1.2",
+        "js-cookie": "3.0.1",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1",
+        "unfetch": "^4.1.0"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
+      "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "unfetch": "^3.1.1"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins/node_modules/unfetch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
+      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==",
+      "license": "MIT"
+    },
+    "node_modules/@segment/facade": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.10.tgz",
+      "integrity": "sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate-traverse": "^1.1.1",
+        "inherits": "^2.0.4",
+        "new-date": "^1.0.3",
+        "obj-case": "0.2.1"
+      }
+    },
+    "node_modules/@segment/isodate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@segment/isodate-traverse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
+      "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate": "^1.0.3"
       }
     },
     "node_modules/@sideway/address": {
@@ -9800,6 +9903,15 @@
         "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
       }
     },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -12641,8 +12753,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -16093,6 +16204,15 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18027,6 +18147,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/new-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
+      "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate": "1.0.3"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -18041,6 +18170,48 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -18472,6 +18643,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -22640,6 +22817,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "@patternfly/react-tokens": "^5.3.1",
     "@patternfly/react-topology": "^5.4.0-prerelease.10",
     "@patternfly/react-virtualized-extension": "^5.1.0",
+    "@segment/analytics-next": "^1.72.0",
     "@types/classnames": "^2.3.1",
     "axios": "^1.6.4",
     "classnames": "^2.2.6",

--- a/frontend/src/components/ExternalLink.tsx
+++ b/frontend/src/components/ExternalLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { fireTrackingEventRaw } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireLinkTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 
 type ExternalLinkProps = {
   text: string;
@@ -14,7 +14,7 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({ text, to }) => (
     isInline
     onClick={() => {
       window.open(to);
-      fireTrackingEventRaw('ExternalLink Clicked', { href: to, from: window.location.pathname });
+      fireLinkTrackingEvent('ExternalLink Clicked', { href: to, from: window.location.pathname });
     }}
     icon={<ExternalLinkAltIcon />}
     iconPosition="right"

--- a/frontend/src/components/OdhDocCard.tsx
+++ b/frontend/src/components/OdhDocCard.tsx
@@ -21,7 +21,7 @@ import {
   launchQuickStart,
   LaunchStatusEnum,
 } from '~/utilities/quickStartUtils';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireMiscTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import BrandImage from './BrandImage';
 import DocCardBadges from './DocCardBadges';
 import { useQuickStartCardSelected } from './useQuickStartCardSelected';
@@ -41,7 +41,7 @@ type OdhDocCardProps = {
 const fireResourceAccessedEvent =
   (name: string, type: string, qsContext?: QuickStartContextValues) => () => {
     const quickStartLabel = getQuickStartLabel(name, qsContext);
-    fireTrackingEvent(
+    fireMiscTrackingEvent(
       type === OdhDocumentType.QuickStart ? `Resource ${quickStartLabel}` : 'Resource Accessed',
       {
         name,

--- a/frontend/src/concepts/analyticsTracking/initSegment.tsx
+++ b/frontend/src/concepts/analyticsTracking/initSegment.tsx
@@ -1,74 +1,27 @@
+import { AnalyticsBrowser } from '@segment/analytics-next';
+
 export const initSegment = async (props: {
   segmentKey: string;
   enabled: boolean;
 }): Promise<void> => {
   const { segmentKey, enabled } = props;
-  const analytics = (window.analytics = window.analytics || []);
-  if (analytics.initialize) {
+  if (!enabled) {
+    window.analytics = window.analytics || [];
     return;
   }
-  if (analytics.invoked) {
-    /* eslint-disable-next-line no-console */
-    console.error('Segment snippet included twice.');
-  } else {
-    analytics.invoked = true;
-    analytics.methods = [
-      'trackSubmit',
-      'trackClick',
-      'trackLink',
-      'trackForm',
-      'pageview',
-      'identify',
-      'reset',
-      'group',
-      'track',
-      'ready',
-      'alias',
-      'debug',
-      'page',
-      'once',
-      'off',
-      'on',
-      'addSourceMiddleware',
-      'addIntegrationMiddleware',
-      'setAnonymousId',
-      'addDestinationMiddleware',
-    ];
-    analytics.factory =
-      (e: string) =>
-      (...t: unknown[]) => {
-        t.unshift(e);
-        analytics.push(t);
-        return analytics;
-      };
-    for (let e = 0; e < analytics.methods.length; e++) {
-      const key = analytics.methods[e];
-      analytics[key] = analytics.factory(key);
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    analytics.load = (key: string, options: any) => {
-      const t = document.createElement('script');
-      t.type = 'text/javascript';
-      t.async = true;
-      t.src = `https://console.redhat.com/connections/cdn/analytics.js/v1/${encodeURIComponent(
-        key,
-      )}/analytics.min.js`;
-      const n = document.getElementsByTagName('script')[0];
-      if (n.parentNode) {
-        n.parentNode.insertBefore(t, n);
-      }
-      analytics._loadOptions = options;
-    };
-    analytics.SNIPPET_VERSION = '4.13.1';
-    if (segmentKey && enabled) {
-      analytics.load(segmentKey, {
-        integrations: {
-          'Segment.io': {
-            apiHost: 'console.redhat.com/connections/api/v1',
-            protocol: 'https',
-          },
+  window.analytics = AnalyticsBrowser.load(
+    {
+      writeKey: segmentKey,
+      cdnURL: 'https://console.redhat.com/connections/cdn',
+    },
+
+    {
+      integrations: {
+        'Segment.io': {
+          apiHost: 'console.redhat.com/connections/api/v1',
+          protocol: 'https',
         },
-      });
-    }
-  }
+      },
+    },
+  );
 };

--- a/frontend/src/concepts/analyticsTracking/trackingProperties.ts
+++ b/frontend/src/concepts/analyticsTracking/trackingProperties.ts
@@ -2,24 +2,38 @@ export type ODHSegmentKey = {
   segmentKey: string;
 };
 
-export enum TrackingOutcome {
+export type IdentifyEventProperties = {
+  anonymousID?: string;
+};
+
+export const enum TrackingOutcome {
   submit = 'submit',
   cancel = 'cancel',
 }
 
-export type TrackingEventProperties = {
-  name?: string;
-  anonymousID?: string;
-  type?: string;
-  term?: string;
-  accelerator?: string;
-  acceleratorCount?: number;
-  lastSelectedSize?: string;
-  lastSelectedImage?: string;
-  projectName?: string;
-  notebookName?: string;
-  lastActivity?: string;
-  outcome?: TrackingOutcome;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type BaseTrackingEventProperties = {
+  // empty for the moment
+};
+
+export type BaseFormTrackingEventProperties = {
+  outcome: TrackingOutcome;
   success?: boolean;
   error?: string;
-};
+} & BaseTrackingEventProperties;
+
+export type FormTrackingEventProperties = {
+  [key: string]: string | number | boolean | undefined;
+} & BaseFormTrackingEventProperties;
+
+export type LinkTrackingEventProperties = {
+  from?: string;
+  href?: string;
+  to?: string;
+  type?: string;
+  section?: string;
+} & BaseTrackingEventProperties;
+
+export type MiscTrackingEventProperties = {
+  [key: string]: string | number | boolean | undefined;
+} & BaseTrackingEventProperties;

--- a/frontend/src/concepts/analyticsTracking/useSegmentTracking.ts
+++ b/frontend/src/concepts/analyticsTracking/useSegmentTracking.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAppContext } from '~/app/AppContext';
 import { useAppSelector } from '~/redux/hooks';
-import { fireTrackingEvent } from './segmentIOUtils';
+import { fireIdentifyEvent, firePageEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { useWatchSegmentKey } from './useWatchSegmentKey';
 import { initSegment } from './initSegment';
 
@@ -28,8 +28,8 @@ export const useSegmentTracking = (): void => {
         enabled: !dashboardConfig.spec.dashboardConfig.disableTracking,
       }).then(() => {
         computeUserId().then((userId) => {
-          fireTrackingEvent('identify', { anonymousID: userId });
-          fireTrackingEvent('page');
+          fireIdentifyEvent({ anonymousID: userId });
+          firePageEvent();
         });
       });
     }

--- a/frontend/src/concepts/analyticsTracking/useTrackHistory.ts
+++ b/frontend/src/concepts/analyticsTracking/useTrackHistory.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { fireTrackingEvent } from './segmentIOUtils';
+import { firePageEvent } from './segmentIOUtils';
 
 export const useTrackHistory = (): void => {
   const { pathname } = useLocation();
 
   // notify url change events
   React.useEffect(() => {
-    fireTrackingEvent('page');
+    firePageEvent();
   }, [pathname]);
 };

--- a/frontend/src/pages/enabledApplications/EnabledApplications.tsx
+++ b/frontend/src/pages/enabledApplications/EnabledApplications.tsx
@@ -5,7 +5,7 @@ import { useWatchComponents } from '~/utilities/useWatchComponents';
 import { OdhApplication } from '~/types';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import OdhAppCard from '~/components/OdhAppCard';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireMiscTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 
 const description = `Launch your enabled applications, view documentation, or get started with quick start instructions and tasks.`;
 
@@ -66,7 +66,7 @@ const EnabledApplications: React.FC = () => {
           .filter((component) => component.spec.isEnabled)
           .map((c) => c.metadata.name),
       ).forEach((name) =>
-        fireTrackingEvent('Application Enabled', {
+        fireMiscTrackingEvent('Application Enabled', {
           name,
         }),
       );

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -14,9 +14,9 @@ import ApplicationsPage from '~/pages/ApplicationsPage';
 import { OdhApplication } from '~/types';
 import { useQueryParams } from '~/utilities/useQueryParams';
 import { removeQueryArgument, setQueryArgument } from '~/utilities/router';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { ODH_PRODUCT_NAME } from '~/utilities/const';
 import { useAppContext } from '~/app/AppContext';
+import { fireMiscTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import GetStartedPanel from './GetStartedPanel';
 
 import './ExploreApplications.scss';
@@ -71,7 +71,7 @@ const ExploreApplicationsInner: React.FC<ExploreApplicationsInnerProps> = React.
                       isSelected={selectedComponent?.metadata.name === c.metadata.name}
                       onSelect={() => {
                         updateSelection(c.metadata.name);
-                        fireTrackingEvent('Explore card clicked', {
+                        fireMiscTrackingEvent('Explore card clicked', {
                           name: c.metadata.name,
                         });
                       }}

--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -19,8 +19,8 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { OdhApplication } from '~/types';
 import MarkdownView from '~/components/MarkdownView';
 import { markdownConverter } from '~/utilities/markdown';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { useAppContext } from '~/app/AppContext';
+import { fireMiscTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 
 const DEFAULT_BETA_TEXT =
   'This application is available for early access prior to official ' +
@@ -86,7 +86,7 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
               <Button
                 icon={<ExternalLinkAltIcon />}
                 onClick={() =>
-                  fireTrackingEvent('Explore card get started clicked', {
+                  fireMiscTrackingEvent('Explore card get started clicked', {
                     name: selectedApp.metadata.name,
                   })
                 }

--- a/frontend/src/pages/home/projects/ProjectCard.tsx
+++ b/frontend/src/pages/home/projects/ProjectCard.tsx
@@ -19,7 +19,7 @@ import TruncatedText from '~/components/TruncatedText';
 import { SectionType } from '~/concepts/design/utils';
 import TypeBorderedCard from '~/concepts/design/TypeBorderedCard';
 import { getProjectOwner } from '~/concepts/projects/utils';
-import { fireTrackingEventRaw } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireLinkTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 
 interface ProjectCardProps {
@@ -38,7 +38,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
           isInline
           onClick={() => {
             navigate(`/projects/${project.metadata.name}`);
-            fireTrackingEventRaw('HomeCardClicked', {
+            fireLinkTrackingEvent('HomeCardClicked', {
               to: `/projects/${project.metadata.name}`,
               type: 'project',
             });

--- a/frontend/src/pages/home/useEnableTeamSection.tsx
+++ b/frontend/src/pages/home/useEnableTeamSection.tsx
@@ -13,7 +13,7 @@ import InfoGalleryItem from '~/concepts/design/InfoGalleryItem';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { SupportedArea } from '~/concepts/areas';
 import useIsAreaAvailable from '~/concepts/areas/useIsAreaAvailable';
-import { fireTrackingEventRaw } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireLinkTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 
 export const useEnableTeamSection = (): React.ReactNode => {
   const navigate = useNavigate();
@@ -34,7 +34,7 @@ export const useEnableTeamSection = (): React.ReactNode => {
   }
 
   const trackAndNavigate = (section: string, to: string): void => {
-    fireTrackingEventRaw('HomeCardClicked', {
+    fireLinkTrackingEvent('HomeCardClicked', {
       to: `${to}`,
       type: 'enableTeam',
       section: `${section}`,

--- a/frontend/src/pages/learningCenter/LearningCenterToolbar.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterToolbar.tsx
@@ -25,7 +25,7 @@ import {
 } from '@patternfly/react-icons';
 import { removeQueryArgument, setQueryArgument } from '~/utilities/router';
 import { useQueryParams } from '~/utilities/useQueryParams';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireMiscTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import {
   SEARCH_FILTER_KEY,
   DOC_SORT_KEY,
@@ -58,7 +58,7 @@ type LearningCenterToolbarProps = {
 // to avoid firing event with every single character input
 const fireSearchedEvent = _.debounce((val: string) => {
   if (val) {
-    fireTrackingEvent('Resource Searched', {
+    fireMiscTrackingEvent('Resource Searched', {
       term: val,
     });
   }

--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { Button, ButtonVariant, Flex, FlexItem, Icon, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { NotebookKind } from '~/k8sTypes';
-import { fireTrackingEventRaw } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { fireMiscTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import useRouteForNotebook from './useRouteForNotebook';
 import { hasStopAnnotation } from './utils';
 
@@ -51,11 +51,11 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
               ? 'var(--pf-v5-global--FontSize--md)'
               : 'var(--pf-v5-global--FontSize--sm)',
           }}
-          onClick={() =>
-            fireTrackingEventRaw('Workbench Opened', {
+          onClick={() => {
+            fireMiscTrackingEvent('Workbench Opened', {
               wbName: getDisplayNameFromK8sResource(notebook),
-            })
-          }
+            });
+          }}
         >
           {label ?? getDisplayNameFromK8sResource(notebook)}
         </Button>

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { Flex, Switch } from '@patternfly/react-core';
 import { startNotebook, stopNotebook } from '~/api';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import useNotebookAcceleratorProfile from '~/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfile';
 import useNotebookDeploymentSize from '~/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize';
 import { computeNotebooksTolerations } from '~/utilities/tolerations';
 import { useAppContext } from '~/app/AppContext';
 import { currentlyHasPipelines } from '~/concepts/pipelines/elyra/utils';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 import { NotebookState } from './types';
 import useRefreshNotebookUntilStartOrStop from './useRefreshNotebookUntilStartOrStop';
 import StopNotebookConfirmModal from './StopNotebookConfirmModal';
@@ -52,7 +53,8 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
 
   const fireNotebookTrackingEvent = React.useCallback(
     (action: 'started' | 'stopped') => {
-      fireTrackingEvent(`Workbench ${action === 'started' ? 'Started' : 'Stopped'}`, {
+      fireFormTrackingEvent(`Workbench ${action === 'started' ? 'Started' : 'Stopped'}`, {
+        outcome: TrackingOutcome.submit,
         acceleratorCount: acceleratorProfile.useExisting ? undefined : acceleratorProfile.count,
         accelerator: acceleratorProfile.acceleratorProfile
           ? `${acceleratorProfile.acceleratorProfile.spec.displayName} (${acceleratorProfile.acceleratorProfile.metadata.name}): ${acceleratorProfile.acceleratorProfile.spec.identifier}`

--- a/frontend/src/pages/projects/screens/projects/DeleteProjectModal.tsx
+++ b/frontend/src/pages/projects/screens/projects/DeleteProjectModal.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { ProjectKind } from '~/k8sTypes';
 import { deleteProject } from '~/api';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
-import { fireTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 
 type DeleteProjectModalProps = {
   onClose: (deleted: boolean) => void;
@@ -18,9 +18,9 @@ const DeleteProjectModal: React.FC<DeleteProjectModalProps> = ({ deleteData, onC
 
   const onBeforeClose = (deleted: boolean) => {
     if (!deleted) {
-      fireTrackingEvent(deleteProjectEventType, { outcome: TrackingOutcome.cancel });
+      fireFormTrackingEvent(deleteProjectEventType, { outcome: TrackingOutcome.cancel });
     } else {
-      fireTrackingEvent(deleteProjectEventType, {
+      fireFormTrackingEvent(deleteProjectEventType, {
         outcome: TrackingOutcome.submit,
         success: true,
       });
@@ -45,7 +45,7 @@ const DeleteProjectModal: React.FC<DeleteProjectModalProps> = ({ deleteData, onC
           deleteProject(deleteData.metadata.name)
             .then(() => onBeforeClose(true))
             .catch((e) => {
-              fireTrackingEvent(deleteProjectEventType, {
+              fireFormTrackingEvent(deleteProjectEventType, {
                 outcome: TrackingOutcome.submit,
                 success: false,
                 error: e,

--- a/frontend/src/pages/projects/screens/projects/ManageProjectModal.tsx
+++ b/frontend/src/pages/projects/screens/projects/ManageProjectModal.tsx
@@ -11,7 +11,7 @@ import {
 import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
 import { NameDescType } from '~/pages/projects/types';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
-import { fireTrackingEventRaw } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 
 import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 
@@ -55,7 +55,7 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({
   const onBeforeClose = (newProjectName?: string) => {
     onClose(newProjectName);
     if (newProjectName) {
-      fireTrackingEventRaw(editProjectData ? 'Project Edited' : 'NewProject Created', {
+      fireFormTrackingEvent(editProjectData ? 'Project Edited' : 'NewProject Created', {
         outcome: TrackingOutcome.submit,
         success: true,
         projectName: newProjectName,
@@ -66,7 +66,7 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({
     setNameDesc({ name: '', k8sName: undefined, description: '' });
   };
   const handleError = (e: Error) => {
-    fireTrackingEventRaw(editProjectData ? 'Project Edited' : 'NewProject Created', {
+    fireFormTrackingEvent(editProjectData ? 'Project Edited' : 'NewProject Created', {
       outcome: TrackingOutcome.submit,
       success: false,
       projectName: '',
@@ -111,7 +111,7 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({
           variant="link"
           onClick={() => {
             onBeforeClose();
-            fireTrackingEventRaw(editProjectData ? 'Project Edited' : 'NewProject Created', {
+            fireFormTrackingEvent(editProjectData ? 'Project Edited' : 'NewProject Created', {
               outcome: TrackingOutcome.cancel,
             });
           }}

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -20,11 +20,11 @@ import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { AppContext } from '~/app/AppContext';
 import usePreferredStorageClass from '~/pages/projects/screens/spawner/storage/usePreferredStorageClass';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import {
-  fireTrackingEvent,
-  fireTrackingEventRaw,
-} from '~/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
+  FormTrackingEventProperties,
+  TrackingOutcome,
+} from '~/concepts/analyticsTracking/trackingProperties';
 import {
   createConfigMapsAndSecretsForNotebook,
   createPvcDataForNotebook,
@@ -87,7 +87,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
   const afterStart = (name: string, type: 'created' | 'updated') => {
     const { acceleratorProfile, notebookSize, image } = startNotebookData;
-    fireTrackingEventRaw(`Workbench ${type === 'created' ? 'Created' : 'Updated'}`, {
+    const tep: FormTrackingEventProperties = {
       acceleratorCount: acceleratorProfile.useExisting ? undefined : acceleratorProfile.count,
       accelerator: acceleratorProfile.acceleratorProfile
         ? `${acceleratorProfile.acceleratorProfile.spec.displayName} (${acceleratorProfile.acceleratorProfile.metadata.name}): ${acceleratorProfile.acceleratorProfile.spec.identifier}`
@@ -105,17 +105,18 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       notebookName: name,
       storageType: storageData.storageType,
       storageDataSize: storageData.creating.size,
-      dataConnectionType: dataConnection.creating?.type,
-      dataConnectionCategory: dataConnection.creating?.values?.category,
+      dataConnectionType: dataConnection.creating?.type?.toString(),
+      dataConnectionCategory: dataConnection.creating?.values?.category?.toString(),
       dataConnectionEnabled: dataConnection.enabled,
       outcome: TrackingOutcome.submit,
       success: true,
-    });
+    };
+    fireFormTrackingEvent(`Workbench ${type === 'created' ? 'Created' : 'Updated'}`, tep);
     refreshAllProjectData();
     navigate(`/projects/${projectName}?section=${ProjectSectionID.WORKBENCHES}`);
   };
   const handleError = (e: Error) => {
-    fireTrackingEvent('Workbench Created', {
+    fireFormTrackingEvent('Workbench Created', {
       outcome: TrackingOutcome.submit,
       success: false,
       error: e.message,
@@ -286,7 +287,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
               variant="link"
               id="cancel-button"
               onClick={() => {
-                fireTrackingEvent(`Workbench ${editNotebook ? 'Updated' : 'Created'}`, {
+                fireFormTrackingEvent(`Workbench ${editNotebook ? 'Updated' : 'Created'}`, {
                   outcome: TrackingOutcome.cancel,
                 });
                 navigate(`/projects/${projectName}?section=${ProjectSectionID.WORKBENCHES}`);


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-9754

## Description
Use the npm-version of the Segment client (Analytics(-next).js) and don't load it on the fly 
on the first load of the UI. 
This change has no impact of the visible appearance and functionality of the UI.

## How Has This Been Tested?
Manual testing by looking at network tab of the browser tools in non-dev mode

## Test Impact
See previous item

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

This currently builds on the code base of #2995  , but I can also rebase that against main 
cc @christianvogt @andrewballantyne 