### PR TITLE
[RHOAIENG-7485] Admin - Database status in Model Registry Table

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
@@ -5,6 +5,7 @@ import { ModelRegistryKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import ViewDatabaseConfigModal from './ViewDatabaseConfigModal';
 import DeleteModelRegistryModal from './DeleteModelRegistryModal';
+import { ModelRegistryTableRowStatus } from './ModelRegistryTableRowStatus';
 
 type ModelRegistriesTableRowProps = {
   modelRegistry: ModelRegistryKind;
@@ -29,6 +30,9 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
           {mr.metadata.annotations?.['openshift.io/description'] && (
             <p>{mr.metadata.annotations['openshift.io/description']}</p>
           )}
+        </Td>
+        <Td dataLabel="Status">
+          <ModelRegistryTableRowStatus conditions={mr.status?.conditions} />
         </Td>
         <Td modifier="fitContent">
           <Link

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+
+import { Label, Popover, Stack, StackItem } from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  DegradedIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InProgressIcon,
+} from '@patternfly/react-icons';
+
+import { K8sCondition } from '~/k8sTypes';
+
+enum ModelRegistryStatus {
+  Progressing = 'Progressing',
+  Degraded = 'Degraded',
+  Available = 'Available',
+  IstioAvailable = 'IstioAvailable',
+  GatewayAvailable = 'GatewayAvailable',
+}
+
+enum ModelRegistryStatusLabel {
+  Progressing = 'Progressing',
+  Available = 'Available',
+  Degrading = 'Degrading',
+  Unavailable = 'Unavailable',
+}
+
+enum ConditionStatus {
+  True = 'True',
+  False = 'False',
+}
+
+interface ModelRegistryTableRowStatusProps {
+  conditions: K8sCondition[] | undefined;
+}
+
+export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusProps> = ({
+  conditions,
+}) => {
+  const conditionsMap =
+    conditions?.reduce((acc: Record<string, K8sCondition | undefined>, condition) => {
+      acc[condition.type] = condition;
+      return acc;
+    }, {}) ?? {};
+  let statusLabel: string = ModelRegistryStatusLabel.Progressing;
+  let icon = <InProgressIcon />;
+  let color: React.ComponentProps<typeof Label>['color'] = 'blue';
+  let popoverMessages: string[] = [];
+  let popoverTitle = '';
+
+  if (Object.values(conditionsMap).length) {
+    const {
+      [ModelRegistryStatus.Available]: availableCondition,
+      [ModelRegistryStatus.Progressing]: progressCondition,
+      [ModelRegistryStatus.Degraded]: degradedCondition,
+    } = conditionsMap;
+    const lastAvailableConditionTime = new Date(
+      availableCondition?.lastTransitionTime ?? '',
+    ).getTime();
+
+    popoverMessages =
+      availableCondition?.status === ConditionStatus.False
+        ? Object.values(conditionsMap).reduce((messages: string[], condition) => {
+            if (condition?.status === ConditionStatus.False && condition.message) {
+              messages.push(condition.message);
+            }
+
+            return messages;
+          }, [])
+        : [];
+
+    // Available
+    if (availableCondition?.status === ConditionStatus.True) {
+      statusLabel = ModelRegistryStatusLabel.Available;
+      icon = <CheckCircleIcon />;
+      color = 'green';
+    }
+    // Progressing
+    else if (
+      progressCondition?.status === ConditionStatus.True &&
+      lastAvailableConditionTime < new Date(progressCondition.lastTransitionTime ?? '').getTime()
+    ) {
+      statusLabel = ModelRegistryStatusLabel.Progressing;
+      icon = <InProgressIcon />;
+      color = 'blue';
+    }
+    // Degrading
+    else if (
+      degradedCondition?.status === ConditionStatus.True &&
+      lastAvailableConditionTime < new Date(degradedCondition.lastTransitionTime ?? '').getTime()
+    ) {
+      statusLabel = ModelRegistryStatusLabel.Degrading;
+      icon = <DegradedIcon />;
+      color = 'gold';
+      popoverTitle = 'Service is degrading';
+    }
+    // Unavailable
+    else {
+      statusLabel = ModelRegistryStatusLabel.Unavailable;
+      icon = <ExclamationCircleIcon />;
+      color = 'red';
+
+      const {
+        [ModelRegistryStatus.IstioAvailable]: istioAvailableCondition,
+        [ModelRegistryStatus.GatewayAvailable]: gatewayAvailableCondition,
+      } = conditionsMap;
+
+      if (
+        istioAvailableCondition?.status === ConditionStatus.False &&
+        gatewayAvailableCondition?.status === ConditionStatus.False
+      ) {
+        popoverTitle = 'Istio resources and Istio Gateway resources are both unavailable';
+      } else if (istioAvailableCondition?.status === ConditionStatus.False) {
+        popoverTitle = 'Istio resources are unavailable';
+      } else if (gatewayAvailableCondition?.status === ConditionStatus.False) {
+        popoverTitle = 'Istio Gateway resources are unavailable';
+      } else if (
+        istioAvailableCondition?.status === ConditionStatus.True &&
+        gatewayAvailableCondition?.status === ConditionStatus.True
+      ) {
+        popoverTitle = 'Deployment is unavailable';
+      } else {
+        popoverTitle = 'Service is unavailable';
+      }
+    }
+  }
+
+  const label = (
+    <Label data-testid="model-registry-label" icon={icon} color={color} isCompact>
+      {statusLabel}
+    </Label>
+  );
+
+  return popoverTitle && popoverMessages.length ? (
+    <Popover
+      headerContent={popoverTitle}
+      {...(statusLabel === ModelRegistryStatusLabel.Degrading
+        ? {
+            alertSeverityVariant: 'warning',
+            headerIcon: <ExclamationTriangleIcon />,
+          }
+        : { alertSeverityVariant: 'danger', headerIcon: <ExclamationCircleIcon /> })}
+      bodyContent={
+        <Stack hasGutter>
+          {popoverMessages.map((message, index) => (
+            <StackItem key={`message-${index}`}>{message}</StackItem>
+          ))}
+        </Stack>
+      }
+    >
+      {label}
+    </Popover>
+  ) : (
+    label
+  );
+};

--- a/frontend/src/pages/modelRegistrySettings/__tests__/ModelRegistryTableRowStatus.spec.tsx
+++ b/frontend/src/pages/modelRegistrySettings/__tests__/ModelRegistryTableRowStatus.spec.tsx
@@ -1,0 +1,389 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { ModelRegistryTableRowStatus } from '~/pages/modelRegistrySettings/ModelRegistryTableRowStatus';
+
+describe('ModelRegistryTableRowStatus', () => {
+  it('renders "Istio resources and Istio Gateway resources are both unavailable" as popover title', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          { status: 'False', type: 'Available', message: 'Some unavailable message' },
+          {
+            status: 'False',
+            type: 'IstioAvailable',
+            message: 'Some istio unavailable message',
+          },
+          {
+            status: 'False',
+            type: 'GatewayAvailable',
+            message: 'Some gateway unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText('Unavailable'));
+    expect(
+      screen.getByRole('heading', {
+        name: 'danger alert: Istio resources and Istio Gateway resources are both unavailable',
+      }),
+    ).toBeVisible();
+  });
+
+  it('renders "Istio resources are unavailable" as popover title', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          { status: 'False', type: 'Available', message: 'Some unavailable message' },
+          {
+            status: 'False',
+            type: 'IstioAvailable',
+            message: 'Some istio unavailable message',
+          },
+          {
+            status: 'True',
+            type: 'GatewayAvailable',
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText('Unavailable'));
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Istio resources are unavailable' }),
+    ).toBeVisible();
+  });
+
+  it('renders "Istio Gateway resources are unavailable" as popover title', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          { status: 'False', type: 'Available', message: 'Some unavailable message' },
+          {
+            status: 'True',
+            type: 'IstioAvailable',
+          },
+          {
+            status: 'False',
+            type: 'GatewayAvailable',
+            message: 'Some gateway unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText('Unavailable'));
+    expect(
+      screen.getByRole('heading', {
+        name: 'danger alert: Istio Gateway resources are unavailable',
+      }),
+    ).toBeVisible();
+  });
+
+  it('renders "Deployment is unavailable" as popover title', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          { status: 'False', type: 'Available', message: 'Some unavailable message' },
+          {
+            status: 'True',
+            type: 'IstioAvailable',
+          },
+          {
+            status: 'True',
+            type: 'GatewayAvailable',
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText('Unavailable'));
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Deployment is unavailable' }),
+    ).toBeVisible();
+  });
+
+  it('renders "Available" status', () => {
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          { status: 'False', type: 'Degraded' },
+          { status: 'True', type: 'Available' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Available')).toBeVisible();
+  });
+
+  it('renders "Progressing" status when conditions are empty', () => {
+    render(<ModelRegistryTableRowStatus conditions={[]} />);
+    expect(screen.getByText('Progressing')).toBeVisible();
+  });
+
+  it('renders "Progressing" status when conditions are undefined', () => {
+    render(<ModelRegistryTableRowStatus conditions={undefined} />);
+    expect(screen.getByText('Progressing')).toBeVisible();
+  });
+
+  it('renders "Unavailable" status when the last "Progressing" time is less than the latest "Available" time', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'True',
+            type: 'Progressing',
+          },
+          {
+            lastTransitionTime: '2024-07-18T00:00:00Z',
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Unavailable');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Service is unavailable' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unavailable message')).toBeVisible();
+  });
+
+  it('renders "Progressing" status when the last "Progressing" time is greater than the latest "Available" time', () => {
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            lastTransitionTime: '2024-07-18T00:00:00Z',
+            status: 'True',
+            type: 'Progressing',
+          },
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Progressing')).toBeVisible();
+  });
+
+  it('renders "Unavailable" status when the last "Progressing" time is equal to the latest "Available" time', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'True',
+            type: 'Progressing',
+          },
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Unavailable');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Service is unavailable' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unavailable message')).toBeVisible();
+  });
+
+  it('renders "Unavailable" status when the last "Degraded" time is less than the latest "Available" time', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'True',
+            type: 'Degraded',
+          },
+          {
+            lastTransitionTime: '2024-07-18T00:00:00Z',
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Unavailable');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Service is unavailable' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unavailable message')).toBeVisible();
+  });
+
+  it('renders "Degrading" status when the last "Degraded" time is greater than the latest "Available" time', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            lastTransitionTime: '2024-07-18T00:00:00Z',
+            status: 'True',
+            type: 'Degraded',
+          },
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Degrading');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'warning alert: Service is degrading' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unavailable message')).toBeVisible();
+  });
+
+  it('renders "Unavailable" status when the last "Degraded" time is equal to the latest "Available" time', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'True',
+            type: 'Degraded',
+          },
+          {
+            lastTransitionTime: '2024-07-17T00:00:00Z',
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Unavailable');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Service is unavailable' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unavailable message')).toBeVisible();
+  });
+
+  it('renders "Unavailable" with multiple messages in popover', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            status: 'False',
+            type: 'Progressing',
+            message: 'Some unavailable message 1',
+          },
+          {
+            status: 'False',
+            type: 'Degraded',
+            message: 'Some unavailable message 2',
+          },
+          {
+            status: 'False',
+            type: 'Available',
+            message: 'Some unavailable message 3',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Unavailable');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Service is unavailable' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unavailable message 1')).toBeVisible();
+    expect(screen.getByText('Some unavailable message 2')).toBeVisible();
+    expect(screen.getByText('Some unavailable message 3')).toBeVisible();
+  });
+
+  it('renders "Unavailable" with an unknown status', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelRegistryTableRowStatus
+        conditions={[
+          {
+            status: 'False',
+            type: 'Available',
+            message: 'Some unknown status message',
+          },
+          {
+            status: 'True',
+            type: 'Unknown',
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText('Unavailable');
+    expect(label).toBeVisible();
+
+    await user.click(label);
+
+    expect(
+      screen.getByRole('heading', { name: 'danger alert: Service is unavailable' }),
+    ).toBeVisible();
+    expect(screen.getByText('Some unknown status message')).toBeVisible();
+  });
+});

--- a/frontend/src/pages/modelRegistrySettings/columns.ts
+++ b/frontend/src/pages/modelRegistrySettings/columns.ts
@@ -9,6 +9,11 @@ export const modelRegistryColumns: SortableData<ModelRegistryKind>[] = [
     width: 30,
   },
   {
+    field: 'status',
+    label: 'Status',
+    sortable: false,
+  },
+  {
     field: 'manage permissions',
     label: '',
     sortable: false,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-7485

## Description
Show various statuses depending on model registry conditions within a new column labeled "Status" for the model registry list table page.

<img width="1717" alt="image" src="https://github.com/user-attachments/assets/11f4d489-0b0c-40b2-85e6-87115f705c11">

**Degrading popover**
<img width="663" alt="image" src="https://github.com/user-attachments/assets/cfe2c58f-c4b1-4d0f-879a-707006d870b8">

**Unavailable with multiple messages**
<img width="663" alt="image" src="https://github.com/user-attachments/assets/48e32853-f0c4-465f-98dc-f0f4a4794a59">
(cc @yih-wang)

## How Has This Been Tested?
Manually tested with sample data, created unit tests with possible status scenarios

## Test Impact
Added unit tests

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
