### PR TITLE
Truncate long connection type description

### DIFF
--- a/frontend/src/components/table/TableRowTitleDescription.tsx
+++ b/frontend/src/components/table/TableRowTitleDescription.tsx
@@ -3,6 +3,7 @@ import { Text } from '@patternfly/react-core';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import MarkdownView from '~/components/MarkdownView';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
+import TruncatedText from '~/components/TruncatedText';
 
 type TableRowTitleDescriptionProps = {
   title: React.ReactNode;
@@ -10,6 +11,7 @@ type TableRowTitleDescriptionProps = {
   subtitle?: React.ReactNode;
   description?: string;
   descriptionAsMarkdown?: boolean;
+  truncateDescriptionLines?: number;
   label?: React.ReactNode;
 };
 
@@ -19,6 +21,7 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
   resource,
   subtitle,
   descriptionAsMarkdown,
+  truncateDescriptionLines,
   label,
 }) => {
   let descriptionNode: React.ReactNode;
@@ -30,7 +33,11 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
         data-testid="table-row-title-description"
         style={{ color: 'var(--pf-v5-global--Color--200)' }}
       >
-        {description}
+        {truncateDescriptionLines !== undefined ? (
+          <TruncatedText maxLines={truncateDescriptionLines} content={description} />
+        ) : (
+          description
+        )}
       </Text>
     );
   }

--- a/frontend/src/concepts/connectionTypes/ConnectionTypePreview.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypePreview.tsx
@@ -46,7 +46,7 @@ const ConnectionTypePreview: React.FC<Props> = ({ obj }) => {
         />
         <HelperText>
           {connectionTypeDescription ? (
-            <HelperTextItem>
+            <HelperTextItem style={{ overflowWrap: 'anywhere' }}>
               <TruncatedText maxLines={2} content={connectionTypeDescription} />
             </HelperTextItem>
           ) : undefined}

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
@@ -67,6 +67,7 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
       <Table
         isStriped
         variant="compact"
+        style={{ tableLayout: 'fixed' }}
         data={filteredConnectionTypes}
         columns={connectionTypeColumns}
         defaultSortColumn={0}

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -79,10 +79,11 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
 
   return (
     <Tr>
-      <Td dataLabel={connectionTypeColumns[0].label} width={30}>
+      <Td dataLabel={connectionTypeColumns[0].label}>
         <TableRowTitleDescription
           title={getDisplayNameFromK8sResource(obj)}
           description={getDescriptionFromK8sResource(obj)}
+          truncateDescriptionLines={2}
         />
       </Td>
       <Td dataLabel={connectionTypeColumns[1].label}>

--- a/frontend/src/pages/connectionTypes/columns.ts
+++ b/frontend/src/pages/connectionTypes/columns.ts
@@ -47,21 +47,25 @@ export const connectionTypeColumns: SortableData<ConnectionTypeConfigMapObj>[] =
     label: 'Name',
     field: 'name',
     sortable: sorter,
+    width: 30,
   },
   {
     label: 'Category',
     field: 'category',
     sortable: false,
+    width: 25,
   },
   {
     label: 'Creator',
     field: 'creator',
     sortable: sorter,
+    width: 15,
   },
   {
     label: 'Created',
     field: 'created',
     sortable: sorter,
+    width: 15,
   },
   {
     label: 'Enable',
@@ -74,5 +78,6 @@ export const connectionTypeColumns: SortableData<ConnectionTypeConfigMapObj>[] =
         headerContent: 'Enable',
       },
     },
+    width: 10,
   },
 ];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Closes https://issues.redhat.com/browse/RHOAIENG-12443

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This is a visual styling change to fix long descriptions. You can still enter really long descripitons, but it won't overflow outside the container the text is in.

I also saw this is a similar issue in the preview page, no idea why. But I fixed that as well.

Before:
![Screenshot from 2024-09-05 11-43-08](https://github.com/user-attachments/assets/3b862cf1-3932-4057-b1ad-e3bc4870baf5)
After: 
![Screenshot from 2024-09-05 11-39-25](https://github.com/user-attachments/assets/a0715cc5-81cf-4ec5-bd3e-6e03520aaee7)

Preview before:
![Screenshot from 2024-09-05 11-43-20](https://github.com/user-attachments/assets/1e9e73f3-f4b1-4976-a16d-0a2af82ad409)
After:
![Screenshot from 2024-09-05 11-39-49](https://github.com/user-attachments/assets/88204d28-c43f-4667-8049-1981f8908589)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
A shared component has been updated, but the new prop is default unsued

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
