### PR TITLE
test: Add a dummy pipeline sample

### DIFF
--- a/frontend/src/__tests__/resources/pipelines_samples/dummy.py
+++ b/frontend/src/__tests__/resources/pipelines_samples/dummy.py
@@ -1,0 +1,19 @@
+from kfp import compiler, dsl
+
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
+@dsl.component(base_image=common_base_image)
+def dummy(message: str):
+    """Print a message"""
+    print(message)
+
+
+@dsl.pipeline(name="dummy-pipeline", description="Dummy Pipeline")
+def dummy_pipeline():
+    dummy_task = dummy(message="Im a dummy pipeline")
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(dummy_pipeline,
+                                package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/frontend/src/__tests__/resources/pipelines_samples/dummy_compiled.yaml
+++ b/frontend/src/__tests__/resources/pipelines_samples/dummy_compiled.yaml
@@ -1,0 +1,61 @@
+# PIPELINE DEFINITION
+# Name: dummy-pipeline
+# Description: Dummy Pipeline
+components:
+  comp-dummy:
+    executorLabel: exec-dummy
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-dummy:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - dummy
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef dummy(message: str):\n    \"\"\"Print a message\"\"\"\n    print(message)\n\
+          \n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+pipelineInfo:
+  description: Dummy Pipeline
+  name: dummy-pipeline
+root:
+  dag:
+    tasks:
+      dummy:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-dummy
+        inputs:
+          parameters:
+            message:
+              runtimeValue:
+                constant: Im a dummy pipeline
+        taskInfo:
+          name: dummy
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.7.0


### PR DESCRIPTION
## Description
Add a sample pipeline to our repo, so we don't need to depend on other repos when testing the "import pipeline" feature.
This is a dummy pipeline, in order to run an e2e in a live cluster as fast as possible

## How Has This Been Tested?
In a 2.13 live cluster
![image](https://github.com/user-attachments/assets/29a2df1b-4c42-4f37-95ab-6c761088b8a2)


## Test Impact
NA
This is going to be used in e2e testing

## Request review criteria:
Import the dummy_compiled.yaml pipeline and run it
The folder structure is good?

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

