### PR TITLE
[RHOAIENG-2404] Replace PF deprecated Dropdown components with PF core Dropdowns

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetailsActions.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
+import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PipelineVersionImportModal from '~/concepts/pipelines/content/import/PipelineVersionImportModal';
@@ -45,99 +40,111 @@ const PipelineDetailsActions: React.FC<PipelineDetailsActionsProps> = ({
   return (
     <>
       <Dropdown
-        data-testid="pipeline-version-details-actions"
+        onOpenChange={(isOpenChange) => setOpen(isOpenChange)}
+        shouldFocusToggleOnSelect
         onSelect={() => setOpen(false)}
-        menuAppendTo={getDashboardMainContainer}
-        toggle={
-          <DropdownToggle toggleVariant="primary" onToggle={() => setOpen(!open)}>
+        popperProps={{ appendTo: getDashboardMainContainer, position: 'right' }}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            data-testid="pipeline-version-details-actions"
+            ref={toggleRef}
+            variant="primary"
+            aria-label="Actions"
+            onClick={() => setOpen(!open)}
+            isExpanded={open}
+          >
             Actions
-          </DropdownToggle>
-        }
+          </MenuToggle>
+        )}
         isOpen={open}
-        position="right"
-        dropdownItems={[
-          <DropdownItem key="upload-version" onClick={() => setIsVersionImportModalOpen(true)}>
-            Upload new version
-          </DropdownItem>,
-          <DropdownSeparator key="separator-create" />,
-          <DropdownItem
-            isAriaDisabled={!isPipelineSupported}
-            tooltip={PIPELINE_CREATE_RUN_TOOLTIP_ARGO_ERROR}
-            key="create-run"
-            onClick={() =>
-              navigate(
-                pipelineVersionCreateRunRoute(
-                  namespace,
-                  pipeline?.pipeline_id,
-                  pipelineVersion?.pipeline_version_id,
-                ),
-                {
-                  state: { lastPipeline: pipeline, lastVersion: pipelineVersion },
-                },
-              )
-            }
-          >
-            Create run
-          </DropdownItem>,
-          <DropdownItem
-            isAriaDisabled={!isPipelineSupported}
-            tooltip={PIPELINE_CREATE_SCHEDULE_TOOLTIP_ARGO_ERROR}
-            key="create-schedule"
-            onClick={() =>
-              navigate(
-                pipelineVersionCreateRecurringRunRoute(
-                  namespace,
-                  pipeline?.pipeline_id,
-                  pipelineVersion?.pipeline_version_id,
-                ),
-                {
-                  state: { lastPipeline: pipeline, lastVersion: pipelineVersion },
-                },
-              )
-            }
-          >
-            Create schedule
-          </DropdownItem>,
-          ...(pipeline && pipelineVersion
-            ? [
-                <DropdownSeparator key="separator-view" />,
-                <DropdownItem
-                  key="view-runs"
-                  onClick={() =>
-                    navigate(
-                      pipelineVersionRunsRoute(
-                        namespace,
-                        pipeline.pipeline_id,
-                        pipelineVersion.pipeline_version_id,
-                      ),
-                    )
-                  }
-                >
-                  View runs
-                </DropdownItem>,
-                <DropdownItem
-                  key="view-schedules"
-                  onClick={() =>
-                    navigate(
-                      pipelineVersionRecurringRunsRoute(
-                        namespace,
-                        pipeline.pipeline_id,
-                        pipelineVersion.pipeline_version_id,
-                      ),
-                    )
-                  }
-                >
-                  View schedules
-                </DropdownItem>,
-              ]
-            : []),
-
-          <DropdownSeparator key="separator-delete" />,
-          <DropdownItem key="delete-pipeline-version" onClick={() => onDelete()}>
-            Delete pipeline version
-          </DropdownItem>,
-        ]}
-      />
+      >
+        <DropdownList>
+          {[
+            <DropdownItem key="upload-version" onClick={() => setIsVersionImportModalOpen(true)}>
+              Upload new version
+            </DropdownItem>,
+            <Divider key="separator-create" />,
+            <DropdownItem
+              isAriaDisabled={!isPipelineSupported}
+              tooltipProps={{ content: PIPELINE_CREATE_RUN_TOOLTIP_ARGO_ERROR }}
+              key="create-run"
+              onClick={() =>
+                navigate(
+                  pipelineVersionCreateRunRoute(
+                    namespace,
+                    pipeline?.pipeline_id,
+                    pipelineVersion?.pipeline_version_id,
+                  ),
+                  {
+                    state: { lastPipeline: pipeline, lastVersion: pipelineVersion },
+                  },
+                )
+              }
+            >
+              Create run
+            </DropdownItem>,
+            <DropdownItem
+              isAriaDisabled={!isPipelineSupported}
+              tooltipProps={{ content: PIPELINE_CREATE_SCHEDULE_TOOLTIP_ARGO_ERROR }}
+              key="create-schedule"
+              onClick={() =>
+                navigate(
+                  pipelineVersionCreateRecurringRunRoute(
+                    namespace,
+                    pipeline?.pipeline_id,
+                    pipelineVersion?.pipeline_version_id,
+                  ),
+                  {
+                    state: { lastPipeline: pipeline, lastVersion: pipelineVersion },
+                  },
+                )
+              }
+            >
+              Create schedule
+            </DropdownItem>,
+            ...(pipeline && pipelineVersion
+              ? [
+                  <Divider key="separator-view" />,
+                  <DropdownItem
+                    key="view-runs"
+                    onClick={() =>
+                      navigate(
+                        pipelineVersionRunsRoute(
+                          namespace,
+                          pipeline.pipeline_id,
+                          pipelineVersion.pipeline_version_id,
+                        ),
+                        {
+                          state: { lastVersion: pipelineVersion },
+                        },
+                      )
+                    }
+                  >
+                    View runs
+                  </DropdownItem>,
+                  <DropdownItem
+                    key="view-schedules"
+                    onClick={() =>
+                      navigate(
+                        pipelineVersionRecurringRunsRoute(
+                          namespace,
+                          pipeline.pipeline_id,
+                          pipelineVersion.pipeline_version_id,
+                        ),
+                      )
+                    }
+                  >
+                    View schedules
+                  </DropdownItem>,
+                ]
+              : []),
+            <Divider key="separator-delete" />,
+            <DropdownItem key="delete-pipeline-version" onClick={() => onDelete()}>
+              Delete pipeline version
+            </DropdownItem>,
+          ]}
+        </DropdownList>
+      </Dropdown>
       {isVersionImportModalOpen && (
         <PipelineVersionImportModal
           existingPipeline={pipeline}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRecurringRun/PipelineRecurringRunDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRecurringRun/PipelineRecurringRunDetailsActions.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
+  Divider,
   Dropdown,
   DropdownItem,
-  DropdownSeparator,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import { Spinner } from '@patternfly/react-core';
-
+  DropdownList,
+  MenuToggle,
+  Spinner,
+} from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineRecurringRunKFv2, RecurringRunStatus } from '~/concepts/pipelines/kfTypes';
 import { cloneRecurringRunRoute } from '~/routes';
@@ -70,18 +70,26 @@ const PipelineRecurringRunDetailsActions: React.FC<PipelineRecurringRunDetailsAc
 
   return (
     <Dropdown
-      data-testid="pipeline-recurring-run-details-actions"
       onSelect={() => setOpen(false)}
-      menuAppendTo={getDashboardMainContainer}
-      toggle={
-        <DropdownToggle toggleVariant="primary" onToggle={() => setOpen(!open)}>
+      onOpenChange={(isOpenChange) => setOpen(isOpenChange)}
+      shouldFocusToggleOnSelect
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          data-testid="pipeline-recurring-run-details-actions"
+          aria-label="Actions"
+          variant="primary"
+          onClick={() => setOpen(!open)}
+          isExpanded={open}
+        >
           Actions
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={open}
-      position="right"
-      dropdownItems={
-        !recurringRun
+      popperProps={{ position: 'right', appendTo: getDashboardMainContainer() }}
+    >
+      <DropdownList>
+        {!recurringRun
           ? []
           : [
               ...(isPipelineSupported
@@ -113,15 +121,15 @@ const PipelineRecurringRunDetailsActions: React.FC<PipelineRecurringRunDetailsAc
                     >
                       Duplicate
                     </DropdownItem>,
-                    <DropdownSeparator key="separator" />,
+                    <Divider key="separator" />,
                   ]
                 : []),
               <DropdownItem key="delete-run" onClick={() => onDelete()}>
                 Delete
               </DropdownItem>,
-            ]
-      }
-    />
+            ]}
+      </DropdownList>
+    </Dropdown>
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsActions.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetailsActions.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Tooltip } from '@patternfly/react-core';
 import {
+  Tooltip,
+  Divider,
   Dropdown,
   DropdownItem,
-  DropdownSeparator,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
+  MenuToggle,
+  DropdownList,
+} from '@patternfly/react-core';
+
 import { useNavigate, useParams } from 'react-router-dom';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import useNotification from '~/utilities/useNotification';
