### PR TITLE
feat(mr): add display name and description for mr selector

### DIFF
--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -2,6 +2,8 @@ import { K8sDSGResource } from '~/k8sTypes';
 
 export const getDisplayNameFromK8sResource = (resource: K8sDSGResource): string =>
   resource.metadata.annotations?.['openshift.io/display-name'] || resource.metadata.name;
+export const getResourceNameFromK8sResource = (resource: K8sDSGResource): string =>
+  resource.metadata.name;
 export const getDescriptionFromK8sResource = (resource: K8sDSGResource): string =>
   resource.metadata.annotations?.['openshift.io/description'] || '';
 

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
@@ -5,11 +5,29 @@ import {
   SelectGroup,
   SelectOption,
 } from '@patternfly/react-core/deprecated';
-import { Bullseye, Flex, FlexItem } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  FlexItem,
+  Popover,
+  Tooltip,
+} from '@patternfly/react-core';
+import truncateStyles from '@patternfly/react-styles/css/components/Truncate/truncate';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
-import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import {
+  getDescriptionFromK8sResource,
+  getDisplayNameFromK8sResource,
+  getResourceNameFromK8sResource,
+} from '~/concepts/k8s/utils';
+import { ModelRegistryKind } from '~/k8sTypes';
 
 const MODEL_REGISTRY_FAVORITE_STORAGE_KEY = 'odh.dashboard.model.registry.favorite';
 
@@ -38,15 +56,42 @@ const ModelRegistrySelector: React.FC<ModelRegistrySelectorProps> = ({
 
   const toggleLabel = modelRegistries.length === 0 ? 'No model registries' : selectionDisplayName;
 
+  const getMRSelectDescription = (mr: ModelRegistryKind) => {
+    const desc = getDescriptionFromK8sResource(mr);
+    if (!desc) {
+      return;
+    }
+    const tooltipContent = (
+      <DescriptionList>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{`${getDisplayNameFromK8sResource(
+            mr,
+          )} description`}</DescriptionListTerm>
+          <DescriptionListDescription>{desc}</DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    );
+    return (
+      <Tooltip content={tooltipContent} isContentLeftAligned>
+        <span className={truncateStyles.truncate}>
+          <span className={truncateStyles.truncateStart}>{desc}</span>
+        </span>
+      </Tooltip>
+    );
+  };
+
   const options = [
     <SelectGroup label="Select a model registry" key="all">
       {modelRegistries.map((mr) => (
         <SelectOption
           id={mr.metadata.name}
           key={mr.metadata.name}
-          value={getDisplayNameFromK8sResource(mr)}
+          value={getResourceNameFromK8sResource(mr)}
+          description={getMRSelectDescription(mr)}
           isFavorite={favorites.includes(mr.metadata.name)}
-        />
+        >
+          {getDisplayNameFromK8sResource(mr)}
+        </SelectOption>
       ))}
     </SelectGroup>,
   ];
@@ -97,6 +142,19 @@ const ModelRegistrySelector: React.FC<ModelRegistrySelectorProps> = ({
           <Bullseye>Model registry</Bullseye>
         </FlexItem>
         <FlexItem>{selector}</FlexItem>
+        {selection && getDescriptionFromK8sResource(selection) && (
+          <FlexItem>
+            <Popover
+              aria-label="Model registry description popover"
+              headerContent={getDisplayNameFromK8sResource(selection)}
+              bodyContent={getDescriptionFromK8sResource(selection)}
+            >
+              <Button variant="link" icon={<InfoCircleIcon />}>
+                View Description
+              </Button>
+            </Popover>
+          </FlexItem>
+        )}
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-8453
closes: https://issues.redhat.com/browse/RHOAIENG-10025

## Description
add display name and description (truncated with tooltip) in the selector, add a "view description" button link off to the side with a popver containing the name/description.
![image](https://github.com/user-attachments/assets/4e986e32-b585-4089-a5f4-c88c7d4d6357)

![image](https://github.com/user-attachments/assets/57994820-4df9-4866-820e-22fb4ba3d110)


## How Has This Been Tested?
tested with MRs that have display name different from resource name. tested with MR that contains a long description, short description, no description.

## Test Impact
just adding some info, tests all still pass

## Request review criteria:
test selector looks correct with various display name, resource name, and description.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
