### PR TITLE
 removed the use of Patch Body

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
@@ -190,10 +190,7 @@ describe('Restoring archive version', () => {
 
     cy.wait('@versionRestored').then((interception) => {
       expect(interception.request.body).to.eql({
-        author: 'Test author',
-        customProperties: {},
         state: 'LIVE',
-        description: 'Description of model version',
       });
     });
   });
@@ -219,10 +216,7 @@ describe('Restoring archive version', () => {
 
     cy.wait('@versionRestored').then((interception) => {
       expect(interception.request.body).to.eql({
-        author: 'Test author',
-        customProperties: {},
         state: 'LIVE',
-        description: 'Description of model version',
       });
     });
   });
@@ -252,10 +246,7 @@ describe('Archiving version', () => {
     archiveVersionModal.findArchiveButton().should('be.enabled').click();
     cy.wait('@versionArchived').then((interception) => {
       expect(interception.request.body).to.eql({
-        author: 'Test author',
-        customProperties: {},
         state: 'ARCHIVED',
-        description: 'Description of model version',
       });
     });
   });
@@ -285,10 +276,7 @@ describe('Archiving version', () => {
     archiveVersionModal.findArchiveButton().should('be.enabled').click();
     cy.wait('@versionArchived').then((interception) => {
       expect(interception.request.body).to.eql({
-        author: 'Test author',
-        customProperties: {},
         state: 'ARCHIVED',
-        description: 'Description of model version',
       });
     });
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
@@ -167,11 +167,7 @@ describe('Restoring archive model', () => {
 
     cy.wait('@modelRestored').then((interception) => {
       expect(interception.request.body).to.eql({
-        customProperties: {},
-        description: '',
-        externalID: '1234132asdfasdf',
         state: 'LIVE',
-        owner: 'Author 1',
       });
     });
   });
@@ -197,11 +193,7 @@ describe('Restoring archive model', () => {
 
     cy.wait('@modelRestored').then((interception) => {
       expect(interception.request.body).to.eql({
-        customProperties: {},
-        description: '',
-        externalID: '1234132asdfasdf',
         state: 'LIVE',
-        owner: 'Author 1',
       });
     });
   });
@@ -231,11 +223,7 @@ describe('Archiving model', () => {
     archiveModelModal.findArchiveButton().should('be.enabled').click();
     cy.wait('@modelArchived').then((interception) => {
       expect(interception.request.body).to.eql({
-        customProperties: {},
-        description: '',
-        externalID: '1234132asdfasdf',
         state: 'ARCHIVED',
-        owner: 'Author 1',
       });
     });
   });
@@ -265,11 +253,7 @@ describe('Archiving model', () => {
     archiveModelModal.findArchiveButton().should('be.enabled').click();
     cy.wait('@modelArchived').then((interception) => {
       expect(interception.request.body).to.eql({
-        customProperties: {},
-        description: '',
-        externalID: '1234132asdfasdf',
         state: 'ARCHIVED',
-        owner: 'Author 1',
       });
     });
   });

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import { ModelVersion, ModelState } from '~/concepts/modelRegistry/types';
-import { getPatchBodyForModelVersion } from '~/pages/modelRegistry/screens/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import {
   modelVersionArchiveDetailsUrl,
@@ -92,8 +91,9 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
           apiState.api
             .patchModelVersion(
               {},
-              // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-              getPatchBodyForModelVersion(mv, { state: ModelState.ARCHIVED }),
+              {
+                state: ModelState.ARCHIVED,
+              },
               mv.id,
             )
             .then(() =>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -5,11 +5,7 @@ import DashboardDescriptionListGroup from '~/components/DashboardDescriptionList
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
 import EditableLabelsDescriptionListGroup from '~/components/EditableLabelsDescriptionListGroup';
 import ModelPropertiesDescriptionListGroup from '~/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup';
-import {
-  getLabels,
-  getPatchBodyForModelVersion,
-  mergeUpdatedLabels,
-} from '~/pages/modelRegistry/screens/utils';
+import { getLabels, mergeUpdatedLabels } from '~/pages/modelRegistry/screens/utils';
 import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
@@ -44,8 +40,9 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
               apiState.api
                 .patchModelVersion(
                   {},
-                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                  getPatchBodyForModelVersion(mv, { description: value }),
+                  {
+                    description: value,
+                  },
                   mv.id,
                 )
                 .then(refresh)
@@ -58,10 +55,9 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
               apiState.api
                 .patchModelVersion(
                   {},
-                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                  getPatchBodyForModelVersion(mv, {
+                  {
                     customProperties: mergeUpdatedLabels(mv.customProperties, editedLabels),
-                  }),
+                  },
                   mv.id,
                 )
                 .then(refresh)
@@ -71,12 +67,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
             customProperties={mv.customProperties}
             saveEditedCustomProperties={(editedProperties) =>
               apiState.api
-                .patchModelVersion(
-                  {},
-                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                  getPatchBodyForModelVersion(mv, { customProperties: editedProperties }),
-                  mv.id,
-                )
+                .patchModelVersion({}, { customProperties: editedProperties }, mv.id)
                 .then(refresh)
             }
           />

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelDetailsView.tsx
@@ -6,11 +6,7 @@ import DashboardDescriptionListGroup from '~/components/DashboardDescriptionList
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
 import EditableLabelsDescriptionListGroup from '~/components/EditableLabelsDescriptionListGroup';
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
-import {
-  getLabels,
-  getPatchBodyForRegisteredModel,
-  mergeUpdatedLabels,
-} from '~/pages/modelRegistry/screens/utils';
+import { getLabels, mergeUpdatedLabels } from '~/pages/modelRegistry/screens/utils';
 import ModelPropertiesDescriptionListGroup from '~/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup';
 
 type ModelDetailsViewProps = {
@@ -36,8 +32,9 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm
               apiState.api
                 .patchRegisteredModel(
                   {},
-                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                  getPatchBodyForRegisteredModel(rm, { description: value }),
+                  {
+                    description: value,
+                  },
                   rm.id,
                 )
                 .then(refresh)
@@ -50,10 +47,9 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm
               apiState.api
                 .patchRegisteredModel(
                   {},
-                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                  getPatchBodyForRegisteredModel(rm, {
+                  {
                     customProperties: mergeUpdatedLabels(rm.customProperties, editedLabels),
-                  }),
+                  },
                   rm.id,
                 )
                 .then(refresh)
@@ -65,8 +61,9 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ registeredModel: rm
               apiState.api
                 .patchRegisteredModel(
                   {},
-                  // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                  getPatchBodyForRegisteredModel(rm, { customProperties: editedProperties }),
+                  {
+                    customProperties: editedProperties,
+                  },
                   rm.id,
                 )
                 .then(refresh)

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsHeaderActions.tsx
@@ -10,7 +10,6 @@ import {
 import { useNavigate } from 'react-router';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import { ArchiveRegisteredModelModal } from '~/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
-import { getPatchBodyForRegisteredModel } from '~/pages/modelRegistry/screens/utils';
 import { registeredModelsUrl } from '~/pages/modelRegistry/screens/routeUtils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { RegisteredModel, ModelState } from '~/concepts/modelRegistry/types';
@@ -70,8 +69,9 @@ const ModelVersionsHeaderActions: React.FC<ModelVersionsHeaderActionsProps> = ({
           apiState.api
             .patchRegisteredModel(
               {},
-              // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-              getPatchBodyForRegisteredModel(rm, { state: ModelState.ARCHIVED }),
+              {
+                state: ModelState.ARCHIVED,
+              },
               rm.id,
             )
             .then(() => navigate(registeredModelsUrl(preferredModelRegistry?.metadata.name)))

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -13,7 +13,6 @@ import {
 } from '~/pages/modelRegistry/screens/routeUtils';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
-import { getPatchBodyForModelVersion } from '~/pages/modelRegistry/screens/utils';
 import { RestoreModelVersionModal } from '~/pages/modelRegistry/screens/components/RestoreModelVersionModal';
 import DeployRegisteredModelModal from '~/pages/modelRegistry/screens/components/DeployRegisteredModelModal';
 
@@ -98,8 +97,9 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
             apiState.api
               .patchModelVersion(
                 {},
-                // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                getPatchBodyForModelVersion(mv, { state: ModelState.ARCHIVED }),
+                {
+                  state: ModelState.ARCHIVED,
+                },
                 mv.id,
               )
               .then(refresh)
@@ -127,8 +127,9 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
             apiState.api
               .patchModelVersion(
                 {},
-                // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                getPatchBodyForModelVersion(mv, { state: ModelState.LIVE }),
+                {
+                  state: ModelState.LIVE,
+                },
                 mv.id,
               )
               .then(() =>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
@@ -10,7 +10,6 @@ import { ModelVersionDetailsTab } from '~/pages/modelRegistry/screens/ModelVersi
 import ModelVersionDetailsTabs from '~/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs';
 import { RestoreModelVersionModal } from '~/pages/modelRegistry/screens/components/RestoreModelVersionModal';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
-import { getPatchBodyForModelVersion } from '~/pages/modelRegistry/screens/utils';
 import { ModelState } from '~/concepts/modelRegistry/types';
 import useInferenceServices from '~/pages/modelServing/useInferenceServices';
 import useServingRuntimes from '~/pages/modelServing/useServingRuntimes';
@@ -92,8 +91,9 @@ const ModelVersionsArchiveDetails: React.FC<ModelVersionsArchiveDetailsProps> = 
             apiState.api
               .patchModelVersion(
                 {},
-                // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                getPatchBodyForModelVersion(mv, { state: ModelState.LIVE }),
+                {
+                  state: ModelState.LIVE,
+                },
                 mv.id,
               )
               .then(() =>

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -12,7 +12,6 @@ import {
 import ModelLabels from '~/pages/modelRegistry/screens/components/ModelLabels';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import { ArchiveRegisteredModelModal } from '~/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
-import { getPatchBodyForRegisteredModel } from '~/pages/modelRegistry/screens/utils';
 import { RestoreRegisteredModelModal } from '~/pages/modelRegistry/screens/components/RestoreRegisteredModel';
 
 type RegisteredModelTableRowProps = {
@@ -86,8 +85,9 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
             apiState.api
               .patchRegisteredModel(
                 {},
-                // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                getPatchBodyForRegisteredModel(rm, { state: ModelState.ARCHIVED }),
+                {
+                  state: ModelState.ARCHIVED,
+                },
                 rm.id,
               )
               .then(refresh)
@@ -101,8 +101,9 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
             apiState.api
               .patchRegisteredModel(
                 {},
-                // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                getPatchBodyForRegisteredModel(rm, { state: ModelState.LIVE }),
+                {
+                  state: ModelState.LIVE,
+                },
                 rm.id,
               )
               .then(() =>

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelArchiveDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelArchiveDetails.tsx
@@ -6,7 +6,6 @@ import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/M
 import { registeredModelUrl } from '~/pages/modelRegistry/screens/routeUtils';
 import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegisteredModelById';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
-import { getPatchBodyForRegisteredModel } from '~/pages/modelRegistry/screens/utils';
 import { ModelState } from '~/concepts/modelRegistry/types';
 import { RestoreRegisteredModelModal } from '~/pages/modelRegistry/screens/components/RestoreRegisteredModel';
 import ModelVersionsTabs from '~/pages/modelRegistry/screens/ModelVersions/ModelVersionsTabs';
@@ -84,8 +83,9 @@ const RegisteredModelsArchiveDetails: React.FC<RegisteredModelsArchiveDetailsPro
             apiState.api
               .patchRegisteredModel(
                 {},
-                // TODO remove the getPatchBody* functions when https://issues.redhat.com/browse/RHOAIENG-6652 is resolved
-                getPatchBodyForRegisteredModel(rm, { state: ModelState.LIVE }),
+                {
+                  state: ModelState.LIVE,
+                },
                 rm.id,
               )
               .then(() =>

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -15,7 +15,6 @@ import {
   getProperties,
   mergeUpdatedProperty,
   mergeUpdatedLabels,
-  getPatchBody,
   filterRegisteredModels,
 } from '~/pages/modelRegistry/screens/utils';
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
@@ -259,68 +258,6 @@ describe('mergeUpdatedProperty', () => {
       label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
       prop1: { string_value: 'val1', metadataType: ModelRegistryMetadataType.STRING },
     } satisfies ModelRegistryCustomProperties);
-  });
-});
-
-describe('getPatchBody', () => {
-  it('returns a given RegisteredModel with id/name/timestamps removed, customProperties updated and other values unchanged', () => {
-    const registeredModel = mockRegisteredModel({
-      id: '1',
-      owner: 'Author 1',
-      name: 'test-model',
-      description: 'Description here',
-      labels: [],
-      state: ModelState.LIVE,
-    });
-    const result = getPatchBody(
-      registeredModel,
-      {
-        customProperties: {
-          label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
-        },
-      },
-      [],
-    );
-    expect(result).toEqual({
-      description: 'Description here',
-      customProperties: {
-        label1: { string_value: '', metadataType: ModelRegistryMetadataType.STRING },
-      },
-      owner: 'Author 1',
-      state: ModelState.LIVE,
-      externalID: '1234132asdfasdf',
-    } satisfies Partial<RegisteredModel>);
-  });
-
-  it('returns a given ModelVersion with id/name/timestamps removed, description updated and other values unchanged', () => {
-    const modelVersion = mockModelVersion({
-      author: 'Test author',
-      registeredModelId: '1',
-    });
-    const result = getPatchBody(modelVersion, { description: 'New description' }, []);
-    expect(result).toEqual({
-      author: 'Test author',
-      registeredModelId: '1',
-      description: 'New description',
-      customProperties: {},
-      state: ModelState.LIVE,
-    } satisfies Partial<ModelVersion>);
-  });
-
-  it('excludes given additional properties', () => {
-    const modelVersion = mockModelVersion({
-      author: 'Test author',
-      registeredModelId: '1',
-    });
-    const result = getPatchBody(modelVersion, { description: 'New description' }, [
-      'registeredModelId',
-    ]);
-    expect(result).toEqual({
-      author: 'Test author',
-      description: 'New description',
-      customProperties: {},
-      state: ModelState.LIVE,
-    } satisfies Partial<ModelVersion>);
   });
 });
 

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -1,6 +1,5 @@
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import {
-  ModelRegistryBase,
   ModelRegistryCustomProperties,
   ModelRegistryMetadataType,
   ModelRegistryStringCustomProperties,
@@ -75,37 +74,6 @@ export const mergeUpdatedProperty = (
   }
   return customPropertiesCopy;
 };
-
-// Returns a patch payload for a Model Registry object, retaining all mutable fields but excluding internal fields to prevent errors
-// TODO this will not be necessary if the backend eventually merges objects on PATCH requests. See https://issues.redhat.com/browse/RHOAIENG-6652
-export const getPatchBody = <T extends ModelRegistryBase>(
-  existingObj: T,
-  updates: Partial<T>,
-  otherExcludedKeys: (keyof T)[],
-): Partial<T> => {
-  const objCopy = { ...existingObj };
-  const excludedKeys: (keyof T)[] = [
-    'id',
-    'name',
-    'createTimeSinceEpoch',
-    'lastUpdateTimeSinceEpoch',
-    ...otherExcludedKeys,
-  ];
-  excludedKeys.forEach((key) => {
-    delete objCopy[key];
-  });
-  return { ...objCopy, ...updates };
-};
-
-export const getPatchBodyForRegisteredModel = (
-  existing: RegisteredModel,
-  updates: Partial<RegisteredModel>,
-): Partial<RegisteredModel> => getPatchBody(existing, updates, []);
-
-export const getPatchBodyForModelVersion = (
-  existing: ModelVersion,
-  updates: Partial<ModelVersion>,
-): Partial<ModelVersion> => getPatchBody(existing, updates, ['registeredModelId']);
 
 export const filterModelVersions = (
   unfilteredModelVersions: ModelVersion[],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-10997)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removed the workaround for Patching the fields from API. As described in the issue, the description, labels, and Properties should remain when I archive the model. See attached Screenshots 
<img width="1432" alt="Screenshot 2024-08-21 at 10 18 06 AM" src="https://github.com/user-attachments/assets/ad555c0f-9d32-4d3f-836c-6902d6133669">
<img width="1609" alt="Screenshot 2024-08-21 at 10 18 23 AM" src="https://github.com/user-attachments/assets/3bf0517f-fddc-435c-9b0c-7b8552caf81f">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the UI see above sreenshots
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I've deleted some tests that were related to the Patching functions, Also updated some fields in the tests now to match the behavior as the remaining fields in those tests are not needed anymore, because they are coming from a different place now.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
