### PR TITLE
Enable KServeMetrics by default (RHOAIENG-8575)

### DIFF
--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -58,7 +58,7 @@ export const blankDashboardCR: DashboardConfig = {
       disablePipelines: false,
       disableKServe: false,
       disableKServeAuth: false,
-      disableKServeMetrics: true,
+      disableKServeMetrics: false,
       disableModelMesh: false,
       disableAcceleratorProfiles: false,
       disablePipelineExperiments: false,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -27,7 +27,7 @@ The following are a list of features that are supported, along with there defaul
 | disableCustomServingRuntimes | false   | Disables Custom Serving Runtimes from the Admin Panel.                                               |
 | disableKServe                | false   | Disables the ability to select KServe as a Serving Platform.                                         |
 | disableKServeAuth            | false   | Disables the ability to use auth in KServe.                                                          |
-| disableKServeMetrics         | true    | Disables the ability to see KServe Metrics.                                                          |
+| disableKServeMetrics         | false   | Disables the ability to see KServe Metrics.                                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
 | disableBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
@@ -58,7 +58,7 @@ spec:
     disableProjectSharing: false
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: false
-    disableKServeMetrics: true
+    disableKServeMetrics: false
     disableBiasMetrics: false
     disablePerformanceMetrics: false
     disablePipelineExperiments: true

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -24,7 +24,7 @@ spec:
     disableAcceleratorProfiles: false
     disableKServe: false
     disableKServeAuth: false
-    disableKServeMetrics: true
+    disableKServeMetrics: false
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: true


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-8575
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Sets `disableKServeMetrics` feature flag to false.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploy on server, verify `disableKServeMetrics` flag is set to false by default. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
