### PR TITLE
surface conflicting env var names as warnings and errors

### DIFF
--- a/frontend/src/concepts/connectionTypes/types.ts
+++ b/frontend/src/concepts/connectionTypes/types.ts
@@ -101,6 +101,10 @@ export type ConnectionTypeField =
 
 export type ConnectionTypeDataField = Exclude<ConnectionTypeField, SectionField>;
 
+export const isConnectionTypeDataField = (
+  field: ConnectionTypeField,
+): field is ConnectionTypeDataField => field.type !== ConnectionTypeFieldType.Section;
+
 export type ConnectionTypeConfigMap = K8sResourceCommon & {
   metadata: {
     name: string;

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldModal.tsx
@@ -9,6 +9,7 @@ type Props = {
   onClose: () => void;
   onSubmit: (field: ConnectionTypeField) => void;
   isEdit?: boolean;
+  fields?: ConnectionTypeField[];
 };
 
 const ConnectionTypeFieldModal: React.FC<Props> = (props) => {

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -13,9 +13,10 @@ import {
   EmptyStateVariant,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { Table, Thead, Tbody, Tr, Th, ThProps } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th } from '@patternfly/react-table';
 import { ConnectionTypeField, ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
 import useDraggableTableControlled from '~/utilities/useDraggableTableControlled';
+import { columns } from '~/pages/connectionTypes/manage/fieldTableColumns';
 import ConnectionTypeFieldModal from './ConnectionTypeFieldModal';
 import ManageConnectionTypeFieldsTableRow from './ManageConnectionTypeFieldsTableRow';
 import { ConnectionTypeMoveFieldToSectionModal } from './ConnectionTypeFieldMoveModal';
@@ -51,14 +52,6 @@ type Props = {
   fields: ConnectionTypeField[];
   onFieldsChange: (fields: ConnectionTypeField[]) => void;
 };
-
-const columns: ThProps[] = [
-  { label: 'Section heading/field name', width: 30 },
-  { label: 'Type', width: 10 },
-  { label: 'Default value', width: 30 },
-  { label: 'Environment variable', width: 20 },
-  { label: 'Required', width: 10 },
-];
 
 const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChange }) => {
   const [modalField, setModalField] = React.useState<
@@ -96,7 +89,6 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
                   key={index}
                   row={row}
                   rowIndex={index}
-                  columns={columns}
                   fields={fields}
                   onEdit={() => {
                     setModalField({
@@ -164,6 +156,7 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
       )}
       {modalField ? (
         <ConnectionTypeFieldModal
+          fields={fields}
           field={modalField.field}
           isEdit={modalField.isEdit}
           onClose={() => setModalField(undefined)}

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
-import { ActionsColumn, Td, ThProps, Tr } from '@patternfly/react-table';
-import { Button, Label, Switch } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { Button, Icon, Label, Switch } from '@patternfly/react-core';
 import {
   ConnectionTypeField,
   ConnectionTypeFieldType,
   SectionField,
+  isConnectionTypeDataField,
 } from '~/concepts/connectionTypes/types';
 import { defaultValueToString, fieldTypeToString } from '~/concepts/connectionTypes/utils';
 import type { RowProps } from '~/utilities/useDraggableTableControlled';
 import TruncatedText from '~/components/TruncatedText';
+import { columns } from '~/pages/connectionTypes/manage/fieldTableColumns';
 
 type Props = {
   row: ConnectionTypeField;
   rowIndex: number;
-  columns: ThProps[];
   fields: ConnectionTypeField[];
   onEdit: () => void;
   onRemove: () => void;
@@ -26,7 +28,6 @@ type Props = {
 const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   row,
   rowIndex,
-  columns,
   fields,
   onEdit,
   onRemove,
@@ -44,6 +45,16 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
     const potentialSectionsToMoveTo = parentSection ? numSections - 1 : numSections;
     return potentialSectionsToMoveTo > 0;
   }, [fields, rowIndex]);
+
+  const isEnvVarConflict = React.useMemo(
+    () =>
+      row.type === ConnectionTypeFieldType.Section
+        ? false
+        : !!fields.find(
+            (f) => f !== row && isConnectionTypeDataField(f) && f.envVar === row.envVar,
+          ),
+    [row, fields],
+  );
 
   if (row.type === ConnectionTypeFieldType.Section) {
     return (
@@ -113,6 +124,14 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
       </Td>
       <Td dataLabel={columns[3].label} data-testid="field-env">
         {row.envVar || '-'}
+        {isEnvVarConflict ? (
+          <>
+            <Icon status="danger" size="sm" className="pf-v5-u-ml-xs">
+              <ExclamationCircleIcon />
+            </Icon>
+            <span className="pf-v5-u-screen-reader">This environment variable is in conflict.</span>
+          </>
+        ) : undefined}
       </Td>
       <Td dataLabel={columns[4].label}>
         <Switch

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
@@ -3,11 +3,12 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { ConnectionTypeDataFieldModal } from '~/pages/connectionTypes/manage/ConnectionTypeDataFieldModal';
-
-let onClose: jest.Mock;
-let onSubmit: jest.Mock;
+import { ShortTextField, TextField } from '~/concepts/connectionTypes/types';
 
 describe('ConnectionTypeDataFieldModal', () => {
+  let onClose: jest.Mock;
+  let onSubmit: jest.Mock;
+
   beforeEach(() => {
     onClose = jest.fn();
     onSubmit = jest.fn();
@@ -229,5 +230,37 @@ describe('ConnectionTypeDataFieldModal', () => {
     });
 
     expect(screen.getByTestId('modal-submit-button')).toBeDisabled();
+  });
+
+  it('should display env var conflict warning', () => {
+    const field: ShortTextField = {
+      type: 'short-text',
+      name: 'test',
+      envVar: 'test-envvar',
+      properties: {},
+    };
+    const field2: TextField = {
+      type: 'text',
+      name: 'test-2',
+      envVar: 'test-envvar',
+      properties: {},
+    };
+    render(
+      <ConnectionTypeDataFieldModal
+        onClose={onClose}
+        onSubmit={onSubmit}
+        field={field}
+        fields={[field, field2]}
+      />,
+    );
+    const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
+    screen.getByTestId('envvar-conflict-warning');
+    expect(screen.getByTestId('modal-submit-button')).not.toBeDisabled();
+
+    act(() => {
+      fireEvent.change(fieldEnvVarInput, { target: { value: 'new-env-value' } });
+    });
+
+    expect(screen.queryByTestId('envvar-conflict-warning')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import ManageConnectionTypeFieldsTableRow from '~/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow';
+import { ShortTextField, TextField } from '~/concepts/connectionTypes/types';
+
+const renderRow = (
+  props: Pick<React.ComponentProps<typeof ManageConnectionTypeFieldsTableRow>, 'row'> &
+    Partial<React.ComponentProps<typeof ManageConnectionTypeFieldsTableRow>>,
+) => {
+  const fn = jest.fn();
+  return (
+    <table>
+      <tbody>
+        <ManageConnectionTypeFieldsTableRow
+          fields={[]}
+          onAddField={fn}
+          onChange={fn}
+          onRemove={fn}
+          onDragEnd={fn}
+          onDragStart={fn}
+          onDrop={fn}
+          onDuplicate={fn}
+          onEdit={fn}
+          onMoveToSection={fn}
+          id="test"
+          rowIndex={0}
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
+};
+
+describe('ManageConnectionTypeFieldsTableRow', () => {
+  it('should display env variable conflict icon', () => {
+    const field: ShortTextField = {
+      type: 'short-text',
+      name: 'test',
+      envVar: 'test-envvar',
+      properties: {},
+    };
+    const field2: TextField = {
+      type: 'text',
+      name: 'test-2',
+      envVar: 'test-envvar',
+      properties: {},
+    };
+
+    const result = render(renderRow({ row: field, fields: [field] }));
+    expect(screen.getByTestId('field-env')).not.toHaveTextContent('conflict');
+
+    result.rerender(renderRow({ row: field, fields: [field, field2] }));
+    expect(screen.getByTestId('field-env')).toHaveTextContent('conflict');
+  });
+});

--- a/frontend/src/pages/connectionTypes/manage/fieldTableColumns.ts
+++ b/frontend/src/pages/connectionTypes/manage/fieldTableColumns.ts
@@ -1,0 +1,9 @@
+import { ThProps } from '@patternfly/react-table';
+
+export const columns: ThProps[] = [
+  { label: 'Section heading/field name', width: 30 },
+  { label: 'Type', width: 10 },
+  { label: 'Default value', width: 30 },
+  { label: 'Environment variable', width: 20 },
+  { label: 'Required', width: 10 },
+];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-11538

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Provides user with feedback when creating fields which have conflicting env var values.
Note that microcopy is not finalized.

![image](https://github.com/user-attachments/assets/eaf7adc6-30b2-4dcf-9447-e01ca73d85dc)

![image](https://github.com/user-attachments/assets/537bf129-dd7d-4043-834a-57c4c0550e82)

cc @simrandhaliw 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Go to `Settings` -> `Connection types` as an admin with the connection type feature flag enabled.
- Create a new connection type.
- Add two fields with the same env var name.
- Observe the error in the table and fields modal and that the form save button is disabled
- Edit a conflicting field to have a unique env var
- Observe the form save button is no longer disabled (providing the rest of the form is valid)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
