### PR TITLE
Update connection type field action "Move to section heading"

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -86,6 +86,12 @@ class CreateConnectionTypePage {
   findSubmitButton() {
     return cy.findByTestId('submit-button');
   }
+
+  shouldHaveTableRowNames(rowNames: string[]) {
+    rowNames.map((name, index) =>
+      this.getFieldsTableRow(index).findName().should('contain.text', name),
+    );
+  }
 }
 
 class ConnectionTypesTableToolbar extends TableToolbar {}

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -178,7 +178,6 @@ describe('edit', () => {
           {
             type: 'section',
             name: 'header1',
-            properties: {},
           },
           {
             type: 'short-text',
@@ -189,7 +188,6 @@ describe('edit', () => {
           {
             type: 'section',
             name: 'header2',
-            properties: {},
           },
           {
             type: 'short-text',
@@ -197,36 +195,46 @@ describe('edit', () => {
             envVar: 'short-text-3',
             properties: {},
           },
-        ] as ConnectionTypeField[],
+        ],
       }),
     );
     createConnectionTypePage.visitEditPage('existing');
+    createConnectionTypePage.shouldHaveTableRowNames([
+      'field1',
+      'header1',
+      'field2',
+      'header2',
+      'field3',
+    ]);
 
-    createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'field1');
-    createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'header1');
-    createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'field2');
-    createConnectionTypePage.getFieldsTableRow(3).findName().should('contain.text', 'header2');
-    createConnectionTypePage.getFieldsTableRow(4).findName().should('contain.text', 'field3');
+    createConnectionTypePage
+      .getFieldsTableRow(4)
+      .findKebabAction('Move to section heading')
+      .click();
+    // move to default which is the first section
+    cy.findByTestId('section-heading-select').should('be.disabled');
+    cy.findByTestId('modal-submit-button').click();
+    createConnectionTypePage.shouldHaveTableRowNames([
+      'field1',
+      'header1',
+      'field3',
+      'field2',
+      'header2',
+    ]);
 
     createConnectionTypePage
       .getFieldsTableRow(0)
       .findKebabAction('Move to section heading')
       .click();
-    // move to default which is the first section
-    cy.findByText('Move').click();
-
-    createConnectionTypePage
-      .getFieldsTableRow(2)
-      .findKebabAction('Move to section heading')
-      .click();
     cy.findByTestId('section-heading-select').click();
-    cy.findByTestId(['select-name-header2']).click();
-    cy.findByText('Move').click();
-
-    createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'header1');
-    createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'field1');
-    createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'header2');
-    createConnectionTypePage.getFieldsTableRow(3).findName().should('contain.text', 'field2');
-    createConnectionTypePage.getFieldsTableRow(4).findName().should('contain.text', 'field3');
+    cy.findByTestId('section-heading-select').findSelectOption('header2').click();
+    cy.findByTestId('modal-submit-button').click();
+    createConnectionTypePage.shouldHaveTableRowNames([
+      'header1',
+      'field3',
+      'field2',
+      'header2',
+      'field1',
+    ]);
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -136,14 +136,14 @@ describe('edit', () => {
         disableConnectionTypes: false,
       }),
     );
+  });
+
+  it('Drag and drop field rows in table', () => {
     cy.interceptOdh(
       'GET /api/connection-types/:name',
       { path: { name: 'existing' } },
       toConnectionTypeConfigMap(existing),
     );
-  });
-
-  it('Drag and drop field rows in table', () => {
     createConnectionTypePage.visitEditPage('existing');
 
     createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'header1');
@@ -161,5 +161,72 @@ describe('edit', () => {
     createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'field2');
     createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'field1');
     createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'header1');
