### PR TITLE
[RHOAIENG-1105] Add Storage Class section in Admin Panel and Feature Flag

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -40,6 +40,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
       disableConnectionTypes: boolean;
+      disableStorageClasses: boolean;
     };
     groupsConfig?: {
       adminGroups: string;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -65,6 +65,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableDistributedWorkloads: false,
       disableModelRegistry: true,
       disableConnectionTypes: true,
+      disableStorageClasses: true,
     },
     notebookController: {
       enabled: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -35,6 +35,7 @@ The following are a list of features that are supported, along with there defaul
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | true    | Disables Model Registry from the dashboard.                                                          |
 | disableConnectionTypes       | true    | Disables creating custom data connection types from the dashboard.                                   |
+| disableStorageClasses        | true    | Disables storage classes settings nav item from the dashboard.                                       |
 
 ## Defaults
 
@@ -65,6 +66,7 @@ spec:
     disablePipelineExperiments: true
     disableDistributedWorkloads: false
     disableConnectionTypes: false
+    disableStorageClasses: true
 ```
 
 ## Additional fields

--- a/frontend/src/__mocks__/index.ts
+++ b/frontend/src/__mocks__/index.ts
@@ -23,3 +23,4 @@ export * from './mockModelArtifactList';
 export * from './mockModelRegistryService';
 export * from './mockServingRuntimeK8sResource';
 export * from './mockInferenceServiceK8sResource';
+export * from './mockStorageClasses';

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -26,6 +26,7 @@ type MockDashboardConfigType = {
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
   disableConnectionTypes?: boolean;
+  disableStorageClasses?: boolean;
   disableNotebookController?: boolean;
   notebookSizes?: NotebookSize[];
 };
@@ -55,6 +56,7 @@ export const mockDashboardConfig = ({
   disableDistributedWorkloads = false,
   disableModelRegistry = true,
   disableConnectionTypes = true,
+  disableStorageClasses = false,
   disableNotebookController = false,
   notebookSizes = [
     {
@@ -161,6 +163,7 @@ export const mockDashboardConfig = ({
       disableDistributedWorkloads,
       disableModelRegistry,
       disableConnectionTypes,
+      disableStorageClasses,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/__mocks__/mockStorageClasses.ts
+++ b/frontend/src/__mocks__/mockStorageClasses.ts
@@ -1,0 +1,201 @@
+import { K8sResourceListResult, StorageClassKind } from '~/k8sTypes';
+
+type MockStorageClass = Omit<StorageClassKind, 'apiVersion' | 'kind'>;
+
+export type MockStorageClassList = Omit<K8sResourceListResult<MockStorageClass>, 'metadata'> & {
+  metadata: {
+    resourceVersion: string;
+  };
+};
+
+export const mockStorageClassList = (
+  storageClasses: MockStorageClass[] = mockStorageClasses,
+): MockStorageClassList => ({
+  kind: 'StorageClassList',
+  apiVersion: 'storage.k8s.io/v1',
+  metadata: {
+    resourceVersion: '55571379',
+  },
+  items: storageClasses,
+});
+
+const mockStorageClasses: MockStorageClass[] = [
+  {
+    metadata: {
+      name: 'csi-manila-ceph',
+      uid: 'c3c05a4a-c1b7-4358-a246-da6b6dfd12cd',
+      resourceVersion: '50902775',
+      creationTimestamp: '2024-07-04T09:21:40Z',
+      annotations: {
+        'opendatahub.io/sc-config':
+          '{"displayName":"csi-manila-ceph","isDefault":false,"isEnabled":false,"lastModified":"2024-08-22T15:42:53.100Z"}',
+      },
+      managedFields: [
+        {
+          manager: 'csi-driver-manila-operator',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-07-04T09:21:40Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:parameters': {
+              '.': {},
+              'f:csi.storage.k8s.io/node-publish-secret-name': {},
+              'f:csi.storage.k8s.io/node-publish-secret-namespace': {},
+              'f:csi.storage.k8s.io/node-stage-secret-name': {},
+              'f:csi.storage.k8s.io/node-stage-secret-namespace': {},
+              'f:csi.storage.k8s.io/provisioner-secret-name': {},
+              'f:csi.storage.k8s.io/provisioner-secret-namespace': {},
+              'f:type': {},
+            },
+            'f:provisioner': {},
+            'f:reclaimPolicy': {},
+            'f:volumeBindingMode': {},
+          },
+        },
+        {
+          manager: 'unknown',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-08-22T15:42:53Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:metadata': {
+              'f:annotations': {
+                '.': {},
+                'f:opendatahub.io/sc-config': {},
+              },
+            },
+          },
+        },
+      ],
+    },
+    provisioner: 'manila.csi.openstack.org',
+    parameters: JSON.stringify({
+      'csi.storage.k8s.io/node-publish-secret-name': 'csi-manila-secrets',
+      'csi.storage.k8s.io/node-publish-secret-namespace': 'openshift-manila-csi-driver',
+      'csi.storage.k8s.io/node-stage-secret-name': 'csi-manila-secrets',
+      'csi.storage.k8s.io/node-stage-secret-namespace': 'openshift-manila-csi-driver',
+      'csi.storage.k8s.io/provisioner-secret-name': 'csi-manila-secrets',
+      'csi.storage.k8s.io/provisioner-secret-namespace': 'openshift-manila-csi-driver',
+      type: 'ceph',
+    }),
+    reclaimPolicy: 'Delete',
+    volumeBindingMode: 'Immediate',
+  },
+  {
+    metadata: {
+      name: 'csi-manila-netapp',
+      uid: 'f818edb6-3936-4ca0-90af-87f469c177d8',
+      resourceVersion: '50902773',
+      creationTimestamp: '2024-07-04T09:21:40Z',
+      annotations: {
+        'opendatahub.io/sc-config':
+          '{"displayName":"csi-manila-netapp","isDefault":false,"isEnabled":false,"lastModified":"2024-08-22T15:42:53.101Z"}',
+      },
+      managedFields: [
+        {
+          manager: 'csi-driver-manila-operator',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-07-04T09:21:40Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:parameters': {
+              '.': {},
+              'f:csi.storage.k8s.io/node-publish-secret-name': {},
+              'f:csi.storage.k8s.io/node-publish-secret-namespace': {},
+              'f:csi.storage.k8s.io/node-stage-secret-name': {},
+              'f:csi.storage.k8s.io/node-stage-secret-namespace': {},
+              'f:csi.storage.k8s.io/provisioner-secret-name': {},
+              'f:csi.storage.k8s.io/provisioner-secret-namespace': {},
+              'f:type': {},
+            },
+            'f:provisioner': {},
+            'f:reclaimPolicy': {},
+            'f:volumeBindingMode': {},
+          },
+        },
+        {
+          manager: 'unknown',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-08-22T15:42:53Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:metadata': {
+              'f:annotations': {
+                '.': {},
+                'f:opendatahub.io/sc-config': {},
+              },
+            },
+          },
+        },
+      ],
+    },
+    provisioner: 'manila.csi.openstack.org',
+    parameters: JSON.stringify({
+      'csi.storage.k8s.io/node-publish-secret-name': 'csi-manila-secrets',
+      'csi.storage.k8s.io/node-publish-secret-namespace': 'openshift-manila-csi-driver',
+      'csi.storage.k8s.io/node-stage-secret-name': 'csi-manila-secrets',
+      'csi.storage.k8s.io/node-stage-secret-namespace': 'openshift-manila-csi-driver',
+      'csi.storage.k8s.io/provisioner-secret-name': 'csi-manila-secrets',
+      'csi.storage.k8s.io/provisioner-secret-namespace': 'openshift-manila-csi-driver',
+      type: 'netapp',
+    }),
+    reclaimPolicy: 'Delete',
+    volumeBindingMode: 'Immediate',
+  },
+  {
+    metadata: {
+      name: 'standard-csi',
+      uid: '5de188ae-aa8e-43d1-a714-4d60ecc5c6da',
+      resourceVersion: '50902774',
+      creationTimestamp: '2024-07-04T09:20:40Z',
+      annotations: {
+        'opendatahub.io/sc-config':
+          '{"displayName":"standard-csi","isDefault":true,"isEnabled":true,"lastModified":"2024-08-22T15:42:53.101Z"}',
+        'storageclass.kubernetes.io/is-default-class': 'true',
+      },
+      managedFields: [
+        {
+          manager: 'openstack-cinder-csi-driver-operator',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-07-04T09:20:40Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:allowVolumeExpansion': {},
+            'f:metadata': {
+              'f:annotations': {
+                '.': {},
+                'f:storageclass.kubernetes.io/is-default-class': {},
+              },
+            },
+            'f:provisioner': {},
+            'f:reclaimPolicy': {},
+            'f:volumeBindingMode': {},
+          },
+        },
+        {
+          manager: 'unknown',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-08-22T15:42:53Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:metadata': {
+              'f:annotations': {
+                'f:opendatahub.io/sc-config': {},
+              },
+            },
+          },
+        },
+      ],
+    },
+    provisioner: 'cinder.csi.openstack.org',
+    reclaimPolicy: 'Delete',
+    allowVolumeExpansion: true,
+    volumeBindingMode: 'WaitForFirstConsumer',
+  },
+];

--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -1,0 +1,23 @@
+import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+
+class StorageClassesPage {
+  visit() {
+    cy.visitWithLogin('/storageClasses');
+    this.wait();
+  }
+
+  private wait() {
+    cy.findByTestId('app-page-title').contains('Storage classes');
+    cy.testA11y();
+  }
+
+  findNavItem() {
+    return appChrome.findNavItem('Storage classes', 'Settings');
+  }
+
+  findEmptyState() {
+    return cy.findByTestId('storage-classes-empty-state');
+  }
+}
+
+export const storageClassesPage = new StorageClassesPage();

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -49,7 +49,7 @@ import type {
   PipelineVersionKFv2,
 } from '~/concepts/pipelines/kfTypes';
 import type { GrpcResponse } from '~/__mocks__/mlmd/utils';
-import type { BuildMockPipelinveVersionsType } from '~/__mocks__';
+import type { BuildMockPipelinveVersionsType, MockStorageClassList } from '~/__mocks__';
 import type { ArtifactStorage } from '~/concepts/pipelines/types';
 import type { ConnectionTypeConfigMap } from '~/concepts/connectionTypes/types';
 
@@ -187,6 +187,10 @@ declare global {
           type: 'POST /api/servingRuntimes/',
           options: { query: { dryRun: 'All' } } | null,
           response: OdhResponse<ServingRuntimeKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+          response: OdhResponse<MockStorageClassList>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/images/byon',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -1,0 +1,28 @@
+import { mockStorageClassList } from '~/__mocks__';
+import { asProductAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
+import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
+import { storageClassesPage } from '~/__tests__/cypress/cypress/pages/storageClasses';
+
+describe('Storage classes', () => {
+  it('shows "page not found" and does not show nav item as a non-admin user', () => {
+    cy.visitWithLogin('/storageClasses');
+    storageClassesPage.findNavItem().should('not.exist');
+    pageNotfound.findPage().should('be.visible');
+  });
+
+  describe('as an admin user', () => {
+    beforeEach(() => {
+      asProductAdminUser();
+    });
+
+    it('shows empty state when the returned storage class list is empty', () => {
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        mockStorageClassList([]),
+      );
+      storageClassesPage.visit();
+      storageClassesPage.findNavItem().should('be.visible');
+      storageClassesPage.findEmptyState().should('be.visible');
+    });
+  });
+});

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -73,7 +73,6 @@ const AppRoutes: React.FC = () => {
   const isJupyterEnabled = useCheckJupyterEnabled();
   const isHomeAvailable = useIsAreaAvailable(SupportedArea.HOME).status;
   const isConnectionTypesAvailable = useIsAreaAvailable(SupportedArea.CONNECTION_TYPES).status;
-  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
 
   if (!isAllowed) {
     return (
@@ -131,9 +130,7 @@ const AppRoutes: React.FC = () => {
             {isConnectionTypesAvailable ? (
               <Route path="/connectionTypes/*" element={<ConnectionTypeRoutes />} />
             ) : null}
-            {isStorageClassesAvailable && (
-              <Route path="/storageClasses/*" element={<StorageClassesPage />} />
-            )}
+            <Route path="/storageClasses/*" element={<StorageClassesPage />} />
             <Route path="/modelRegistrySettings/*" element={<ModelRegistrySettingsRoutes />} />
             <Route path="/groupSettings" element={<GroupSettingsPage />} />
           </>

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -64,6 +64,8 @@ const AcceleratorProfileRoutes = React.lazy(
   () => import('../pages/acceleratorProfiles/AcceleratorProfilesRoutes'),
 );
 
+const StorageClassesPage = React.lazy(() => import('../pages/storageClasses/StorageClassesPage'));
+
 const ModelRegistryRoutes = React.lazy(() => import('../pages/modelRegistry/ModelRegistryRoutes'));
 
 const AppRoutes: React.FC = () => {
@@ -71,6 +73,7 @@ const AppRoutes: React.FC = () => {
   const isJupyterEnabled = useCheckJupyterEnabled();
   const isHomeAvailable = useIsAreaAvailable(SupportedArea.HOME).status;
   const isConnectionTypesAvailable = useIsAreaAvailable(SupportedArea.CONNECTION_TYPES).status;
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
 
   if (!isAllowed) {
     return (
@@ -128,6 +131,9 @@ const AppRoutes: React.FC = () => {
             {isConnectionTypesAvailable ? (
               <Route path="/connectionTypes/*" element={<ConnectionTypeRoutes />} />
             ) : null}
+            {isStorageClassesAvailable && (
+              <Route path="/storageClasses/*" element={<StorageClassesPage />} />
+            )}
             <Route path="/modelRegistrySettings/*" element={<ModelRegistrySettingsRoutes />} />
             <Route path="/groupSettings" element={<GroupSettingsPage />} />
           </>

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -28,6 +28,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
   disableConnectionTypes: false,
+  disableStorageClasses: false,
 } satisfies DashboardCommonConfig);
 
 export const SupportedAreasStateMap: SupportedAreasState = {
@@ -46,6 +47,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.CONNECTION_TYPES]: {
     featureFlags: ['disableConnectionTypes'],
+  },
+  [SupportedArea.STORAGE_CLASSES]: {
+    featureFlags: ['disableStorageClasses'],
   },
   [SupportedArea.DS_PIPELINES]: {
     featureFlags: ['disablePipelines'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -39,6 +39,7 @@ export enum SupportedArea {
   USER_MANAGEMENT = 'user-management',
   ACCELERATOR_PROFILES = 'accelerator-profiles',
   CONNECTION_TYPES = 'connections-types',
+  STORAGE_CLASSES = 'storage-classes',
 
   /* DS Projects specific areas */
   DS_PROJECTS_PERMISSIONS = 'ds-projects-permission',

--- a/frontend/src/concepts/design/utils.ts
+++ b/frontend/src/concepts/design/utils.ts
@@ -16,6 +16,7 @@ import clusterStorageEmptyStateImg from '~/images/empty-state-cluster-storage.sv
 import modelServerEmptyStateImg from '~/images/empty-state-model-serving.svg';
 import dataConnectionEmptyStateImg from '~/images/empty-state-data-connections.svg';
 import modelRegistryEmptyStateImg from '~/images/empty-state-model-registries.svg';
+import storageClassesEmptyStateImg from '~/images/empty-state-storage-classes.svg';
 
 import './vars.scss';
 
@@ -40,6 +41,7 @@ export enum ProjectObjectType {
   dataConnection = 'data-connection',
   user = 'user',
   group = 'group',
+  storageClasses = 'storageClasses',
 }
 
 export const typedBackgroundColor = (objectType: ProjectObjectType): string => {
@@ -118,6 +120,8 @@ export const typedEmptyImage = (objectType: ProjectObjectType): string => {
       return modelServerEmptyStateImg;
     case ProjectObjectType.registeredModels:
       return modelRegistryEmptyStateImg;
+    case ProjectObjectType.storageClasses:
+      return storageClassesEmptyStateImg;
     case ProjectObjectType.dataConnection:
       return dataConnectionEmptyStateImg;
     default:

--- a/frontend/src/images/empty-state-storage-classes.svg
+++ b/frontend/src/images/empty-state-storage-classes.svg
@@ -1,0 +1,56 @@
+<svg id="f375cd2b-e6f3-4bc7-98f2-a51b347295b2" data-name="Icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+  <title>Gear icon - Black</title>
+  <desc>cog, machine, operation, automation, factory, industry, automate, function, teeth, spin, objects</desc>
+  <metadata>
+    <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+    <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 8.0-c001 1.000000, 0000/00/00-00:00:00        ">
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:tiff="http://ns.adobe.com/tiff/1.0/">
+          <xmp:rhcc-effective-on>2023-12-08T17:35:40.666Z</xmp:rhcc-effective-on>
+          <xmp:rhcc-metadata-complete-moderator>pending</xmp:rhcc-metadata-complete-moderator>
+          <xmp:rhcc-translation-id>TRAf30b2948-fc0a-41cd-9d48-da7866412b00</xmp:rhcc-translation-id>
+          <xmp:brand-content-type>Icon</xmp:brand-content-type>
+          <xmp:CreateDate>2023-12-08T17:35:40.666Z</xmp:CreateDate>
+          <xmp:rhcc-effective-on-set-on-upload>true</xmp:rhcc-effective-on-set-on-upload>
+          <xmp:rhcc-metadata-complete-uploader>pending</xmp:rhcc-metadata-complete-uploader>
+          <xmp:rhcc-file-last-modified>2023-12-08T17:36:26.508Z</xmp:rhcc-file-last-modified>
+          <xmp:rhcc-audience>rhcc-audience:internal</xmp:rhcc-audience>
+          <xmp:rhcc-rights-restricted>no</xmp:rhcc-rights-restricted>
+          <xmp:brand-content-subtype>Icon</xmp:brand-content-subtype>
+          <xmp:rhcc-derivative-id>DERf30b2948-fc0a-41cd-9d48-da7866412b00</xmp:rhcc-derivative-id>
+          <xmp:brand-logo-color>Black</xmp:brand-logo-color>
+          <xmp:rhcc-notify-portal-subscribers-on-change>yes</xmp:rhcc-notify-portal-subscribers-on-change>
+          <dc:format>image/svg+xml</dc:format>
+          <dc:modified>2024-02-09T20:30:42.645Z</dc:modified>
+          <dc:title>
+            <rdf:Alt>
+              <rdf:li xml:lang="x-default">Gear icon - Black</rdf:li>
+            </rdf:Alt>
+          </dc:title>
+          <dc:description>
+            <rdf:Alt>
+              <rdf:li xml:lang="x-default">cog, machine, operation, automation, factory, industry, automate, function, teeth, spin, objects</rdf:li>
+            </rdf:Alt>
+          </dc:description>
+          <cq:lastReplicationAction_scene7>Activate</cq:lastReplicationAction_scene7>
+          <cq:lastReplicationAction_publish>Activate</cq:lastReplicationAction_publish>
+          <cq:lastReplicated_publish>2024-02-09T22:17:38.468Z</cq:lastReplicated_publish>
+          <cq:lastReplicatedBy>workflow-process-service</cq:lastReplicatedBy>
+          <cq:lastReplicationAction>Activate</cq:lastReplicationAction>
+          <cq:lastReplicatedBy_publish>workflow-process-service</cq:lastReplicatedBy_publish>
+          <cq:isDelivered>true</cq:isDelivered>
+          <cq:lastReplicated>2024-02-09T22:17:38.468Z</cq:lastReplicated>
+          <cq:lastReplicatedBy_scene7>workflow-process-service</cq:lastReplicatedBy_scene7>
+          <cq:lastReplicated_scene7>2024-02-09T22:17:38.468Z</cq:lastReplicated_scene7>
+          <tiff:ImageLength>36</tiff:ImageLength>
+          <tiff:ImageWidth>36</tiff:ImageWidth>
+        </rdf:Description>
+      </rdf:RDF>
+    </x:xmpmeta>
+    <?xpacket end="w"?>
+  </metadata>
+  <g>
+    <path d="M32.36,15.29a.62.62,0,0,0-.61-.51H28.41A10.58,10.58,0,0,0,27.67,13L30,10.6a.62.62,0,0,0,.08-.79A14.72,14.72,0,0,0,26.3,6a.62.62,0,0,0-.8.08L23.15,8.39a11,11,0,0,0-1.84-.77V4.26a.62.62,0,0,0-.51-.61,14.25,14.25,0,0,0-5.41,0,.62.62,0,0,0-.52.62V7.56a10.8,10.8,0,0,0-1.9.77L10.6,6a.63.63,0,0,0-.79-.08A14.72,14.72,0,0,0,6,9.7a.62.62,0,0,0,.08.8l2.35,2.35a10.48,10.48,0,0,0-.8,1.93H4.25a.62.62,0,0,0-.61.51,14.25,14.25,0,0,0,0,5.42.62.62,0,0,0,.61.51H7.59a10.48,10.48,0,0,0,.8,1.93L6,25.5a.62.62,0,0,0-.08.8,14.72,14.72,0,0,0,3.85,3.82A.62.62,0,0,0,10.6,30L13,27.67a10.8,10.8,0,0,0,1.9.77v3.32a.62.62,0,0,0,.52.62,14.49,14.49,0,0,0,5.41,0,.62.62,0,0,0,.51-.61V28.38a11,11,0,0,0,1.84-.77L25.5,30a.62.62,0,0,0,.8.08,14.72,14.72,0,0,0,3.82-3.85A.62.62,0,0,0,30,25.4L27.67,23a10.58,10.58,0,0,0,.74-1.81h3.34a.62.62,0,0,0,.61-.51,14.25,14.25,0,0,0,0-5.42ZM31.22,20H27.94a.62.62,0,0,0-.6.47,9.78,9.78,0,0,1-1,2.39.62.62,0,0,0,.1.75l2.33,2.33A13.13,13.13,0,0,1,26,28.7L23.7,26.39a.64.64,0,0,0-.77-.1,9.49,9.49,0,0,1-2.41,1,.63.63,0,0,0-.46.61v3.29a12.69,12.69,0,0,1-3.94,0V28a.62.62,0,0,0-.47-.6,9.92,9.92,0,0,1-2.48-1,.62.62,0,0,0-.75.1l-2.33,2.33A13.13,13.13,0,0,1,7.3,26l2.31-2.32a.62.62,0,0,0,.1-.76,9.27,9.27,0,0,1-1.05-2.49.62.62,0,0,0-.6-.47H4.78a12.21,12.21,0,0,1,0-3.94H8.06a.62.62,0,0,0,.6-.47,9.27,9.27,0,0,1,1.05-2.49.64.64,0,0,0-.1-.77L7.3,10a13.13,13.13,0,0,1,2.79-2.78l2.33,2.33a.62.62,0,0,0,.75.1,9.92,9.92,0,0,1,2.48-1,.62.62,0,0,0,.47-.6V4.77a12.69,12.69,0,0,1,3.94,0V8.08a.63.63,0,0,0,.46.61,9.49,9.49,0,0,1,2.41,1,.64.64,0,0,0,.77-.1L26,7.3a13.13,13.13,0,0,1,2.78,2.79l-2.33,2.33a.62.62,0,0,0-.1.75,9.78,9.78,0,0,1,1,2.39.62.62,0,0,0,.6.47h3.28a12.21,12.21,0,0,1,0,3.94Z" />
+    <path d="M18,13.38A4.62,4.62,0,1,0,22.62,18,4.62,4.62,0,0,0,18,13.38Zm0,8A3.38,3.38,0,1,1,21.38,18,3.39,3.39,0,0,1,18,21.38Z" />
+  </g>
+</svg>

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -55,13 +55,19 @@ export type StorageClassConfig = {
   description?: string;
 };
 
+export enum Annotation {
+  StorageClassIsDefault = 'storageclass.kubernetes.io/is-default-class',
+  K8sDescription = 'kubernetes.io/description',
+  OdhStorageClassConfig = 'opendatahub.io/sc-config',
+}
+
 type StorageClassAnnotations = Partial<{
   // if true, enables any persistent volume claim (PVC) that does not specify a specific storage class to automatically be provisioned.
   // Only one, if any, StorageClass per cluster can be set as default.
-  'storageclass.kubernetes.io/is-default-class': 'true' | 'false';
+  [Annotation.StorageClassIsDefault]: 'true' | 'false';
   // the description provided by the cluster admin or Container Storage Interface (CSI) provider
-  'kubernetes.io/description': string;
-  'opendatahub.io/sc-config': StorageClassConfig;
+  [Annotation.K8sDescription]: string;
+  [Annotation.OdhStorageClassConfig]: string;
 }>;
 
 export type K8sDSGResource = K8sResourceCommon & {
@@ -1295,6 +1301,7 @@ export type DashboardCommonConfig = {
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
   disableConnectionTypes: boolean;
+  disableStorageClasses: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -55,7 +55,7 @@ export type StorageClassConfig = {
   description?: string;
 };
 
-export enum Annotation {
+export enum MetadataAnnotation {
   StorageClassIsDefault = 'storageclass.kubernetes.io/is-default-class',
   K8sDescription = 'kubernetes.io/description',
   OdhStorageClassConfig = 'opendatahub.io/sc-config',
@@ -64,10 +64,10 @@ export enum Annotation {
 type StorageClassAnnotations = Partial<{
   // if true, enables any persistent volume claim (PVC) that does not specify a specific storage class to automatically be provisioned.
   // Only one, if any, StorageClass per cluster can be set as default.
-  [Annotation.StorageClassIsDefault]: 'true' | 'false';
+  [MetadataAnnotation.StorageClassIsDefault]: 'true' | 'false';
   // the description provided by the cluster admin or Container Storage Interface (CSI) provider
-  [Annotation.K8sDescription]: string;
-  [Annotation.OdhStorageClassConfig]: string;
+  [MetadataAnnotation.K8sDescription]: string;
+  [MetadataAnnotation.OdhStorageClassConfig]: string;
 }>;
 
 export type K8sDSGResource = K8sResourceCommon & {

--- a/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppContext } from '~/app/AppContext';
-import { StorageClassKind } from '~/k8sTypes';
+import { Annotation, StorageClassKind } from '~/k8sTypes';
 
 const usePreferredStorageClass = (): StorageClassKind | undefined => {
   const {
@@ -10,10 +10,9 @@ const usePreferredStorageClass = (): StorageClassKind | undefined => {
     storageClasses,
   } = React.useContext(AppContext);
 
-  const defaultClusterStorageClasses = storageClasses.filter((storageclass) =>
-    storageclass.metadata.annotations?.['storageclass.kubernetes.io/is-default-class']?.includes(
-      'true',
-    ),
+  const defaultClusterStorageClasses = storageClasses.filter(
+    (storageclass) =>
+      storageclass.metadata.annotations?.[Annotation.StorageClassIsDefault] === 'true',
   );
 
   const configStorageClassName = notebookController?.storageClassName ?? '';

--- a/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { AppContext } from '~/app/AppContext';
-import { Annotation, StorageClassKind } from '~/k8sTypes';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { MetadataAnnotation, StorageClassKind } from '~/k8sTypes';
 
 const usePreferredStorageClass = (): StorageClassKind | undefined => {
   const {
@@ -9,13 +10,16 @@ const usePreferredStorageClass = (): StorageClassKind | undefined => {
     },
     storageClasses,
   } = React.useContext(AppContext);
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
 
   const defaultClusterStorageClasses = storageClasses.filter(
     (storageclass) =>
-      storageclass.metadata.annotations?.[Annotation.StorageClassIsDefault] === 'true',
+      storageclass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true',
   );
 
-  const configStorageClassName = notebookController?.storageClassName ?? '';
+  const configStorageClassName = !isStorageClassesAvailable
+    ? notebookController?.storageClassName ?? ''
+    : '';
 
   if (defaultClusterStorageClasses.length !== 0) {
     return undefined;

--- a/frontend/src/pages/storageClasses/StorageClassesPage.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesPage.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+import {
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+  PageSection,
+  Title,
+  Alert,
+  AlertActionCloseButton,
+} from '@patternfly/react-core';
+
+import { Annotation, StorageClassConfig } from '~/k8sTypes';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
+import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+
+const StorageClassesPage: React.FC = () => {
+  const [storageClasses, storageClassesLoaded, storageClassesError] = useStorageClasses();
+  const [isAlertOpen, setIsAlertOpen] = React.useState(false);
+
+  const defaultStorageClass = storageClasses.find(
+    (storageClass) =>
+      storageClass.metadata.annotations?.[Annotation.StorageClassIsDefault] === 'true',
+  );
+
+  // Open default class alert when no default class exists
+  React.useEffect(() => {
+    setIsAlertOpen(!defaultStorageClass?.metadata.name);
+  }, [defaultStorageClass?.metadata.name]);
+
+  // Add storage class config annotations automatically for all storage classes without them
+  React.useEffect(() => {
+    storageClasses.forEach((storageClass, index) => {
+      const { metadata } = storageClass;
+      const { name: storageClassName } = metadata;
+
+      if (!metadata.annotations?.[Annotation.OdhStorageClassConfig]) {
+        const isDefault = defaultStorageClass?.metadata.uid === metadata.uid;
+        const storageClassConfig: StorageClassConfig = {
+          displayName: storageClassName,
+          ...(!defaultStorageClass
+            ? {
+                isEnabled: true,
+                isDefault: index === 0,
+              }
+            : {
+                isDefault,
+                isEnabled: isDefault,
+              }),
+          lastModified: new Date().toISOString(),
+        };
+
+        updateStorageClassConfig(storageClassName, storageClassConfig);
+      }
+    });
+  }, [defaultStorageClass, storageClasses]);
+
+  const emptyStatePage = (
+    <PageSection isFilled>
+      <EmptyState variant={EmptyStateVariant.lg} data-testid="storage-classes-empty-state">
+        <img
+          width="60px"
+          height="60px"
+          src={typedEmptyImage(ProjectObjectType.storageClasses)}
+          alt=""
+          className="pf-v5-u-mb-sm"
+        />
+
+        <Title headingLevel="h5" size="lg">
+          Configure storage classes
+        </Title>
+        <EmptyStateBody>
+          At least one OpenShift storage class is required to use OpenShift AI. Configure a storage
+          class in OpenShift, or request that your admin configure one.
+        </EmptyStateBody>
+      </EmptyState>
+    </PageSection>
+  );
+
+  return (
+    <ApplicationsPage
+      title="Storage classes"
+      description="Manage your organization's OpenShift cluster storage class settings for usage within OpenShift AI. These settings do not impact the storage classes within OpenShift."
+      loaded={storageClassesLoaded}
+      empty={storageClasses.length === 0}
+      loadError={storageClassesError}
+      errorMessage="Unable to load storage classes."
+      emptyStatePage={emptyStatePage}
+      provideChildrenPadding
+    >
+      {isAlertOpen && (
+        <Alert
+          variant="warning"
+          isInline
+          title="Review default storage class"
+          actionClose={<AlertActionCloseButton onClose={() => setIsAlertOpen(false)} />}
+        >
+          Some OpenShift AI features won&apos;t work without a default storage class. No OpenShift
+          default exists, so an OpenShift AI default was set automatically. Review the default
+          storage class, and set a new one if needed.
+        </Alert>
+      )}
+
+      {/* TODO, https://issues.redhat.com/browse/RHOAIENG-1106 */}
+    </ApplicationsPage>
+  );
+};
+
+export default StorageClassesPage;

--- a/frontend/src/pages/storageClasses/index.ts
+++ b/frontend/src/pages/storageClasses/index.ts
@@ -1,0 +1,1 @@
+export { default as StorageClassesPage } from './StorageClassesPage';

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -1,0 +1,14 @@
+import { MetadataAnnotation, StorageClassConfig, StorageClassKind } from '~/k8sTypes';
+
+export const getStorageClassConfig = (
+  storageClass: StorageClassKind,
+): StorageClassConfig | undefined => {
+  const storageClassConfig: StorageClassConfig | undefined = JSON.parse(
+    storageClass.metadata.annotations?.[MetadataAnnotation.OdhStorageClassConfig] || '',
+  );
+
+  return storageClassConfig;
+};
+
+export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>
+  storageClass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -150,6 +150,15 @@ const useConnectionTypesNav = (): NavDataHref[] =>
     },
   ]);
 
+const useStorageClassesNav = (): NavDataHref[] =>
+  useAreaCheck<NavDataHref>(SupportedArea.STORAGE_CLASSES, [
+    {
+      id: 'settings-storage-classes',
+      label: 'Storage classes',
+      href: '/storageClasses',
+    },
+  ]);
+
 const useModelRegisterySettingsNav = (): NavDataHref[] =>
   useAreaCheck<NavDataHref>(SupportedArea.MODEL_REGISTRY, [
     {
@@ -184,6 +193,7 @@ const useSettingsNav = (): NavDataGroup[] => {
     ...useAcceleratorProfilesNav(),
     ...useCustomRuntimesNav(),
     ...useConnectionTypesNav(),
+    ...useStorageClassesNav(),
     ...useModelRegisterySettingsNav(),
     ...useUserManagementNav(),
   ];

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -75,6 +75,8 @@ spec:
                       type: boolean
                     disableConnectionTypes:
                       type: boolean
+                    disableStorageClasses:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -29,6 +29,7 @@ spec:
     disableDistributedWorkloads: false
     disableModelRegistry: true
     disableConnectionTypes: true
+    disableStorageClasses: true
   groupsConfig:
     adminGroups: "$(admin_groups)"
     allowedGroups: "system:authenticated"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-1105

## Description
- Added feature flag for storage classes
- Showing empty state when no storage classes are found
- Showing blank page in anticipation for a table to be rendered as a part of [RHOAIENG-1106](https://issues.redhat.com/browse/RHOAIENG-1106) coming soon
- Added logic on render to add annotations to storage class metadata if those storage classes are absent of the `sc-config` annotation.

**Empty state**
<img width="1719" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/9a540405-6c07-4fd5-9f99-c8f6ecc7abfa">

**With feature turned off or as a non-admin user**
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/d95103cc-5601-4bff-9c22-61563488b10c">

(cc @xianli123)

## How Has This Been Tested?
Manual testing with creation of annotations, although that data can be inspected in the network tab. This will be visualized in [RHOAIENG-1106](https://issues.redhat.com//browse/RHOAIENG-1106), so the expectation is to test this logic more thoroughly there. Otherwise, cypress tests have been added to verify what can and can't be seen as a regular user and admin user, along with empty state.

This can be tested by navigating to `/storageClasses?devFeatureFlags=disableStorageClasses`. If storage classes exist, the title will show without content since the table will eventually be rendered there. If no storage classes exist, you'll see the empty state as shown in the screenshot above. If you do not enable the feature via the dev feature flag queryparam or by other means, the nav item won't show and the "page not found" page will be rendered as seen in the screenshot above.

## Test Impact
Added initial cypress tests

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
