### PR TITLE
add cache message in logs

### DIFF
--- a/frontend/src/__mocks__/mlmd/mockGetExecutionsByContext.ts
+++ b/frontend/src/__mocks__/mlmd/mockGetExecutionsByContext.ts
@@ -38,7 +38,7 @@ const mockedExecutionsByContextResponse: GetExecutionsByContextResponse = {
           stringValue: '211',
         },
         display_name: {
-          stringValue: 'create-dataset',
+          stringValue: 'digit-classification',
         },
         image: {
           stringValue: '',
@@ -66,7 +66,7 @@ const mockedExecutionsByContextResponse: GetExecutionsByContextResponse = {
           stringValue: '',
         },
         task_name: {
-          stringValue: 'create-dataset',
+          stringValue: 'digit-classification',
         },
       },
     },
@@ -134,7 +134,7 @@ const mockedExecutionsByContextResponse: GetExecutionsByContextResponse = {
           stringValue: '222',
         },
         display_name: {
-          stringValue: 'wine-classification',
+          stringValue: 'create-dataset',
         },
         image: {
           stringValue: '',
@@ -162,7 +162,7 @@ const mockedExecutionsByContextResponse: GetExecutionsByContextResponse = {
           stringValue: '',
         },
         task_name: {
-          stringValue: 'wine-classification',
+          stringValue: 'create-dataset',
         },
       },
     },

--- a/frontend/src/__mocks__/mlmd/mockGetExecutionsByContext.ts
+++ b/frontend/src/__mocks__/mlmd/mockGetExecutionsByContext.ts
@@ -38,7 +38,7 @@ const mockedExecutionsByContextResponse: GetExecutionsByContextResponse = {
           stringValue: '211',
         },
         display_name: {
-          stringValue: 'digit-classification',
+          stringValue: 'create-dataset',
         },
         image: {
           stringValue: '',
@@ -66,7 +66,7 @@ const mockedExecutionsByContextResponse: GetExecutionsByContextResponse = {
           stringValue: '',
         },
         task_name: {
-          stringValue: 'digit-classification',
+          stringValue: 'create-dataset',
         },
       },
     },

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -304,6 +304,10 @@ class PipelineRunDetails extends RunDetails {
     return cy.findByTestId('logs-success-alert');
   }
 
