### PR TITLE
Add deployment modal for model registry

### DIFF
--- a/frontend/src/__mocks__/mockModelArtifact.ts
+++ b/frontend/src/__mocks__/mockModelArtifact.ts
@@ -8,6 +8,9 @@ export const mockModelArtifact = (): ModelArtifact => ({
   description: 'Description of model version',
   artifactType: 'model-artifact',
   customProperties: {},
+  storageKey: 'test storage key',
   storagePath: 'test path',
-  uri: 'https://huggingface.io/mnist.onnx',
+  uri: 's3://test-bucket/demo-models/test-path?endpoint=test-endpoint&defaultRegion=test-region',
+  modelFormatName: 'test model format',
+  modelFormatVersion: 'test version 1',
 });

--- a/frontend/src/__mocks__/mockSecretK8sResource.ts
+++ b/frontend/src/__mocks__/mockSecretK8sResource.ts
@@ -6,6 +6,8 @@ type MockResourceConfigType = {
   namespace?: string;
   displayName?: string;
   s3Bucket?: string;
+  endPoint?: string;
+  region?: string;
   uid?: string;
 };
 
@@ -13,7 +15,9 @@ export const mockSecretK8sResource = ({
   name = 'test-secret',
   namespace = 'test-project',
   displayName = 'Test Secret',
-  s3Bucket = 'test-bucket',
+  s3Bucket = 'dGVzdC1idWNrZXQ=',
+  endPoint = 'aHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tLw==',
+  region = 'dXMtZWFzdC0x',
   uid = genUID('secret'),
 }: MockResourceConfigType): SecretKind => ({
   kind: 'Secret',
@@ -35,9 +39,9 @@ export const mockSecretK8sResource = ({
   },
   data: {
     AWS_ACCESS_KEY_ID: 'c2RzZA==',
-    AWS_DEFAULT_REGION: 'dXMtZWFzdC0x',
+    AWS_DEFAULT_REGION: region,
     AWS_S3_BUCKET: s3Bucket,
-    AWS_S3_ENDPOINT: 'aHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tLw==',
+    AWS_S3_ENDPOINT: endPoint,
     AWS_SECRET_ACCESS_KEY: 'c2RzZA==',
   },
   type: 'Opaque',

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -1,0 +1,17 @@
+import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
+
+class ModelVersionDeployModal extends Modal {
+  constructor() {
+    super('Deploy model');
+  }
+
+  findProjectSelector() {
+    return cy.findByTestId('deploy-model-project-selector');
+  }
+
+  selectProjectByName(name: string) {
+    this.findProjectSelector().findDropdownItem(name).click();
+  }
+}
+
+export const modelVersionDeployModal = new ModelVersionDeployModal();

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -141,6 +141,10 @@ class InferenceServiceModal extends Modal {
     return this.find().findByTestId('field AWS_S3_BUCKET');
   }
 
+  findLocationRegionInput() {
+    return this.find().findByTestId('field AWS_DEFAULT_REGION');
+  }
+
   findLocationPathInput() {
     return this.find().findByTestId('folder-path');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -1,0 +1,326 @@
+/* eslint-disable camelcase */
+import {
+  mockDscStatus,
+  mockK8sResourceList,
+  mockProjectK8sResource,
+  mockSecretK8sResource,
+} from '~/__mocks__';
+import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
+import { mockRegisteredModelList } from '~/__mocks__/mockRegisteredModelsList';
+import {
+  ProjectModel,
+  SecretModel,
+  ServiceModel,
+  ServingRuntimeModel,
+  TemplateModel,
+} from '~/__tests__/cypress/cypress/utils/models';
+import { mockModelVersionList } from '~/__mocks__/mockModelVersionList';
+import { mockModelVersion } from '~/__mocks__/mockModelVersion';
+import type { ModelVersion } from '~/concepts/modelRegistry/types';
+import { ModelState } from '~/concepts/modelRegistry/types';
+import { mockRegisteredModel } from '~/__mocks__/mockRegisteredModel';
+import { modelRegistry } from '~/__tests__/cypress/cypress/pages/modelRegistry';
+import { mockModelRegistryService } from '~/__mocks__/mockModelRegistryService';
+import { modelVersionDeployModal } from '~/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal';
+import { mockModelArtifactList } from '~/__mocks__/mockModelArtifactList';
+import {
+  mockInvalidTemplateK8sResource,
+  mockServingRuntimeTemplateK8sResource,
+} from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
+import { ServingRuntimePlatform } from '~/types';
+import { kserveModal } from '~/__tests__/cypress/cypress/pages/modelServing';
+import { mockModelArtifact } from '~/__mocks__/mockModelArtifact';
+
+const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
+
+type HandlersProps = {
+  registeredModelsSize?: number;
+  modelVersions?: ModelVersion[];
+  modelMeshInstalled?: boolean;
+  kServeInstalled?: boolean;
+};
+
+const registeredModelMocked = mockRegisteredModel({ name: 'test-1' });
+const modelVersionMocked = mockModelVersion({
+  id: '1',
+  name: 'test model version',
+  state: ModelState.LIVE,
+});
+const modelArtifactMocked = mockModelArtifact();
+
+const initIntercepts = ({
+  registeredModelsSize = 4,
+  modelVersions = [mockModelVersion({ id: '1', name: 'test model version' })],
+  modelMeshInstalled = true,
+  kServeInstalled = true,
+}: HandlersProps) => {
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableModelRegistry: false,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      installedComponents: {
+        kserve: kServeInstalled,
+        'model-mesh': modelMeshInstalled,
+        'model-registry-operator': true,
+      },
+    }),
+  );
+
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([mockModelRegistryService({ name: 'modelregistry-sample' })]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models',
+    { path: { serviceName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION } },
+    mockRegisteredModelList({ size: registeredModelsSize }),
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
+    mockModelVersionList({
+      items: modelVersions,
+    }),
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId',
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
+    registeredModelMocked,
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 1,
+      },
+    },
+    modelVersionMocked,
+  );
+
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([
+      mockProjectK8sResource({
+        enableModelMesh: true,
+        k8sName: 'model-mesh-project',
+        displayName: 'Model mesh project',
+      }),
+      mockProjectK8sResource({
+        enableModelMesh: false,
+        k8sName: 'kserve-project',
+        displayName: 'KServe project',
+      }),
+      mockProjectK8sResource({ k8sName: 'test-project', displayName: 'Test project' }),
+    ]),
+  );
+
+  cy.interceptOdh(
+    `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts`,
+    {
+      path: {
+        serviceName: 'modelregistry-sample',
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 1,
+      },
+    },
+    mockModelArtifactList(),
+  );
+
+  cy.interceptK8sList(
+    TemplateModel,
+    mockK8sResourceList(
+      [
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-1',
+          displayName: 'Multi Platform',
+          platforms: [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI],
+        }),
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-2',
+          displayName: 'Caikit',
+          platforms: [ServingRuntimePlatform.SINGLE],
+        }),
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-3',
+          displayName: 'New OVMS Server',
+          platforms: [ServingRuntimePlatform.MULTI],
+        }),
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-4',
+          displayName: 'Serving Runtime with No Annotations',
+        }),
+        mockInvalidTemplateK8sResource({}),
+      ],
+      { namespace: 'opendatahub' },
+    ),
+  );
+};
+
+describe('Deploy model version', () => {
+  it('Deploy model version on unsupported platform', () => {
+    initIntercepts({ kServeInstalled: false, modelMeshInstalled: false });
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('Model mesh project');
+    cy.findByText('Multi-model platform is not installed').should('exist');
+    modelVersionDeployModal.selectProjectByName('KServe project');
+    cy.findByText('Single-model platform is not installed').should('exist');
+  });
+
+  it('Deploy model version on a project which platform is not selected', () => {
+    initIntercepts({});
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('Test project');
+    cy.findByText('Cannot deploy the model until you select a model serving platform').should(
+      'exist',
+    );
+  });
+
+  it('Deploy model version on a model mesh project that has no model servers', () => {
+    initIntercepts({});
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
+    cy.interceptK8sList(ServingRuntimeModel, mockK8sResourceList([]));
+    modelVersionDeployModal.selectProjectByName('Model mesh project');
+    cy.findByText('Cannot deploy the model until you configure a model server').should('exist');
+  });
+
+  it('Pre-fill deployment information on KServe modal', () => {
+    initIntercepts({});
+    cy.interceptK8sList(
+      SecretModel,
+      mockK8sResourceList([
+        mockSecretK8sResource({
+          name: 'test-secret-not-match',
+          displayName: 'Test Secret Not Match',
+          namespace: 'kserve-project',
+          s3Bucket: 'dGVzdC1idWNrZXQ=',
+          endPoint: 'dGVzdC1lbmRwb2ludC1ub3QtbWF0Y2g=', // endpoint not match
+          region: 'dGVzdC1yZWdpb24=',
+        }),
+      ]),
+    );
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+
+    // Validate name input field
+    kserveModal
+      .findModelNameInput()
+      .should('contain.value', `${registeredModelMocked.name} - ${modelVersionMocked.name} - `);
+
+    // Validate model framework section
+    kserveModal.findModelFrameworkSelect().should('be.disabled');
+    cy.findByText('The source model format is').should('not.exist');
+    kserveModal.findServingRuntimeTemplateDropdown().findDropdownItem('Multi Platform').click();
+    kserveModal.findModelFrameworkSelect().should('be.enabled');
+    cy.findByText(
+      `The source model format is ${modelArtifactMocked.modelFormatName} - ${modelArtifactMocked.modelFormatVersion}`,
+    ).should('exist');
+
+    // Validate data connection section
+    cy.findByText(
+      "We've auto-switched to create a new data connection and pre-filled the details for you.",
+    ).should('exist');
+    kserveModal.findNewDataConnectionOption().should('be.checked');
+    kserveModal.findLocationNameInput().should('have.value', modelArtifactMocked.storageKey);
+    kserveModal.findLocationBucketInput().should('have.value', 'test-bucket');
+    kserveModal.findLocationRegionInput().should('have.value', 'test-region');
+    kserveModal.findLocationEndpointInput().should('have.value', 'test-endpoint');
+    kserveModal.findLocationPathInput().should('have.value', 'demo-models/test-path');
+  });
+
+  it('One match data connection on KServe modal', () => {
+    initIntercepts({});
+    cy.interceptK8sList(
+      SecretModel,
+      mockK8sResourceList([
+        mockSecretK8sResource({
+          namespace: 'kserve-project',
+          s3Bucket: 'dGVzdC1idWNrZXQ=',
+          endPoint: 'dGVzdC1lbmRwb2ludA==',
+          region: 'dGVzdC1yZWdpb24=',
+        }),
+        mockSecretK8sResource({
+          name: 'test-secret-not-match',
+          displayName: 'Test Secret Not Match',
+          namespace: 'kserve-project',
+          s3Bucket: 'dGVzdC1idWNrZXQ=',
+          endPoint: 'dGVzdC1lbmRwb2ludC1ub3QtbWF0Y2g=', // endpoint not match
+          region: 'dGVzdC1yZWdpb24=',
+        }),
+      ]),
+    );
+
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+
+    // Validate data connection section
+    kserveModal.findExistingDataConnectionOption().should('be.checked');
+    kserveModal.findExistingConnectionSelect().should('contain.text', 'Test Secret');
+    kserveModal.findLocationPathInput().should('have.value', 'demo-models/test-path');
+  });
+
+  it('More than one match data connections on KServe modal', () => {
+    initIntercepts({});
+    cy.interceptK8sList(
+      SecretModel,
+      mockK8sResourceList([
+        mockSecretK8sResource({
+          namespace: 'kserve-project',
+          s3Bucket: 'dGVzdC1idWNrZXQ=',
+          endPoint: 'dGVzdC1lbmRwb2ludA==',
+          region: 'dGVzdC1yZWdpb24=',
+        }),
+        mockSecretK8sResource({
+          name: 'test-secret-2',
+          displayName: 'Test Secret 2',
+          namespace: 'kserve-project',
+          s3Bucket: 'dGVzdC1idWNrZXQ=',
+          endPoint: 'dGVzdC1lbmRwb2ludA==',
+          region: 'dGVzdC1yZWdpb24=',
+        }),
+      ]),
+    );
+
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+
+    // Validate data connection section
+    kserveModal.findExistingDataConnectionOption().should('be.checked');
+    kserveModal.findExistingConnectionSelect().should('contain.text', 'Select...');
+    kserveModal.findLocationPathInput().should('have.value', 'demo-models/test-path');
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -143,7 +143,7 @@ describe('Model version details', () => {
       'Label y',
       'Label z',
     ]);
-    modelVersionDetails.findStorageLocation().contains('https://huggingface.io/mnist.onnx');
+    modelVersionDetails.findStorageLocation().contains('s3://test-bucket/demo-models/test-path');
   });
 
   it('Switching model versions', () => {

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistryContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistryContext.tsx
@@ -1,10 +1,21 @@
 import * as React from 'react';
 import { SupportedArea, conditionalArea } from '~/concepts/areas';
+import { useTemplates } from '~/api';
+import { useDashboardNamespace } from '~/redux/selectors';
+import { useContextResourceData } from '~/utilities/useContextResourceData';
+import useTemplateOrder from '~/pages/modelServing/customServingRuntimes/useTemplateOrder';
+import { ContextResourceData, CustomWatchK8sResult } from '~/types';
+import { TemplateKind } from '~/k8sTypes';
+import { DEFAULT_CONTEXT_DATA, DEFAULT_LIST_WATCH_RESULT } from '~/utilities/const';
+import useTemplateDisablement from '~/pages/modelServing/customServingRuntimes/useTemplateDisablement';
 import useModelRegistryAPIState, { ModelRegistryAPIState } from './useModelRegistryAPIState';
 
 export type ModelRegistryContextType = {
   apiState: ModelRegistryAPIState;
   refreshAPIState: () => void;
+  servingRuntimeTemplates: CustomWatchK8sResult<TemplateKind[]>;
+  servingRuntimeTemplateOrder: ContextResourceData<string>;
+  servingRuntimeTemplateDisablement: ContextResourceData<string>;
 };
 
 type ModelRegistryContextProviderProps = {
@@ -16,12 +27,25 @@ export const ModelRegistryContext = React.createContext<ModelRegistryContextType
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   apiState: { apiAvailable: false, api: null as unknown as ModelRegistryAPIState['api'] },
   refreshAPIState: () => undefined,
+  servingRuntimeTemplates: DEFAULT_LIST_WATCH_RESULT,
+  servingRuntimeTemplateOrder: DEFAULT_CONTEXT_DATA,
+  servingRuntimeTemplateDisablement: DEFAULT_CONTEXT_DATA,
 });
 
 export const ModelRegistryContextProvider = conditionalArea<ModelRegistryContextProviderProps>(
   SupportedArea.MODEL_REGISTRY,
   true,
 )(({ children, modelRegistryName }) => {
+  const { dashboardNamespace } = useDashboardNamespace();
+
+  const servingRuntimeTemplates = useTemplates(dashboardNamespace);
+  const servingRuntimeTemplateOrder = useContextResourceData<string>(
+    useTemplateOrder(dashboardNamespace),
+  );
+  const servingRuntimeTemplateDisablement = useContextResourceData<string>(
+    useTemplateDisablement(dashboardNamespace),
+  );
+
   const hostPath = modelRegistryName ? `/api/service/modelregistry/${modelRegistryName}` : null;
 
   const [apiState, refreshAPIState] = useModelRegistryAPIState(hostPath);
@@ -31,6 +55,9 @@ export const ModelRegistryContextProvider = conditionalArea<ModelRegistryContext
       value={{
         apiState,
         refreshAPIState,
+        servingRuntimeTemplates,
+        servingRuntimeTemplateOrder,
+        servingRuntimeTemplateDisablement,
       }}
     >
       {children}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -7,6 +7,7 @@ import { ModelVersion, ModelState } from '~/concepts/modelRegistry/types';
 import { getPatchBodyForModelVersion } from '~/pages/modelRegistry/screens/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { modelVersionArchiveDetailsUrl } from '~/pages/modelRegistry/screens/routeUtils';
+import DeployRegisteredModelModal from '~/pages/modelRegistry/screens/components/DeployRegisteredModelModal';
 
 interface ModelVersionsDetailsHeaderActionsProps {
   mv: ModelVersion;
@@ -21,6 +22,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   const navigate = useNavigate();
   const [isOpenActionDropdown, setOpenActionDropdown] = React.useState(false);
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
+  const [isDeployModalOpen, setIsDeployModalOpen] = React.useState(false);
   const tooltipRef = React.useRef<HTMLButtonElement>(null);
 
   return (
@@ -48,9 +50,8 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
             id="deploy-button"
             aria-label="Deploy version"
             key="deploy-button"
-            onClick={() => undefined}
+            onClick={() => setIsDeployModalOpen(true)}
             ref={tooltipRef}
-            isDisabled // TODO This feature is currently disabled but will be enabled in a future PR post-summit release.
           >
             Deploy
           </DropdownItem>
@@ -65,6 +66,11 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
           </DropdownItem>
         </DropdownList>
       </Dropdown>
+      <DeployRegisteredModelModal
+        onCancel={() => setIsDeployModalOpen(false)}
+        isOpen={isDeployModalOpen}
+        modelVersion={mv}
+      />
       <ArchiveModelVersionModal
         onCancel={() => setIsArchiveModalOpen(false)}
         onSubmit={() =>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -14,6 +14,7 @@ import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/componen
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import { getPatchBodyForModelVersion } from '~/pages/modelRegistry/screens/utils';
 import { RestoreModelVersionModal } from '~/pages/modelRegistry/screens/components/RestoreModelVersionModal';
+import DeployRegisteredModelModal from '~/pages/modelRegistry/screens/components/DeployRegisteredModelModal';
 
 type ModelVersionsTableRowProps = {
   modelVersion: ModelVersion;
@@ -30,6 +31,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
+  const [isDeployModalOpen, setIsDeployModalOpen] = React.useState(false);
   const { apiState } = React.useContext(ModelRegistryContext);
 
   const actions = isArchiveRow
@@ -42,8 +44,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
     : [
         {
           title: 'Deploy',
-          // TODO: Implement functionality for onClick. This will be added in another PR
-          onClick: () => undefined,
+          onClick: () => setIsDeployModalOpen(true),
         },
         {
           title: 'Archive version',
@@ -104,6 +105,11 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
           }
           isOpen={isArchiveModalOpen}
           modelVersionName={mv.name}
+        />
+        <DeployRegisteredModelModal
+          onCancel={() => setIsDeployModalOpen(false)}
+          isOpen={isDeployModalOpen}
+          modelVersion={mv}
         />
         <RestoreModelVersionModal
           onCancel={() => setIsRestoreModalOpen(false)}

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -43,12 +43,6 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
       ]
     : [
         {
-          title: 'Deploy',
-          isDisabled: true,
-          // TODO: Implement functionality for onClick. This will be added in another PR
-          onClick: () => undefined,
-        },
-        {
           title: 'Archive model',
           onClick: () => setIsArchiveModalOpen(true),
         },

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useLabeledDataConnections.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useLabeledDataConnections.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import { ObjectStorageFields, uriToObjectStorageFields } from '~/concepts/modelRegistry/utils';
+import { LabeledDataConnection } from '~/pages/modelServing/screens/types';
+import { AwsKeys } from '~/pages/projects/dataConnections/const';
+import { convertAWSSecretData } from '~/pages/projects/screens/detail/data-connections/utils';
+import { DataConnection } from '~/pages/projects/types';
+
+const useLabeledDataConnections = (
+  modelArtifactUri: string | undefined,
+  dataConnections: DataConnection[] = [],
+): {
+  dataConnections: LabeledDataConnection[];
+  storageFields: ObjectStorageFields | null;
+} =>
+  React.useMemo(() => {
+    if (!modelArtifactUri) {
+      return {
+        dataConnections: dataConnections.map((dataConnection) => ({ dataConnection })),
+        storageFields: null,
+      };
+    }
+    const storageFields = uriToObjectStorageFields(modelArtifactUri);
+    if (!storageFields) {
+      return {
+        dataConnections: dataConnections.map((dataConnection) => ({ dataConnection })),
+        storageFields,
+      };
+    }
+    const labeledDataConnections = dataConnections.map((dataConnection) => {
+      const awsData = convertAWSSecretData(dataConnection);
+      const bucket = awsData.find((data) => data.key === AwsKeys.AWS_S3_BUCKET)?.value;
+      const endpoint = awsData.find((data) => data.key === AwsKeys.S3_ENDPOINT)?.value;
+      const region = awsData.find((data) => data.key === AwsKeys.DEFAULT_REGION)?.value;
+      if (
+        bucket === storageFields.bucket &&
+        endpoint === storageFields.endpoint &&
+        (region === storageFields.region || !storageFields.region)
+      ) {
+        return { dataConnection, isRecommended: true };
+      }
+      return { dataConnection };
+    });
+    return { dataConnections: labeledDataConnections, storageFields };
+  }, [dataConnections, modelArtifactUri]);
+
+export default useLabeledDataConnections;

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -1,0 +1,87 @@
+import { AlertVariant } from '@patternfly/react-core';
+import React from 'react';
+import { ProjectKind } from '~/k8sTypes';
+import useLabeledDataConnections from '~/pages/modelRegistry/screens/RegisteredModels/useLabeledDataConnections';
+import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
+import {
+  CreatingInferenceServiceObject,
+  InferenceServiceStorageType,
+  LabeledDataConnection,
+} from '~/pages/modelServing/screens/types';
+import { AwsKeys, EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
+import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
+import { DataConnection, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+
+const usePrefillDeployModalFromModelRegistry = (
+  projectContext: { currentProject: ProjectKind; dataConnections: DataConnection[] } | undefined,
+  createData: CreatingInferenceServiceObject,
+  setCreateData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>,
+  registeredModelDeployInfo?: RegisteredModelDeployInfo,
+): [LabeledDataConnection[], boolean, Error | undefined] => {
+  const [fetchedDataConnections, dataConnectionsLoaded, dataConnectionsLoadError] =
+    useDataConnections(projectContext ? undefined : createData.project);
+  const allDataConnections = projectContext?.dataConnections || fetchedDataConnections;
+  const { dataConnections, storageFields } = useLabeledDataConnections(
+    registeredModelDeployInfo?.modelArtifactUri,
+    allDataConnections,
+  );
+
+  React.useEffect(() => {
+    if (registeredModelDeployInfo) {
+      setCreateData('name', registeredModelDeployInfo.modelName);
+      const recommendedDataConnections = dataConnections.filter(
+        (dataConnection) => dataConnection.isRecommended,
+      );
+
+      if (!storageFields) {
+        setCreateData('storage', {
+          awsData: EMPTY_AWS_SECRET_DATA,
+          dataConnection: '',
+          path: '',
+          type: InferenceServiceStorageType.EXISTING_STORAGE,
+        });
+      } else {
+        const prefilledAWSData = [
+          { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
+          { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.bucket },
+          { key: AwsKeys.S3_ENDPOINT, value: storageFields.endpoint },
+          { key: AwsKeys.DEFAULT_REGION, value: storageFields.region || '' },
+          ...EMPTY_AWS_SECRET_DATA,
+        ];
+        if (recommendedDataConnections.length === 0) {
+          setCreateData('storage', {
+            awsData: prefilledAWSData,
+            dataConnection: '',
+            path: storageFields.path,
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            alert: {
+              type: AlertVariant.info,
+              title:
+                "We've auto-switched to create a new data connection and pre-filled the details for you.",
+              message:
+                'Model location info is available in the registry but no matching data connection in the project. So we automatically switched the option to create a new data connection and prefilled the information.',
+            },
+          });
+        } else if (recommendedDataConnections.length === 1) {
+          setCreateData('storage', {
+            awsData: prefilledAWSData,
+            dataConnection: recommendedDataConnections[0].dataConnection.data.metadata.name,
+            path: storageFields.path,
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        } else {
+          setCreateData('storage', {
+            awsData: prefilledAWSData,
+            dataConnection: '',
+            path: storageFields.path,
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        }
+      }
+    }
+  }, [dataConnections, storageFields, registeredModelDeployInfo, setCreateData]);
+
+  return [dataConnections, dataConnectionsLoaded, dataConnectionsLoadError];
+};
+
+export default usePrefillDeployModalFromModelRegistry;

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useProjectErrorForRegisteredModel.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useProjectErrorForRegisteredModel.ts
@@ -1,0 +1,34 @@
+import useServingRuntimes from '~/pages/modelServing/useServingRuntimes';
+import { ServingRuntimePlatform } from '~/types';
+
+const useProjectErrorForRegisteredModel = (
+  projectName?: string,
+  platform?: ServingRuntimePlatform,
+): Error | undefined => {
+  const [servingRuntimes, loaded, loadError] = useServingRuntimes(projectName);
+
+  // If project is not selected, there is no error
+  if (!projectName) {
+    return undefined;
+  }
+
+  // If the platform is not selected
+  if (!platform) {
+    return new Error('Cannot deploy the model until you select a model serving platform');
+  }
+
+  if (loadError) {
+    return loadError;
+  }
+
+  // If the platform is MULTI but it doesn't have a server
+  if (platform === ServingRuntimePlatform.MULTI) {
+    if (loaded && servingRuntimes.length === 0) {
+      return new Error('Cannot deploy the model until you configure a model server');
+    }
+  }
+
+  return undefined;
+};
+
+export default useProjectErrorForRegisteredModel;

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
@@ -10,26 +10,54 @@ export type RegisteredModelDeployInfo = {
   modelArtifactStorageKey?: string;
 };
 
-const useRegisteredModelDeployInfo = (modelVersion: ModelVersion): RegisteredModelDeployInfo => {
-  const [registeredModel] = useRegisteredModelById(modelVersion.registeredModelId);
-  const [modelArtifactList] = useModelArtifactsByVersionId(modelVersion.id);
+const useRegisteredModelDeployInfo = (
+  modelVersion: ModelVersion,
+): {
+  registeredModelDeployInfo: RegisteredModelDeployInfo;
+  loaded: boolean;
+  error: Error | undefined;
+} => {
+  const [registeredModel, registeredModelLoaded, registeredModelError] = useRegisteredModelById(
+    modelVersion.registeredModelId,
+  );
+  const [modelArtifactList, modelArtifactListLoaded, modelArtifactListError] =
+    useModelArtifactsByVersionId(modelVersion.id);
 
   const registeredModelDeployInfo = React.useMemo(() => {
+    const dateString = new Date().toISOString();
+    const modelName = `${registeredModel?.name} - ${modelVersion.name} - ${dateString}`;
     if (modelArtifactList.size === 0) {
       return {
-        modelName: `${registeredModel?.name} - ${modelVersion.name}`,
+        registeredModelDeployInfo: {
+          modelName,
+        },
+        loaded: registeredModelLoaded && modelArtifactListLoaded,
+        error: registeredModelError || modelArtifactListError,
       };
     }
     const modelArtifact = modelArtifactList.items[0];
     return {
-      modelName: `${registeredModel?.name} - ${modelVersion.name} - ${new Date().toISOString()}`,
-      modelFormat: modelArtifact.modelFormatName
-        ? `${modelArtifact.modelFormatName} - ${modelArtifact.modelFormatVersion}`
-        : undefined,
-      modelArtifactUri: modelArtifact.uri,
-      modelArtifactStorageKey: modelArtifact.storageKey,
+      registeredModelDeployInfo: {
+        modelName,
+        modelFormat: modelArtifact.modelFormatName
+          ? `${modelArtifact.modelFormatName} - ${modelArtifact.modelFormatVersion}`
+          : undefined,
+        modelArtifactUri: modelArtifact.uri,
+        modelArtifactStorageKey: modelArtifact.storageKey,
+      },
+      loaded: registeredModelLoaded && modelArtifactListLoaded,
+      error: registeredModelError || modelArtifactListError,
     };
-  }, [modelArtifactList.items, modelArtifactList.size, modelVersion.name, registeredModel?.name]);
+  }, [
+    modelArtifactList.items,
+    modelArtifactList.size,
+    modelArtifactListError,
+    modelArtifactListLoaded,
+    modelVersion.name,
+    registeredModel?.name,
+    registeredModelError,
+    registeredModelLoaded,
+  ]);
 
   return registeredModelDeployInfo;
 };

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
+import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegisteredModelById';
+import { ModelVersion } from '~/concepts/modelRegistry/types';
+
+export type RegisteredModelDeployInfo = {
+  modelName: string;
+  modelFormat?: string;
+  modelArtifactUri?: string;
+  modelArtifactStorageKey?: string;
+};
+
+const useRegisteredModelDeployInfo = (modelVersion: ModelVersion): RegisteredModelDeployInfo => {
+  const [registeredModel] = useRegisteredModelById(modelVersion.registeredModelId);
+  const [modelArtifactList] = useModelArtifactsByVersionId(modelVersion.id);
+
+  const registeredModelDeployInfo = React.useMemo(() => {
+    if (modelArtifactList.size === 0) {
+      return {
+        modelName: `${registeredModel?.name} - ${modelVersion.name}`,
+      };
+    }
+    const modelArtifact = modelArtifactList.items[0];
+    return {
+      modelName: `${registeredModel?.name} - ${modelVersion.name} - ${new Date().toISOString()}`,
+      modelFormat: modelArtifact.modelFormatName
+        ? `${modelArtifact.modelFormatName} - ${modelArtifact.modelFormatVersion}`
+        : undefined,
+      modelArtifactUri: modelArtifact.uri,
+      modelArtifactStorageKey: modelArtifact.storageKey,
+    };
+  }, [modelArtifactList.items, modelArtifactList.size, modelVersion.name, registeredModel?.name]);
+
+  return registeredModelDeployInfo;
+};
+
+export default useRegisteredModelDeployInfo;

--- a/frontend/src/pages/modelRegistry/screens/__tests__/useProjectErrorForRegisteredModel.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/useProjectErrorForRegisteredModel.spec.ts
@@ -1,0 +1,97 @@
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockDashboardConfig, mockK8sResourceList } from '~/__mocks__';
+import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { useAccessReview } from '~/api';
+import { useAppContext } from '~/app/AppContext';
+import { ServingRuntimeKind } from '~/k8sTypes';
+import useProjectErrorForRegisteredModel from '~/pages/modelRegistry/screens/RegisteredModels/useProjectErrorForRegisteredModel';
+import { ServingRuntimePlatform } from '~/types';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+// Mock the API functions
+jest.mock('~/api', () => ({
+  ...jest.requireActual('~/api'),
+  useAccessReview: jest.fn(),
+}));
+
+jest.mock('~/pages/modelServing/useServingPlatformStatuses', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('~/app/AppContext', () => ({
+  __esModule: true,
+  useAppContext: jest.fn(),
+}));
+
+const useAppContextMock = jest.mocked(useAppContext);
+const k8sListResourceMock = jest.mocked(k8sListResource<ServingRuntimeKind>);
+const useAccessReviewMock = jest.mocked(useAccessReview);
+
+describe('useProjectErrorForRegisteredModel', () => {
+  beforeEach(() => {
+    useAppContextMock.mockReturnValue({
+      buildStatuses: [],
+      dashboardConfig: mockDashboardConfig({}),
+      storageClasses: [],
+      isRHOAI: false,
+    });
+    useAccessReviewMock.mockReturnValue([true, true]);
+  });
+  it('should return undefined when the project is not selected', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([]));
+    const renderResult = testHook(useProjectErrorForRegisteredModel)(undefined, undefined);
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(undefined);
+  });
+
+  it('should return undefined when only kServe is supported', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([]));
+    const renderResult = testHook(useProjectErrorForRegisteredModel)(
+      'test-project',
+      ServingRuntimePlatform.SINGLE,
+    );
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(undefined);
+  });
+
+  it('should return undefined when only modelMesh is supported with server deployed', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([mockServingRuntimeK8sResource({})]));
+    const renderResult = testHook(useProjectErrorForRegisteredModel)(
+      'test-project',
+      ServingRuntimePlatform.MULTI,
+    );
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(undefined);
+  });
+
+  it('should return error when only modelMesh is supported with no server deployed', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([]));
+    const renderResult = testHook(useProjectErrorForRegisteredModel)(
+      'test-project',
+      ServingRuntimePlatform.MULTI,
+    );
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(
+      new Error('Cannot deploy the model until you configure a model server'),
+    );
+  });
+
+  it('should return error when platform is not selected', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([]));
+    const renderResult = testHook(useProjectErrorForRegisteredModel)('test-project', undefined);
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(
+      new Error('Cannot deploy the model until you select a model serving platform'),
+    );
+  });
+});

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Form, Modal } from '@patternfly/react-core';
+import { Alert, Button, Form, Modal, Spinner } from '@patternfly/react-core';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import { ProjectKind } from '~/k8sTypes';
 import useProjectErrorForRegisteredModel from '~/pages/modelRegistry/screens/RegisteredModels/useProjectErrorForRegisteredModel';
@@ -41,7 +41,11 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
   const [dataConnections] = useDataConnections(selectedProject?.metadata.name);
   const error = platformError || projectError;
 
-  const registeredModelDeployInfo = useRegisteredModelDeployInfo(modelVersion);
+  const {
+    registeredModelDeployInfo,
+    loaded,
+    error: deployInfoError,
+  } = useRegisteredModelDeployInfo(modelVersion);
 
   const onClose = React.useCallback(() => {
     setSelectedProject(null);
@@ -67,11 +71,19 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
         showClose
       >
         <Form>
-          <ProjectSelector
-            selectedProject={selectedProject}
-            setSelectedProject={setSelectedProject}
-            error={error}
-          />
+          {deployInfoError ? (
+            <Alert variant="danger" isInline title={deployInfoError.name}>
+              {deployInfoError.message}
+            </Alert>
+          ) : !loaded ? (
+            <Spinner />
+          ) : (
+            <ProjectSelector
+              selectedProject={selectedProject}
+              setSelectedProject={setSelectedProject}
+              error={error}
+            />
+          )}
         </Form>
       </Modal>
     );

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Button, Form, Modal } from '@patternfly/react-core';
+import { ModelVersion } from '~/concepts/modelRegistry/types';
+import { ProjectKind } from '~/k8sTypes';
+import useProjectErrorForRegisteredModel from '~/pages/modelRegistry/screens/RegisteredModels/useProjectErrorForRegisteredModel';
+import ProjectSelector from '~/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector';
+import ManageKServeModal from '~/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
+import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
+import { getProjectModelServingPlatform } from '~/pages/modelServing/screens/projects/utils';
+import { ServingRuntimePlatform } from '~/types';
+import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
+import useRegisteredModelDeployInfo from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
+import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
+import { getKServeTemplates } from '~/pages/modelServing/customServingRuntimes/utils';
+import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
+
+interface DeployRegisteredModelModalProps {
+  onCancel: () => void;
+  isOpen: boolean;
+  modelVersion: ModelVersion;
+}
+
+const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
+  isOpen,
+  onCancel,
+  modelVersion,
+}) => {
+  const {
+    servingRuntimeTemplates: [templates],
+    servingRuntimeTemplateOrder: { data: templateOrder },
+    servingRuntimeTemplateDisablement: { data: templateDisablement },
+  } = React.useContext(ModelRegistryContext);
+
+  const [selectedProject, setSelectedProject] = React.useState<ProjectKind | null>(null);
+  const servingPlatformStatuses = useServingPlatformStatuses();
+  const { platform, error: platformError } = getProjectModelServingPlatform(
+    selectedProject,
+    servingPlatformStatuses,
+  );
+  const projectError = useProjectErrorForRegisteredModel(selectedProject?.metadata.name, platform);
+  const [dataConnections] = useDataConnections(selectedProject?.metadata.name);
+  const error = platformError || projectError;
+
+  const registeredModelDeployInfo = useRegisteredModelDeployInfo(modelVersion);
+
+  const onClose = React.useCallback(() => {
+    setSelectedProject(null);
+    onCancel();
+  }, [onCancel]);
+
+  if (!selectedProject || !platform) {
+    return (
+      <Modal
+        title="Deploy model"
+        description="Configure properties for deploying your model"
+        variant="medium"
+        isOpen={isOpen}
+        onClose={onClose}
+        actions={[
+          <Button key="deploy" variant="primary" isDisabled>
+            Deploy
+          </Button>,
+          <Button key="cancel" variant="link" onClick={onClose}>
+            Cancel
+          </Button>,
+        ]}
+        showClose
+      >
+        <Form>
+          <ProjectSelector
+            selectedProject={selectedProject}
+            setSelectedProject={setSelectedProject}
+            error={error}
+          />
+        </Form>
+      </Modal>
+    );
+  }
+
+  return (
+    <>
+      <ManageKServeModal
+        onClose={onClose}
+        isOpen={isOpen && platform === ServingRuntimePlatform.SINGLE}
+        servingRuntimeTemplates={getKServeTemplates(templates, templateOrder, templateDisablement)}
+        shouldFormHidden={!!error}
+        registeredModelDeployInfo={registeredModelDeployInfo}
+        projectContext={{ currentProject: selectedProject, dataConnections }}
+        projectSection={
+          <ProjectSelector
+            selectedProject={selectedProject}
+            setSelectedProject={setSelectedProject}
+            error={error}
+          />
+        }
+      />
+      <ManageInferenceServiceModal
+        onClose={onClose}
+        isOpen={isOpen && platform === ServingRuntimePlatform.MULTI}
+        shouldFormHidden={!!error}
+        registeredModelDeployInfo={registeredModelDeployInfo}
+        projectContext={{ currentProject: selectedProject, dataConnections }}
+        projectSection={
+          <ProjectSelector
+            selectedProject={selectedProject}
+            setSelectedProject={setSelectedProject}
+            error={error}
+          />
+        }
+      />
+    </>
+  );
+};
+
+export default DeployRegisteredModelModal;

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -164,3 +164,17 @@ export const getAPIProtocolFromServingRuntime = (
     ) ?? undefined
   );
 };
+
+export const getKServeTemplates = (
+  templates: TemplateKind[],
+  templateOrder: string[],
+  templateDisablement: string[],
+): TemplateKind[] => {
+  const templatesSorted = getSortedTemplates(templates, templateOrder);
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, templateDisablement),
+  );
+  return templatesEnabled.filter((template) =>
+    getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+  );
+};

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionExistingField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionExistingField.tsx
@@ -1,9 +1,21 @@
 import * as React from 'react';
