### PR TITLE
Refactor accelerator profile state hooks to no longer manage its own selected

### DIFF
--- a/frontend/src/__mocks__/mockStartNotebookData.ts
+++ b/frontend/src/__mocks__/mockStartNotebookData.ts
@@ -36,12 +36,16 @@ export const mockStartNotebookData = ({
       },
     },
   },
-  acceleratorProfile: {
+  initialAcceleratorProfile: {
     acceleratorProfile: undefined,
     acceleratorProfiles: [],
-    initialAcceleratorProfile: undefined,
     count: 0,
-    useExisting: false,
+    unknownProfileDetected: false,
+  },
+  selectedAcceleratorProfile: {
+    profile: undefined,
+    count: 0,
+    useExistingSettings: false,
   },
   volumes: [
     {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -61,7 +61,7 @@ describe('NotebookServer', () => {
         notebookSizeName: 'XSmall',
         imageName: 'code-server-notebook',
         imageTagName: '2023.2',
-        acceleratorProfile: { acceleratorProfiles: [], count: 0, useExisting: false },
+        acceleratorProfile: { acceleratorProfiles: [], count: 0, unknownProfileDetected: false },
         envVars: { configMap: {}, secrets: {} },
         state: 'started',
       });

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -28,6 +28,7 @@ import { InferenceServiceKind, ProjectKind } from '~/k8sTypes';
 import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { ModelServingSize } from '~/pages/modelServing/screens/types';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResource: jest.fn(),
@@ -169,10 +170,14 @@ describe('assembleInferenceService', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const inferenceService = assembleInferenceService(
@@ -182,6 +187,7 @@ describe('assembleInferenceService', () => {
       false,
       undefined,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
     );
 
     expect(inferenceService.spec.predictor.tolerations).toBeDefined();
@@ -196,10 +202,14 @@ describe('assembleInferenceService', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const inferenceService = assembleInferenceService(
@@ -209,6 +219,7 @@ describe('assembleInferenceService', () => {
       true,
       undefined,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
     );
 
     expect(inferenceService.spec.predictor.tolerations).toBeUndefined();
@@ -221,10 +232,14 @@ describe('assembleInferenceService', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const inferenceService = assembleInferenceService(
@@ -237,6 +252,7 @@ describe('assembleInferenceService', () => {
       false,
       undefined,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
     );
 
     expect(inferenceService.spec.predictor.maxReplicas).toBe(replicaCount);
@@ -247,10 +263,14 @@ describe('assembleInferenceService', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const inferenceService = assembleInferenceService(
@@ -260,6 +280,7 @@ describe('assembleInferenceService', () => {
       true,
       undefined,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
     );
 
     expect(inferenceService.spec.predictor.maxReplicas).toBeUndefined();
@@ -270,10 +291,14 @@ describe('assembleInferenceService', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const modelSize: ModelServingSize = {
@@ -297,6 +322,7 @@ describe('assembleInferenceService', () => {
       false,
       undefined,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
     );
 
     expect(inferenceService.spec.predictor.model?.resources?.requests?.cpu).toBe(
@@ -317,10 +343,14 @@ describe('assembleInferenceService', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const modelSize: ModelServingSize = {
@@ -344,6 +374,7 @@ describe('assembleInferenceService', () => {
       true,
       undefined,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
     );
 
     expect(inferenceService.spec.predictor.model?.resources).toBeUndefined();

--- a/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
+++ b/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
@@ -25,6 +25,7 @@ import {
 } from '~/api/k8s/servingRuntimes';
 import { ProjectModel, ServingRuntimeModel } from '~/api/models';
 import { ProjectKind, ServingRuntimeKind } from '~/k8sTypes';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
@@ -115,10 +116,14 @@ describe('assembleServingRuntime', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const servingRuntime = assembleServingRuntime(
@@ -131,6 +136,7 @@ describe('assembleServingRuntime', () => {
       true,
       false,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
       true,
     );
 
@@ -143,10 +149,14 @@ describe('assembleServingRuntime', () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
-      initialAcceleratorProfile: mockAcceleratorProfile({}),
       count: 1,
-      additionalOptions: {},
-      useExisting: false,
+      unknownProfileDetected: false,
+    };
+
+    const selectedAcceleratorProfile: AcceleratorProfileSelectFieldState = {
+      profile: mockAcceleratorProfile({}),
+      count: 1,
+      useExistingSettings: false,
     };
 
     const servingRuntime = assembleServingRuntime(
@@ -159,6 +169,7 @@ describe('assembleServingRuntime', () => {
       true,
       false,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
       false,
     );
 
@@ -182,6 +193,7 @@ describe('assembleServingRuntime', () => {
       true,
       false,
       undefined,
+      undefined,
       true,
     );
 
@@ -198,6 +210,7 @@ describe('assembleServingRuntime', () => {
       mockServingRuntimeK8sResource({ auth: false, route: false }),
       true,
       false,
+      undefined,
       undefined,
       false,
     );
@@ -426,6 +439,7 @@ describe('updateServingRuntime', () => {
     true,
     false,
     undefined,
+    undefined,
     false,
   );
   it('should update serving runtimes when isCustomServingRuntimesEnabled is false', async () => {
@@ -495,6 +509,7 @@ describe('createServingRuntime', () => {
     MocksevingRuntime,
     true,
     false,
+    undefined,
     undefined,
     false,
   );

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -14,6 +14,7 @@ import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
 import { ContainerResources } from '~/types';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { getModelServingProjects } from './projects';
 import { assemblePodSpecOptions } from './utils';
 
@@ -23,7 +24,8 @@ export const assembleInferenceService = (
   editName?: string,
   isModelMesh?: boolean,
   inferenceService?: InferenceServiceKind,
-  acceleratorState?: AcceleratorProfileState,
+  initialAcceleratorProfile?: AcceleratorProfileState,
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState,
 ): InferenceServiceKind => {
   const {
     storage,
@@ -144,7 +146,11 @@ export const assembleInferenceService = (
       },
     };
 
-    const { tolerations, resources } = assemblePodSpecOptions(resourceSettings, acceleratorState);
+    const { tolerations, resources } = assemblePodSpecOptions(
+      resourceSettings,
+      initialAcceleratorProfile,
+      selectedAcceleratorProfile,
+    );
 
     if (tolerations.length !== 0) {
       updateInferenceService.spec.predictor.tolerations = tolerations;
@@ -225,7 +231,8 @@ export const createInferenceService = (
   data: CreatingInferenceServiceObject,
   secretKey?: string,
   isModelMesh?: boolean,
-  acceleratorState?: AcceleratorProfileState,
+  initialAcceleratorProfile?: AcceleratorProfileState,
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState,
   dryRun = false,
 ): Promise<InferenceServiceKind> => {
   const inferenceService = assembleInferenceService(
@@ -234,7 +241,8 @@ export const createInferenceService = (
     undefined,
     isModelMesh,
     undefined,
-    acceleratorState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
   );
   return k8sCreateResource<InferenceServiceKind>(
     applyK8sAPIOptions(
@@ -252,7 +260,8 @@ export const updateInferenceService = (
   existingData: InferenceServiceKind,
   secretKey?: string,
   isModelMesh?: boolean,
-  acceleratorState?: AcceleratorProfileState,
+  initialAcceleratorProfile?: AcceleratorProfileState,
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState,
   dryRun = false,
 ): Promise<InferenceServiceKind> => {
   const inferenceService = assembleInferenceService(
@@ -261,7 +270,8 @@ export const updateInferenceService = (
     existingData.metadata.name,
     isModelMesh,
     existingData,
-    acceleratorState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
   );
 
   return k8sUpdateResource<InferenceServiceKind>(

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -41,7 +41,8 @@ export const assembleNotebook = (
     description,
     notebookSize,
     envFrom,
-    acceleratorProfile,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     image,
     volumes: formVolumes,
     volumeMounts: formVolumeMounts,
@@ -55,7 +56,8 @@ export const assembleNotebook = (
 
   const { affinity, tolerations, resources } = assemblePodSpecOptions(
     notebookSize.resources,
-    acceleratorProfile,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     tolerationSettings,
     existingTolerations,
     undefined,
@@ -107,8 +109,7 @@ export const assembleNotebook = (
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'notebooks.opendatahub.io/inject-oauth': 'true',
         'opendatahub.io/username': username,
-        'opendatahub.io/accelerator-name':
-          acceleratorProfile.acceleratorProfile?.metadata.name || '',
+        'opendatahub.io/accelerator-name': selectedAcceleratorProfile.profile?.metadata.name || '',
       },
       name: notebookId,
       namespace: projectName,

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -19,6 +19,7 @@ import { getModelServingRuntimeName } from '~/pages/modelServing/utils';
 import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { getModelServingProjects } from './projects';
 import { assemblePodSpecOptions, getshmVolume, getshmVolumeMount } from './utils';
 
@@ -28,7 +29,8 @@ export const assembleServingRuntime = (
   servingRuntime: ServingRuntimeKind,
   isCustomServingRuntimesEnabled: boolean,
   isEditing?: boolean,
-  acceleratorProfileState?: AcceleratorProfileState,
+  initialAcceleratorProfile?: AcceleratorProfileState,
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState,
   isModelMesh?: boolean,
 ): ServingRuntimeKind => {
   const { name: displayName, numReplicas, modelSize, externalRoute, tokenAuth } = data;
@@ -71,7 +73,7 @@ export const assembleServingRuntime = (
         ...(isCustomServingRuntimesEnabled && {
           'opendatahub.io/template-display-name': getDisplayNameFromK8sResource(servingRuntime),
           'opendatahub.io/accelerator-name':
-            acceleratorProfileState?.acceleratorProfile?.metadata.name || '',
+            selectedAcceleratorProfile?.profile?.metadata.name || '',
         }),
       },
     };
@@ -80,8 +82,7 @@ export const assembleServingRuntime = (
       ...updatedServingRuntime.metadata,
       annotations: {
         ...annotations,
-        'opendatahub.io/accelerator-name':
-          acceleratorProfileState?.acceleratorProfile?.metadata.name || '',
+        'opendatahub.io/accelerator-name': selectedAcceleratorProfile?.profile?.metadata.name || '',
         ...(isCustomServingRuntimesEnabled && { 'openshift.io/display-name': displayName.trim() }),
       },
     };
@@ -107,7 +108,8 @@ export const assembleServingRuntime = (
 
   const { affinity, tolerations, resources } = assemblePodSpecOptions(
     resourceSettings,
-    acceleratorProfileState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     undefined,
     servingRuntime.spec.tolerations,
     undefined,
@@ -210,7 +212,8 @@ export const updateServingRuntime = (options: {
   existingData: ServingRuntimeKind;
   isCustomServingRuntimesEnabled: boolean;
   opts?: K8sAPIOptions;
-  acceleratorProfileState?: AcceleratorProfileState;
+  initialAcceleratorProfile?: AcceleratorProfileState;
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState;
   isModelMesh?: boolean;
 }): Promise<ServingRuntimeKind> => {
   const {
@@ -218,7 +221,8 @@ export const updateServingRuntime = (options: {
     existingData,
     isCustomServingRuntimesEnabled,
     opts,
-    acceleratorProfileState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     isModelMesh,
   } = options;
 
@@ -228,7 +232,8 @@ export const updateServingRuntime = (options: {
     existingData,
     isCustomServingRuntimesEnabled,
     true,
-    acceleratorProfileState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     isModelMesh,
   );
 
@@ -249,7 +254,8 @@ export const createServingRuntime = (options: {
   servingRuntime: ServingRuntimeKind;
   isCustomServingRuntimesEnabled: boolean;
   opts?: K8sAPIOptions;
-  acceleratorProfileState?: AcceleratorProfileState;
+  initialAcceleratorProfile?: AcceleratorProfileState;
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState;
   isModelMesh?: boolean;
 }): Promise<ServingRuntimeKind> => {
   const {
@@ -258,7 +264,8 @@ export const createServingRuntime = (options: {
     servingRuntime,
     isCustomServingRuntimesEnabled,
     opts,
-    acceleratorProfileState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     isModelMesh,
   } = options;
   const assembledServingRuntime = assembleServingRuntime(
@@ -267,7 +274,8 @@ export const createServingRuntime = (options: {
     servingRuntime,
     isCustomServingRuntimesEnabled,
     false,
-    acceleratorProfileState,
+    initialAcceleratorProfile,
+    selectedAcceleratorProfile,
     isModelMesh,
   );
 

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -20,7 +20,7 @@ type ServingRuntimeDetailsProps = {
 
 const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc }) => {
   const { dashboardConfig } = React.useContext(AppContext);
-  const [acceleratorProfile] = useServingAcceleratorProfile(obj, isvc);
+  const acceleratorProfile = useServingAcceleratorProfile(obj, isvc);
   const selectedAcceleratorProfile = acceleratorProfile.acceleratorProfile;
   const enabledAcceleratorProfiles = acceleratorProfile.acceleratorProfiles.filter(
     (ac) => ac.spec.enabled,
@@ -64,12 +64,12 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc
               }`
             : enabledAcceleratorProfiles.length === 0
             ? 'No accelerator enabled'
-            : acceleratorProfile.useExisting
+            : acceleratorProfile.unknownProfileDetected
             ? 'Unknown'
             : 'No accelerator selected'}
         </DescriptionListDescription>
       </DescriptionListGroup>
-      {!acceleratorProfile.useExisting && acceleratorProfile.acceleratorProfile && (
+      {!acceleratorProfile.unknownProfileDetected && acceleratorProfile.acceleratorProfile && (
         <DescriptionListGroup>
           <DescriptionListTerm>Number of accelerators</DescriptionListTerm>
           <DescriptionListDescription>{acceleratorProfile.count}</DescriptionListDescription>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -18,6 +18,8 @@ import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
 import { ServingRuntimeEditInfo } from '~/pages/modelServing/screens/types';
 import { useAccessReview } from '~/api';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
 import ServingRuntimeReplicaSection from './ServingRuntimeReplicaSection';
 import ServingRuntimeSizeSection from './ServingRuntimeSizeSection';
 import ServingRuntimeTemplateSection from './ServingRuntimeTemplateSection';
@@ -49,8 +51,13 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
   editInfo,
 }) => {
   const [createData, setCreateData, resetData, sizes] = useCreateServingRuntimeObject(editInfo);
-  const [acceleratorProfileState, setAcceleratorProfileState, resetAcceleratorProfileData] =
-    useServingAcceleratorProfile(editInfo?.servingRuntime);
+  const initialAcceleratorProfile = useServingAcceleratorProfile(editInfo?.servingRuntime);
+  const [selectedAcceleratorProfile, setSelectedAcceleratorProfile] =
+    useGenericObjectState<AcceleratorProfileSelectFieldState>({
+      profile: undefined,
+      count: 0,
+      useExistingSettings: false,
+    });
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
 
@@ -78,7 +85,13 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
     actionInProgress ||
     tokenErrors ||
     !inputValueValid ||
-    !isModelServerEditInfoChanged(createData, sizes, acceleratorProfileState, editInfo);
+    !isModelServerEditInfoChanged(
+      createData,
+      sizes,
+      initialAcceleratorProfile,
+      selectedAcceleratorProfile,
+      editInfo,
+    );
 
   const servingRuntimeSelected = React.useMemo(
     () =>
@@ -92,7 +105,6 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
     setError(undefined);
     setActionInProgress(false);
     resetData();
-    resetAcceleratorProfileData();
   };
 
   const setErrorModal = (e: Error) => {
@@ -115,7 +127,8 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
       namespace,
       editInfo,
       allowCreate,
-      acceleratorProfileState,
+      initialAcceleratorProfile,
+      selectedAcceleratorProfile,
       NamespaceApplicationCase.MODEL_MESH_PROMOTION,
       currentProject,
       undefined,
@@ -162,7 +175,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
               setData={setCreateData}
               templates={servingRuntimeTemplates || []}
               isEditing={!!editInfo}
-              acceleratorProfileState={acceleratorProfileState}
+              selectedAcceleratorProfile={selectedAcceleratorProfile}
             />
           </StackItem>
           <StackItem>
@@ -179,8 +192,9 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
               setData={setCreateData}
               sizes={sizes}
               servingRuntimeSelected={servingRuntimeSelected}
-              acceleratorProfileState={acceleratorProfileState}
-              setAcceleratorProfileState={setAcceleratorProfileState}
+              acceleratorProfileState={initialAcceleratorProfile}
+              selectedAcceleratorProfile={selectedAcceleratorProfile}
+              setSelectedAcceleratorProfile={setSelectedAcceleratorProfile}
               infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
             />
           </StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -9,7 +9,9 @@ import {
 } from '~/pages/modelServing/screens/types';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import { isGpuDisabled } from '~/pages/modelServing/screens/projects/utils';
-import AcceleratorProfileSelectField from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
+import AcceleratorProfileSelectField, {
+  AcceleratorProfileSelectFieldState,
+} from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { getCompatibleAcceleratorIdentifiers } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
 import SimpleSelect from '~/components/SimpleSelect';
@@ -23,7 +25,8 @@ type ServingRuntimeSizeSectionProps = {
   sizes: ModelServingSize[];
   servingRuntimeSelected?: ServingRuntimeKind;
   acceleratorProfileState: AcceleratorProfileState;
-  setAcceleratorProfileState: UpdateObjectAtPropAndValue<AcceleratorProfileState>;
+  selectedAcceleratorProfile: AcceleratorProfileSelectFieldState;
+  setSelectedAcceleratorProfile: UpdateObjectAtPropAndValue<AcceleratorProfileSelectFieldState>;
   infoContent?: string;
 };
 
@@ -33,7 +36,8 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
   sizes,
   servingRuntimeSelected,
   acceleratorProfileState,
-  setAcceleratorProfileState,
+  selectedAcceleratorProfile,
+  setSelectedAcceleratorProfile,
   infoContent,
 }) => {
   const [supportedAcceleratorProfiles, setSupportedAcceleratorProfiles] = React.useState<
@@ -111,10 +115,11 @@ const ServingRuntimeSizeSection: React.FC<ServingRuntimeSizeSectionProps> = ({
         <FormGroup>
           <AcceleratorProfileSelectField
             acceleratorProfileState={acceleratorProfileState}
-            setAcceleratorProfileState={setAcceleratorProfileState}
             supportedAcceleratorProfiles={supportedAcceleratorProfiles}
             resourceDisplayName="serving runtime"
             infoContent="Ensure that appropriate tolerations are in place before adding an accelerator to your model server."
+            selectedAcceleratorProfile={selectedAcceleratorProfile}
+            setSelectedAcceleratorProfile={setSelectedAcceleratorProfile}
           />
         </FormGroup>
       )}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -10,14 +10,14 @@ import {
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { isCompatibleWithAccelerator as isCompatibleWithAcceleratorProfile } from '~/pages/projects/screens/spawner/spawnerUtils';
 import SimpleSelect from '~/components/SimpleSelect';
-import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 
 type ServingRuntimeTemplateSectionProps = {
   data: CreatingServingRuntimeObject;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
   templates: TemplateKind[];
   isEditing?: boolean;
-  acceleratorProfileState: AcceleratorProfileState;
+  selectedAcceleratorProfile: AcceleratorProfileSelectFieldState;
 };
 
 const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps> = ({
@@ -25,7 +25,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
   setData,
   templates,
   isEditing,
-  acceleratorProfileState,
+  selectedAcceleratorProfile,
 }) => {
   const filteredTemplates = React.useMemo(
     () =>
@@ -50,7 +50,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
         <SplitItem isFilled />
         <SplitItem>
           {isCompatibleWithAcceleratorProfile(
-            acceleratorProfileState.acceleratorProfile?.spec.identifier,
+            selectedAcceleratorProfile.profile?.spec.identifier,
             template.objects[0],
           ) && <Label color="blue">Compatible with accelerator</Label>}
         </SplitItem>

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -48,6 +48,8 @@ import { useAccessReview } from '~/api';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
 import usePrefillDeployModalFromModelRegistry from '~/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
 import KServeAutoscalerReplicaSection from './KServeAutoscalerReplicaSection';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
@@ -111,11 +113,19 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const isInferenceServiceNameWithinLimit =
     translateDisplayNameForK8s(createDataInferenceService.name).length <= 253;
 
-  const [acceleratorProfileState, setAcceleratorProfileState, resetAcceleratorProfileData] =
-    useServingAcceleratorProfile(
-      editInfo?.servingRuntimeEditInfo?.servingRuntime,
-      editInfo?.inferenceServiceEditInfo,
-    );
+  const acceleratorProfileState = useServingAcceleratorProfile(
+    editInfo?.servingRuntimeEditInfo?.servingRuntime,
+    editInfo?.inferenceServiceEditInfo,
+  );
+  const [
+    selectedAcceleratorProfile,
+    setSelectedAcceleratorProfile,
+    resetSelectedAcceleratorProfile,
+  ] = useGenericObjectState<AcceleratorProfileSelectFieldState>({
+    profile: undefined,
+    count: 0,
+    useExistingSettings: false,
+  });
   const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
   const [allowCreate] = useAccessReview({
     ...accessReviewResource,
@@ -188,7 +198,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     setActionInProgress(false);
     resetDataServingRuntime();
     resetDataInferenceService();
-    resetAcceleratorProfileData();
+    resetSelectedAcceleratorProfile();
     setAlertVisible(true);
   };
 
@@ -218,6 +228,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       editInfo?.servingRuntimeEditInfo,
       false,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
       NamespaceApplicationCase.KSERVE_PROMOTION,
       projectContext?.currentProject,
       servingRuntimeName,
@@ -233,6 +244,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       servingRuntimeName,
       false,
       acceleratorProfileState,
+      selectedAcceleratorProfile,
       allowCreate,
       editInfo?.secrets,
     );
@@ -329,7 +341,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   setData={setCreateDataServingRuntime}
                   templates={servingRuntimeTemplates || []}
                   isEditing={!!editInfo}
-                  acceleratorProfileState={acceleratorProfileState}
+                  selectedAcceleratorProfile={selectedAcceleratorProfile}
                 />
               </StackItem>
               <StackItem>
@@ -355,7 +367,8 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   sizes={sizes}
                   servingRuntimeSelected={servingRuntimeSelected}
                   acceleratorProfileState={acceleratorProfileState}
-                  setAcceleratorProfileState={setAcceleratorProfileState}
+                  selectedAcceleratorProfile={selectedAcceleratorProfile}
+                  setSelectedAcceleratorProfile={setSelectedAcceleratorProfile}
                   infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
                 />
               </StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfile.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfile.ts
@@ -2,12 +2,11 @@ import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import useAcceleratorProfileState, {
   AcceleratorProfileState,
 } from '~/utilities/useAcceleratorProfileState';
-import { GenericObjectState } from '~/utilities/useGenericObjectState';
 
 const useServingAcceleratorProfile = (
   servingRuntime?: ServingRuntimeKind | null,
   inferenceService?: InferenceServiceKind | null,
-): GenericObjectState<AcceleratorProfileState> => {
+): AcceleratorProfileState => {
   const acceleratorProfileName =
     servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-name'];
   const resources =

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -17,41 +17,56 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { isHTMLInputElement } from '~/utilities/utils';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
-import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import useDetectedAccelerators from './useDetectedAccelerators';
 
 type AcceleratorProfileSelectFieldProps = {
   acceleratorProfileState: AcceleratorProfileState;
-  setAcceleratorProfileState: UpdateObjectAtPropAndValue<AcceleratorProfileState>;
   supportedAcceleratorProfiles?: string[];
   resourceDisplayName?: string;
   infoContent?: string;
+  selectedAcceleratorProfile: AcceleratorProfileSelectFieldState;
+  setSelectedAcceleratorProfile: UpdateObjectAtPropAndValue<AcceleratorProfileSelectFieldState>;
 };
+
+export type AcceleratorProfileSelectFieldState =
+  | {
+      profile?: AcceleratorProfileKind;
+      count: number;
+      useExistingSettings: false;
+    }
+  | {
+      profile: undefined;
+      count: 1;
+      useExistingSettings: true;
+    };
 
 const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps> = ({
   acceleratorProfileState,
-  setAcceleratorProfileState,
   supportedAcceleratorProfiles,
   resourceDisplayName = 'image',
   infoContent,
+  selectedAcceleratorProfile,
+  setSelectedAcceleratorProfile,
 }) => {
   const [detectedAccelerators] = useDetectedAccelerators();
 
-  const {
-    acceleratorProfile,
-    count: acceleratorCount,
-    acceleratorProfiles,
-    useExisting,
-    additionalOptions,
-  } = acceleratorProfileState;
+  React.useEffect(() => {
+    setSelectedAcceleratorProfile('profile', acceleratorProfileState.acceleratorProfile);
+    setSelectedAcceleratorProfile('count', acceleratorProfileState.count);
+    setSelectedAcceleratorProfile(
+      'useExistingSettings',
+      acceleratorProfileState.unknownProfileDetected,
+    );
+  }, [acceleratorProfileState, setSelectedAcceleratorProfile]);
 
   const generateAcceleratorCountWarning = (newSize: number) => {
-    if (!acceleratorProfile) {
+    if (!selectedAcceleratorProfile.profile) {
       return '';
     }
 
-    const { identifier } = acceleratorProfile.spec;
+    const { identifier } = selectedAcceleratorProfile.profile.spec;
 
     const detectedAcceleratorCount = Object.entries(detectedAccelerators.available).find(
       ([id]) => identifier === id,
@@ -69,12 +84,14 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     return '';
   };
 
-  const acceleratorCountWarning = generateAcceleratorCountWarning(acceleratorCount);
+  const acceleratorCountWarning = generateAcceleratorCountWarning(selectedAcceleratorProfile.count);
 
   const isAcceleratorProfileSupported = (cr: AcceleratorProfileKind) =>
     supportedAcceleratorProfiles?.includes(cr.spec.identifier);
 
-  const enabledAcceleratorProfiles = acceleratorProfiles.filter((ac) => ac.spec.enabled);
+  const enabledAcceleratorProfiles = acceleratorProfileState.acceleratorProfiles.filter(
+    (ac) => ac.spec.enabled,
+  );
 
   const formatOption = (cr: AcceleratorProfileKind): SimpleSelectOption => {
     const displayName = `${cr.spec.displayName}${!cr.spec.enabled ? ' (disabled)' : ''}`;
@@ -112,13 +129,13 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     .map((ac) => formatOption(ac));
 
   let acceleratorAlertMessage: { title: string; variant: AlertVariant } | null = null;
-  if (acceleratorProfile && supportedAcceleratorProfiles !== undefined) {
+  if (selectedAcceleratorProfile.profile && supportedAcceleratorProfiles !== undefined) {
     if (supportedAcceleratorProfiles.length === 0) {
       acceleratorAlertMessage = {
         title: `The ${resourceDisplayName} you have selected doesn't support the selected accelerator. It is recommended to use a compatible ${resourceDisplayName} for optimal performance.`,
         variant: AlertVariant.info,
       };
-    } else if (!isAcceleratorProfileSupported(acceleratorProfile)) {
+    } else if (!isAcceleratorProfileSupported(selectedAcceleratorProfile.profile)) {
       acceleratorAlertMessage = {
         title: `The ${resourceDisplayName} you have selected is not compatible with the selected accelerator`,
         variant: AlertVariant.warning,
@@ -133,18 +150,21 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     isPlaceholder: true,
   });
 
-  if (additionalOptions?.useExisting) {
+  if (acceleratorProfileState.unknownProfileDetected) {
     options.push({
       key: 'use-existing',
       label: 'Existing settings',
       description: 'Use the existing accelerator settings from the notebook server',
     });
-  } else if (additionalOptions?.useDisabled) {
-    options.push(formatOption(additionalOptions.useDisabled));
+  } else if (
+    selectedAcceleratorProfile.profile &&
+    !selectedAcceleratorProfile.profile.spec.enabled
+  ) {
+    options.push(formatOption(selectedAcceleratorProfile.profile));
   }
 
   const onStep = (step: number) => {
-    setAcceleratorProfileState('count', Math.max(acceleratorCount + step, 1));
+    setSelectedAcceleratorProfile('count', Math.max(selectedAcceleratorProfile.count + step, 1));
   };
 
   // if there is more than a none option, show the dropdown
@@ -171,25 +191,31 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
           <SimpleSelect
             isFullWidth
             options={options}
-            value={useExisting ? 'use-existing' : acceleratorProfile?.metadata.name ?? ''}
+            value={
+              selectedAcceleratorProfile.useExistingSettings
+                ? 'use-existing'
+                : selectedAcceleratorProfile.profile?.metadata.name ?? ''
+            }
             onChange={(key, isPlaceholder) => {
               if (isPlaceholder) {
                 // none
-                setAcceleratorProfileState('useExisting', false);
-                setAcceleratorProfileState('acceleratorProfile', undefined);
-                setAcceleratorProfileState('count', 0);
+                setSelectedAcceleratorProfile('useExistingSettings', false);
+                setSelectedAcceleratorProfile('profile', undefined);
+                setSelectedAcceleratorProfile('count', 0);
               } else if (key === 'use-existing') {
                 // use existing settings
-                setAcceleratorProfileState('useExisting', true);
-                setAcceleratorProfileState('acceleratorProfile', undefined);
-                setAcceleratorProfileState('count', 0);
+                setSelectedAcceleratorProfile('useExistingSettings', true);
+                setSelectedAcceleratorProfile('profile', undefined);
+                setSelectedAcceleratorProfile('count', 0);
               } else {
                 // normal flow
-                setAcceleratorProfileState('count', 1);
-                setAcceleratorProfileState('useExisting', false);
-                setAcceleratorProfileState(
-                  'acceleratorProfile',
-                  acceleratorProfiles.find((ac) => ac.metadata.name === key),
+                setSelectedAcceleratorProfile('count', 1);
+                setSelectedAcceleratorProfile('useExistingSettings', false);
+                setSelectedAcceleratorProfile(
+                  'profile',
+                  acceleratorProfileState.acceleratorProfiles.find(
+                    (ac) => ac.metadata.name === key,
+                  ),
                 );
               }
             }}
@@ -206,7 +232,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
           />
         </StackItem>
       )}
-      {acceleratorProfile && (
+      {selectedAcceleratorProfile.profile && (
         <StackItem>
           <FormGroup label="Number of accelerators" fieldId="number-of-accelerators">
             <InputGroup>
@@ -214,7 +240,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 inputAriaLabel="Number of accelerators"
                 id="number-of-accelerators"
                 name="number-of-accelerators"
-                value={acceleratorCount}
+                value={selectedAcceleratorProfile.count}
                 validated={acceleratorCountWarning ? 'warning' : 'default'}
                 min={1}
                 onPlus={() => onStep(1)}
@@ -222,7 +248,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 onChange={(event) => {
                   if (isHTMLInputElement(event.target)) {
                     const newSize = Number(event.target.value);
-                    setAcceleratorProfileState('count', Math.max(newSize, 1));
+                    setSelectedAcceleratorProfile('count', Math.max(newSize, 1));
                   }
                 }}
               />

--- a/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServerDetails.tsx
@@ -28,7 +28,7 @@ const NotebookServerDetails: React.FC = () => {
   const { images, loaded } = useWatchImages();
   const [isExpanded, setExpanded] = React.useState(false);
   const { dashboardConfig } = useAppContext();
-  const [acceleratorProfile] = useNotebookAcceleratorProfile(notebook);
+  const acceleratorProfile = useNotebookAcceleratorProfile(notebook);
 
   const container: PodContainer | undefined = notebook?.spec.template.spec.containers.find(
     (currentContainer) => currentContainer.name === notebook.metadata.name,
@@ -112,12 +112,12 @@ const NotebookServerDetails: React.FC = () => {
           <DescriptionListDescription>
             {acceleratorProfile.acceleratorProfile
               ? acceleratorProfile.acceleratorProfile.spec.displayName
-              : acceleratorProfile.useExisting
+              : acceleratorProfile.unknownProfileDetected
               ? 'Unknown'
               : 'None'}
           </DescriptionListDescription>
         </DescriptionListGroup>
-        {!acceleratorProfile.useExisting && (
+        {!acceleratorProfile.unknownProfileDetected && (
           <DescriptionListGroup>
             <DescriptionListTerm>Number of accelerators</DescriptionListTerm>
             <DescriptionListDescription>{acceleratorProfile.count}</DescriptionListDescription>

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -28,7 +28,7 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
   isDisabled,
 }) => {
   const { notebook, isStarting, isRunning, isStopping, refresh } = notebookState;
-  const [acceleratorProfile] = useNotebookAcceleratorProfile(notebook);
+  const acceleratorProfile = useNotebookAcceleratorProfile(notebook);
   const { size } = useNotebookDeploymentSize(notebook);
   const [isOpenConfirm, setOpenConfirm] = React.useState(false);
   const [inProgress, setInProgress] = React.useState(false);
@@ -55,10 +55,12 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
     (action: 'started' | 'stopped') => {
       fireFormTrackingEvent(`Workbench ${action === 'started' ? 'Started' : 'Stopped'}`, {
         outcome: TrackingOutcome.submit,
-        acceleratorCount: acceleratorProfile.useExisting ? undefined : acceleratorProfile.count,
+        acceleratorCount: acceleratorProfile.unknownProfileDetected
+          ? undefined
+          : acceleratorProfile.count,
         accelerator: acceleratorProfile.acceleratorProfile
           ? `${acceleratorProfile.acceleratorProfile.spec.displayName} (${acceleratorProfile.acceleratorProfile.metadata.name}): ${acceleratorProfile.acceleratorProfile.spec.identifier}`
-          : acceleratorProfile.useExisting
+          : acceleratorProfile.unknownProfileDetected
           ? 'Unknown'
           : 'None',
         lastSelectedSize:

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfile.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfile.ts
@@ -3,11 +3,10 @@ import { Notebook } from '~/types';
 import useAcceleratorProfileState, {
   AcceleratorProfileState,
 } from '~/utilities/useAcceleratorProfileState';
-import { GenericObjectState } from '~/utilities/useGenericObjectState';
 
 const useNotebookAcceleratorProfile = (
   notebook?: NotebookKind | Notebook | null,
-): GenericObjectState<AcceleratorProfileState> => {
+): AcceleratorProfileState => {
   const name = notebook?.metadata.annotations?.['opendatahub.io/accelerator-name'];
   const resources = notebook?.spec.template.spec.containers.find(
     (container) => container.name === notebook.metadata.name,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -84,14 +84,15 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     editNotebook,
     existingDataConnections,
   );
-
   const afterStart = (name: string, type: 'created' | 'updated') => {
-    const { acceleratorProfile, notebookSize, image } = startNotebookData;
+    const { selectedAcceleratorProfile, notebookSize, image } = startNotebookData;
     const tep: FormTrackingEventProperties = {
-      acceleratorCount: acceleratorProfile.useExisting ? undefined : acceleratorProfile.count,
-      accelerator: acceleratorProfile.acceleratorProfile
-        ? `${acceleratorProfile.acceleratorProfile.spec.displayName} (${acceleratorProfile.acceleratorProfile.metadata.name}): ${acceleratorProfile.acceleratorProfile.spec.identifier}`
-        : acceleratorProfile.useExisting
+      acceleratorCount: selectedAcceleratorProfile.useExistingSettings
+        ? undefined
+        : selectedAcceleratorProfile.count,
+      accelerator: selectedAcceleratorProfile.profile
+        ? `${selectedAcceleratorProfile.profile.spec.displayName} (${selectedAcceleratorProfile.profile.metadata.name}): ${selectedAcceleratorProfile.profile.spec.identifier}`
+        : selectedAcceleratorProfile.useExistingSettings
         ? 'Unknown'
         : 'None',
       lastSelectedSize: notebookSize.name,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -21,10 +21,13 @@ import useNotebookImageData from '~/pages/projects/screens/detail/notebooks/useN
 import NotebookRestartAlert from '~/pages/projects/components/NotebookRestartAlert';
 import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksRestart';
 import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableElyraPipelinesCheck';
-import AcceleratorProfileSelectField from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
+import AcceleratorProfileSelectField, {
+  AcceleratorProfileSelectFieldState,
+} from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import useNotebookAcceleratorProfile from '~/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfile';
 import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
 import { SpawnerPageSectionID } from './types';
 import { ScrollableSelectorID, SpawnerPageSectionTitles } from './const';
 import SpawnerFooter from './SpawnerFooter';
@@ -72,6 +75,13 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     existingNotebook,
   );
 
+  const [selectedAcceleratorProfile, setSelectedAcceleratorProfile] =
+    useGenericObjectState<AcceleratorProfileSelectFieldState>({
+      profile: undefined,
+      count: 0,
+      useExistingSettings: false,
+    });
+
   const restartNotebooks = useWillNotebooksRestart([existingNotebook?.metadata.name || '']);
 
   React.useEffect(() => {
@@ -94,8 +104,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     }
   }, [data, loaded, loadError]);
 
-  const [notebookAcceleratorProfileState, setNotebookAcceleratorProfileState] =
-    useNotebookAcceleratorProfile(existingNotebook);
+  const notebookAcceleratorProfileState = useNotebookAcceleratorProfile(existingNotebook);
 
   React.useEffect(() => {
     if (selectedImage.imageStream) {
@@ -181,8 +190,9 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
               />
               <AcceleratorProfileSelectField
                 acceleratorProfileState={notebookAcceleratorProfileState}
-                setAcceleratorProfileState={setNotebookAcceleratorProfileState}
                 supportedAcceleratorProfiles={supportedAcceleratorProfiles}
+                selectedAcceleratorProfile={selectedAcceleratorProfile}
+                setSelectedAcceleratorProfile={setSelectedAcceleratorProfile}
               />
             </FormSection>
             <FormSection
@@ -241,7 +251,8 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                     projectName: currentProject.metadata.name,
                     image: selectedImage,
                     notebookSize: selectedSize,
-                    acceleratorProfile: notebookAcceleratorProfileState,
+                    initialAcceleratorProfile: notebookAcceleratorProfileState,
+                    selectedAcceleratorProfile,
                     volumes: [],
                     volumeMounts: [],
                     existingTolerations: existingNotebook?.spec.template.spec.tolerations || [],

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -12,6 +12,7 @@ import {
 import { ValueOf } from '~/typeHelpers';
 import { AWSSecretKind } from '~/k8sTypes';
 import { AcceleratorProfileState } from '~/utilities/useAcceleratorProfileState';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { AwsKeys } from './dataConnections/const';
 
 export type UpdateObjectAtPropAndValue<T> = (propKey: keyof T, propValue: ValueOf<T>) => void;
@@ -65,7 +66,8 @@ export type StartNotebookData = {
   projectName: string;
   notebookName: string;
   notebookSize: NotebookSize;
-  acceleratorProfile: AcceleratorProfileState;
+  initialAcceleratorProfile: AcceleratorProfileState;
+  selectedAcceleratorProfile: AcceleratorProfileSelectFieldState;
   image: ImageStreamAndVersion;
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];

--- a/frontend/src/utilities/tolerations.ts
+++ b/frontend/src/utilities/tolerations.ts
@@ -2,6 +2,7 @@ import { Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import _ from 'lodash-es';
 import { Toleration, TolerationEffect, TolerationOperator, TolerationSettings } from '~/types';
 import { DashboardConfigKind, NotebookKind } from '~/k8sTypes';
+import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { AcceleratorProfileState } from './useAcceleratorProfileState';
 
 export type TolerationChanges = {
@@ -11,24 +12,25 @@ export type TolerationChanges = {
 
 export const determineTolerations = (
   tolerationSettings?: TolerationSettings,
-  acceleratorProfileState?: AcceleratorProfileState,
+  initialAcceleratorProfile?: AcceleratorProfileState,
+  selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState,
   existingTolerations?: Toleration[],
 ): Toleration[] => {
   let tolerations = existingTolerations || [];
 
   // remove old accelerator tolerations if they exist
-  if (acceleratorProfileState?.initialAcceleratorProfile) {
+  if (initialAcceleratorProfile?.acceleratorProfile) {
     tolerations = tolerations.filter(
       (t) =>
-        !acceleratorProfileState.initialAcceleratorProfile?.spec.tolerations?.some((t2) =>
+        !initialAcceleratorProfile.acceleratorProfile?.spec.tolerations?.some((t2) =>
           _.isEqual(t2, t),
         ),
     );
   }
 
   // add new accelerator tolerations if they exist
-  if (acceleratorProfileState?.acceleratorProfile?.spec.tolerations) {
-    tolerations.push(...acceleratorProfileState.acceleratorProfile.spec.tolerations);
+  if (selectedAcceleratorProfile?.profile?.spec.tolerations) {
+    tolerations.push(...selectedAcceleratorProfile.profile.spec.tolerations);
   }
 
   // remove duplicated tolerations
@@ -60,6 +62,7 @@ export const computeNotebooksTolerations = (
 
   const settings = determineTolerations(
     dashboardConfig.spec.notebookController?.notebookTolerationSettings,
+    undefined,
     undefined,
     tolerations,
   );

--- a/frontend/src/utilities/useAcceleratorProfileState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileState.ts
@@ -9,127 +9,147 @@ import {
   TolerationEffect,
   TolerationOperator,
 } from '~/types';
-import useGenericObjectState, { GenericObjectState } from '~/utilities/useGenericObjectState';
 import { getAcceleratorProfileCount, isEnumMember } from '~/utilities/utils';
 
 export type AcceleratorProfileState = {
-  acceleratorProfile?: AcceleratorProfileKind;
   acceleratorProfiles: AcceleratorProfileKind[];
-  initialAcceleratorProfile?: AcceleratorProfileKind;
-  useExisting: boolean;
   count: number;
-  additionalOptions?: {
-    useExisting?: boolean;
-    useDisabled?: AcceleratorProfileKind;
-  };
-};
+} & (
+  | { acceleratorProfile?: AcceleratorProfileKind; unknownProfileDetected: false }
+  | {
+      acceleratorProfile: undefined;
+      unknownProfileDetected: true;
+    }
+);
 
 const useAcceleratorProfileState = (
   resources?: ContainerResources,
   tolerations?: Toleration[],
   existingAcceleratorProfileName?: string,
-): GenericObjectState<AcceleratorProfileState> => {
-  const [acceleratorProfileState, setData, resetData] =
-    useGenericObjectState<AcceleratorProfileState>({
-      acceleratorProfile: undefined,
-      acceleratorProfiles: [],
-      initialAcceleratorProfile: undefined,
-      count: 0,
-      useExisting: false,
-    });
+): AcceleratorProfileState => {
+  // const [acceleratorProfileState, setData] = useGenericObjectState<AcceleratorProfileState>({
+  // acceleratorProfiles: [],
+  // acceleratorProfile: undefined,
+  // count: 0,
+  // unknownProfileDetected: false,
+  // });
 
   const { dashboardNamespace } = useDashboardNamespace();
-  const [acceleratorProfiles, loaded, loadError, refresh] =
-    useAcceleratorProfiles(dashboardNamespace);
+  const [acceleratorProfiles, loaded, loadError] = useAcceleratorProfiles(dashboardNamespace);
 
-  React.useEffect(() => {
-    if (loaded && !loadError) {
-      setData('acceleratorProfiles', acceleratorProfiles);
-
-      // Exit early if no resources = not in edit mode
-      if (!resources) {
-        return;
-      }
-
+  return React.useMemo(() => {
+    if (!loaded || loadError) {
+      return {
+        acceleratorProfiles: [],
+        acceleratorProfile: undefined,
+        count: 0,
+        unknownProfileDetected: false,
+      };
+    }
+    // Exit early if no resources = not in edit mode
+    if (resources) {
       const acceleratorProfile = acceleratorProfiles.find(
         (cr) => cr.metadata.name === existingAcceleratorProfileName,
       );
 
       if (acceleratorProfile) {
-        setData('acceleratorProfile', acceleratorProfile);
-        setData('initialAcceleratorProfile', acceleratorProfile);
-        setData('count', getAcceleratorProfileCount(acceleratorProfile, resources));
-        if (!acceleratorProfile.spec.enabled) {
-          setData('additionalOptions', { useDisabled: acceleratorProfile });
-        }
-      } else {
-        // check if there is accelerator usage in the container
-        // this is to handle the case where the accelerator is disabled, deleted, or empty
-        const possibleAcceleratorRequests = Object.entries(resources.requests ?? {})
-          .filter(([key]) => !isEnumMember(key, ContainerResourceAttributes))
-          .map(([key, value]) => ({ identifier: key, count: value }));
-        if (possibleAcceleratorRequests.length > 0) {
-          // check if they are just using the nvidia.com/gpu
-          // if so, lets migrate them over to using the migrated-gpu accelerator profile if it exists
-          const nvidiaAcceleratorRequests = possibleAcceleratorRequests.find(
-            (request) => request.identifier === 'nvidia.com/gpu',
+        // setData('acceleratorProfile', acceleratorProfile);
+        // setData('count', getAcceleratorProfileCount(acceleratorProfile, resources));
+        // setData('unknownProfileDetected', false);
+        return {
+          acceleratorProfiles,
+          acceleratorProfile,
+          count: getAcceleratorProfileCount(acceleratorProfile, resources),
+          unknownProfileDetected: false,
+        };
+      }
+      // check if there is accelerator usage in the container
+      // this is to handle the case where the accelerator is disabled, deleted, or empty
+      const possibleAcceleratorRequests = Object.entries(resources.requests ?? {})
+        .filter(([key]) => !isEnumMember(key, ContainerResourceAttributes))
+        .map(([key, value]) => ({ identifier: key, count: value }));
+      if (possibleAcceleratorRequests.length > 0) {
+        // check if they are just using the nvidia.com/gpu
+        // if so, lets migrate them over to using the migrated-gpu accelerator profile if it exists
+        const nvidiaAcceleratorRequests = possibleAcceleratorRequests.find(
+          (request) => request.identifier === 'nvidia.com/gpu',
+        );
+
+        if (
+          nvidiaAcceleratorRequests &&
+          tolerations?.some(
+            (toleration) =>
+              toleration.key === 'nvidia.com/gpu' &&
+              toleration.operator === 'Exists' &&
+              toleration.effect === 'NoSchedule',
+          )
+        ) {
+          const migratedAcceleratorProfile = acceleratorProfiles.find(
+            (cr) => cr.metadata.name === 'migrated-gpu',
           );
 
-          if (
-            nvidiaAcceleratorRequests &&
-            tolerations?.some(
-              (toleration) =>
-                toleration.key === 'nvidia.com/gpu' &&
-                toleration.operator === 'Exists' &&
-                toleration.effect === 'NoSchedule',
-            )
-          ) {
-            const migratedAcceleratorProfile = acceleratorProfiles.find(
-              (cr) => cr.metadata.name === 'migrated-gpu',
-            );
-
-            if (migratedAcceleratorProfile) {
-              setData('acceleratorProfile', migratedAcceleratorProfile);
-              setData('initialAcceleratorProfile', migratedAcceleratorProfile);
-              setData('count', Number(nvidiaAcceleratorRequests.count ?? 0));
-              if (!migratedAcceleratorProfile.spec.enabled) {
-                setData('additionalOptions', { useDisabled: acceleratorProfile });
-              }
-            } else {
-              // create a fake accelerator to use
-              const fakeAcceleratorProfile: AcceleratorProfileKind = {
-                apiVersion: 'dashboard.opendatahub.io/v1',
-                kind: 'AcceleratorProfile',
-                metadata: {
-                  name: 'migrated-gpu',
-                },
-                spec: {
-                  identifier: 'nvidia.com/gpu',
-                  displayName: 'NVIDIA GPU',
-                  enabled: true,
-                  tolerations: [
-                    {
-                      key: 'nvidia.com/gpu',
-                      operator: TolerationOperator.EXISTS,
-                      effect: TolerationEffect.NO_SCHEDULE,
-                    },
-                  ],
-                },
-              };
-
-              setData('acceleratorProfile', fakeAcceleratorProfile);
-              setData('acceleratorProfiles', [fakeAcceleratorProfile, ...acceleratorProfiles]);
-              setData('initialAcceleratorProfile', fakeAcceleratorProfile);
-              setData('count', Number(nvidiaAcceleratorRequests.count ?? 0));
-            }
-          } else {
-            // fallback to using the existing accelerator
-            setData('useExisting', true);
-            setData('additionalOptions', { useExisting: true });
+          if (migratedAcceleratorProfile) {
+            // setData('acceleratorProfile', migratedAcceleratorProfile);
+            // setData('count', Number(nvidiaAcceleratorRequests.count ?? 0));
+            // setData('unknownProfileDetected', false);
+            return {
+              acceleratorProfiles,
+              acceleratorProfile: migratedAcceleratorProfile,
+              count: getAcceleratorProfileCount(migratedAcceleratorProfile, resources),
+              unknownProfileDetected: false,
+            };
           }
+          // create a fake accelerator to use
+          const fakeAcceleratorProfile: AcceleratorProfileKind = {
+            apiVersion: 'dashboard.opendatahub.io/v1',
+            kind: 'AcceleratorProfile',
+            metadata: {
+              name: 'migrated-gpu',
+            },
+            spec: {
+              identifier: 'nvidia.com/gpu',
+              displayName: 'NVIDIA GPU',
+              enabled: true,
+              tolerations: [
+                {
+                  key: 'nvidia.com/gpu',
+                  operator: TolerationOperator.EXISTS,
+                  effect: TolerationEffect.NO_SCHEDULE,
+                },
+              ],
+            },
+          };
+
+          // setData('acceleratorProfile', fakeAcceleratorProfile);
+          // setData('acceleratorProfiles', [fakeAcceleratorProfile, ...acceleratorProfiles]);
+          // setData('count', Number(nvidiaAcceleratorRequests.count ?? 0));
+          // setData('unknownProfileDetected', false);
+          return {
+            acceleratorProfiles: [fakeAcceleratorProfile, ...acceleratorProfiles],
+            acceleratorProfile: fakeAcceleratorProfile,
+            count: Number(nvidiaAcceleratorRequests.count ?? 0),
+            unknownProfileDetected: false,
+          };
         }
+        // fallback to using the existing accelerator
+        // setData('unknownProfileDetected', true);
+        // setData('acceleratorProfile', undefined);
+        // setData('count', 0);
+        return {
+          acceleratorProfiles,
+          acceleratorProfile: undefined,
+          count: 0,
+          unknownProfileDetected: true,
+        };
       }
     }
+
+    return {
+      acceleratorProfiles,
+      acceleratorProfile: undefined,
+      count: 0,
+      unknownProfileDetected: false,
+    };
   }, [
     acceleratorProfiles,
     loaded,
@@ -137,15 +157,7 @@ const useAcceleratorProfileState = (
     resources,
     tolerations,
     existingAcceleratorProfileName,
-    setData,
   ]);
-
-  const resetDataAndRefresh = React.useCallback(() => {
-    resetData();
-    refresh();
-  }, [refresh, resetData]);
-
-  return [acceleratorProfileState, setData, resetDataAndRefresh];
 };
 
 export default useAcceleratorProfileState;

--- a/frontend/src/utilities/useAcceleratorProfileState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileState.ts
@@ -27,13 +27,6 @@ const useAcceleratorProfileState = (
   tolerations?: Toleration[],
   existingAcceleratorProfileName?: string,
 ): AcceleratorProfileState => {
-  // const [acceleratorProfileState, setData] = useGenericObjectState<AcceleratorProfileState>({
-  // acceleratorProfiles: [],
-  // acceleratorProfile: undefined,
-  // count: 0,
-  // unknownProfileDetected: false,
-  // });
-
   const { dashboardNamespace } = useDashboardNamespace();
   const [acceleratorProfiles, loaded, loadError] = useAcceleratorProfiles(dashboardNamespace);
 
@@ -53,9 +46,6 @@ const useAcceleratorProfileState = (
       );
 
       if (acceleratorProfile) {
-        // setData('acceleratorProfile', acceleratorProfile);
-        // setData('count', getAcceleratorProfileCount(acceleratorProfile, resources));
-        // setData('unknownProfileDetected', false);
         return {
           acceleratorProfiles,
           acceleratorProfile,
@@ -89,9 +79,6 @@ const useAcceleratorProfileState = (
           );
 
           if (migratedAcceleratorProfile) {
-            // setData('acceleratorProfile', migratedAcceleratorProfile);
-            // setData('count', Number(nvidiaAcceleratorRequests.count ?? 0));
-            // setData('unknownProfileDetected', false);
             return {
               acceleratorProfiles,
               acceleratorProfile: migratedAcceleratorProfile,
@@ -120,10 +107,6 @@ const useAcceleratorProfileState = (
             },
           };
 
-          // setData('acceleratorProfile', fakeAcceleratorProfile);
-          // setData('acceleratorProfiles', [fakeAcceleratorProfile, ...acceleratorProfiles]);
-          // setData('count', Number(nvidiaAcceleratorRequests.count ?? 0));
-          // setData('unknownProfileDetected', false);
           return {
             acceleratorProfiles: [fakeAcceleratorProfile, ...acceleratorProfiles],
             acceleratorProfile: fakeAcceleratorProfile,
@@ -131,10 +114,6 @@ const useAcceleratorProfileState = (
             unknownProfileDetected: false,
           };
         }
-        // fallback to using the existing accelerator
-        // setData('unknownProfileDetected', true);
-        // setData('acceleratorProfile', undefined);
-        // setData('count', 0);
         return {
           acceleratorProfiles,
           acceleratorProfile: undefined,


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-9368

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
refactors accelerator hook to now only show the current state of the resource's accelerator
moved all selected accelerator to the accelerator dropdown component

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
existing tests pass
and
1. create a accelerator from the admin panel
2. create workbench and make sure that the option shows up in the workbench under accelerators
3. check that save works
4. do this for model serving modal too
5. disable the accelerator from he admin page
6. edit the workbench and verify that the disabled option is still selectable
7. delete the accelerator
8. edit the workbench
9. verify that a use existing settings option is available

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
there is existing test coverage

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
