### PR TITLE
add actions to create and edit section fields

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/ConnectionTypeFormFields.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/ConnectionTypeFormFields.tsx
@@ -17,9 +17,6 @@ type Props = {
 
 type FieldGroup = { section: SectionField | undefined; fields: ConnectionTypeDataField[] };
 
-const createKey = (field: ConnectionTypeField) =>
-  `${field.type}-${field.type === ConnectionTypeFieldType.Section ? field.name : field.envVar}`;
-
 const ConnectionTypeFormFields: React.FC<Props> = ({ fields, isPreview, onChange }) => {
   const fieldGroups = React.useMemo(
     () =>
@@ -37,9 +34,9 @@ const ConnectionTypeFormFields: React.FC<Props> = ({ fields, isPreview, onChange
   );
 
   const renderDataFields = (dataFields: ConnectionTypeDataField[]) =>
-    dataFields.map((field) => (
+    dataFields.map((field, i) => (
       <ConnectionTypeDataFormField
-        key={createKey(field)}
+        key={i}
         field={field}
         isPreview={isPreview}
         onChange={onChange}
@@ -48,9 +45,9 @@ const ConnectionTypeFormFields: React.FC<Props> = ({ fields, isPreview, onChange
 
   return (
     <>
-      {fieldGroups?.map((fieldGroup) =>
+      {fieldGroups?.map((fieldGroup, i) =>
         fieldGroup.section ? (
-          <SectionFormField field={fieldGroup.section} key={createKey(fieldGroup.section)}>
+          <SectionFormField field={fieldGroup.section} key={i}>
             {renderDataFields(fieldGroup.fields)}
           </SectionFormField>
         ) : (

--- a/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
+++ b/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
@@ -56,7 +56,13 @@ const DashboardModalFooter: React.FC<DashboardModalFooterProps> = ({
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button key="cancel" variant="link" isDisabled={isCancelDisabled} onClick={onCancel}>
+          <Button
+            key="cancel"
+            variant="link"
+            isDisabled={isCancelDisabled}
+            onClick={onCancel}
+            data-testid="modal-cancel-button"
+          >
             Cancel
           </Button>
         </ActionListItem>

--- a/frontend/src/pages/connectionTypes/create/ConnectionTypeFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/create/ConnectionTypeFieldModal.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import {
+  ConnectionTypeField,
+  ConnectionTypeFieldType,
+  SectionField,
+} from '~/concepts/connectionTypes/types';
+import ConnectionTypeSectionModal from '~/pages/connectionTypes/create/ConnectionTypeSectionModal';
+
+type Props = {
+  field?: ConnectionTypeField;
+  isOpen?: boolean;
+  onClose: () => void;
+  onSubmit: (field: SectionField) => void;
+  isEdit?: boolean;
+};
+
+const ConnectionTypeFieldModal: React.FC<Props> = (props) => {
+  if (props.field?.type === ConnectionTypeFieldType.Section) {
+    return <ConnectionTypeSectionModal {...props} field={props.field} />;
+  }
+  // TODO open data field modal
+  return null;
+};
+
+export default ConnectionTypeFieldModal;

--- a/frontend/src/pages/connectionTypes/create/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/create/ConnectionTypeSectionModal.tsx
@@ -1,0 +1,99 @@
+import { Form, FormGroup, Modal, TextInput, TextArea, Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { SectionField } from '~/concepts/connectionTypes/types';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+
+type Props = {
+  field?: SectionField;
+  isOpen?: boolean;
+  onClose: () => void;
+  onSubmit: (field: SectionField) => void;
+  isEdit?: boolean;
+};
+
+const ConnectionTypeSectionModal: React.FC<Props> = ({
+  field,
+  isOpen,
+  onClose,
+  onSubmit,
+  isEdit,
+}) => {
+  const [name, setName] = React.useState(field?.name || '');
+  const [description, setDescription] = React.useState(field?.description || '');
+
+  const isValid = name.length > 0;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={isEdit ? 'Edit section heading' : 'Add section heading'}
+      onClose={onClose}
+      variant="medium"
+      footer={
+        <DashboardModalFooter
+          submitLabel={isEdit ? 'Edit' : 'Add'}
+          onCancel={onClose}
+          onSubmit={() => {
+            onSubmit({ type: 'section', name, description });
+            onClose();
+          }}
+          isSubmitDisabled={!isValid}
+          alertTitle=""
+        />
+      }
+    >
+      <Form>
+        <FormGroup
+          label="Section heading"
+          isRequired
+          fieldId="section-name"
+          labelIcon={
+            <Popover
+              headerContent="Section heading"
+              bodyContent="Use section headings to indicate groups of related fields. Use descriptive headings, for example, Details, Configuration, Preferences."
+            >
+              <DashboardPopupIconButton
+                icon={<OutlinedQuestionCircleIcon />}
+                aria-label="More info for section heading"
+              />
+            </Popover>
+          }
+        >
+          <TextInput
+            isRequired
+            id="section-name"
+            data-testid="section-name"
+            value={name}
+            onChange={(_e, value) => setName(value)}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Section description"
+          fieldId="section-description"
+          labelIcon={
+            <Popover
+              headerContent="Section description"
+              bodyContent="Use section descriptions to summarize the required input."
+            >
+              <DashboardPopupIconButton
+                icon={<OutlinedQuestionCircleIcon />}
+                aria-label="More info for section description"
+              />
+            </Popover>
+          }
+        >
+          <TextArea
+            id="section-description"
+            data-testid="section-description"
+            value={description}
+            onChange={(_e, value) => setDescription(value)}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default ConnectionTypeSectionModal;

--- a/frontend/src/pages/connectionTypes/create/CreateConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/create/CreateConnectionTypeFieldsTable.tsx
@@ -1,36 +1,63 @@
 import React from 'react';
 import {
+  ActionList,
+  ActionListItem,
   Bullseye,
+  Button,
   EmptyState,
+  EmptyStateActions,
   EmptyStateBody,
+  EmptyStateFooter,
   EmptyStateHeader,
   EmptyStateIcon,
   EmptyStateVariant,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tbody, Tr, Th } from '@patternfly/react-table';
-import { ConnectionTypeField } from '~/concepts/connectionTypes/types';
+import ConnectionTypeFieldModal from '~/pages/connectionTypes/create/ConnectionTypeFieldModal';
+import { ConnectionTypeField, ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
 import { CreateConnectionTypeFieldsTableRow } from './CreateConnectionTypeFieldsTableRow';
 
-const EmptyFieldsTable: React.FC = () => (
+type EmptyFieldsTableProps = {
+  onAddSection: () => void;
+  onAddField: () => void;
+};
+
+const EmptyFieldsTable: React.FC<EmptyFieldsTableProps> = ({ onAddSection, onAddField }) => (
   <Bullseye>
-    <EmptyState variant={EmptyStateVariant.sm}>
+    <EmptyState variant={EmptyStateVariant.lg}>
       <EmptyStateHeader icon={<EmptyStateIcon icon={PlusCircleIcon} />} titleText="No fields" />
       <EmptyStateBody>
         Add fields to prompt users to input information, and optionally assign default values to
         those fields. Connection name and description fields are included by default.
       </EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button variant="secondary" onClick={onAddSection}>
+            Add section heading
+          </Button>
+          <Button variant="secondary" onClick={onAddField}>
+            Add field
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
     </EmptyState>
   </Bullseye>
 );
 
 type CreateConnectionTypeFieldsTableProps = {
   fields: ConnectionTypeField[];
+  onFieldsChange: (fields: ConnectionTypeField[]) => void;
 };
 
 export const CreateConnectionTypeFieldsTable: React.FC<CreateConnectionTypeFieldsTableProps> = ({
   fields,
+  onFieldsChange,
 }) => {
+  const [modalField, setModalField] = React.useState<
+    { field?: ConnectionTypeField; index?: number; isEdit?: boolean } | undefined
+  >();
+
   const columns = [
     'Section heading/field name',
     'Type',
@@ -43,23 +70,107 @@ export const CreateConnectionTypeFieldsTable: React.FC<CreateConnectionTypeField
   return (
     <>
       {fields.length > 0 ? (
-        <Table data-testid="connection-type-fields-table">
-          <Thead>
-            <Tr>
-              {columns.map((column, columnIndex) => (
-                <Th key={columnIndex}>{column}</Th>
+        <>
+          <Table data-testid="connection-type-fields-table">
+            <Thead>
+              <Tr>
+                {columns.map((column, columnIndex) => (
+                  <Th key={columnIndex}>{column}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {fields.map((row, index) => (
+                <CreateConnectionTypeFieldsTableRow
+                  key={index}
+                  row={row}
+                  columns={columns}
+                  onEdit={() => {
+                    setModalField({
+                      field: row,
+                      isEdit: true,
+                    });
+                  }}
+                  onDelete={() => onFieldsChange(fields.filter((f) => f !== row))}
+                  onDuplicate={(field) => {
+                    setModalField({
+                      field: structuredClone(field),
+                    });
+                  }}
+                  onAddField={() => {
+                    const nextSectionIndex = fields.findIndex(
+                      (f) => f.type === ConnectionTypeFieldType.Section,
+                      index + 1,
+                    );
+                    if (nextSectionIndex >= 0) {
+                      setModalField({ index: nextSectionIndex });
+                    } else {
+                      setModalField({});
+                    }
+                  }}
+                  onChange={(updatedField) => {
+                    onFieldsChange([
+                      ...fields.slice(0, index),
+                      updatedField,
+                      ...fields.slice(index + 1),
+                    ]);
+                  }}
+                />
               ))}
-            </Tr>
-          </Thead>
-          <Tbody>
-            {fields.map((row, index) => (
-              <CreateConnectionTypeFieldsTableRow key={index} row={row} columns={columns} />
-            ))}
-          </Tbody>
-        </Table>
+            </Tbody>
+          </Table>
+          <ActionList className="pf-v5-u-mt-md">
+            <ActionListItem>
+              <Button
+                variant="secondary"
+                onClick={() =>
+                  setModalField({ field: { type: ConnectionTypeFieldType.Section, name: '' } })
+                }
+              >
+                Add section heading
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button variant="secondary" onClick={() => setModalField({})}>
+                Add field
+              </Button>
+            </ActionListItem>
+          </ActionList>
+        </>
       ) : (
-        <EmptyFieldsTable />
+        <EmptyFieldsTable
+          onAddSection={() =>
+            setModalField({ field: { type: ConnectionTypeFieldType.Section, name: '' } })
+          }
+          onAddField={() => setModalField({})}
+        />
       )}
+      {modalField ? (
+        <ConnectionTypeFieldModal
+          field={modalField.field}
+          isEdit={modalField.isEdit}
+          onClose={() => setModalField(undefined)}
+          isOpen
+          onSubmit={(field) => {
+            const i = modalField.field ? fields.indexOf(modalField.field) : -1;
+            if (i >= 0) {
+              // update
+              onFieldsChange([...fields.slice(0, i), field, ...fields.slice(i + 1)]);
+            } else if (modalField.index != null) {
+              // insert
+              onFieldsChange([
+                ...fields.slice(0, modalField.index),
+                field,
+                ...fields.slice(modalField.index),
+              ]);
+            } else {
+              // add
+              onFieldsChange([...fields, field]);
+            }
+            setModalField(undefined);
+          }}
+        />
+      ) : undefined}
     </>
   );
 };

--- a/frontend/src/pages/connectionTypes/create/CreateConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/create/CreateConnectionTypeFieldsTableRow.tsx
@@ -1,17 +1,32 @@
 import * as React from 'react';
-import { Td, Tr } from '@patternfly/react-table';
-import { Label, Switch, Text, TextContent, Truncate } from '@patternfly/react-core';
-import { ConnectionTypeField, ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { Button, Label, Switch, Text, TextContent, Truncate } from '@patternfly/react-core';
+import {
+  ConnectionTypeField,
+  ConnectionTypeFieldType,
+  SectionField,
+} from '~/concepts/connectionTypes/types';
 import { defaultValueToString, fieldTypeToString } from '~/concepts/connectionTypes/utils';
 
-type CreateConnectionTypeFieldsTableRowProps = {
+type Props = {
   row: ConnectionTypeField;
   columns: string[];
+  onEdit: () => void;
+  onDelete: () => void;
+  onDuplicate: (field: ConnectionTypeField) => void;
+  onAddField: (parentSection: SectionField) => void;
+  onChange: (updatedField: ConnectionTypeField) => void;
 };
 
-export const CreateConnectionTypeFieldsTableRow: React.FC<
-  CreateConnectionTypeFieldsTableRowProps
-> = ({ row, columns }) => {
+export const CreateConnectionTypeFieldsTableRow: React.FC<Props> = ({
+  row,
+  columns,
+  onEdit,
+  onDelete,
+  onDuplicate,
+  onAddField,
+  onChange,
+}) => {
   if (row.type === ConnectionTypeFieldType.Section) {
     return (
       <Tr id={row.name} isStriped data-testid="row">
@@ -24,11 +39,31 @@ export const CreateConnectionTypeFieldsTableRow: React.FC<
             <Text className="pf-v5-u-color-200">{row.description}</Text>
           </TextContent>
         </Td>
+        <Td isActionCell modifier="nowrap">
+          <Button variant="secondary" onClick={() => onAddField(row)}>
+            Add field
+          </Button>
+          <ActionsColumn
+            items={[
+              {
+                title: 'Edit',
+                onClick: () => onEdit(),
+              },
+              {
+                title: 'Duplicate',
+                onClick: () => onDuplicate({ ...row, name: `Duplicate of ${row.name}` }),
+              },
+              {
+                title: 'Delete',
+                onClick: () => onDelete(),
+              },
+            ]}
+          />
+        </Td>
       </Tr>
     );
   }
 
-  // TODO: support row.required toggle
   return (
     <Tr id={row.name} data-testid="row">
       <Td dataLabel={columns[0]} data-testid="field-name">
@@ -50,10 +85,28 @@ export const CreateConnectionTypeFieldsTableRow: React.FC<
       </Td>
       <Td dataLabel={columns[4]}>
         <Switch
-          aria-label="switch"
+          aria-label="toggle field required"
           isChecked={row.required}
-          isDisabled
           data-testid="field-required"
+          onChange={() => onChange({ ...row, required: !row.required })}
+        />
+      </Td>
+      <Td isActionCell>
+        <ActionsColumn
+          items={[
+            {
+              title: 'Edit',
+              onClick: () => onEdit(),
+            },
+            {
+              title: 'Duplicate',
+              onClick: () => onDuplicate(row),
+            },
+            {
+              title: 'Delete',
+              onClick: () => onDelete(),
+            },
+          ]}
         />
       </Td>
     </Tr>

--- a/frontend/src/pages/connectionTypes/create/CreateConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/create/CreateConnectionTypePage.tsx
@@ -49,7 +49,8 @@ export const CreateConnectionTypePage: React.FC<CreateConnectionTypePageProps> =
     description: prefillDescription,
   });
   const [connectionEnabled, setConnectionEnabled] = React.useState<boolean>(prefillEnabled);
-  const [connectionFields] = React.useState<ConnectionTypeField[]>(prefillFields);
+  const [connectionFields, setConnectionFields] =
+    React.useState<ConnectionTypeField[]>(prefillFields);
 
   const previewConnectionTypeObj = React.useMemo(
     () =>
@@ -143,7 +144,10 @@ export const CreateConnectionTypePage: React.FC<CreateConnectionTypePageProps> =
               Add fields to prompt users to input information, and optionally assign default values
               to those fields.
               <FormGroup>
-                <CreateConnectionTypeFieldsTable fields={connectionFields} />
+                <CreateConnectionTypeFieldsTable
+                  fields={connectionFields}
+                  onFieldsChange={(fields) => setConnectionFields(fields)}
+                />
               </FormGroup>
             </FormSection>
           </Form>

--- a/frontend/src/pages/connectionTypes/create/__tests__/ConnectionTypeSectionModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/create/__tests__/ConnectionTypeSectionModal.spec.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import ConnectionTypeSectionModal from '~/pages/connectionTypes/create/ConnectionTypeSectionModal';
+import { ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
+
+describe('ConnectionTypeSectionModal', () => {
+  it('should disable submit until valid', () => {
+    const closeFn = jest.fn();
+    const submitFn = jest.fn();
+    const result = render(
+      <ConnectionTypeSectionModal isOpen onClose={closeFn} onSubmit={submitFn} />,
+    );
+
+    const nameInput = result.getByTestId('section-name');
+    const descriptionInput = result.getByTestId('section-description');
+    const submitButton = result.getByTestId('modal-submit-button');
+    const cancelButton = result.getByTestId('modal-cancel-button');
+
+    expect(nameInput).toHaveValue('');
+    expect(descriptionInput).toHaveValue('');
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(nameInput, { target: { value: 'test' } });
+
+    expect(submitButton).not.toBeDisabled();
+
+    fireEvent.click(cancelButton);
+
+    expect(submitFn).not.toHaveBeenCalled();
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it('should submit new field', () => {
+    const closeFn = jest.fn();
+    const submitFn = jest.fn();
+    const result = render(
+      <ConnectionTypeSectionModal
+        isOpen
+        onClose={closeFn}
+        onSubmit={submitFn}
+        field={{
+          type: ConnectionTypeFieldType.Section,
+          name: 'test name',
+          description: 'test desc',
+        }}
+      />,
+    );
+
+    const nameInput = result.getByTestId('section-name');
+    const descriptionInput = result.getByTestId('section-description');
+    const submitButton = result.getByTestId('modal-submit-button');
+
+    expect(nameInput).toHaveValue('test name');
+    expect(descriptionInput).toHaveValue('test desc');
+
+    fireEvent.change(nameInput, { target: { value: 'renamed' } });
+    fireEvent.change(descriptionInput, { target: { value: 'updated' } });
+    fireEvent.click(submitButton);
+
+    expect(submitFn).toHaveBeenCalledWith({
+      type: ConnectionTypeFieldType.Section,
+      name: 'renamed',
+      description: 'updated',
+    });
+    expect(closeFn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-10317

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
cc @simrandhaliw 

Adds the ability to create, edit and delete field sections.
Tests will be added. This PR provides some plumbing for integrating the add field modal as well.

Creation modal:
![image](https://github.com/user-attachments/assets/e10a7647-c8dd-4a25-940d-a1835109ba5f)

Editing modal:
![image](https://github.com/user-attachments/assets/48d06731-3bc8-41d2-ac07-1d0f6ee96358)

Popovers:
![image](https://github.com/user-attachments/assets/de1dcc95-3ddc-4f74-a2c2-2635a2100619)
![image](https://github.com/user-attachments/assets/e2cf87a6-2f10-431e-9639-660d8e30b7db)

Empty field state:
![image](https://github.com/user-attachments/assets/b5faaa69-c95e-4eea-81ef-af76d52157d0)

Section row with actions:
![image](https://github.com/user-attachments/assets/2b891cf7-a49d-46b9-8891-852935302ee4)

Buttons beneath fields table:
![image](https://github.com/user-attachments/assets/420f9493-5f67-4d89-ad0c-c65c16508fb8)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Construct a connection type:
<details>
<summary>ConfigMap</summary>
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: test-ct
  namespace: opendatahub
  labels:
    opendatahub.io/connection-type: 'true'
    opendatahub.io/dashboard: 'true'
  annotations:
    opendatahub.io/enabled: 'true'
    opendatahub.io/username: test
    openshift.io/description: this is the description
    openshift.io/display-name: test connection type
```

</details>

Go to `/connectionTypes/duplicate/test-ct`.
Try all actions related to section headings. Delete, edit, add...

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a unit test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
