### PR TITLE
Remove squash commits checklist item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,6 @@
 
 Self checklist (all need to be checked):
 - [ ] The developer has manually tested the changes and verified that the changes work
-- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
 - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 - [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
 


### PR DESCRIPTION
We auto-squash now with the merge bot. Removing the review checklist item that says squash commits from the template.