### PR TITLE
Add character length limit to the description field on create run form

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
@@ -164,11 +164,12 @@ describe('Pipeline create runs', () => {
       );
       createRunPage.find();
 
+      const veryLongDesc = 'Test description'.repeat(30); // A string over 255 characters
       // Fill out the form without a schedule and submit
       createRunPage.fillName(initialMockRuns[0].display_name);
       cy.findByTestId('duplicate-name-help-text').should('be.visible');
       createRunPage.fillName('New run');
-      createRunPage.fillDescription('New run description');
+      createRunPage.fillDescription(veryLongDesc);
       createRunPage.findExperimentSelect().should('contain.text', 'Select an experiment');
       createRunPage.findExperimentSelect().should('not.be.disabled').click();
       createRunPage.selectExperimentByName('Test experiment 1');
@@ -189,7 +190,7 @@ describe('Pipeline create runs', () => {
       cy.wait('@createRun').then((interception) => {
         expect(interception.request.body).to.eql({
           display_name: 'New run',
-          description: 'New run description',
+          description: veryLongDesc.substring(0, 255), // Verify the description in truncated
           pipeline_version_reference: {
             pipeline_id: 'test-pipeline',
             pipeline_version_id: 'test-pipeline-version',

--- a/frontend/src/concepts/k8s/NameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/NameDescriptionField.tsx
@@ -25,7 +25,8 @@ type NameDescriptionFieldProps = {
   K8sLabelName?: string;
   showK8sName?: boolean;
   disableK8sName?: boolean;
-  maxLength?: number;
+  maxLengthName?: number;
+  maxLengthDesc?: number;
   nameHelperText?: React.ReactNode;
   onNameChange?: (value: string) => void;
 };
@@ -41,7 +42,8 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
   K8sLabelName = 'Resource name',
   showK8sName,
   disableK8sName,
-  maxLength,
+  maxLengthName,
+  maxLengthDesc,
   nameHelperText,
   onNameChange,
 }) => {
@@ -81,12 +83,12 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
                   }
                 : undefined
             }
-            maxLength={maxLength}
+            maxLength={maxLengthName}
           />
 
-          {maxLength && (
+          {maxLengthName && (
             <HelperText>
-              <HelperTextItem>{`Cannot exceed ${maxLength} characters`}</HelperTextItem>
+              <HelperTextItem>{`Cannot exceed ${maxLengthName} characters`}</HelperTextItem>
             </HelperText>
           )}
 
@@ -160,7 +162,13 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
             name={descriptionFieldId}
             value={data.description}
             onChange={setData ? (e, description) => setData({ ...data, description }) : undefined}
+            maxLength={maxLengthDesc}
           />
+          {maxLengthDesc && (
+            <HelperText>
+              <HelperTextItem>{`Cannot exceed ${maxLengthDesc} characters`}</HelperTextItem>
+            </HelperText>
+          )}
         </FormGroup>
       </StackItem>
     </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -21,7 +21,12 @@ import useDebounceCallback from '~/utilities/useDebounceCallback';
 import { isArgoWorkflow } from '~/concepts/pipelines/content/tables/utils';
 import PipelineSection from './contentSections/PipelineSection';
 import { RunTypeSection } from './contentSections/RunTypeSection';
-import { CreateRunPageSections, RUN_NAME_CHARACTER_LIMIT, runPageSectionTitles } from './const';
+import {
+  CreateRunPageSections,
+  RUN_DESCRIPTION_CHARACTER_LIMIT,
+  RUN_NAME_CHARACTER_LIMIT,
+  runPageSectionTitles,
+} from './const';
 import { getInputDefinitionParams } from './utils';
 
 type RunFormProps = {
@@ -122,7 +127,8 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isCloned }) => {
           descriptionFieldId="run-description"
           data={data.nameDesc}
           setData={(nameDesc) => onValueChange('nameDesc', nameDesc)}
-          maxLength={RUN_NAME_CHARACTER_LIMIT}
+          maxLengthName={RUN_NAME_CHARACTER_LIMIT}
+          maxLengthDesc={RUN_DESCRIPTION_CHARACTER_LIMIT}
           onNameChange={(value) => {
             setHasDuplicateName(false);
             checkForDuplicateName(value);

--- a/frontend/src/concepts/pipelines/content/createRun/const.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/const.ts
@@ -36,3 +36,4 @@ export const runPageSectionTitles: Record<CreateRunPageSections, string> = {
 };
 
 export const RUN_NAME_CHARACTER_LIMIT = 255;
+export const RUN_DESCRIPTION_CHARACTER_LIMIT = 255;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-11058

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a helper text and a length limit to the text area of the description field on the create run/schedule page.

<img width="1510" alt="Screenshot 2024-08-21 at 12 10 01 PM" src="https://github.com/user-attachments/assets/2f8c3b33-8762-445e-b1ab-bd37c81cc39d">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the create run/schedule page
2. Check if the helper text "Cannot exceed 255 characters" is under the description field
3. Try to type in a long string, and you cannot type more when you reach the limit of 255 characters

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added some cypress checks in the current test cases to make sure the input field character length is limited.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
