### PR TITLE
Use artifact downloader hook to get the artifact URI

### DIFF
--- a/frontend/src/__mocks__/mockArtifactStorage.ts
+++ b/frontend/src/__mocks__/mockArtifactStorage.ts
@@ -4,22 +4,30 @@ import { ArtifactStorage } from '~/concepts/pipelines/types';
 type MockArtifactStorageType = {
   namespace?: string;
   artifactId?: string;
+  storage_path?: string;
+  uri?: string;
+  download_url?: string;
+  artifact_type?: string;
+  artifact_size?: string;
 };
 
 export const mockArtifactStorage = ({
   namespace = 'test',
-  artifactId = '16',
+  artifactId = '1',
+  storage_path = 'metrics-visualization-pipeline/5e873c64-39fa-4dd4-83db-eff0cdd1e274/html-visualization/html_artifact',
+  uri = 's3://aballant-pipelines/metrics-visualization-pipeline/5e873c64-39fa-4dd4-83db-eff0cdd1e274/html-visualization/html_artifact',
+  download_url = 'https://test.s3.dualstack.us-east-1.amazonaws.com/metrics-visualization-pipeline/5e873c64-39fa-4dd4-83db-eff0cdd1e274/html-visualization/html_artifact?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=AKIAYQPE7PSILMBBLXMO%2F20240808%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20240808T070034Z\u0026X-Amz-Expires=15\u0026X-Amz-SignedHeaders=host\u0026response-content-disposition=attachment%3B%20filename%3D%22%22\u0026X-Amz-Signature=de39ee684dd606e75da3b07c1b9f0820f7442ea7a037ae1bffccea9e33610ea9',
+  artifact_type = 'system.Markdown',
+  artifact_size = '61',
 }: MockArtifactStorageType): ArtifactStorage => ({
   artifact_id: artifactId,
   storage_provider: 's3',
-  storage_path:
-    'metrics-visualization-pipeline/5e873c64-39fa-4dd4-83db-eff0cdd1e274/html-visualization/html_artifact',
-  uri: 's3://aballant-pipelines/metrics-visualization-pipeline/5e873c64-39fa-4dd4-83db-eff0cdd1e274/html-visualization/html_artifact',
-  download_url:
-    'https://test.s3.dualstack.us-east-1.amazonaws.com/metrics-visualization-pipeline/5e873c64-39fa-4dd4-83db-eff0cdd1e274/html-visualization/html_artifact?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=AKIAYQPE7PSILMBBLXMO%2F20240808%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20240808T070034Z\u0026X-Amz-Expires=15\u0026X-Amz-SignedHeaders=host\u0026response-content-disposition=attachment%3B%20filename%3D%22%22\u0026X-Amz-Signature=de39ee684dd606e75da3b07c1b9f0820f7442ea7a037ae1bffccea9e33610ea9',
+  storage_path,
+  uri,
+  download_url,
   namespace,
-  artifact_type: 'system.Markdownxw',
-  artifact_size: '61',
-  created_at: '2024-08-07T07:13:46.078Z',
-  last_updated_at: '2024-08-07T07:13:46.078Z',
+  artifact_size,
+  artifact_type,
+  created_at: '2024-06-19T12:27:19.827Z',
+  last_updated_at: '2024-06-19T12:27:19.827Z',
 });

--- a/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
+++ b/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
@@ -869,3 +869,289 @@ export const mockArgoWorkflowPipelineVersion = ({
     },
   },
 });
