### PR TITLE
[RHOAIENG-8816] Automatic discovery of Accelerator profile handles AMD GPUs like they were NVIDIA

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -677,8 +677,11 @@ export const cleanupGPU = async (fastify: KubeFastifyInstance): Promise<void> =>
     ) {
       // if gpu detected on cluster, create our default migrated-gpu
       const acceleratorDetected = await getDetectedAccelerators(fastify);
+      const hasNvidiaNodes = Object.keys(acceleratorDetected.total).some(
+        (nodeKey) => nodeKey === 'nvidia.com/gpu',
+      );
 
-      if (acceleratorDetected.configured) {
+      if (acceleratorDetected.configured && hasNvidiaNodes) {
         const payload: AcceleratorProfileKind = {
           kind: 'AcceleratorProfile',
           apiVersion: 'dashboard.opendatahub.io/v1',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-8816

## Description
Only create accelerator when nvidia type nodes are detected from the server's list of nodes.

## How Has This Been Tested?
Manually tested. This doesn't seem to be re-creatable in dev without some hard-coded intervention. The condition to create the accelerator has been adjusted to make sure nvidia nodes exist, however I was not able to simulate the "configured" state being true, which is the other part of the condition.

### Test steps
Testing this is not straight forward and requires deleting resources in the openshift console and restarting the backend afterwards + manually editing the condition to bypass the "configured" state. I believe this change is one we can have the reporter of the issue test once released to be sure this resolves his issue.

1. Update https://github.com/opendatahub-io/odh-dashboard/blob/3f026963c167bc011c8aa3ab00f5c4a762d6b0e7/backend/src/utils/resourceUtils.ts#L684 locally and remove the `acceleratorDetected.configured` portion of the condition.
2. Stop your locally running dev "backend"
3. Delete console resources:
<img width="1386" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/6331bad1-f43b-486e-b0b0-4abaa758c13d">
<img width="1386" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/39f66476-9d3e-42b5-b8b1-c4982636853c">
5. Start your local dev "backend" and see the accelerator profile created. If no Nvidia nodes exist, then no accelerator should be created.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
