### PR TITLE
API integration for Register Model form

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -167,6 +167,10 @@ class ModelRegistry {
   findModelVersionsTableFilter() {
     return cy.findByTestId('model-versions-table-filter');
   }
+
+  findRegisterModelButton() {
+    return cy.findByRole('button', { name: 'Register model' });
+  }
 }
 
 export const modelRegistry = new ModelRegistry();

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
@@ -1,0 +1,37 @@
+export enum FormFieldSelector {
+  MODEL_NAME = '#model-name',
+  MODEL_DESCRIPTION = '#model-description',
+  VERSION_NAME = '#version-name',
+  VERSION_DESCRIPTION = '#version-description',
+  SOURCE_MODEL_FORMAT = '#source-model-format',
+  SOURCE_MODEL_FORMAT_VERSION = '#source-model-format-version',
+  LOCATION_TYPE_OBJECT_STORAGE = '#location-type-object-storage',
+  LOCATION_ENDPOINT = '#location-endpoint',
+  LOCATION_BUCKET = '#location-bucket',
+  LOCATION_REGION = '#location-region',
+  LOCATION_PATH = '#location-path',
+  LOCATION_TYPE_URL = '#location-type-uri',
+  LOCATION_URI = '#location-uri',
+}
+
+class RegisterModelPage {
+  visit() {
+    const preferredModelRegistry = 'modelregistry-sample';
+    cy.visitWithLogin(`/modelRegistry/${preferredModelRegistry}/registerModel`);
+    this.wait();
+  }
+
+  private wait() {
+    const preferredModelRegistry = 'modelregistry-sample';
+    cy.findByTestId('app-page-title').should('exist');
+    cy.findByTestId('app-page-title').contains('Register model');
+    cy.findByText(preferredModelRegistry).should('exist');
+    cy.testA11y();
+  }
+
+  findFormField(selector: FormFieldSelector) {
+    return cy.get(selector);
+  }
+}
+
+export const registerModelPage = new RegisterModelPage();

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
@@ -10,7 +10,7 @@ export enum FormFieldSelector {
   LOCATION_BUCKET = '#location-bucket',
   LOCATION_REGION = '#location-region',
   LOCATION_PATH = '#location-path',
-  LOCATION_TYPE_URL = '#location-type-uri',
+  LOCATION_TYPE_URI = '#location-type-uri',
   LOCATION_URI = '#location-uri',
 }
 
