### PR TITLE
Add disableConnectionTypes feature flag

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -41,6 +41,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableArtifactsAPI: boolean;
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
+      disableConnectionTypes: boolean;
     };
     groupsConfig?: {
       adminGroups: string;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -66,6 +66,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableArtifactsAPI: true,
       disableDistributedWorkloads: false,
       disableModelRegistry: true,
+      disableConnectionTypes: true,
     },
     notebookController: {
       enabled: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -34,6 +34,7 @@ The following are a list of features that are supported, along with there defaul
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | true    | Disables Model Registry from the dashboard.                                                          |
+| disableConnectionTypes       | true    | Disables creating custom data connection types from the dashboard.                                   |
 
 ## Defaults
 
@@ -65,6 +66,7 @@ spec:
     disableS3Endpoint: true
     disableArtifactsAPI: true
     disableDistributedWorkloads: false
+    disableConnectionTypes: false
 ```
 
 ## Additional fields

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -27,6 +27,7 @@ type MockDashboardConfigType = {
   disableArtifactsAPI?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
+  disableConnectionTypes?: boolean;
   disableNotebookController?: boolean;
   notebookSizes?: NotebookSize[];
 };
@@ -57,6 +58,7 @@ export const mockDashboardConfig = ({
   disableArtifactsAPI = true,
   disableDistributedWorkloads = false,
   disableModelRegistry = true,
+  disableConnectionTypes = true,
   disableNotebookController = false,
   notebookSizes = [
     {
@@ -164,6 +166,7 @@ export const mockDashboardConfig = ({
       disableArtifactsAPI,
       disableDistributedWorkloads,
       disableModelRegistry,
+      disableConnectionTypes,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -29,6 +29,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableArtifactsAPI: false,
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
+  disableConnectionTypes: false,
 } satisfies DashboardCommonConfig);
 
 export const SupportedAreasStateMap: SupportedAreasState = {
@@ -122,5 +123,8 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     featureFlags: ['disableModelRegistry'],
     requiredComponents: [StackComponent.MODEL_REGISTRY],
     requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+  },
+  [SupportedArea.DATA_CONNECTIONS_TYPES]: {
+    featureFlags: ['disableConnectionTypes'],
   },
 };

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -61,6 +61,8 @@ export enum SupportedArea {
 
   /* Model Registry areas */
   MODEL_REGISTRY = 'model-registry',
+
+  DATA_CONNECTIONS_TYPES = 'data-connections-types',
 }
 
 /** Components deployed by the Operator. Part of the DSC Status. */

--- a/frontend/src/concepts/connectionTypes/useConnectionTypesEnabled.ts
+++ b/frontend/src/concepts/connectionTypes/useConnectionTypesEnabled.ts
@@ -1,0 +1,6 @@
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+
+const useConnectionTypesEnabled = (): boolean =>
+  useIsAreaAvailable(SupportedArea.DATA_CONNECTIONS_TYPES).status;
+
+export default useConnectionTypesEnabled;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1239,6 +1239,7 @@ export type DashboardCommonConfig = {
   disableArtifactsAPI: boolean;
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
+  disableConnectionTypes: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -75,6 +75,8 @@ spec:
                       type: boolean
                     disableModelRegistry:
                       type: boolean
+                    disableConnectionTypes:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -28,6 +28,7 @@ spec:
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: true
+    disableConnectionTypes: true
   groupsConfig:
     adminGroups: "$(admin_groups)"
     allowedGroups: "system:authenticated"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-10564

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a new feature flag to the odhDashboardConfig for the upcoming work on the custom data connection types feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Pushed the updated CRD to my personal cluster with the new flags and verified the flag being received in network requests.
- Running the frontend and backend locally, got the new flag saw it in the browser console.
- turned the flag to true and false to verify it switches
![Screenshot from 2024-07-29 14-45-20](https://github.com/user-attachments/assets/a7abde6f-f133-4de0-a707-245d7f237f18)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- no tests added, not really much to test yet? other feature flags don't have tests either

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] ~~Included any necessary screenshots or gifs if it was a UI change.~~
- [ ] ~~Included tags to the UX team if it was a UI/UX change.~~

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
