### PR TITLE
fixed nb-events SSAR failure status code

### DIFF
--- a/backend/src/routes/api/nb-events/index.ts
+++ b/backend/src/routes/api/nb-events/index.ts
@@ -34,9 +34,9 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         return getNotebookEvents(fastify, namespace, notebookName, podUID);
       }
       throw createCustomError(
-        '404 Referenced pod not found for the notebook',
-        'Referenced pod not found for the notebook',
-        404,
+        '403 Unauthorized access to notebook',
+        'User does not have access to this notebook',
+        403,
       );
     },
   );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-536](https://issues.redhat.com/browse/RHOAIENG-536)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

SSAR failure should show 403 not 404 (followup pr)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

SSAR failure should show 403 not 404

reproduction steps: https://github.com/opendatahub-io/odh-dashboard/pull/3010

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