@@ -31,6 +31,10 @@ class RegisterModelPage {
 
   findFormField(selector: FormFieldSelector) {
     return cy.get(selector);
+  }
+
+  findSubmitButton() {
+    return cy.findByTestId('create-button');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
@@ -25,7 +25,7 @@ class RegisterModelPage {
     const preferredModelRegistry = 'modelregistry-sample';
     cy.findByTestId('app-page-title').should('exist');
     cy.findByTestId('app-page-title').contains('Register model');
-    cy.findByText(preferredModelRegistry).should('exist');
+    cy.findByText(`Model registry - ${preferredModelRegistry}`).should('exist');
     cy.testA11y();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -2,6 +2,7 @@ import type { K8sResourceListResult } from '@openshift/dynamic-plugin-sdk-utils'
 import type { GenericStaticResponse, RouteHandlerController } from 'cypress/types/net-stubbing';
 import type { BaseMetricCreationResponse, BaseMetricListResponse } from '~/api';
 import type {
+  ModelArtifact,
   ModelArtifactList,
   ModelVersion,
   ModelVersionList,
@@ -295,9 +296,19 @@ declare global {
           response: OdhResponse<RegisteredModelList>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models',
+          options: { path: { serviceName: string; apiVersion: string } },
+          response: OdhResponse<RegisteredModel>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
           options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
           response: OdhResponse<ModelVersionList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
+          options: { path: { serviceName: string; apiVersion: string; registeredModelId: number } },
+          response: OdhResponse<ModelVersion>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId',
@@ -320,6 +331,11 @@ declare global {
           type: 'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
           options: { path: { serviceName: string; apiVersion: string; modelVersionId: number } },
           response: OdhResponse<ModelArtifactList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
+          options: { path: { serviceName: string; apiVersion: string; modelVersionId: number } },
+          response: OdhResponse<ModelArtifact>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'PATCH /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -200,7 +200,7 @@ describe('Register Model button', () => {
     modelRegistry.findRegisterModelButton().click();
     cy.findByTestId('app-page-title').should('exist');
     cy.findByTestId('app-page-title').contains('Register model');
-    cy.findByText('modelregistry-sample').should('exist');
+    cy.findByText('Model registry - modelregistry-sample').should('exist');
   });
 
   it('Navigates to register page from table toolbar', () => {
@@ -209,6 +209,6 @@ describe('Register Model button', () => {
     modelRegistry.findRegisterModelButton().click();
     cy.findByTestId('app-page-title').should('exist');
     cy.findByTestId('app-page-title').contains('Register model');
-    cy.findByText('modelregistry-sample').should('exist');
+    cy.findByText('Model registry - modelregistry-sample').should('exist');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -101,7 +101,7 @@ const initIntercepts = ({
   );
 };
 
-describe('Model Registry', () => {
+describe('Model Registry core', () => {
   it('Model Registry Disabled in the cluster', () => {
     initIntercepts({
       disableModelRegistryFeature: true,
@@ -134,57 +134,81 @@ describe('Model Registry', () => {
     modelRegistry.shouldregisteredModelsEmpty();
   });
 
-  it('Registered model table', () => {
-    initIntercepts({
-      disableModelRegistryFeature: false,
+  describe('Registered model table', () => {
+    beforeEach(() => {
+      initIntercepts({ disableModelRegistryFeature: false });
+      modelRegistry.visit();
     });
 
+    it('Renders row contents', () => {
+      const registeredModelRow = modelRegistry.getRow('Fraud detection model');
+      registeredModelRow.findName().contains('Fraud detection model');
+      registeredModelRow
+        .findDescription()
+        .contains(
+          'A machine learning model trained to detect fraudulent transactions in financial data',
+        );
+      registeredModelRow.findOwner().contains('Author 1');
+
+      // Label popover
+      registeredModelRow.findLabelPopoverText().contains('2 more');
+      registeredModelRow.findLabelPopoverText().click();
+      registeredModelRow.shouldContainsPopoverLabels([
+        'Machine learning',
+        'Next data to be overflow',
+      ]);
+    });
+
+    it('Renders labels in modal', () => {
+      const registeredModelRow2 = modelRegistry.getRow('Label modal');
+      registeredModelRow2.findLabelModalText().contains('6 more');
+      registeredModelRow2.findLabelModalText().click();
+      labelModal.shouldContainsModalLabels([
+        'Testing label',
+        'Financial',
+        'Financial data',
+        'Fraud detection',
+        'Machine learning',
+        'Next data to be overflow',
+        'Label x',
+        'Label y',
+        'Label z',
+      ]);
+      labelModal.findModalSearchInput().type('Financial');
+      labelModal.shouldContainsModalLabels(['Financial', 'Financial data']);
+      labelModal.findCloseModal().click();
+    });
+
+    it('Sorts by model name', () => {
+      modelRegistry.findRegisteredModelTableHeaderButton('Model name').should(be.sortAscending);
+      modelRegistry.findRegisteredModelTableHeaderButton('Model name').click();
+      modelRegistry.findRegisteredModelTableHeaderButton('Model name').should(be.sortDescending);
+    });
+
+    it('Filters by keyword', () => {
+      modelRegistry.findTableSearch().type('Fraud detection model');
+      modelRegistry.findTableRows().should('have.length', 1);
+      modelRegistry.findTableRows().contains('Fraud detection model');
+    });
+  });
+});
+
+describe('Register Model button', () => {
+  it('Navigates to register page from empty state', () => {
+    initIntercepts({ disableModelRegistryFeature: false, registeredModels: [] });
     modelRegistry.visit();
+    modelRegistry.findRegisterModelButton().click();
+    cy.findByTestId('app-page-title').should('exist');
+    cy.findByTestId('app-page-title').contains('Register model');
+    cy.findByText('modelregistry-sample').should('exist');
+  });
 
-    const registeredModelRow = modelRegistry.getRow('Fraud detection model');
-    registeredModelRow.findName().contains('Fraud detection model');
-    registeredModelRow
-      .findDescription()
-      .contains(
-        'A machine learning model trained to detect fraudulent transactions in financial data',
-      );
-    registeredModelRow.findOwner().contains('Author 1');
-
-    // Label popover
-    registeredModelRow.findLabelPopoverText().contains('2 more');
-    registeredModelRow.findLabelPopoverText().click();
-    registeredModelRow.shouldContainsPopoverLabels([
-      'Machine learning',
-      'Next data to be overflow',
-    ]);
-
-    // Label modal
-    const registeredModelRow2 = modelRegistry.getRow('Label modal');
-    registeredModelRow2.findLabelModalText().contains('6 more');
-    registeredModelRow2.findLabelModalText().click();
-    labelModal.shouldContainsModalLabels([
-      'Testing label',
-      'Financial',
-      'Financial data',
-      'Fraud detection',
-      'Machine learning',
-      'Next data to be overflow',
-      'Label x',
-      'Label y',
-      'Label z',
-    ]);
-    labelModal.findModalSearchInput().type('Financial');
-    labelModal.shouldContainsModalLabels(['Financial', 'Financial data']);
-    labelModal.findCloseModal().click();
-
-    // sort by modelName
-    modelRegistry.findRegisteredModelTableHeaderButton('Model name').should(be.sortAscending);
-    modelRegistry.findRegisteredModelTableHeaderButton('Model name').click();
-    modelRegistry.findRegisteredModelTableHeaderButton('Model name').should(be.sortDescending);
-
-    // filtering by keyword
-    modelRegistry.findTableSearch().type('Fraud detection model');
-    modelRegistry.findTableRows().should('have.length', 1);
-    modelRegistry.findTableRows().contains('Fraud detection model');
+  it('Navigates to register page from table toolbar', () => {
+    initIntercepts({ disableModelRegistryFeature: false });
+    modelRegistry.visit();
+    modelRegistry.findRegisterModelButton().click();
+    cy.findByTestId('app-page-title').should('exist');
+    cy.findByTestId('app-page-title').contains('Register model');
+    cy.findByText('modelregistry-sample').should('exist');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
@@ -1,0 +1,52 @@
+import { mockDashboardConfig, mockDscStatus, mockK8sResourceList } from '~/__mocks__';
+import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';
+import { StackCapability, StackComponent } from '~/concepts/areas/types';
+import { ModelRegistryModel } from '~/__tests__/cypress/cypress/utils/models';
+import {
+  FormFieldSelector,
+  registerModelPage,
+} from '~/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage';
+import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
+
+const initIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableModelRegistry: false,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      installedComponents: {
+        [StackComponent.MODEL_REGISTRY]: true,
+        [StackComponent.MODEL_MESH]: true,
+      },
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/dsci/status',
+    mockDsciStatus({
+      requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+    }),
+  );
+
+  // TODO replace these with a mock list of services when https://github.com/opendatahub-io/odh-dashboard/pull/3034 is merged
+  cy.interceptK8sList(
+    ModelRegistryModel,
+    mockK8sResourceList([mockModelRegistry({ name: 'modelregistry-sample' })]),
+  );
+  cy.interceptK8s(ModelRegistryModel, mockModelRegistry({ name: 'modelregistry-sample' }));
+};
+
+describe('Register model page', () => {
+  beforeEach(() => {
+    initIntercepts();
+    registerModelPage.visit();
+  });
+
+  it('Renders', () => {
+    // TODO replace this stub test
+    registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).should('exist');
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
@@ -11,11 +11,11 @@ import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
 import { mockModelVersion } from '~/__mocks__/mockModelVersion';
 import { mockModelArtifact } from '~/__mocks__/mockModelArtifact';
 import {
-  ModelArtifact,
   ModelArtifactState,
   ModelState,
-  ModelVersion,
   type RegisteredModel,
+  type ModelVersion,
+  type ModelArtifact,
 } from '~/concepts/modelRegistry/types';
 
 const MODEL_REGISTRY_API_VERSION = 'v1alpha3';

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
@@ -7,6 +7,18 @@ import {
   registerModelPage,
 } from '~/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
+import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
+import { mockModelVersion } from '~/__mocks__/mockModelVersion';
+import { mockModelArtifact } from '~/__mocks__/mockModelArtifact';
+import {
+  ModelArtifact,
+  ModelArtifactState,
+  ModelState,
+  ModelVersion,
+  type RegisteredModel,
+} from '~/concepts/modelRegistry/types';
+
+const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
 
 const initIntercepts = () => {
   cy.interceptOdh(
@@ -37,6 +49,41 @@ const initIntercepts = () => {
     mockK8sResourceList([mockModelRegistry({ name: 'modelregistry-sample' })]),
   );
   cy.interceptK8s(ModelRegistryModel, mockModelRegistry({ name: 'modelregistry-sample' }));
+
+  cy.interceptOdh(
+    'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models',
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+      },
+    },
+    mockRegisteredModel({ id: '1', name: 'Test model name' }),
+  ).as('createRegisteredModel');
+
+  cy.interceptOdh(
+    'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
+    mockModelVersion({ id: '2', name: 'Test version name' }),
+  ).as('createModelVersion');
+
+  cy.interceptOdh(
+    'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 2,
+      },
+    },
+    mockModelArtifact(),
+  ).as('createModelArtifact');
 };
 
 describe('Register model page', () => {
@@ -45,8 +92,144 @@ describe('Register model page', () => {
     registerModelPage.visit();
   });
 
-  it('Renders', () => {
-    // TODO replace this stub test
-    registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).should('exist');
+  it('Disables submit until required fields are filled in object storage mode', () => {
+    registerModelPage.findSubmitButton().should('be.disabled');
+    registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).type('Test model name');
+    registerModelPage.findFormField(FormFieldSelector.VERSION_NAME).type('Test version name');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_OBJECT_STORAGE).click();
+    registerModelPage
+      .findFormField(FormFieldSelector.LOCATION_ENDPOINT)
+      .type('http://s3.amazonaws.com/');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_BUCKET).type('test-bucket');
+    registerModelPage
+      .findFormField(FormFieldSelector.LOCATION_PATH)
+      .type('demo-models/flan-t5-small-caikit');
+    registerModelPage.findSubmitButton().should('be.enabled');
+  });
+
+  it('Creates expected resources on submit in object storage mode', () => {
+    registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).type('Test model name');
+    registerModelPage
+      .findFormField(FormFieldSelector.MODEL_DESCRIPTION)
+      .type('Test model description');
+    registerModelPage.findFormField(FormFieldSelector.VERSION_NAME).type('Test version name');
+    registerModelPage
+      .findFormField(FormFieldSelector.VERSION_DESCRIPTION)
+      .type('Test version description');
+    registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT).type('caikit');
+    registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT_VERSION).type('1');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_OBJECT_STORAGE).click();
+    registerModelPage
+      .findFormField(FormFieldSelector.LOCATION_ENDPOINT)
+      .type('http://s3.amazonaws.com/');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_BUCKET).type('test-bucket');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_REGION).type('us-east-1');
+    registerModelPage
+      .findFormField(FormFieldSelector.LOCATION_PATH)
+      .type('demo-models/flan-t5-small-caikit');
+
+    registerModelPage.findSubmitButton().click();
+
+    cy.wait('@createRegisteredModel').then((interception) => {
+      expect(interception.request.body).to.containSubset({
+        name: 'Test model name',
+        description: 'Test model description',
+        customProperties: {},
+        state: ModelState.LIVE,
+      } satisfies Partial<RegisteredModel>);
+    });
+    cy.wait('@createModelVersion').then((interception) => {
+      expect(interception.request.body).to.containSubset({
+        name: 'Test version name',
+        description: 'Test version description',
+        customProperties: {},
+        state: ModelState.LIVE,
+        author: 'test-user',
+        registeredModelId: '1',
+      } satisfies Partial<ModelVersion>);
+    });
+    cy.wait('@createModelArtifact').then((interception) => {
+      expect(interception.request.body).to.containSubset({
+        name: 'Test model name-Test version name-artifact',
+        description: 'Test version description',
+        customProperties: {},
+        state: ModelArtifactState.LIVE,
+        author: 'test-user',
+        modelFormatName: 'caikit',
+        modelFormatVersion: '1',
+        uri: 's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+        artifactType: 'model-artifact',
+      } satisfies Partial<ModelArtifact>);
+    });
+
+    cy.url().should('include', '/modelRegistry/modelregistry-sample/registeredModels/1');
+  });
+
+  it('Disables submit until required fields are filled in URI mode', () => {
+    registerModelPage.findSubmitButton().should('be.disabled');
+    registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).type('Test model name');
+    registerModelPage.findFormField(FormFieldSelector.VERSION_NAME).type('Test version name');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_URI).click();
+    registerModelPage
+      .findFormField(FormFieldSelector.LOCATION_URI)
+      .type(
+        's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+      );
+    registerModelPage.findSubmitButton().should('be.enabled');
+  });
+
+  it('Creates expected resources on submit in URI mode', () => {
+    registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).type('Test model name');
+    registerModelPage
+      .findFormField(FormFieldSelector.MODEL_DESCRIPTION)
+      .type('Test model description');
+    registerModelPage.findFormField(FormFieldSelector.VERSION_NAME).type('Test version name');
+    registerModelPage
+      .findFormField(FormFieldSelector.VERSION_DESCRIPTION)
+      .type('Test version description');
+    registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT).type('caikit');
+    registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT_VERSION).type('1');
+    registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_URI).click();
+    registerModelPage
+      .findFormField(FormFieldSelector.LOCATION_URI)
+      .type(
+        's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+      );
+
+    registerModelPage.findSubmitButton().click();
+
+    cy.wait('@createRegisteredModel').then((interception) => {
+      expect(interception.request.body).to.containSubset({
+        name: 'Test model name',
+        description: 'Test model description',
+        customProperties: {},
+        state: ModelState.LIVE,
+      } satisfies Partial<RegisteredModel>);
+    });
+    cy.wait('@createModelVersion').then((interception) => {
+      expect(interception.request.body).to.containSubset({
+        name: 'Test version name',
+        description: 'Test version description',
+        customProperties: {},
+        state: ModelState.LIVE,
+        author: 'test-user',
+        registeredModelId: '1',
+      } satisfies Partial<ModelVersion>);
+    });
+    cy.wait('@createModelArtifact').then((interception) => {
+      expect(interception.request.body).to.containSubset({
+        name: 'Test model name-Test version name-artifact',
+        description: 'Test version description',
+        customProperties: {},
+        state: ModelArtifactState.LIVE,
+        author: 'test-user',
+        modelFormatName: 'caikit',
+        modelFormatVersion: '1',
+        uri: 's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+        artifactType: 'model-artifact',
+      } satisfies Partial<ModelArtifact>);
+    });
+
+    cy.url().should('include', '/modelRegistry/modelregistry-sample/registeredModels/1');
   });
 });

--- a/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
+++ b/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
@@ -16,6 +16,8 @@ import {
   patchModelVersion,
   patchRegisteredModel,
   getModelArtifactsByModelVersion,
+  createModelVersionForRegisteredModel,
+  createModelArtifactForModelVersion,
 } from '~/api/modelRegistry/custom';
 import { MODEL_REGISTRY_API_VERSION } from '~/concepts/modelRegistry/const';
 
@@ -104,6 +106,40 @@ describe('createModelVersion', () => {
   });
 });
 
+describe('createModelVersionForRegisteredModel', () => {
+  it('should call proxyCREATE and handleModelRegistryFailures to create model version for a model', () => {
+    expect(
+      createModelVersionForRegisteredModel('hostPath')(K8sAPIOptionsMock, '1', {
+        description: 'test',
+        externalID: '1',
+        author: 'test author',
+        registeredModelId: '1',
+        name: 'test new model version',
+        state: ModelState.LIVE,
+        customProperties: {},
+      }),
+    ).toBe(mockResultPromise);
+    expect(proxyCREATEMock).toHaveBeenCalledTimes(1);
+    expect(proxyCREATEMock).toHaveBeenCalledWith(
+      'hostPath',
+      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/1/versions`,
+      {
+        description: 'test',
+        externalID: '1',
+        author: 'test author',
+        registeredModelId: '1',
+        name: 'test new model version',
+        state: ModelState.LIVE,
+        customProperties: {},
+      },
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
 describe('createModelArtifact', () => {
   it('should call proxyCREATE and handleModelRegistryFailures to create model artifact', () => {
     expect(
@@ -138,6 +174,51 @@ describe('createModelArtifact', () => {
         modelFormatVersion: 'testmodelFormatVersion',
         serviceAccountName: 'testserviceAccountname',
         customProperties: {},
+        artifactType: 'model-artifact',
+      },
+      {},
+      K8sAPIOptionsMock,
+    );
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledTimes(1);
+    expect(handleModelRegistryFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+  });
+});
+
+describe('createModelArtifactForModelVersion', () => {
+  it('should call proxyCREATE and handleModelRegistryFailures to create model artifact for version', () => {
+    expect(
+      createModelArtifactForModelVersion('hostPath')(K8sAPIOptionsMock, '2', {
+        description: 'test',
+        externalID: 'test',
+        uri: 'test-uri',
+        state: ModelArtifactState.LIVE,
+        name: 'test-name',
+        modelFormatName: 'test-modelformatname',
+        storageKey: 'teststoragekey',
+        storagePath: 'teststoragePath',
+        modelFormatVersion: 'testmodelFormatVersion',
+        serviceAccountName: 'testserviceAccountname',
+        customProperties: {},
+        artifactType: 'model-artifact',
+      }),
+    ).toBe(mockResultPromise);
+    expect(proxyCREATEMock).toHaveBeenCalledTimes(1);
+    expect(proxyCREATEMock).toHaveBeenCalledWith(
+      'hostPath',
+      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions/2/artifacts`,
+      {
+        description: 'test',
+        externalID: 'test',
+        uri: 'test-uri',
+        state: ModelArtifactState.LIVE,
+        name: 'test-name',
+        modelFormatName: 'test-modelformatname',
+        storageKey: 'teststoragekey',
+        storagePath: 'teststoragePath',
+        modelFormatVersion: 'testmodelFormatVersion',
+        serviceAccountName: 'testserviceAccountname',
+        customProperties: {},
+        artifactType: 'model-artifact',
       },
       {},
       K8sAPIOptionsMock,

--- a/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
+++ b/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
@@ -119,6 +119,7 @@ describe('createModelArtifact', () => {
         modelFormatVersion: 'testmodelFormatVersion',
         serviceAccountName: 'testserviceAccountname',
         customProperties: {},
+        artifactType: 'model-artifact',
       }),
     ).toBe(mockResultPromise);
     expect(proxyCREATEMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/api/modelRegistry/custom.ts
+++ b/frontend/src/api/modelRegistry/custom.ts
@@ -39,6 +39,22 @@ export const createModelVersion =
         opts,
       ),
     );
+export const createModelVersionForRegisteredModel =
+  (hostpath: string) =>
+  (
+    opts: K8sAPIOptions,
+    registeredModelId: string,
+    data: CreateModelVersionData,
+  ): Promise<ModelVersion> =>
+    handleModelRegistryFailures(
+      proxyCREATE(
+        hostpath,
+        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models/${registeredModelId}/versions`,
+        data,
+        {},
+        opts,
+      ),
+    );
 
 export const createModelArtifact =
   (hostPath: string) =>
@@ -47,6 +63,23 @@ export const createModelArtifact =
       proxyCREATE(
         hostPath,
         `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_artifacts`,
+        data,
+        {},
+        opts,
+      ),
+    );
+
+export const createModelArtifactForModelVersion =
+  (hostPath: string) =>
+  (
+    opts: K8sAPIOptions,
+    modelVersionId: string,
+    data: CreateModelArtifactData,
+  ): Promise<ModelArtifact> =>
+    handleModelRegistryFailures(
+      proxyCREATE(
+        hostPath,
+        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions/${modelVersionId}/artifacts`,
         data,
         {},
         opts,

--- a/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
@@ -27,6 +27,48 @@ describe('objectStorageFieldsToUri', () => {
       's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F',
     );
   });
+
+  it('converts fields to URI with region empty', () => {
+    const uri = objectStorageFieldsToUri({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: 'test-bucket',
+      region: '',
+      path: 'demo-models/flan-t5-small-caikit',
+    });
+    expect(uri).toEqual(
+      's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F',
+    );
+  });
+
+  it('falls back to null if endpoint is empty', () => {
+    const uri = objectStorageFieldsToUri({
+      endpoint: '',
+      bucket: 'test-bucket',
+      region: 'us-east-1',
+      path: 'demo-models/flan-t5-small-caikit',
+    });
+    expect(uri).toEqual(null);
+  });
+
+  it('falls back to null if bucket is empty', () => {
+    const uri = objectStorageFieldsToUri({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: '',
+      region: 'us-east-1',
+      path: 'demo-models/flan-t5-small-caikit',
+    });
+    expect(uri).toEqual(null);
+  });
+
+  it('falls back to null if path is empty', () => {
+    const uri = objectStorageFieldsToUri({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: 'test-bucket',
+      region: 'us-east-1',
+      path: '',
+    });
+    expect(uri).toEqual(null);
+  });
 });
 
 describe('uriToObjectStorageFields', () => {

--- a/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
@@ -1,0 +1,80 @@
+import {
+  ObjectStorageFields,
+  objectStorageFieldsToUri,
+  uriToObjectStorageFields,
+} from '~/concepts/modelRegistry/utils';
+
+describe('objectStorageFieldsToUri', () => {
+  it('converts fields to URI with all fields present', () => {
+    const uri = objectStorageFieldsToUri({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: 'test-bucket',
+      region: 'us-east-1',
+      path: 'demo-models/flan-t5-small-caikit',
+    });
+    expect(uri).toEqual(
+      's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+    );
+  });
+
+  it('converts fields to URI with region missing', () => {
+    const uri = objectStorageFieldsToUri({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: 'test-bucket',
+      path: 'demo-models/flan-t5-small-caikit',
+    });
+    expect(uri).toEqual(
+      's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F',
+    );
+  });
+});
+
+describe('uriToObjectStorageFields', () => {
+  it('converts URI to fields with all params present', () => {
+    const fields = uriToObjectStorageFields(
+      's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+    );
+    expect(fields).toEqual({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: 'test-bucket',
+      region: 'us-east-1',
+      path: 'demo-models/flan-t5-small-caikit',
+    } satisfies ObjectStorageFields);
+  });
+
+  it('converts URI to fields with region missing', () => {
+    const fields = uriToObjectStorageFields(
+      's3://test-bucket/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F',
+    );
+    expect(fields).toEqual({
+      endpoint: 'http://s3.amazonaws.com/',
+      bucket: 'test-bucket',
+      path: 'demo-models/flan-t5-small-caikit',
+      region: undefined,
+    } satisfies ObjectStorageFields);
+  });
+
+  it('falls back to null if endpoint is missing', () => {
+    const fields = uriToObjectStorageFields('s3://test-bucket/demo-models/flan-t5-small-caikit');
+    expect(fields).toBeNull();
+  });
+
+  it('falls back to null if path is missing', () => {
+    const fields = uriToObjectStorageFields(
+      's3://test-bucket/?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+    );
+    expect(fields).toBeNull();
+  });
+
+  it('falls back to null if bucket is missing', () => {
+    const fields = uriToObjectStorageFields(
+      's3://?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+    );
+    expect(fields).toBeNull();
+  });
+
+  it('falls back to null if the URI is malformed', () => {
+    const fields = uriToObjectStorageFields('test-bucket/demo-models/flan-t5-small-caikit');
+    expect(fields).toBeNull();
+  });
+});

--- a/frontend/src/concepts/modelRegistry/context/useModelRegistryAPIState.tsx
+++ b/frontend/src/concepts/modelRegistry/context/useModelRegistryAPIState.tsx
@@ -3,7 +3,9 @@ import { APIState } from '~/concepts/proxy/types';
 import { ModelRegistryAPIs } from '~/concepts/modelRegistry/types';
 import {
   createModelArtifact,
+  createModelArtifactForModelVersion,
   createModelVersion,
+  createModelVersionForRegisteredModel,
   createRegisteredModel,
   getListModelArtifacts,
   getListModelVersions,
@@ -28,7 +30,9 @@ const useModelRegistryAPIState = (
     (path: string) => ({
       createRegisteredModel: createRegisteredModel(path),
       createModelVersion: createModelVersion(path),
+      createModelVersionForRegisteredModel: createModelVersionForRegisteredModel(path),
       createModelArtifact: createModelArtifact(path),
+      createModelArtifactForModelVersion: createModelArtifactForModelVersion(path),
       getRegisteredModel: getRegisteredModel(path),
       getModelVersion: getModelVersion(path),
       getModelArtifact: getModelArtifact(path),

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -145,7 +145,7 @@ export type CreateModelVersionData = Omit<
 
 export type CreateModelArtifactData = Omit<
   ModelArtifact,
-  'lastUpdateTimeSinceEpoch' | 'createTimeSinceEpoch' | 'id' | 'artifactType'
+  'lastUpdateTimeSinceEpoch' | 'createTimeSinceEpoch' | 'id'
 >;
 
 export type ModelRegistryListParams = {
@@ -170,8 +170,20 @@ export type CreateModelVersion = (
   data: CreateModelVersionData,
 ) => Promise<ModelVersion>;
 
+export type CreateModelVersionForRegisteredModel = (
+  opts: K8sAPIOptions,
+  registeredModelId: string,
+  data: CreateModelVersionData,
+) => Promise<ModelVersion>;
+
 export type CreateModelArtifact = (
   opts: K8sAPIOptions,
+  data: CreateModelArtifactData,
+) => Promise<ModelArtifact>;
+
+export type CreateModelArtifactForModelVersion = (
+  opts: K8sAPIOptions,
+  modelVersionId: string,
   data: CreateModelArtifactData,
 ) => Promise<ModelArtifact>;
 
@@ -227,7 +239,9 @@ export type PatchModelArtifact = (
 export type ModelRegistryAPIs = {
   createRegisteredModel: CreateRegisteredModel;
   createModelVersion: CreateModelVersion;
+  createModelVersionForRegisteredModel: CreateModelVersionForRegisteredModel;
   createModelArtifact: CreateModelArtifact;
+  createModelArtifactForModelVersion: CreateModelArtifactForModelVersion;
   getRegisteredModel: GetRegisteredModel;
   getModelVersion: GetModelVersion;
   getModelArtifact: GetModelArtifact;

--- a/frontend/src/concepts/modelRegistry/utils.ts
+++ b/frontend/src/concepts/modelRegistry/utils.ts
@@ -1,0 +1,36 @@
+export type ObjectStorageFields = {
+  endpoint: string;
+  bucket: string;
+  region?: string;
+  path: string;
+};
+
+export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string => {
+  const { endpoint, bucket, region, path } = fields;
+  const searchParams = new URLSearchParams();
+  searchParams.set('endpoint', endpoint);
+  if (region) {
+    searchParams.set('defaultRegion', region);
+  }
+  return `s3://${bucket}/${path}?${searchParams.toString()}`;
+};
+
+export const uriToObjectStorageFields = (uri: string): ObjectStorageFields | null => {
+  try {
+    const urlObj = new URL(uri);
+    // Some environments include the first token after the protocol (our bucket) in the pathname and some have it as the hostname
+    const [bucket, ...pathSplit] = `${urlObj.hostname}/${urlObj.pathname}`
+      .split('/')
+      .filter(Boolean);
+    const path = pathSplit.join('/');
+    const searchParams = new URLSearchParams(urlObj.search);
+    const endpoint = searchParams.get('endpoint');
+    const region = searchParams.get('defaultRegion');
+    if (endpoint && bucket && path) {
+      return { endpoint, bucket, region: region || undefined, path };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};

--- a/frontend/src/concepts/modelRegistry/utils.ts
+++ b/frontend/src/concepts/modelRegistry/utils.ts
@@ -5,8 +5,11 @@ export type ObjectStorageFields = {
   path: string;
 };
 
-export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string => {
+export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string | null => {
   const { endpoint, bucket, region, path } = fields;
+  if (!endpoint || !bucket || !path) {
+    return null;
+  }
   const searchParams = new URLSearchParams();
   searchParams.set('endpoint', endpoint);
   if (region) {

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
@@ -85,8 +85,9 @@ const RegisterModel: React.FC = () => {
       description="Create a new model and register a first version of the new model."
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem render={() => <Link to="/modelRegistry">Model registry</Link>} />
-          <BreadcrumbItem render={() => <Link to={`/modelRegistry/${mrName}`}>{mrName}</Link>} />
+          <BreadcrumbItem
+            render={() => <Link to={`/modelRegistry/${mrName}`}>Model registry - {mrName}</Link>}
+          />
           <BreadcrumbItem>Register model</BreadcrumbItem>
         </Breadcrumb>
       }

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
@@ -13,6 +13,7 @@ import {
   HelperTextItem,
   InputGroupItem,
   InputGroupText,
+  PageSection,
   Radio,
   Split,
   SplitItem,
@@ -23,6 +24,7 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useParams, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
@@ -41,6 +43,7 @@ const RegisterModel: React.FC = () => {
     versionName,
     versionDescription,
     sourceModelFormat,
+    sourceModelFormatVersion,
     modelLocationType,
     modelLocationEndpoint,
     modelLocationBucket,
@@ -89,195 +92,225 @@ const RegisterModel: React.FC = () => {
       }
       loaded
       empty={false}
-      provideChildrenPadding
     >
-      <Form>
-        <Stack hasGutter>
-          <StackItem>
-            <FormGroup label="Model registry" isRequired fieldId="mr-name">
-              <TextInput
-                isDisabled
+      <PageSection variant="light" isFilled>
+        <Form isWidthLimited>
+          <Stack hasGutter>
+            <StackItem>
+              <FormGroup
+                label="Model registry"
                 isRequired
-                type="text"
-                id="mr-name"
-                name="mr-name"
-                value={mrName}
-              />
-            </FormGroup>
-          </StackItem>
-          <StackItem>
-            <FormSection
-              title={
-                <>
-                  <Title headingLevel="h2">Model info</Title>
-                  <Text component="p" className="form-subtitle-text">
-                    Configure the model info you want to create.
-                  </Text>
-                </>
-              }
-            >
-              <FormGroup label="Model name" isRequired fieldId="model-name">
+                fieldId="mr-name"
+                className={spacing.mbLg}
+              >
                 <TextInput
+                  isDisabled
                   isRequired
                   type="text"
-                  id="model-name"
-                  name="model-name"
-                  value={modelName}
-                  onChange={(_e, value) => setData('modelName', value)}
+                  id="mr-name"
+                  name="mr-name"
+                  value={mrName}
                 />
               </FormGroup>
-              <FormGroup label="Model description" fieldId="model-description">
-                <TextArea
-                  type="text"
-                  id="model-description"
-                  name="model-description"
-                  value={modelDescription}
-                  onChange={(_e, value) => setData('modelDescription', value)}
-                />
-              </FormGroup>
-            </FormSection>
-            <FormSection
-              title={
-                <>
-                  <Title headingLevel="h2">Version info</Title>
-                  <Text component="p" className="form-subtitle-text">
-                    Configure the version info for the run that you want to register.
-                  </Text>
-                </>
-              }
-            >
-              <FormGroup label="Version name" isRequired fieldId="version-name">
-                <TextInput
-                  isRequired
-                  type="text"
-                  id="version-name"
-                  name="version-name"
-                  value={versionName}
-                  onChange={(_e, value) => setData('versionName', value)}
-                />
-              </FormGroup>
-              <FormGroup label="Version description" fieldId="version-description">
-                <TextArea
-                  type="text"
-                  id="version-description"
-                  name="version-description"
-                  value={versionDescription}
-                  onChange={(_e, value) => setData('versionDescription', value)}
-                />
-              </FormGroup>
-              <FormGroup label="Source model format" fieldId="source-model-format">
-                <TextInput
-                  type="text"
-                  placeholder="Example, tensorflow"
-                  id="source-model-format"
-                  name="source-model-format"
-                  value={sourceModelFormat}
-                  onChange={(_e, value) => setData('sourceModelFormat', value)}
-                />
-              </FormGroup>
-            </FormSection>
-            <FormSection
-              title={
-                <>
-                  <Title headingLevel="h2">Model location</Title>
-                  <Text component="p" className="form-subtitle-text">
-                    Specify the model location by providing either the object storage details or the
-                    URI.
-                  </Text>
-                </>
-              }
-            >
-              <Radio
-                isChecked={modelLocationType === ModelLocationType.ObjectStorage}
-                name="location-type-object-storage"
-                onChange={() => {
-                  setData('modelLocationType', ModelLocationType.ObjectStorage);
-                }}
-                label="Object storage"
-                id="location-type-object-storage"
-              />
-              {modelLocationType === ModelLocationType.ObjectStorage && (
-                <>
-                  <FormGroup label="Endpoint" isRequired fieldId="location-endpoint">
-                    <TextInput
-                      isRequired
-                      type="text"
-                      id="location-endpoint"
-                      name="location-endpoint"
-                      value={modelLocationEndpoint}
-                      onChange={(_e, value) => setData('modelLocationEndpoint', value)}
-                    />
-                  </FormGroup>
-                  <FormGroup label="Bucket" isRequired fieldId="location-bucket">
-                    <TextInput
-                      isRequired
-                      type="text"
-                      id="location-bucket"
-                      name="location-bucket"
-                      value={modelLocationBucket}
-                      onChange={(_e, value) => setData('modelLocationBucket', value)}
-                    />
-                  </FormGroup>
-                  <FormGroup label="Region" fieldId="location-region">
-                    <TextInput
-                      type="text"
-                      id="location-region"
-                      name="location-region"
-                      value={modelLocationRegion}
-                      onChange={(_e, value) => setData('modelLocationRegion', value)}
-                    />
-                  </FormGroup>
-                  <FormGroup label="Path" isRequired fieldId="location-path">
-                    <Split hasGutter>
-                      <SplitItem>
-                        <InputGroupText isPlain>/</InputGroupText>
-                      </SplitItem>
-                      <SplitItem isFilled>
-                        <InputGroupItem>
+            </StackItem>
+            <StackItem>
+              <FormSection
+                title={
+                  <>
+                    <Title headingLevel="h2" size="md">
+                      Model details
+                    </Title>
+                    <Text component="p" className="form-subtitle-text">
+                      Provide general details that apply to all versions of this model.
+                    </Text>
+                  </>
+                }
+              >
+                <FormGroup label="Model name" isRequired fieldId="model-name">
+                  <TextInput
+                    isRequired
+                    type="text"
+                    id="model-name"
+                    name="model-name"
+                    value={modelName}
+                    onChange={(_e, value) => setData('modelName', value)}
+                  />
+                </FormGroup>
+                <FormGroup label="Model description" fieldId="model-description">
+                  <TextArea
+                    type="text"
+                    id="model-description"
+                    name="model-description"
+                    value={modelDescription}
+                    onChange={(_e, value) => setData('modelDescription', value)}
+                  />
+                </FormGroup>
+              </FormSection>
+              <FormSection
+                title={
+                  <>
+                    <Title headingLevel="h2">Version details</Title>
+                    <Text component="p" className="form-subtitle-text">
+                      Configure details for the first version of this model.
+                    </Text>
+                  </>
+                }
+              >
+                <FormGroup label="Version name" isRequired fieldId="version-name">
+                  <TextInput
+                    isRequired
+                    type="text"
+                    id="version-name"
+                    name="version-name"
+                    value={versionName}
+                    onChange={(_e, value) => setData('versionName', value)}
+                  />
+                </FormGroup>
+                <FormGroup label="Version description" fieldId="version-description">
+                  <TextArea
+                    type="text"
+                    id="version-description"
+                    name="version-description"
+                    value={versionDescription}
+                    onChange={(_e, value) => setData('versionDescription', value)}
+                  />
+                </FormGroup>
+                <FormGroup label="Source model format" fieldId="source-model-format">
+                  <TextInput
+                    type="text"
+                    placeholder="Example, tensorflow"
+                    id="source-model-format"
+                    name="source-model-format"
+                    value={sourceModelFormat}
+                    onChange={(_e, value) => setData('sourceModelFormat', value)}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label="Source model format version"
+                  fieldId="source-model-format-version"
+                >
+                  <TextInput
+                    type="text"
+                    placeholder="Example, 1"
+                    id="source-model-format-version"
+                    name="source-model-format-version"
+                    value={sourceModelFormatVersion}
+                    onChange={(_e, value) => setData('sourceModelFormatVersion', value)}
+                  />
+                </FormGroup>
+              </FormSection>
+              <FormSection
+                title={
+                  <>
+                    <Title headingLevel="h2">Model location</Title>
+                    <Text component="p" className="form-subtitle-text">
+                      Specify the model location by providing either the object storage details or
+                      the URI.
+                    </Text>
+                  </>
+                }
+              >
+                <Radio
+                  isChecked={modelLocationType === ModelLocationType.ObjectStorage}
+                  name="location-type-object-storage"
+                  onChange={() => {
+                    setData('modelLocationType', ModelLocationType.ObjectStorage);
+                  }}
+                  label="Object storage"
+                  id="location-type-object-storage"
+                  body={
+                    modelLocationType === ModelLocationType.ObjectStorage && (
+                      <Form>
+                        <FormGroup label="Endpoint" isRequired fieldId="location-endpoint">
                           <TextInput
                             isRequired
                             type="text"
-                            id="location-path"
-                            name="location-path"
-                            value={modelLocationPath}
-                            onChange={(_e, value) => setData('modelLocationPath', value)}
+                            id="location-endpoint"
+                            name="location-endpoint"
+                            value={modelLocationEndpoint}
+                            onChange={(_e, value) => setData('modelLocationEndpoint', value)}
                           />
-                        </InputGroupItem>
-                      </SplitItem>
-                    </Split>
-                    <HelperText>
-                      <HelperTextItem>
-                        Enter a path to a model or folder. This path cannot point to a root folder.
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormGroup>
-                </>
-              )}
-              <Radio
-                isChecked={modelLocationType === ModelLocationType.URI}
-                name="location-type-uri"
-                onChange={() => {
-                  setData('modelLocationType', ModelLocationType.URI);
-                }}
-                label="URI"
-                id="location-type-uri"
-              />
-              {modelLocationType === ModelLocationType.URI && (
-                <>
-                  <FormGroup label="URI" isRequired fieldId="location-uri">
-                    <TextInput
-                      isRequired
-                      type="text"
-                      id="location-uri"
-                      name="location-uri"
-                      value={modelLocationURI}
-                      onChange={(_e, value) => setData('modelLocationURI', value)}
-                    />
-                  </FormGroup>
-                </>
-              )}
-            </FormSection>
-          </StackItem>
+                        </FormGroup>
+                        <FormGroup label="Bucket" isRequired fieldId="location-bucket">
+                          <TextInput
+                            isRequired
+                            type="text"
+                            id="location-bucket"
+                            name="location-bucket"
+                            value={modelLocationBucket}
+                            onChange={(_e, value) => setData('modelLocationBucket', value)}
+                          />
+                        </FormGroup>
+                        <FormGroup label="Region" fieldId="location-region">
+                          <TextInput
+                            type="text"
+                            id="location-region"
+                            name="location-region"
+                            value={modelLocationRegion}
+                            onChange={(_e, value) => setData('modelLocationRegion', value)}
+                          />
+                        </FormGroup>
+                        <FormGroup label="Path" isRequired fieldId="location-path">
+                          <Split hasGutter>
+                            <SplitItem>
+                              <InputGroupText isPlain>/</InputGroupText>
+                            </SplitItem>
+                            <SplitItem isFilled>
+                              <InputGroupItem>
+                                <TextInput
+                                  isRequired
+                                  type="text"
+                                  id="location-path"
+                                  name="location-path"
+                                  value={modelLocationPath}
+                                  onChange={(_e, value) => setData('modelLocationPath', value)}
+                                />
+                              </InputGroupItem>
+                            </SplitItem>
+                          </Split>
+                          <HelperText>
+                            <HelperTextItem>
+                              Enter a path to a model or folder. This path cannot point to a root
+                              folder.
+                            </HelperTextItem>
+                          </HelperText>
+                        </FormGroup>
+                      </Form>
+                    )
+                  }
+                />
+                <Radio
+                  isChecked={modelLocationType === ModelLocationType.URI}
+                  name="location-type-uri"
+                  onChange={() => {
+                    setData('modelLocationType', ModelLocationType.URI);
+                  }}
+                  label="URI"
+                  id="location-type-uri"
+                  body={
+                    modelLocationType === ModelLocationType.URI && (
+                      <Form>
+                        <FormGroup label="URI" isRequired fieldId="location-uri">
+                          <TextInput
+                            isRequired
+                            type="text"
+                            id="location-uri"
+                            name="location-uri"
+                            value={modelLocationURI}
+                            onChange={(_e, value) => setData('modelLocationURI', value)}
+                          />
+                        </FormGroup>
+                      </Form>
+                    )
+                  }
+                />
+              </FormSection>
+            </StackItem>
+          </Stack>
+        </Form>
+      </PageSection>
+      <PageSection stickyOnBreakpoint={{ default: 'bottom' }} variant="light">
+        <Stack hasGutter>
           {error && (
             <StackItem>
               <Alert
@@ -313,7 +346,7 @@ const RegisterModel: React.FC = () => {
             </ActionGroup>
           </StackItem>
         </Stack>
-      </Form>
+      </PageSection>
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
@@ -14,6 +14,7 @@ export type RegisterVersionFormData = {
   versionName: string;
   versionDescription: string;
   sourceModelFormat: string;
+  sourceModelFormatVersion: string;
   modelLocationType: ModelLocationType;
   modelLocationEndpoint: string;
   modelLocationBucket: string;
@@ -26,6 +27,7 @@ const registerVersionFormDataDefaults: RegisterVersionFormData = {
   versionName: '',
   versionDescription: '',
   sourceModelFormat: '',
+  sourceModelFormatVersion: '',
   modelLocationType: ModelLocationType.ObjectStorage,
   modelLocationEndpoint: '',
   modelLocationBucket: '',

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/useRegisterModelData.ts
@@ -1,13 +1,20 @@
 import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
 
-export type RegisterModelData = {
-  modelRegistryName: string;
+export enum ModelLocationType {
+  ObjectStorage = 'Object storage',
+  URI = 'URI',
+}
+
+export type RegisterModelFormData = RegisterVersionFormData & {
   modelName: string;
   modelDescription: string;
+};
+
+export type RegisterVersionFormData = {
   versionName: string;
   versionDescription: string;
   sourceModelFormat: string;
-  modelLocationType: string;
+  modelLocationType: ModelLocationType;
   modelLocationEndpoint: string;
   modelLocationBucket: string;
   modelLocationRegion: string;
@@ -15,20 +22,25 @@ export type RegisterModelData = {
   modelLocationURI: string;
 };
 
-const useRegisterModelData = (mrName?: string): GenericObjectState<RegisterModelData> =>
-  useGenericObjectState<RegisterModelData>({
-    modelRegistryName: mrName || '',
-    modelName: '',
-    modelDescription: '',
-    versionName: '',
-    versionDescription: '',
-    sourceModelFormat: '',
-    modelLocationType: 'Object storage',
-    modelLocationEndpoint: '',
-    modelLocationBucket: '',
-    modelLocationRegion: '',
-    modelLocationPath: '',
-    modelLocationURI: '',
-  });
+const registerVersionFormDataDefaults: RegisterVersionFormData = {
+  versionName: '',
+  versionDescription: '',
+  sourceModelFormat: '',
+  modelLocationType: ModelLocationType.ObjectStorage,
+  modelLocationEndpoint: '',
+  modelLocationBucket: '',
+  modelLocationRegion: '',
+  modelLocationPath: '',
+  modelLocationURI: '',
+};
+const registerModelFormDataDefaults: RegisterModelFormData = {
+  ...registerVersionFormDataDefaults,
+  modelName: '',
+  modelDescription: '',
+};
 
-export default useRegisterModelData;
+export const useRegisterModelData = (): GenericObjectState<RegisterModelFormData> =>
+  useGenericObjectState<RegisterModelFormData>(registerModelFormDataDefaults);
+
+export const useRegisterVersionData = (): GenericObjectState<RegisterVersionFormData> =>
+  useGenericObjectState<RegisterVersionFormData>(registerVersionFormDataDefaults);

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -68,8 +68,8 @@ export const registerVersion = async (
     customProperties: {},
     state: ModelArtifactState.LIVE,
     author,
-    modelFormatName: formData.sourceModelFormat, // TODO change to sourceModelFormatName
-    modelFormatVersion: '1', // TODO add new formData.sourceModelFormatVersion
+    modelFormatName: formData.sourceModelFormat,
+    modelFormatVersion: formData.sourceModelFormatVersion,
     // storageKey: 'TODO', // TODO fill in the name of the data connection we used to prefill if we used one - reference ticket
     uri:
       formData.modelLocationType === ModelLocationType.ObjectStorage

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -81,7 +81,7 @@ export const registerVersion = async (
             bucket: formData.modelLocationBucket,
             region: formData.modelLocationRegion,
             path: formData.modelLocationPath,
-          })
+          }) || '' // We'll only hit this case if required fields are empty strings, so form validation should catch it.
         : formData.modelLocationURI,
     artifactType: 'model-artifact',
   });

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -6,6 +6,7 @@ import {
   RegisteredModel,
 } from '~/concepts/modelRegistry/types';
 import { ModelRegistryAPIState } from '~/concepts/modelRegistry/context/useModelRegistryAPIState';
+import { objectStorageFieldsToUri } from '~/concepts/modelRegistry/utils';
 import {
   ModelLocationType,
   RegisterModelFormData,
@@ -83,49 +84,4 @@ export const registerVersion = async (
     artifactType: 'model-artifact',
   });
   return { modelVersion, modelArtifact };
-};
-
-type ObjectStorageFields = {
-  endpoint: string;
-  bucket: string;
-  region?: string;
-  path: string;
-};
-
-// TODO unit tests for the below using:
-/*
-s3://rhods-public/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1
-{
-  endpoint: 'http://s3.amazonaws.com/',
-  bucket: 'rhods-public',
-  region: 'us-east-1',
-  path: 'demo-models/flan-t5-small-caikit',
-}
-*/
-
-export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string => {
-  const { endpoint, bucket, region, path } = fields;
-  const searchParams = new URLSearchParams();
-  searchParams.set('endpoint', endpoint);
-  if (region) {
-    searchParams.set('defaultRegion', region);
-  }
-  return `s3://${bucket}/${path}?${searchParams.toString()}`;
-};
-
-export const uriToObjectStorageFields = (uri: string): ObjectStorageFields | null => {
-  try {
-    const urlObj = new URL(uri);
-    const [bucket, ...pathSplit] = urlObj.pathname.split('/').filter(Boolean);
-    const path = pathSplit.join('/');
-    const searchParams = new URLSearchParams(urlObj.search);
-    const endpoint = searchParams.get('endpoint');
-    const region = searchParams.get('defaultRegion');
-    if (endpoint && bucket && path) {
-      return { endpoint, bucket, region: region || undefined, path };
-    }
-    return null;
-  } catch {
-    return null;
-  }
 };

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -71,7 +71,9 @@ export const registerVersion = async (
     author,
     modelFormatName: formData.sourceModelFormat,
     modelFormatVersion: formData.sourceModelFormatVersion,
-    // storageKey: 'TODO', // TODO fill in the name of the data connection we used to prefill if we used one - reference ticket
+    // TODO fill in the name of the data connection we used to prefill if we used one
+    // TODO this should be done as part of https://issues.redhat.com/browse/RHOAIENG-9914
+    // storageKey: 'TODO',
     uri:
       formData.modelLocationType === ModelLocationType.ObjectStorage
         ? objectStorageFieldsToUri({

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -6,7 +6,11 @@ import {
   RegisteredModel,
 } from '~/concepts/modelRegistry/types';
 import { ModelRegistryAPIState } from '~/concepts/modelRegistry/context/useModelRegistryAPIState';
-import { RegisterModelFormData, RegisterVersionFormData } from './useRegisterModelData';
+import {
+  ModelLocationType,
+  RegisterModelFormData,
+  RegisterVersionFormData,
+} from './useRegisterModelData';
 
 export type RegisterModelCreatedResources = RegisterVersionCreatedResources & {
   registeredModel: RegisteredModel;
@@ -67,9 +71,61 @@ export const registerVersion = async (
     modelFormatName: formData.sourceModelFormat, // TODO change to sourceModelFormatName
     modelFormatVersion: '1', // TODO add new formData.sourceModelFormatVersion
     // storageKey: 'TODO', // TODO fill in the name of the data connection we used to prefill if we used one - reference ticket
-    // TODO construct this URI from formData according to agreed-upon structure
-    uri: 's3://rhods-public/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+    uri:
+      formData.modelLocationType === ModelLocationType.ObjectStorage
+        ? objectStorageFieldsToUri({
+            endpoint: formData.modelLocationEndpoint,
+            bucket: formData.modelLocationBucket,
+            region: formData.modelLocationRegion,
+            path: formData.modelLocationPath,
+          })
+        : formData.modelLocationURI,
     artifactType: 'model-artifact',
   });
   return { modelVersion, modelArtifact };
+};
+
+type ObjectStorageFields = {
+  endpoint: string;
+  bucket: string;
+  region?: string;
+  path: string;
+};
+
+// TODO unit tests for the below using:
+/*
+s3://rhods-public/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1
+{
+  endpoint: 'http://s3.amazonaws.com/',
+  bucket: 'rhods-public',
+  region: 'us-east-1',
+  path: 'demo-models/flan-t5-small-caikit',
+}
+*/
+
+export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string => {
+  const { endpoint, bucket, region, path } = fields;
+  const searchParams = new URLSearchParams();
+  searchParams.set('endpoint', endpoint);
+  if (region) {
+    searchParams.set('defaultRegion', region);
+  }
+  return `s3://${bucket}/${path}?${searchParams.toString()}`;
+};
+
+export const uriToObjectStorageFields = (uri: string): ObjectStorageFields | null => {
+  try {
+    const urlObj = new URL(uri);
+    const [bucket, ...pathSplit] = urlObj.pathname.split('/').filter(Boolean);
+    const path = pathSplit.join('/');
+    const searchParams = new URLSearchParams(urlObj.search);
+    const endpoint = searchParams.get('endpoint');
+    const region = searchParams.get('defaultRegion');
+    if (endpoint && bucket && path) {
+      return { endpoint, bucket, region: region || undefined, path };
+    }
+    return null;
+  } catch {
+    return null;
+  }
 };

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -1,0 +1,75 @@
+import {
+  ModelArtifact,
+  ModelArtifactState,
+  ModelState,
+  ModelVersion,
+  RegisteredModel,
+} from '~/concepts/modelRegistry/types';
+import { ModelRegistryAPIState } from '~/concepts/modelRegistry/context/useModelRegistryAPIState';
+import { RegisterModelFormData, RegisterVersionFormData } from './useRegisterModelData';
+
+export type RegisterModelCreatedResources = RegisterVersionCreatedResources & {
+  registeredModel: RegisteredModel;
+};
+
+export type RegisterVersionCreatedResources = {
+  modelVersion: ModelVersion;
+  modelArtifact: ModelArtifact;
+};
+
+export const registerModel = async (
+  apiState: ModelRegistryAPIState,
+  formData: RegisterModelFormData,
+  author: string,
+): Promise<RegisterModelCreatedResources> => {
+  const registeredModel = await apiState.api.createRegisteredModel(
+    {},
+    {
+      name: formData.modelName,
+      description: formData.modelDescription,
+      customProperties: {},
+      state: ModelState.LIVE,
+    },
+  );
+  const { modelVersion, modelArtifact } = await registerVersion(
+    apiState,
+    registeredModel,
+    formData,
+    author,
+  );
+  return { registeredModel, modelVersion, modelArtifact };
+};
+
+export const registerVersion = async (
+  apiState: ModelRegistryAPIState,
+  registeredModel: RegisteredModel,
+  formData: RegisterVersionFormData,
+  author: string,
+): Promise<RegisterVersionCreatedResources> => {
+  const modelVersion = await apiState.api.createModelVersionForRegisteredModel(
+    {},
+    registeredModel.id,
+    {
+      name: formData.versionName,
+      description: formData.versionDescription,
+      customProperties: {},
+      state: ModelState.LIVE,
+      author,
+      registeredModelId: registeredModel.id,
+    },
+  );
+  const modelArtifact = await apiState.api.createModelArtifactForModelVersion({}, modelVersion.id, {
+    name: `${registeredModel.name}-${formData.versionName}-artifact`,
+    description: formData.versionDescription,
+    customProperties: {},
+    state: ModelArtifactState.LIVE,
+    author,
+    modelFormatName: formData.sourceModelFormat, // TODO change to sourceModelFormatName
+    modelFormatVersion: '1', // TODO add new formData.sourceModelFormatVersion
+    // storageKey: 'TODO', // TODO fill in the name of the data connection we used to prefill if we used one - reference ticket
+    // TODO construct this URI from formData according to agreed-upon structure
+    uri: 's3://rhods-public/demo-models/flan-t5-small-caikit?endpoint=http%3A%2F%2Fs3.amazonaws.com%2F&defaultRegion=us-east-1',
+    artifactType: 'model-artifact',
+  });
+  return { modelVersion, modelArtifact };
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Closes https://issues.redhat.com/browse/RHOAIENG-2240
Unblocks and partially addresses https://issues.redhat.com/browse/RHOAIENG-7571

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Implements API calls on submitting the Register Model form, and adjusts some presentation details of the page to match the latest mockups.

* Adds new API client functions to `useModelRegistryAPIState`: `createModelVersionForRegisteredModel` and `createModelArtifactForModelVersion`. The existing `createModelVersion` and `createModelArtifact` functions use the base endpoint for those resources, but (1) in the case of creating artifacts we need to use the sub-route under the model version URL to associate the artifact with that version, and (2) it made sense to be consistent and do the same for creating versions under the associated model's URL.
* Adds the `artifactType` property to the required params for creating artifacts since it is now required by the API.
* Adds new utils under `~/concepts/modelRegistry/utils`: `objectStorageFieldsToUri` and `uriToObjectStorageFields`. The former is used for constructing the URI when we create our artifact here, and the latter will be used in the future to destructure this URI for prefilling the deployment form (for [RHOAIENG-8396](https://issues.redhat.com/browse/RHOAIENG-8396), cc @DaoDaoNoCode ). The URI format we're using here is defined in [RHOAIENG-3979](https://issues.redhat.com/browse/RHOAIENG-3979).
* Changes to existing RegisterModel form:
  * Connects the submit button to the API and navigates to the new model's page after submission
  * Removes `modelRegistryName` from the state held by `useRegisterModelData` - it never changes and we already have a prop for it
  * Rearranges the PageSections so we can have a floating footer in its own PageSection with `stickyOnBreakpoint` below the form as specified in the mockups
    * Unfortunately this changes whitespace on a lot of extra lines, the diff may be hard to read.
  * Sets `isWidthLimited` on the Form
  * Updates some text in the form ([see latest mockup here](https://www.figma.com/proto/KTsYhANYQqB0NUrXW7wQH1/Model-Registry?page-id=6782%3A296930&type=design&node-id=7742-12333&viewport=985%2C-1054%2C0.1&t=Tar1fktYL7sXp9c3-1&scaling=min-zoom&starting-point-node-id=7742%3A12333&show-proto-sidebar=1))
  * Adds the "Source model format version" field per slack discussion
  * Connects the cancel button so it navigates back to the MR landing page
* Splits out some fields of `useRegisterModelData` into `useRegisterVersionData` in anticipation of reusing this state for the upcoming Register Version form

Note - See the TODO comment in `frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts`: Once we have prefilling from data connections in this form ([RHOAIENG-9914](https://issues.redhat.com/browse/RHOAIENG-9914)) we should update the artifact creation so it includes a `storageKey` property set to the data connection name. cc @gitdallas 

Top of form with sticky footer
<img width="1724" alt="Screenshot 2024-08-06 at 12 00 35 PM" src="https://github.com/user-attachments/assets/ce183b7f-0678-4741-8a3b-13f00738dcd9">

Bottom of form in object storage mode
<img width="1723" alt="Screenshot 2024-08-06 at 12 00 41 PM" src="https://github.com/user-attachments/assets/2abf070a-becd-4b14-a853-5ab5a88c84db">

Bottom of form in URI mode
<img width="1725" alt="Screenshot 2024-08-06 at 12 00 48 PM" src="https://github.com/user-attachments/assets/78035e49-0b54-42d9-a3f4-370a94e76d75">

cc @yih-wang 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on the modelregistry-ui cluster. Also tested after disconnecting the VPN to make sure it would render network errors properly.

Any fake data is sufficient to test this - just put anything in all the required fields and it should create the required resources and redirect you to the new registered model's page.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

* Added unit tests for the `objectStorageFieldsToUri` and `uriToObjectStorageFields` utils
* Added Cypress tests for submitting the form in both object storage and URI modes and asserting the request bodies for the created model, version and artifact. These tests sufficiently cover the utilities `registerModel` and `registerVersion` in `frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts`.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