+export const mockMetricsVisualizationVersion: PipelineVersionKFv2 = {
+  pipeline_id: 'metrics-pipeline',
+  pipeline_version_id: 'metrics-pipeline-version',
+  display_name: 'metrics visualization',
+  created_at: '2024-06-19T11:28:05Z',
+  pipeline_spec: {
+    components: {
+      'comp-digit-classification': {
+        executorLabel: 'exec-digit-classification',
+        outputDefinitions: {
+          artifacts: {
+            metrics: {
+              artifactType: {
+                schemaTitle: ArtifactType.METRICS,
+                schemaVersion: '0.0.1',
+              },
+            },
+          },
+        },
+      },
+      'comp-html-visualization': {
+        executorLabel: 'exec-html-visualization',
+        outputDefinitions: {
+          artifacts: {
+            html_artifact: {
+              artifactType: {
+                schemaTitle: ArtifactType.HTML,
+                schemaVersion: '0.0.1',
+              },
+            },
+          },
+        },
+      },
+      'comp-iris-sgdclassifier': {
+        executorLabel: 'exec-iris-sgdclassifier',
+        inputDefinitions: {
+          parameters: {
+            test_samples_fraction: {
+              parameterType: InputDefinitionParameterType.DOUBLE,
+            },
+          },
+        },
+        outputDefinitions: {
+          artifacts: {
+            metrics: {
+              artifactType: {
+                schemaTitle: ArtifactType.CLASSIFICATION_METRICS,
+                schemaVersion: '0.0.1',
+              },
+            },
+          },
+        },
+      },
+      'comp-markdown-visualization': {
+        executorLabel: 'exec-markdown-visualization',
+        outputDefinitions: {
+          artifacts: {
+            markdown_artifact: {
+              artifactType: {
+                schemaTitle: ArtifactType.MARKDOWN,
+                schemaVersion: '0.0.1',
+              },
+            },
+          },
+        },
+      },
+      'comp-wine-classification': {
+        executorLabel: 'exec-wine-classification',
+        outputDefinitions: {
+          artifacts: {
+            metrics: {
+              artifactType: {
+                schemaTitle: ArtifactType.CLASSIFICATION_METRICS,
+                schemaVersion: '0.0.1',
+              },
+            },
+          },
+        },
+      },
+    },
+    deploymentSpec: {
+      executors: {
+        'exec-digit-classification': {
+          container: {
+            args: ['--executor_input', '{{$}}', '--function_to_execute', 'digit_classification'],
+            command: [
+              'sh',
+              '-c',
+              '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location \'kfp==2.7.0\' \'--no-deps\' \'typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c"3.9"\'  \u0026\u0026  python3 -m pip install --quiet --no-warn-script-location \'scikit-learn\' \u0026\u0026 "$0" "$@"\n',
+              'sh',
+              '-ec',
+              'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef digit_classification(metrics: Output[Metrics]):\n    from sklearn import model_selection\n    from sklearn.linear_model import LogisticRegression\n    from sklearn import datasets\n    from sklearn.metrics import accuracy_score\n\n    # Load digits dataset\n    iris = datasets.load_iris()\n\n    # # Create feature matrix\n    X = iris.data\n\n    # Create target vector\n    y = iris.target\n\n    #test size\n    test_size = 0.33\n\n    seed = 7\n    #cross-validation settings\n    kfold = model_selection.KFold(n_splits=10, random_state=seed, shuffle=True)\n\n    #Model instance\n    model = LogisticRegression()\n    scoring = 'accuracy'\n    results = model_selection.cross_val_score(model, X, y, cv=kfold, scoring=scoring)\n\n    #split data\n    X_train, X_test, y_train, y_test = model_selection.train_test_split(X, y, test_size=test_size, random_state=seed)\n    #fit model\n    model.fit(X_train, y_train)\n\n    #accuracy on test set\n    result = model.score(X_test, y_test)\n    metrics.log_metric('accuracy', (result*100.0))\n\n",
+            ],
+            image: 'ubi8/python-39:latest',
+          },
+        },
+        'exec-html-visualization': {
+          container: {
+            args: ['--executor_input', '{{$}}', '--function_to_execute', 'html_visualization'],
+            command: [
+              'sh',
+              '-c',
+              '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location \'kfp==2.7.0\' \'--no-deps\' \'typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c"3.9"\' \u0026\u0026 "$0" "$@"\n',
+              'sh',
+              '-ec',
+              'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef html_visualization(html_artifact: Output[HTML]):\n    html_content = '\u003c!DOCTYPE html\u003e\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eHello world\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e'\n    with open(html_artifact.path, 'w') as f:\n        f.write(html_content)\n\n",
+            ],
+            image: 'python:3.7',
+          },
+        },
+        'exec-iris-sgdclassifier': {
+          container: {
+            args: ['--executor_input', '{{$}}', '--function_to_execute', 'iris_sgdclassifier'],
+            command: [
+              'sh',
+              '-c',
+              '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location \'kfp==2.7.0\' \'--no-deps\' \'typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c"3.9"\'  \u0026\u0026  python3 -m pip install --quiet --no-warn-script-location \'scikit-learn\' \u0026\u0026 "$0" "$@"\n',
+              'sh',
+              '-ec',
+              'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef iris_sgdclassifier(test_samples_fraction: float, metrics: Output[ClassificationMetrics]):\n    from sklearn import datasets, model_selection\n    from sklearn.linear_model import SGDClassifier\n    from sklearn.metrics import confusion_matrix\n\n    iris_dataset = datasets.load_iris()\n    train_x, test_x, train_y, test_y = model_selection.train_test_split(\n        iris_dataset['data'], iris_dataset['target'], test_size=test_samples_fraction)\n\n\n    classifier = SGDClassifier()\n    classifier.fit(train_x, train_y)\n    predictions = model_selection.cross_val_predict(classifier, train_x, train_y, cv=3)\n    metrics.log_confusion_matrix(\n        ['Setosa', 'Versicolour', 'Virginica'],\n        confusion_matrix(train_y, predictions).tolist() # .tolist() to convert np array to list.\n    )\n\n",
+            ],
+            image: 'ubi8/python-39:latest',
+          },
+        },
+        'exec-markdown-visualization': {
+          container: {
+            args: ['--executor_input', '{{$}}', '--function_to_execute', 'markdown_visualization'],
+            command: [
+              'sh',
+              '-c',
+              '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location \'kfp==2.7.0\' \'--no-deps\' \'typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c"3.9"\' \u0026\u0026 "$0" "$@"\n',
+              'sh',
+              '-ec',
+              'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef markdown_visualization(markdown_artifact: Output[Markdown]):\n    markdown_content = '## Hello world \\n\\n Markdown content'\n    with open(markdown_artifact.path, 'w') as f:\n        f.write(markdown_content)\n\n",
+            ],
+            image: 'python:3.7',
+          },
+        },
+        'exec-wine-classification': {
+          container: {
+            args: ['--executor_input', '{{$}}', '--function_to_execute', 'wine_classification'],
+            command: [
+              'sh',
+              '-c',
+              '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location \'kfp==2.7.0\' \'--no-deps\' \'typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c"3.9"\'  \u0026\u0026  python3 -m pip install --quiet --no-warn-script-location \'scikit-learn\' \u0026\u0026 "$0" "$@"\n',
+              'sh',
+              '-ec',
+              'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef wine_classification(metrics: Output[ClassificationMetrics]):\n    from sklearn.ensemble import RandomForestClassifier\n    from sklearn.metrics import roc_curve\n    from sklearn.datasets import load_wine\n    from sklearn.model_selection import train_test_split, cross_val_predict\n\n    X, y = load_wine(return_X_y=True)\n    # Binary classification problem for label 1.\n    y = y == 1\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)\n    rfc = RandomForestClassifier(n_estimators=10, random_state=42)\n    rfc.fit(X_train, y_train)\n    y_scores = cross_val_predict(rfc, X_train, y_train, cv=3, method='predict_proba')\n    y_predict = cross_val_predict(rfc, X_train, y_train, cv=3, method='predict')\n    fpr, tpr, thresholds = roc_curve(y_true=y_train, y_score=y_scores[:,1], pos_label=True)\n    thresholds[0] = 2\n    metrics.log_roc_curve(fpr, tpr, thresholds)\n\n",
+            ],
+            image: 'ubi8/python-39:latest',
+          },
+        },
+      },
+    },
+    pipelineInfo: {
+      name: 'metrics-visualization-pipeline',
+    },
+    root: {
+      dag: {
+        outputs: {
+          artifacts: {
+            'digit-classification-metrics': {
+              artifactSelectors: [
+                {
+                  outputArtifactKey: 'metrics',
+                  producerSubtask: 'digit-classification',
+                },
+              ],
+            },
+            'iris-sgdclassifier-metrics': {
+              artifactSelectors: [
+                {
+                  outputArtifactKey: 'metrics',
+                  producerSubtask: 'iris-sgdclassifier',
+                },
+              ],
+            },
+            'wine-classification-metrics': {
+              artifactSelectors: [
+                {
+                  outputArtifactKey: 'metrics',
+                  producerSubtask: 'wine-classification',
+                },
+              ],
+            },
+          },
+        },
+        tasks: {
+          'digit-classification': {
+            cachingOptions: {
+              enableCache: true,
+            },
+            componentRef: {
+              name: 'comp-digit-classification',
+            },
+            taskInfo: {
+              name: 'digit-classification',
+            },
+          },
+          'html-visualization': {
+            cachingOptions: {
+              enableCache: true,
+            },
+            componentRef: {
+              name: 'comp-html-visualization',
+            },
+            taskInfo: {
+              name: 'html-visualization',
+            },
+          },
+          'iris-sgdclassifier': {
+            cachingOptions: {
+              enableCache: true,
+            },
+            componentRef: {
+              name: 'comp-iris-sgdclassifier',
+            },
+            inputs: {
+              parameters: {
+                test_samples_fraction: {
+                  runtimeValue: {
+                    constant: '0.3',
+                  },
+                },
+              },
+            },
+            taskInfo: {
+              name: 'iris-sgdclassifier',
+            },
+          },
+          'markdown-visualization': {
+            cachingOptions: {
+              enableCache: true,
+            },
+            componentRef: {
+              name: 'comp-markdown-visualization',
+            },
+            taskInfo: {
+              name: 'markdown-visualization',
+            },
+          },
+          'wine-classification': {
+            cachingOptions: {
+              enableCache: true,
+            },
+            componentRef: {
+              name: 'comp-wine-classification',
+            },
+            taskInfo: {
+              name: 'wine-classification',
+            },
+          },
+        },
+      },
+      outputDefinitions: {
+        artifacts: {
+          'digit-classification-metrics': {
+            artifactType: {
+              schemaTitle: ArtifactType.METRICS,
+              schemaVersion: '0.0.1',
+            },
+          },
+          'iris-sgdclassifier-metrics': {
+            artifactType: {
+              schemaTitle: ArtifactType.CLASSIFICATION_METRICS,
+              schemaVersion: '0.0.1',
+            },
+          },
+          'wine-classification-metrics': {
+            artifactType: {
+              schemaTitle: ArtifactType.CLASSIFICATION_METRICS,
+              schemaVersion: '0.0.1',
+            },
+          },
+        },
+      },
+    },
+    schemaVersion: '2.1.0',
+    sdkVersion: 'kfp-2.7.0',
+  },
+};

