### PR TITLE
Show correct state text on pipeline run node side drawer

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeDetailsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeDetailsTab.tsx
@@ -7,7 +7,6 @@ import {
 import { relativeDuration } from '~/utilities/time';
 import { RuntimeStateKF } from '~/concepts/pipelines/kfTypes';
 import { PipelineTask } from '~/concepts/pipelines/topology';
-import { translateStatusForNode } from '~/concepts/pipelines/topology/parseUtils';
 
 type SelectedNodeDetailsTabProps = {
   task: PipelineTask;
@@ -36,7 +35,7 @@ const SelectedNodeDetailsTab: React.FC<SelectedNodeDetailsTabProps> = ({ task })
         taskName,
         {
           key: 'Status',
-          value: translateStatusForNode(state) ?? '-',
+          value: state ?? '-',
         },
         {
           key: 'Started',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-8903

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We should not translate the state in the side panel because it's only used to show the PF topology node status. Instead, we should show whatever state is returned by the KFP server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Follow the instructions in the JIRA ticket, check the node status, and make sure the text is correct and the same as the KFP UI.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
