### PR TITLE
Add connection type dropdown advanced properties

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
@@ -85,17 +85,17 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
       >
         <SelectList>
           {field.properties.items?.map(
-            (i) =>
-              (i.value || i.label) && (
+            (item, index) =>
+              (item.value || item.label) && (
                 <SelectOption
-                  value={i.value}
-                  key={i.value}
+                  value={item.value}
+                  key={index}
                   hasCheckbox={isMulti}
-                  isSelected={selected?.includes(i.value)}
-                  description={`Value: ${i.value}`}
-                  isDisabled={!i.value}
+                  isSelected={selected?.includes(item.value)}
+                  description={`Value: ${item.value}`}
+                  isDisabled={!item.value}
                 >
-                  {i.label || i.value}
+                  {item.label || item.value}
                 </SelectOption>
               ),
           )}

--- a/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
@@ -17,6 +17,25 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
   const isMulti = field.properties.variant === 'multi';
   const selected = isPreview ? field.properties.defaultValue : value;
   const hasValidOption = field.properties.items?.find((f) => f.value || f.label);
+
+  const menuToggleText = () => {
+    let text = field.name ? `Select ${field.name} ` : 'No values defined yet ';
+    if (!isMulti && isPreview) {
+      const defaultOption = field.properties.items?.find(
+        (i) => i.value === field.properties.defaultValue?.[0],
+      );
+      if (defaultOption) {
+        text = defaultOption.label || defaultOption.value;
+      }
+    } else if (!isMulti && !isPreview) {
+      const currentSelection = field.properties.items?.find((i) => value?.includes(i.value));
+      if (currentSelection) {
+        text = currentSelection.label || currentSelection.value;
+      }
+    }
+    return text;
+  };
+
   return (
     <DefaultValueTextRenderer id={id} field={field} mode={mode}>
       <Select
@@ -52,26 +71,15 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
             isExpanded={isOpen}
             isDisabled={!hasValidOption}
           >
-            {isMulti ? (
-              <>
-                {field.name ? `Select ${field.name} ` : 'No values defined yet '}
+            <>
+              {menuToggleText()}
+              {isMulti && (
                 <Badge>
                   {(isPreview ? field.properties.defaultValue?.length : value?.length) ?? 0}{' '}
                   selected
                 </Badge>
-              </>
-            ) : (
-              (isPreview
-                ? field.properties.items?.find(
-                    (i) => i.value === field.properties.defaultValue?.[0],
-                  )?.label ||
-                  field.properties.items?.find(
-                    (i) => i.value === field.properties.defaultValue?.[0],
-                  )?.value
-                : field.properties.items?.find((i) => value?.includes(i.value))?.label ||
-                  field.properties.items?.find((i) => value?.includes(i.value))?.value) ||
-              (field.name ? `Select ${field.name} ` : 'No values defined yet')
-            )}
+              )}
+            </>
           </MenuToggle>
         )}
       >

--- a/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
@@ -4,6 +4,7 @@ import BooleanAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanc
 import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/types';
 import NumericAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/NumericAdvancedPropertiesForm';
 import FileUploadAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm';
+import DropdownAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm';
 
 const CustomFieldPropertiesForm = <T extends ConnectionTypeDataField>(
   props: AdvancedFieldProps<T>,
@@ -21,7 +22,7 @@ const CustomFieldPropertiesForm = <T extends ConnectionTypeDataField>(
         return NumericAdvancedPropertiesForm;
 
       case ConnectionTypeFieldType.Dropdown:
-        return () => null;
+        return DropdownAdvancedPropertiesForm;
     }
     return undefined;
   })();

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -187,6 +187,7 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
                     data-testid={`dropdown-item-row-remove-${i}`}
                     variant="plain"
                     aria-label="Remove item"
