### PR TITLE
Fix error in loading Enabled applications after uninstalling an ISV

### DIFF
--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -12,6 +12,7 @@ import {
   getInstalledKfdefs,
   getSubscriptions,
 } from './resourceUtils';
+import { isHttpError } from '../utils';
 
 type RoutesResponse = {
   body: {
@@ -205,10 +206,11 @@ const getCSVForApp = (
       return undefined;
     })
     .catch((e) => {
-      if (e?.statusCode === 404) {
+      if (isHttpError(e) && e.statusCode === 404) {
         fastify.log.error(e);
+        return undefined;
       }
-      return undefined;
+      throw e;
     });
 };
 

--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -203,6 +203,12 @@ const getCSVForApp = (
         return csv;
       }
       return undefined;
+    })
+    .catch((e) => {
+      if (e?.statusCode === 404) {
+        fastify.log.error(e);
+      }
+      return undefined;
     });
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-1135

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a catch block to `fastify.kube.customObjectsApi.getNamespacedCustomObject`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Install an ISV operator(e.g. Elastic(ECK) operator/NVIDIA GPU(Certified) operator).
2. If the corresponding `OdhApplication` isn't present, create the corresponding `OdhApplication` using https://github.com/opendatahub-io/odh-dashboard/blob/main/manifests/rhoai/addon/apps/starburst/starburst-app.yaml with `enabled: true` inside `spec`
3. Go to Dashboard > Enabled and wait for the card to appear.
4. Uninstall the operator and head back to the Enabled page
5. You should not see an `HTTP request failed` page.
6. For the Elastic tile.. when you have the operator installed you shouldn't see `Disabled` in the tile and vice-versa. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
