### PR TITLE
feat(MR): register model page skeleton

### DIFF
--- a/frontend/src/pages/modelRegistry/ModelRegistryRoutes.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryRoutes.tsx
@@ -10,6 +10,7 @@ import ModelVersionsArchive from './screens/ModelVersionsArchive/ModelVersionsAr
 import ModelVersionsArchiveDetails from './screens/ModelVersionsArchive/ModelVersionArchiveDetails';
 import RegisteredModelsArchive from './screens/RegisteredModelsArchive/RegisteredModelsArchive';
 import RegisteredModelsArchiveDetails from './screens/RegisteredModelsArchive/RegisteredModelArchiveDetails';
+import RegisterModel from './screens/RegisterModel/RegisterModel';
 
 const ModelRegistryRoutes: React.FC = () => (
   <Routes>
@@ -94,6 +95,7 @@ const ModelRegistryRoutes: React.FC = () => (
         </Route>
         <Route path="*" element={<Navigate to="." />} />
       </Route>
+      <Route path="registerModel" element={<RegisterModel />} />
       <Route path="*" element={<Navigate to="." />} />
     </Route>
   </Routes>

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
@@ -1,0 +1,336 @@
+import React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Form,
+  FormGroup,
+  FormSection,
+  HelperText,
+  HelperTextItem,
+  InputGroupItem,
+  InputGroupText,
+  Radio,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Text,
+  TextArea,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import useRegisterModelData from './useRegisterModelData';
+
+const RegisterModel: React.FC = () => {
+  const { modelRegistry: mrName } = useParams();
+  const [
+    {
+      modelRegistryName,
+      modelName,
+      modelDescription,
+      versionName,
+      versionDescription,
+      sourceModelFormat,
+      modelLocationType,
+      modelLocationEndpoint,
+      modelLocationBucket,
+      modelLocationRegion,
+      modelLocationPath,
+      modelLocationURI,
+    },
+    setData,
+    resetData,
+  ] = useRegisterModelData(mrName);
+  const [loading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>(undefined);
+
+  enum ModelLocationType {
+    ObjectStorage = 'Object storage',
+    URI = 'URI',
+  }
+
+  const isSubmitDisabled =
+    !modelRegistryName ||
+    !modelName ||
+    !versionName ||
+    loading ||
+    (modelLocationType === ModelLocationType.URI && !modelLocationURI) ||
+    (modelLocationType === ModelLocationType.ObjectStorage &&
+      (!modelLocationBucket || !modelLocationEndpoint || !modelLocationPath));
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    setError(undefined);
+    //TODO: implement submit calls/logic. remove console log and alert
+    alert('This functionality is not yet implemented');
+    /* eslint-disable-next-line no-console */
+    console.log({
+      modelRegistryName,
+      modelName,
+      modelDescription,
+      versionName,
+      versionDescription,
+      sourceModelFormat,
+      modelLocationType,
+      modelLocationEndpoint,
+      modelLocationBucket,
+      modelLocationRegion,
+      modelLocationPath,
+      modelLocationURI,
+    });
+  };
+
+  return (
+    <ApplicationsPage
+      title="Register model"
+      description="Create a new model and register a first version of the new model."
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem render={() => <Link to="/modelRegistry">Model registry</Link>} />
+          <BreadcrumbItem
+            render={() => (
+              <Link to={`/modelRegistry/${modelRegistryName}`}>{modelRegistryName}</Link>
+            )}
+          />
+          <BreadcrumbItem>Register model</BreadcrumbItem>
+        </Breadcrumb>
+      }
+      loaded
+      empty={false}
+      provideChildrenPadding
+    >
+      <Form>
+        <Stack hasGutter>
+          <StackItem>
+            <FormGroup label="Model registry" isRequired fieldId="mr-name">
+              <TextInput
+                isDisabled
+                isRequired
+                type="text"
+                id="mr-name"
+                name="mr-name"
+                value={modelRegistryName}
+              />
+            </FormGroup>
+          </StackItem>
+          <StackItem>
+            <FormSection
+              title={
+                <>
+                  <Title headingLevel="h2">Model info</Title>
+                  <Text component="p" className="form-subtitle-text">
+                    Configure the model info you want to create.
+                  </Text>
+                </>
+              }
+            >
+              <FormGroup label="Model name" isRequired fieldId="model-name">
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="model-name"
+                  name="model-name"
+                  value={modelName}
+                  onChange={(_e, value) => setData('modelName', value)}
+                />
+              </FormGroup>
+              <FormGroup label="Model description" fieldId="model-description">
+                <TextArea
+                  type="text"
+                  id="model-description"
+                  name="model-description"
+                  value={modelDescription}
+                  onChange={(_e, value) => setData('modelDescription', value)}
+                />
+              </FormGroup>
+            </FormSection>
+            <FormSection
+              title={
+                <>
+                  <Title headingLevel="h2">Version info</Title>
+                  <Text component="p" className="form-subtitle-text">
+                    Configure the version info for the run that you want to register.
+                  </Text>
+                </>
+              }
+            >
+              <FormGroup label="Version name" isRequired fieldId="version-name">
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="version-name"
+                  name="version-name"
+                  value={versionName}
+                  onChange={(_e, value) => setData('versionName', value)}
+                />
+              </FormGroup>
+              <FormGroup label="Version description" fieldId="version-description">
+                <TextArea
+                  type="text"
+                  id="version-description"
+                  name="version-description"
+                  value={versionDescription}
+                  onChange={(_e, value) => setData('versionDescription', value)}
+                />
+              </FormGroup>
+              <FormGroup label="Source model format" fieldId="source-model-format">
+                <TextInput
+                  type="text"
+                  placeholder="Example, tensorflow"
+                  id="source-model-format"
+                  name="source-model-format"
+                  value={sourceModelFormat}
+                  onChange={(_e, value) => setData('sourceModelFormat', value)}
+                />
+              </FormGroup>
+            </FormSection>
+            <FormSection
+              title={
+                <>
+                  <Title headingLevel="h2">Model location</Title>
+                  <Text component="p" className="form-subtitle-text">
+                    Specify the model location by providing either the object storage details or the
+                    URI.
+                  </Text>
+                </>
+              }
+            >
+              <Radio
+                isChecked={modelLocationType === ModelLocationType.ObjectStorage}
+                name="location-type-object-storage"
+                onChange={() => {
+                  setData('modelLocationType', ModelLocationType.ObjectStorage);
+                }}
+                label="Object storage"
+                id="location-type-object-storage"
+              />
+              {modelLocationType === ModelLocationType.ObjectStorage && (
+                <>
+                  <FormGroup label="Endpoint" isRequired fieldId="location-endpoint">
+                    <TextInput
+                      isRequired
+                      type="text"
+                      id="location-endpoint"
+                      name="location-endpoint"
+                      value={modelLocationEndpoint}
+                      onChange={(_e, value) => setData('modelLocationEndpoint', value)}
+                    />
+                  </FormGroup>
+                  <FormGroup label="Bucket" isRequired fieldId="location-bucket">
+                    <TextInput
+                      isRequired
+                      type="text"
+                      id="location-bucket"
+                      name="location-bucket"
+                      value={modelLocationBucket}
+                      onChange={(_e, value) => setData('modelLocationBucket', value)}
+                    />
+                  </FormGroup>
+                  <FormGroup label="Region" fieldId="location-region">
+                    <TextInput
+                      type="text"
+                      id="location-region"
+                      name="location-region"
+                      value={modelLocationRegion}
+                      onChange={(_e, value) => setData('modelLocationRegion', value)}
+                    />
+                  </FormGroup>
+                  <FormGroup label="Path" isRequired fieldId="location-path">
+                    <Split hasGutter>
+                      <SplitItem>
+                        <InputGroupText isPlain>/</InputGroupText>
+                      </SplitItem>
+                      <SplitItem isFilled>
+                        <InputGroupItem>
+                          <TextInput
+                            isRequired
+                            type="text"
+                            id="location-path"
+                            name="location-path"
+                            value={modelLocationPath}
+                            onChange={(_e, value) => setData('modelLocationPath', value)}
+                          />
+                        </InputGroupItem>
+                      </SplitItem>
+                    </Split>
+                    <HelperText>
+                      <HelperTextItem>
+                        Enter a path to a model or folder. This path cannot point to a root folder.
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormGroup>
+                </>
+              )}
+              <Radio
+                isChecked={modelLocationType === ModelLocationType.URI}
+                name="location-type-uri"
+                onChange={() => {
+                  setData('modelLocationType', ModelLocationType.URI);
+                }}
+                label="URI"
+                id="location-type-uri"
+              />
+              {modelLocationType === ModelLocationType.URI && (
+                <>
+                  <FormGroup label="URI" isRequired fieldId="location-uri">
+                    <TextInput
+                      isRequired
+                      type="text"
+                      id="location-uri"
+                      name="location-uri"
+                      value={modelLocationURI}
+                      onChange={(_e, value) => setData('modelLocationURI', value)}
+                    />
+                  </FormGroup>
+                </>
+              )}
+            </FormSection>
+          </StackItem>
+          {error && (
+            <StackItem>
+              <Alert
+                isInline
+                variant="danger"
+                title={error.name}
+                actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
+              >
+                {error.message}
+              </Alert>
+            </StackItem>
+          )}
+          <StackItem>
+            <ActionGroup>
+              <Button
+                isDisabled={isSubmitDisabled}
+                variant="primary"
+                id="create-button"
+                data-testid="create-button"
+                isLoading={loading}
+                onClick={() => handleSubmit()}
+              >
+                Register model
+              </Button>
+              <Button
+                isDisabled={loading}
+                variant="link"
+                id="cancel-button"
+                onClick={() => resetData()}
+              >
+                Cancel
+              </Button>
+            </ActionGroup>
+          </StackItem>
+        </Stack>
+      </Form>
+    </ApplicationsPage>
+  );
+};
+
+export default RegisterModel;

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
@@ -1,0 +1,34 @@
+import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
+
+export type RegisterModelData = {
+  modelRegistryName: string;
+  modelName: string;
+  modelDescription: string;
+  versionName: string;
+  versionDescription: string;
+  sourceModelFormat: string;
+  modelLocationType: string;
+  modelLocationEndpoint: string;
+  modelLocationBucket: string;
+  modelLocationRegion: string;
+  modelLocationPath: string;
+  modelLocationURI: string;
+};
+
+const useRegisterModelData = (mrName?: string): GenericObjectState<RegisterModelData> =>
+  useGenericObjectState<RegisterModelData>({
+    modelRegistryName: mrName || '',
+    modelName: '',
+    modelDescription: '',
+    versionName: '',
+    versionDescription: '',
+    sourceModelFormat: '',
+    modelLocationType: 'Object storage',
+    modelLocationEndpoint: '',
+    modelLocationBucket: '',
+    modelLocationRegion: '',
+    modelLocationPath: '',
+    modelLocationURI: '',
+  });
+
+export default useRegisterModelData;

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -8,7 +8,10 @@ import SimpleDropdownSelect from '~/components/SimpleDropdownSelect';
 import { filterRegisteredModels } from '~/pages/modelRegistry/screens/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import EmptyModelRegistryState from '~/pages/modelRegistry/screens/components/EmptyModelRegistryState';
-import { registeredModelArchiveUrl } from '~/pages/modelRegistry/screens/routeUtils';
+import {
+  registerModelUrl,
+  registeredModelArchiveUrl,
+} from '~/pages/modelRegistry/screens/routeUtils';
 import { asEnumMember } from '~/utilities/utils';
 import RegisteredModelTable from './RegisteredModelTable';
 import RegisteredModelsTableToolbar from './RegisteredModelsTableToolbar';
@@ -38,7 +41,7 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
         primaryActionText="Register model"
         secondaryActionText="View archived models"
         primaryActionOnClick={() => {
-          // TODO: Add primary action
+          navigate(registerModelUrl(preferredModelRegistry?.metadata.name));
         }}
         secondaryActionOnClick={() => {
           navigate(registeredModelArchiveUrl(preferredModelRegistry?.metadata.name));

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableToolbar.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableToolbar.tsx
@@ -13,7 +13,10 @@ import {
 } from '@patternfly/react-core';
 import { EllipsisVIcon, FilterIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router';
-import { registeredModelArchiveUrl } from '~/pages/modelRegistry/screens/routeUtils';
+import {
+  registerModelUrl,
+  registeredModelArchiveUrl,
+} from '~/pages/modelRegistry/screens/routeUtils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 
 type RegisteredModelsTableToolbarProps = {
@@ -56,7 +59,9 @@ const RegisteredModelsTableToolbar: React.FC<RegisteredModelsTableToolbarProps> 
                       key="register-model-button"
                       data-testid="register-model-button"
                       aria-label="Register model"
-                      onClick={() => undefined}
+                      onClick={() =>
+                        navigate(registerModelUrl(preferredModelRegistry?.metadata.name))
+                      }
                     >
                       Register model
                     </MenuToggleAction>,

--- a/frontend/src/pages/modelRegistry/screens/routeUtils.ts
+++ b/frontend/src/pages/modelRegistry/screens/routeUtils.ts
@@ -16,6 +16,9 @@ export const modelVersionArchiveUrl = (rmId?: string, preferredModelRegistry?: s
 export const registeredModelArchiveUrl = (preferredModelRegistry?: string): string =>
   `/modelRegistry/${preferredModelRegistry}/registeredModels/archive`;
 
+export const registerModelUrl = (preferredModelRegistry?: string): string =>
+  `/modelRegistry/${preferredModelRegistry}/registerModel`;
+
 export const registeredModelsUrl = (preferredModelRegistry?: string): string =>
   `/modelRegistry/${preferredModelRegistry}/registeredModels`;
 


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHOAIENG-9913

## Description
Skeleton for the register model page/form
![image](https://github.com/user-attachments/assets/66d90c82-2ff1-4a6f-86b5-fa3c215ab9d6)


## How Has This Been Tested?
ran through and made sure validation works for submit button, radio buttons work for displaying different location inputs

## Test Impact
none yet - skeleton

## Request review criteria:
go to a MR, add `/registerModel` to the URL, see validation and radio buttons work properly.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
