### PR TITLE
Fix for URI form field regex validation

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/UriFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/UriFormField.tsx
@@ -11,13 +11,12 @@ import { UriField } from '~/concepts/connectionTypes/types';
 import { FieldProps } from '~/concepts/connectionTypes/fields/types';
 import DefaultValueTextRenderer from '~/concepts/connectionTypes/fields/DefaultValueTextRenderer';
 
-const URI_REGEX = new RegExp(
-  '(?:(?:https?|ftp|file)://|www.|ftp.)(?:([-A-Z0-9+&@#/%=~_|$?!:,.]*)|[-A-Z0-9+&@#/%=~_|$?!:,.])*(?:([-A-Z0-9+&@#/%=~_|$?!:,.]*)|[A-Z0-9+&@#/%=~_|$])',
-);
-
 const validateUrl = (url?: string) => {
+  if (!url) {
+    return true;
+  }
   try {
-    return !url || URI_REGEX.test(url);
+    return !!new URL(url);
   } catch (e) {
     return false;
   }
@@ -68,9 +67,9 @@ const UriFormField: React.FC<FieldProps<UriField>> = ({
       />
       {!isValid && (
         <FormHelperText>
-          <HelperText>
+          <HelperText data-testid="uri-form-field-helper-text">
             <HelperTextItem icon={<ExclamationCircleIcon />} variant={ValidatedOptions.error}>
-              Invalid URL
+              Invalid URI
             </HelperTextItem>
           </HelperText>
         </FormHelperText>


### PR DESCRIPTION
Closes [RHOAIENG-12292](https://issues.redhat.com/browse/RHOAIENG-12292)

## Description
Fixes the regular expression test for the connection type URI field input

## How Has This Been Tested?
Added additional RTL tests to validate/invalidate different URI entries

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
