### PR TITLE
[RHOAIENG-9764] Pipeline run details page code editor has style issues on pipeline spec tab

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsTabs.tsx
@@ -105,6 +105,7 @@ export const PipelineRunDetailsTabs: React.FC<PipelineRunDetailsTabsProps> = ({
             eventKey={DetailsTabKey.Spec}
             hidden={activeKey !== DetailsTabKey.Spec}
             style={{ flex: 1 }}
+            className="pf-v5-u-h-100"
             data-testid="pipeline-spec-tab"
           >
             <TabContentBody className="pf-v5-u-h-100" hasPadding>


### PR DESCRIPTION
Closes: [RHOAIENG-9764](https://issues.redhat.com/browse/RHOAIENG-9764)

## Description
The "styling issue" as described in the JIRA prevented users from seeing any of the pipeline spec content. A height of 100% needed to be applied to the tab content.

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/c64ec009-8ccd-409c-9d71-5f7e433b528c">

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
