### PR TITLE
[RHOAIENG-7943] Navigate to pipeline details on import

### DIFF
--- a/frontend/src/__mocks__/index.ts
+++ b/frontend/src/__mocks__/index.ts
@@ -13,3 +13,5 @@ export * from './mockDscStatus';
 export * from './mockNotebookK8sResource';
 export * from './mockPipelineKF';
 export * from './mockSecretK8sResource';
+export * from './mockGoogleRpcStatusKF';
+export * from './mockK8sStatus';

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesList.cy.ts
@@ -5,11 +5,12 @@ import {
   mockProjectK8sResource,
   mockRouteK8sResource,
   mockSecretK8sResource,
+  mockDataSciencePipelineApplicationK8sResource,
+  mockK8sResourceList,
+  mock404Error,
+  buildMockPipelineV2,
+  buildMockPipelines,
 } from '~/__mocks__';
-import { mockDataSciencePipelineApplicationK8sResource } from '~/__mocks__/mockDataSciencePipelinesApplicationK8sResource';
-import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
-import { mock404Error } from '~/__mocks__/mockK8sStatus';
-import { buildMockPipelineV2, buildMockPipelines } from '~/__mocks__/mockPipelinesProxy';
 import {
   pipelinesTable,
   configurePipelineServerModal,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-7943

## Description
Redirect to the pipeline details page after a pipeline is created via URL or uploaded using a yaml file.

## How Has This Been Tested?
Manually tested & updated pipeline creation cypress tests to verify the user is redirected to the appropriate URL.

## How to test
Import a pipeline using a yaml file and a URL, verify both methods lead to being redirected to the pipeline version details page.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
