### PR TITLE
feat(MR detail): truncate description in header

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { Breadcrumb, BreadcrumbItem, Flex, FlexItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Flex, FlexItem, Truncate } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import useModelVersionById from '~/concepts/modelRegistry/apiHooks/useModelVersionById';
@@ -90,7 +90,7 @@ const ModelVersionsDetails: React.FC<ModelVersionsDetailProps> = ({ tab, ...page
           </Flex>
         )
       }
-      description={mv?.description}
+      description={<Truncate content={mv?.description || ''} />}
       loadError={mvLoadError}
       loaded={mvLoaded}
       provideChildrenPadding

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router';
-import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Truncate } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import useModelVersionsByRegisteredModel from '~/concepts/modelRegistry/apiHooks/useModelVersionsByRegisteredModel';
@@ -45,7 +45,7 @@ const ModelVersions: React.FC<ModelVersionsProps> = ({ tab, ...pageProps }) => {
       }
       title={rm?.name}
       headerAction={rm && <ModelVersionsHeaderActions rm={rm} />}
-      description={rm?.description}
+      description={<Truncate content={rm?.description || ''} />}
       loadError={loadError}
       loaded={loaded}
       provideChildrenPadding

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { Button, Flex, FlexItem, Label, Text } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Label, Text, Truncate } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import useModelVersionById from '~/concepts/modelRegistry/apiHooks/useModelVersionById';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
@@ -69,7 +69,7 @@ const ModelVersionsArchiveDetails: React.FC<ModelVersionsArchiveDetailsProps> = 
             Restore version
           </Button>
         }
-        description={mv?.description}
+        description={<Truncate content={mv?.description || ''} />}
         loadError={mvLoadError}
         loaded={mvLoaded}
         provideChildrenPadding

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelArchiveDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelArchiveDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { Button, Flex, FlexItem, Label, Text } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Label, Text, Truncate } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { registeredModelUrl } from '~/pages/modelRegistry/screens/routeUtils';
@@ -61,7 +61,7 @@ const RegisteredModelsArchiveDetails: React.FC<RegisteredModelsArchiveDetailsPro
             Restore model
           </Button>
         }
-        description={rm?.description}
+        description={<Truncate content={rm?.description || ''} />}
         loadError={rmLoadError}
         loaded={rmLoaded}
         provideChildrenPadding


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-12026

## Description
truncates long descriptions in the header for mr details 
![image](https://github.com/user-attachments/assets/e2e2566a-e660-4570-b881-4c1c8c2734bf)


## How Has This Been Tested?
ran locally

## Test Impact
no logical change, no test impact

## Request review criteria:
description is truncated if it would extend multiple lines, on hover a tooltip will show up

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