-import { Button, FormGroup, Popover, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  FormGroup,
+  Label,
+  Popover,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { DataConnection, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
-import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import {
+  CreatingInferenceServiceObject,
+  LabeledDataConnection,
+} from '~/pages/modelServing/screens/types';
 import { filterOutConnectionsWithoutBucket } from '~/pages/modelServing/screens/projects/utils';
 import { getDataConnectionDisplayName } from '~/pages/projects/screens/detail/data-connections/utils';
 import DataConnectionFolderPathField from './DataConnectionFolderPathField';
@@ -11,7 +23,7 @@ import DataConnectionFolderPathField from './DataConnectionFolderPathField';
 type DataConnectionExistingFieldType = {
   data: CreatingInferenceServiceObject;
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
-  dataConnections: DataConnection[];
+  dataConnections: LabeledDataConnection[];
 };
 
 const DataConnectionExistingField: React.FC<DataConnectionExistingFieldType> = ({
@@ -64,10 +76,19 @@ const DataConnectionExistingField: React.FC<DataConnectionExistingFieldType> = (
           >
             {connectionsWithoutBucket.map((connection) => (
               <SelectOption
-                key={connection.data.metadata.name}
-                value={connection.data.metadata.name}
+                key={connection.dataConnection.data.metadata.name}
+                value={connection.dataConnection.data.metadata.name}
               >
-                {getDataConnectionDisplayName(connection)}
+                <Flex spaceItems={{ default: 'spaceItemsXs' }}>
+                  <FlexItem>{getDataConnectionDisplayName(connection.dataConnection)}</FlexItem>
+                  {connection.isRecommended && (
+                    <FlexItem>
+                      <Label color="blue" isCompact>
+                        Recommended
+                      </Label>
+                    </FlexItem>
+                  )}
+                </Flex>
               </SelectOption>
             ))}
           </Select>

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/InferenceServiceFrameworkSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/InferenceServiceFrameworkSection.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Alert, FormGroup, Skeleton } from '@patternfly/react-core';
+import {
+  Alert,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Skeleton,
+} from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
@@ -10,12 +17,14 @@ type InferenceServiceFrameworkSectionProps = {
   data: CreatingInferenceServiceObject;
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
   modelContext?: SupportedModelFormats[];
+  registeredModelFormat?: string;
 };
 
 const InferenceServiceFrameworkSection: React.FC<InferenceServiceFrameworkSectionProps> = ({
   data,
   setData,
   modelContext,
+  registeredModelFormat,
 }) => {
   const [isOpen, setOpen] = React.useState(false);
 
@@ -74,6 +83,13 @@ const InferenceServiceFrameworkSection: React.FC<InferenceServiceFrameworkSectio
           return <SelectOption key={name} value={name} />;
         })}
       </Select>
+      {registeredModelFormat && models.length !== 0 && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>The source model format is {registeredModelFormat}</HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
     </FormGroup>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {
+  Alert,
+  FormGroup,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
+import { ProjectKind } from '~/k8sTypes';
+import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
+
+type ProjectSelectorProps = {
+  selectedProject: ProjectKind | null;
+  setSelectedProject: (project: ProjectKind | null) => void;
+  error?: Error;
+};
+
+const ProjectSelector: React.FC<ProjectSelectorProps> = ({
+  selectedProject,
+  setSelectedProject,
+  error,
+}) => {
+  const [isOpen, setOpen] = React.useState(false);
+
+  const { projects } = React.useContext(ProjectsContext);
+
+  return (
+    <FormGroup label="Project" isRequired>
+      <Stack hasGutter>
+        <StackItem>
+          <Select
+            onSelect={(e, selection) => {
+              if (typeof selection === 'string') {
+                const foundProject = projects.find(byName(selection));
+                if (foundProject) {
+                  setSelectedProject(foundProject);
+                } else {
+                  setSelectedProject(null);
+                }
+              }
+              setOpen(false);
+            }}
+            selected={selectedProject}
+            onOpenChange={(open) => setOpen(open)}
+            isOpen={isOpen}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setOpen(!isOpen)}
+                isExpanded={isOpen}
+                isFullWidth
+                data-testid="deploy-model-project-selector"
+              >
+                {selectedProject
+                  ? getDisplayNameFromK8sResource(selectedProject)
+                  : 'Select target project'}
+              </MenuToggle>
+            )}
+          >
+            <SelectList>
+              {projects.map((project) => (
+                <SelectOption
+                  key={project.metadata.uid}
+                  value={project.metadata.name}
+                  role="menuitem"
+                >
+                  {getDisplayNameFromK8sResource(project)}
+                </SelectOption>
+              ))}
+            </SelectList>
+          </Select>
+        </StackItem>
+        {error && selectedProject && (
+          <StackItem>
+            <Alert isInline variant="danger" title={error.message}>
+              <Link
+                to={`/projects/${selectedProject.metadata.name}?section=${ProjectSectionID.MODEL_SERVER}`}
+              >
+                Go to {getDisplayNameFromK8sResource(selectedProject)} project page
+              </Link>
+            </Alert>
+          </StackItem>
+        )}
+      </Stack>
+    </FormGroup>
+  );
+};
+
+export default ProjectSelector;

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -5,30 +5,33 @@ import {
   getProjectModelServingPlatform,
   getUrlFromKserveInferenceService,
 } from '~/pages/modelServing/screens/projects/utils';
-import { DataConnection } from '~/pages/projects/types';
-import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
+import { LabeledDataConnection, ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
 import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
 
 describe('filterOutConnectionsWithoutBucket', () => {
   it('should return an empty array if input connections array is empty', () => {
-    const inputConnections: DataConnection[] = [];
+    const inputConnections: LabeledDataConnection[] = [];
     const result = filterOutConnectionsWithoutBucket(inputConnections);
     expect(result).toEqual([]);
   });
 
   it('should filter out connections without an AWS_S3_BUCKET property', () => {
     const dataConnections = [
-      mockDataConnection({ name: 'name1', s3Bucket: 'bucket1' }),
-      mockDataConnection({ name: 'name2', s3Bucket: '' }),
-      mockDataConnection({ name: 'name3', s3Bucket: 'bucket2' }),
+      { dataConnection: mockDataConnection({ name: 'name1', s3Bucket: 'bucket1' }) },
+      { dataConnection: mockDataConnection({ name: 'name2', s3Bucket: '' }) },
+      { dataConnection: mockDataConnection({ name: 'name3', s3Bucket: 'bucket2' }) },
     ];
 
     const result = filterOutConnectionsWithoutBucket(dataConnections);
 
     expect(result).toMatchObject([
-      { data: { data: { Name: 'name1' } } },
-      { data: { data: { Name: 'name3' } } },
+      {
+        dataConnection: { data: { data: { Name: 'name1' } } },
+      },
+      {
+        dataConnection: { data: { data: { Name: 'name3' } } },
+      },
     ]);
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -7,11 +7,7 @@ import {
   SecretKind,
   ServingRuntimeKind,
 } from '~/k8sTypes';
-import {
-  DataConnection,
-  NamespaceApplicationCase,
-  UpdateObjectAtPropAndValue,
-} from '~/pages/projects/types';
+import { NamespaceApplicationCase, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
 import {
   CreatingInferenceServiceObject,
@@ -20,6 +16,7 @@ import {
   ServingPlatformStatuses,
   ServingRuntimeEditInfo,
   ModelServingSize,
+  LabeledDataConnection,
 } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
 import { DEFAULT_MODEL_SERVER_SIZES } from '~/pages/modelServing/screens/const';
@@ -536,8 +533,10 @@ export const isUrlInternalService = (url: string | undefined): boolean =>
   url !== undefined && url.endsWith('.svc.cluster.local');
 
 export const filterOutConnectionsWithoutBucket = (
-  connections: DataConnection[],
-): DataConnection[] =>
+  connections: LabeledDataConnection[],
+): LabeledDataConnection[] =>
   connections.filter(
-    (obj) => isDataConnectionAWS(obj) && obj.data.data.AWS_S3_BUCKET.trim() !== '',
+    (obj) =>
+      isDataConnectionAWS(obj.dataConnection) &&
+      obj.dataConnection.data.data.AWS_S3_BUCKET.trim() !== '',
   );

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -1,5 +1,6 @@
+import { AlertVariant } from '@patternfly/react-core';
 import { SecretKind, ServingRuntimeKind } from '~/k8sTypes';
-import { EnvVariableDataEntry } from '~/pages/projects/types';
+import { DataConnection, EnvVariableDataEntry } from '~/pages/projects/types';
 import { ContainerResources } from '~/types';
 
 export enum PerformanceMetricType {
@@ -78,6 +79,11 @@ export type InferenceServiceStorage = {
   path: string;
   dataConnection: string;
   awsData: EnvVariableDataEntry[];
+  alert?: {
+    type: AlertVariant;
+    title: string;
+    message: string;
+  };
 };
 
 export type InferenceServiceFormat = {
@@ -99,4 +105,9 @@ export type ServingPlatformStatuses = {
     enabled: boolean;
     installed: boolean;
   };
+};
+
+export type LabeledDataConnection = {
+  dataConnection: DataConnection;
+  isRecommended?: boolean;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-8396](https://issues.redhat.com/browse/RHOAIENG-8396)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When you deploy a model based on a model registry, the following modal will show:

<img width="1511" alt="Screenshot 2024-08-07 at 1 27 46 PM" src="https://github.com/user-attachments/assets/83ae3c3a-1af2-490f-948b-97565d0c482d">

If anything wrong with the project, the corresponding error message will pop up:

<img width="1511" alt="Screenshot 2024-08-07 at 1 28 32 PM" src="https://github.com/user-attachments/assets/ad57cdea-2bca-4a1e-8892-1569d95f012d">

Otherwise, the current KServe modal or InferenceService modal will pop up depending on the project's serving platform. The name will be pre-filled as `{modelName} - {versionName}`:

<img width="1511" alt="Screenshot 2024-08-07 at 1 29 29 PM" src="https://github.com/user-attachments/assets/32d22f8a-1ecc-4b2c-8c11-cdc62adcdd12">

There is a helper text if the model registry version contains a prompt model format:

<img width="812" alt="Screenshot 2024-08-07 at 1 32 08 PM" src="https://github.com/user-attachments/assets/24bc1830-44d6-45a1-92a9-d6de3c420c2a">

The data connections part will be decided by the model artifact URI.
If there are more than 1 matches, we don't pre-select the data connection:

<img width="1510" alt="Screenshot 2024-08-07 at 1 32 32 PM" src="https://github.com/user-attachments/assets/78f4ca6b-551a-4dad-a102-6470d6a86b6a">

If there is only one match, we pre-select the recommended data connection:

<img width="1510" alt="Screenshot 2024-08-07 at 1 34 19 PM" src="https://github.com/user-attachments/assets/439bff95-7b62-41b6-a443-7349f036ea95">

If there is no match, we pre-select the new data connection field:

<img width="1510" alt="Screenshot 2024-08-07 at 1 35 14 PM" src="https://github.com/user-attachments/assets/cd1a153d-8b6d-4ea5-a6e7-5759f2e204e9">

The path will always be pre-filled based on the URI parsing result:

<img width="806" alt="Screenshot 2024-08-07 at 1 36 58 PM" src="https://github.com/user-attachments/assets/f1ab15e3-07d2-4660-8164-0544c0e6d57c">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create project A, B and C
2. For project A, make it an unsupported serving platform (or don't select a serving platform if both platforms are supported)
3. Go to Model registry page, choose one model registry and click on `Deploy` on the version action
4. Choose project A, check the error message
5. For project B and C, make the serving platform selected (or make your cluster only support one platform)
6. Choose project B, check if the name field is auto-filled
7. Check the data connection field is pre-selected as `New data connection` and `path` field is pre-filled
8. Create one matching secret in project B and 2 matching secrets in project C ("matching" means the secret has the same `bucket`, `endpoint` and `region` as the model registry version artifact URI you are going to deploy with)
9. Choose project B again, check the data connection field is pre-selected as `Existing data connection` and the only matching data connection is labeled and pre-selected
10. Choose project C, check the data connection field is pre-selected as `Existing data connection` and both data connections in the dropdown menu are labeled as recommended, but neither is pre-selected

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add a unit test to test the util function that shows the error message when choosing the project.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
