### PR TITLE
Fix disabled create button for connection types empty table

### DIFF
--- a/frontend/src/pages/connectionTypes/EmptyConnectionTypes.tsx
+++ b/frontend/src/pages/connectionTypes/EmptyConnectionTypes.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
   Button,
   EmptyState,
@@ -21,7 +22,11 @@ const EmptyConnectionTypes: React.FC = () => (
       />
       <EmptyStateBody>To get started create a connection type.</EmptyStateBody>
       <EmptyStateFooter>
-        <Button data-testid="add-connection-type" isDisabled>
+        <Button
+          data-testid="add-connection-type"
+          variant="primary"
+          component={(props) => <Link {...props} to="/connectionTypes/create" />}
+        >
           Create connection type
         </Button>
       </EmptyStateFooter>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Super simple change to route the user to the `connectionTypes/create` url. (same as the non empty create button)

<details>

<summary> screenshots </summary>

Before:
![image](https://github.com/user-attachments/assets/459b9799-738a-4309-8b1d-d302f66d8591)

After:
![Screenshot from 2024-08-19 15-45-58](https://github.com/user-attachments/assets/a08b9221-02ac-4918-8714-f968ba372dee)

![vid](https://github.com/user-attachments/assets/41cf51d2-c8e1-4f0c-817e-eb9b89e4b9f2)


</details


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

No tests added since it's very simple

To test, go to `/connectionTypes` route and make sure all are delete so you see the empty table.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

none 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
