### PR TITLE
fix(ProjectList): notebook status listen and update

### DIFF
--- a/frontend/src/pages/projects/screens/projects/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/screens/projects/NotebookStateStatus.tsx
@@ -18,7 +18,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
   return (
     <NotebookStatusToggle
       notebookState={notebookState}
-      doListen={false}
+      doListen
       enablePipelines={enablePipelines}
       isDisabled={
         notebookImage?.imageAvailability === NotebookImageAvailability.DELETED &&


### PR DESCRIPTION
closes: [RHOAIENG-5084](https://issues.redhat.com/browse/RHOAIENG-5084)

## Description
In the big "UI Refresh", it seems that the `doListen` got set to false where it shouldn't have. Previously here: https://github.com/opendatahub-io/odh-dashboard/commit/d5124d28feb555770aa2c8b7f00e36783a4ebdc7#diff-2c0ccfc2c2e7347604445b4d648b808d62e96fe6fd36c05cec54ea14bcd3d10dL46

Setting it to true for the project list view fixes the issue.

It's interesting that the status is used in the projects page and the notebook page, but is updated differently. The notebook tab has `doListen={false}` and updates fine (must update at a different level instead of from the statusToggle component itself).

## How Has This Been Tested?
Tested that the status updates properly and doesn't continue to make network calls for the status after getting the update.

## Test Impact
none

## Request review criteria:
test that the toggle works properly and updates properly on both pages.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
