### PR TITLE
Fix for untrue !Deleted flag

### DIFF
--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/useNotebookImageData.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/useNotebookImageData.spec.ts
@@ -106,4 +106,38 @@ describe('getNotebookImageData', () => {
     const result = getNotebookImageData(notebook, images);
     expect(result?.imageAvailability).toBe(NotebookImageAvailability.DELETED);
   });
+
+  it('should fail when custom image shows unexpected Deleted flag', () => {
+    const imageName = 'jupyter-datascience-notebook';
+    const tagName = '2024.1';
+    const notebook = mockNotebookK8sResource({
+      lastImageSelection: `${imageName}:${tagName}`,
+      image: `quay.io/opendatahub/${imageName}:${tagName}`,
+    });
+    const images = [
+      mockImageStreamK8sResource({
+        tagName,
+        name: imageName,
+      }),
+    ];
+    const result = getNotebookImageData(notebook, images);
+    expect(result?.imageAvailability).toBe(NotebookImageAvailability.ENABLED);
+  });
+
+  it('should test an image defined via sha', () => {
+    const imageName = 'jupyter-datascience-notebook';
+    const imageSha = 'sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75';
+    const notebook = mockNotebookK8sResource({
+      lastImageSelection: `${imageName}:${imageSha}`,
+      image: `quay.io/opendatahub/${imageName}@${imageSha}`,
+    });
+    const images = [
+      mockImageStreamK8sResource({
+        imageTag: `quay.io/opendatahub/${imageName}@${imageSha}`,
+        name: imageName,
+      }),
+    ];
+    const result = getNotebookImageData(notebook, images);
+    expect(result?.imageAvailability).toBe(NotebookImageAvailability.ENABLED);
+  });
 });


### PR DESCRIPTION
Closes: [RHOAIENG-8553](https://issues.redhat.com/browse/RHOAIENG-8553)

## Description
Fixes a bug where a workbench created with a custom images shows a "! Deleted" flag when not true
Steps to reproduce this bug is in the JIRA ticket linked. Note the cluster type. I'm unable to reproduce this bug on a ROSA cluster currently. 
Please reach out to me on slack if you need help testing this.

## How Has This Been Tested?
`npm run test`. Locally on an OCP cluster

## Test Impact
A jest test was added that checks if the fix fails when the image doesn't match
Before:
<img width="1414" alt="Screenshot 2024-07-31 at 1 52 59 PM" src="https://github.com/user-attachments/assets/abcd2768-d280-4cb0-a2f2-c868e7242b80">

After:
<img width="1415" alt="Screenshot 2024-07-31 at 1 52 32 PM" src="https://github.com/user-attachments/assets/623c91fc-1591-4f52-bfa0-5358d5884f8f">

 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