+                    isDisabled={rowsToRender.length === 1 && !r.data.label && !r.data.value}
                     onClick={() => {
                       if (rowsToRender.length === 1) {
                         setDropdownItems([{ label: '', value: '' }]);

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -111,7 +111,8 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
               <Th screenReaderText="Drag and drop" />
               <Th
                 info={{
-                  popover: 'This label is the display name for the dropdown item.',
+                  popover:
+                    'This label is the display name for the dropdown item. If no value is specified, the value is used as the label.',
                   popoverProps: {
                     headerContent: 'Dropdown item label',
                   },
@@ -121,8 +122,7 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
               </Th>
               <Th
                 info={{
-                  popover:
-                    'This value is associated with the dropdown item. If no value is specified, the label is used as the value.',
+                  popover: 'This value is associated with the dropdown item.',
                   popoverProps: {
                     headerContent: 'Dropdown item value',
                   },

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -112,7 +112,7 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
               <Th
                 info={{
                   popover:
-                    'This label is the display name for the dropdown item. If no value is specified, the value is used as the label.',
+                    'This label is the display name for the dropdown item. If no label is specified, the value is used as the label.',
                   popoverProps: {
                     headerContent: 'Dropdown item label',
                   },

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import { Button, Flex, FlexItem, FormGroup, Radio, TextInput } from '@patternfly/react-core';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
+import useDraggableTableControlled from '~/utilities/useDraggableTableControlled';
+import { DropdownField } from '~/concepts/connectionTypes/types';
+import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/types';
+import ExpandableFormSection from '~/components/ExpandableFormSection';
+
+const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>> = ({
+  properties,
+  onChange,
+  onValidate,
+}) => {
+  React.useEffect(() => {
+    if (!properties.variant) {
+      onChange({ ...properties, variant: 'single' });
+    }
+  });
+
+  React.useEffect(() => {
+    // TODO: warn user of duplicate values in table
+    const duplicates = properties.items?.find((item1, index1) =>
+      properties.items?.find((item2, index2) => item1.value === item2.value && index1 !== index2),
+    );
+    onValidate(
+      !!properties.variant && !!properties.items?.every((item) => item.value) && !duplicates,
+    );
+  }, [properties.variant, properties.items, onValidate]);
+
+  const dropdownItems = React.useMemo(
+    () => properties.items || [{ label: '', value: '' }],
+    [properties],
+  );
+  const setDropdownItems = React.useCallback(
+    (newItems: { label: string; value: string }[]) => {
+      // if a default value no longer exists as a possible option, remove it
+      const newDefaults = properties.defaultValue?.filter((defaultOption) =>
+        newItems.find((newOption) => defaultOption === newOption.value),
+      );
+      onChange({
+        ...properties,
+        defaultValue: newDefaults,
+        items: newItems,
+      });
+    },
+    [properties, onChange],
+  );
+
+  const { tableProps, rowsToRender } = useDraggableTableControlled<{
+    label: string;
+    value: string;
+  }>(dropdownItems, setDropdownItems);
+
+  return (
+    <ExpandableFormSection
+      toggleText="Advanced settings"
+      data-testid="advanced-settings-toggle"
+      initExpanded
+    >
+      <FormGroup
+        label="Dropdown variation"
+        fieldId="dropdown-variation-radio-group"
+        role="radiogroup"
+        isRequired
+      >
+        <Flex>
+          <FlexItem>
+            <Radio
+              id="radio-single-select"
+              data-testid="radio-single-select"
+              name="dropdown-variation-radio"
+              label="Single-select"
+              isChecked={properties.variant === 'single'}
+              onChange={() => onChange({ ...properties, variant: 'single' })}
+            />
+          </FlexItem>
+          <FlexItem>
+            <Radio
+              id="radio-multi-select"
+              data-testid="radio-multi-select"
+              name="dropdown-variation-radio"
+              label="Multi-select"
+              isChecked={properties.variant === 'multi'}
+              onChange={() => onChange({ ...properties, variant: 'multi' })}
+            />
+          </FlexItem>
+        </Flex>
+      </FormGroup>
+      <FormGroup>
+        <Table data-testid="connection-type-fields-table" className={tableProps.className}>
+          <Thead>
+            <Tr>
+              <Th screenReaderText="Drag and drop" />
+              <Th
+                info={{
+                  popover: 'This label is the display name for the dropdown item.',
+                  popoverProps: {
+                    headerContent: 'Dropdown item label',
+                  },
+                }}
+              >
+                Dropdown item labels
+              </Th>
+              <Th
+                info={{
+                  popover:
+                    'This value is associated with the dropdown item. If no value is specified, the label is used as the value.',
+                  popoverProps: {
+                    headerContent: 'Dropdown item value',
+                  },
+                }}
+              >
+                <div>
+                  Dropdown item values
+                  <span aria-hidden="true" className={text.dangerColor_100}>
+                    {' *'}
+                  </span>
+                </div>
+              </Th>
+              <Th screenReaderText="Actions" width={10} />
+            </Tr>
+          </Thead>
+          <Tbody {...tableProps.tbodyProps}>
+            {rowsToRender.map((r, i) => (
+              <Tr key={i} draggable {...r.rowProps} data-testid="dropdown-item-row">
+                <Td
+                  draggableRow={{
+                    id: `draggable-row-${r.rowProps.id}`,
+                  }}
+                />
+                <Td dataLabel="Dropdown item labels">
+                  <TextInput
+                    data-testid={`dropdown-item-row-label-${i}`}
+                    value={r.data.label}
+                    type="text"
+                    onChange={(_, label) => {
+                      setDropdownItems([
+                        ...dropdownItems.slice(0, i),
+                        {
+                          label,
+                          value: dropdownItems[i].value,
+                        },
+                        ...dropdownItems.slice(i + 1),
+                      ]);
+                    }}
+                    aria-label="dropdown item label"
+                  />
+                </Td>
+                <Td dataLabel="Dropdown item values">
+                  <TextInput
+                    data-testid={`dropdown-item-row-value-${i}`}
+                    value={r.data.value}
+                    type="text"
+                    onChange={(_, value) => {
+                      setDropdownItems([
+                        ...dropdownItems.slice(0, i),
+                        {
+                          label: dropdownItems[i].label,
+                          value,
+                        },
+                        ...dropdownItems.slice(i + 1),
+                      ]);
+                    }}
+                    aria-label="dropdown item value"
+                  />
+                </Td>
+                <Td>
+                  <Button
+                    data-testid={`dropdown-item-row-remove-${i}`}
+                    variant="plain"
+                    aria-label="Remove item"
+                    isDisabled={rowsToRender.length === 1}
+                    onClick={() => {
+                      setDropdownItems(dropdownItems.filter((_, index) => i !== index));
+                    }}
+                  >
+                    <MinusCircleIcon />
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+        <Button
+          data-testid="add-dropdown-table-item"
+          variant="link"
+          icon={<PlusCircleIcon />}
+          onClick={() => {
+            setDropdownItems([...dropdownItems, { label: '', value: '' }]);
+          }}
+        >
+          Add dropdown item
+        </Button>
+      </FormGroup>
+    </ExpandableFormSection>
+  );
+};
+
+export default DropdownAdvancedPropertiesForm;

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -73,7 +73,14 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
               name="dropdown-variation-radio"
               label="Single-select"
               isChecked={properties.variant === 'single'}
-              onChange={() => onChange({ ...properties, variant: 'single' })}
+              onChange={() =>
+                onChange({
+                  ...properties,
+                  variant: 'single',
+                  // if there were multiple defaults from a multi select, clear all but one
+                  defaultValue: properties.defaultValue?.length ? [properties.defaultValue[0]] : [],
+                })
+              }
             />
           </FlexItem>
           <FlexItem>

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -20,12 +20,21 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
   });
 
   React.useEffect(() => {
-    // TODO: warn user of duplicate values in table
-    const duplicates = properties.items?.find((item1, index1) =>
+    // filter out empty rows for validation (they will be removed on save)
+    const itemsWithoutEmptyRows =
+      properties.items?.filter((item) => item.label || item.value) ?? [];
+
+    // TODO: warn user of duplicate values in table (and labels?)
+    const duplicateValues = itemsWithoutEmptyRows.find((item1, index1) =>
       properties.items?.find((item2, index2) => item1.value === item2.value && index1 !== index2),
     );
+    const noMissingValues = itemsWithoutEmptyRows.every((item) => item.value);
+
     onValidate(
-      !!properties.variant && !!properties.items?.every((item) => item.value) && !duplicates,
+      !!properties.variant &&
+        itemsWithoutEmptyRows.length > 0 &&
+        noMissingValues &&
+        !duplicateValues,
     );
   }, [properties.variant, properties.items, onValidate]);
 
@@ -178,9 +187,12 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
                     data-testid={`dropdown-item-row-remove-${i}`}
                     variant="plain"
                     aria-label="Remove item"
-                    isDisabled={rowsToRender.length === 1}
                     onClick={() => {
-                      setDropdownItems(dropdownItems.filter((_, index) => i !== index));
+                      if (rowsToRender.length === 1) {
+                        setDropdownItems([{ label: '', value: '' }]);
+                      } else {
+                        setDropdownItems(dropdownItems.filter((_, index) => i !== index));
+                      }
                     }}
                   >
                     <MinusCircleIcon />

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
@@ -37,6 +37,7 @@ describe('DropdownFieldAdvancedPropertiesForm', () => {
     expect(screen.getAllByTestId('dropdown-item-row').length).toEqual(1);
     expect(screen.getByTestId('dropdown-item-row-label-0')).toHaveValue('');
     expect(screen.getByTestId('dropdown-item-row-value-0')).toHaveValue('');
+    expect(screen.getByTestId('dropdown-item-row-remove-0')).toBeDisabled();
     expect(screen.getByTestId('add-dropdown-table-item')).toBeVisible();
 
     // will preselect 'single' variant on load

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { ConnectionTypeFieldType, DropdownField } from '~/concepts/connectionTypes/types';
+import DropdownAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm';
+
+let onChange: jest.Mock;
+let onValidate: jest.Mock;
+let field: DropdownField;
+
+describe('DropdownFieldAdvancedPropertiesForm', () => {
+  beforeEach(() => {
+    onChange = jest.fn();
+    onValidate = jest.fn();
+    field = {
+      type: ConnectionTypeFieldType.Dropdown,
+      name: 'Test Dropdown',
+      envVar: 'TEST_DROPDOWN',
+      properties: {},
+    };
+  });
+
+  it('should show the empty state', () => {
+    render(
+      <DropdownAdvancedPropertiesForm
+        properties={{}}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    // default is the expandable form is already open
+    expect(screen.getByTestId('radio-single-select')).toBeVisible();
+    expect(screen.getByTestId('radio-multi-select')).toBeVisible();
+    expect(screen.getAllByTestId('dropdown-item-row').length).toEqual(1);
+    expect(screen.getByTestId('dropdown-item-row-label-0')).toHaveValue('');
+    expect(screen.getByTestId('dropdown-item-row-value-0')).toHaveValue('');
+    expect(screen.getByTestId('add-dropdown-table-item')).toBeVisible();
+
+    // will preselect 'single' variant on load
+    expect(onChange).toBeCalledWith({
+      variant: 'single',
+    });
+  });
+
+  it('should update select type', async () => {
+    render(
+      <DropdownAdvancedPropertiesForm
+        properties={{ variant: 'single' }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    const multiSelect = screen.getByTestId('radio-multi-select');
+    act(() => fireEvent.click(multiSelect));
+    await waitFor(() =>
+      expect(onChange).toHaveBeenNthCalledWith(1, {
+        variant: 'multi',
+      }),
+    );
+  });
+
+  it('should update row label and value', async () => {
+    render(
+      <DropdownAdvancedPropertiesForm
+        properties={{
+          variant: 'single',
+          items: [{ label: 'a', value: 'a' }],
+        }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    const itemLabel = screen.getByTestId('dropdown-item-row-label-0');
+    act(() => fireEvent.change(itemLabel, { target: { value: 'b' } }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      variant: 'single',
+      items: [{ label: 'b', value: 'a' }],
+    });
+
+    const itemValue = screen.getByTestId('dropdown-item-row-value-0');
+    act(() => fireEvent.change(itemValue, { target: { value: 'b' } }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      variant: 'single',
+      items: [{ label: 'a', value: 'b' }],
+    });
+  });
+
+  it('should add row', async () => {
+    render(
+      <DropdownAdvancedPropertiesForm
+        properties={{
+          variant: 'single',
+          items: [{ label: 'a', value: 'a' }],
+        }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    const addButton = screen.getByTestId('add-dropdown-table-item');
+    act(() => fireEvent.click(addButton));
+    expect(onChange).toHaveBeenLastCalledWith({
+      variant: 'single',
+      items: [
+        { label: 'a', value: 'a' },
+        { label: '', value: '' },
+      ],
+    });
+  });
+
+  it('should delete row', async () => {
+    render(
+      <DropdownAdvancedPropertiesForm
+        properties={{
+          variant: 'single',
+          items: [
+            { label: 'a', value: 'a' },
+            { label: 'b', value: 'b' },
+          ],
+        }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    const removeButton = screen.getByTestId('dropdown-item-row-remove-0');
+    act(() => fireEvent.click(removeButton));
+    expect(onChange).toHaveBeenLastCalledWith({
+      variant: 'single',
+      items: [{ label: 'b', value: 'b' }],
+    });
+  });
+});

--- a/frontend/src/pages/connectionTypes/manage/manageFieldUtils.ts
+++ b/frontend/src/pages/connectionTypes/manage/manageFieldUtils.ts
@@ -1,6 +1,7 @@
 import {
   ConnectionTypeDataField,
   ConnectionTypeFieldType,
+  DropdownField,
   FileField,
 } from '~/concepts/connectionTypes/types';
 
@@ -12,10 +13,20 @@ const cleanupFileUploadField = (field: FileField): FileField => ({
   },
 });
 
+const cleanupDropdownField = (field: DropdownField): DropdownField => ({
+  ...field,
+  properties: {
+    ...field.properties,
+    items: field.properties.items?.filter((item) => item.value),
+  },
+});
+
 export const prepareFieldForSave = (field: ConnectionTypeDataField): ConnectionTypeDataField => {
   switch (field.type) {
     case ConnectionTypeFieldType.File:
       return cleanupFileUploadField(field);
+    case ConnectionTypeFieldType.Dropdown:
+      return cleanupDropdownField(field);
   }
   return field;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Completes https://issues.redhat.com/browse/RHOAIENG-10322

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- This adds the "Advanced settings" dropdown / expandable form to the dropdown creation modal. It is defaulted to open when you select the dropdown variant (because there are required options).
- The single select variant is automatically selected.
- The table has draggable rows, and they can be deleted and added. A minimum of 1 row will always exist. 
- The "Dropdown item values" is the required field, so an option can exist without a label. In this scenario, I default the label to be the value. 
- The default values will be updated with the list of options from the table row. Blank options will not be added. If an option has a blank value, it will still be added, but the option will be disabled until a value is added. 
- If there are duplicate values in the table, currently the creation will be disabled. There isn't any design on how to handle this yet.
- If a item has been selected as a default value, and you modify that item (like delete it or change the value), the default value will be removed (so it's not orphaned) 

Initial state
![image](https://github.com/user-attachments/assets/7312797d-7223-45f0-8607-9b4ad9fd2864)
Single select with options:
![image](https://github.com/user-attachments/assets/6bcd4ce5-a8a6-43dc-acc3-8cf0a16e402d)
Multi select with options (and 1 blank option that is omitted):
![image](https://github.com/user-attachments/assets/8fe58c15-4fd2-4e71-8982-1d24a78b0339)
Single select with options (1 is missing a label, a 2nd is missing a value)
![image](https://github.com/user-attachments/assets/248cce17-a899-4756-ba78-894200001b06)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to /connectionTypes/create
2. Add a new field
3. Select field type of "dropdown"
4. New changes appear 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Jest tests have been added like the other advanced forms to test all the functionality of the component

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.
@simrandhaliw 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
