### PR TITLE
add backend route for storage class metadata

### DIFF
--- a/backend/src/routes/api/storage-class/index.ts
+++ b/backend/src/routes/api/storage-class/index.ts
@@ -1,0 +1,26 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { StorageClassConfig, KubeFastifyInstance } from '../../../types';
+import { secureAdminRoute } from '../../../utils/route-security';
+import { updateStorageClassMetadata } from './utils';
+
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.put(
+    '/:storageClassName/metadata',
+    secureAdminRoute(fastify)(
+      async (
+        request: FastifyRequest<{
+          Body: StorageClassConfig;
+        }>,
+        reply: FastifyReply,
+      ) => {
+        return updateStorageClassMetadata(fastify, request)
+          .then((res) => {
+            return res;
+          })
+          .catch((res) => {
+            reply.send(res);
+          });
+      },
+    ),
+  );
+};

--- a/backend/src/routes/api/storage-class/index.ts
+++ b/backend/src/routes/api/storage-class/index.ts
@@ -1,19 +1,20 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { StorageClassConfig, KubeFastifyInstance } from '../../../types';
 import { secureAdminRoute } from '../../../utils/route-security';
-import { updateStorageClassMetadata } from './utils';
+import { updateStorageClassConfig } from './utils';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   fastify.put(
-    '/:storageClassName/metadata',
+    '/:storageClassName/config',
     secureAdminRoute(fastify)(
       async (
         request: FastifyRequest<{
           Body: StorageClassConfig;
+          Params: { storageClassName: string };
         }>,
         reply: FastifyReply,
       ) => {
-        return updateStorageClassMetadata(fastify, request)
+        return updateStorageClassConfig(fastify, request)
           .then((res) => {
             return res;
           })

--- a/backend/src/routes/api/storage-class/utils.ts
+++ b/backend/src/routes/api/storage-class/utils.ts
@@ -1,14 +1,19 @@
 import { FastifyRequest } from 'fastify';
-import { K8sResourceCommon, KubeFastifyInstance, StorageClassConfig } from '../../../types';
+import {
+  K8sResourceCommon,
+  KubeFastifyInstance,
+  ResponseStatus,
+  StorageClassConfig,
+} from '../../../types';
 import { isHttpError } from '../../../utils';
 import { errorHandler } from '../../../utils';
 
-export async function updateStorageClassMetadata(
+export async function updateStorageClassConfig(
   fastify: KubeFastifyInstance,
-  request: FastifyRequest<{ Body: StorageClassConfig }>,
-): Promise<{ success: boolean; error: string }> {
-  const params = request.params as { storageClassName: string };
-  const body = request.body as StorageClassConfig;
+  request: FastifyRequest<{ Body: StorageClassConfig; Params: { storageClassName: string } }>,
+): Promise<ResponseStatus> {
+  const params = request.params;
+  const body = request.body;
 
   try {
     // Fetch the existing custom object for the StorageClass

--- a/backend/src/routes/api/storage-class/utils.ts
+++ b/backend/src/routes/api/storage-class/utils.ts
@@ -1,0 +1,61 @@
+import { FastifyRequest } from 'fastify';
+import { KubeFastifyInstance, StorageClassConfig } from '../../../types';
+import { isHttpError } from '../../../utils';
+import { errorHandler } from '../../../utils';
+
+export async function updateStorageClassMetadata(
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest<{ Body: StorageClassConfig }>,
+): Promise<{ success: boolean; error: string }> {
+  const { namespace } = fastify.kube;
+  const params = request.params as { storageClassName: string };
+  const body = request.body as StorageClassConfig;
+
+  try {
+    // Fetch the existing custom object for the StorageClass
+    const storageClass = await fastify.kube.customObjectsApi.getNamespacedCustomObject(
+      'storage.k8s.io',
+      'v1',
+      namespace,
+      'storageclasses',
+      params.storageClassName,
+    );
+
+    // Extract and update the annotations
+    const annotations = (storageClass.body as any).metadata.annotations || {};
+    annotations['opendatahub.io/sc-config'] = JSON.stringify(body);
+
+    // Patch the StorageClass with the new annotations
+    await fastify.kube.customObjectsApi.patchNamespacedCustomObject(
+      'storage.k8s.io',
+      'v1',
+      namespace,
+      'storageclasses',
+      params.storageClassName,
+      {
+        metadata: {
+          annotations,
+        },
+      },
+      undefined,
+      undefined,
+      undefined,
+      {
+        headers: {
+          'Content-Type': 'application/merge-patch+json',
+        },
+      },
+    );
+
+    return { success: true, error: '' };
+  } catch (e) {
+    if (!isHttpError(e) || e.statusCode !== 404) {
+      fastify.log.error(e, 'Unable to update storage class metadata.');
+      return {
+        success: false,
+        error: `Unable to update storage class metadata: ${errorHandler(e)}`,
+      };
+    }
+    throw e;
+  }
+}

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1199,3 +1199,8 @@ export type ModelRegistryKind = K8sResourceCommon & {
     conditions?: K8sCondition[];
   };
 };
+
+export type ResponseStatus = {
+  success: boolean;
+  error: string;
+};

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -624,6 +624,14 @@ export type ImageTagInfo = {
 
 export type ImageType = 'byon' | 'jupyter' | 'other';
 
+export type StorageClassConfig = {
+  displayName: string;
+  isEnabled: boolean;
+  isDefault: boolean;
+  lastModified: string;
+  description?: string;
+};
+
 export type PersistentVolumeClaimKind = {
   apiVersion?: string;
   kind?: string;

--- a/frontend/src/services/StorageClassService.ts
+++ b/frontend/src/services/StorageClassService.ts
@@ -1,0 +1,16 @@
+import axios from '~/utilities/axios';
+import { StorageClassConfig } from '~/k8sTypes';
+import { ResponseStatus } from '~/types';
+
+export const updateStorageClassMetadata = (
+  name: string,
+  spec: StorageClassConfig,
+): Promise<ResponseStatus> => {
+  const url = `/api/storage-class/${name}/metadata`;
+  return axios
+    .put(url, spec)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+};

--- a/frontend/src/services/StorageClassService.ts
+++ b/frontend/src/services/StorageClassService.ts
@@ -2,11 +2,11 @@ import axios from '~/utilities/axios';
 import { StorageClassConfig } from '~/k8sTypes';
 import { ResponseStatus } from '~/types';
 
-export const updateStorageClassMetadata = (
+export const updateStorageClassConfig = (
   name: string,
   spec: StorageClassConfig,
 ): Promise<ResponseStatus> => {
-  const url = `/api/storage-class/${name}/metadata`;
+  const url = `/api/storage-class/${name}/config`;
   return axios
     .put(url, spec)
     .then((response) => response.data)

--- a/manifests/core-bases/base/role.yaml
+++ b/manifests/core-bases/base/role.yaml
@@ -4,6 +4,15 @@ metadata:
   name: odh-dashboard
 rules:
   - verbs:
+      - get
+      - list
+      - update
+      - patch
+    apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+  - verbs:
       - create
       - get
       - list


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes: https://issues.redhat.com/browse/RHOAIENG-11855

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds backend route `/api/storage-class/{name}/metadata` and a frontend service function to call it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
backend -- no tests

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