@@ -56,18 +58,26 @@ const PipelineRunDetailsActions: React.FC<PipelineRunDetailsActionsProps> = ({
 
   return (
     <Dropdown
-      data-testid="pipeline-run-details-actions"
+      onOpenChange={(isOpenChange) => setOpen(isOpenChange)}
+      shouldFocusToggleOnSelect
       onSelect={() => setOpen(false)}
-      menuAppendTo={getDashboardMainContainer}
-      toggle={
-        <DropdownToggle toggleVariant="primary" onToggle={() => setOpen(!open)}>
+      toggle={(toggleRef) => (
+        <MenuToggle
+          data-testid="pipeline-run-details-actions"
+          ref={toggleRef}
+          variant="primary"
+          aria-label="Actions"
+          onClick={() => setOpen(!open)}
+          isExpanded={open}
+        >
           Actions
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={open}
-      position="right"
-      dropdownItems={
-        !run
+      popperProps={{ position: 'right', appendTo: getDashboardMainContainer() }}
+    >
+      <DropdownList>
+        {!run
           ? []
           : [
               ...(isPipelineSupported
@@ -147,7 +157,7 @@ const PipelineRunDetailsActions: React.FC<PipelineRunDetailsActionsProps> = ({
                     ) : (
                       <React.Fragment key="restore-run" />
                     ),
-                    <DropdownSeparator key="separator" />,
+                    <Divider key="separator" />,
                   ]
                 : []),
               !isRunActive ? (
@@ -159,9 +169,9 @@ const PipelineRunDetailsActions: React.FC<PipelineRunDetailsActionsProps> = ({
                   <DropdownItem onClick={() => onArchive()}>Archive</DropdownItem>
                 </React.Fragment>
               ),
-            ]
-      }
-    />
+            ]}
+      </DropdownList>
+    </Dropdown>
   );
 };
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/DownloadDropdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
+import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 
 type DownloadDropdownProps = {
@@ -17,22 +17,27 @@ const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
 
   return (
     <Dropdown
-      isPlain
-      position="right"
-      toggle={
-        <DropdownToggle
+      popperProps={{ position: 'right' }}
+      onOpenChange={(isOpenChange) => setIsDownloadDropdownOpen(isOpenChange)}
+      shouldFocusToggleOnSelect
+      toggle={(toggleRef) => (
+        <MenuToggle
           data-testid="download-steps-toggle"
           className="pf-v5-u-px-sm"
-          style={{ width: '60px' }}
+          ref={toggleRef}
+          variant="plainText"
+          style={{ width: '70px' }}
           aria-label="Download step logs"
           id="download-steps-logs-toggle"
-          onToggle={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)}
+          onClick={() => setIsDownloadDropdownOpen(!isDownloadDropdownOpen)}
+          isExpanded={isDownloadDropdownOpen}
         >
           <DownloadIcon />
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={isDownloadDropdownOpen}
-      dropdownItems={[
+    >
+      <DropdownList>
         <DropdownItem
           data-testid="download-current-step-logs"
           isDisabled={isSingleStepLogsEmpty}
@@ -40,12 +45,12 @@ const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
           onClick={onDownload}
         >
           Download current step log
-        </DropdownItem>,
+        </DropdownItem>
         <DropdownItem key="all-step-logs" onClick={onDownloadAll}>
           Download all step logs
-        </DropdownItem>,
-      ]}
-    />
+        </DropdownItem>
+      </DropdownList>
+    </Dropdown>
   );
 };
 export default DownloadDropdown;

--- a/frontend/src/concepts/pipelines/content/tables/PipelineFilterBar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/PipelineFilterBar.tsx
@@ -5,8 +5,11 @@ import {
   ToolbarItem,
   ToolbarChip,
   Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  DropdownList,
 } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
 import { FilterIcon } from '@patternfly/react-icons';
 import { FilterOptions } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 
@@ -54,28 +57,39 @@ export function FilterToolbar<T extends string>({
       <ToolbarGroup variant="filter-group" data-testid={testId} {...toolbarGroupProps}>
         <ToolbarItem>
           <Dropdown
-            toggle={
-              <DropdownToggle id={`${testId}-toggle-button`} onToggle={() => setOpen(!open)}>
+            onOpenChange={(isOpenChange) => setOpen(isOpenChange)}
+            shouldFocusToggleOnSelect
+            toggle={(toggleRef) => (
+              <MenuToggle
+                data-testid={`${testId}-dropdown`}
+                id={`${testId}-toggle-button`}
+                ref={toggleRef}
+                aria-label="Pipeline Filter toggle"
+                onClick={() => setOpen(!open)}
+                isExpanded={open}
+              >
                 <>
                   <FilterIcon /> {filterOptions[currentFilterType]}
                 </>
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={open}
-            dropdownItems={keys.map((filterKey) => (
-              <DropdownItem
-                key={filterKey}
-                id={filterKey}
-                onClick={() => {
-                  setOpen(false);
-                  setCurrentFilterType(filterKey);
-                }}
-              >
-                {filterOptions[filterKey]}
-              </DropdownItem>
-            ))}
-            data-testid={`${testId}-dropdown`}
-          />
+          >
+            <DropdownList>
+              {keys.map((filterKey) => (
+                <DropdownItem
+                  key={filterKey}
+                  id={filterKey}
+                  onClick={() => {
+                    setOpen(false);
+                    setCurrentFilterType(filterKey);
+                  }}
+                >
+                  {filterOptions[filterKey]}
+                </DropdownItem>
+              ))}
+            </DropdownList>
+          </Dropdown>
         </ToolbarItem>
         <ToolbarFilter
           categoryName="Filters"

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
-import { Bullseye, Flex, FlexItem } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
+import {
+  Bullseye,
+  Flex,
+  FlexItem,
+  Dropdown,
+  MenuToggle,
+  DropdownItem,
+  DropdownList,
+} from '@patternfly/react-core';
+
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
@@ -42,46 +50,53 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
 
   const selector = (
     <Dropdown
-      toggle={
-        <DropdownToggle
+      onOpenChange={(isOpenChange) => setDropdownOpen(isOpenChange)}
+      shouldFocusToggleOnSelect
+      toggle={(toggleRef) => (
+        <MenuToggle
           isDisabled={projects.length === 0}
-          onToggle={() => setDropdownOpen(!dropdownOpen)}
-          toggleVariant={primary ? 'primary' : undefined}
+          ref={toggleRef}
           aria-label={`Project: ${toggleLabel}`}
+          variant={primary ? 'primary' : undefined}
+          onClick={() => setDropdownOpen(!dropdownOpen)}
+          isExpanded={dropdownOpen}
+          data-testid="project-selector-dropdown"
         >
           {toggleLabel}
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={dropdownOpen}
-      dropdownItems={[
-        ...(selectAllProjects
-          ? [
-              <DropdownItem
-                key="all-projects"
-                onClick={() => {
-                  setDropdownOpen(false);
-                  onSelection('');
-                  updatePreferredProject(null);
-                }}
-              >
-                All projects
-              </DropdownItem>,
-            ]
-          : []),
-        ...filteredProjects.map((project) => (
-          <DropdownItem
-            key={project.metadata.name}
-            onClick={() => {
-              setDropdownOpen(false);
-              onSelection(project.metadata.name);
-            }}
-          >
-            {getDisplayNameFromK8sResource(project)}
-          </DropdownItem>
-        )),
-      ]}
-      data-testid="project-selector-dropdown"
-    />
+    >
+      <DropdownList>
+        {[
+          ...(selectAllProjects
+            ? [
+                <DropdownItem
+                  key="all-projects"
+                  onClick={() => {
+                    setDropdownOpen(false);
+                    onSelection('');
+                    updatePreferredProject(null);
+                  }}
+                >
+                  All projects
+                </DropdownItem>,
+              ]
+            : []),
+          ...filteredProjects.map((project) => (
+            <DropdownItem
+              key={project.metadata.name}
+              onClick={() => {
+                setDropdownOpen(false);
+                onSelection(project.metadata.name);
+              }}
+            >
+              {getDisplayNameFromK8sResource(project)}
+            </DropdownItem>
+          )),
+        ]}
+      </DropdownList>
+    </Dropdown>
   );
   if (showTitle) {
     return (


### PR DESCRIPTION
Towards [RHOAIENG-2404](https://issues.redhat.com/browse/RHOAIENG-2404)

## Description
Replaces the usages of Dropdown from the `@patternfly/react-core/deprecated` package with the Dropdown in `@patternfly/react-core` package

## How Has This Been Tested?
Tested manually

## Test Impact
The following components are effected:

- Data Science Pipelines -> Project select
- Data Science Pipelines -> click a pipeline: Actions select.
- Data Science Pipelines -> Actions -> View schedules -> click a schedule -> Actions select
- Data Science Pipelines -> expand a pipeline -> kebab from a pipeline version -> view runs -> click a run -> Action select
- Data Science Pipelines -> expand a pipeline -> kebab from a pipeline version -> view runs -> click a run -> select a node -> side panel logs tab -> download button

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

