### PR TITLE
[RHOAIENG-9754] Use the npm-Version of the Segment libraries.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@patternfly/react-tokens": "^5.3.1",
         "@patternfly/react-topology": "^5.4.0-prerelease.10",
         "@patternfly/react-virtualized-extension": "^5.1.0",
+        "@segment/analytics-next": "^1.72.0",
         "@types/classnames": "^2.3.1",
         "axios": "^1.6.4",
         "classnames": "^2.2.6",
@@ -3716,6 +3717,27 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
@@ -4209,6 +4231,87 @@
       "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.6.0.tgz",
+      "integrity": "sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-next": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.72.0.tgz",
+      "integrity": "sha512-NqJ8819q1DJ2nWo71XnJhkdBYIh0oYOP8yBqJhcyqsQYiSo3Eg4NGLm+7ubMcFzB/1YRM005medyvokEmDocuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.6.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "@segment/analytics.js-video-plugins": "^0.2.1",
+        "@segment/facade": "^3.4.9",
+        "dset": "^3.1.2",
+        "js-cookie": "3.0.1",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1",
+        "unfetch": "^4.1.0"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
+      "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "unfetch": "^3.1.1"
+      }
+    },
+    "node_modules/@segment/analytics.js-video-plugins/node_modules/unfetch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
+      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==",
+      "license": "MIT"
+    },
+    "node_modules/@segment/facade": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.10.tgz",
+      "integrity": "sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate-traverse": "^1.1.1",
+        "inherits": "^2.0.4",
+        "new-date": "^1.0.3",
+        "obj-case": "0.2.1"
+      }
+    },
+    "node_modules/@segment/isodate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@segment/isodate-traverse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
+      "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate": "^1.0.3"
       }
     },
     "node_modules/@sideway/address": {
@@ -9798,6 +9901,15 @@
         "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
       }
     },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -12639,8 +12751,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -16091,6 +16202,15 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18025,6 +18145,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "devOptional": true
     },
+    "node_modules/new-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
+      "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@segment/isodate": "1.0.3"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -18039,6 +18168,48 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -18470,6 +18641,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -22638,6 +22815,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "@patternfly/react-tokens": "^5.3.1",
     "@patternfly/react-topology": "^5.4.0-prerelease.10",
     "@patternfly/react-virtualized-extension": "^5.1.0",
+    "@segment/analytics-next": "^1.72.0",
     "@types/classnames": "^2.3.1",
     "axios": "^1.6.4",
     "classnames": "^2.2.6",

--- a/frontend/src/concepts/analyticsTracking/initSegment.tsx
+++ b/frontend/src/concepts/analyticsTracking/initSegment.tsx
@@ -1,74 +1,26 @@
+import { AnalyticsBrowser } from '@segment/analytics-next';
+
 export const initSegment = async (props: {
   segmentKey: string;
   enabled: boolean;
 }): Promise<void> => {
   const { segmentKey, enabled } = props;
-  const analytics = (window.analytics = window.analytics || []);
-  if (analytics.initialize) {
+  if (!enabled || !segmentKey) {
     return;
   }
-  if (analytics.invoked) {
-    /* eslint-disable-next-line no-console */
-    console.error('Segment snippet included twice.');
-  } else {
-    analytics.invoked = true;
-    analytics.methods = [
-      'trackSubmit',
-      'trackClick',
-      'trackLink',
-      'trackForm',
-      'pageview',
-      'identify',
-      'reset',
-      'group',
-      'track',
-      'ready',
-      'alias',
-      'debug',
-      'page',
-      'once',
-      'off',
-      'on',
-      'addSourceMiddleware',
-      'addIntegrationMiddleware',
-      'setAnonymousId',
-      'addDestinationMiddleware',
-    ];
-    analytics.factory =
-      (e: string) =>
-      (...t: unknown[]) => {
-        t.unshift(e);
-        analytics.push(t);
-        return analytics;
-      };
-    for (let e = 0; e < analytics.methods.length; e++) {
-      const key = analytics.methods[e];
-      analytics[key] = analytics.factory(key);
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    analytics.load = (key: string, options: any) => {
-      const t = document.createElement('script');
-      t.type = 'text/javascript';
-      t.async = true;
-      t.src = `https://console.redhat.com/connections/cdn/analytics.js/v1/${encodeURIComponent(
-        key,
-      )}/analytics.min.js`;
-      const n = document.getElementsByTagName('script')[0];
-      if (n.parentNode) {
-        n.parentNode.insertBefore(t, n);
-      }
-      analytics._loadOptions = options;
-    };
-    analytics.SNIPPET_VERSION = '4.13.1';
-    if (segmentKey && enabled) {
-      analytics.load(segmentKey, {
-        integrations: {
-          'Segment.io': {
-            apiHost: 'console.redhat.com/connections/api/v1',
-            protocol: 'https',
-          },
+  window.analytics = AnalyticsBrowser.load(
+    {
+      writeKey: segmentKey,
+      cdnURL: 'https://console.redhat.com/connections/cdn',
+    },
+
+    {
+      integrations: {
+        'Segment.io': {
+          apiHost: 'console.redhat.com/connections/api/v1',
+          protocol: 'https',
         },
-      });
-    }
-  }
+      },
+    },
+  );
 };


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-9754

## Description
Use the npm-version of the Segment client (Analytics(-next).js) and don't load it on the fly 
on the first load of the UI. 
This change has no impact of the visible appearance and functionality of the UI.

## How Has This Been Tested?
Manual testing by looking at network tab of the browser tools in non-dev mode

## Test Impact
See previous item

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @christianvogt @andrewballantyne 
Superseeds #3012