### PR TITLE
Allow users to select pipeline edges to highlight the dependency route

### DIFF
--- a/frontend/src/concepts/topology/PipelineTaskEdge.tsx
+++ b/frontend/src/concepts/topology/PipelineTaskEdge.tsx
@@ -5,10 +5,11 @@ import {
   EdgeTerminalType,
   observer,
   TaskEdge,
+  WithSelectionProps,
   isEdge,
 } from '@patternfly/react-topology';
 
-interface PipelineTaskEdgeProps {
+interface PipelineTaskEdgeProps extends WithSelectionProps {
   element: GraphElement;
 }
 

--- a/frontend/src/concepts/topology/factories.ts
+++ b/frontend/src/concepts/topology/factories.ts
@@ -28,7 +28,7 @@ export const pipelineComponentFactory: ComponentFactory = (kind, type) => {
     case DEFAULT_SPACER_NODE_TYPE:
       return SpacerNode;
     case DEFAULT_EDGE_TYPE:
-      return PipelineTaskEdge;
+      return withSelection()(PipelineTaskEdge);
     case EXECUTION_TASK_NODE_TYPE:
       return withSelection()(PipelineDefaultTaskGroup);
     default:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-7066

## Description
Allowing  users to select pipeline edges to highlight the dependency route
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Import a pipeline
2. Click on the edge of the pipeline topology and check whether it highlight the dependency route

<img width="1507" alt="Screenshot 2024-08-06 at 6 02 37 PM" src="https://github.com/user-attachments/assets/090b579a-9ce7-475a-857a-52e726267c28">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