+  findLogsCachedAlert() {
+    return cy.findByTestId('logs-cached-alert');
+  }
+
   findLogs() {
     return cy.findByTestId('logs');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
@@ -30,6 +30,7 @@ import {
 } from '~/__tests__/cypress/cypress/utils/models';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import { RecurringRunStatus } from '~/concepts/pipelines/kfTypes';
+import { initMlmdIntercepts } from './mlmdUtils';
 
 const projectId = 'test-project';
 const mockPipeline = buildMockPipelineV2({
@@ -679,6 +680,12 @@ describe('Pipeline topology', () => {
 
     beforeEach(() => {
       initIntercepts();
+    });
+
+    it('test cached logs', () => {
+      initMlmdIntercepts(projectId);
+      navigateToLogsTab();
+      pipelineRunDetails.findLogsCachedAlert().should('be.visible');
     });
 
     it('test logs paused while loading', () => {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -32,6 +32,10 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
     (e) => e.getCustomPropertiesMap().get('task_name')?.getStringValue() === task.name,
   );
 
+  const isCachedTask =
+    !!taskExecution &&
+    !!taskExecution.getCustomPropertiesMap().get('cached_execution_id')?.getStringValue();
+
   const tabs: Record<string, { title: string; isDisabled?: boolean; content: React.ReactNode }> = {
     [PipelineRunNodeTab.INPUT_OUTPUT]: {
       title: 'Input/Output',
@@ -51,8 +55,8 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
     },
     [PipelineRunNodeTab.LOGS]: {
       title: 'Logs',
-      isDisabled: !task.status?.podName,
-      content: <LogsTab task={task} />,
+      isDisabled: !task.status?.podName && !isCachedTask,
+      content: <LogsTab task={task} isCached={isCachedTask} />,
     },
   };
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -32,7 +32,10 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
     (e) => e.getCustomPropertiesMap().get('task_name')?.getStringValue() === task.name,
   );
 
-  const isCachedTask = !!taskExecution?.getCustomPropertiesMap().get('cached_execution_id')?.getStringValue();
+  const isCachedTask = !!taskExecution
+    ?.getCustomPropertiesMap()
+    .get('cached_execution_id')
+    ?.getStringValue();
 
   const tabs: Record<string, { title: string; isDisabled?: boolean; content: React.ReactNode }> = {
     [PipelineRunNodeTab.INPUT_OUTPUT]: {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -32,9 +32,7 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
     (e) => e.getCustomPropertiesMap().get('task_name')?.getStringValue() === task.name,
   );
 
-  const isCachedTask =
-    !!taskExecution &&
-    !!taskExecution.getCustomPropertiesMap().get('cached_execution_id')?.getStringValue();
+  const isCachedTask = !!taskExecution?.getCustomPropertiesMap().get('cached_execution_id')?.getStringValue();
 
   const tabs: Record<string, { title: string; isDisabled?: boolean; content: React.ReactNode }> = {
     [PipelineRunNodeTab.INPUT_OUTPUT]: {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -43,11 +43,12 @@ import { ExecutionStateKF } from '~/concepts/pipelines/kfTypes';
 
 interface LogsTabProps {
   task: PipelineTask;
+  isCached: boolean;
 }
 
-const LogsTab: React.FC<LogsTabProps> = ({ task }) => {
+const LogsTab: React.FC<LogsTabProps> = ({ task, isCached }) => {
   const { namespace } = usePipelinesAPI();
-  const podName = task.status?.podName ?? '';
+  const podName = isCached ? '' : task.status?.podName ?? '';
   const isFailedPod = task.status?.state === ExecutionStateKF.FAILED;
   const {
     pod,
@@ -184,7 +185,7 @@ const LogsTab: React.FC<LogsTabProps> = ({ task }) => {
   const error = podError || logsError || downloadError;
   const loaded = podLoaded && logsLoaded;
   let data: string;
-  if (error || podStatus?.podInitializing) {
+  if (error || podStatus?.podInitializing || isCached) {
     data = '';
   } else if (!logsLoaded || !podLoaded) {
     data = 'Loading...';
@@ -204,6 +205,7 @@ const LogsTab: React.FC<LogsTabProps> = ({ task }) => {
             podStatus={podStatus}
             loaded={loaded}
             error={error}
+            isCached={isCached}
             isFailedPod={isFailedPod}
             isLogsAvailable={podContainers.length !== 1 && !!logs}
             onDownload={onDownloadAll}
@@ -223,7 +225,8 @@ const LogsTab: React.FC<LogsTabProps> = ({ task }) => {
             logViewerRef={logViewerRef}
             isTextWrapped={isTextWrapped}
             toolbar={
-              !error && (
+              !error &&
+              !isCached && (
                 <Toolbar className={isFullScreen ? 'pf-v5-u-p-sm' : ''}>
                   <ToolbarContent>
                     <ToolbarGroup

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTabStatus.tsx
@@ -11,6 +11,7 @@ type LogsTabStatusProps = {
   podName?: string;
   podStatus?: PodStatus | null;
   error?: Error;
+  isCached: boolean;
   isLogsAvailable?: boolean;
   isFailedPod?: boolean;
   loaded: boolean;
@@ -19,6 +20,7 @@ type LogsTabStatusProps = {
 
 const LogsTabStatus: React.FC<LogsTabStatusProps> = ({
   error,
+  isCached,
   isLogsAvailable,
   podError,
   podName,
@@ -27,6 +29,18 @@ const LogsTabStatus: React.FC<LogsTabStatusProps> = ({
   isFailedPod,
   onDownload,
 }) => {
+  if (isCached) {
+    return (
+      <Alert
+        data-testid="logs-cached-alert"
+        component="h2"
+        isInline
+        variant="info"
+        title="No logs. This task did not run because it reused cached outputs from a previous run."
+      />
+    );
+  }
+
   if (error) {
     const isNetworkError = error.message.includes('Failed to fetch');
     const podCondition = podStatus === null || (podError && podStatus?.completed);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes: https://issues.redhat.com/browse/RHOAIENG-10000

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds a condition to show a cache message in pipeline logs when the task is cached
![Screenshot 2024-09-03 at 11 46 58 AM](https://github.com/user-attachments/assets/e07c5cc3-5ca6-423e-b794-05f35d8c40be)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
create a pipeline run that will cache a task
check that the log tab is visible with the cache alert


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added a test for the alert

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


cc @yannnz This is the UX I went with. @kaedward for wording
