### PR TITLE
Feat/5463 mr new design refactor

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -70,7 +70,7 @@ class ModelRegistry {
 
   private wait() {
     cy.findByTestId('app-page-title').should('exist');
-    cy.findByTestId('app-page-title').contains('Model registry');
+    cy.findByTestId('app-page-title').contains('Model Registry');
     cy.testA11y();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -26,8 +26,24 @@ class ModelVersionDetails {
     return cy.findByTestId('label-group').find('button');
   }
 
-  findStorageLocation() {
-    return cy.findByTestId('storage-location');
+  findStorageURI() {
+    return cy.findByTestId('storage-uri');
+  }
+
+  findStorageEndpoint() {
+    return cy.findByTestId('storage-endpoint');
+  }
+
+  findStorageRegion() {
+    return cy.findByTestId('storage-region');
+  }
+
+  findStorageBucket() {
+    return cy.findByTestId('storage-bucket');
+  }
+
+  findStoragePath() {
+    return cy.findByTestId('storage-path');
   }
 
   shouldContainsModalLabels(labels: string[]) {

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
@@ -46,7 +46,7 @@ class ModelRegistrySettings {
 
   private findHeading() {
     cy.findByTestId('app-page-title').should('exist');
-    cy.findByTestId('app-page-title').contains('Model registry settings');
+    cy.findByTestId('app-page-title').contains('Model Registry Settings');
   }
 
   findNavItem() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -162,7 +162,10 @@ describe('Model version details', () => {
         'Label y',
         'Label z',
       ]);
-      modelVersionDetails.findStorageLocation().contains('s3://test-bucket/demo-models/test-path');
+      modelVersionDetails.findStorageEndpoint().contains('test-endpoint');
+      modelVersionDetails.findStorageRegion().contains('test-region');
+      modelVersionDetails.findStorageBucket().contains('test-bucket');
+      modelVersionDetails.findStoragePath().contains('demo-models/test-path');
     });
 
     it('Switching model versions', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
@@ -153,6 +153,17 @@ describe('Model archive list', () => {
   });
 });
 
+it('Opens the detail page when we select "View Details" from action menu', () => {
+  initIntercepts({});
+  registeredModelArchive.visit();
+  const archiveModelRow = registeredModelArchive.getRow('model 2');
+  archiveModelRow.findKebabAction('View details').click();
+  cy.location('pathname').should(
+    'be.equals',
+    '/modelRegistry/modelregistry-sample/registeredModels/2/details',
+  );
+});
+
 describe('Restoring archive model', () => {
   it('Restore from archive models table', () => {
     cy.interceptOdh(

--- a/frontend/src/components/InlineTruncatedClipboardCopy.tsx
+++ b/frontend/src/components/InlineTruncatedClipboardCopy.tsx
@@ -1,0 +1,32 @@
+import { ClipboardCopy, Truncate } from '@patternfly/react-core';
+import * as React from 'react';
+
+type Props = {
+  textToCopy: string;
+  width?: string;
+  testId?: string;
+};
+
+/** Hopefully PF will add some flexibility with ClipboardCopy
+ *  in the future and this will not be necessary
+ * https://github.com/patternfly/patternfly-react/issues/10890
+ **/
+
+const InlineTruncatedClipboardCopy: React.FC<Props> = ({ textToCopy, width = '100%', testId }) => (
+  <div style={{ width }}>
+    <ClipboardCopy
+      variant="inline-compact"
+      style={{ display: 'inline-flex' }}
+      hoverTip="Copy"
+      clickTip="Copied"
+      onCopy={() => {
+        navigator.clipboard.writeText(textToCopy);
+      }}
+      data-testid={testId}
+    >
+      <Truncate content={textToCopy} />
+    </ClipboardCopy>
+  </div>
+);
+
+export default InlineTruncatedClipboardCopy;

--- a/frontend/src/components/InlineTruncatedClipboardCopy.tsx
+++ b/frontend/src/components/InlineTruncatedClipboardCopy.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 
 type Props = {
   textToCopy: string;
-  width?: string;
   testId?: string;
 };
 
@@ -12,21 +11,19 @@ type Props = {
  * https://github.com/patternfly/patternfly-react/issues/10890
  **/
 
-const InlineTruncatedClipboardCopy: React.FC<Props> = ({ textToCopy, width = '100%', testId }) => (
-  <div style={{ width }}>
-    <ClipboardCopy
-      variant="inline-compact"
-      style={{ display: 'inline-flex' }}
-      hoverTip="Copy"
-      clickTip="Copied"
-      onCopy={() => {
-        navigator.clipboard.writeText(textToCopy);
-      }}
-      data-testid={testId}
-    >
-      <Truncate content={textToCopy} />
-    </ClipboardCopy>
-  </div>
+const InlineTruncatedClipboardCopy: React.FC<Props> = ({ textToCopy, testId }) => (
+  <ClipboardCopy
+    variant="inline-compact"
+    style={{ display: 'inline-flex' }}
+    hoverTip="Copy"
+    clickTip="Copied"
+    onCopy={() => {
+      navigator.clipboard.writeText(textToCopy);
+    }}
+    data-testid={testId}
+  >
+    <Truncate content={textToCopy} />
+  </ClipboardCopy>
 );
 
 export default InlineTruncatedClipboardCopy;

--- a/frontend/src/concepts/design/utils.ts
+++ b/frontend/src/concepts/design/utils.ts
@@ -4,6 +4,7 @@ import pipelineImg from '~/images/UI_icon-Red_Hat-Branch-RGB.svg';
 import pipelineRunImg from '~/images/UI_icon-Red_Hat-Double_arrow_right-RGB.svg';
 import clusterStorageImg from '~/images/UI_icon-Red_Hat-Storage-RGB.svg';
 import modelServerImg from '~/images/UI_icon-Red_Hat-Server-RGB.svg';
+import registeredModelsImg from '~/images/Icon-Red_Hat-Layered_A_Black-RGB.svg';
 import deployedModelsImg from '~/images/UI_icon-Red_Hat-Cubes-RGB.svg';
 import deployingModelsImg from '~/images/UI_icon-Red_Hat-Server_upload-RGB.svg';
 import dataConnectionImg from '~/images/UI_icon-Red_Hat-Connected-RGB.svg';
@@ -17,6 +18,8 @@ import modelServerEmptyStateImg from '~/images/empty-state-model-serving.svg';
 import dataConnectionEmptyStateImg from '~/images/empty-state-data-connections.svg';
 import modelRegistryEmptyStateImg from '~/images/empty-state-model-registries.svg';
 import storageClassesEmptyStateImg from '~/images/empty-state-storage-classes.svg';
+import modelRegistryMissingModelImg from '~/images/no-models-model-registry.svg';
+import modelRegistryMissingVersionImg from '~/images/no-versions-model-registry.svg';
 
 import './vars.scss';
 
@@ -89,6 +92,7 @@ export const typedObjectImage = (objectType: ProjectObjectType): string => {
     case ProjectObjectType.modelServer:
       return modelServerImg;
     case ProjectObjectType.registeredModels:
+      return registeredModelsImg;
     case ProjectObjectType.deployedModels:
       return deployedModelsImg;
     case ProjectObjectType.deployingModels:
@@ -104,7 +108,7 @@ export const typedObjectImage = (objectType: ProjectObjectType): string => {
   }
 };
 
-export const typedEmptyImage = (objectType: ProjectObjectType): string => {
+export const typedEmptyImage = (objectType: ProjectObjectType, option?: string): string => {
   switch (objectType) {
     case ProjectObjectType.project:
       return projectEmptyStateImg;
@@ -119,7 +123,16 @@ export const typedEmptyImage = (objectType: ProjectObjectType): string => {
     case ProjectObjectType.modelServer:
       return modelServerEmptyStateImg;
     case ProjectObjectType.registeredModels:
-      return modelRegistryEmptyStateImg;
+      switch (option) {
+        case 'MissingModel':
+          return modelRegistryMissingModelImg
+        case 'MissingVersion':
+          return modelRegistryMissingVersionImg
+        case 'MissingDeployment':
+          return modelServerEmptyStateImg
+        default:
+          return modelRegistryEmptyStateImg;
+      }
     case ProjectObjectType.storageClasses:
       return storageClassesEmptyStateImg;
     case ProjectObjectType.dataConnection:

--- a/frontend/src/concepts/design/utils.ts
+++ b/frontend/src/concepts/design/utils.ts
@@ -125,11 +125,11 @@ export const typedEmptyImage = (objectType: ProjectObjectType, option?: string):
     case ProjectObjectType.registeredModels:
       switch (option) {
         case 'MissingModel':
-          return modelRegistryMissingModelImg
+          return modelRegistryMissingModelImg;
         case 'MissingVersion':
-          return modelRegistryMissingVersionImg
+          return modelRegistryMissingVersionImg;
         case 'MissingDeployment':
-          return modelServerEmptyStateImg
+          return modelServerEmptyStateImg;
         default:
           return modelRegistryEmptyStateImg;
       }

--- a/frontend/src/concepts/pipelines/NoPipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/NoPipelineServer.tsx
@@ -21,7 +21,7 @@ const NoPipelineServer: React.FC<NoPipelineServerProps> = ({ variant = 'link' })
           ? ''
           : ' Before you can work with pipelines, you must first configure a pipeline server in your project.'
       }`}
-      iconImage={typedEmptyImage(ProjectObjectType.pipeline, "MissingModel")}
+      iconImage={typedEmptyImage(ProjectObjectType.pipeline, 'MissingModel')}
       imageAlt=""
       createButton={
         installed ? (

--- a/frontend/src/concepts/pipelines/NoPipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/NoPipelineServer.tsx
@@ -21,7 +21,7 @@ const NoPipelineServer: React.FC<NoPipelineServerProps> = ({ variant = 'link' })
           ? ''
           : ' Before you can work with pipelines, you must first configure a pipeline server in your project.'
       }`}
-      iconImage={typedEmptyImage(ProjectObjectType.pipeline)}
+      iconImage={typedEmptyImage(ProjectObjectType.pipeline, "MissingModel")}
       imageAlt=""
       createButton={
         installed ? (

--- a/frontend/src/images/Icon-Red_Hat-Layered_A_Black-RGB.svg
+++ b/frontend/src/images/Icon-Red_Hat-Layered_A_Black-RGB.svg
@@ -1,0 +1,66 @@
+<svg id="f5aa912d-8d1f-4bdf-a271-498170a1de49" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+  <title>Layered icon - Black</title>
+<desc>stacks, stacked, combine, merge, top, bottom, sandwich, overlap, multiple, diagrams and graphs</desc>
+<metadata><?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 8.0-c001 1.000000, 0000/00/00-00:00:00        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:cq="http://www.day.com/jcr/cq/1.0"
+            xmlns:tiff="http://ns.adobe.com/tiff/1.0/">
+         <xmp:rhcc-effective-on>2023-12-08T17:35:00.619Z</xmp:rhcc-effective-on>
+         <xmp:rhcc-metadata-complete-moderator>pending</xmp:rhcc-metadata-complete-moderator>
+         <xmp:rhcc-translation-id>TRA85f90967-e20e-494c-afe3-285b3277006f</xmp:rhcc-translation-id>
+         <xmp:brand-content-type>Icon</xmp:brand-content-type>
+         <xmp:CreateDate>2023-12-08T17:35:00.619Z</xmp:CreateDate>
+         <xmp:rhcc-effective-on-set-on-upload>true</xmp:rhcc-effective-on-set-on-upload>
+         <xmp:rhcc-metadata-complete-uploader>pending</xmp:rhcc-metadata-complete-uploader>
+         <xmp:rhcc-file-last-modified>2023-12-08T17:35:17.197Z</xmp:rhcc-file-last-modified>
+         <xmp:rhcc-audience>rhcc-audience:internal</xmp:rhcc-audience>
+         <xmp:rhcc-rights-restricted>no</xmp:rhcc-rights-restricted>
+         <xmp:brand-content-subtype>Icon</xmp:brand-content-subtype>
+         <xmp:rhcc-derivative-id>DER85f90967-e20e-494c-afe3-285b3277006f</xmp:rhcc-derivative-id>
+         <xmp:brand-logo-color>Black</xmp:brand-logo-color>
+         <xmp:rhcc-notify-portal-subscribers-on-change>yes</xmp:rhcc-notify-portal-subscribers-on-change>
+         <dc:format>image/svg+xml</dc:format>
+         <dc:modified>2024-02-09T20:35:03.611Z</dc:modified>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Layered icon - Black</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">stacks, stacked, combine, merge, top, bottom, sandwich, overlap, multiple, diagrams and graphs</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <cq:lastReplicationAction_scene7>Activate</cq:lastReplicationAction_scene7>
+         <cq:lastReplicationAction_publish>Activate</cq:lastReplicationAction_publish>
+         <cq:lastReplicated_publish>2024-02-09T22:22:36.870Z</cq:lastReplicated_publish>
+         <cq:lastReplicatedBy>workflow-process-service</cq:lastReplicatedBy>
+         <cq:lastReplicationAction>Activate</cq:lastReplicationAction>
+         <cq:lastReplicatedBy_publish>workflow-process-service</cq:lastReplicatedBy_publish>
+         <cq:isDelivered>true</cq:isDelivered>
+         <cq:lastReplicated>2024-02-09T22:22:36.870Z</cq:lastReplicated>
+         <cq:lastReplicatedBy_scene7>workflow-process-service</cq:lastReplicatedBy_scene7>
+         <cq:lastReplicated_scene7>2024-02-09T22:22:36.870Z</cq:lastReplicated_scene7>
+         <tiff:ImageLength>36</tiff:ImageLength>
+         <tiff:ImageWidth>36</tiff:ImageWidth>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                 
+<?xpacket end="w"?></metadata>
+<path d="M31,11.38H24.62V5A.62.62,0,0,0,24,4.38H5A.62.62,0,0,0,4.38,5V24a.62.62,0,0,0,.62.62h6.38V31a.62.62,0,0,0,.62.62H31a.62.62,0,0,0,.62-.62V12A.62.62,0,0,0,31,11.38ZM11.38,12V23.38H5.62V5.62H23.38v5.76H12A.62.62,0,0,0,11.38,12Zm19,18.38H12.62V12.62H30.38Z"/>
+</svg>

--- a/frontend/src/images/no-models-model-registry.svg
+++ b/frontend/src/images/no-models-model-registry.svg
@@ -1,0 +1,180 @@
+<svg id="fbcc6e56-f19a-485f-9312-3d9e5fc94cf8" data-name="artwork" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 659.71704 451.32691">
+  <defs>
+    <clipPath id="be027f95-e91e-4839-924d-b1acb589b874">
+      <path d="M622.91844,240.50644C623.94587,12.35106,669.95518,58.004,354.04765,54.217,154.3294,51.82286,85.17685,155.82942,85.17685,282.845s92.47828,152.94787,138.57042,152.94787,71.62365-2.92361,107.07109-43.15385c42.10639-47.78766,115.46782-24.9698,184.55176-50.52011C583.67037,316.8584,622.68611,292.09841,622.91844,240.50644Z" style="fill: none"/>
+    </clipPath>
+  </defs>
+  <g>
+    <path d="M622.94266,240.50644c0-59.27391-69.204-186.28944-269.12646-186.28944S84.68973,155.82942,84.68973,282.845,177.256,435.79282,223.39192,435.79282s72.91252-2.6375,107.35629-42.86774c41.437-48.39828,115.33992-25.40311,184.54386-50.80622S622.94266,291.31265,622.94266,240.50644Z" style="fill: #b9dafc"/>
+    <path d="M440.78789,87.73568A31.41638,31.41638,0,0,0,401.03416,57.4441a48.79534,48.79534,0,0,0-92.51888-4.75778,33.33153,33.33153,0,0,0,2.81428,66.54437c.72577,0,1.44378-.03138,2.158-.07706h40.49236l.00864.00011.00887-.00011h55.36789l.00443.00011.00432-.00011h2.10181l.00111-.07805A31.41422,31.41422,0,0,0,440.78789,87.73568Z" style="fill: #b9dafc;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+    <g>
+      <rect x="325.94585" y="58.4066" width="37.13553" height="37.13553" style="fill: #fff"/>
+      <g>
+        <g>
+          <g>
+            <g>
+              <polyline points="373.858 106.424 363.406 95.972 344.461 95.972" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <polyline points="344.461 95.972 344.461 106.023 353.141 114.703" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <polyline points="335.457 95.972 335.457 106.774 342.482 113.799" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <polyline points="359.486 117.227 359.486 110.219 353.607 104.352 353.607 95.972" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <circle cx="359.48601" cy="119.48901" r="3.91957" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3.69160761468312px"/>
+              <circle cx="373.85777" cy="106.42377" r="2.93968" style="fill: #e00"/>
+            </g>
+            <g>
+              <polyline points="315.064 106.424 325.516 95.972 344.461 95.972" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <circle cx="315.06421" cy="106.42377" r="2.93968" style="fill: #e00"/>
+            </g>
+          </g>
+          <g>
+            <g>
+              <g>
+                <polyline points="370.106 51.382 363.406 58.082 363.406 77.027" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <line x1="408.50277" y1="77.02699" x2="363.40558" y2="77.02699" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <circle cx="409.09597" cy="77.02699" r="2.93968" style="fill: #e00"/>
+                <polyline points="382.41 62.002 375.402 62.002 369.535 67.881 363.406 67.881" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <circle cx="386.92301" cy="62.00197" r="3.91957" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <circle cx="370.10626" cy="51.38172" r="2.93968" style="fill: #e00"/>
+              </g>
+              <g>
+                <line x1="363.40558" y1="95.97158" x2="363.40558" y2="77.02699" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <polyline points="382.41 92.052 375.402 92.052 369.535 86.173 363.406 86.173" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <circle cx="386.92301" cy="92.05201" r="3.91957" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3.69160761468312px"/>
+              </g>
+            </g>
+            <g>
+              <g>
+                <g>
+                  <polyline points="315.169 47.525 325.622 57.977 344.566 57.977" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <line x1="344.56624" y1="50.39509" x2="344.56624" y2="57.97715" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="344.56624" cy="49.80189" r="2.93968" style="fill: #e00"/>
+                  <polyline points="329.541 23.966 329.541 45.98 335.421 51.848 335.421 57.977" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="329.54122" cy="19.45367" r="3.91957" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="315.16946" cy="47.52496" r="2.93968" style="fill: #e00"/>
+                </g>
+                <g>
+                  <line x1="363.51083" y1="57.97715" x2="344.56624" y2="57.97715" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <polyline points="359.591 38.972 359.591 45.98 353.712 51.848 353.712 57.977" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="359.59126" cy="34.45972" r="3.91957" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                </g>
+              </g>
+              <g>
+                <g>
+                  <line x1="325.62165" y1="95.86633" x2="325.62165" y2="76.92174" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <line x1="318.03959" y1="76.92174" x2="325.62165" y2="76.92174" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="317.44639" cy="76.92174" r="2.93968" style="fill: #e00"/>
+                  <polyline points="306.617 91.947 313.625 91.947 319.492 86.067 325.622 86.067" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="302.10422" cy="91.94676" r="3.91957" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                </g>
+                <g>
+                  <line x1="325.62165" y1="57.97715" x2="325.62165" y2="76.92174" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <polyline points="284.108 61.897 298.619 61.897 304.486 67.776 325.622 67.776" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                  <circle cx="279.59514" cy="61.89672" r="3.91957" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+        <rect x="337.981" y="70.44175" width="13.06524" height="13.06524" style="fill: #b9dafc;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+      </g>
+    </g>
+    <g>
+      <g style="clip-path: url(#be027f95-e91e-4839-924d-b1acb589b874)">
+        <g>
+          <rect x="332.05742" y="110.2401" width="275.71933" height="291.03707"/>
+          <path d="M355.35751,245.82271H322.88017a4.49357,4.49357,0,0,1-4.49357-4.49358v-34.9345a4.49359,4.49359,0,0,0-4.49358-4.49358h-51.846" style="fill: none;stroke: #e00;stroke-linejoin: round;stroke-width: 3px"/>
+          <line x1="262.79736" y1="186.85486" x2="355.3168" y2="186.85486" style="fill: none;stroke: #e00;stroke-linejoin: round;stroke-width: 3px"/>
+          <g>
+            <rect x="356.36049" y="85.44568" width="262.31256" height="71.33061" style="fill: #fff;stroke: #b9dafc;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <circle cx="576.15076" cy="121.11099" r="8.3871" style="fill: #e00"/>
+            <rect x="356.36049" y="156.77629" width="262.31256" height="71.33061" style="fill: #fff;stroke: #b9dafc;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <circle cx="588.16534" cy="192.44159" r="9.319" style="fill: #e00"/>
+            <circle cx="562.56374" cy="192.44159" r="9.319" style="fill: #e00"/>
+            <rect x="356.36049" y="228.1069" width="262.31256" height="71.33061" style="fill: #fff;stroke: #b9dafc;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <circle cx="576.15076" cy="263.7722" r="9.319" style="fill: #e00"/>
+            <rect x="356.36049" y="299.43751" width="262.31256" height="71.33061" style="fill: #fff;stroke: #b9dafc;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <rect x="356.36049" y="370.76812" width="262.31256" height="71.33061" style="fill: #fff;stroke: #dedede;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3.17505303206457px"/>
+            <circle cx="576.15076" cy="335.10281" r="9.319" style="fill: #e00"/>
+            <g>
+              <rect x="397.77547" y="114.31744" width="142.81761" height="13.5871" style="fill: #e00"/>
+              <rect x="378.59752" y="173.94677" width="13.17876" height="37.64319" style="fill: #e00"/>
+              <rect x="398.36076" y="173.94677" width="13.17876" height="37.64319" style="fill: #e00"/>
+              <rect x="398.65706" y="257.06252" width="141.05443" height="13.41936" style="fill: #e00"/>
+              <rect x="398.65706" y="328.39313" width="141.05443" height="13.41936" style="fill: #e00"/>
+            </g>
+          </g>
+        </g>
+      </g>
+      <path d="M216.70977,131.88169c-.15932,0-.31686.00689-.475.012a20.81175,20.81175,0,0,0-20.33249-16.38795c-.19182,0-.38135.00932-.57188.01446a37.57079,37.57079,0,0,0-74.47568,3.73994c-.03742-.00022-.07427-.00283-.11176-.00283a20.80752,20.80752,0,0,0,0,41.615h95.96678a14.49533,14.49533,0,1,0,0-28.99066Z" style="fill: #fff;stroke: #b9dafc;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+      <g>
+        <rect x="73.18889" y="178.50294" width="193.35998" height="193.35998" rx="1.06111"/>
+        <g>
+          <rect x="84.10298" y="173.34667" width="193.35998" height="193.35998" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <rect x="84.10298" y="173.34667" width="193.35998" height="40.39075" style="fill: #e00"/>
+          <g>
+            <circle cx="242.42627" cy="193.54205" r="4.64922" style="fill: #fff"/>
+            <circle cx="260.4732" cy="193.54205" r="4.64922" style="fill: #fff"/>
+          </g>
+          <line x1="155.00164" y1="194.40142" x2="100.86085" y2="194.40142" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <g>
+            <g>
+              <line x1="151.88469" y1="238.6475" x2="193.91286" y2="238.6475" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+              <line x1="100.51691" y1="238.6475" x2="142.54509" y2="238.6475" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            </g>
+            <line x1="115.1347" y1="257.25921" x2="184.61689" y2="257.25921" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <g>
+              <line x1="245.28064" y1="275.87092" x2="171.23823" y2="275.87092" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+              <line x1="115.57452" y1="275.87092" x2="163.52342" y2="275.87092" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            </g>
+            <g>
+              <line x1="115.1347" y1="350.31774" x2="142.10527" y2="350.31774" style="fill: none;stroke: #aaa;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.43612386705161px"/>
+              <line x1="193.47304" y1="350.31774" x2="151.44486" y2="350.31774" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+              <line x1="244.84082" y1="350.31774" x2="202.81264" y2="350.31774" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            </g>
+            <line x1="115.1347" y1="294.48262" x2="160.26067" y2="294.48262" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <g>
+              <line x1="115.1347" y1="331.70604" x2="160.26067" y2="331.70604" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+              <line x1="209.66416" y1="331.70604" x2="169.60027" y2="331.70604" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+              <line x1="244.84082" y1="331.70604" x2="219.00376" y2="331.70604" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            </g>
+            <g>
+              <line x1="100.07709" y1="313.09433" x2="135.31209" y2="313.09433" style="fill: none;stroke: #aaa;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.43612386705161px"/>
+              <line x1="179.06422" y1="313.09433" x2="143.02689" y2="313.09433" style="fill: none;stroke: #92c5f9;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            </g>
+          </g>
+        </g>
+        <g>
+          <rect x="30.21291" y="292.09841" width="109.27826" height="105.79268" rx="1.0599"/>
+          <g>
+            <path d="M41.05116,286.96424H151.23309a0,0,0,0,1,0,0v106.7469a.804.804,0,0,1-.804.804H41.05116a0,0,0,0,1,0,0V286.96424A0,0,0,0,1,41.05116,286.96424Z" style="fill: #fff;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <rect x="41.05116" y="286.96424" width="110.18193" height="23.11025" style="fill: #e00"/>
+            <line x1="49.73843" y1="298.51937" x2="100.40744" y2="298.51937" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <circle cx="130.38665" cy="298.51937" r="3.0677" style="fill: #fff"/>
+            <circle cx="139.58976" cy="298.51937" r="3.0677" style="fill: #fff"/>
+            <g>
+              <line x1="49.73843" y1="321.21977" x2="111.75943" y2="321.21977" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <g>
+                <line x1="57.26723" y1="343.99571" x2="70.6418" y2="343.99571" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <line x1="77.64788" y1="343.99571" x2="103.60482" y2="343.99571" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              </g>
+              <g>
+                <line x1="57.26723" y1="355.38368" x2="103.13305" y2="355.38368" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <line x1="110.16166" y1="355.38368" x2="126.93031" y2="355.38368" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              </g>
+              <line x1="57.26723" y1="332.60774" x2="79.71525" y2="332.60774" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="57.26723" y1="378.15962" x2="100.04436" y2="378.15962" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <g>
+                <line x1="49.73843" y1="366.77165" x2="70.60008" y2="366.77165" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+                <line x1="77.64788" y1="366.77165" x2="112.99749" y2="366.77165" style="fill: none;stroke: #e00;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <circle cx="305.42167" cy="149.40881" r="6.00242" style="fill: none;stroke: #e00;stroke-linejoin: round;stroke-width: 3px"/>
+      <path d="M209.77057,173.34667V155.34422a5.93541,5.93541,0,0,1,5.93541-5.93541h83.71327" style="fill: none;stroke: #e00;stroke-linejoin: round;stroke-width: 3px"/>
+      <path d="M157.89272,131.79334v8.5228a5.9354,5.9354,0,0,1-5.93541,5.9354h-13.7634a5.93541,5.93541,0,0,0-5.93541,5.93541v21.15972" style="fill: none;stroke: #e00;stroke-linejoin: round;stroke-width: 3px"/>
+      <circle cx="158.13013" cy="125.98327" r="6.00242" style="fill: none;stroke: #e00;stroke-linejoin: round;stroke-width: 3px"/>
+    </g>
+    <path d="M235.448,372.59211a15.87371,15.87371,0,0,0-3.37624.36912,18.5668,18.5668,0,0,0-35.66034,7.21415,12.04842,12.04842,0,0,0,.2983,24.09328H235.448a15.83827,15.83827,0,0,0,0-31.67655Z" style="fill: #b9dafc;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+  </g>
+</svg>

--- a/frontend/src/images/no-versions-model-registry.svg
+++ b/frontend/src/images/no-versions-model-registry.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <g id="ba680cc3-8a37-4647-9284-e8da36974a73" data-name="Model Registry">
+    <path d="M946.455,581.19c-6.79-69.38-54.09-117.55-105.21-159.99q-63-52.32-127.65-102.61c-47.87-37.24-94.98-83.3-149.62-110.78-64.23-32.3-136.42-31.01-204.38-11.46-54.61,15.71-96.42,53.84-114.66,107.84-8.66,25.65-13.56,54.45-12.72,81.46.72,22.99,5.03,45.78,7.18,68.67,1.24,13.14,1.76,26.32.49,39.57-.36,3.79-.88,7.49-1.52,11.14-5.4,31.1-20.11,57.32-36.41,83.28-7.22,11.5-14.74,22.95-21.89,34.76-23.74,39.17-31.6,89.05-27.59,134.29,4.21,47.44,19.92,99.55,58.56,130.22,66.02,52.41,173.53,27.21,230.63-27.7,45.63-43.87,107.84-69.32,170.89-73.11,64.27-3.87,129.61,1.78,193.25-10.61,47.75-9.3,86.82-29.31,112.26-71.58,21.88-36.36,32.55-81.09,28.41-123.4Z" style="fill: #bbd9f3"/>
+    <path d="M909.33061,667.61981a39.3961,39.3961,0,0,0-9.82711,1.23383,56.0606,56.0606,0,0,0-49.79589-34.321,82.4747,82.4747,0,0,0-149.8482-9.08854A61.94293,61.94293,0,1,0,681.6128,746.58426H909.33061a39.48221,39.48221,0,0,0,0-78.96442h0Z" style="fill: #fff;stroke: #bcd9f3;stroke-miterlimit: 10;stroke-width: 3px"/>
+    <path d="M183.91021,302.21543a28.82157,28.82157,0,0,1,7.18184.89872,40.99407,40.99407,0,0,1,36.42167-25.101A60.33225,60.33225,0,0,1,337.094,271.36738a45.29845,45.29845,0,1,1,13.32309,88.60241H183.91021a28.87718,28.87718,0,0,1,0-57.75436Z" style="fill: #fff;stroke: #bbd9f3;stroke-miterlimit: 10;stroke-width: 3px"/>
+    <g>
+      <path d="M677.01161,385.60882h158.8532A1.57122,1.57122,0,0,1,837.436,387.18V540.86618a1.57117,1.57117,0,0,1-1.57117,1.57117H677.0116a1.57121,1.57121,0,0,1-1.57121-1.57121V387.18A1.57122,1.57122,0,0,1,677.01161,385.60882Z" style="fill: #030303"/>
+      <g>
+        <path d="M691.50715,377.99787H854.84241V536.241a1.19185,1.19185,0,0,1-1.19184,1.19189H691.50715v-159.435Z" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <rect x="691.50715" y="377.99787" width="163.33526" height="34.25898" style="fill: #e51814"/>
+        <line x1="704.38529" y1="395.12734" x2="779.49775" y2="395.12734" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <circle cx="823.93936" cy="395.12734" r="4.5476" style="fill: #fff"/>
+        <circle cx="837.58218" cy="395.12734" r="4.5476" style="fill: #fff"/>
+        <g>
+          <line x1="704.38529" y1="428.77874" x2="796.3261" y2="428.77874" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <g>
+            <line x1="715.54609" y1="462.54216" x2="735.37274" y2="462.54216" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="745.75867" y1="462.54216" x2="784.2376" y2="462.54216" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          </g>
+          <g>
+            <line x1="715.54609" y1="479.42381" x2="783.53824" y2="479.42381" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="793.95755" y1="479.42381" x2="818.8156" y2="479.42381" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          </g>
+          <line x1="715.54609" y1="445.66043" x2="748.82334" y2="445.66043" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <line x1="715.54609" y1="513.18718" x2="778.95951" y2="513.18718" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <g>
+            <line x1="704.38529" y1="496.30554" x2="735.3109" y2="496.30554" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="745.75867" y1="496.30554" x2="798.16142" y2="496.30554" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g>
+      <g>
+        <path d="M440.9041,300.4942v13.41952a9.34554,9.34554,0,0,1-9.34555,9.34555h-21.956a9.06065,9.06065,0,0,0-9.06065,9.06065v33.60177" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <circle cx="440.90407" cy="291.04316" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+      </g>
+      <g>
+        <path d="M559.49236,370.00548V346.786a9.34559,9.34559,0,0,1,9.3456-9.3456l42.23972,0" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <circle cx="620.52875" cy="337.44042" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+      </g>
+      <g>
+        <circle cx="783.05989" cy="632.23818" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <path d="M661.8797,589.42723h81.10178a9.3456,9.3456,0,0,1,9.3456,9.3456v24.11975a9.3456,9.3456,0,0,0,9.3456,9.3456h11.93614" style="fill: none;stroke: #e51814;stroke-miterlimit: 10;stroke-width: 3px"/>
+      </g>
+      <g>
+        <rect x="344.60632" y="374.10294" width="304.4534" height="304.45342" rx="1.67074" style="fill: #030303"/>
+        <rect x="361.79101" y="365.98416" width="304.45344" height="304.45347" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <rect x="361.79101" y="365.98416" width="304.45344" height="63.59693" style="fill: #e51814"/>
+        <g>
+          <circle cx="611.07768" cy="397.78268" r="7.32041" style="fill: #fff"/>
+          <circle cx="639.49334" cy="397.78268" r="7.32041" style="fill: #fff"/>
+        </g>
+        <line x1="473.42394" y1="399.1358" x2="388.17699" y2="399.1358" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <g>
+          <g>
+            <line x1="468.51616" y1="468.80308" x2="534.6913" y2="468.80308" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="387.63543" y1="468.80308" x2="453.81057" y2="468.80308" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+          <line x1="410.65174" y1="498.10803" x2="520.05437" y2="498.10803" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          <g>
+            <line x1="615.57201" y1="527.41292" x2="498.98913" y2="527.41292" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="411.34426" y1="527.41292" x2="486.84183" y2="527.41292" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+          <g>
+            <line x1="410.65174" y1="644.63259" x2="453.11805" y2="644.63259" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.436123847961426px"/>
+            <line x1="533.99879" y1="644.63259" x2="467.82365" y2="644.63259" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="614.87949" y1="644.63259" x2="548.70438" y2="644.63259" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+          <line x1="410.65174" y1="556.71786" x2="481.70451" y2="556.71786" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          <g>
+            <line x1="410.65174" y1="615.32765" x2="481.70451" y2="615.32765" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="559.49236" y1="615.32765" x2="496.41008" y2="615.32765" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="614.87949" y1="615.32765" x2="574.19795" y2="615.32765" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+          <g>
+            <line x1="386.94292" y1="586.02276" x2="442.4219" y2="586.02276" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.436123847961426px"/>
+            <line x1="511.31148" y1="586.02276" x2="454.5692" y2="586.02276" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g>
+      <g>
+        <path d="M400.99187,743.63907H423.8154A10.23058,10.23058,0,0,1,434.046,753.86965v14.82754" style="fill: none;stroke: #e51814;stroke-miterlimit: 10;stroke-width: 3px"/>
+        <circle cx="434.04598" cy="776.31907" r="7.62189" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+      </g>
+      <g>
+        <path d="M220.26786,630.26839H382.95828a1.60917,1.60917,0,0,1,1.60917,1.60917V789.27611a1.60913,1.60913,0,0,1-1.60913,1.60913H220.26785a1.60916,1.60916,0,0,1-1.60916-1.60916V631.87756A1.60917,1.60917,0,0,1,220.26786,630.26839Z" style="fill: #030303"/>
+        <g>
+          <path d="M235.11356,622.4736H402.3943V784.53916a1.22064,1.22064,0,0,1-1.22063,1.22068H235.11356V622.4736Z" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <rect x="235.11356" y="622.4736" width="167.28074" height="35.08653" style="fill: #e51814"/>
+          <line x1="248.30277" y1="640.01684" x2="325.22963" y2="640.01684" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <circle cx="370.74476" cy="640.01684" r="4.65745" style="fill: #fff"/>
+          <circle cx="384.71713" cy="640.01684" r="4.65745" style="fill: #fff"/>
+          <g>
+            <line x1="248.30277" y1="674.48112" x2="342.46448" y2="674.48112" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <g>
+              <line x1="259.73317" y1="709.06012" x2="280.03875" y2="709.06012" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="290.67555" y1="709.06012" x2="330.08397" y2="709.06012" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            </g>
+            <g>
+              <line x1="259.73317" y1="726.34955" x2="329.36772" y2="726.34955" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="340.03872" y1="726.34955" x2="365.49724" y2="726.34955" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            </g>
+            <line x1="259.73317" y1="691.77059" x2="293.81426" y2="691.77059" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="259.73317" y1="760.9285" x2="324.67839" y2="760.9285" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <g>
+              <line x1="248.30277" y1="743.63907" x2="279.97541" y2="743.63907" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="290.67555" y1="743.63907" x2="344.34414" y2="743.63907" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g>
+      <line x1="496.93518" y1="717.13091" x2="582.02939" y2="717.13091" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="544.26811" y1="734.36139" x2="582.02939" y2="734.36139" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="496.93518" y1="734.36139" x2="534.89244" y2="734.36139" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="566.39028" y1="752.5091" x2="582.02939" y2="752.5091" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="496.93518" y1="752.5091" x2="557.01461" y2="752.5091" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="519.1906" y1="770.20209" x2="582.02939" y2="770.20209" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="496.93518" y1="770.20209" x2="509.68168" y2="770.20209" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="485.96819" y1="715.8296" x2="485.96819" y2="771.44854" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+    </g>
+    <g>
+      <line x1="588.43246" y1="245.19402" x2="673.52666" y2="245.19402" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="635.76538" y1="262.42451" x2="673.52666" y2="262.42451" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="588.43246" y1="262.42451" x2="626.38972" y2="262.42451" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="657.88755" y1="280.57221" x2="673.52666" y2="280.57221" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="588.43246" y1="280.57221" x2="648.51188" y2="280.57221" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="610.68788" y1="298.2652" x2="673.52666" y2="298.2652" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="588.43246" y1="298.2652" x2="601.17896" y2="298.2652" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="577.46546" y1="243.89272" x2="577.46546" y2="299.51165" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+    </g>
+    <g>
+      <g>
+        <line x1="232.81842" y1="427.83163" x2="317.91265" y2="427.83163" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="280.15134" y1="445.06214" x2="317.91265" y2="445.06214" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="232.81842" y1="445.06214" x2="270.7757" y2="445.06214" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="302.28134" y1="463.20982" x2="317.91265" y2="463.20982" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="232.81842" y1="463.20982" x2="292.90569" y2="463.20982" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="255.08169" y1="480.90284" x2="317.91265" y2="480.90284" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="232.81842" y1="480.90284" x2="245.57277" y2="480.90284" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      </g>
+      <line x1="221.85927" y1="426.53034" x2="221.85927" y2="482.14926" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+    </g>
+  </g>
+</svg>

--- a/frontend/src/images/no-versions-model-registry.svg
+++ b/frontend/src/images/no-versions-model-registry.svg
@@ -1,149 +1,149 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
-  <g id="ba680cc3-8a37-4647-9284-e8da36974a73" data-name="Model Registry">
-    <path d="M946.455,581.19c-6.79-69.38-54.09-117.55-105.21-159.99q-63-52.32-127.65-102.61c-47.87-37.24-94.98-83.3-149.62-110.78-64.23-32.3-136.42-31.01-204.38-11.46-54.61,15.71-96.42,53.84-114.66,107.84-8.66,25.65-13.56,54.45-12.72,81.46.72,22.99,5.03,45.78,7.18,68.67,1.24,13.14,1.76,26.32.49,39.57-.36,3.79-.88,7.49-1.52,11.14-5.4,31.1-20.11,57.32-36.41,83.28-7.22,11.5-14.74,22.95-21.89,34.76-23.74,39.17-31.6,89.05-27.59,134.29,4.21,47.44,19.92,99.55,58.56,130.22,66.02,52.41,173.53,27.21,230.63-27.7,45.63-43.87,107.84-69.32,170.89-73.11,64.27-3.87,129.61,1.78,193.25-10.61,47.75-9.3,86.82-29.31,112.26-71.58,21.88-36.36,32.55-81.09,28.41-123.4Z" style="fill: #bbd9f3"/>
-    <path d="M909.33061,667.61981a39.3961,39.3961,0,0,0-9.82711,1.23383,56.0606,56.0606,0,0,0-49.79589-34.321,82.4747,82.4747,0,0,0-149.8482-9.08854A61.94293,61.94293,0,1,0,681.6128,746.58426H909.33061a39.48221,39.48221,0,0,0,0-78.96442h0Z" style="fill: #fff;stroke: #bcd9f3;stroke-miterlimit: 10;stroke-width: 3px"/>
-    <path d="M183.91021,302.21543a28.82157,28.82157,0,0,1,7.18184.89872,40.99407,40.99407,0,0,1,36.42167-25.101A60.33225,60.33225,0,0,1,337.094,271.36738a45.29845,45.29845,0,1,1,13.32309,88.60241H183.91021a28.87718,28.87718,0,0,1,0-57.75436Z" style="fill: #fff;stroke: #bbd9f3;stroke-miterlimit: 10;stroke-width: 3px"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 831.38904 768.25444">
+  <g id="b3a9774d-d30b-43c8-9cac-37ece57528e6" data-name="Model Registry">
+    <path d="M816.32578,417.78664c-6.79-69.38-54.09-117.55-105.21-159.99q-63-52.32-127.65-102.61c-47.87-37.24-94.98-83.3-149.62-110.78-64.23-32.3-136.42-31.01-204.38-11.46-54.61,15.71-96.42,53.84-114.66,107.84-8.66,25.65-13.56,54.45-12.72,81.46.72,22.99,5.03,45.78,7.18,68.67,1.24,13.14,1.76,26.32.49,39.57-.36,3.79-.88,7.49-1.52,11.14-5.4,31.1-20.11,57.32-36.41,83.28-7.22,11.5-14.74,22.95-21.89,34.76-23.74,39.17-31.6,89.05-27.59,134.29,4.21,47.44,19.92,99.55,58.56,130.22,66.02,52.41,173.53,27.21,230.63-27.7,45.63-43.87,107.84-69.32,170.89-73.11,64.27-3.87,129.61,1.78,193.25-10.61,47.75-9.3,86.82-29.31,112.26-71.58,21.88-36.36,32.55-81.09,28.41-123.4Z" style="fill: #bbd9f3"/>
+    <path d="M779.20137,504.21643a39.39616,39.39616,0,0,0-9.82711,1.23383,56.06058,56.06058,0,0,0-49.79588-34.321,82.4747,82.4747,0,0,0-149.8482-9.08854,61.94293,61.94293,0,1,0-18.24662,121.14017H779.20137a39.4822,39.4822,0,1,0,0-78.96441h0Z" style="fill: #fff;stroke: #bcd9f3;stroke-miterlimit: 10;stroke-width: 3px"/>
+    <path d="M53.781,138.81205a28.8215,28.8215,0,0,1,7.18184.89871,40.99408,40.99408,0,0,1,36.42167-25.101A60.33225,60.33225,0,0,1,206.9648,107.964a45.29845,45.29845,0,1,1,13.32309,88.6024H53.781a28.87718,28.87718,0,0,1,0-57.75435Z" style="fill: #fff;stroke: #bbd9f3;stroke-miterlimit: 10;stroke-width: 3px"/>
     <g>
-      <path d="M677.01161,385.60882h158.8532A1.57122,1.57122,0,0,1,837.436,387.18V540.86618a1.57117,1.57117,0,0,1-1.57117,1.57117H677.0116a1.57121,1.57121,0,0,1-1.57121-1.57121V387.18A1.57122,1.57122,0,0,1,677.01161,385.60882Z" style="fill: #030303"/>
+      <path d="M546.88237,222.20543h158.8532a1.57122,1.57122,0,0,1,1.57122,1.57122V377.4628a1.57117,1.57117,0,0,1-1.57117,1.57117H546.88236a1.57121,1.57121,0,0,1-1.57121-1.57121V223.77665A1.57122,1.57122,0,0,1,546.88237,222.20543Z" style="fill: #030303"/>
       <g>
-        <path d="M691.50715,377.99787H854.84241V536.241a1.19185,1.19185,0,0,1-1.19184,1.19189H691.50715v-159.435Z" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-        <rect x="691.50715" y="377.99787" width="163.33526" height="34.25898" style="fill: #e51814"/>
-        <line x1="704.38529" y1="395.12734" x2="779.49775" y2="395.12734" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-        <circle cx="823.93936" cy="395.12734" r="4.5476" style="fill: #fff"/>
-        <circle cx="837.58218" cy="395.12734" r="4.5476" style="fill: #fff"/>
+        <path d="M561.37791,214.59449H724.71317V372.83758a1.19184,1.19184,0,0,1-1.19184,1.19189H561.37791v-159.435Z" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <rect x="561.37791" y="214.59449" width="163.33526" height="34.25898" style="fill: #e51814"/>
+        <line x1="574.25605" y1="231.72396" x2="649.36851" y2="231.72396" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <circle cx="693.81012" cy="231.72396" r="4.5476" style="fill: #fff"/>
+        <circle cx="707.45294" cy="231.72396" r="4.5476" style="fill: #fff"/>
         <g>
-          <line x1="704.38529" y1="428.77874" x2="796.3261" y2="428.77874" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <line x1="574.25605" y1="265.37536" x2="666.19686" y2="265.37536" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
           <g>
-            <line x1="715.54609" y1="462.54216" x2="735.37274" y2="462.54216" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-            <line x1="745.75867" y1="462.54216" x2="784.2376" y2="462.54216" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="585.41685" y1="299.13878" x2="605.2435" y2="299.13878" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="615.62943" y1="299.13878" x2="654.10836" y2="299.13878" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
           </g>
           <g>
-            <line x1="715.54609" y1="479.42381" x2="783.53824" y2="479.42381" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-            <line x1="793.95755" y1="479.42381" x2="818.8156" y2="479.42381" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="585.41685" y1="316.02042" x2="653.409" y2="316.02042" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="663.82831" y1="316.02042" x2="688.68637" y2="316.02042" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
           </g>
-          <line x1="715.54609" y1="445.66043" x2="748.82334" y2="445.66043" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-          <line x1="715.54609" y1="513.18718" x2="778.95951" y2="513.18718" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <line x1="585.41685" y1="282.25705" x2="618.6941" y2="282.25705" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <line x1="585.41685" y1="349.7838" x2="648.83027" y2="349.7838" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
           <g>
-            <line x1="704.38529" y1="496.30554" x2="735.3109" y2="496.30554" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-            <line x1="745.75867" y1="496.30554" x2="798.16142" y2="496.30554" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="574.25605" y1="332.90216" x2="605.18166" y2="332.90216" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="615.62943" y1="332.90216" x2="668.03219" y2="332.90216" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
           </g>
         </g>
       </g>
     </g>
     <g>
       <g>
-        <path d="M440.9041,300.4942v13.41952a9.34554,9.34554,0,0,1-9.34555,9.34555h-21.956a9.06065,9.06065,0,0,0-9.06065,9.06065v33.60177" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
-        <circle cx="440.90407" cy="291.04316" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <path d="M310.77487,137.09081v13.41953a9.34556,9.34556,0,0,1-9.34556,9.34555h-21.956a9.06065,9.06065,0,0,0-9.06065,9.06065V202.5183" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <circle cx="310.77484" cy="127.63978" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
       </g>
       <g>
-        <path d="M559.49236,370.00548V346.786a9.34559,9.34559,0,0,1,9.3456-9.3456l42.23972,0" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
-        <circle cx="620.52875" cy="337.44042" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <path d="M429.36312,206.6021V183.38264a9.3456,9.3456,0,0,1,9.3456-9.3456h42.23973" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <circle cx="490.39952" cy="174.03704" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
       </g>
       <g>
-        <circle cx="783.05989" cy="632.23818" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
-        <path d="M661.8797,589.42723h81.10178a9.3456,9.3456,0,0,1,9.3456,9.3456v24.11975a9.3456,9.3456,0,0,0,9.3456,9.3456h11.93614" style="fill: none;stroke: #e51814;stroke-miterlimit: 10;stroke-width: 3px"/>
+        <circle cx="652.93065" cy="468.8348" r="9.45106" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <path d="M531.75046,426.02384h81.10178a9.3456,9.3456,0,0,1,9.3456,9.3456V459.4892a9.3456,9.3456,0,0,0,9.3456,9.3456h11.93614" style="fill: none;stroke: #e51814;stroke-miterlimit: 10;stroke-width: 3px"/>
       </g>
       <g>
-        <rect x="344.60632" y="374.10294" width="304.4534" height="304.45342" rx="1.67074" style="fill: #030303"/>
-        <rect x="361.79101" y="365.98416" width="304.45344" height="304.45347" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-        <rect x="361.79101" y="365.98416" width="304.45344" height="63.59693" style="fill: #e51814"/>
+        <rect x="214.47708" y="210.69956" width="304.4534" height="304.45342" rx="1.67074" style="fill: #030303"/>
+        <rect x="231.66178" y="202.58078" width="304.45344" height="304.45347" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <rect x="231.66178" y="202.58078" width="304.45344" height="63.59693" style="fill: #e51814"/>
         <g>
-          <circle cx="611.07768" cy="397.78268" r="7.32041" style="fill: #fff"/>
-          <circle cx="639.49334" cy="397.78268" r="7.32041" style="fill: #fff"/>
+          <circle cx="480.94845" cy="234.37929" r="7.32041" style="fill: #fff"/>
+          <circle cx="509.3641" cy="234.37929" r="7.32041" style="fill: #fff"/>
         </g>
-        <line x1="473.42394" y1="399.1358" x2="388.17699" y2="399.1358" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+        <line x1="343.29471" y1="235.73242" x2="258.04775" y2="235.73242" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
         <g>
           <g>
-            <line x1="468.51616" y1="468.80308" x2="534.6913" y2="468.80308" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-            <line x1="387.63543" y1="468.80308" x2="453.81057" y2="468.80308" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="338.38692" y1="305.3997" x2="404.56206" y2="305.3997" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="257.50619" y1="305.3997" x2="323.68133" y2="305.3997" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
           </g>
-          <line x1="410.65174" y1="498.10803" x2="520.05437" y2="498.10803" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          <line x1="280.5225" y1="334.70464" x2="389.92514" y2="334.70464" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
           <g>
-            <line x1="615.57201" y1="527.41292" x2="498.98913" y2="527.41292" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-            <line x1="411.34426" y1="527.41292" x2="486.84183" y2="527.41292" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-          </g>
-          <g>
-            <line x1="410.65174" y1="644.63259" x2="453.11805" y2="644.63259" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.436123847961426px"/>
-            <line x1="533.99879" y1="644.63259" x2="467.82365" y2="644.63259" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-            <line x1="614.87949" y1="644.63259" x2="548.70438" y2="644.63259" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-          </g>
-          <line x1="410.65174" y1="556.71786" x2="481.70451" y2="556.71786" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-          <g>
-            <line x1="410.65174" y1="615.32765" x2="481.70451" y2="615.32765" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-            <line x1="559.49236" y1="615.32765" x2="496.41008" y2="615.32765" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
-            <line x1="614.87949" y1="615.32765" x2="574.19795" y2="615.32765" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="485.44277" y1="364.00954" x2="368.8599" y2="364.00954" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="281.21502" y1="364.00954" x2="356.7126" y2="364.00954" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
           </g>
           <g>
-            <line x1="386.94292" y1="586.02276" x2="442.4219" y2="586.02276" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.436123847961426px"/>
-            <line x1="511.31148" y1="586.02276" x2="454.5692" y2="586.02276" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="280.5225" y1="481.22921" x2="322.98882" y2="481.22921" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.43612384796143px"/>
+            <line x1="403.86955" y1="481.22921" x2="337.69441" y2="481.22921" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="484.75026" y1="481.22921" x2="418.57514" y2="481.22921" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+          <line x1="280.5225" y1="393.31448" x2="351.57527" y2="393.31448" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          <g>
+            <line x1="280.5225" y1="451.92427" x2="351.57527" y2="451.92427" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="429.36312" y1="451.92427" x2="366.28084" y2="451.92427" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+            <line x1="484.75026" y1="451.92427" x2="444.06871" y2="451.92427" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
+          </g>
+          <g>
+            <line x1="256.81368" y1="422.61937" x2="312.29267" y2="422.61937" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3.43612384796143px"/>
+            <line x1="381.18224" y1="422.61937" x2="324.43996" y2="422.61937" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-miterlimit: 10;stroke-width: 3px"/>
           </g>
         </g>
       </g>
     </g>
     <g>
       <g>
-        <path d="M400.99187,743.63907H423.8154A10.23058,10.23058,0,0,1,434.046,753.86965v14.82754" style="fill: none;stroke: #e51814;stroke-miterlimit: 10;stroke-width: 3px"/>
-        <circle cx="434.04598" cy="776.31907" r="7.62189" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
+        <path d="M270.86263,580.23569h22.82353a10.23058,10.23058,0,0,1,10.23058,10.23058V605.2938" style="fill: none;stroke: #e51814;stroke-miterlimit: 10;stroke-width: 3px"/>
+        <circle cx="303.91674" cy="612.91569" r="7.62189" style="fill: none;stroke: #e51814;stroke-linejoin: round;stroke-width: 3px"/>
       </g>
       <g>
-        <path d="M220.26786,630.26839H382.95828a1.60917,1.60917,0,0,1,1.60917,1.60917V789.27611a1.60913,1.60913,0,0,1-1.60913,1.60913H220.26785a1.60916,1.60916,0,0,1-1.60916-1.60916V631.87756A1.60917,1.60917,0,0,1,220.26786,630.26839Z" style="fill: #030303"/>
+        <path d="M90.13863,466.865H252.829a1.60917,1.60917,0,0,1,1.60917,1.60917V625.87272a1.60913,1.60913,0,0,1-1.60913,1.60913H90.13862a1.60916,1.60916,0,0,1-1.60916-1.60916V468.47418A1.60917,1.60917,0,0,1,90.13863,466.865Z" style="fill: #030303"/>
         <g>
-          <path d="M235.11356,622.4736H402.3943V784.53916a1.22064,1.22064,0,0,1-1.22063,1.22068H235.11356V622.4736Z" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-          <rect x="235.11356" y="622.4736" width="167.28074" height="35.08653" style="fill: #e51814"/>
-          <line x1="248.30277" y1="640.01684" x2="325.22963" y2="640.01684" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-          <circle cx="370.74476" cy="640.01684" r="4.65745" style="fill: #fff"/>
-          <circle cx="384.71713" cy="640.01684" r="4.65745" style="fill: #fff"/>
+          <path d="M104.98432,459.07021H272.26506V621.13578a1.22064,1.22064,0,0,1-1.22063,1.22068H104.98432V459.07021Z" style="fill: #fff;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <rect x="104.98432" y="459.07021" width="167.28074" height="35.08653" style="fill: #e51814"/>
+          <line x1="118.17353" y1="476.61345" x2="195.10039" y2="476.61345" style="fill: none;stroke: #fff;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+          <circle cx="240.61553" cy="476.61345" r="4.65745" style="fill: #fff"/>
+          <circle cx="254.5879" cy="476.61345" r="4.65745" style="fill: #fff"/>
           <g>
-            <line x1="248.30277" y1="674.48112" x2="342.46448" y2="674.48112" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="118.17353" y1="511.07773" x2="212.33524" y2="511.07773" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
             <g>
-              <line x1="259.73317" y1="709.06012" x2="280.03875" y2="709.06012" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-              <line x1="290.67555" y1="709.06012" x2="330.08397" y2="709.06012" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="129.60393" y1="545.65673" x2="149.90951" y2="545.65673" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="160.54632" y1="545.65673" x2="199.95474" y2="545.65673" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
             </g>
             <g>
-              <line x1="259.73317" y1="726.34955" x2="329.36772" y2="726.34955" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-              <line x1="340.03872" y1="726.34955" x2="365.49724" y2="726.34955" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="129.60393" y1="562.94616" x2="199.23848" y2="562.94616" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="209.90948" y1="562.94616" x2="235.368" y2="562.94616" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
             </g>
-            <line x1="259.73317" y1="691.77059" x2="293.81426" y2="691.77059" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-            <line x1="259.73317" y1="760.9285" x2="324.67839" y2="760.9285" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="129.60393" y1="528.36721" x2="163.68502" y2="528.36721" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+            <line x1="129.60393" y1="597.52512" x2="194.54915" y2="597.52512" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
             <g>
-              <line x1="248.30277" y1="743.63907" x2="279.97541" y2="743.63907" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
-              <line x1="290.67555" y1="743.63907" x2="344.34414" y2="743.63907" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="118.17353" y1="580.23569" x2="149.84618" y2="580.23569" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
+              <line x1="160.54632" y1="580.23569" x2="214.2149" y2="580.23569" style="fill: none;stroke: #e51814;stroke-linecap: round;stroke-linejoin: round;stroke-width: 3px"/>
             </g>
           </g>
         </g>
       </g>
     </g>
     <g>
-      <line x1="496.93518" y1="717.13091" x2="582.02939" y2="717.13091" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="544.26811" y1="734.36139" x2="582.02939" y2="734.36139" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="496.93518" y1="734.36139" x2="534.89244" y2="734.36139" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="566.39028" y1="752.5091" x2="582.02939" y2="752.5091" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="496.93518" y1="752.5091" x2="557.01461" y2="752.5091" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="519.1906" y1="770.20209" x2="582.02939" y2="770.20209" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="496.93518" y1="770.20209" x2="509.68168" y2="770.20209" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="485.96819" y1="715.8296" x2="485.96819" y2="771.44854" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="366.80594" y1="553.72753" x2="451.90015" y2="553.72753" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="414.13887" y1="570.95801" x2="451.90015" y2="570.95801" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="366.80594" y1="570.95801" x2="404.7632" y2="570.95801" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="436.26104" y1="589.10571" x2="451.90015" y2="589.10571" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="366.80594" y1="589.10571" x2="426.88537" y2="589.10571" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="389.06137" y1="606.79871" x2="451.90015" y2="606.79871" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="366.80594" y1="606.79871" x2="379.55245" y2="606.79871" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="355.83895" y1="552.42622" x2="355.83895" y2="608.04516" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
     </g>
     <g>
-      <line x1="588.43246" y1="245.19402" x2="673.52666" y2="245.19402" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="635.76538" y1="262.42451" x2="673.52666" y2="262.42451" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="588.43246" y1="262.42451" x2="626.38972" y2="262.42451" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="657.88755" y1="280.57221" x2="673.52666" y2="280.57221" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="588.43246" y1="280.57221" x2="648.51188" y2="280.57221" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="610.68788" y1="298.2652" x2="673.52666" y2="298.2652" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="588.43246" y1="298.2652" x2="601.17896" y2="298.2652" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-      <line x1="577.46546" y1="243.89272" x2="577.46546" y2="299.51165" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="458.30322" y1="81.79064" x2="543.39742" y2="81.79064" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="505.63615" y1="99.02112" x2="543.39742" y2="99.02112" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="458.30322" y1="99.02112" x2="496.26048" y2="99.02112" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="527.75831" y1="117.16883" x2="543.39742" y2="117.16883" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="458.30322" y1="117.16883" x2="518.38265" y2="117.16883" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="480.55864" y1="134.86182" x2="543.39742" y2="134.86182" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="458.30322" y1="134.86182" x2="471.04972" y2="134.86182" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="447.33623" y1="80.48933" x2="447.33623" y2="136.10827" style="fill: none;stroke: #4e8fcb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
     </g>
     <g>
       <g>
-        <line x1="232.81842" y1="427.83163" x2="317.91265" y2="427.83163" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-        <line x1="280.15134" y1="445.06214" x2="317.91265" y2="445.06214" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-        <line x1="232.81842" y1="445.06214" x2="270.7757" y2="445.06214" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-        <line x1="302.28134" y1="463.20982" x2="317.91265" y2="463.20982" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-        <line x1="232.81842" y1="463.20982" x2="292.90569" y2="463.20982" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-        <line x1="255.08169" y1="480.90284" x2="317.91265" y2="480.90284" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
-        <line x1="232.81842" y1="480.90284" x2="245.57277" y2="480.90284" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="102.68918" y1="264.42825" x2="187.78341" y2="264.42825" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="150.02211" y1="281.65876" x2="187.78341" y2="281.65876" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="102.68918" y1="281.65876" x2="140.64646" y2="281.65876" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="172.1521" y1="299.80644" x2="187.78341" y2="299.80644" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="102.68918" y1="299.80644" x2="162.77646" y2="299.80644" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="124.95245" y1="317.49945" x2="187.78341" y2="317.49945" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+        <line x1="102.68918" y1="317.49945" x2="115.44353" y2="317.49945" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
       </g>
-      <line x1="221.85927" y1="426.53034" x2="221.85927" y2="482.14926" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
+      <line x1="91.73004" y1="263.12695" x2="91.73004" y2="318.74588" style="fill: none;stroke: #4f90cb;stroke-linecap: round;stroke-linejoin: round;stroke-width: 2px"/>
     </g>
   </g>
 </svg>

--- a/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
@@ -134,7 +134,7 @@ const ModelRegistryCoreLoader: React.FC<ModelRegistryCoreLoaderProps> =
     return (
       <ApplicationsPage
         title={
-          <TitleWithIcon title="Model registry" objectType={ProjectObjectType.registeredModels} />
+          <TitleWithIcon title="Model Registry" objectType={ProjectObjectType.registeredModels} />
         }
         description="Select a model registry to view and manage your registered models. Model registries provide a structured and organized way to store, share, version, deploy, and track models."
         headerContent={

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistry.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistry.tsx
@@ -25,7 +25,7 @@ const ModelRegistry: React.FC<ModelRegistryProps> = ({ ...pageProps }) => {
   return (
     <ApplicationsPage
       {...pageProps}
-      title={<TitleWithIcon title="Model registry" objectType={ProjectObjectType.deployedModels} />}
+      title={<TitleWithIcon title="Model Registry" objectType={ProjectObjectType.deployedModels} />}
       description="Select a model registry to view and manage your registered models. Model registries provide a structured and organized way to store, share, version, deploy, and track models."
       headerContent={
         <ModelRegistrySelectorNavigator

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistry.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistry.tsx
@@ -25,7 +25,9 @@ const ModelRegistry: React.FC<ModelRegistryProps> = ({ ...pageProps }) => {
   return (
     <ApplicationsPage
       {...pageProps}
-      title={<TitleWithIcon title="Model Registry" objectType={ProjectObjectType.registeredModels} />}
+      title={
+        <TitleWithIcon title="Model Registry" objectType={ProjectObjectType.registeredModels} />
+      }
       description="Select a model registry to view and manage your registered models. Model registries provide a structured and organized way to store, share, version, deploy, and track models."
       headerContent={
         <ModelRegistrySelectorNavigator

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistry.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistry.tsx
@@ -25,7 +25,7 @@ const ModelRegistry: React.FC<ModelRegistryProps> = ({ ...pageProps }) => {
   return (
     <ApplicationsPage
       {...pageProps}
-      title={<TitleWithIcon title="Model Registry" objectType={ProjectObjectType.deployedModels} />}
+      title={<TitleWithIcon title="Model Registry" objectType={ProjectObjectType.registeredModels} />}
       description="Select a model registry to view and manage your registered models. Model registries provide a structured and organized way to store, share, version, deploy, and track models."
       headerContent={
         <ModelRegistrySelectorNavigator

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
@@ -22,7 +22,6 @@ import truncateStyles from '@patternfly/react-styles/css/components/Truncate/tru
 import { InfoCircleIcon, BlueprintIcon } from '@patternfly/react-icons';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
-import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import {
   getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
@@ -177,7 +176,9 @@ const ModelRegistrySelector: React.FC<ModelRegistrySelectorProps> = ({
 
   return (
     <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
-      <Icon><BlueprintIcon /></Icon>
+      <Icon>
+        <BlueprintIcon />
+      </Icon>
       <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem>
           <Bullseye>Model registry</Bullseye>

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
@@ -9,6 +9,7 @@ import {
   Divider,
   Flex,
   FlexItem,
+  Icon,
   MenuToggle,
   Popover,
   Select,
@@ -18,7 +19,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import truncateStyles from '@patternfly/react-styles/css/components/Truncate/truncate';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon, BlueprintIcon } from '@patternfly/react-icons';
 import { useBrowserStorage } from '~/components/browserStorage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
@@ -176,11 +177,7 @@ const ModelRegistrySelector: React.FC<ModelRegistrySelectorProps> = ({
 
   return (
     <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
-      <img
-        src={typedObjectImage(ProjectObjectType.project)}
-        alt=""
-        style={{ height: 'var(--pf-v5-global--icon--FontSize--lg)' }}
-      />
+      <Icon><BlueprintIcon /></Icon>
       <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem>
           <Bullseye>Model registry</Bullseye>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { ClipboardCopy, DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
+import {
+  ClipboardCopy,
+  DescriptionList,
+  Flex,
+  FlexItem,
+  TextVariants,
+  Title,
+} from '@patternfly/react-core';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
@@ -10,6 +17,7 @@ import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useM
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
 import DashboardHelpTooltip from '~/concepts/dashboard/DashboardHelpTooltip';
+import { uriToObjectStorageFields } from '~/concepts/modelRegistry/utils';
 
 type ModelVersionDetailsViewProps = {
   modelVersion: ModelVersion;
@@ -22,6 +30,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
 }) => {
   const [modelArtifact] = useModelArtifactsByVersionId(mv.id);
   const { apiState } = React.useContext(ModelRegistryContext);
+  const storageFields = uriToObjectStorageFields(modelArtifact.items[0]?.uri || '');
 
   return (
     <Flex
@@ -89,20 +98,85 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
               {mv.id}
             </ClipboardCopy>
           </DashboardDescriptionListGroup>
-          <DashboardDescriptionListGroup
-            title="Storage location"
-            isEmpty={modelArtifact.size === 0 || !modelArtifact.items[0].uri}
-            contentWhenEmpty="No storage location"
-          >
-            <ClipboardCopy
-              data-testid="storage-location"
-              hoverTip="Copy"
-              clickTip="Copied"
-              variant="inline-compact"
-            >
-              {modelArtifact.items[0]?.uri}
-            </ClipboardCopy>
-          </DashboardDescriptionListGroup>
+          <Title headingLevel={TextVariants.h3}>Model location</Title>
+          {storageFields && (
+            <>
+              <DashboardDescriptionListGroup
+                title="Endpoint"
+                isEmpty={modelArtifact.size === 0 || !storageFields.endpoint}
+                contentWhenEmpty="No endpoint"
+              >
+                <ClipboardCopy
+                  data-testid="storage-endpoint"
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant="inline-compact"
+                >
+                  {storageFields.endpoint}
+                </ClipboardCopy>
+              </DashboardDescriptionListGroup>
+              <DashboardDescriptionListGroup
+                title="Region"
+                isEmpty={modelArtifact.size === 0 || !storageFields.region}
+                contentWhenEmpty="No region"
+              >
+                <ClipboardCopy
+                  data-testid="storage-region"
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant="inline-compact"
+                >
+                  {storageFields.region}
+                </ClipboardCopy>
+              </DashboardDescriptionListGroup>
+              <DashboardDescriptionListGroup
+                title="Bucket"
+                isEmpty={modelArtifact.size === 0 || !storageFields.bucket}
+                contentWhenEmpty="No bucket"
+              >
+                <ClipboardCopy
+                  data-testid="storage-bucket"
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant="inline-compact"
+                >
+                  {storageFields.bucket}
+                </ClipboardCopy>
+              </DashboardDescriptionListGroup>
+              <DashboardDescriptionListGroup
+                title="Path"
+                isEmpty={modelArtifact.size === 0 || !storageFields.path}
+                contentWhenEmpty="No path"
+              >
+                <ClipboardCopy
+                  data-testid="storage-path"
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant="inline-compact"
+                >
+                  {storageFields.path}
+                </ClipboardCopy>
+              </DashboardDescriptionListGroup>
+            </>
+          )}
+          {!storageFields && (
+            <>
+              <DashboardDescriptionListGroup
+                title="URI"
+                isEmpty={modelArtifact.size === 0 || !modelArtifact.items[0].uri}
+                contentWhenEmpty="No URI"
+              >
+                <ClipboardCopy
+                  data-testid="storage-uri"
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant="inline-compact"
+                >
+                  {modelArtifact.items[0]?.uri}
+                </ClipboardCopy>
+              </DashboardDescriptionListGroup>
+            </>
+          )}
           <DashboardDescriptionListGroup
             title="Source model format"
             isEmpty={modelArtifact.size === 0 || !modelArtifact.items[0].modelFormatName}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-  ClipboardCopy,
-  DescriptionList,
-  Flex,
-  FlexItem,
-  TextVariants,
-  Title,
-} from '@patternfly/react-core';
+import { DescriptionList, Flex, FlexItem, TextVariants, Title } from '@patternfly/react-core';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
@@ -18,6 +11,7 @@ import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegi
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
 import DashboardHelpTooltip from '~/concepts/dashboard/DashboardHelpTooltip';
 import { uriToObjectStorageFields } from '~/concepts/modelRegistry/utils';
+import InlineTruncatedClipboardCopy from '~/components/InlineTruncatedClipboardCopy';
 
 type ModelVersionDetailsViewProps = {
   modelVersion: ModelVersion;
@@ -89,14 +83,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
             isEmpty={!mv.id}
             contentWhenEmpty="No model ID"
           >
-            <ClipboardCopy
-              data-testid="model-version-id"
-              hoverTip="Copy"
-              clickTip="Copied"
-              variant="inline-compact"
-            >
-              {mv.id}
-            </ClipboardCopy>
+            <InlineTruncatedClipboardCopy testId="model-version-id" textToCopy={mv.id} />
           </DashboardDescriptionListGroup>
           <Title headingLevel={TextVariants.h3}>Model location</Title>
           {storageFields && (
@@ -106,56 +93,40 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
                 isEmpty={modelArtifact.size === 0 || !storageFields.endpoint}
                 contentWhenEmpty="No endpoint"
               >
-                <ClipboardCopy
-                  data-testid="storage-endpoint"
-                  hoverTip="Copy"
-                  clickTip="Copied"
-                  variant="inline-compact"
-                >
-                  {storageFields.endpoint}
-                </ClipboardCopy>
+                <InlineTruncatedClipboardCopy
+                  testId="storage-endpoint"
+                  textToCopy={storageFields.endpoint}
+                />
               </DashboardDescriptionListGroup>
               <DashboardDescriptionListGroup
                 title="Region"
                 isEmpty={modelArtifact.size === 0 || !storageFields.region}
                 contentWhenEmpty="No region"
               >
-                <ClipboardCopy
-                  data-testid="storage-region"
-                  hoverTip="Copy"
-                  clickTip="Copied"
-                  variant="inline-compact"
-                >
-                  {storageFields.region}
-                </ClipboardCopy>
+                <InlineTruncatedClipboardCopy
+                  testId="storage-region"
+                  textToCopy={storageFields.region || ''}
+                />
               </DashboardDescriptionListGroup>
               <DashboardDescriptionListGroup
                 title="Bucket"
                 isEmpty={modelArtifact.size === 0 || !storageFields.bucket}
                 contentWhenEmpty="No bucket"
               >
-                <ClipboardCopy
-                  data-testid="storage-bucket"
-                  hoverTip="Copy"
-                  clickTip="Copied"
-                  variant="inline-compact"
-                >
-                  {storageFields.bucket}
-                </ClipboardCopy>
+                <InlineTruncatedClipboardCopy
+                  testId="storage-bucket"
+                  textToCopy={storageFields.bucket}
+                />
               </DashboardDescriptionListGroup>
               <DashboardDescriptionListGroup
                 title="Path"
                 isEmpty={modelArtifact.size === 0 || !storageFields.path}
                 contentWhenEmpty="No path"
               >
-                <ClipboardCopy
-                  data-testid="storage-path"
-                  hoverTip="Copy"
-                  clickTip="Copied"
-                  variant="inline-compact"
-                >
-                  {storageFields.path}
-                </ClipboardCopy>
+                <InlineTruncatedClipboardCopy
+                  testId="storage-path"
+                  textToCopy={storageFields.path}
+                />
               </DashboardDescriptionListGroup>
             </>
           )}
@@ -166,14 +137,10 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
                 isEmpty={modelArtifact.size === 0 || !modelArtifact.items[0].uri}
                 contentWhenEmpty="No URI"
               >
-                <ClipboardCopy
-                  data-testid="storage-uri"
-                  hoverTip="Copy"
-                  clickTip="Copied"
-                  variant="inline-compact"
-                >
-                  {modelArtifact.items[0]?.uri}
-                </ClipboardCopy>
+                <InlineTruncatedClipboardCopy
+                  testId="storage-uri"
+                  textToCopy={modelArtifact.items[0]?.uri || ''}
+                />
               </DashboardDescriptionListGroup>
             </>
           )}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.tsx
@@ -6,8 +6,8 @@ import { Alert, Stack } from '@patternfly/react-core';
 import EmptyModelRegistryState from '~/pages/modelRegistry/screens/components/EmptyModelRegistryState';
 import InferenceServiceTable from '~/pages/modelServing/screens/global/InferenceServiceTable';
 import { getVersionDetailsInferenceServiceColumns } from '~/pages/modelServing/screens/global/data';
-import ModelVersionDetailsTabs from './ModelVersionDetailsTabs';
 import { typedEmptyImage, ProjectObjectType } from '~/concepts/design/utils';
+import ModelVersionDetailsTabs from './ModelVersionDetailsTabs';
 
 type ModelVersionRegisteredDeploymentsViewProps = Pick<
   React.ComponentProps<typeof ModelVersionDetailsTabs>,
@@ -24,7 +24,10 @@ const ModelVersionRegisteredDeploymentsView: React.FC<
       <EmptyModelRegistryState
         title="No deployments from model registry"
         headerIcon={() => (
-          <img src={typedEmptyImage(ProjectObjectType.registeredModels, "MissingDeployment")} />
+          <img
+            src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingDeployment')}
+            alt="missing deployment"
+          />
         )}
         description="No deployments initiated from model registry for this model version."
         testid="model-version-deployments-empty-state"

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.tsx
@@ -7,6 +7,7 @@ import EmptyModelRegistryState from '~/pages/modelRegistry/screens/components/Em
 import InferenceServiceTable from '~/pages/modelServing/screens/global/InferenceServiceTable';
 import { getVersionDetailsInferenceServiceColumns } from '~/pages/modelServing/screens/global/data';
 import ModelVersionDetailsTabs from './ModelVersionDetailsTabs';
+import { typedEmptyImage, ProjectObjectType } from '~/concepts/design/utils';
 
 type ModelVersionRegisteredDeploymentsViewProps = Pick<
   React.ComponentProps<typeof ModelVersionDetailsTabs>,
@@ -22,6 +23,9 @@ const ModelVersionRegisteredDeploymentsView: React.FC<
     return (
       <EmptyModelRegistryState
         title="No deployments from model registry"
+        headerIcon={() => (
+          <img src={typedEmptyImage(ProjectObjectType.registeredModels, "MissingDeployment")} />
+        )}
         description="No deployments initiated from model registry for this model version."
         testid="model-version-deployments-empty-state"
       />

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
@@ -27,6 +27,7 @@ import {
 } from '~/pages/modelRegistry/screens/routeUtils';
 import { asEnumMember } from '~/utilities/utils';
 import ModelVersionsTable from './ModelVersionsTable';
+import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 
 type ModelVersionListViewProps = {
   modelVersions: ModelVersion[];
@@ -57,6 +58,9 @@ const ModelVersionListView: React.FC<ModelVersionListViewProps> = ({
       <EmptyModelRegistryState
         testid="empty-model-versions"
         title="No versions"
+        headerIcon={() => (
+          <img src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingVersion')} />
+        )}
         description={`${rm?.name} has no registered versions. Register a version to this model.`}
         primaryActionText="Register new version"
         secondaryActionText="View archived versions"

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
@@ -26,8 +26,8 @@ import {
   registerVersionForModelUrl,
 } from '~/pages/modelRegistry/screens/routeUtils';
 import { asEnumMember } from '~/utilities/utils';
-import ModelVersionsTable from './ModelVersionsTable';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
+import ModelVersionsTable from './ModelVersionsTable';
 
 type ModelVersionListViewProps = {
   modelVersions: ModelVersion[];
@@ -59,7 +59,10 @@ const ModelVersionListView: React.FC<ModelVersionListViewProps> = ({
         testid="empty-model-versions"
         title="No versions"
         headerIcon={() => (
-          <img src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingVersion')} />
+          <img
+            src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingVersion')}
+            alt="missing version"
+          />
         )}
         description={`${rm?.name} has no registered versions. Register a version to this model.`}
         primaryActionText="Register new version"

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -13,9 +13,9 @@ import {
   registeredModelArchiveUrl,
 } from '~/pages/modelRegistry/screens/routeUtils';
 import { asEnumMember } from '~/utilities/utils';
+import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import RegisteredModelTable from './RegisteredModelTable';
 import RegisteredModelsTableToolbar from './RegisteredModelsTableToolbar';
-import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 
 type RegisteredModelListViewProps = {
   registeredModels: RegisteredModel[];
@@ -39,7 +39,10 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
         testid="empty-registered-models"
         title="No models in selected registry"
         headerIcon={() => (
-          <img src={typedEmptyImage(ProjectObjectType.registeredModels, "MissingModel")} />
+          <img
+            src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingModel')}
+            alt="missing model"
+          />
         )}
         description={`${preferredModelRegistry?.metadata.name} has no active registered models. Register a model in this registry, or select a different registry.`}
         primaryActionText="Register model"

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -15,6 +15,7 @@ import {
 import { asEnumMember } from '~/utilities/utils';
 import RegisteredModelTable from './RegisteredModelTable';
 import RegisteredModelsTableToolbar from './RegisteredModelsTableToolbar';
+import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 
 type RegisteredModelListViewProps = {
   registeredModels: RegisteredModel[];
@@ -37,6 +38,9 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
       <EmptyModelRegistryState
         testid="empty-registered-models"
         title="No models in selected registry"
+        headerIcon={() => (
+          <img src={typedEmptyImage(ProjectObjectType.registeredModels, "MissingModel")} />
+        )}
         description={`${preferredModelRegistry?.metadata.name} has no active registered models. Register a model in this registry, or select a different registry.`}
         primaryActionText="Register model"
         secondaryActionText="View archived models"

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -13,6 +13,7 @@ import ModelLabels from '~/pages/modelRegistry/screens/components/ModelLabels';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import { ArchiveRegisteredModelModal } from '~/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
 import { RestoreRegisteredModelModal } from '~/pages/modelRegistry/screens/components/RestoreRegisteredModel';
+import { ModelVersionsTab } from '~/pages/modelRegistry/screens/ModelVersions/const';
 
 type RegisteredModelTableRowProps = {
   registeredModel: RegisteredModel;
@@ -32,19 +33,21 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
   const rmUrl = registeredModelUrl(rm.id, preferredModelRegistry?.metadata.name);
 
-  const actions = isArchiveRow
-    ? [
-        {
+  const actions = [
+    {
+      title: 'View details',
+      onClick: () => navigate(`${rmUrl}/${ModelVersionsTab.DETAILS}`),
+    },
+    isArchiveRow
+      ? {
           title: 'Restore model',
           onClick: () => setIsRestoreModalOpen(true),
-        },
-      ]
-    : [
-        {
+        }
+      : {
           title: 'Archive model',
           onClick: () => setIsArchiveModalOpen(true),
         },
-      ];
+  ];
 
   return (
     <Tr>

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -12,10 +12,10 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import useModelRegistriesBackend from '~/concepts/modelRegistrySettings/useModelRegistriesBackend';
-import ModelRegistriesTable from './ModelRegistriesTable';
-import CreateModal from './CreateModal';
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
+import ModelRegistriesTable from './ModelRegistriesTable';
+import CreateModal from './CreateModal';
 
 const ModelRegistrySettings: React.FC = () => {
   const [createModalOpen, setCreateModalOpen] = React.useState(false);
@@ -23,7 +23,12 @@ const ModelRegistrySettings: React.FC = () => {
   return (
     <>
       <ApplicationsPage
-        title={<TitleWithIcon title="Model Registry Settings" objectType={ProjectObjectType.registeredModels} />}
+        title={
+          <TitleWithIcon
+            title="Model Registry Settings"
+            objectType={ProjectObjectType.registeredModels}
+          />
+        }
         description="Manage model registry settings for all users in your organization."
         loaded={loaded}
         loadError={loadError}

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -14,6 +14,8 @@ import ApplicationsPage from '~/pages/ApplicationsPage';
 import useModelRegistriesBackend from '~/concepts/modelRegistrySettings/useModelRegistriesBackend';
 import ModelRegistriesTable from './ModelRegistriesTable';
 import CreateModal from './CreateModal';
+import TitleWithIcon from '~/concepts/design/TitleWithIcon';
+import { ProjectObjectType } from '~/concepts/design/utils';
 
 const ModelRegistrySettings: React.FC = () => {
   const [createModalOpen, setCreateModalOpen] = React.useState(false);
@@ -21,7 +23,7 @@ const ModelRegistrySettings: React.FC = () => {
   return (
     <>
       <ApplicationsPage
-        title="Model registry settings"
+        title={<TitleWithIcon title="Model Registry Settings" objectType={ProjectObjectType.registeredModels} />}
         description="Manage model registry settings for all users in your organization."
         loaded={loaded}
         loadError={loadError}


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-5463

## Description
several design changes

new emptystate images:
![image](https://github.com/user-attachments/assets/7d7d1975-4e77-449b-a2da-19b603e5d97c)
![image](https://github.com/user-attachments/assets/2161a79c-0ef1-4640-9b33-dfe455add2a0)
![image](https://github.com/user-attachments/assets/089ffa23-91a5-41e0-948c-4a0ed675491d)


breadcrumbs/titles/icons:
![image](https://github.com/user-attachments/assets/575f9453-1f52-4cfd-b15d-2f1286b0d058)
![image](https://github.com/user-attachments/assets/98ab1871-da9b-477c-8fc3-e3dcb2a10175)
![image](https://github.com/user-attachments/assets/9376f37f-6905-402b-b7cf-d4a4baffc690)

model location parts
![image](https://github.com/user-attachments/assets/084b206c-5477-42fa-9608-ed66fe0665f7)
with uri
![image](https://github.com/user-attachments/assets/eddac0bf-9254-4f97-b246-dc6252c12893)

view details is back
![image](https://github.com/user-attachments/assets/63883427-1756-4f03-833f-de688561aa06)
on archived as well
![image](https://github.com/user-attachments/assets/4fa4dc45-45cd-4282-bb57-49c017a3ff32)



## How Has This Been Tested?
locally, mr cluster

## Test Impact
updated tests where necessary

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
