### PR TITLE
Change metrics artifact node icon and hide non-metrics artifact visualization tab

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -12,7 +12,7 @@ import { Artifact } from '~/third_party/mlmd';
 const artifactTask: PipelineTask = {
   type: 'artifact',
   name: 'metrics',
-  metadata: new Artifact(),
+  metadata: new Artifact().setType('system.Metrics'),
   inputs: { artifacts: [{ label: 'metrics', type: 'system.Metrics (0.0.1)' }] },
 };
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent.tsx
@@ -16,6 +16,7 @@ import {
 } from '@patternfly/react-core';
 
 import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
+import { isMetricsArtifactType } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
 import { ArtifactNodeDetails } from './ArtifactNodeDetails';
 import { ArtifactVisualization } from './ArtifactVisualization';
 
@@ -62,13 +63,15 @@ export const ArtifactNodeDrawerContent: React.FC<ArtifactNodeDrawerContentProps>
             >
               <ArtifactNodeDetails artifact={artifact} upstreamTaskName={upstreamTaskName} />
             </Tab>
-            <Tab
-              eventKey={ArtifactNodeDrawerTab.Visualization}
-              title={<TabTitleText>Visualization</TabTitleText>}
-              aria-label="Visualization"
-            >
-              <ArtifactVisualization artifact={artifact} />
-            </Tab>
+            {isMetricsArtifactType(artifact.getType()) && (
+              <Tab
+                eventKey={ArtifactNodeDrawerTab.Visualization}
+                title={<TabTitleText>Visualization</TabTitleText>}
+                aria-label="Visualization"
+              >
+                <ArtifactVisualization artifact={artifact} />
+              </Tab>
+            )}
           </Tabs>
         ) : (
           <EmptyState variant={EmptyStateVariant.xs}>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -183,6 +183,50 @@ describe('ArtifactNodeDrawerContent', () => {
     await user.click(screen.getByRole('tab', { name: 'Visualization' }));
     expect(screen.getByRole('heading', { name: 'Confusion matrix metrics' })).toBeVisible();
   });
+
+  it('should not render "Dataset" visualization drawer tab', async () => {
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.Dataset', {
+                key: 'dataset',
+                value: new Value(),
+              }),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Visualization' })).toBeNull();
+  });
+
+  it('should not render "Model" visualization drawer tab', async () => {
+    render(
+      <BrowserRouter>
+        <Drawer isExpanded>
+          <ArtifactNodeDrawerContent
+            task={{
+              ...task,
+              metadata: createArtifact('system.Model', {
+                key: 'model',
+                value: new Value(),
+              }),
+            }}
+            upstreamTaskName="some-upstream-task"
+            onClose={jest.fn()}
+          />
+        </Drawer>
+      </BrowserRouter>,
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Visualization' })).toBeNull();
+  });
 });
 
 function createArtifact(type: string, customProperty?: { key: string; value: Value }) {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
@@ -1,4 +1,5 @@
 import { Artifact } from '~/third_party/mlmd';
+import { ArtifactType } from '~/concepts/pipelines/kfTypes';
 import { ArtifactProperty } from './types';
 
 export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] =>
@@ -20,3 +21,10 @@ export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] =>
       },
       [],
     );
+
+export const isMetricsArtifactType = (artifactType?: string): boolean =>
+  artifactType === ArtifactType.METRICS ||
+  artifactType === ArtifactType.CLASSIFICATION_METRICS ||
+  artifactType === ArtifactType.HTML ||
+  artifactType === ArtifactType.MARKDOWN ||
+  artifactType === ArtifactType.SLICED_CLASSIFICATION_METRICS;

--- a/frontend/src/concepts/topology/customNodes/ArtifactTaskNode.tsx
+++ b/frontend/src/concepts/topology/customNodes/ArtifactTaskNode.tsx
@@ -21,6 +21,7 @@ import { ListIcon, MonitoringIcon } from '@patternfly/react-icons';
 import { TaskNodeProps } from '@patternfly/react-topology/dist/esm/pipelines/components/nodes/TaskNode';
 import { css } from '@patternfly/react-styles';
 import { StandardTaskNodeData } from '~/concepts/topology/types';
+import { isMetricsArtifactType } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
 
 const ICON_PADDING = 8;
 
@@ -85,7 +86,7 @@ const IconTaskNode: React.FC<IconTaskNodeProps> = observer(({ element, selected,
             : 'var(--pf-v5-global--icon--Color--light)'
         }
       >
-        {data?.artifactType === 'system.Metrics' ? (
+        {isMetricsArtifactType(data?.artifactType) ? (
           <MonitoringIcon width={iconSize} height={iconSize} />
         ) : (
           <ListIcon width={iconSize} height={iconSize} />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-11570

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change the icon of all the artifact nodes with a visualization metrics (system.Metrics, system.ClassificationMetrics, system.HTML, system.Markdown, system.SlicedClassificationMetrics) to the monitoring icon. And hide the `Visualization` side panel tab for those non-metrics type artifact nodes (system.Model, system.Dataset, system.Artifact)

Monitoring icon:
<img width="1511" alt="Screenshot 2024-08-29 at 3 48 18 PM" src="https://github.com/user-attachments/assets/fdcd3055-e84f-47cd-b23a-a779de90147d">

No "visualization" tab:
<img width="1511" alt="Screenshot 2024-08-29 at 3 47 43 PM" src="https://github.com/user-attachments/assets/0b63d304-f1a2-4c41-b0e3-656d8442164b">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a run with the metrics visualization pipeline
2. Make sure all the artifact nodes are using the Monitoring icon
3. Create a run with the iris training pipeline
4. Make sure the artifacts nodes with the type of `system.Model` or `system.Dataset` don't have the Visualization tab in the side panel when clicking the node

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add unit tests to verify the "Visualization" tab for specific nodes is invisible.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
