### PR TITLE
changed the source of Owner and updated field to be searchable and so…

### DIFF
--- a/frontend/src/__mocks__/mockRegisteredModel.ts
+++ b/frontend/src/__mocks__/mockRegisteredModel.ts
@@ -4,6 +4,8 @@ import { createModelRegistryLabelsObject } from './utils';
 type MockRegisteredModelType = {
   id?: string;
   name?: string;
+  author?: string;
+  owner?: string;
   state?: ModelState;
   description?: string;
   labels?: string[];
@@ -11,6 +13,8 @@ type MockRegisteredModelType = {
 
 export const mockRegisteredModel = ({
   name = 'test',
+  author = 'Author 1',
+  owner = 'Author 1',
   state = ModelState.LIVE,
   description = '',
   labels = [],
@@ -23,5 +27,7 @@ export const mockRegisteredModel = ({
   lastUpdateTimeSinceEpoch: '1710404288975',
   name,
   state,
+  author,
+  owner,
   customProperties: createModelRegistryLabelsObject(labels),
 });

--- a/frontend/src/__mocks__/mockRegisteredModel.ts
+++ b/frontend/src/__mocks__/mockRegisteredModel.ts
@@ -4,7 +4,6 @@ import { createModelRegistryLabelsObject } from './utils';
 type MockRegisteredModelType = {
   id?: string;
   name?: string;
-  author?: string;
   owner?: string;
   state?: ModelState;
   description?: string;
@@ -13,7 +12,6 @@ type MockRegisteredModelType = {
 
 export const mockRegisteredModel = ({
   name = 'test',
-  author = 'Author 1',
   owner = 'Author 1',
   state = ModelState.LIVE,
   description = '',
@@ -27,7 +25,6 @@ export const mockRegisteredModel = ({
   lastUpdateTimeSinceEpoch: '1710404288975',
   name,
   state,
-  author,
   owner,
   customProperties: createModelRegistryLabelsObject(labels),
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -30,8 +30,8 @@ class ModelRegistryTableRow extends TableRow {
     return this.find().findByTestId('description');
   }
 
-  findAuthor() {
-    return this.find().findByTestId('registered-model-author');
+  findOwner() {
+    return this.find().findByTestId('registered-model-owner');
   }
 
   findLabelPopoverText() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -66,7 +66,10 @@ const initIntercepts = ({
       ],
     }),
   ],
-  modelVersions = [mockModelVersion({ name: 'model version' })],
+  modelVersions = [
+    mockModelVersion({ author: 'Author 1' }),
+    mockModelVersion({ name: 'model version' }),
+  ],
   allowed = true,
 }: HandlersProps) => {
   cy.interceptOdh(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -178,7 +178,14 @@ describe('Model Registry core', () => {
         .contains(
           'A machine learning model trained to detect fraudulent transactions in financial data',
         );
+<<<<<<< HEAD
       registeredModelRow.findAuthor().contains('Author 1');
+=======
+      registeredModelRow.findOwner().should(($owner) => {
+        const text = $owner.text();
+        expect(text).to.be.oneOf(['Author 1', '-']);
+      });
+>>>>>>> 8ca179e7 (fixed lint and test)
 
       // Label popover
       registeredModelRow.findLabelPopoverText().contains('2 more');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -178,21 +178,7 @@ describe('Model Registry core', () => {
         .contains(
           'A machine learning model trained to detect fraudulent transactions in financial data',
         );
-<<<<<<< HEAD
-<<<<<<< HEAD
-      registeredModelRow.findAuthor().contains('Author 1');
-=======
-=======
       registeredModelRow.findOwner().contains('Author 1');
-<<<<<<< HEAD
->>>>>>> f9da61fb (updated tests)
-      registeredModelRow.findOwner().should(($owner) => {
-        const text = $owner.text();
-        expect(text).to.be.oneOf(['Author 1', '-']);
-      });
->>>>>>> 8ca179e7 (fixed lint and test)
-=======
->>>>>>> 05749f70 (removed assertion)
 
       // Label popover
       registeredModelRow.findLabelPopoverText().contains('2 more');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -181,12 +181,15 @@ describe('Model Registry core', () => {
 =======
 =======
       registeredModelRow.findOwner().contains('Author 1');
+<<<<<<< HEAD
 >>>>>>> f9da61fb (updated tests)
       registeredModelRow.findOwner().should(($owner) => {
         const text = $owner.text();
         expect(text).to.be.oneOf(['Author 1', '-']);
       });
 >>>>>>> 8ca179e7 (fixed lint and test)
+=======
+>>>>>>> 05749f70 (removed assertion)
 
       // Label popover
       registeredModelRow.findLabelPopoverText().contains('2 more');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -66,10 +66,7 @@ const initIntercepts = ({
       ],
     }),
   ],
-  modelVersions = [
-    mockModelVersion({ author: 'Author 1' }),
-    mockModelVersion({ name: 'model version' }),
-  ],
+  modelVersions = [mockModelVersion({ name: 'model version' })],
   allowed = true,
 }: HandlersProps) => {
   cy.interceptOdh(
@@ -179,8 +176,12 @@ describe('Model Registry core', () => {
           'A machine learning model trained to detect fraudulent transactions in financial data',
         );
 <<<<<<< HEAD
+<<<<<<< HEAD
       registeredModelRow.findAuthor().contains('Author 1');
 =======
+=======
+      registeredModelRow.findOwner().contains('Author 1');
+>>>>>>> f9da61fb (updated tests)
       registeredModelRow.findOwner().should(($owner) => {
         const text = $owner.text();
         expect(text).to.be.oneOf(['Author 1', '-']);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
@@ -171,6 +171,7 @@ describe('Restoring archive model', () => {
         description: '',
         externalID: '1234132asdfasdf',
         state: 'LIVE',
+        owner: 'Author 1',
       });
     });
   });
@@ -200,6 +201,7 @@ describe('Restoring archive model', () => {
         description: '',
         externalID: '1234132asdfasdf',
         state: 'LIVE',
+        owner: 'Author 1',
       });
     });
   });
@@ -233,6 +235,7 @@ describe('Archiving model', () => {
         description: '',
         externalID: '1234132asdfasdf',
         state: 'ARCHIVED',
+        owner: 'Author 1',
       });
     });
   });
@@ -266,6 +269,7 @@ describe('Archiving model', () => {
         description: '',
         externalID: '1234132asdfasdf',
         state: 'ARCHIVED',
+        owner: 'Author 1',
       });
     });
   });

