### PR TITLE
[RHOAIENG-11528] Update connection types admin screens with final microcopy

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -91,7 +91,7 @@ describe('duplicate', () => {
       .findConnectionTypeName()
       .should(
         'have.value',
-        `Duplicate of ${existing.metadata.annotations?.['openshift.io/display-name']}`,
+        `Copy of ${existing.metadata.annotations?.['openshift.io/display-name']}`,
       );
     createConnectionTypePage
       .findConnectionTypeDesc()

--- a/frontend/src/concepts/connectionTypes/ConnectionTypePreviewDrawer.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypePreviewDrawer.tsx
@@ -41,7 +41,7 @@ const ConnectionTypePreviewDrawer: React.FC<Props> = ({ children, isExpanded, on
           }}
         >
           This preview shows the user view of the connection type form, and is for reference only.
-          Updates in the developer view are automatically in the user view.
+          Updates in the developer view are automatically rendered in the user view.
         </div>
       </DrawerContentBody>
       <Divider />

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
@@ -31,11 +31,21 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
       connectionTypes.filter((connectionType) => {
         const keywordFilter = filterData.Keyword?.toLowerCase();
         const createFilter = filterData['Created by']?.toLowerCase();
+        const categoryFilter = filterData.Category?.toLowerCase();
 
         if (
           keywordFilter &&
           !getDisplayNameFromK8sResource(connectionType).toLowerCase().includes(keywordFilter) &&
           !getDescriptionFromK8sResource(connectionType).toLowerCase().includes(keywordFilter)
+        ) {
+          return false;
+        }
+
+        if (
+          categoryFilter &&
+          !connectionType.data?.category?.find((category) =>
+            category.toLowerCase().includes(categoryFilter),
+          )
         ) {
           return false;
         }
@@ -55,6 +65,7 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
   return (
     <>
       <Table
+        isStriped
         variant="compact"
         data={filteredConnectionTypes}
         columns={connectionTypeColumns}

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableToolbar.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableToolbar.tsx
@@ -34,6 +34,14 @@ const ConnectionTypesTableToolbar: React.FC<Props> = ({
             onChange={(_event, value) => onChange(value)}
           />
         ),
+        [ConnectionTypesOptions.category]: ({ onChange, ...props }) => (
+          <TextInput
+            {...props}
+            aria-label="Filter by category"
+            placeholder="Filter by category"
+            onChange={(_event, value) => onChange(value)}
+          />
+        ),
         [ConnectionTypesOptions.createdBy]: ({ onChange, ...props }) => (
           <TextInput
             {...props}

--- a/frontend/src/pages/connectionTypes/const.ts
+++ b/frontend/src/pages/connectionTypes/const.ts
@@ -1,10 +1,12 @@
 export enum ConnectionTypesOptions {
   keyword = 'Keyword',
+  category = 'Category',
   createdBy = 'Created by',
 }
 
 export const options = {
   [ConnectionTypesOptions.keyword]: 'Keyword',
+  [ConnectionTypesOptions.category]: 'Category',
   [ConnectionTypesOptions.createdBy]: 'Created By',
 };
 
@@ -12,6 +14,7 @@ export type FilterDataType = Record<ConnectionTypesOptions, string | undefined>;
 
 export const initialFilterData: Record<ConnectionTypesOptions, string | undefined> = {
   [ConnectionTypesOptions.keyword]: '',
+  [ConnectionTypesOptions.category]: '',
   [ConnectionTypesOptions.createdBy]: '',
 };
 

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -195,11 +195,17 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
                   {`Invalid variable name. The name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit.`}
                 </HelperTextItem>
               </HelperText>
-            ) : undefined}
+            ) : (
+              <HelperText>
+                <HelperTextItem variant="default">
+                  Valid characters include uppercase letters, numbers, and underscores ( _ ).
+                </HelperTextItem>
+              </HelperText>
+            )}
             {isEnvVarConflict ? (
               <HelperText data-testid="envvar-conflict-warning">
                 <HelperTextItem icon={<WarningTriangleIcon />} variant="warning">
-                  This environment variable name is already being used for an existing field.
+                  {envVar} already exists within this connection type.
                 </HelperTextItem>
               </HelperText>
             ) : undefined}

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldRemoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldRemoveModal.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Modal } from '@patternfly/react-core';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+
+type Props = {
+  field: string;
+  isSection: boolean;
+  onClose: (submit: boolean) => void;
+};
+
+export const ConnectionTypeFieldRemoveModal: React.FC<Props> = ({ field, isSection, onClose }) => (
+  <Modal
+    isOpen
+    title={isSection ? 'Remove section heading?' : 'Remove field?'}
+    onClose={() => onClose(false)}
+    variant="small"
+    footer={
+      <DashboardModalFooter
+        submitLabel="Remove"
+        onCancel={() => onClose(false)}
+        onSubmit={() => onClose(true)}
+        alertTitle=""
+        isSubmitDisabled={false}
+      />
+    }
+  >
+    The <b>{field}</b>{' '}
+    {isSection
+      ? `section heading will be removed. Associated fields will not be removed.`
+      : `field will be removed.`}
+  </Modal>
+);

--- a/frontend/src/pages/connectionTypes/manage/DuplicateConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/DuplicateConnectionTypePage.tsx
@@ -21,7 +21,7 @@ const DuplicateConnectionTypePage: React.FC = () => {
           name: '',
           annotations: {
             ...existingConnectionType.metadata.annotations,
-            'openshift.io/display-name': `Duplicate of ${getDisplayNameFromK8sResource(
+            'openshift.io/display-name': `Copy of ${getDisplayNameFromK8sResource(
               existingConnectionType,
             )}`,
             'opendatahub.io/username': '',

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -12,6 +12,7 @@ import { defaultValueToString, fieldTypeToString } from '~/concepts/connectionTy
 import type { RowProps } from '~/utilities/useDraggableTableControlled';
 import TruncatedText from '~/components/TruncatedText';
 import { columns } from '~/pages/connectionTypes/manage/fieldTableColumns';
+import { ConnectionTypeFieldRemoveModal } from '~/pages/connectionTypes/manage/ConnectionTypeFieldRemoveModal';
 
 type Props = {
   row: ConnectionTypeField;
@@ -45,6 +46,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
     const potentialSectionsToMoveTo = parentSection ? numSections - 1 : numSections;
     return potentialSectionsToMoveTo > 0;
   }, [fields, rowIndex]);
+  const [showRemoveField, setShowRemoveField] = React.useState<boolean>();
 
   const isEnvVarConflict = React.useMemo(
     () =>
@@ -64,7 +66,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
             id: `draggable-row-${props.id}`,
           }}
         />
-        <Td dataLabel={columns[0].label} data-testid="field-name">
+        <Td colSpan={4} dataLabel={columns[0].label} data-testid="field-name">
           <div>
             {row.name}{' '}
             <Label color="blue" data-testid="section-heading">
@@ -75,7 +77,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
             </div>
           </div>
         </Td>
-        <Td colSpan={4} />
+        <Td />
         <Td isActionCell modifier="nowrap">
           <Button variant="secondary" onClick={() => onAddField(row)}>
             Add field
@@ -92,11 +94,23 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
               },
               {
                 title: 'Remove',
-                onClick: () => onRemove(),
+                onClick: () => setShowRemoveField(true),
               },
             ]}
           />
         </Td>
+        {showRemoveField ? (
+          <ConnectionTypeFieldRemoveModal
+            field={row.name}
+            isSection
+            onClose={(submit) => {
+              setShowRemoveField(false);
+              if (submit) {
+                onRemove();
+              }
+            }}
+          />
+        ) : null}
       </Tr>
     );
   }
@@ -162,11 +176,23 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
               : []),
             {
               title: 'Remove',
-              onClick: () => onRemove(),
+              onClick: () => setShowRemoveField(true),
             },
           ]}
         />
       </Td>
+      {showRemoveField ? (
+        <ConnectionTypeFieldRemoveModal
+          field={row.name}
+          isSection={false}
+          onClose={(submit) => {
+            setShowRemoveField(false);
+            if (submit) {
+              onRemove();
+            }
+          }}
+        />
+      ) : null}
     </Tr>
   );
 };

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -134,7 +134,7 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
             <Alert
               isInline
               variant="warning"
-              title="Editing this connection will not affect existing connections of this type."
+              title="Editing this connection type does not affect existing connections of this type."
             />
           </PageSection>
         ) : undefined}
@@ -176,13 +176,11 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
               </FormGroup>
             </FormSection>
             <FormSection title="Fields" className="pf-v5-u-mt-0">
-              Add fields to prompt users to input information, and optionally assign default values
-              to those fields.
               <FormGroup>
                 {isEnvVarConflict ? (
                   <Alert isInline variant="danger" title="Environment variables conflict">
-                    Environment variables for one or more fields are conflicting. Change them to
-                    resolve and proceed.
+                    Two or more fields are using the same environment variable. Ensure that each
+                    field uses a unique environment variable to proceed.
                   </Alert>
                 ) : null}
                 <ManageConnectionTypeFieldsTable


### PR DESCRIPTION
Closes [RHOAIENG-11528](https://issues.redhat.com/browse/RHOAIENG-11528)

## Description
Updates the connection type admin screens with the latest micro copy found in [Figma mocks](https://www.figma.com/proto/97akqulXiGIGtvxkdPLjMm/Data-connections-enhancement?node-id=1168-156206&t=QAO1jyYn2P3dP1yX-0&scaling=scale-down&content-scaling=fixed&page-id=24%3A74&starting-point-node-id=1168%3A156206)

## How Has This Been Tested?
Manually tested

## Test Impact
Updated e2e tests where necessary

## Screen shots
![image](https://github.com/user-attachments/assets/56568d45-7542-481f-99f4-331b0eac7a13)

![image](https://github.com/user-attachments/assets/3c7efd0c-1740-44f4-b7e1-d06203ae4c14)

![image](https://github.com/user-attachments/assets/18086c50-a02e-44dd-8051-19e82045d58f)

![image](https://github.com/user-attachments/assets/1d7a0ba5-3917-4534-bf78-2db4e7227745)

![image](https://github.com/user-attachments/assets/6debbf74-cae5-400c-b88f-97ec872b598a)

![image](https://github.com/user-attachments/assets/c2f41f1a-f941-45a5-af1c-a8aad422d3b0)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw 