### PR TITLE
Upversion Node & NPM to match other dependency needs

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -5,8 +5,8 @@
 ODH requires the following to run:
 
 - [NodeJS and NPM](https://nodejs.org/)
-  - Node recommended version -> `18.16.0`
-  - NPM recommended version -> `9.6.7`
+  - Node recommended version -> `18.18.2`
+  - NPM recommended version -> `9.8.1`
 - [OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize) (if you need to do deployment)
 


### PR DESCRIPTION
Due to issues with various optional dependencies (who don't report errors until you made the dev dependencies), we need to be on v18.18 of Node. Our previous recommended versions did not match this, updating them.

I matched the NPM version that was auto upgraded when I switched my Node.