### PR TITLE
[RHOAIENG-11530] Add file field advanced settings for connection type fields

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "react": "^18.2.0",
         "react-cool-dimensions": "^2.0.5",
         "react-dom": "^18.2.0",
+        "react-dropzone": "^14.2.3",
         "react-redux": "^8.0.4",
         "react-router": "^6.4.1",
         "react-router-dom": "^6.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,6 +85,7 @@
     "react": "^18.2.0",
     "react-cool-dimensions": "^2.0.5",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-redux": "^8.0.4",
     "react-router": "^6.4.1",
     "react-router-dom": "^6.4.1",

--- a/frontend/src/concepts/connectionTypes/fields/FileFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/FileFormField.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import { FileUpload } from '@patternfly/react-core';
+import { ErrorCode, FileError } from 'react-dropzone';
+import { FileUpload, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { FileField } from '~/concepts/connectionTypes/types';
 import { FieldProps } from '~/concepts/connectionTypes/fields/types';
+import { EXTENSION_REGEX, isDuplicateExtension } from './fieldUtils';
+
+const MAX_SIZE = 1024 * 1024; // 1 MB as bytes
 
 const FileFormField: React.FC<FieldProps<FileField>> = ({
   id,
@@ -14,31 +19,97 @@ const FileFormField: React.FC<FieldProps<FileField>> = ({
   const isPreview = mode === 'preview';
   const [isLoading, setIsLoading] = React.useState(false);
   const [filename, setFilename] = React.useState('');
-  const readOnly = isPreview || field.properties.defaultReadOnly;
+  const [rejectedReason, setRejectedReason] = React.useState<string | undefined>();
+  const readOnly = isPreview || (mode !== 'default' && field.properties.defaultReadOnly);
+  const extensions =
+    field.properties.extensions
+      ?.filter(
+        (ext, index) =>
+          !isDuplicateExtension(index, field.properties.extensions || []) &&
+          EXTENSION_REGEX.test(ext),
+      )
+      .map((ext) => ext.toLowerCase()) ?? [];
+
+  React.useEffect(() => {
+    setRejectedReason(undefined);
+  }, [field.properties.extensions]);
+
+  const formatString = extensions.length
+    ? `File format must be ${extensions.slice(0, -1).join(', ')}${
+        extensions.length > 1
+          ? `${extensions.length > 2 ? ',' : ''} or ${extensions[extensions.length - 1]}`
+          : extensions[0]
+      }`
+    : '';
+
+  const getRejectionMessage = (error?: FileError): string => {
+    switch (error?.code) {
+      case ErrorCode.FileTooLarge:
+        return 'File is larger than 1MB';
+      case ErrorCode.FileInvalidType:
+        return formatString;
+      case ErrorCode.TooManyFiles:
+        return 'Only a single file may be uploaded';
+      default:
+        return 'Unable to upload the file';
+    }
+  };
+
   return (
-    <FileUpload
-      id={id}
-      name={id}
-      data-testid={dataTestId}
-      type="text"
-      isLoading={isLoading}
-      value={isPreview || field.properties.defaultReadOnly ? field.properties.defaultValue : value}
-      filename={filename}
-      allowEditingUploadedText
-      isReadOnly={readOnly}
-      isDisabled={readOnly}
-      filenamePlaceholder={readOnly ? '' : 'Drag and drop a file or upload one'}
-      browseButtonText="Upload"
-      clearButtonText="Clear"
-      onDataChange={isPreview || !onChange ? undefined : (e, content) => onChange(content)}
-      onFileInputChange={(_e, file) => setFilename(file.name)}
-      onReadStarted={() => {
-        setIsLoading(true);
-      }}
-      onReadFinished={() => {
-        setIsLoading(false);
-      }}
-    />
+    <>
+      <FileUpload
+        id={id}
+        name={id}
+        data-testid={dataTestId}
+        type="text"
+        isLoading={isLoading}
+        value={
+          isPreview || field.properties.defaultReadOnly ? field.properties.defaultValue : value
+        }
+        filename={filename}
+        allowEditingUploadedText
+        isReadOnly={readOnly}
+        isDisabled={readOnly}
+        filenamePlaceholder={readOnly ? '' : 'Drag and drop a file or upload one'}
+        browseButtonText="Upload"
+        clearButtonText="Clear"
+        onDataChange={isPreview || !onChange ? undefined : (e, content) => onChange(content)}
+        onFileInputChange={(_e, file) => setFilename(file.name)}
+        isClearButtonDisabled={rejectedReason ? false : undefined}
+        onClearClick={() => {
+          if (onChange) {
+            onChange('');
+          }
+          setFilename('');
+          setRejectedReason(undefined);
+        }}
+        onReadStarted={() => {
+          setRejectedReason(undefined);
+          setIsLoading(true);
+        }}
+        onReadFinished={() => {
+          setIsLoading(false);
+        }}
+        dropzoneProps={{
+          accept: extensions.length ? { '': extensions } : undefined,
+          maxSize: MAX_SIZE,
+          onDropRejected: (reason) => {
+            setRejectedReason(getRejectionMessage(reason[0]?.errors?.[0]));
+          },
+        }}
+      />
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem
+            icon={rejectedReason ? <ExclamationCircleIcon /> : undefined}
+            variant={rejectedReason ? 'error' : 'default'}
+            data-testid="file-form-field-helper-text"
+          >
+            {rejectedReason || formatString}
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    </>
   );
 };
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/FileFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/FileFormField.spec.tsx
@@ -14,6 +14,7 @@ describe('FileFormField', () => {
       envVar: 'test-envVar',
       properties: {
         defaultValue: 'default-value',
+        extensions: ['.jpg', '.svg', '.png'],
       },
     };
 
@@ -23,6 +24,9 @@ describe('FileFormField', () => {
     expect(contentInput).not.toBeDisabled();
     expect(screen.getByRole('button', { name: 'Upload' })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: 'Clear' })).not.toBeDisabled();
+
+    const helperText = screen.getByTestId('file-form-field-helper-text');
+    expect(helperText).toHaveTextContent('.jpg, .svg, or .png');
 
     act(() => {
       fireEvent.change(contentInput, { target: { value: 'new-value' } });

--- a/frontend/src/concepts/connectionTypes/fields/fieldUtils.ts
+++ b/frontend/src/concepts/connectionTypes/fields/fieldUtils.ts
@@ -1,0 +1,5 @@
+export const EXTENSION_REGEX = /^\.[a-zA-Z0-9]+(^.[a-zA-Z0-9]+)?$/;
+
+export const isDuplicateExtension = (index: number, values: string[]): boolean =>
+  index !== 0 &&
+  !!values.slice(0, index).find((val) => values[index].toLowerCase() === val.toLowerCase());

--- a/frontend/src/concepts/connectionTypes/types.ts
+++ b/frontend/src/concepts/connectionTypes/types.ts
@@ -59,10 +59,16 @@ export type DataField<T extends ConnectionTypeFieldTypeUnion, V = string, P = {}
 export type SectionField = Field<ConnectionTypeFieldType.Section | 'section'>;
 
 export type HiddenField = DataField<ConnectionTypeFieldType.Hidden | 'hidden'>;
-export type FileField = DataField<ConnectionTypeFieldType.File | 'file'>;
 export type ShortTextField = DataField<ConnectionTypeFieldType.ShortText | 'short-text'>;
 export type TextField = DataField<ConnectionTypeFieldType.Text | 'text'>;
 export type UriField = DataField<ConnectionTypeFieldType.URI | 'uri'>;
+export type FileField = DataField<
+  ConnectionTypeFieldType.File | 'file',
+  string,
+  {
+    extensions?: string[];
+  }
+>;
 export type BooleanField = DataField<
   ConnectionTypeFieldType.Boolean | 'boolean',
   boolean,

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -32,6 +32,7 @@ import { fieldNameToEnvVar, fieldTypeToString } from '~/concepts/connectionTypes
 import { isEnumMember } from '~/utilities/utils';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import DataFieldPropertiesForm from '~/pages/connectionTypes/manage/DataFieldPropertiesForm';
+import { prepareFieldForSave } from '~/pages/connectionTypes/manage/manageFieldUtils';
 
 const ENV_VAR_NAME_REGEX = new RegExp('^[-._a-zA-Z][-._a-zA-Z0-9]*$');
 
@@ -98,7 +99,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
   const handleSubmit = () => {
     if (isValid) {
       if (newField) {
-        onSubmit(newField);
+        onSubmit(prepareFieldForSave(newField));
       }
       onClose();
     }

--- a/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
@@ -3,6 +3,7 @@ import { ConnectionTypeDataField, ConnectionTypeFieldType } from '~/concepts/con
 import BooleanAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/BooleanAdvancedPropertiesForm';
 import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/types';
 import NumericAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/NumericAdvancedPropertiesForm';
+import FileUploadAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm';
 
 const CustomFieldPropertiesForm = <T extends ConnectionTypeDataField>(
   props: AdvancedFieldProps<T>,
@@ -11,7 +12,7 @@ const CustomFieldPropertiesForm = <T extends ConnectionTypeDataField>(
     // TODO define advanced forms
     switch (props.field.type) {
       case ConnectionTypeFieldType.File:
-        return () => null;
+        return FileUploadAdvancedPropertiesForm;
 
       case ConnectionTypeFieldType.Boolean:
         return BooleanAdvancedPropertiesForm;

--- a/frontend/src/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { Button, FormGroup } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { FileField } from '~/concepts/connectionTypes/types';
+import {
+  EXTENSION_REGEX,
+  isDuplicateExtension,
+} from '~/concepts/connectionTypes/fields/fieldUtils';
+import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/types';
+import ExpandableFormSection from '~/components/ExpandableFormSection';
+import FileUploadExtensionRow from '~/pages/connectionTypes/manage/advanced/FileUploadExtensionRow';
+
+const FileUploadAdvancedPropertiesForm: React.FC<AdvancedFieldProps<FileField>> = ({
+  properties,
+  onChange,
+  onValidate,
+}) => {
+  const displayedExtensions = React.useMemo(
+    () => [...(properties.extensions?.length ? properties.extensions : [''])],
+    [properties.extensions],
+  );
+  const lastTextRef = React.useRef<HTMLInputElement | null>(null);
+
+  React.useEffect(() => {
+    if (!properties.extensions?.length) {
+      onValidate(true);
+      return;
+    }
+    const valid = properties.extensions.every(
+      (extension, i) =>
+        !extension ||
+        (EXTENSION_REGEX.test(extension) && !isDuplicateExtension(i, properties.extensions || [])),
+    );
+    onValidate(valid);
+    // do not run when callback changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [properties.extensions]);
+
+  return (
+    <ExpandableFormSection
+      toggleText="Advanced settings"
+      initExpanded={!!properties.extensions?.length}
+      data-testid="advanced-settings-toggle"
+    >
+      <FormGroup label="Allow specific files" fieldId="file-types" isStack>
+        {displayedExtensions.map((extension, index) => (
+          <FileUploadExtensionRow
+            key={index}
+            extension={extension}
+            isDuplicate={isDuplicateExtension(index, displayedExtensions)}
+            textRef={index === displayedExtensions.length - 1 ? lastTextRef : undefined}
+            onChange={(val) => {
+              onChange({
+                ...properties,
+                extensions: [
+                  ...displayedExtensions.slice(0, index),
+                  val,
+                  ...displayedExtensions.slice(index + 1),
+                ],
+              });
+            }}
+            onRemove={() =>
+              onChange({
+                ...properties,
+                extensions: [
+                  ...displayedExtensions.slice(0, index),
+                  ...displayedExtensions.slice(index + 1),
+                ],
+              })
+            }
+            allowRemove={displayedExtensions.length > 1 || !!displayedExtensions[0]}
+          />
+        ))}
+        <Button
+          variant="link"
+          data-testid="add-variable-button"
+          isInline
+          icon={<PlusCircleIcon />}
+          iconPosition="left"
+          onClick={() => {
+            onChange({ ...properties, extensions: [...displayedExtensions, ''] });
+            requestAnimationFrame(() => lastTextRef.current?.focus());
+          }}
+        >
+          Add file type
+        </Button>
+      </FormGroup>
+    </ExpandableFormSection>
+  );
+};
+
+export default FileUploadAdvancedPropertiesForm;

--- a/frontend/src/pages/connectionTypes/manage/advanced/FileUploadExtensionRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/FileUploadExtensionRow.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import {
+  Button,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
+import { EXTENSION_REGEX } from '~/concepts/connectionTypes/fields/fieldUtils';
+
+type FileUploadExtensionRowProps = {
+  extension?: string;
+  isDuplicate?: boolean;
+  onChange: (newValue: string) => void;
+  onRemove?: () => void;
+  allowRemove: boolean;
+  textRef?: React.RefObject<HTMLInputElement>;
+};
+
+const FileUploadExtensionRow: React.FC<FileUploadExtensionRowProps> = ({
+  extension,
+  isDuplicate,
+  onRemove,
+  allowRemove,
+  onChange,
+  textRef,
+}) => {
+  const [isValid, setIsValid] = React.useState<boolean>(!isDuplicate);
+
+  React.useEffect(
+    () => setIsValid(extension ? !isDuplicate && EXTENSION_REGEX.test(extension) : true),
+    // only run on entry or if a duplicate, otherwise wait for blur
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isDuplicate],
+  );
+
+  return (
+    <>
+      <InputGroup data-testid="file-upload-extension-row">
+        <InputGroupItem isFill>
+          <TextInput
+            name="file-extension"
+            data-testid="file-upload-extension-row-input"
+            type="text"
+            aria-label="allowed extension"
+            ref={textRef}
+            value={extension || ''}
+            style={{ textTransform: 'lowercase' }}
+            placeholder="Example: .json"
+            onChange={(_ev, val) => {
+              if (!isValid && !isDuplicate && EXTENSION_REGEX.test(val)) {
+                setIsValid(true);
+              }
+              onChange(val);
+            }}
+            onBlur={() => {
+              setIsValid(extension ? !isDuplicate && EXTENSION_REGEX.test(extension) : true);
+            }}
+          />
+        </InputGroupItem>
+        <InputGroupItem isPlain>
+          <Button
+            variant="plain"
+            data-testid="file-upload-extension-row-remove"
+            aria-label="remove extension"
+            isDisabled={!allowRemove}
+            onClick={onRemove}
+          >
+            <MinusCircleIcon />
+          </Button>
+        </InputGroupItem>
+      </InputGroup>
+      {!isValid ? (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem
+              icon={<ExclamationCircleIcon />}
+              variant="error"
+              data-testid="file-upload-extension-row-error"
+            >
+              {isDuplicate
+                ? 'Extension has already been specified.'
+                : `Please enter a valid extension starting with '.'`}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      ) : null}
+    </>
+  );
+};
+
+export default FileUploadExtensionRow;

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/FileUploadAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/FileUploadAdvancedPropertiesForm.spec.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { ConnectionTypeFieldType, FileField } from '~/concepts/connectionTypes/types';
+import FileUploadAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm';
+
+let onChange: jest.Mock;
+let onValidate: jest.Mock;
+let field: FileField;
+
+describe('FileUploadAdvancedPropertiesForm', () => {
+  beforeEach(() => {
+    onChange = jest.fn();
+    onValidate = jest.fn();
+    field = {
+      type: ConnectionTypeFieldType.File,
+      name: 'Test Number',
+      envVar: 'TEST_NUMBER',
+      properties: {},
+    };
+  });
+
+  it('should show the empty state', () => {
+    render(
+      <FileUploadAdvancedPropertiesForm
+        properties={{}}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(true);
+
+    const advancedToggle = screen.getByTestId('advanced-settings-toggle');
+    const toggleButton = within(advancedToggle).getByRole('button');
+
+    act(() => {
+      toggleButton.click();
+    });
+
+    // there should only be one row
+    const extensionRow = screen.getByTestId('file-upload-extension-row');
+    expect(extensionRow).toBeVisible();
+    // there should only be one remove button and it should be disabled
+    const removeButton = screen.getByTestId('file-upload-extension-row-remove');
+    expect(removeButton).toBeDisabled();
+
+    const input = screen.getByTestId('file-upload-extension-row-input');
+    act(() => {
+      fireEvent.change(input, { target: { value: '.jsp' } });
+    });
+    expect(onChange).toHaveBeenCalledWith({ extensions: ['.jsp'] });
+  });
+
+  it('should show the given extensions', () => {
+    render(
+      <FileUploadAdvancedPropertiesForm
+        properties={{ extensions: ['.svg', '.jpg', '.png'] }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(true);
+
+    // there should be 3 visible rows
+    const extensionRows = screen.getAllByTestId('file-upload-extension-row');
+    expect(extensionRows).toHaveLength(3);
+    extensionRows.forEach((extensionRow) => expect(extensionRow).toBeVisible());
+
+    // there should only be three remove buttons and all should be enabled
+    const removeButtons = screen.getAllByTestId('file-upload-extension-row-remove');
+    expect(removeButtons).toHaveLength(3);
+    removeButtons.forEach((removeButton) => expect(removeButton).toBeEnabled());
+
+    act(() => {
+      removeButtons[0].click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ extensions: ['.jpg', '.png'] });
+
+    act(() => {
+      removeButtons[1].click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ extensions: ['.svg', '.png'] });
+
+    act(() => {
+      removeButtons[2].click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ extensions: ['.svg', '.jpg'] });
+
+    const addButton = screen.getByTestId('add-variable-button');
+    act(() => {
+      addButton.click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ extensions: ['.svg', '.jpg', '.png', ''] });
+  });
+
+  it('should invalidate invalid extensions', () => {
+    render(
+      <FileUploadAdvancedPropertiesForm
+        properties={{ extensions: ['bad', '.jpg', '.png'] }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(false);
+    expect(screen.getByTestId('file-upload-extension-row-error')).toBeVisible();
+  });
+});

--- a/frontend/src/pages/connectionTypes/manage/manageFieldUtils.ts
+++ b/frontend/src/pages/connectionTypes/manage/manageFieldUtils.ts
@@ -1,0 +1,21 @@
+import {
+  ConnectionTypeDataField,
+  ConnectionTypeFieldType,
+  FileField,
+} from '~/concepts/connectionTypes/types';
+
+const cleanupFileUploadField = (field: FileField): FileField => ({
+  ...field,
+  properties: {
+    ...field.properties,
+    extensions: field.properties.extensions?.filter((ext) => !!ext).map((ext) => ext.toLowerCase()),
+  },
+});
+
+export const prepareFieldForSave = (field: ConnectionTypeDataField): ConnectionTypeDataField => {
+  switch (field.type) {
+    case ConnectionTypeFieldType.File:
+      return cleanupFileUploadField(field);
+  }
+  return field;
+};


### PR DESCRIPTION
Closes [RHOAIENG-11530](https://issues.redhat.com/browse/RHOAIENG-11530)

## Description
Adds the field field advanced settings for connection type fields

## How Has This Been Tested?
Tested manually. Added RTL tests.

## Screen shots

![image](https://github.com/user-attachments/assets/bbd87a8d-ecbc-4131-9dba-bda41ca34f12)


![image](https://github.com/user-attachments/assets/17b29702-a4dc-4654-9610-adc7fefa3c60)


![image](https://github.com/user-attachments/assets/da5a2140-dec9-4444-a05a-2a309a07d633)


![image](https://github.com/user-attachments/assets/560a9918-1d0c-4cc3-b8c1-a6f112fa3dcc)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw 