### PR TITLE
[RHOAIENG-1106] Storage classes table

### DIFF
--- a/frontend/src/__mocks__/mockStorageClasses.ts
+++ b/frontend/src/__mocks__/mockStorageClasses.ts
@@ -1,6 +1,6 @@
 import { K8sResourceListResult, StorageClassKind } from '~/k8sTypes';
 
-type MockStorageClass = Omit<StorageClassKind, 'apiVersion' | 'kind'>;
+export type MockStorageClass = Omit<StorageClassKind, 'apiVersion' | 'kind'>;
 
 export type MockStorageClassList = Omit<K8sResourceListResult<MockStorageClass>, 'metadata'> & {
   metadata: {
@@ -19,16 +19,68 @@ export const mockStorageClassList = (
   items: storageClasses,
 });
 
-const mockStorageClasses: MockStorageClass[] = [
+export const mockStorageClasses: MockStorageClass[] = [
   {
     metadata: {
-      name: 'csi-manila-ceph',
+      name: 'openshift-default-sc',
+      uid: '5de188ae-aa8e-43d1-a714-4d60ecc5c6da',
+      resourceVersion: '50902774',
+      creationTimestamp: '2024-07-04T09:20:40Z',
+      annotations: {
+        'opendatahub.io/sc-config':
+          '{"displayName":"openshift-default-sc","isDefault":true,"isEnabled":true,"lastModified":"2024-08-22T15:42:53.101Z"}',
+        'storageclass.kubernetes.io/is-default-class': 'true',
+      },
+      managedFields: [
+        {
+          manager: 'openstack-cinder-csi-driver-operator',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-07-04T09:20:40Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:allowVolumeExpansion': {},
+            'f:metadata': {
+              'f:annotations': {
+                '.': {},
+                'f:storageclass.kubernetes.io/is-default-class': {},
+              },
+            },
+            'f:provisioner': {},
+            'f:reclaimPolicy': {},
+            'f:volumeBindingMode': {},
+          },
+        },
+        {
+          manager: 'unknown',
+          operation: 'Update',
+          apiVersion: 'storage.k8s.io/v1',
+          time: '2024-08-22T15:42:53Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:metadata': {
+              'f:annotations': {
+                'f:opendatahub.io/sc-config': {},
+              },
+            },
+          },
+        },
+      ],
+    },
+    provisioner: 'cinder.csi.openstack.org',
+    reclaimPolicy: 'Delete',
+    allowVolumeExpansion: true,
+    volumeBindingMode: 'WaitForFirstConsumer',
+  },
+  {
+    metadata: {
+      name: 'test-storage-class-1',
       uid: 'c3c05a4a-c1b7-4358-a246-da6b6dfd12cd',
       resourceVersion: '50902775',
       creationTimestamp: '2024-07-04T09:21:40Z',
       annotations: {
         'opendatahub.io/sc-config':
-          '{"displayName":"csi-manila-ceph","isDefault":false,"isEnabled":false,"lastModified":"2024-08-22T15:42:53.100Z"}',
+          '{"displayName":"Test SC 1","isDefault":false,"isEnabled":false,"lastModified":"2024-08-22T15:42:53.100Z"}',
       },
       managedFields: [
         {
@@ -82,120 +134,5 @@ const mockStorageClasses: MockStorageClass[] = [
     }),
     reclaimPolicy: 'Delete',
     volumeBindingMode: 'Immediate',
-  },
-  {
-    metadata: {
-      name: 'csi-manila-netapp',
-      uid: 'f818edb6-3936-4ca0-90af-87f469c177d8',
-      resourceVersion: '50902773',
-      creationTimestamp: '2024-07-04T09:21:40Z',
-      annotations: {
-        'opendatahub.io/sc-config':
-          '{"displayName":"csi-manila-netapp","isDefault":false,"isEnabled":false,"lastModified":"2024-08-22T15:42:53.101Z"}',
-      },
-      managedFields: [
-        {
-          manager: 'csi-driver-manila-operator',
-          operation: 'Update',
-          apiVersion: 'storage.k8s.io/v1',
-          time: '2024-07-04T09:21:40Z',
-          fieldsType: 'FieldsV1',
-          fieldsV1: {
-            'f:parameters': {
-              '.': {},
-              'f:csi.storage.k8s.io/node-publish-secret-name': {},
-              'f:csi.storage.k8s.io/node-publish-secret-namespace': {},
-              'f:csi.storage.k8s.io/node-stage-secret-name': {},
-              'f:csi.storage.k8s.io/node-stage-secret-namespace': {},
-              'f:csi.storage.k8s.io/provisioner-secret-name': {},
-              'f:csi.storage.k8s.io/provisioner-secret-namespace': {},
-              'f:type': {},
-            },
-            'f:provisioner': {},
-            'f:reclaimPolicy': {},
-            'f:volumeBindingMode': {},
-          },
-        },
-        {
-          manager: 'unknown',
-          operation: 'Update',
-          apiVersion: 'storage.k8s.io/v1',
-          time: '2024-08-22T15:42:53Z',
-          fieldsType: 'FieldsV1',
-          fieldsV1: {
-            'f:metadata': {
-              'f:annotations': {
-                '.': {},
-                'f:opendatahub.io/sc-config': {},
-              },
-            },
-          },
-        },
-      ],
-    },
-    provisioner: 'manila.csi.openstack.org',
-    parameters: JSON.stringify({
-      'csi.storage.k8s.io/node-publish-secret-name': 'csi-manila-secrets',
-      'csi.storage.k8s.io/node-publish-secret-namespace': 'openshift-manila-csi-driver',
-      'csi.storage.k8s.io/node-stage-secret-name': 'csi-manila-secrets',
-      'csi.storage.k8s.io/node-stage-secret-namespace': 'openshift-manila-csi-driver',
-      'csi.storage.k8s.io/provisioner-secret-name': 'csi-manila-secrets',
-      'csi.storage.k8s.io/provisioner-secret-namespace': 'openshift-manila-csi-driver',
-      type: 'netapp',
-    }),
-    reclaimPolicy: 'Delete',
-    volumeBindingMode: 'Immediate',
-  },
-  {
-    metadata: {
-      name: 'standard-csi',
-      uid: '5de188ae-aa8e-43d1-a714-4d60ecc5c6da',
-      resourceVersion: '50902774',
-      creationTimestamp: '2024-07-04T09:20:40Z',
-      annotations: {
-        'opendatahub.io/sc-config':
-          '{"displayName":"standard-csi","isDefault":true,"isEnabled":true,"lastModified":"2024-08-22T15:42:53.101Z"}',
-        'storageclass.kubernetes.io/is-default-class': 'true',
-      },
-      managedFields: [
-        {
-          manager: 'openstack-cinder-csi-driver-operator',
-          operation: 'Update',
-          apiVersion: 'storage.k8s.io/v1',
-          time: '2024-07-04T09:20:40Z',
-          fieldsType: 'FieldsV1',
-          fieldsV1: {
-            'f:allowVolumeExpansion': {},
-            'f:metadata': {
-              'f:annotations': {
-                '.': {},
-                'f:storageclass.kubernetes.io/is-default-class': {},
-              },
-            },
-            'f:provisioner': {},
-            'f:reclaimPolicy': {},
-            'f:volumeBindingMode': {},
-          },
-        },
-        {
-          manager: 'unknown',
-          operation: 'Update',
-          apiVersion: 'storage.k8s.io/v1',
-          time: '2024-08-22T15:42:53Z',
-          fieldsType: 'FieldsV1',
-          fieldsV1: {
-            'f:metadata': {
-              'f:annotations': {
-                'f:opendatahub.io/sc-config': {},
-              },
-            },
-          },
-        },
-      ],
-    },
-    provisioner: 'cinder.csi.openstack.org',
-    reclaimPolicy: 'Delete',
-    allowVolumeExpansion: true,
-    volumeBindingMode: 'WaitForFirstConsumer',
   },
 ];

--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -1,4 +1,7 @@
+import type { MockStorageClass } from '~/__mocks__';
+import { mockStorageClassList } from '~/__mocks__';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 
 class StorageClassesPage {
   visit() {
@@ -20,4 +23,55 @@ class StorageClassesPage {
   }
 }
 
+class StorageClassesTableRow extends TableRow {
+  findOpenshiftDefaultLabel() {
+    return this.find().findByTestId('openshift-sc-default-label');
+  }
+
+  findEnableSwitch() {
+    return this.find().findByTestId('enable-switch');
+  }
+
+  findDefaultRadio() {
+    return this.find().findByTestId('set-default-radio');
+  }
+
+  findOpenshiftScName() {
+    return this.find().find(`[data-label="Openshift storage class"]`);
+  }
+}
+
+class StorageClassesTable {
+  find() {
+    return cy.findByTestId('storage-classes-table');
+  }
+
+  getRowByName(name: string) {
+    return new StorageClassesTableRow(() =>
+      this.find().find(`[data-label="Display name"]`).contains(name).parents('tr'),
+    );
+  }
+
+  findRowByName(name: string) {
+    return this.getRowByName(name).find();
+  }
+
+  mockUpdateStorageClass(storageClassName: string, times?: number) {
+    return cy.interceptOdh(
+      `PUT /api/storage-class/:name/config`,
+      { path: { name: storageClassName }, times },
+      { success: true, error: '' },
+    );
+  }
+
+  mockGetStorageClasses(storageClasses: MockStorageClass[], times?: number) {
+    return cy.interceptOdh(
+      'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+      { times },
+      mockStorageClassList(storageClasses),
+    );
+  }
+}
+
 export const storageClassesPage = new StorageClassesPage();
+export const storageClassesTable = new StorageClassesTable();

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -34,6 +34,7 @@ import type {
   OdhDocument,
   PrometheusQueryRangeResponse,
   PrometheusQueryResponse,
+  ResponseStatus,
   SubscriptionStatusData,
 } from '~/types';
 import type {
@@ -195,7 +196,13 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+          options: { times?: number },
           response: OdhResponse<MockStorageClassList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PUT /api/storage-class/:name/config',
+          options: { path: { name: string }; times?: number },
+          response: OdhResponse<ResponseStatus>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/images/byon',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -1,7 +1,12 @@
-import { mockStorageClassList } from '~/__mocks__';
+import type { MockStorageClass } from '~/__mocks__';
+import { mockStorageClassList, mockStorageClasses } from '~/__mocks__';
 import { asProductAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
-import { storageClassesPage } from '~/__tests__/cypress/cypress/pages/storageClasses';
+import {
+  storageClassesPage,
+  storageClassesTable,
+} from '~/__tests__/cypress/cypress/pages/storageClasses';
+import type { StorageClassConfig } from '~/k8sTypes';
 
 describe('Storage classes', () => {
   it('shows "page not found" and does not show nav item as a non-admin user', () => {
@@ -18,11 +23,112 @@ describe('Storage classes', () => {
     it('shows empty state when the returned storage class list is empty', () => {
       cy.interceptOdh(
         'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
         mockStorageClassList([]),
       );
       storageClassesPage.visit();
       storageClassesPage.findNavItem().should('be.visible');
       storageClassesPage.findEmptyState().should('be.visible');
     });
+
+    it('renders table with data', () => {
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList(),
+      );
+      storageClassesPage.visit();
+
+      storageClassesTable.findRowByName('Test SC 1').should('be.visible');
+      storageClassesTable.findRowByName('openshift-default-sc').should('be.visible');
+    });
+
+    it('table rows allow for toggling of Enable and Default values', () => {
+      const [openshiftDefaultStorageClass, otherStorageClass] = mockStorageClasses;
+
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList(),
+      );
+      storageClassesPage.visit();
+
+      const openshiftDefaultTableRow = storageClassesTable.getRowByName('openshift-default-sc');
+      openshiftDefaultTableRow.findOpenshiftDefaultLabel().should('be.visible');
+      openshiftDefaultTableRow.findEnableSwitch().should('have.attr', 'aria-checked', 'true');
+      openshiftDefaultTableRow.findEnableSwitch().should('have.attr', 'disabled');
+      openshiftDefaultTableRow.findDefaultRadio().should('have.attr', 'checked');
+      openshiftDefaultTableRow.findDefaultRadio().should('not.have.attr', 'disabled');
+
+      const otherStorageClassTableRow = storageClassesTable.getRowByName('Test SC 1');
+      otherStorageClassTableRow.findOpenshiftDefaultLabel().should('not.exist');
+      otherStorageClassTableRow.findEnableSwitch().should('have.attr', 'aria-checked', 'false');
+      otherStorageClassTableRow.findEnableSwitch().should('not.have.attr', 'disabled');
+      otherStorageClassTableRow.findDefaultRadio().should('not.have.attr', 'checked');
+      otherStorageClassTableRow.findDefaultRadio().should('have.attr', 'disabled');
+
+      storageClassesTable
+        .mockUpdateStorageClass(otherStorageClass.metadata.name, 1)
+        .as('updateStorageClass-1');
+      storageClassesTable
+        .mockGetStorageClasses(
+          [
+            openshiftDefaultStorageClass,
+            buildMockStorageClass(otherStorageClass, { isEnabled: true }),
+          ],
+          1,
+        )
+        .as('refreshStorageClasses-1');
+
+      // Enable the other storage class so that the RHOAI default can be toggled
+      otherStorageClassTableRow.findEnableSwitch().click({ force: true });
+      cy.wait('@updateStorageClass-1');
+      cy.wait('@refreshStorageClasses-1');
+
+      otherStorageClassTableRow.findEnableSwitch().should('have.attr', 'aria-checked', 'true');
+      otherStorageClassTableRow.findDefaultRadio().should('not.have.attr', 'disabled');
+
+      storageClassesTable
+        .mockUpdateStorageClass(otherStorageClass.metadata.name, 1)
+        .as('updateStorageClass-2');
+      storageClassesTable
+        .mockUpdateStorageClass(openshiftDefaultStorageClass.metadata.name, 1)
+        .as('updateStorageClass-3');
+      storageClassesTable
+        .mockGetStorageClasses(
+          [
+            buildMockStorageClass(openshiftDefaultStorageClass, { isDefault: false }),
+            buildMockStorageClass(otherStorageClass, { isEnabled: true, isDefault: true }),
+          ],
+          1,
+        )
+        .as('refreshStorageClasses-2');
+
+      // Set the other storage class as the RHOAI default
+      otherStorageClassTableRow.findDefaultRadio().click();
+      cy.wait('@updateStorageClass-2');
+      cy.wait('@updateStorageClass-3');
+      cy.wait('@refreshStorageClasses-2');
+
+      openshiftDefaultTableRow.findEnableSwitch().should('not.have.attr', 'disabled');
+      openshiftDefaultTableRow.findDefaultRadio().should('have.attr', 'checked');
+    });
   });
+});
+
+const buildMockStorageClass = (
+  mockStorageClass: MockStorageClass,
+  config: Partial<StorageClassConfig>,
+) => ({
+  ...mockStorageClass,
+  metadata: {
+    ...mockStorageClass.metadata,
+    annotations: {
+      ...mockStorageClass.metadata.annotations,
+      'opendatahub.io/sc-config': JSON.stringify({
+        ...JSON.parse(String(mockStorageClass.metadata.annotations?.['opendatahub.io/sc-config'])),
+        ...config,
+      }),
+    },
+  },
 });

--- a/frontend/src/pages/storageClasses/StorageClassDefaultRadio.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassDefaultRadio.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Flex, Radio, Spinner, Tooltip } from '@patternfly/react-core';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+
+interface StorageClassDefaultRadioProps {
+  storageClassName: string;
+  isChecked: boolean;
+  isDisabled: boolean;
+  onChange: () => Promise<void>;
+}
+
+export const StorageClassDefaultRadio: React.FC<StorageClassDefaultRadioProps> = ({
+  storageClassName,
+  isChecked: isInitialChecked,
+  isDisabled,
+  onChange,
+}) => {
+  const [isChecked, setIsChecked] = React.useState(isInitialChecked);
+  const [isUpdating, setIsUpdating] = React.useState(false);
+  const id = `${storageClassName}-default-radio`;
+
+  // Update checked state when updating isChecked from parent component
+  React.useEffect(() => {
+    setIsChecked(isInitialChecked);
+  }, [isInitialChecked]);
+
+  const update = React.useCallback(async () => {
+    setIsUpdating(true);
+
+    try {
+      await updateStorageClassConfig(storageClassName, { isDefault: true });
+      await onChange();
+      setIsUpdating(false);
+    } catch {
+      setIsUpdating(false);
+    }
+
+    setIsChecked(true);
+  }, [storageClassName, onChange]);
+
+  const radioInput = React.useMemo(
+    () => (
+      <Radio
+        id={id}
+        name={id}
+        data-testid="set-default-radio"
+        label="Set as default"
+        isChecked={isChecked}
+        isDisabled={isDisabled || isUpdating}
+        onChange={update}
+      />
+    ),
+    [id, isChecked, isDisabled, isUpdating, update],
+  );
+
+  return (
+    <Flex spaceItems={{ default: 'spaceItemsMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+      {isDisabled ? (
+        <Tooltip content="Enable this class to set it as the default.">{radioInput}</Tooltip>
+      ) : (
+        radioInput
+      )}
+
+      <Spinner
+        size="md"
+        aria-label="Loading default radio selection"
+        style={{ visibility: isUpdating ? 'visible' : 'hidden' }}
+      />
+    </Flex>
+  );
+};

--- a/frontend/src/pages/storageClasses/StorageClassEnableSwitch.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEnableSwitch.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Flex, FlexItem, Switch, Tooltip } from '@patternfly/react-core';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+import { StorageClassKind } from '~/k8sTypes';
+
+interface StorageClassEnableSwitchProps {
+  storageClassName: string;
+  isChecked: boolean;
+  isDisabled: boolean;
+  onChange: () => Promise<void | StorageClassKind[]>;
+}
+
+export const StorageClassEnableSwitch: React.FC<StorageClassEnableSwitchProps> = ({
+  storageClassName,
+  isChecked: isInitialChecked,
+  isDisabled,
+  onChange,
+}) => {
+  const [isChecked, setIsChecked] = React.useState(isInitialChecked);
+  const [isUpdating, setIsUpdating] = React.useState(false);
+
+  // Update checked state when updating isChecked from parent component
+  React.useEffect(() => {
+    setIsChecked(isInitialChecked);
+  }, [isInitialChecked]);
+
+  const update = React.useCallback(
+    async (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+      setIsUpdating(true);
+
+      try {
+        await updateStorageClassConfig(storageClassName, { isEnabled: checked });
+        await onChange();
+        setIsUpdating(false);
+      } catch {
+        setIsUpdating(false);
+      }
+
+      setIsChecked(checked);
+    },
+    [onChange, storageClassName],
+  );
+
+  const switchInput = React.useMemo(
+    () => (
+      <Switch
+        id={`${storageClassName}-enable-switch`}
+        aria-label="Storage class enable switch"
+        isChecked={isChecked}
+        aria-checked={isChecked}
+        isDisabled={isDisabled || isUpdating}
+        onChange={update}
+        data-testid="enable-switch"
+      />
+    ),
+    [isChecked, isDisabled, isUpdating, storageClassName, update],
+  );
+
+  return (
+    <Flex spaceItems={{ default: 'spaceItemsMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>
+        {isDisabled ? (
+          <Tooltip content="Set a new default storage class to disable this one.">
+            {switchInput}
+          </Tooltip>
+        ) : (
+          switchInput
+        )}
+      </FlexItem>
+
+      <FlexItem
+        className="pf-v5-u-disabled-color-100"
+        style={{ visibility: isUpdating ? 'visible' : 'hidden' }}
+      >
+        {isChecked ? 'Disabling' : 'Enabling'}...
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/frontend/src/pages/storageClasses/StorageClassesTable.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTable.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+
+import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
+import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
+import { Table } from '~/components/table';
+import { columns } from './constants';
+import { getStorageClassConfig } from './utils';
+import { StorageClassesTableRow } from './StorageClassesTableRow';
+
+interface StorageClassesTableProps {
+  storageClasses: StorageClassKind[];
+  refresh: FetchStateRefreshPromise<StorageClassKind[]>;
+}
+
+export const StorageClassesTable: React.FC<StorageClassesTableProps> = ({
+  storageClasses,
+  refresh,
+}) => {
+  const storageClassConfigMap = React.useMemo(
+    () =>
+      storageClasses.reduce((acc: Record<string, StorageClassConfig | undefined>, sc) => {
+        acc[sc.metadata.name] = getStorageClassConfig(sc);
+
+        return acc;
+      }, {}),
+    [storageClasses],
+  );
+
+  return (
+    <Table
+      variant="compact"
+      data={storageClasses}
+      hasNestedHeader
+      columns={columns}
+      emptyTableView={<>{/* TODO, https://issues.redhat.com/browse/RHOAIENG-1107 */}</>}
+      data-testid="storage-classes-table"
+      rowRenderer={(storageClass) => (
+        <StorageClassesTableRow
+          key={storageClass.metadata.name}
+          storageClass={storageClass}
+          storageClassConfigMap={storageClassConfigMap}
+          refresh={refresh}
+        />
+      )}
+      toolbarContent={
+        <ToolbarGroup>
+          <ToolbarItem>{/* TODO, https://issues.redhat.com/browse/RHOAIENG-1107 */}</ToolbarItem>
+        </ToolbarGroup>
+      }
+    />
+  );
+};

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+
+import {
+  Flex,
+  FlexItem,
+  Popover,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Tooltip,
+  Label,
+  Timestamp,
+} from '@patternfly/react-core';
+import { Tr, Td, ActionsColumn } from '@patternfly/react-table';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+
+import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
+import { TableRowTitleDescription } from '~/components/table';
+import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import { NoValue } from '~/components/NoValue';
+import { ColumnLabel } from './constants';
+import { isOpenshiftDefaultStorageClass } from './utils';
+import { StorageClassEnableSwitch } from './StorageClassEnableSwitch';
+import { StorageClassDefaultRadio } from './StorageClassDefaultRadio';
+
+interface StorageClassesTableRowProps {
+  storageClass: StorageClassKind;
+  storageClassConfigMap: Record<string, StorageClassConfig | undefined>;
+  refresh: FetchStateRefreshPromise<StorageClassKind[]>;
+}
+
+export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
+  storageClass,
+  storageClassConfigMap,
+  refresh,
+}) => {
+  const storageClassConfig = storageClassConfigMap[storageClass.metadata.name];
+  const isOpenshiftDefault = isOpenshiftDefaultStorageClass(storageClass);
+  const { metadata, provisioner, reclaimPolicy, volumeBindingMode, allowVolumeExpansion } =
+    storageClass;
+
+  const storageClassInfoItems = [
+    {
+      label: 'OpenShift storage class',
+      value: storageClassConfig?.displayName,
+    },
+    {
+      label: 'Provisioner',
+      value: provisioner,
+    },
+    {
+      label: 'Description',
+      value: storageClassConfig?.description ?? <NoValue />,
+    },
+    {
+      label: 'Reclaim policy',
+      value: reclaimPolicy,
+    },
+    {
+      label: 'Volume binding mode',
+      value: volumeBindingMode,
+    },
+    {
+      label: 'Allow PersistentVolumeClaims to be expanded',
+      value: allowVolumeExpansion ? 'True' : 'False',
+    },
+  ];
+
+  const isEnableSwitchDisabled = React.useMemo(() => {
+    const hasOtherStorageClassesEnabled = Object.entries(storageClassConfigMap).some(
+      ([storageClassName, config]) =>
+        storageClassName !== storageClass.metadata.name && config?.isEnabled,
+    );
+
+    // Prevent disabling when the storage class is enabled and all
+    // others are disabled or if the storage class is set as the default
+    if (
+      storageClassConfig?.isEnabled &&
+      (!hasOtherStorageClassesEnabled || storageClassConfig.isDefault)
+    ) {
+      return true;
+    }
+
+    return false;
+  }, [
+    storageClass.metadata.name,
+    storageClassConfig?.isDefault,
+    storageClassConfig?.isEnabled,
+    storageClassConfigMap,
+  ]);
+
+  const onDefaultRadioChange = React.useCallback(async () => {
+    const existingDefaultConfigMap = Object.entries(storageClassConfigMap).find(
+      ([name, config]) => storageClass.metadata.name !== name && config?.isDefault,
+    );
+
+    if (existingDefaultConfigMap) {
+      const [name, config] = existingDefaultConfigMap;
+      await updateStorageClassConfig(name, { ...config, isDefault: false });
+      refresh();
+    }
+  }, [storageClass.metadata.name, storageClassConfigMap, refresh]);
+
+  return (
+    <Tr>
+      <Td dataLabel={ColumnLabel.DisplayName}>
+        <TableRowTitleDescription
+          title={storageClassConfig?.displayName}
+          description={storageClassConfig?.description}
+        />
+      </Td>
+
+      <Td dataLabel={ColumnLabel.OpenshiftStorageClass}>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>{metadata.name}</FlexItem>
+
+          <FlexItem>
+            <Popover
+              position="right"
+              headerContent="Storage class info"
+              bodyContent={
+                <DescriptionList isCompact className="pf-v5-u-mt-lg">
+                  {storageClassInfoItems.map((storageClassInfoItem) => (
+                    <DescriptionListGroup key={storageClassInfoItem.label}>
+                      <DescriptionListTerm>{storageClassInfoItem.label}</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {storageClassInfoItem.value}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  ))}
+                </DescriptionList>
+              }
+            >
+              <DashboardPopupIconButton
+                icon={<OutlinedQuestionCircleIcon />}
+                aria-label="Storage class info popover"
+              />
+            </Popover>
+          </FlexItem>
+
+          {isOpenshiftDefault && (
+            <FlexItem>
+              <Tooltip content="This is the default storage class in OpenShift.">
+                <Label color="green" isCompact data-testid="openshift-sc-default-label">
+                  Default
+                </Label>
+              </Tooltip>
+            </FlexItem>
+          )}
+        </Flex>
+      </Td>
+
+      <Td dataLabel={ColumnLabel.Enable}>
+        <StorageClassEnableSwitch
+          storageClassName={metadata.name}
+          isChecked={!!storageClassConfig?.isEnabled}
+          isDisabled={isEnableSwitchDisabled}
+          onChange={refresh}
+        />
+      </Td>
+
+      <Td dataLabel={ColumnLabel.Default}>
+        <StorageClassDefaultRadio
+          storageClassName={metadata.name}
+          isChecked={!!storageClassConfig?.isDefault}
+          isDisabled={!storageClassConfig?.isDefault && !storageClassConfig?.isEnabled}
+          onChange={onDefaultRadioChange}
+        />
+      </Td>
+
+      <Td dataLabel={ColumnLabel.LastModified}>
+        {storageClassConfig?.lastModified ? (
+          <Timestamp date={new Date(storageClassConfig.lastModified)} />
+        ) : (
+          'Unknown'
+        )}
+      </Td>
+
+      <Td isActionCell>
+        <ActionsColumn
+          items={[
+            {
+              // TODO, https://issues.redhat.com/browse/RHOAIENG-1108
+              title: 'Edit',
+            },
+          ]}
+        />
+      </Td>
+    </Tr>
+  );
+};

--- a/frontend/src/pages/storageClasses/constants.ts
+++ b/frontend/src/pages/storageClasses/constants.ts
@@ -1,0 +1,62 @@
+import { SortableData, kebabTableColumn } from '~/components/table';
+import { StorageClassKind } from '~/k8sTypes';
+import { getStorageClassConfig } from './utils';
+
+export enum ColumnLabel {
+  DisplayName = 'Display name',
+  OpenshiftStorageClass = 'Openshift storage class',
+  Enable = 'Enable',
+  Default = 'Default',
+  LastModified = 'Last modified',
+}
+
+export const columns: SortableData<StorageClassKind>[] = [
+  {
+    field: 'displayName',
+    label: ColumnLabel.DisplayName,
+    sortable: (a, b) => a.metadata.name.localeCompare(b.metadata.name),
+    info: {
+      popoverProps: { headerContent: 'Display name' },
+      popover:
+        'The display name identifies a storage class within OpenShift AI, and can be edited.',
+    },
+  },
+  {
+    field: 'storageClassName',
+    label: ColumnLabel.OpenshiftStorageClass,
+    sortable: false,
+    info: {
+      popoverProps: { headerContent: 'OpenShift storage class' },
+      popover:
+        'Storage classes are defined and supported by OpenShift. Their details can be edited for use in OpenShift AI.',
+    },
+  },
+  {
+    field: 'isEnabled',
+    label: ColumnLabel.Enable,
+    sortable: false,
+    info: {
+      popoverProps: { headerContent: 'Enable' },
+      popover:
+        'Enable users in your organization to use this storage class when creating or editing cluster storage.',
+    },
+  },
+  {
+    field: 'isDefault',
+    label: ColumnLabel.Default,
+    sortable: false,
+    info: {
+      popoverProps: { headerContent: 'Default' },
+      popover:
+        'The default storage class is automatically selected for OpenShift AI users when creating new cluster storage.',
+    },
+  },
+  {
+    field: 'lastModified',
+    label: ColumnLabel.LastModified,
+    sortable: (a, b) =>
+      new Date(getStorageClassConfig(a)?.lastModified || '').getTime() -
+      new Date(getStorageClassConfig(b)?.lastModified || '').getTime(),
+  },
+  kebabTableColumn(),
+];

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -3,11 +3,15 @@ import { MetadataAnnotation, StorageClassConfig, StorageClassKind } from '~/k8sT
 export const getStorageClassConfig = (
   storageClass: StorageClassKind,
 ): StorageClassConfig | undefined => {
-  const storageClassConfig: StorageClassConfig | undefined = JSON.parse(
-    storageClass.metadata.annotations?.[MetadataAnnotation.OdhStorageClassConfig] || '',
-  );
+  try {
+    const storageClassConfig: StorageClassConfig | undefined = JSON.parse(
+      storageClass.metadata.annotations?.[MetadataAnnotation.OdhStorageClassConfig] || '',
+    );
 
-  return storageClassConfig;
+    return storageClassConfig;
+  } catch {
+    return undefined;
+  }
 };
 
 export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>

--- a/frontend/src/services/StorageClassService.ts
+++ b/frontend/src/services/StorageClassService.ts
@@ -4,11 +4,11 @@ import { ResponseStatus } from '~/types';
 
 export const updateStorageClassConfig = (
   name: string,
-  spec: StorageClassConfig,
+  config: Partial<Omit<StorageClassConfig, 'lastModified'>> | undefined,
 ): Promise<ResponseStatus> => {
   const url = `/api/storage-class/${name}/config`;
   return axios
-    .put(url, spec)
+    .put(url, config ? { ...config, lastModified: new Date().toISOString() } : undefined)
     .then((response) => response.data)
     .catch((e) => {
       throw new Error(e.response.data.message);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-1106

## Description
Added storage classes table which includes column sorting, labels, popovers, tooltips, requests to update the default or the enabled state of storage classes (the underlying metadata for each row), placeholders for future table related stories.

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/45e1759a-47da-4a06-8c1d-84e71963a2a1">
https://github.com/user-attachments/assets/1b7b71b8-39d0-4f4c-8a04-25be2517630d
(cc @xianli123)

## How Has This Been Tested?
Manual and cypress tests. Running the dev environment via the root directory of the project (npm run dev) and navigating to `/storageClasses?devFeatureFlags=disableStorageClasses` should lead to the storage classes table so long as storage classes exist to be rendered. Here you can compare to the design and interact with the default radio buttons and enable switches to verify that behavior.

## Test Impact
Added cypress tests covering rendering of data & toggling "enable" switches and "default" radio selections.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
