### PR TITLE
Admin - Model Registry RBAC Management Projects

### DIFF
--- a/frontend/src/__mocks__/mockRoleBindingK8sResource.ts
+++ b/frontend/src/__mocks__/mockRoleBindingK8sResource.ts
@@ -8,6 +8,7 @@ type MockResourceConfigType = {
   roleRefName?: string;
   uid?: string;
   modelRegistryName?: string;
+  isProjectSubject?: boolean;
 };
 
 export const mockRoleBindingK8sResource = ({
@@ -22,6 +23,7 @@ export const mockRoleBindingK8sResource = ({
   ],
   roleRefName = 'view',
   uid = genUID('rolebinding'),
+  isProjectSubject = false,
   modelRegistryName = '',
 }: MockResourceConfigType): RoleBindingKind => {
   let labels;
@@ -33,6 +35,7 @@ export const mockRoleBindingK8sResource = ({
       'app.kubernetes.io/part-of': 'model-registry',
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',
       component: 'model-registry',
+      ...(isProjectSubject && { [KnownLabels.PROJECT_SUBJECT]: 'true' }),
     };
   } else {
     labels = {

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistryPermissions.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistryPermissions.ts
@@ -3,7 +3,35 @@ import { TableRow } from './components/table';
 
 class PermissionsTableRow extends TableRow {}
 
-class UsersTab {
+class UsersTab extends Contextual<HTMLElement> {
+  findAddUserButton() {
+    return this.find().findByTestId('add-button user');
+  }
+
+  findAddGroupButton() {
+    return this.find().findByTestId('add-button group');
+  }
+
+  getUserTable() {
+    return new PermissionTable(() => this.find().findByTestId('role-binding-table User'));
+  }
+
+  getGroupTable() {
+    return new PermissionTable(() => this.find().findByTestId('role-binding-table Group'));
+  }
+}
+
+class ProjectsTab extends Contextual<HTMLElement> {
+  findAddProjectButton() {
+    return this.find().findByTestId('add-button project');
+  }
+
+  getProjectTable() {
+    return new PermissionTable(() => this.find().findByTestId('role-binding-table Group'));
+  }
+}
+
+class MRPermissions {
   visit(mrName: string, wait = true) {
     cy.visitWithLogin(`/modelRegistrySettings/permissions/${mrName}`);
     if (wait) {
@@ -16,20 +44,16 @@ class UsersTab {
     cy.testA11y();
   }
 
-  findAddUserButton() {
-    return cy.findByTestId('add-button User');
+  findProjectTab() {
+    return cy.findByTestId('projects-tab');
   }
 
-  findAddGroupButton() {
-    return cy.findByTestId('add-button Group');
+  getUsersContent() {
+    return new UsersTab(() => cy.findByTestId('users-tab-content'));
   }
 
-  getUserTable() {
-    return new PermissionTable(() => cy.findByTestId('role-binding-table User'));
-  }
-
-  getGroupTable() {
-    return new PermissionTable(() => cy.findByTestId('role-binding-table Group'));
+  getProjectsContent() {
+    return new ProjectsTab(() => cy.findByTestId('projects-tab-content'));
   }
 }
 
@@ -46,7 +70,7 @@ class PermissionTable extends Contextual<HTMLElement> {
     return this.find().findByTestId(['role-binding-name-input', id]);
   }
 
-  findGroupSelect() {
+  findNameSelect() {
     return this.find().get(`[aria-label="Name selection"]`);
   }
 
@@ -69,4 +93,4 @@ class PermissionTable extends Contextual<HTMLElement> {
   }
 }
 
-export const usersTab = new UsersTab();
+export const modelRegistryPermissions = new MRPermissions();

--- a/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
@@ -15,11 +15,11 @@ class PermissionsTab {
   }
 
   findAddUserButton() {
-    return cy.findByTestId('add-button User');
+    return cy.findByTestId('add-button user');
   }
 
   findAddGroupButton() {
-    return cy.findByTestId('add-button Group');
+    return cy.findByTestId('add-button group');
   }
 
   getUserTable() {

--- a/frontend/src/concepts/projects/utils.ts
+++ b/frontend/src/concepts/projects/utils.ts
@@ -1,4 +1,5 @@
 import { ProjectKind } from '~/k8sTypes';
+import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 
 export const isAvailableProject = (projectName: string, dashboardNamespace: string): boolean =>
   !(
@@ -14,3 +15,21 @@ export const getProjectOwner = (project: ProjectKind): string =>
   project.metadata.annotations?.['openshift.io/requester'] || '';
 export const getProjectCreationTime = (project: ProjectKind): number =>
   project.metadata.creationTimestamp ? new Date(project.metadata.creationTimestamp).getTime() : 0;
+
+export const namespaceToProjectDisplayName = (
+  namespace: string,
+  projects: ProjectKind[],
+): string => {
+  const project = projects.find((p) => p.metadata.name === namespace);
+  return project ? getDisplayNameFromK8sResource(project) : namespace;
+};
+
+export const projectDisplayNameToNamespace = (
+  displayName: string,
+  projects: ProjectKind[],
+): string => {
+  const project = projects.find(
+    (p) => p.metadata.annotations?.['openshift.io/display-name'] === displayName,
+  );
+  return project?.metadata.name || displayName;
+};

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
 import { RoleBindingSubject } from '~/k8sTypes';
+import { namespaceToProjectDisplayName } from '~/concepts/projects/utils';
+import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import { RoleBindingPermissionsRBType } from './types';
 
 type RoleBindingPermissionsNameInputProps = {
@@ -11,6 +13,7 @@ type RoleBindingPermissionsNameInputProps = {
   onClear: () => void;
   placeholderText: string;
   typeAhead?: string[];
+  isProjectSubject?: boolean;
 };
 
 const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputProps> = ({
@@ -20,7 +23,9 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
   onClear,
   placeholderText,
   typeAhead,
+  isProjectSubject,
 }) => {
+  const { projects } = React.useContext(ProjectsContext);
   const [isOpen, setIsOpen] = React.useState(false);
 
   if (!typeAhead) {
@@ -32,7 +37,11 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
         type="text"
         value={value}
         placeholder={`Type ${
-          subjectKind === RoleBindingPermissionsRBType.GROUP ? 'group name' : 'username'
+          isProjectSubject
+            ? 'project name'
+            : subjectKind === RoleBindingPermissionsRBType.GROUP
+            ? 'group name'
+            : 'username'
         }`}
         onChange={(e, newValue) => onChange(newValue)}
       />
@@ -60,7 +69,10 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
       placeholderText={placeholderText}
     >
       {typeAhead.map((option, index) => (
-        <SelectOption key={index} value={option} />
+        <SelectOption
+          key={index}
+          value={isProjectSubject ? namespaceToProjectDisplayName(option, projects) : option}
+        />
       ))}
     </Select>
   );

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsTable.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsTable.tsx
@@ -16,6 +16,7 @@ type RoleBindingPermissionsTableProps = {
   roleRefKind: RoleBindingRoleRef['kind'];
   roleRefName?: RoleBindingRoleRef['name'];
   labels?: { [key: string]: string };
+  isProjectSubject?: boolean;
   defaultRoleBindingName?: string;
   permissions: RoleBindingKind[];
   permissionOptions: {
@@ -40,12 +41,14 @@ const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = 
   permissions,
   permissionOptions,
   typeAhead,
+  isProjectSubject,
   isAdding,
   onDismissNewRow,
   onError,
   refresh,
 }) => {
   const [editCell, setEditCell] = React.useState<string[]>([]);
+
   return (
     <Table
       variant="compact"
@@ -58,6 +61,7 @@ const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = 
           <RoleBindingPermissionsTableRowAdd
             key="add-permission-row"
             subjectKind={subjectKind}
+            isProjectSubject={isProjectSubject}
             permissionOptions={permissionOptions}
             typeAhead={typeAhead}
             onChange={(subjectName, rbRoleRefName) => {
@@ -85,12 +89,15 @@ const RoleBindingPermissionsTable: React.FC<RoleBindingPermissionsTableProps> = 
       }
       rowRenderer={(rb) => (
         <RoleBindingPermissionsTableRow
+          isProjectSubject={isProjectSubject}
           defaultRoleBindingName={defaultRoleBindingName}
           key={rb.metadata.name || ''}
           permissionOptions={permissionOptions}
           roleBindingObject={rb}
           subjectKind={subjectKind}
-          isEditing={firstSubject(rb) === '' || editCell.includes(rb.metadata.name)}
+          isEditing={
+            firstSubject(rb, isProjectSubject) === '' || editCell.includes(rb.metadata.name)
+          }
           typeAhead={typeAhead}
           onChange={(subjectName, rbRoleRefName) => {
             const newRBObject = generateRoleBindingPermissions(

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRowAdd.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRowAdd.tsx
@@ -3,6 +3,8 @@ import { Tbody, Td, Tr } from '@patternfly/react-table';
 import { Button, Split, SplitItem, Text } from '@patternfly/react-core';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
 import { RoleBindingSubject } from '~/k8sTypes';
+import { projectDisplayNameToNamespace } from '~/concepts/projects/utils';
+import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import { RoleBindingPermissionsRoleType } from './types';
 import RoleBindingPermissionsNameInput from './RoleBindingPermissionsNameInput';
 import RoleBindingPermissionsPermissionSelection from './RoleBindingPermissionsPermissionSelection';
@@ -11,6 +13,7 @@ import { roleLabel } from './utils';
 type RoleBindingPermissionsTableRowPropsAdd = {
   typeAhead?: string[];
   subjectKind: RoleBindingSubject['kind'];
+  isProjectSubject?: boolean;
   permissionOptions: {
     type: RoleBindingPermissionsRoleType;
     description: string;
@@ -24,9 +27,11 @@ const RoleBindingPermissionsTableRowAdd: React.FC<RoleBindingPermissionsTableRow
   typeAhead,
   subjectKind,
   permissionOptions,
+  isProjectSubject,
   onChange,
   onCancel,
 }) => {
+  const { projects } = React.useContext(ProjectsContext);
   const [roleBindingName, setRoleBindingName] = React.useState('');
   const [roleBindingRoleRef, setRoleBindingRoleRef] =
     React.useState<RoleBindingPermissionsRoleType>(permissionOptions[0]?.type);
@@ -43,8 +48,9 @@ const RoleBindingPermissionsTableRowAdd: React.FC<RoleBindingPermissionsTableRow
               setRoleBindingName(selection);
             }}
             onClear={() => setRoleBindingName('')}
-            placeholderText={roleBindingName}
+            placeholderText={isProjectSubject ? 'Select or enter a project' : 'Select a group'}
             typeAhead={typeAhead}
+            isProjectSubject={isProjectSubject}
           />
         </Td>
         <Td dataLabel="Permission">
@@ -73,7 +79,15 @@ const RoleBindingPermissionsTableRowAdd: React.FC<RoleBindingPermissionsTableRow
                 isDisabled={isLoading || !roleBindingName || !roleBindingRoleRef}
                 onClick={() => {
                   setIsLoading(true);
-                  onChange(roleBindingName, roleBindingRoleRef);
+                  onChange(
+                    isProjectSubject
+                      ? `system:serviceaccounts:${projectDisplayNameToNamespace(
+                          roleBindingName,
+                          projects,
+                        )}`
+                      : roleBindingName,
+                    roleBindingRoleRef,
+                  );
                 }}
               />
             </SplitItem>

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableSection.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableSection.tsx
@@ -30,9 +30,10 @@ export type RoleBindingPermissionsTableSectionAltProps = {
   }[];
   typeAhead?: string[];
   refresh: () => void;
-  typeModifier?: string;
+  typeModifier: string;
   defaultRoleBindingName?: string;
   labels?: { [key: string]: string };
+  isProjectSubject?: boolean;
 };
 
 const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSectionAltProps> = ({
@@ -48,6 +49,7 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
   typeModifier,
   defaultRoleBindingName,
   labels,
+  isProjectSubject,
 }) => {
   const [addField, setAddField] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>(undefined);
@@ -63,14 +65,20 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
         >
           <HeaderIcon
             type={
-              subjectKind === RoleBindingPermissionsRBType.USER
+              isProjectSubject
+                ? ProjectObjectType.project
+                : subjectKind === RoleBindingPermissionsRBType.USER
                 ? ProjectObjectType.user
                 : ProjectObjectType.group
             }
           />
           <FlexItem>
-            <Title id={`user-permission-${subjectKind}`} headingLevel="h2" size="xl">
-              {subjectKind === RoleBindingPermissionsRBType.USER ? 'Users' : 'Groups'}
+            <Title id={`user-permission-${typeModifier}`} headingLevel="h2" size="xl">
+              {isProjectSubject
+                ? 'Projects'
+                : subjectKind === RoleBindingPermissionsRBType.USER
+                ? 'Users'
+                : 'Groups'}
             </Title>
           </FlexItem>
         </Flex>
@@ -84,6 +92,7 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
           namespace={projectName}
           roleRefKind={roleRefKind}
           roleRefName={roleRefName}
+          isProjectSubject={isProjectSubject}
           labels={labels}
           subjectKind={subjectKind}
           typeAhead={typeAhead}
@@ -113,7 +122,7 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
       )}
       <StackItem>
         <Button
-          data-testid={`add-button ${subjectKind}`}
+          data-testid={`add-button ${typeModifier}`}
           variant="link"
           isInline
           icon={<PlusCircleIcon />}
@@ -121,7 +130,11 @@ const RoleBindingPermissionsTableSection: React.FC<RoleBindingPermissionsTableSe
           onClick={() => setAddField(true)}
           style={{ paddingLeft: 'var(--pf-v5-global--spacer--lg)' }}
         >
-          {subjectKind === RoleBindingPermissionsRBType.USER ? 'Add user' : 'Add group'}
+          {isProjectSubject
+            ? 'Add project'
+            : subjectKind === RoleBindingPermissionsRBType.USER
+            ? 'Add user'
+            : 'Add group'}
         </Button>
       </StackItem>
     </Stack>

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -23,6 +23,7 @@ export enum KnownLabels {
   MODEL_SERVING_PROJECT = 'modelmesh-enabled',
   DATA_CONNECTION_AWS = 'opendatahub.io/managed',
   LABEL_SELECTOR_MODEL_REGISTRY = 'component=model-registry',
+  PROJECT_SUBJECT = 'opendatahub.io/rb-project-subject',
 }
 
 export type K8sVerb =

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
@@ -20,6 +20,7 @@ import { SupportedArea } from '~/concepts/areas';
 import { RoleBindingPermissionsRoleType } from '~/concepts/roleBinding/types';
 import { useModelRegistryNamespaceCR } from '~/concepts/modelRegistry/context/useModelRegistryNamespaceCR';
 import useModelRegistryRoleBindings from './useModelRegistryRoleBindings';
+import ProjectsSettingsTab from './ProjectsTab/ProjectsSettingsTab';
 
 const ModelRegistriesManagePermissions: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = React.useState('users');
@@ -51,7 +52,7 @@ const ModelRegistriesManagePermissions: React.FC = () => {
   return (
     <ApplicationsPage
       title={`Manage permissions of ${mrName}`}
-      description="Manage users and projects that can access this model registry."
+      description="Manage access to this model registry for individual users and user groups, and for service accounts in a project."
       breadcrumb={
         <Breadcrumb>
           <BreadcrumbItem>Settings</BreadcrumbItem>
@@ -76,11 +77,17 @@ const ModelRegistriesManagePermissions: React.FC = () => {
           eventKey="projects"
           title="Projects"
           id="projects-tab"
+          data-testid="projects-tab"
           tabContentId="projects-tab-content"
         />
       </Tabs>
       <div>
-        <TabContent id="users-tab-content" eventKey="users" hidden={activeTabKey !== 'users'}>
+        <TabContent
+          id="users-tab-content"
+          eventKey="users"
+          hidden={activeTabKey !== 'users'}
+          data-testid="users-tab-content"
+        >
           <TabContentBody>
             <RoleBindingPermissions
               ownerReference={ownerReference}
@@ -118,9 +125,34 @@ const ModelRegistriesManagePermissions: React.FC = () => {
         <TabContent
           id="projects-tab-content"
           eventKey="projects"
+          data-testid="projects-tab-content"
           hidden={activeTabKey !== 'projects'}
         >
-          TODO: This feature is not yet implemented
+          <TabContentBody>
+            <ProjectsSettingsTab
+              ownerReference={ownerReference}
+              permissionOptions={[
+                {
+                  type: RoleBindingPermissionsRoleType.DEFAULT,
+                  description: 'Default role for all projects',
+                },
+              ]}
+              description="To enable access for all service accounts in a project, add the project name to the projects list."
+              roleRefName={`registry-user-${mrName}`}
+              labels={{
+                [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+                [KnownLabels.PROJECT_SUBJECT]: 'true',
+                app: mrName || '',
+                'app.kubernetes.io/component': SupportedArea.MODEL_REGISTRY,
+                'app.kubernetes.io/part-of': SupportedArea.MODEL_REGISTRY,
+                'app.kubernetes.io/name': mrName || '',
+                component: SupportedArea.MODEL_REGISTRY,
+              }}
+              projectName={MODEL_REGISTRY_DEFAULT_NAMESPACE}
+              isProjectSubject={activeTabKey === 'projects'}
+              roleBindingPermissionsRB={{ ...roleBindings, data: filteredRoleBindings }}
+            />
+          </TabContentBody>
         </TabContent>
       </div>
     </ApplicationsPage>

--- a/frontend/src/pages/modelRegistrySettings/ProjectsTab/ProjectsSettingsTab.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ProjectsTab/ProjectsSettingsTab.tsx
@@ -1,0 +1,125 @@
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+import {
+  RoleBindingPermissionsRBType,
+  RoleBindingPermissionsRoleType,
+} from '~/concepts/roleBinding/types';
+import { filterRoleBindingSubjects, removePrefix } from '~/concepts/roleBinding/utils';
+import { RoleBindingKind, RoleBindingRoleRef } from '~/k8sTypes';
+import { ContextResourceData } from '~/types';
+import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
+import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
+import RoleBindingPermissionsTableSection from '~/concepts/roleBinding/RoleBindingPermissionsTableSection';
+
+type RoleBindingProjectPermissionsProps = {
+  ownerReference?: K8sResourceCommon;
+  roleBindingPermissionsRB: ContextResourceData<RoleBindingKind>;
+  permissionOptions: {
+    type: RoleBindingPermissionsRoleType;
+    description: string;
+  }[];
+  projectName: string;
+  roleRefName?: RoleBindingRoleRef['name'];
+  labels?: { [key: string]: string };
+  isProjectSubject?: boolean;
+  description: string;
+};
+
+const ProjectsSettingsTab: React.FC<RoleBindingProjectPermissionsProps> = ({
+  ownerReference,
+  roleBindingPermissionsRB,
+  permissionOptions,
+  projectName,
+  roleRefName,
+  labels,
+  isProjectSubject,
+  description,
+}) => {
+  const {
+    data: roleBindings,
+    loaded,
+    error: loadError,
+    refresh: refreshRB,
+  } = roleBindingPermissionsRB;
+
+  const { projects } = React.useContext(ProjectsContext);
+  const filteredProjects = projects.filter(
+    (project) => !removePrefix(roleBindings).includes(project.metadata.name),
+  );
+
+  if (loadError) {
+    return (
+      <EmptyState
+        variant={EmptyStateVariant.lg}
+        data-id="error-empty-state"
+        id={ProjectSectionID.PERMISSIONS}
+      >
+        <EmptyStateHeader
+          titleText="There was an issue loading projects"
+          icon={<EmptyStateIcon icon={ExclamationCircleIcon} />}
+          headingLevel="h2"
+        />
+        <EmptyStateBody>{loadError.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <EmptyState
+        variant={EmptyStateVariant.lg}
+        data-id="loading-empty-state"
+        id={ProjectSectionID.PERMISSIONS}
+      >
+        <Spinner size="xl" />
+        <EmptyStateHeader titleText="Loading" headingLevel="h2" />
+      </EmptyState>
+    );
+  }
+
+  return (
+    <PageSection isFilled variant="light">
+      <Stack hasGutter>
+        <StackItem>{description}</StackItem>
+        <StackItem>
+          <RoleBindingPermissionsTableSection
+            ownerReference={ownerReference}
+            roleBindings={filterRoleBindingSubjects(
+              roleBindings,
+              RoleBindingPermissionsRBType.GROUP,
+              isProjectSubject,
+            )}
+            projectName={projectName}
+            roleRefKind="Role"
+            roleRefName={roleRefName}
+            labels={labels}
+            subjectKind={RoleBindingPermissionsRBType.GROUP}
+            permissionOptions={permissionOptions}
+            typeAhead={
+              filteredProjects.length > 0
+                ? filteredProjects.map((project) => project.metadata.name)
+                : undefined
+            }
+            refresh={refreshRB}
+            typeModifier="project"
+            isProjectSubject={isProjectSubject}
+          />
+        </StackItem>
+      </Stack>
+    </PageSection>
+  );
+};
+
+export default ProjectsSettingsTab;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-8632](https://issues.redhat.com/browse/RHOAIENG-8632)

## Description
This PR aims to add projects tab under MR Permissions.

![Screenshot from 2024-08-08 18-39-47](https://github.com/user-attachments/assets/cf39a9f4-7499-4d09-ad84-10c6f2601099)

![Screenshot from 2024-08-08 16-59-38](https://github.com/user-attachments/assets/1ea53728-bd0a-4f06-8592-1e5490784445)

![Screenshot from 2024-08-08 17-55-41](https://github.com/user-attachments/assets/2503dc2c-5a58-4870-8788-575673fa1b38)

## How Has This Been Tested?
In MR permission, click on Projects tab
create/ edit/ delete rolebindings for projects.

## Test Impact
Added cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
