### PR TITLE
Display pipeline run volume name correctly

### DIFF
--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -293,6 +293,7 @@ export type PipelineExecutorKF = {
   };
   pvcMount?: {
     mountPath: string;
+    constant?: string;
     taskOutputParameter?: {
       outputParameterKey: string;
       producerTask: string;

--- a/frontend/src/concepts/pipelines/topology/__tests__/parseUtils.spec.ts
+++ b/frontend/src/concepts/pipelines/topology/__tests__/parseUtils.spec.ts
@@ -598,6 +598,10 @@ describe('pipeline topology parseUtils', () => {
                         producerTask: 'test-task-1',
                       },
                     },
+                    {
+                      mountPath: 'path-2',
+                      constant: 'test-constant-value',
+                    },
                   ],
                 },
               },
@@ -606,7 +610,10 @@ describe('pipeline topology parseUtils', () => {
         },
       };
       const result = parseVolumeMounts(testPlatformSpec, testExecutorLabel);
-      expect(result).toEqual([{ mountPath: 'path-1', name: 'test-task-1' }]);
+      expect(result).toEqual([
+        { mountPath: 'path-1', name: 'test-task-1' },
+        { mountPath: 'path-2', name: 'test-constant-value' },
+      ]);
     });
   });
 });

--- a/frontend/src/concepts/pipelines/topology/parseUtils.ts
+++ b/frontend/src/concepts/pipelines/topology/parseUtils.ts
@@ -340,7 +340,7 @@ export const parseVolumeMounts = (
   }
   return executor.pvcMount.map((pvc) => ({
     mountPath: pvc.mountPath,
-    name: pvc.taskOutputParameter?.producerTask ?? '',
+    name: pvc.taskOutputParameter?.producerTask ?? pvc.constant ?? '',
   }));
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-9327

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add detection for edge cases where `pvcMount` is another format that includes `constant` field as the PVC name.

<img width="1512" alt="Screenshot 2024-07-22 at 2 14 04 PM" src="https://github.com/user-attachments/assets/a26c1739-76b6-4f3f-bdaa-fd00b68b4922">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Upload the pipeline in the ticket and create a run with it
2. Check the `Volumes` tab, make sure the volume name is correctly shown as `your-pvc-name` instead of `No value`.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated unit test to verify the change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
