### PR TITLE
Show only active experiments on create/duplicate schedules page

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -106,7 +106,6 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isCloned }) => {
         projectName={getDisplayNameFromK8sResource(data.project)}
         value={data.experiment}
         onChange={(experiment) => onValueChange('experiment', experiment)}
-        isSchedule={isSchedule}
       />
 
       <FormSection

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/ProjectAndExperimentSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/ProjectAndExperimentSection.tsx
@@ -6,10 +6,7 @@ import {
   CreateRunPageSections,
   runPageSectionTitles,
 } from '~/concepts/pipelines/content/createRun/const';
-import {
-  ActiveExperimentSelector,
-  AllExperimentSelector,
-} from '~/concepts/pipelines/content/experiment/ExperimentSelector';
+import { ActiveExperimentSelector } from '~/concepts/pipelines/content/experiment/ExperimentSelector';
 import CreateExperimentButton from '~/concepts/pipelines/content/experiment/CreateExperimentButton';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
@@ -17,14 +14,12 @@ type ProjectAndExperimentSectionProps = {
   projectName: string;
   value: ExperimentKFv2 | null;
   onChange: (experiment: ExperimentKFv2) => void;
-  isSchedule: boolean;
 };
 
 const ProjectAndExperimentSection: React.FC<ProjectAndExperimentSectionProps> = ({
   projectName,
   value,
   onChange,
-  isSchedule,
 }) => {
   const isExperimentsAvailable = useIsAreaAvailable(SupportedArea.PIPELINE_EXPERIMENTS).status;
 
@@ -44,11 +39,7 @@ const ProjectAndExperimentSection: React.FC<ProjectAndExperimentSectionProps> = 
         <FormGroup label="Experiment" aria-label="Experiment" isRequired>
           <Stack hasGutter>
             <StackItem>
-              {isSchedule ? (
-                <AllExperimentSelector selection={value?.display_name} onSelect={onChange} />
-              ) : (
-                <ActiveExperimentSelector selection={value?.display_name} onSelect={onChange} />
-              )}
+              <ActiveExperimentSelector selection={value?.display_name} onSelect={onChange} />
             </StackItem>
             <StackItem>
               <CreateExperimentButton

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -102,23 +102,16 @@ const useUpdateExperimentFormData = (
   const [formData, setFormValue] = formState;
 
   React.useEffect(() => {
-    // on create run page, we always check the experiment archived state
-    // no matter it's duplicated or carried from the create schedules pages
-    if (formData.runType.type === RunTypeOption.ONE_TRIGGER) {
-      if (formData.experiment) {
-        if (formData.experiment.storage_state === StorageStateKF.ARCHIVED) {
-          setFormValue('experiment', null);
-        }
-      } else if (experiment) {
-        if (experiment.storage_state === StorageStateKF.ARCHIVED) {
-          setFormValue('experiment', null);
-        } else {
-          setFormValue('experiment', experiment);
-        }
+    if (formData.experiment) {
+      if (formData.experiment.storage_state === StorageStateKF.ARCHIVED) {
+        setFormValue('experiment', null);
       }
-    } else if (!formData.experiment && experiment) {
-      // else, on create schedules page, we do what we did before
-      setFormValue('experiment', experiment);
+    } else if (experiment) {
+      if (experiment.storage_state === StorageStateKF.ARCHIVED) {
+        setFormValue('experiment', null);
+      } else {
+        setFormValue('experiment', experiment);
+      }
     }
   }, [formData.experiment, setFormValue, experiment, formData.runType.type]);
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-10401](https://issues.redhat.com/browse/RHOAIENG-10401)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When user creates/duplicates a schedule, prevent user from selecting the archived experiments from the selector and only show active experiments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create `ExperimentA`
2. Create a schedule `ScheduleA` with `ExperimentA`
3. Archive `ExperimentA`
4. Create a schedule, make sure you cannot select `ExperimentA` in the experiment selector
5. Duplicate the `ScheduleA`, make sure `ExperimentA` is not pre-filled

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added/changed some cypress tests to better test selecting archived experiments on a create schedules page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