+  });
+
+  it('Move field to section modal', () => {
+    cy.interceptOdh(
+      'GET /api/connection-types/:name',
+      { path: { name: 'existing' } },
+      mockConnectionTypeConfigMap({
+        fields: [
+          {
+            type: 'short-text',
+            name: 'field1',
+            envVar: 'short-text-1',
+            properties: {},
+          },
+          {
+            type: 'section',
+            name: 'header1',
+            properties: {},
+          },
+          {
+            type: 'short-text',
+            name: 'field2',
+            envVar: 'short-text-2',
+            properties: {},
+          },
+          {
+            type: 'section',
+            name: 'header2',
+            properties: {},
+          },
+          {
+            type: 'short-text',
+            name: 'field3',
+            envVar: 'short-text-3',
+            properties: {},
+          },
+        ] as ConnectionTypeField[],
+      }),
+    );
+    createConnectionTypePage.visitEditPage('existing');
+
+    createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'field1');
+    createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'header1');
+    createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'field2');
+    createConnectionTypePage.getFieldsTableRow(3).findName().should('contain.text', 'header2');
+    createConnectionTypePage.getFieldsTableRow(4).findName().should('contain.text', 'field3');
+
+    createConnectionTypePage
+      .getFieldsTableRow(0)
+      .findKebabAction('Move to section heading')
+      .click();
+    // move to default which is the first section
+    cy.findByText('Move').click();
+
+    createConnectionTypePage
+      .getFieldsTableRow(2)
+      .findKebabAction('Move to section heading')
+      .click();
+    cy.findByTestId('section-heading-select').click();
+    cy.findByTestId(['select-name-header2']).click();
+    cy.findByText('Move').click();
+
+    createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'header1');
+    createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'field1');
+    createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'header2');
+    createConnectionTypePage.getFieldsTableRow(3).findName().should('contain.text', 'field2');
+    createConnectionTypePage.getFieldsTableRow(4).findName().should('contain.text', 'field3');
   });
 });

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import {
+  Form,
+  FormGroup,
+  MenuToggle,
+  Modal,
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import { ConnectionTypeField, ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+
+type SectionSelection = { sectionName: string; sectionIndex: number };
+
+type Props = {
+  field?: ConnectionTypeField;
+  rows?: ConnectionTypeField[];
+  onClose: () => void;
+  onSubmit: (field: ConnectionTypeField, index: number) => void;
+};
+
+export const ConnectionTypeMoveFieldToSectionModal: React.FC<Props> = ({
+  field,
+  rows,
+  onClose,
+  onSubmit,
+}) => {
+  const options = React.useMemo(() => {
+    const temp: SectionSelection[] = [];
+    for (let i = 0; rows && i < rows.length; i++) {
+      if (rows[i].type === ConnectionTypeFieldType.Section) {
+        temp.push({ sectionName: rows[i].name, sectionIndex: i });
+      }
+    }
+    return temp;
+  }, [rows]);
+
+  const [isSelectOpen, setIsSelectOpen] = React.useState(false);
+  const [selectedSection, setSelectedSection] = React.useState<SectionSelection | undefined>(
+    options[0],
+  );
+
+  return (
+    <Modal
+      isOpen
+      title="Move to section"
+      onClose={onClose}
+      variant="medium"
+      footer={
+        <DashboardModalFooter
+          submitLabel="Move"
+          onCancel={onClose}
+          onSubmit={() => {
+            if (field && selectedSection) {
+              onSubmit(field, selectedSection.sectionIndex);
+              onClose();
+            }
+          }}
+          isSubmitDisabled={!selectedSection}
+          alertTitle=""
+        />
+      }
+    >
+      Select the section heading that <b>{field?.name}</b> will be moved to.
+      <Form>
+        <FormGroup
+          fieldId="sectionHeading"
+          label="Section heading"
+          isRequired
+          data-testid="section-heading-select"
+        >
+          <Select
+            id="sectionHeading"
+            isOpen={isSelectOpen}
+            shouldFocusToggleOnSelect
+            selected={selectedSection}
+            onSelect={(_e, value) => {
+              setSelectedSection(options.find((s) => s.sectionIndex === value));
+              setIsSelectOpen(false);
+            }}
+            onOpenChange={(open) => setIsSelectOpen(open)}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                id="type-select"
+                isFullWidth
+                onClick={() => {
+                  setIsSelectOpen((open) => !open);
+                }}
+                isExpanded={isSelectOpen}
+                isDisabled={options.length === 1}
+              >
+                {selectedSection?.sectionName}
+              </MenuToggle>
+            )}
+          >
+            <SelectList>
+              {options.map((s, i) => (
+                <SelectOption
+                  key={s.sectionName}
+                  value={s.sectionIndex}
+                  data-testid={`select-value-${i} select-name-${s.sectionName}`}
+                >
+                  {s.sectionName}
+                </SelectOption>
+              ))}
+            </SelectList>
+          </Select>
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -98,7 +98,7 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
                       index,
                     });
                   }}
