### PR TITLE
feat(RegisterModel): 9914 autofill connection

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
@@ -33,6 +33,26 @@ class RegisterModelPage {
     return cy.get(selector);
   }
 
+  findObjectStorageAutofillButton() {
+    return cy.findByTestId('object-storage-autofill-button');
+  }
+
+  findConnectionAutofillModal() {
+    return cy.findByTestId('connection-autofill-modal');
+  }
+
+  findProjectSelector() {
+    return this.findConnectionAutofillModal().findByTestId('project-selector-dropdown');
+  }
+
+  findConnectionSelector() {
+    return this.findConnectionAutofillModal().findByTestId('select-data-connection');
+  }
+
+  findAutofillButton() {
+    return cy.findByTestId('autofill-modal-button');
+  }
+
   findSubmitButton() {
     return cy.findByTestId('create-button');
   }

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -22,6 +22,7 @@ type ProjectSelectorProps = {
   filterLabel?: string;
   showTitle?: boolean;
   selectorLabel?: string;
+  isFullWidth?: boolean;
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
@@ -33,6 +34,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   filterLabel,
   showTitle = false,
   selectorLabel = 'Project',
+  isFullWidth = false,
 }) => {
   const { projects, updatePreferredProject } = React.useContext(ProjectsContext);
   const selection = projects.find(byName(namespace));
@@ -60,6 +62,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           variant={primary ? 'primary' : undefined}
           onClick={() => setDropdownOpen(!dropdownOpen)}
           isExpanded={dropdownOpen}
+          isFullWidth={isFullWidth}
           data-testid="project-selector-dropdown"
         >
           {toggleLabel}

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionDropdown.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionDropdown.tsx
@@ -1,0 +1,101 @@
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  Dropdown,
+  MenuList,
+  MenuToggle,
+  Spinner,
+} from '@patternfly/react-core';
+import React from 'react';
+import { DataConnection } from '~/pages/projects/types';
+import { getDataConnectionDisplayName } from '~/pages/projects/screens/detail/data-connections/utils';
+// TODO: temporarily importing across pages so not to interfere with ongoing dataconnection work
+import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
+
+type ConnectionDropdownProps = {
+  onSelect: (connectionInfo: DataConnection) => void;
+  project?: string;
+  selectedConnection?: DataConnection;
+};
+export const ConnectionDropdown = ({
+  onSelect,
+  project,
+  selectedConnection,
+}: ConnectionDropdownProps): React.JSX.Element => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [connections, connectionsLoaded, connectionsLoadError] = useDataConnections(project);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const filteredConnections = connections.filter((c) => c.data.data?.AWS_S3_BUCKET);
+
+  const getToggleContent = () => {
+    if (!project) {
+      return 'Select a project to view its available data connections';
+    }
+    if (connectionsLoadError) {
+      return 'Error loading connections';
+    }
+    if (!connectionsLoaded) {
+      return (
+        <>
+          <Spinner size="sm" /> Loading Data Connections for the selected project...
+        </>
+      );
+    }
+    if (!filteredConnections.length) {
+      return 'No available data connections';
+    }
+    if (selectedConnection) {
+      return getDataConnectionDisplayName(selectedConnection);
+    }
+    return 'Select data connection';
+  };
+
+  const onSelectConnection = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    option?: string | number | null,
+  ) => {
+    setIsOpen(false);
+    if (typeof option === 'string') {
+      const value = connections.find((d) => d.data.metadata.name === option);
+      if (!value) {
+        return;
+      }
+      onSelect(value);
+    }
+  };
+  return (
+    <Dropdown
+      onOpenChange={(isOpened) => setIsOpen(isOpened)}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          isDisabled={!filteredConnections.length}
+          isFullWidth
+          data-testid="select-data-connection"
+          ref={toggleRef}
+          onClick={onToggle}
+          isExpanded={isOpen}
+        >
+          {getToggleContent()}
+        </MenuToggle>
+      )}
+      isOpen={isOpen}
+    >
+      <Menu onSelect={onSelectConnection} isScrollable isPlain>
+        <MenuContent>
+          <MenuList>
+            {filteredConnections.map((dataItem) => (
+              <MenuItem key={dataItem.data.metadata.name} itemId={dataItem.data.metadata.name}>
+                {getDataConnectionDisplayName(dataItem)}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    </Dropdown>
+  );
+};

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionModal.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
-import { Modal, Button, FormGroup, HelperText, Form } from '@patternfly/react-core';
+import { Modal, Button, FormGroup, HelperText, Form, FormHelperText } from '@patternfly/react-core';
 import ProjectSelector from '~/concepts/projects/ProjectSelector';
 import { DataConnection } from '~/pages/projects/types';
 import { ConnectionDropdown } from './ConnectionDropdown';
-
-export type ConnectionInfoType = {
-  name: string;
-  endpoint: string;
-  bucket: string;
-  region: string;
-  path: string;
-};
 
 export const ConnectionModal: React.FC<{
   isOpen: boolean;
@@ -26,7 +18,7 @@ export const ConnectionModal: React.FC<{
       data-testid="connection-autofill-modal"
       variant="medium"
       title="Autofill from data connection"
-      description="Select a project to list its [object storage]/[URI] data connections. Select a data connection to autofill the model location."
+      description="Select a project to list its object storage data connections. Select a data connection to autofill the model location."
       onClose={() => {
         setProject(undefined);
         setConnection(undefined);
@@ -68,9 +60,11 @@ export const ConnectionModal: React.FC<{
             selectedConnection={connection}
             project={project}
           />
-          <HelperText>
-            Data connection list includes only object storage types that contain a bucket.
-          </HelperText>
+          <FormHelperText>
+            <HelperText>
+              Data connection list includes only object storage types that contain a bucket.
+            </HelperText>
+          </FormHelperText>
         </FormGroup>
       </Form>
     </Modal>

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionModal.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Modal, Button, FormGroup, HelperText, Form } from '@patternfly/react-core';
+import ProjectSelector from '~/concepts/projects/ProjectSelector';
+import { DataConnection } from '~/pages/projects/types';
+import { ConnectionDropdown } from './ConnectionDropdown';
+
+export type ConnectionInfoType = {
+  name: string;
+  endpoint: string;
+  bucket: string;
+  region: string;
+  path: string;
+};
+
+export const ConnectionModal: React.FC<{
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (connection: DataConnection) => void;
+}> = ({ isOpen = false, onClose, onSubmit }) => {
+  const [project, setProject] = React.useState<string | undefined>(undefined);
+  const [connection, setConnection] = React.useState<DataConnection | undefined>(undefined);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      data-testid="connection-autofill-modal"
+      variant="medium"
+      title="Autofill from data connection"
+      description="Select a project to list its [object storage]/[URI] data connections. Select a data connection to autofill the model location."
+      onClose={() => {
+        setProject(undefined);
+        setConnection(undefined);
+        onClose();
+      }}
+      actions={[
+        <Button
+          isDisabled={!connection}
+          data-testid="autofill-modal-button"
+          key="confirm"
+          onClick={() => {
+            if (connection) {
+              onSubmit(connection);
+            }
+          }}
+        >
+          Autofill
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Form>
+        <FormGroup label="Project" isRequired fieldId="autofillProject">
+          <ProjectSelector
+            isFullWidth
+            onSelection={(projectName: string) => {
+              setProject(projectName);
+              setConnection(undefined);
+            }}
+            namespace={project || ''}
+            invalidDropdownPlaceholder="Select project"
+          />
+        </FormGroup>
+        <FormGroup label="Data connection name" isRequired fieldId="autofillConnection">
+          <ConnectionDropdown
+            onSelect={setConnection}
+            selectedConnection={connection}
+            project={project}
+          />
+          <HelperText>
+            Data connection list includes only object storage types that contain a bucket.
+          </HelperText>
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.scss
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.scss
@@ -1,0 +1,4 @@
+/* to help with getting the "Autofill" buttons to align properly */
+.pf-v5-c-radio__label {
+    width: 100%;
+}

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.scss
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.scss
@@ -1,4 +1,0 @@
-/* to help with getting the "Autofill" buttons to align properly */
-.pf-v5-c-radio__label {
-    width: 100%;
-}

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
@@ -13,6 +13,7 @@ import {
   InputGroupItem,
   InputGroupText,
   PageSection,
+  Panel,
   Radio,
   Split,
   SplitItem,
@@ -37,7 +38,6 @@ import {
   RegisterVersionFormData,
 } from './useRegisterModelData';
 import { registerModel } from './utils';
-import './RegisterModel.scss';
 import { ConnectionModal } from './ConnectionModal';
 
 const RegisterModel: React.FC = () => {
@@ -209,92 +209,105 @@ const RegisterModel: React.FC = () => {
                 title="Model location"
                 description="Specify the model location by providing either the object storage details or the URI."
               >
-                <Radio
-                  isChecked={modelLocationType === ModelLocationType.ObjectStorage}
-                  name="location-type-object-storage"
-                  onChange={() => {
-                    setData('modelLocationType', ModelLocationType.ObjectStorage);
-                  }}
-                  label={
-                    <Split>
-                      <SplitItem isFilled>Object storage</SplitItem>
-                      {modelLocationType === ModelLocationType.ObjectStorage && (
+                <Split>
+                  <SplitItem isFilled>
+                    <Radio
+                      isChecked={modelLocationType === ModelLocationType.ObjectStorage}
+                      name="location-type-object-storage"
+                      onChange={() => {
+                        setData('modelLocationType', ModelLocationType.ObjectStorage);
+                      }}
+                      label="Object storage"
+                      id="location-type-object-storage"
+                    />
+                  </SplitItem>
+                  {modelLocationType === ModelLocationType.ObjectStorage && (
+                    <SplitItem>
+                      <Button
+                        data-testid="object-storage-autofill-button"
+                        variant="link"
+                        isInline
+                        icon={<OptimizeIcon />}
+                        onClick={() => setAutofillModalOpen(true)}
+                      >
+                        Autofill from data connection
+                      </Button>
+                    </SplitItem>
+                  )}
+                </Split>
+                {modelLocationType === ModelLocationType.ObjectStorage && (
+                  <>
+                    <FormGroup
+                      className={spacing.mlLg}
+                      label="Endpoint"
+                      isRequired
+                      fieldId="location-endpoint"
+                    >
+                      <TextInput
+                        isRequired
+                        type="text"
+                        id="location-endpoint"
+                        name="location-endpoint"
+                        value={modelLocationEndpoint}
+                        onChange={(_e, value) => setData('modelLocationEndpoint', value)}
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      className={spacing.mlLg}
+                      label="Bucket"
+                      isRequired
+                      fieldId="location-bucket"
+                    >
+                      <TextInput
+                        isRequired
+                        type="text"
+                        id="location-bucket"
+                        name="location-bucket"
+                        value={modelLocationBucket}
+                        onChange={(_e, value) => setData('modelLocationBucket', value)}
+                      />
+                    </FormGroup>
+                    <FormGroup className={spacing.mlLg} label="Region" fieldId="location-region">
+                      <TextInput
+                        type="text"
+                        id="location-region"
+                        name="location-region"
+                        value={modelLocationRegion}
+                        onChange={(_e, value) => setData('modelLocationRegion', value)}
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      className={spacing.mlLg}
+                      label="Path"
+                      isRequired
+                      fieldId="location-path"
+                    >
+                      <Split hasGutter>
                         <SplitItem>
-                          <Button
-                            data-testid="object-storage-autofill-button"
-                            variant="link"
-                            isInline
-                            icon={<OptimizeIcon />}
-                            onClick={() => setAutofillModalOpen(true)}
-                          >
-                            Autofill from data connection
-                          </Button>
+                          <InputGroupText isPlain>/</InputGroupText>
                         </SplitItem>
-                      )}
-                    </Split>
-                  }
-                  id="location-type-object-storage"
-                  body={
-                    modelLocationType === ModelLocationType.ObjectStorage && (
-                      <Form>
-                        <FormGroup label="Endpoint" isRequired fieldId="location-endpoint">
-                          <TextInput
-                            isRequired
-                            type="text"
-                            id="location-endpoint"
-                            name="location-endpoint"
-                            value={modelLocationEndpoint}
-                            onChange={(_e, value) => setData('modelLocationEndpoint', value)}
-                          />
-                        </FormGroup>
-                        <FormGroup label="Bucket" isRequired fieldId="location-bucket">
-                          <TextInput
-                            isRequired
-                            type="text"
-                            id="location-bucket"
-                            name="location-bucket"
-                            value={modelLocationBucket}
-                            onChange={(_e, value) => setData('modelLocationBucket', value)}
-                          />
-                        </FormGroup>
-                        <FormGroup label="Region" fieldId="location-region">
-                          <TextInput
-                            type="text"
-                            id="location-region"
-                            name="location-region"
-                            value={modelLocationRegion}
-                            onChange={(_e, value) => setData('modelLocationRegion', value)}
-                          />
-                        </FormGroup>
-                        <FormGroup label="Path" isRequired fieldId="location-path">
-                          <Split hasGutter>
-                            <SplitItem>
-                              <InputGroupText isPlain>/</InputGroupText>
-                            </SplitItem>
-                            <SplitItem isFilled>
-                              <InputGroupItem>
-                                <TextInput
-                                  isRequired
-                                  type="text"
-                                  id="location-path"
-                                  name="location-path"
-                                  value={modelLocationPath}
-                                  onChange={(_e, value) => setData('modelLocationPath', value)}
-                                />
-                              </InputGroupItem>
-                            </SplitItem>
-                          </Split>
-                          <HelperText>
-                            <HelperTextItem>
-                              Enter a path to a model or folder. This path cannot point to a root
-                              folder.
-                            </HelperTextItem>
-                          </HelperText>
-                        </FormGroup>
-                      </Form>
-                    )
-                  }
-                />
+                        <SplitItem isFilled>
+                          <InputGroupItem>
+                            <TextInput
+                              isRequired
+                              type="text"
+                              id="location-path"
+                              name="location-path"
+                              value={modelLocationPath}
+                              onChange={(_e, value) => setData('modelLocationPath', value)}
+                            />
+                          </InputGroupItem>
+                        </SplitItem>
+                      </Split>
+                      <HelperText>
+                        <HelperTextItem>
+                          Enter a path to a model or folder. This path cannot point to a root
+                          folder.
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormGroup>
+                  </>
+                )}
                 <Radio
                   isChecked={modelLocationType === ModelLocationType.URI}
                   name="location-type-uri"

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisterModel.tsx
@@ -13,7 +13,6 @@ import {
   InputGroupItem,
   InputGroupText,
   PageSection,
-  Panel,
   Radio,
   Split,
   SplitItem,


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-9914

![image](https://github.com/user-attachments/assets/5f40e254-18a7-4a24-8aa7-ef7bb1927c9c)
![image](https://github.com/user-attachments/assets/f93adba6-ec53-4396-b102-d3b44235d831)
![image](https://github.com/user-attachments/assets/0dd18335-dabd-4bc4-9ce5-fa1511fe3131)
![image](https://github.com/user-attachments/assets/11a38f9d-e87d-4d60-a40d-e742afc52bd7)
![image](https://github.com/user-attachments/assets/02543fbc-3aee-454c-b14a-382ded6f9d4e)
![image](https://github.com/user-attachments/assets/dd3ce593-8576-4ae8-8078-09443267ad71)
![image](https://github.com/user-attachments/assets/d07c162d-f06b-48e0-a51a-16632ccc641f)


## Description
On the register modal page, there will be a new button to the right of Model Location / Object Storage (when selected) that says "Autofill from data connection".

Clicking that should bring up a modal with a project selector and a data connection selector. Selecting a project will populate the data connection selector with it's available data connections that contain a bucket.

Selecting a data connection and hitting the submit button will populate the Object Storage region/endpoint/bucket in the register model form.

## How Has This Been Tested?
Made sure that projects appear in project selector, and data connection is disabled with a note about selecting a project.
Upon selecting a project, data connection will either be populated or remain disabled with a note that the project does not contain any data connections.

Selected multiple data connections and made sure that the form populated with data from that data connection.

## Test Impact
Added tests to the register model to check that the button appears when it should, the modal appears when the button is clicked, the correct labeling/content appears in the dropdowns, and the fields get populated correctly.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
