### PR TITLE
[RHOAIENG-10454] mock cypress test flake: pipelines.cy.ts 'imports a new pipeline'

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -1,6 +1,10 @@
 import { Contextual } from '~/__tests__/cypress/cypress/pages/components/Contextual';
 import { DashboardCodeEditor } from '~/__tests__/cypress/cypress/pages/components/DashboardCodeEditor';
-import type { PipelineRecurringRunKFv2 } from '~/concepts/pipelines/kfTypes';
+import type {
+  PipelineKFv2,
+  PipelineRecurringRunKFv2,
+  PipelineVersionKFv2,
+} from '~/concepts/pipelines/kfTypes';
 
 class TaskDrawer extends Contextual<HTMLElement> {
   findInputArtifacts() {
@@ -178,6 +182,29 @@ class PipelineDetails extends PipelinesTopology {
   selectActionDropdownItem(label: string) {
     this.findActionsDropdown().click();
     cy.findByRole('menuitem', { name: label }).click();
+  }
+
+  mockGetPipeline(namespace: string, pipeline: PipelineKFv2): Cypress.Chainable<null> {
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
+      { path: { namespace, serviceName: 'dspa', pipelineId: pipeline.pipeline_id } },
+      pipeline,
+    );
+  }
+
+  mockGetPipelineVersion(pipelineId: string, version: PipelineVersionKFv2, namespace: string) {
+    return cy.interceptOdh(
+      'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+      {
+        path: {
+          namespace,
+          pipelineId,
+          serviceName: 'dspa',
+          pipelineVersionId: version.pipeline_version_id,
+        },
+      },
+      version,
+    );
   }
 }
 


### PR DESCRIPTION
[RHOAIENG-10454](https://issues.redhat.com/browse/RHOAIENG-10454)

## Description
The reloading of pipelines after uploading a new pipeline in the 2 tests updated here was causing the page to reload and in some cases that reload would impede on the redirect to the pipeline details page.

## Test Impact
2 cypress tests were updated to address the issue

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
