### PR TITLE
RHOAIENG-11049 Add tracking for model serving

### DIFF
--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -7,6 +7,8 @@ import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableVie
 import { isModelMesh } from '~/pages/modelServing/utils';
 import ManageKServeModal from '~/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
 import ResourceTr from '~/components/ResourceTr';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 import InferenceServiceTableRow from './InferenceServiceTableRow';
 import { getGlobalInferenceServiceColumns, getProjectInferenceServiceColumns } from './data';
 import DeleteInferenceServiceModal from './DeleteInferenceServiceModal';
@@ -91,6 +93,10 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
             : undefined
         }
         onClose={(deleted) => {
+          fireFormTrackingEvent('Model Deleted', {
+            outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
+            type: 'multi',
+          });
           if (deleted) {
             refresh?.();
           }
@@ -101,6 +107,10 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
         isOpen={!!editInferenceService && isModelMesh(editInferenceService)}
         editInfo={editInferenceService}
         onClose={(edited) => {
+          fireFormTrackingEvent('Model Updated', {
+            outcome: edited ? TrackingOutcome.submit : TrackingOutcome.cancel,
+            type: 'multi',
+          });
           if (edited) {
             refresh?.();
           }

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -6,6 +6,8 @@ import KServeInferenceServiceTableRow from '~/pages/modelServing/screens/project
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import ManageKServeModal from '~/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
 import DeleteInferenceServiceModal from '~/pages/modelServing/screens/global/DeleteInferenceServiceModal';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 
 const KServeInferenceServiceTable: React.FC = () => {
   const [editKserveResources, setEditKServeResources] = React.useState<
@@ -56,6 +58,10 @@ const KServeInferenceServiceTable: React.FC = () => {
         inferenceService={deleteKserveResources?.inferenceService}
         servingRuntime={deleteKserveResources?.servingRuntime}
         onClose={(deleted) => {
+          fireFormTrackingEvent('Model Deleted', {
+            outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
+            type: 'single',
+          });
           if (deleted) {
             refreshServingRuntime();
             refreshInferenceServices();

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
@@ -8,6 +8,8 @@ import ServingRuntimeTableRow from '~/pages/modelServing/screens/projects/ModelM
 import DeleteServingRuntimeModal from '~/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal';
 import ManageServingRuntimeModal from '~/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'rbac.authorization.k8s.io',
@@ -62,6 +64,9 @@ const ServingRuntimeTable: React.FC = () => {
           servingRuntime={deleteServingRuntime}
           inferenceServices={inferenceServices}
           onClose={(deleted) => {
+            fireFormTrackingEvent('Model Server Deleted', {
+              outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
+            });
             if (deleted) {
               refreshServingRuntime();
             }
@@ -95,6 +100,10 @@ const ServingRuntimeTable: React.FC = () => {
               refreshDataConnections();
               setExpandedServingRuntimeName(deployServingRuntime.metadata.name);
             }
+            fireFormTrackingEvent('Model Deployed', {
+              outcome: submit ? TrackingOutcome.submit : TrackingOutcome.cancel,
+              type: 'multi',
+            });
           }}
           projectContext={{
             currentProject,

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -50,6 +50,11 @@ import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/Registe
 import usePrefillDeployModalFromModelRegistry from '~/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry';
 import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import {
+  FormTrackingEventProperties,
+  TrackingOutcome,
+} from '~/concepts/analyticsTracking/trackingProperties';
 import KServeAutoscalerReplicaSection from './KServeAutoscalerReplicaSection';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
@@ -193,6 +198,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   );
 
   const onBeforeClose = (submitted: boolean) => {
+    fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', {
+      outcome: TrackingOutcome.cancel,
+    });
     onClose(submitted);
     setError(undefined);
     setActionInProgress(false);
@@ -207,9 +215,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     setActionInProgress(false);
   };
 
-  const onSuccess = () => {
+  const onSuccess = (tProps: FormTrackingEventProperties) => {
     setActionInProgress(false);
     onBeforeClose(true);
+    fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', tProps);
   };
 
   const submit = () => {
@@ -249,6 +258,15 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       editInfo?.secrets,
     );
 
+    const props: FormTrackingEventProperties = {
+      outcome: TrackingOutcome.submit,
+      type: 'single',
+      runtime: servingRuntimeName,
+      isCustomRuntime: customServingRuntimesEnabled,
+      servingRuntimeName: createDataServingRuntime.servingRuntimeTemplateName,
+      servingRuntimeFormat: createDataInferenceService.format.name,
+      numReplicas: createDataServingRuntime.servingRuntimeTemplateName,
+    };
     Promise.all([
       submitServingRuntimeResources({ dryRun: true }),
       submitInferenceServiceResource({ dryRun: true }),
@@ -259,9 +277,15 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
           submitInferenceServiceResource({ dryRun: false }),
         ]),
       )
-      .then(onSuccess)
+      .then(() => {
+        props.success = true;
+        onSuccess(props);
+      })
       .catch((e) => {
+        props.success = false;
+        props.errorMessage = e;
         setErrorModal(e);
+        fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
       });
   };
 

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -279,6 +279,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       )
       .then(() => {
         props.success = true;
+        fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
         onSuccess(props);
       })
       .catch((e) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-11049

## Description
Add Segment tracking for Model serving Deploy/Edit/Delete  operations

## How Has This Been Tested?

Manual testing by clicking in the UI and watching the events fired in the browser console

* Deploy a Model in Kserve (submit / cancel cases)  
* Deploy a Model server, (submit / cancel )
* Edit a Model server (submit /cancel)
* Deploy a model on a model server

Those should all yield lines like the following in the browser console, when in dev-mode. The `outcome` property should match the action submit/cancel of the dialog.

> Telemetry event triggered: Model Deployed - {"outcome":"cancel","type":"multi"} for version v2.25.0 
> Telemetry event triggered: Model Server Modified - {"outcome":"submit","type":"OpenVINO Model Server","size":"Small","success":true} for version v2.25.0
> Telemetry event triggered: Model Server Deleted - {"outcome":"submit"} for version v2.25.0


## Test Impact

Manual testing as described above

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
