### PR TITLE
Show connection type creation error message on failure

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -84,6 +84,10 @@ class CreateConnectionTypePage {
     return new CreateConnectionTypeTableRow(() => this.findAllFieldsTableRows().eq(index));
   }
 
+  findFooterError() {
+    return cy.findByTestId('connection-type-footer-error');
+  }
+
   findSubmitButton() {
     return cy.findByTestId('submit-button');
   }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -608,6 +608,10 @@ declare global {
           response: ConnectionTypeConfigMap[],
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'POST /api/connection-types',
+          response: OdhResponse<SuccessErrorResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'DELETE /api/connection-types/:name',
           options: { path: { name: string } },
           response: OdhResponse<SuccessErrorResponse>,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -42,6 +42,25 @@ describe('create', () => {
     createConnectionTypePage.findSubmitButton().should('be.enabled');
   });
 
+  it('Shows creation error message when creation fails', () => {
+    cy.interceptOdh('POST /api/connection-types', {
+      success: false,
+      error: 'returned error message',
+    });
+    const categorySection = createConnectionTypePage.getCategorySection();
+    createConnectionTypePage.visitCreatePage();
+
+    createConnectionTypePage.findConnectionTypeName().should('have.value', '');
+    createConnectionTypePage.findSubmitButton().should('be.disabled');
+
+    createConnectionTypePage.findConnectionTypeName().type('hello');
+    categorySection.findCategoryTable();
+    categorySection.findMultiGroupSelectButton('Object-storage');
+    createConnectionTypePage.findSubmitButton().should('be.enabled').click();
+
+    createConnectionTypePage.findFooterError().should('contain.text', 'returned error message');
+  });
+
   it('Selects category or creates new category', () => {
     createConnectionTypePage.visitCreatePage();
 

--- a/frontend/src/pages/connectionTypes/manage/CreateConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/CreateConnectionTypePage.tsx
@@ -13,7 +13,7 @@ const CreateConnectionTypePage: React.FC<Props> = ({ prefill }) => (
     onSave={async (obj) => {
       const response = await createConnectionType(obj);
       if (response.error) {
-        throw response.error;
+        throw new Error(response.error);
       }
     }}
   />

--- a/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
@@ -20,7 +20,7 @@ const EditConnectionTypePage: React.FC = () => {
       onSave={async (obj) => {
         const response = await updateConnectionType(obj);
         if (response.error) {
-          throw response.error;
+          throw new Error(response.error);
         }
       }}
     />

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFooter.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFooter.tsx
@@ -27,7 +27,12 @@ const ManageConnectionTypeFooter: React.FC<Props> = ({
     <Stack hasGutter>
       {error && (
         <StackItem>
-          <Alert isInline variant="danger" title="Error saving connection type">
+          <Alert
+            isInline
+            variant="danger"
+            title="Error saving connection type"
+            data-testid="connection-type-footer-error"
+          >
             {error}
           </Alert>
         </StackItem>


### PR DESCRIPTION
Closes [RHOAIENG-12439](https://issues.redhat.com/browse/RHOAIENG-12439)

## Description
Fix handling of the error response when creating a connection type.

## How Has This Been Tested?
Tested manually

## Test Impact
Added e2e test to verify response error text is shown on the page after an error.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

