### PR TITLE
Add useDeepCompareMemoize hook for memoizing artifact in ArtifactVisu…

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactVisualization.tsx
@@ -27,6 +27,7 @@ import { buildConfusionMatrixConfig } from '~/concepts/pipelines/content/artifac
 import { isConfusionMatrix } from '~/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/utils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { useArtifactStorage } from '~/concepts/pipelines/apiHooks/useArtifactStorage';
+import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
 import { getArtifactProperties } from './utils';
 
 interface ArtifactVisualizationProps {
@@ -40,12 +41,14 @@ export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ ar
   const { getStorageObjectUrl } = useArtifactStorage();
   const artifactType = artifact.getType();
 
+  const memoizedArtifact = useDeepCompareMemoize(artifact);
+
   React.useEffect(() => {
     if (artifactType === ArtifactType.MARKDOWN || artifactType === ArtifactType.HTML) {
-      const uri = artifact.getUri();
+      const uri = memoizedArtifact.getUri();
       if (uri) {
         const downloadArtifact = async () => {
-          await getStorageObjectUrl(artifact)
+          await getStorageObjectUrl(memoizedArtifact)
             .then((url) => setDownloadedArtifactUrl(url))
             .catch(() => null);
           setLoading(false);
@@ -55,7 +58,7 @@ export const ArtifactVisualization: React.FC<ArtifactVisualizationProps> = ({ ar
         downloadArtifact();
       }
     }
-  }, [artifact, getStorageObjectUrl, artifactType, namespace]);
+  }, [memoizedArtifact, getStorageObjectUrl, artifactType, namespace]);
 
   if (artifactType === ArtifactType.CLASSIFICATION_METRICS) {
     const confusionMatrix = artifact.getCustomPropertiesMap().get('confusionMatrix');


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-11432

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
prevents s3 endpoint from polling during running of a pipeline

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
create a new run with markdown or html artifacts
open the markdown artifact
once it succeeds (has a uri)
it should not keep polling (check network tab)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
