### PR TITLE
fix cypress flake in modelVersionDeployModal.cy.ts

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -6,11 +6,12 @@ class ModelVersionDeployModal extends Modal {
   }
 
   findProjectSelector() {
-    return cy.findByTestId('deploy-model-project-selector');
+    return this.find().findByTestId('deploy-model-project-selector');
   }
 
   selectProjectByName(name: string) {
-    this.findProjectSelector().findDropdownItem(name).click();
+    this.findProjectSelector().click();
+    this.find().findByRole('menuitem', { name }).click();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/executions.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/executions.ts
@@ -34,7 +34,10 @@ class ExecutionFilter {
   }
 
   findTypeSearchFilterItem(item: string) {
-    return this.find().findByTestId('filter-toolbar-text-field').findSelectOption(item);
+    return this.find()
+      .findByTestId('filter-toolbar-text-field')
+      .findByRole('button')
+      .findSelectOption(item);
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
@@ -150,7 +150,7 @@ class ExperimentsTable {
   }
 
   findActionsKebab() {
-    return cy.findByTestId('experiment-table-toolbar-actions').parent();
+    return cy.findByTestId('experiment-table-toolbar-actions');
   }
 
   findRestoreExperimentButton() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
@@ -54,7 +54,7 @@ class PipelineRunsTable {
   }
 
   findActionsKebab() {
-    return cy.findByRole('button', { name: 'Actions' }).parent();
+    return cy.findByRole('button', { name: 'Actions' });
   }
 
   findEmptyState() {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -177,7 +177,7 @@ Cypress.Commands.add(
 Cypress.Commands.add('findDropdownItem', { prevSubject: 'element' }, (subject, name) => {
   Cypress.log({ displayName: 'findDropdownItem', message: name });
   return cy.wrap(subject).then(($el) => {
-    if ($el.find('[aria-expanded=false]').addBack().length) {
+    if ($el.attr('aria-expanded') === 'false') {
       cy.wrap($el).click();
     }
     return cy.wrap($el).parent().findByRole('menuitem', { name });
@@ -187,7 +187,7 @@ Cypress.Commands.add('findDropdownItem', { prevSubject: 'element' }, (subject, n
 Cypress.Commands.add('findDropdownItemByTestId', { prevSubject: 'element' }, (subject, testId) => {
   Cypress.log({ displayName: 'findDropdownItemByTestId', message: testId });
   return cy.wrap(subject).then(($el) => {
-    if ($el.find('[aria-expanded=false]').addBack().length) {
+    if ($el.attr('aria-expanded') === 'false') {
       cy.wrap($el).click();
     }
     return cy.wrap($el).parent().findByTestId(testId);
@@ -197,7 +197,7 @@ Cypress.Commands.add('findDropdownItemByTestId', { prevSubject: 'element' }, (su
 Cypress.Commands.add('findSelectOption', { prevSubject: 'element' }, (subject, name) => {
   Cypress.log({ displayName: 'findSelectOption', message: name });
   return cy.wrap(subject).then(($el) => {
-    if ($el.find('[aria-expanded=false]').addBack().length) {
+    if ($el.attr('aria-expanded') === 'false') {
       cy.wrap($el).click();
     }
     //cy.get('[role=listbox]') TODO fix cases where there are multiple listboxes
@@ -208,7 +208,7 @@ Cypress.Commands.add('findSelectOption', { prevSubject: 'element' }, (subject, n
 Cypress.Commands.add('findSelectOptionByTestId', { prevSubject: 'element' }, (subject, testId) => {
   Cypress.log({ displayName: 'findSelectOptionByTestId', message: testId });
   return cy.wrap(subject).then(($el) => {
-    if ($el.find('[aria-expanded=false]').addBack().length) {
+    if ($el.attr('aria-expanded') === 'false') {
       cy.wrap($el).click();
     }
     return cy.wrap($el).parent().findByTestId(testId);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
@@ -121,6 +121,10 @@ const initIntercepts = ({
 
 describe('Model version archive list', () => {
   it('No archive versions in the selected registered model', () => {
+    // Bypass patternfly ExpandableSection error https://github.com/patternfly/patternfly-react/issues/10410
+    // Cannot destructure property 'offsetWidth' of 'this.expandableContentRef.current' as it is null.
+    Cypress.on('uncaught:exception', () => false);
+
     initIntercepts({ modelVersions: [mockModelVersion({ id: '3', name: 'model version 2' })] });
     modelVersionArchive.visitModelVersionList();
     verifyRelativeURL('/modelRegistry/modelregistry-sample/registeredModels/1/versions');

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -27,6 +27,7 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
   onCancel,
   onSubmit,
 }) => {
+  const [isProjectSelectorOpen, setProjectSelectorOpen] = React.useState(false);
   const {
     servingRuntimeTemplates: [templates],
     servingRuntimeTemplateOrder: { data: templateOrder },
@@ -62,69 +63,82 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
     [onCancel, onSubmit],
   );
 
-  if (
-    (platform === ServingRuntimePlatform.MULTI && !projectDeployStatusLoaded) ||
-    !selectedProject ||
-    !platform
-  ) {
-    return (
-      <Modal
-        title="Deploy model"
-        description="Configure properties for deploying your model"
-        variant="medium"
-        isOpen={isOpen}
-        onClose={() => onClose(false)}
-        actions={[
-          <Button key="deploy" variant="primary" isDisabled>
-            Deploy
-          </Button>,
-          <Button key="cancel" variant="link" onClick={() => onClose(false)}>
-            Cancel
-          </Button>,
-        ]}
-        showClose
-      >
-        <Form>
-          {deployInfoError ? (
-            <Alert variant="danger" isInline title={deployInfoError.name}>
-              {deployInfoError.message}
-            </Alert>
-          ) : !deployInfoLoaded ? (
-            <Spinner />
-          ) : (
-            <FormSection title="Model deployment">
-              <ProjectSelector
-                selectedProject={selectedProject}
-                setSelectedProject={setSelectedProject}
-                error={error}
-              />
-            </FormSection>
-          )}
-        </Form>
-      </Modal>
-    );
-  }
+  if (isOpen) {
+    if (
+      (platform === ServingRuntimePlatform.MULTI && !projectDeployStatusLoaded) ||
+      !selectedProject ||
+      !platform
+    ) {
+      return (
+        <Modal
+          title="Deploy model"
+          description="Configure properties for deploying your model"
+          variant="medium"
+          isOpen
+          onClose={() => onClose(false)}
+          actions={[
+            <Button key="deploy" variant="primary" isDisabled>
+              Deploy
+            </Button>,
+            <Button key="cancel" variant="link" onClick={() => onClose(false)}>
+              Cancel
+            </Button>,
+          ]}
+          showClose
+        >
+          <Form>
+            {deployInfoError ? (
+              <Alert variant="danger" isInline title={deployInfoError.name}>
+                {deployInfoError.message}
+              </Alert>
+            ) : !deployInfoLoaded ? (
+              <Spinner />
+            ) : (
+              <FormSection title="Model deployment">
+                <ProjectSelector
+                  selectedProject={selectedProject}
+                  setSelectedProject={setSelectedProject}
+                  error={error}
+                  isOpen={isProjectSelectorOpen}
+                  setOpen={setProjectSelectorOpen}
+                />
+              </FormSection>
+            )}
+          </Form>
+        </Modal>
+      );
+    }
 
-  return (
-    <>
-      <ManageKServeModal
-        onClose={onClose}
-        isOpen={isOpen && platform === ServingRuntimePlatform.SINGLE}
-        servingRuntimeTemplates={getKServeTemplates(templates, templateOrder, templateDisablement)}
-        shouldFormHidden={!!error}
-        registeredModelDeployInfo={registeredModelDeployInfo}
-        projectContext={{ currentProject: selectedProject, dataConnections }}
-        projectSection={
-          <ProjectSelector
-            selectedProject={selectedProject}
-            setSelectedProject={setSelectedProject}
-            error={error}
-          />
-        }
-      />
+    if (platform === ServingRuntimePlatform.SINGLE) {
+      return (
+        <ManageKServeModal
+          onClose={onClose}
+          isOpen
+          servingRuntimeTemplates={getKServeTemplates(
+            templates,
+            templateOrder,
+            templateDisablement,
+          )}
+          shouldFormHidden={!!error}
+          registeredModelDeployInfo={registeredModelDeployInfo}
+          projectContext={{ currentProject: selectedProject, dataConnections }}
+          projectSection={
+            <ProjectSelector
+              selectedProject={selectedProject}
+              setSelectedProject={setSelectedProject}
+              error={error}
+              isOpen={isProjectSelectorOpen}
+              setOpen={setProjectSelectorOpen}
+            />
+          }
+        />
+      );
+    }
+    // platform === ServingRuntimePlatform.MULTI
+    return (
       <ManageInferenceServiceModal
         onClose={onClose}
-        isOpen={isOpen && platform === ServingRuntimePlatform.MULTI}
+        isOpen
         shouldFormHidden={!!error}
         registeredModelDeployInfo={registeredModelDeployInfo}
         projectContext={{ currentProject: selectedProject, dataConnections }}
@@ -133,11 +147,14 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
             selectedProject={selectedProject}
             setSelectedProject={setSelectedProject}
             error={error}
+            isOpen={isProjectSelectorOpen}
+            setOpen={setProjectSelectorOpen}
           />
         }
       />
-    </>
-  );
+    );
+  }
+  return null;
 };
 
 export default DeployRegisteredModelModal;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -19,15 +19,17 @@ type ProjectSelectorProps = {
   selectedProject: ProjectKind | null;
   setSelectedProject: (project: ProjectKind | null) => void;
   error?: Error;
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   selectedProject,
   setSelectedProject,
   error,
+  isOpen,
+  setOpen,
 }) => {
-  const [isOpen, setOpen] = React.useState(false);
-
   const { projects } = React.useContext(ProjectsContext);
 
   return (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-11791

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The `DeployRegistrationModelModal` renders 3 separate modals depending on the project selected. When the cypress tests switches modals, it acts too fast to interact again with the dropdown only to have the UI unmount the current modal and mount a new one. Since our custom commands store the selector dom node in order to perform multiple actions, this node becomes stale and no longer applicable to the current DOM. Thus the command fails.

Changed the selector for clicking on them project selector menu item to be two separate commands.

Had to update the code to move the project selector open state management to the parent so that all modal instances share the same state, otherwise the dropdown could close when rendering a new modal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run cypress test `modelVersionDeployModal.cy.ts` for the primary fix.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