--- a/frontend/src/__mocks__/mockRunKF.ts
+++ b/frontend/src/__mocks__/mockRunKF.ts
@@ -177,3 +177,420 @@ export const buildMockRunKF = (run?: Partial<PipelineRunKFv2>): PipelineRunKFv2 
   ],
   ...run,
 });
+
+export const mockMetricsVisualizationRun: PipelineRunKFv2 = {
+  experiment_id: '337b4750-40fa-4593-8c07-f80c542cbb7d',
+  run_id: 'test-metrics-pipeline-run',
+  display_name: 'test',
+  storage_state: StorageStateKF.AVAILABLE,
+  pipeline_version_reference: {
+    pipeline_id: 'metrics-pipeline',
+    pipeline_version_id: 'metrics-pipeline-version',
+  },
+  service_account: 'pipeline-runner-dspa',
+  created_at: '2024-06-19T11:28:32Z',
+  scheduled_at: '2024-06-19T11:28:32Z',
+  finished_at: '2024-06-19T11:29:03Z',
+  state: RuntimeStateKF.SUCCEEDED,
+  run_details: {
+    task_details: [
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '0eca1834-a6cc-4dd5-b872-d3aa7b3ff6e8',
+        display_name: 'root-driver',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:32Z',
+        end_time: '2024-06-19T11:28:43Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:33Z',
+            state: RuntimeStateKF.PENDING,
+          },
+          {
+            update_time: '2024-06-19T11:28:43Z',
+            state: RuntimeStateKF.RUNNING,
+          },
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-2493393560',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '19bd4da0-0550-4c94-b664-6c926dce8001',
+        display_name: 'iris-sgdclassifier',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-4194317718',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '37cd492c-a01d-4fa2-898b-7eb0e8b30419',
+        display_name: 'executor',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SKIPPED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SKIPPED,
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '3e119baf-3c52-450d-b4cc-2ab2bc4de10b',
+        display_name: 'digit-classification',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-1101486161',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '41252b5a-ac35-4a16-9450-6df59de90af1',
+        display_name: 'html-visualization-driver',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:53Z',
+        end_time: '2024-06-19T11:28:59Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.PENDING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-1024349010',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '42a1b696-462e-4d04-a1d8-42a78f32a3d4',
+        display_name: 'iris-sgdclassifier-driver',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:53Z',
+        end_time: '2024-06-19T11:28:57Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.PENDING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-2388146295',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '46877f5d-bc58-4a3f-bd16-142c89bb3472',
+        display_name: 'executor',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SKIPPED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SKIPPED,
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '7809de66-7d83-44f4-ac27-6c1a49a1fe9a',
+        display_name: 'executor',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SKIPPED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SKIPPED,
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '9d9b708d-7c6e-43a3-9d47-037ee35d07ec',
+        display_name: 'metrics-visualization-pipeline-wbfhf',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:32Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:33Z',
+            state: RuntimeStateKF.RUNNING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-2043659685',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: '9f3c7a93-3b9c-4830-9ec6-968a470c61ac',
+        display_name: 'wine-classification-driver',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:53Z',
+        end_time: '2024-06-19T11:28:59Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.PENDING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-232158710',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'a1920cb4-cf8c-4d2b-8ec5-b92ac29d732f',
+        display_name: 'markdown-visualization-driver',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:53Z',
+        end_time: '2024-06-19T11:28:59Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.PENDING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-2636276234',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'a2b45cc2-d999-4af3-b4f8-f7213f7c7b7d',
+        display_name: 'markdown-visualization',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-522038993',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'cb3c1755-25ee-4772-bfda-60524dfeafea',
+        display_name: 'executor',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SKIPPED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SKIPPED,
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'cff9af15-9a73-4cc7-acc1-41be78f6cf2f',
+        display_name: 'root',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:53Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.RUNNING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-3563862527',
+          },
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-1985932151',
+          },
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-3374311824',
+          },
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-3118730367',
+          },
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-1337836723',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'd7851ef9-d74d-4c54-899d-5a2f7b787347',
+        display_name: 'html-visualization',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-378883961',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'de0741cd-b2b6-4876-b819-31bcd7ead154',
+        display_name: 'digit-classification-driver',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:28:53Z',
+        end_time: '2024-06-19T11:28:57Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:28:54Z',
+            state: RuntimeStateKF.PENDING,
+          },
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-1495298698',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'e1b44a5c-37c8-478b-a6bc-9f788d3c2027',
+        display_name: 'wine-classification',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SUCCEEDED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SUCCEEDED,
+          },
+        ],
+        child_tasks: [
+          {
+            pod_name: 'metrics-visualization-pipeline-wbfhf-1000874645',
+          },
+        ],
+      },
+      {
+        run_id: 'test-metrics-pipeline-run',
+        task_id: 'f06409c9-0305-4187-a878-ba4996ffc5ca',
+        display_name: 'executor',
+        create_time: '2024-06-19T11:28:32Z',
+        start_time: '2024-06-19T11:29:03Z',
+        end_time: '2024-06-19T11:29:03Z',
+        state: RuntimeStateKF.SKIPPED,
+        state_history: [
+          {
+            update_time: '2024-06-19T11:29:04Z',
+            state: RuntimeStateKF.SKIPPED,
+          },
+        ],
+      },
+    ],
+  },
+  state_history: [
+    {
+      update_time: '2024-06-19T11:28:32Z',
+      state: RuntimeStateKF.PENDING,
+    },
+    {
+      update_time: '2024-06-19T11:28:33Z',
+      state: RuntimeStateKF.RUNNING,
+    },
+    {
+      update_time: '2024-06-19T11:29:04Z',
+      state: RuntimeStateKF.SUCCEEDED,
+    },
+  ],
+};

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -323,6 +323,10 @@ class PipelineRunDetails extends RunDetails {
     return cy.findByTestId('Output-artifacts');
   }
 