-                  onDelete={() => onFieldsChange(fields.filter((f, i) => i !== index))}
+                  onRemove={() => onFieldsChange(fields.filter((f, i) => i !== index))}
                   onDuplicate={(field) => {
                     setModalField({
                       field: structuredClone(field),

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -95,6 +95,7 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
                 <ManageConnectionTypeFieldsTableRow
                   key={index}
                   row={row}
+                  rowIndex={index}
                   columns={columns}
                   fields={fields}
                   onEdit={() => {
@@ -192,8 +193,8 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
       ) : undefined}
       {moveToSectionModalField && (
         <ConnectionTypeMoveFieldToSectionModal
-          field={moveToSectionModalField.field}
-          rows={fields}
+          row={moveToSectionModalField}
+          fields={fields}
           onClose={() => setMoveToSectionModalField(undefined)}
           onSubmit={(field, sectionIndex) => {
             const temp = fields.toSpliced(moveToSectionModalField.index, 1);

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -18,6 +18,7 @@ import { ConnectionTypeField, ConnectionTypeFieldType } from '~/concepts/connect
 import useDraggableTableControlled from '~/utilities/useDraggableTableControlled';
 import ConnectionTypeFieldModal from './ConnectionTypeFieldModal';
 import ManageConnectionTypeFieldsTableRow from './ManageConnectionTypeFieldsTableRow';
+import { ConnectionTypeMoveFieldToSectionModal } from './ConnectionTypeFieldMoveModal';
 
 type EmptyFieldsTableProps = {
   onAddSection: () => void;
@@ -63,6 +64,10 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
   const [modalField, setModalField] = React.useState<
     { field?: ConnectionTypeField; index?: number; isEdit?: boolean } | undefined
   >();
+  const [moveToSectionModalField, setMoveToSectionModalField] = React.useState<{
+    field: ConnectionTypeField;
+    index: number;
+  }>();
 
   const { tableProps, rowsToRender } = useDraggableTableControlled<ConnectionTypeField>(
     fields,
@@ -91,6 +96,7 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
                   key={index}
                   row={row}
                   columns={columns}
+                  fields={fields}
                   onEdit={() => {
                     setModalField({
                       field: row,
@@ -113,6 +119,9 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
                     } else {
                       setModalField({});
                     }
+                  }}
+                  onMoveToSection={() => {
+                    setMoveToSectionModalField({ field: row, index });
                   }}
                   onChange={(updatedField) => {
                     onFieldsChange([
@@ -181,6 +190,20 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
           }}
         />
       ) : undefined}
+      {moveToSectionModalField && (
+        <ConnectionTypeMoveFieldToSectionModal
+          field={moveToSectionModalField.field}
+          rows={fields}
+          onClose={() => setMoveToSectionModalField(undefined)}
+          onSubmit={(field, sectionIndex) => {
+            const temp = fields.toSpliced(moveToSectionModalField.index, 1);
+            const newFieldIndex =
+              moveToSectionModalField.index < sectionIndex ? sectionIndex : sectionIndex + 1;
+            onFieldsChange(temp.toSpliced(newFieldIndex, 0, field));
+            setMoveToSectionModalField(undefined);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -14,7 +14,7 @@ type Props = {
   row: ConnectionTypeField;
   columns: ThProps[];
   onEdit: () => void;
-  onDelete: () => void;
+  onRemove: () => void;
   onDuplicate: (field: ConnectionTypeField) => void;
   onAddField: (parentSection: SectionField) => void;
   onChange: (updatedField: ConnectionTypeField) => void;
@@ -24,7 +24,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   row,
   columns,
   onEdit,
-  onDelete,
+  onRemove,
   onDuplicate,
   onAddField,
   onChange,
@@ -65,8 +65,8 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
                 onClick: () => onDuplicate({ ...row, name: `Duplicate of ${row.name}` }),
               },
               {
-                title: 'Delete',
-                onClick: () => onDelete(),
+                title: 'Remove',
+                onClick: () => onRemove(),
               },
             ]}
           />

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -12,6 +12,7 @@ import TruncatedText from '~/components/TruncatedText';
 
 type Props = {
   row: ConnectionTypeField;
+  rowIndex: number;
   columns: ThProps[];
   fields: ConnectionTypeField[];
   onEdit: () => void;
@@ -24,6 +25,7 @@ type Props = {
 
 const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   row,
+  rowIndex,
   columns,
   fields,
   onEdit,
@@ -34,15 +36,14 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   onChange,
   ...props
 }) => {
-  const numSections = React.useMemo(
-    () =>
-      fields.reduce(
-        (accumulator, currentValue) =>
-          currentValue.type === ConnectionTypeFieldType.Section ? accumulator + 1 : accumulator,
-        0,
-      ),
-    [fields],
-  );
+  const showMoveToSection = React.useMemo(() => {
+    const parentSection = fields.findLast(
+      (f, i) => f.type === ConnectionTypeFieldType.Section && i < rowIndex,
+    );
+    const numSections = fields.filter((f) => f.type === ConnectionTypeFieldType.Section).length;
+    const potentialSectionsToMoveTo = parentSection ? numSections - 1 : numSections;
+    return potentialSectionsToMoveTo > 0;
+  }, [fields, rowIndex]);
 
   if (row.type === ConnectionTypeFieldType.Section) {
     return (
@@ -132,7 +133,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
               title: 'Duplicate',
               onClick: () => onDuplicate(row),
             },
-            ...(numSections > 0
+            ...(showMoveToSection
               ? [
                   {
                     title: 'Move to section heading',

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -13,23 +13,37 @@ import TruncatedText from '~/components/TruncatedText';
 type Props = {
   row: ConnectionTypeField;
   columns: ThProps[];
+  fields: ConnectionTypeField[];
   onEdit: () => void;
   onRemove: () => void;
   onDuplicate: (field: ConnectionTypeField) => void;
   onAddField: (parentSection: SectionField) => void;
+  onMoveToSection: () => void;
   onChange: (updatedField: ConnectionTypeField) => void;
 } & RowProps;
 
 const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   row,
   columns,
+  fields,
   onEdit,
   onRemove,
   onDuplicate,
   onAddField,
+  onMoveToSection,
   onChange,
   ...props
 }) => {
+  const numSections = React.useMemo(
+    () =>
+      fields.reduce(
+        (accumulator, currentValue) =>
+          currentValue.type === ConnectionTypeFieldType.Section ? accumulator + 1 : accumulator,
+        0,
+      ),
+    [fields],
+  );
+
   if (row.type === ConnectionTypeFieldType.Section) {
     return (
       <Tr draggable isStriped data-testid="row" {...props}>
@@ -118,9 +132,17 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
               title: 'Duplicate',
               onClick: () => onDuplicate(row),
             },
+            ...(numSections > 0
+              ? [
+                  {
+                    title: 'Move to section heading',
+                    onClick: () => onMoveToSection(),
+                  },
+                ]
+              : []),
             {
-              title: 'Delete',
-              onClick: () => onDelete(),
+              title: 'Remove',
+              onClick: () => onRemove(),
             },
           ]}
         />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-11540

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Renames the "Delete" to "Remove" in the page for modifying the fields on the connection type.
- Adds a kebab action to data field types, to move to it to a new section
  - action doesn't show up if there are 0 section rows
  - if there is only 1 section, it will be greyed out in the modal

![Screenshot from 2024-08-22 13-18-31](https://github.com/user-attachments/assets/962781bb-da38-4ee9-a4ae-fcbc1173b4aa)
![image](https://github.com/user-attachments/assets/7045001f-616b-406f-bcf3-870063b50583)
![Screenshot from 2024-08-22 13-18-59](https://github.com/user-attachments/assets/2eed9497-fb8c-47c8-8718-a2484e09b2e7)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, changes are isolated to the affected area.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added test to click the modal and make sure the rows are moved correctly

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