--- a/frontend/src/concepts/dashboard/DashboardSearchField.tsx
+++ b/frontend/src/concepts/dashboard/DashboardSearchField.tsx
@@ -19,6 +19,7 @@ export enum SearchType {
   IDENTIFIER = 'Identifier',
   KEYWORD = 'Keyword',
   AUTHOR = 'Author',
+  OWNER = 'Owner',
 }
 
 type DashboardSearchFieldProps = {

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -85,8 +85,6 @@ export type ModelRegistryBase = {
   id: string;
   name: string;
   externalID?: string;
-  author?: string;
-  owner?: string;
   description?: string;
   createTimeSinceEpoch?: string;
   lastUpdateTimeSinceEpoch: string;
@@ -96,6 +94,7 @@ export type ModelRegistryBase = {
 export type ModelArtifact = ModelRegistryBase & {
   uri?: string;
   state?: ModelArtifactState;
+  author?: string;
   modelFormatName?: string;
   storageKey?: string;
   storagePath?: string;
@@ -106,11 +105,13 @@ export type ModelArtifact = ModelRegistryBase & {
 
 export type ModelVersion = ModelRegistryBase & {
   state?: ModelState;
+  author?: string;
   registeredModelId: string;
 };
 
 export type RegisteredModel = ModelRegistryBase & {
   state?: ModelState;
+  owner?: string;
 };
 
 export type InferenceService = ModelRegistryBase & {

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -85,6 +85,8 @@ export type ModelRegistryBase = {
   id: string;
   name: string;
   externalID?: string;
+  author?: string;
+  owner?: string;
   description?: string;
   createTimeSinceEpoch?: string;
   lastUpdateTimeSinceEpoch: string;
@@ -94,7 +96,6 @@ export type ModelRegistryBase = {
 export type ModelArtifact = ModelRegistryBase & {
   uri?: string;
   state?: ModelArtifactState;
-  author?: string;
   modelFormatName?: string;
   storageKey?: string;
   storagePath?: string;
@@ -105,7 +106,6 @@ export type ModelArtifact = ModelRegistryBase & {
 
 export type ModelVersion = ModelRegistryBase & {
   state?: ModelState;
-  author?: string;
   registeredModelId: string;
 };
 

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelDetailsView.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { ClipboardCopy, DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
+import { ClipboardCopy, DescriptionList, Flex, FlexItem, Text } from '@patternfly/react-core';
 import { RegisteredModel } from '~/concepts/modelRegistry/types';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
 import EditableLabelsDescriptionListGroup from '~/components/EditableLabelsDescriptionListGroup';
-import RegisteredModelAuthor from '~/pages/modelRegistry/screens/RegisteredModels/RegisteredModelAuthor';
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
 import {
   getLabels,
@@ -82,8 +81,8 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm
               {rm.id}
             </ClipboardCopy>
           </DashboardDescriptionListGroup>
-          <DashboardDescriptionListGroup title="Author">
-            <RegisteredModelAuthor registeredModelId={rm.id} />
+          <DashboardDescriptionListGroup title="Owner">
+            <Text data-testid="registered-model-owner">{rm.author || '-'}</Text>
           </DashboardDescriptionListGroup>
           <DashboardDescriptionListGroup
             title="Last modified at"

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelDetailsView.tsx
@@ -82,7 +82,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm
             </ClipboardCopy>
           </DashboardDescriptionListGroup>
           <DashboardDescriptionListGroup title="Owner">
-            <Text data-testid="registered-model-owner">{rm.author || '-'}</Text>
+            <Text data-testid="registered-model-owner">{rm.owner || '-'}</Text>
           </DashboardDescriptionListGroup>
           <DashboardDescriptionListGroup
             title="Last modified at"

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -33,7 +33,7 @@ export const registerModel = async (
       name: formData.modelName,
       description: formData.modelDescription,
       customProperties: {},
-      author,
+      owner: author,
       state: ModelState.LIVE,
     },
   );

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/utils.ts
@@ -33,6 +33,7 @@ export const registerModel = async (
       name: formData.modelName,
       description: formData.modelDescription,
       customProperties: {},
+      author,
       state: ModelState.LIVE,
     },
   );

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -30,7 +30,7 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.KEYWORD);
   const [search, setSearch] = React.useState('');
 
-  const searchTypes = React.useMemo(() => [SearchType.KEYWORD], []); // TODO Add owner once RHOAIENG-7566 is completed.
+  const searchTypes = React.useMemo(() => [SearchType.KEYWORD, SearchType.OWNER], []);
 
   if (unfilteredRegisteredModels.length === 0) {
     return (

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -14,10 +14,6 @@ import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegi
 import { ArchiveRegisteredModelModal } from '~/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
 import { getPatchBodyForRegisteredModel } from '~/pages/modelRegistry/screens/utils';
 import { RestoreRegisteredModelModal } from '~/pages/modelRegistry/screens/components/RestoreRegisteredModel';
-<<<<<<< HEAD
-import RegisteredModelAuthor from './RegisteredModelAuthor';
-=======
->>>>>>> b0f9e160 (changed the source of Owner and updated field to be searchable and sortable)
 
 type RegisteredModelTableRowProps = {
   registeredModel: RegisteredModel;
@@ -79,13 +75,8 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
       <Td dataLabel="Last modified">
         <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
       </Td>
-<<<<<<< HEAD
-      <Td dataLabel="Author">
-        <RegisteredModelAuthor registeredModelId={rm.id} />
-=======
       <Td dataLabel="Owner">
         <Text data-testid="registered-model-owner">{rm.owner || '-'}</Text>
->>>>>>> b0f9e160 (changed the source of Owner and updated field to be searchable and sortable)
       </Td>
       <Td isActionCell>
         <ActionsColumn items={actions} />

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -14,7 +14,10 @@ import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegi
 import { ArchiveRegisteredModelModal } from '~/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
 import { getPatchBodyForRegisteredModel } from '~/pages/modelRegistry/screens/utils';
 import { RestoreRegisteredModelModal } from '~/pages/modelRegistry/screens/components/RestoreRegisteredModel';
+<<<<<<< HEAD
 import RegisteredModelAuthor from './RegisteredModelAuthor';
+=======
+>>>>>>> b0f9e160 (changed the source of Owner and updated field to be searchable and sortable)
 
 type RegisteredModelTableRowProps = {
   registeredModel: RegisteredModel;
@@ -76,8 +79,13 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
       <Td dataLabel="Last modified">
         <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
       </Td>
+<<<<<<< HEAD
       <Td dataLabel="Author">
         <RegisteredModelAuthor registeredModelId={rm.id} />
+=======
+      <Td dataLabel="Owner">
+        <Text data-testid="registered-model-owner">{rm.owner || '-'}</Text>
+>>>>>>> b0f9e160 (changed the source of Owner and updated field to be searchable and sortable)
       </Td>
       <Td isActionCell>
         <ActionsColumn items={actions} />

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableColumns.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableColumns.ts
@@ -24,9 +24,9 @@ export const rmColumns: SortableData<RegisteredModel>[] = [
     },
   },
   {
-    field: 'author',
-    label: 'Author',
-    sortable: false, // TODO Add sortable once RHOAIENG-7566 is completed.
+    field: 'owner',
+    label: 'Owner',
+    sortable: true,
     info: {
       tooltip: 'The owner is the user who registered the model.',
       tooltipProps: {

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -270,6 +270,8 @@ describe('getPatchBody', () => {
   it('returns a given RegisteredModel with id/name/timestamps removed, customProperties updated and other values unchanged', () => {
     const registeredModel = mockRegisteredModel({
       id: '1',
+      author: 'Author 1',
+      owner: 'Author 1',
       name: 'test-model',
       description: 'Description here',
       labels: [],
@@ -286,9 +288,11 @@ describe('getPatchBody', () => {
     );
     expect(result).toEqual({
       description: 'Description here',
+      author: 'Author 1',
       customProperties: {
         label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
       },
+      owner: 'Author 1',
       state: ModelState.LIVE,
       externalID: '1234132asdfasdf',
     } satisfies Partial<RegisteredModel>);

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -270,7 +270,6 @@ describe('getPatchBody', () => {
   it('returns a given RegisteredModel with id/name/timestamps removed, customProperties updated and other values unchanged', () => {
     const registeredModel = mockRegisteredModel({
       id: '1',
-      author: 'Author 1',
       owner: 'Author 1',
       name: 'test-model',
       description: 'Description here',
@@ -288,7 +287,6 @@ describe('getPatchBody', () => {
     );
     expect(result).toEqual({
       description: 'Description here',
-      author: 'Author 1',
       customProperties: {
         label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
       },

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -154,9 +154,8 @@ export const filterRegisteredModels = (
           (rm.description && rm.description.toLowerCase().includes(search.toLowerCase()))
         );
 
-      case SearchType.AUTHOR:
-        // TODO Implement owner search functionality once RHOAIENG-7566 is completed.
-        return;
+      case SearchType.OWNER:
+        return rm.owner && rm.owner.toLowerCase().includes(search.toLowerCase());
 
       default:
         return true;


### PR DESCRIPTION
…rtable

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->


https://issues.redhat.com/browse/RHOAIENG-7566
## Description
Update the source of the Owner - now it's just a field that we get from the API response. I've attached the screenshot that shows where this field on the page now is coming from. 
In addition I've made the owner a sortable field as well as a Search option. See screenshots attached.

## How Has This Been Tested?
Tested on the Model Registry Cluster

## Test Impact
Updated the tests to cover now both field options scenarios( with Author and when "-" )

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

![Screenshot 2024-08-15 at 9 00 24 AM](https://github.com/user-attachments/assets/4edbfa73-b7c7-4516-b1d5-fe97520ebadc)
![Screenshot 2024-08-15 at 9 00 37 AM](https://github.com/user-attachments/assets/8b188b5a-c6cc-4cc5-ac80-7d8212d1a39c)
![Screenshot 2024-08-15 at 9 02 16 AM](https://github.com/user-attachments/assets/a48428a4-410b-4b35-82cd-0f664055379b)