+  findArtifactItems(itemId: string) {
+    return cy.findByTestId(`${itemId}-item`);
+  }
+
   findErrorState(id: string) {
     return cy.findByTestId(id);
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/artifacts.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/artifacts.cy.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {
   artifactDetails,
   artifactsGlobal,
@@ -8,9 +9,23 @@ import {
   mockGetArtifactsResponse,
   mockedArtifactsResponse,
 } from '~/__mocks__/mlmd/mockGetArtifacts';
+import {
+  buildMockPipelineV2,
+  mockDashboardConfig,
+  mockMetricsVisualizationRun,
+  mockMetricsVisualizationVersion,
+} from '~/__mocks__';
+import { mockArtifactStorage } from '~/__mocks__/mockArtifactStorage';
+import { pipelineRunDetails } from '~/__tests__/cypress/cypress/pages/pipelines';
 import { configIntercept, dspaIntercepts, projectsIntercept } from './intercepts';
+import { initMlmdIntercepts } from './mlmdUtils';
 
 const projectName = 'test-project-name';
+
+const mockPipeline = buildMockPipelineV2({
+  pipeline_id: 'metrics-pipeline',
+  display_name: 'metrics-pipeline',
+});
 
 describe('Artifacts', () => {
   beforeEach(() => {
@@ -152,7 +167,124 @@ describe('Artifacts', () => {
         .should('have.text', 'scalar metrics');
     });
   });
+
+  describe('artifact in pipeline run details page', () => {
+    it('only url text when both artifactsAPI and s3Endpoint are disabled', () => {
+      initPipelineTopologyIntercepts({ disableArtifactsAPI: true, disableS3Endpoint: true });
+      pipelineRunDetails.visit(
+        projectName,
+        mockPipeline.pipeline_id,
+        mockMetricsVisualizationVersion.pipeline_version_id,
+        mockMetricsVisualizationRun.run_id,
+      );
+
+      pipelineRunDetails.findTaskNode('markdown-visualization').click();
+
+      pipelineRunDetails
+        .findArtifactItems('markdown_artifact')
+        .should(
+          'contain.text',
+          's3://aballant-pipelines/metrics-visualization-pipeline/16dbff18-a3d5-4684-90ac-4e6198a9da0f/markdown-visualization/markdown_artifact',
+        );
+    });
+
+    it('url is clickable when artifact api is enabled', () => {
+      initPipelineTopologyIntercepts({ disableArtifactsAPI: false, disableS3Endpoint: false });
+      pipelineRunDetails.visit(
+        projectName,
+        mockPipeline.pipeline_id,
+        mockMetricsVisualizationVersion.pipeline_version_id,
+        mockMetricsVisualizationRun.run_id,
+      );
+
+      pipelineRunDetails.findTaskNode('markdown-visualization').click();
+
+      pipelineRunDetails
+        .findArtifactItems('markdown_artifact')
+        .should(
+          'contain.text',
+          's3://aballant-pipelines/metrics-visualization-pipeline/16dbff18-a3d5-4684-90ac-4e6198a9da0f/markdown-visualization/markdown_artifact',
+        )
+        .click()
+        .then(() =>
+          cy.get('a').each(($el) => {
+            cy.wrap($el).should('have.attr', 'href').and('not.be.empty');
+          }),
+        );
+    });
+  });
 });
+
+type InitPipelineTopologyInterceptsType = {
+  disableArtifactsAPI?: boolean;
+  disableS3Endpoint?: boolean;
+};
+
+const initPipelineTopologyIntercepts = ({
+  disableArtifactsAPI = false,
+  disableS3Endpoint = false,
+}: InitPipelineTopologyInterceptsType) => {
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableArtifactsAPI,
+      disableS3Endpoint,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
+    {
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        pipelineId: mockPipeline.pipeline_id,
+      },
+    },
+    mockPipeline,
+  );
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+    {
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        pipelineId: mockPipeline.pipeline_id,
+        pipelineVersionId: 'metrics-pipeline-version',
+      },
+    },
+    mockMetricsVisualizationVersion,
+  );
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
+    {
+      path: { namespace: projectName, serviceName: 'dspa', runId: 'test-metrics-pipeline-run' },
+    },
+    mockMetricsVisualizationRun,
+  );
+  initMlmdIntercepts(projectName);
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/artifacts/:artifactId',
+    {
+      query: { view: 'DOWNLOAD' },
+      path: {
+        namespace: projectName,
+        serviceName: 'dspa',
+        artifactId: 16,
+      },
+    },
+    mockArtifactStorage({
+      namespace: projectName,
+      artifactId: '16',
+      storage_path:
+        'iris-training-pipeline/caf9116b-501e-491c-88e3-7772ba2b3334/create-dataset/iris_dataset',
+      uri: 's3://aballant-pipelines/metrics-visualization-pipeline/16dbff18-a3d5-4684-90ac-4e6198a9da0f/markdown-visualization/markdown_artifact',
+      download_url:
+        'http://test-bucket.s3.dualstack.ap-south.amazonaws.com/metrics-visualization-pipeline',
+      artifact_type: 'system.Dataset',
+      artifact_size: '5098',
+    }),
+  );
+};
 
 export const initIntercepts = (): void => {
   configIntercept();

--- a/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
@@ -1,46 +1,32 @@
 import React from 'react';
-import { Button, Flex, FlexItem, Icon, Popover, Truncate } from '@patternfly/react-core';
-import { ExclamationTriangleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
-import { MAX_STORAGE_OBJECT_SIZE, fetchStorageObjectSize } from '~/services/storageService';
-import { bytesAsRoundedGiB } from '~/utilities/number';
+import { Button, Flex, FlexItem, Truncate } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { ArtifactType } from '~/concepts/pipelines/kfTypes';
-import { extractS3UriComponents, getArtifactUrlFromUri } from './utils';
+import { useArtifactStorage } from '~/concepts/pipelines/apiHooks/useArtifactStorage';
+import { Artifact } from '~/third_party/mlmd';
+import { triggerFileDownload } from '~/utilities/string';
 
 interface ArtifactUriLinkProps {
-  uri: string;
-  type: string;
+  artifact: Artifact;
 }
 
-export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri, type }) => {
-  const { namespace } = usePipelinesAPI();
-  const isS3EndpointAvailable = useIsAreaAvailable(SupportedArea.S3_ENDPOINT).status;
-  const [size, setSize] = React.useState<number | null>(null);
-  const isClassificationMetrics = type === ArtifactType.CLASSIFICATION_METRICS;
+export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ artifact }) => {
+  const isClassificationMetrics = artifact.getType() === ArtifactType.CLASSIFICATION_METRICS;
+  const [loading, setLoading] = React.useState<boolean>(false);
 
-  const url = React.useMemo(() => {
-    if (!uri || !isS3EndpointAvailable) {
-      return;
+  const artifactStorage = useArtifactStorage();
+
+  const handleOnClick = async () => {
+    if (artifactStorage.enabled) {
+      const url = await artifactStorage.getStorageObjectUrl(artifact);
+      return url;
     }
+    return undefined;
+  };
 
-    const uriComponents = extractS3UriComponents(uri);
-
-    if (uriComponents) {
-      fetchStorageObjectSize(namespace, uriComponents.path)
-        .then((sizeBytes) => setSize(sizeBytes))
-        .catch(() => null);
-    }
-
-    return getArtifactUrlFromUri(uri, namespace);
-  }, [isS3EndpointAvailable, namespace, uri]);
-
-  if (!url || isClassificationMetrics) {
-    return uri;
+  if (!artifactStorage.enabled || isClassificationMetrics) {
+    return artifact.getUri();
   }
-
-  // we do not fetch over 100MB
-  const isOversizedFile = size !== null && size > MAX_STORAGE_OBJECT_SIZE;
 
   return (
     <Flex
@@ -48,25 +34,9 @@ export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri, type }) =
       flexWrap={{ default: 'nowrap' }}
       spaceItems={{ default: 'spaceItemsNone' }}
     >
-      {isOversizedFile && (
-        <FlexItem>
-          <Popover
-            aria-label="Oversized file popover"
-            headerContent="Oversized file"
-            bodyContent={`This file is ${bytesAsRoundedGiB(
-              size,
-            )} GiB in size but we do not fetch files over 100MB. To view the full file, please download it from your S3 bucket.`}
-          >
-            <Button variant="plain" isInline data-testid="storage-file-oversized-warning">
-              <Icon status="warning">
-                <ExclamationTriangleIcon />
-              </Icon>
-            </Button>
-          </Popover>
-        </FlexItem>
-      )}
       <FlexItem>
         <Button
+          isLoading={loading}
           variant="link"
           isInline
           icon={<ExternalLinkAltIcon />}
@@ -74,10 +44,23 @@ export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ uri, type }) =
           // TODO: remove this style override after upgrading to PFv6
           style={{ display: 'inline-flex' }}
           onClick={() => {
-            window.open(url);
+            setLoading(true);
+            handleOnClick()
+              .then((url) => {
+                if (url) {
+                  triggerFileDownload('', url);
+                }
+              })
+              .catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error('Failed to get the storage URL:', error);
+              })
+              .finally(() => {
+                setLoading(false);
+              });
           }}
         >
