### PR TITLE
[RHOAIENG-10489] reset duplicate name warning for pipeline and version upload modals

### DIFF
--- a/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
@@ -50,6 +50,7 @@ const PipelineImportModal: React.FC<PipelineImportModalProps> = ({ isOpen, onClo
       setImporting(false);
       setError(undefined);
       resetData();
+      setHasDuplicateName(false);
     },
     [onClose, resetData],
   );

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -58,6 +58,7 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
     setImporting(false);
     setError(undefined);
     resetData();
+    setHasDuplicateName(false);
   };
 
   const checkForDuplicateName = useDebounceCallback(


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-10489

## Description
Reset the duplicate name warning flag on modal close for the pipeline upload and pipeline version upload modals

## How Has This Been Tested?
Manually tested by triggering the info text using duplicate names in both modals, then closing and re-opening those modals verifying the info text is reset.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