-          <Truncate content={uri} position="middle" trailingNumChars={30} />
+          <Truncate content={artifact.getUri()} position="middle" trailingNumChars={30} />
         </Button>
       </FlexItem>
     </Flex>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { Drawer } from '@patternfly/react-core';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-
+import { act } from 'react-dom/test-utils';
 import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
 import { PipelineTask } from '~/concepts/pipelines/topology';
 import { Artifact } from '~/third_party/mlmd';
@@ -39,14 +39,46 @@ jest.mock('~/concepts/areas/useIsAreaAvailable', () => () => ({
   customCondition: jest.fn(),
 }));
 
+jest.mock('~/concepts/pipelines/context/PipelinesContext', () => ({
+  usePipelinesAPI: jest.fn(() => ({
+    pipelinesServer: {
+      initializing: false,
+      installed: true,
+      compatible: true,
+      timedOut: false,
+      name: 'dspa',
+    },
+    namespace: 'Test namespace',
+    project: {
+      metadata: {
+        name: 'Test namespace',
+      },
+      kind: 'Project',
+    },
+    apiAvailable: true,
+    api: {
+      getArtifact: jest.fn(() =>
+        // eslint-disable-next-line camelcase
+        Promise.resolve({ download_url: 'https://example.com/download-url' }),
+      ),
+    },
+  })),
+}));
+
 describe('PipelineRunDrawerRightContent', () => {
-  it('renders artifact drawer tabs when the task prop is of type "artifact"', () => {
-    render(
-      <BrowserRouter>
-        <Drawer isExpanded>
-          <PipelineRunDrawerRightContent task={artifactTask} executions={[]} onClose={jest.fn()} />
-        </Drawer>
-      </BrowserRouter>,
+  it('renders artifact drawer tabs when the task prop is of type "artifact"', async () => {
+    await act(async () =>
+      render(
+        <BrowserRouter>
+          <Drawer isExpanded>
+            <PipelineRunDrawerRightContent
+              task={artifactTask}
+              executions={[]}
+              onClose={jest.fn()}
+            />
+          </Drawer>
+        </BrowserRouter>,
+      ),
     );
 
     const tabs = screen.getAllByRole('tab');
@@ -56,17 +88,19 @@ describe('PipelineRunDrawerRightContent', () => {
     expect(screen.getByRole('tab', { name: 'Visualization' })).toBeVisible();
   });
 
-  it('renders task drawer tabs when the task prop is of type "groupTask"', () => {
-    render(
-      <BrowserRouter>
-        <Drawer isExpanded>
-          <PipelineRunDrawerRightContent
-            task={{ ...task, type: 'groupTask' }}
-            executions={[]}
-            onClose={jest.fn()}
-          />
-        </Drawer>
-      </BrowserRouter>,
+  it('renders task drawer tabs when the task prop is of type "groupTask"', async () => {
+    await act(async () =>
+      render(
+        <BrowserRouter>
+          <Drawer isExpanded>
+            <PipelineRunDrawerRightContent
+              task={{ ...task, type: 'groupTask' }}
+              executions={[]}
+              onClose={jest.fn()}
+            />
+          </Drawer>
+        </BrowserRouter>,
+      ),
     );
 
     const tabs = screen.getAllByRole('tab');
@@ -78,13 +112,15 @@ describe('PipelineRunDrawerRightContent', () => {
     expect(screen.getByRole('tab', { name: 'Logs' })).toBeVisible();
   });
 
-  it('renders task drawer tabs when the task prop is of type "task"', () => {
-    render(
-      <BrowserRouter>
-        <Drawer isExpanded>
-          <PipelineRunDrawerRightContent task={task} executions={[]} onClose={jest.fn()} />
-        </Drawer>
-      </BrowserRouter>,
+  it('renders task drawer tabs when the task prop is of type "task"', async () => {
+    await act(async () =>
+      render(
+        <BrowserRouter>
+          <Drawer isExpanded>
+            <PipelineRunDrawerRightContent task={task} executions={[]} onClose={jest.fn()} />
+          </Drawer>
+        </BrowserRouter>,
+      ),
     );
 
     const tabs = screen.getAllByRole('tab');

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDetails.tsx
@@ -33,7 +33,7 @@ export const ArtifactNodeDetails: React.FC<ArtifactNodeDetailsProps> = ({
   upstreamTaskName,
 }) => {
   const { namespace } = usePipelinesAPI();
-  const artifactName = getArtifactName(artifact.toObject());
+  const artifactName = getArtifactName(artifact);
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
   return (
@@ -88,7 +88,7 @@ export const ArtifactNodeDetails: React.FC<ArtifactNodeDetailsProps> = ({
             <DescriptionListGroup>
               <DescriptionListTerm>{artifactName}</DescriptionListTerm>
               <DescriptionListDescription>
-                <ArtifactUriLink uri={artifact.getUri()} type={artifact.getType()} />
+                <ArtifactUriLink artifact={artifact} />
               </DescriptionListDescription>
             </DescriptionListGroup>
           </DescriptionList>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -6,7 +6,7 @@ import { Drawer } from '@patternfly/react-core';
 import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-
+import { act } from 'react-dom/test-utils';
 import { PipelineTask } from '~/concepts/pipelines/topology';
 import { Artifact, Value } from '~/third_party/mlmd';
 import { ArtifactNodeDrawerContent } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent';
@@ -43,18 +43,46 @@ jest.mock('~/concepts/areas/useIsAreaAvailable', () => () => ({
   customCondition: jest.fn(),
 }));
 
+jest.mock('~/concepts/pipelines/context/PipelinesContext', () => ({
+  usePipelinesAPI: jest.fn(() => ({
+    pipelinesServer: {
+      initializing: false,
+      installed: true,
+      compatible: true,
+      timedOut: false,
+      name: 'dspa',
+    },
+    namespace: 'Test namespace',
+    project: {
+      metadata: {
+        name: 'Test namespace',
+      },
+      kind: 'Project',
+    },
+    apiAvailable: true,
+    api: {
+      getArtifact: jest.fn(() =>
+        // eslint-disable-next-line camelcase
+        Promise.resolve({ download_url: 'https://example.com/download-url' }),
+      ),
+    },
+  })),
+}));
+
 describe('ArtifactNodeDrawerContent', () => {
-  it('renders artifact drawer content', () => {
-    render(
-      <BrowserRouter>
-        <Drawer isExpanded>
-          <ArtifactNodeDrawerContent
-            task={task}
-            upstreamTaskName="some-upstream-task"
-            onClose={jest.fn()}
-          />
-        </Drawer>
-      </BrowserRouter>,
+  it('renders artifact drawer content', async () => {
+    await act(async () =>
+      render(
+        <BrowserRouter>
+          <Drawer isExpanded>
+            <ArtifactNodeDrawerContent
+              task={task}
+              upstreamTaskName="some-upstream-task"
+              onClose={jest.fn()}
+            />
+          </Drawer>
+        </BrowserRouter>,
+      ),
     );
 
     expect(screen.getByRole('tab', { name: 'Artifact details' })).toHaveAttribute(
@@ -74,17 +102,18 @@ describe('ArtifactNodeDrawerContent', () => {
 
   it('renders "Scalar metrics" visualization drawer content', async () => {
     const user = userEvent.setup();
-
-    render(
-      <BrowserRouter>
-        <Drawer isExpanded>
-          <ArtifactNodeDrawerContent
-            task={task}
-            upstreamTaskName="some-upstream-task"
-            onClose={jest.fn()}
-          />
-        </Drawer>
-      </BrowserRouter>,
+    await act(async () =>
+      render(
+        <BrowserRouter>
+          <Drawer isExpanded>
+            <ArtifactNodeDrawerContent
+              task={task}
+              upstreamTaskName="some-upstream-task"
+              onClose={jest.fn()}
+            />
+          </Drawer>
+        </BrowserRouter>,
+      ),
     );
 
     await user.click(screen.getByRole('tab', { name: 'Visualization' }));
@@ -106,22 +135,24 @@ describe('ArtifactNodeDrawerContent', () => {
     const confidenceMetricsValue = new Value();
     confidenceMetricsValue.setStructValue(confidenceMetricsStruct);
 
-    render(
-      <BrowserRouter>
-        <Drawer isExpanded>
-          <ArtifactNodeDrawerContent
-            task={{
-              ...task,
-              metadata: createArtifact('system.ClassificationMetrics', {
-                key: 'confidenceMetrics',
-                value: confidenceMetricsValue,
-              }),
-            }}
-            upstreamTaskName="some-upstream-task"
-            onClose={jest.fn()}
-          />
-        </Drawer>
-      </BrowserRouter>,
+    await act(async () =>
+      render(
+        <BrowserRouter>
+          <Drawer isExpanded>
+            <ArtifactNodeDrawerContent
+              task={{
+                ...task,
+                metadata: createArtifact('system.ClassificationMetrics', {
+                  key: 'confidenceMetrics',
+                  value: confidenceMetricsValue,
+                }),
+              }}
+              upstreamTaskName="some-upstream-task"
+              onClose={jest.fn()}
+            />
+          </Drawer>
+        </BrowserRouter>,
+      ),
     );
 
     await user.click(screen.getByRole('tab', { name: 'Visualization' }));

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsInputOutput.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsInputOutput.tsx
@@ -27,7 +27,7 @@ const TaskDetailsInputOutput: React.FC<TaskDetailsInputOutputProps> = ({
       if (artifact) {
         return {
           label: artifactInputOutput.label,
-          value: <ArtifactUriLink uri={artifact.getUri()} type={artifact.getType()} />,
+          value: <ArtifactUriLink artifact={artifact} />,
         };
       }
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsPrintKeyValues.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsPrintKeyValues.tsx
@@ -14,7 +14,9 @@ const TaskDetailsPrintKeyValues: React.FC<TaskDetailsPrintKeyValuesProps> = ({ i
             <Truncate content={result.label} />
           </b>
         </GridItem>
-        <GridItem span={6}>{result.value}</GridItem>
+        <GridItem span={6} data-testid={`${result.label}-item`}>
+          {result.value}
+        </GridItem>
       </React.Fragment>
     ))}
   </Grid>

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -267,6 +267,19 @@ export type TaskKF = {
 
 export type DAG = {
   tasks: Record<string, TaskKF>;
+  outputs?: {
+    artifacts?: Record<
+      string,
+      {
+        artifactSelectors?: [
+          {
+            outputArtifactKey: string;
+            producerSubtask: string;
+          },
+        ];
+      }
+    >;
+  };
   // TODO: determine if there are more properties
 };
 
@@ -334,6 +347,7 @@ export type PipelineSpec = {
   root: {
     dag: DAG;
     inputDefinitions?: InputOutputDefinition;
+    outputDefinitions?: InputOutputDefinition;
   };
   schemaVersion: string;
   sdkVersion: string;

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetails.tsx
@@ -27,10 +27,7 @@ import { ArtifactOverviewDetails } from './ArtifactOverviewDetails';
 
 export const ArtifactDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) => {
   const { artifactId } = useParams();
-  const [artifactResponse, isArtifactLoaded, artifactError] = useGetArtifactById(
-    Number(artifactId),
-  );
-  const artifact = artifactResponse?.toObject();
+  const [artifact, isArtifactLoaded, artifactError] = useGetArtifactById(Number(artifactId));
   const artifactName = getArtifactName(artifact);
 
   if (artifactError) {

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactOverviewDetails.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactOverviewDetails.tsx
@@ -16,57 +16,60 @@ import { ArtifactUriLink } from '~/concepts/pipelines/content/artifacts/Artifact
 import { ArtifactPropertyDescriptionList } from './ArtifactPropertyDescriptionList';
 
 interface ArtifactOverviewDetailsProps {
-  artifact: Artifact.AsObject | undefined;
+  artifact: Artifact | undefined;
 }
 
-export const ArtifactOverviewDetails: React.FC<ArtifactOverviewDetailsProps> = ({ artifact }) => (
-  <Flex
-    spaceItems={{ default: 'spaceItems2xl' }}
-    direction={{ default: 'column' }}
-    className="pf-v5-u-pt-lg pf-v5-u-pb-lg"
-  >
-    <FlexItem>
-      <Stack hasGutter>
-        <Title headingLevel="h3">Live system dataset</Title>
-        <DescriptionList isHorizontal data-testid="dataset-description-list">
-          <DescriptionListGroup>
-            {artifact?.uri && (
-              <>
-                <DescriptionListTerm data-testid="dataset-description-list-URI">
-                  URI
-                </DescriptionListTerm>
-                <DescriptionListDescription>
-                  <ArtifactUriLink uri={artifact.uri} type={artifact.type} />
-                </DescriptionListDescription>
-              </>
-            )}
-          </DescriptionListGroup>
-        </DescriptionList>
-      </Stack>
-    </FlexItem>
-
-    {!!artifact?.propertiesMap.length && (
+export const ArtifactOverviewDetails: React.FC<ArtifactOverviewDetailsProps> = ({ artifact }) => {
+  const artifactObject = artifact?.toObject();
+  return (
+    <Flex
+      spaceItems={{ default: 'spaceItems2xl' }}
+      direction={{ default: 'column' }}
+      className="pf-v5-u-pt-lg pf-v5-u-pb-lg"
+    >
       <FlexItem>
         <Stack hasGutter>
-          <Title headingLevel="h3">Properties</Title>
-          <ArtifactPropertyDescriptionList
-            propertiesMap={artifact.propertiesMap}
-            testId="props-description-list"
-          />
+          <Title headingLevel="h3">Live system dataset</Title>
+          <DescriptionList isHorizontal data-testid="dataset-description-list">
+            <DescriptionListGroup>
+              {artifact && artifactObject && (
+                <>
+                  <DescriptionListTerm data-testid="dataset-description-list-URI">
+                    URI
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <ArtifactUriLink artifact={artifact} />
+                  </DescriptionListDescription>
+                </>
+              )}
+            </DescriptionListGroup>
+          </DescriptionList>
         </Stack>
       </FlexItem>
-    )}
 
-    {!!artifact?.customPropertiesMap.length && (
-      <FlexItem>
-        <Stack hasGutter>
-          <Title headingLevel="h3">Custom properties</Title>
-          <ArtifactPropertyDescriptionList
-            propertiesMap={artifact.customPropertiesMap}
-            testId="custom-props-description-list"
-          />
-        </Stack>
-      </FlexItem>
-    )}
-  </Flex>
-);
+      {!!artifactObject?.propertiesMap.length && (
+        <FlexItem>
+          <Stack hasGutter>
+            <Title headingLevel="h3">Properties</Title>
+            <ArtifactPropertyDescriptionList
+              propertiesMap={artifactObject.propertiesMap}
+              testId="props-description-list"
+            />
+          </Stack>
+        </FlexItem>
+      )}
+
+      {!!artifactObject?.customPropertiesMap.length && (
+        <FlexItem>
+          <Stack hasGutter>
+            <Title headingLevel="h3">Custom properties</Title>
+            <ArtifactPropertyDescriptionList
+              propertiesMap={artifactObject.customPropertiesMap}
+              testId="custom-props-description-list"
+            />
+          </Stack>
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTable.tsx
@@ -145,20 +145,20 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
   );
 
   const rowRenderer = React.useCallback(
-    (artifact: Artifact.AsObject) => (
-      <Tr key={artifact.id}>
+    (artifact: Artifact) => (
+      <Tr key={artifact.getId()}>
         <Td dataLabel="Artifact">
-          <Link to={artifactsDetailsRoute(namespace, artifact.id)}>
+          <Link to={artifactsDetailsRoute(namespace, artifact.getId())}>
             {getArtifactName(artifact)}
           </Link>
         </Td>
-        <Td dataLabel="ID">{artifact.id}</Td>
-        <Td dataLabel="Type">{artifact.type}</Td>
+        <Td dataLabel="ID">{artifact.getId()}</Td>
+        <Td dataLabel="Type">{artifact.getType()}</Td>
         <Td dataLabel="URI">
-          <ArtifactUriLink uri={artifact.uri} type={artifact.type} />
+          <ArtifactUriLink artifact={artifact} />
         </Td>
         <Td dataLabel="Created">
-          <PipelinesTableRowTime date={new Date(artifact.createTimeSinceEpoch)} />
+          <PipelinesTableRowTime date={new Date(artifact.getCreateTimeSinceEpoch())} />
         </Td>
       </Tr>
     ),
@@ -168,7 +168,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
   return (
     <TableBase
       loading={!isLoaded}
-      data={artifacts?.map((artifact) => artifact.toObject()) ?? []}
+      data={artifacts ?? []}
       columns={columns}
       enablePagination="compact"
       page={page}

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/constants.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/constants.ts
@@ -18,7 +18,7 @@ export const options = {
   [FilterOptions.Type]: 'Type',
 };
 
-export const columns: SortableData<MlmdArtifact.AsObject>[] = [
+export const columns: SortableData<MlmdArtifact>[] = [
   {
     label: 'Artifact',
     field: 'name',

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/utils.ts
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/utils.ts
@@ -1,7 +1,12 @@
 /** URI related utils source: https://github.com/kubeflow/pipelines/blob/master/frontend/src/lib/Utils.tsx */
 import { Artifact } from '~/third_party/mlmd';
 
-export const getArtifactName = (artifact: Artifact.AsObject | undefined): string =>
-  artifact?.name ||
-  artifact?.customPropertiesMap.find(([name]) => name === 'display_name')?.[1].stringValue ||
-  '(No name)';
+export const getArtifactName = (artifact: Artifact | undefined): string => {
+  const artifactObject = artifact?.toObject();
+  return (
+    artifactObject?.name ||
+    artifactObject?.customPropertiesMap.find(([name]) => name === 'display_name')?.[1]
+      .stringValue ||
+    '(No name)'
+  );
+};

--- a/frontend/src/utilities/__tests__/string.spec.ts
+++ b/frontend/src/utilities/__tests__/string.spec.ts
@@ -6,6 +6,7 @@ import {
   replaceNonNumericPartWithString,
   replaceNumericPartWithString,
   containsMultipleSlashesPattern,
+  triggerFileDownload,
 } from '~/utilities/string';
 
 global.URL.createObjectURL = jest.fn(() => 'test-url');
@@ -195,5 +196,41 @@ describe('isS3PathValid', () => {
 
   it('should return false when contains multiple slashes', () => {
     expect(isS3PathValid('folder//file.txt')).toBe(false);
+  });
+});
+
+describe('triggerFileDownload', () => {
+  it('should create an anchor element, set its attributes, append it to the document, trigger a click, and remove it', () => {
+    const filename = 'test-file.txt';
+    const href = 'https://example.com/test-file.txt';
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+    const appendChildSpy = jest
+      .spyOn(document.body, 'appendChild')
+      .mockImplementation((node: Node) => node);
+    const removeChildSpy = jest
+      .spyOn(document.body, 'removeChild')
+      .mockImplementation((node: Node) => node);
+
+    const mockElement = document.createElement('a');
+
+    const clickMock = jest.fn();
+    mockElement.click = clickMock;
+
+    createElementSpy.mockReturnValue(mockElement);
+
+    triggerFileDownload(filename, href);
+
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(mockElement.href).toBe(href);
+    expect(mockElement.download).toBe(filename);
+    expect(mockElement.target).toBe('_blank');
+    expect(appendChildSpy).toHaveBeenCalledWith(mockElement);
+    expect(clickMock).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalledWith(mockElement);
+
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
   });
 });

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -14,6 +14,16 @@ export const downloadString = (filename: string, data: string): void => {
   document.body.removeChild(element);
 };
 
+export const triggerFileDownload = (filename: string, href: string): void => {
+  const element = document.createElement('a');
+  element.href = href;
+  element.download = filename;
+  element.target = '_blank';
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+};
+
 /**
  * This function replaces the first occurrence of a numeric part in the input string
  * with the specified replacement numeric value.


### PR DESCRIPTION
Closes: [RHOAIENG-9699](https://issues.redhat.com/browse/RHOAIENG-9699)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Refractored the Artifact URI to use `useArtifactStorage` to get the artifact uri.

It opens new tab 

https://github.com/user-attachments/assets/a711430c-5581-4aac-bab4-db5ffa74506b


If both artifactURI and s3Endpoint is disabled it only shows a text url
![Screenshot 2024-08-06 at 8 38 07 PM](https://github.com/user-attachments/assets/8ae1fb2c-0cbe-449e-a9ca-35c2f23ddac2)


## How Has This Been Tested?
Try changing feature flags, disableArtifactsAPI and disableS3Endpoint.
* disableArtifactsAPI: false disableS3Endpoint: true => new tab (for models it downloads)
* disableArtifactsAPI: false disableS3Endpoint: false => new tab (for models it downloads)
* disableArtifactsAPI: true disableS3Endpoint: false => new tab
* disableArtifactsAPI: true disableS3Endpoint: true => just text url

## Test Impact
Added cypress test to check the artifact uri in pipeline run details page. Modified the existing unit test to accommodate change in `ArtifactUriLink.tax`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
