### PR TITLE
MR selector doesn't update without page reload

### DIFF
--- a/frontend/src/api/useRulesReview.ts
+++ b/frontend/src/api/useRulesReview.ts
@@ -19,11 +19,12 @@ const checkAccess = (ns: string): Promise<SelfSubjectRulesReviewKind> => {
 
 export const useRulesReview = (
   namespace: string,
-): [SelfSubjectRulesReviewKind['status'], boolean] => {
+): [SelfSubjectRulesReviewKind['status'], boolean, () => void] => {
   const [loaded, setLoaded] = React.useState(false);
   const [status, setStatus] = React.useState<SelfSubjectRulesReviewKind['status']>(undefined);
 
-  React.useEffect(() => {
+  const refreshRulesReview = React.useCallback(() => {
+    setLoaded(false);
     checkAccess(namespace)
       .then((result) => {
         if (!result.status?.incomplete && !result.status?.evaluationError) {
@@ -38,5 +39,9 @@ export const useRulesReview = (
       });
   }, [namespace]);
 
-  return [status, loaded];
+  React.useEffect(() => {
+    refreshRulesReview();
+  }, [refreshRulesReview]);
+
+  return [status, loaded, refreshRulesReview];
 };

--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
@@ -1,5 +1,5 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import { useAccessReview, useRulesReview, listServices } from '~/api';
 import { ServiceKind } from '~/k8sTypes';
 import {
@@ -8,7 +8,6 @@ import {
 } from '~/concepts/modelRegistry/apiHooks/useModelRegistryServices';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockModelRegistryService } from '~/__mocks__/mockModelRegistryService';
-import { waitFor } from '@testing-library/react';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResource: jest.fn(),

--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
@@ -1,5 +1,5 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { useAccessReview, useRulesReview, listServices } from '~/api';
 import { ServiceKind } from '~/k8sTypes';
 import {

--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '~/concepts/modelRegistry/apiHooks/useModelRegistryServices';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockModelRegistryService } from '~/__mocks__/mockModelRegistryService';
+import { waitFor } from '@testing-library/react';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResource: jest.fn(),
@@ -80,12 +81,10 @@ describe('useModelRegistryServices', () => {
 
     const { result } = testHook(() => useModelRegistryServices('test-namespace'))();
 
-    await act(async () => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
+    await waitFor(() => {
+      const [, isLoaded] = objectToStandardUseFetchState(result.current);
+      expect(isLoaded).toBe(true);
     });
-
     const [services, isLoaded] = objectToStandardUseFetchState(result.current);
     expect(services).toEqual([
       mockModelRegistryService({ name: 'service-1', namespace: 'test-namespace' }),

--- a/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
@@ -54,7 +54,7 @@ export type ModelRegistryServicesResult = {
   modelRegistryServices: ServiceKind[];
   isLoaded: boolean;
   error?: Error;
-  refreshRulesReview: () => void; // Add this line
+  refreshRulesReview: () => void;
 };
 
 export const useModelRegistryServices = (namespace: string): ModelRegistryServicesResult => {

--- a/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
@@ -1,10 +1,6 @@
 import React from 'react';
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import useFetchState, {
-  FetchState,
-  FetchStateCallbackPromise,
-  NotReadyError,
-} from '~/utilities/useFetchState';
+import useFetchState, { FetchStateCallbackPromise, NotReadyError } from '~/utilities/useFetchState';
 import { AccessReviewResourceAttributes, ServiceKind } from '~/k8sTypes';
 import { ServiceModel, useAccessReview, useRulesReview, listServices } from '~/api';
 import { MODEL_REGISTRY_DEFAULT_NAMESPACE } from '~/concepts/modelRegistry/const';
@@ -54,21 +50,28 @@ const listServicesOrFetchThemByNames = async (
   return services;
 };
 
-export const useModelRegistryServices = (): FetchState<ServiceKind[]> => {
+export type ModelRegistryServicesResult = {
+  modelRegistryServices: ServiceKind[];
+  isLoaded: boolean;
+  error?: Error;
+  refreshRulesReview: () => void; // Add this line
+};
+
+export const useModelRegistryServices = (namespace: string): ModelRegistryServicesResult => {
   const [allowList, accessReviewLoaded] = useAccessReview(accessReviewResource);
-  const [statuses, rulesReviewLoaded] = useRulesReview(MODEL_REGISTRY_DEFAULT_NAMESPACE);
+  const [rulesReviewStatus, rulesReviewLoaded, refreshRulesReview] = useRulesReview(namespace);
 
   const serviceNames = React.useMemo(() => {
     if (!rulesReviewLoaded) {
       return [];
     }
-    return statuses?.resourceRules
+    return rulesReviewStatus?.resourceRules
       .filter(
         ({ resources, verbs }) =>
           resources?.includes('services') && verbs.some((verb) => verb === 'get'),
       )
       .flatMap((rule) => rule.resourceNames || []);
-  }, [rulesReviewLoaded, statuses]);
+  }, [rulesReviewLoaded, rulesReviewStatus]);
 
   const callback = React.useCallback<FetchStateCallbackPromise<ServiceKind[]>>(
     () =>
@@ -81,7 +84,14 @@ export const useModelRegistryServices = (): FetchState<ServiceKind[]> => {
     [allowList, accessReviewLoaded, rulesReviewLoaded, serviceNames],
   );
 
-  return useFetchState(callback, [], {
+  const [modelRegistryServices, isLoaded, error] = useFetchState(callback, [], {
     initialPromisePurity: true,
   });
+
+  return {
+    modelRegistryServices,
+    isLoaded,
+    error,
+    refreshRulesReview,
+  };
 };

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -23,7 +23,7 @@ export const ModelRegistrySelectorContext = React.createContext<ModelRegistrySel
   modelRegistryServices: [],
   preferredModelRegistry: undefined,
   updatePreferredModelRegistry: () => undefined,
-  refreshRulesReview: () => undefined, // Add this line
+  refreshRulesReview: () => undefined,
 });
 
 export const ModelRegistrySelectorContextProvider: React.FC<
@@ -59,7 +59,7 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<
       modelRegistryServices,
       preferredModelRegistry: preferredModelRegistry ?? modelRegistryServices[0],
       updatePreferredModelRegistry: setPreferredModelRegistry,
-      refreshRulesReview, // Remove the wrapper function
+      refreshRulesReview,
     }),
     [isLoaded, error, modelRegistryServices, preferredModelRegistry, refreshRulesReview],
   );

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -14,12 +14,20 @@ import ApplicationsPage from '~/pages/ApplicationsPage';
 import useModelRegistriesBackend from '~/concepts/modelRegistrySettings/useModelRegistriesBackend';
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
+import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import ModelRegistriesTable from './ModelRegistriesTable';
 import CreateModal from './CreateModal';
 
 const ModelRegistrySettings: React.FC = () => {
   const [createModalOpen, setCreateModalOpen] = React.useState(false);
-  const [modelRegistries, loaded, loadError, refresh] = useModelRegistriesBackend();
+  const [modelRegistries, loaded, loadError, refreshModelRegistries] = useModelRegistriesBackend();
+  const { refreshRulesReview } = React.useContext(ModelRegistrySelectorContext);
+
+  const refreshAll = React.useCallback(
+    () => Promise.all([refreshModelRegistries(), refreshRulesReview()]),
+    [refreshModelRegistries, refreshRulesReview],
+  );
+
   return (
     <>
       <ApplicationsPage
@@ -57,14 +65,17 @@ const ModelRegistrySettings: React.FC = () => {
       >
         <ModelRegistriesTable
           modelRegistries={modelRegistries}
-          refresh={refresh}
-          onCreateModelRegistryClick={() => setCreateModalOpen(true)}
+          refresh={refreshAll}
+          onCreateModelRegistryClick={() => {
+            setCreateModalOpen(true);
+            return Promise.resolve();
+          }}
         />
       </ApplicationsPage>
       <CreateModal
         isOpen={createModalOpen}
         onClose={() => setCreateModalOpen(false)}
-        refresh={refresh}
+        refresh={refreshAll}
       />
     </>
   );

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -68,7 +68,6 @@ const ModelRegistrySettings: React.FC = () => {
           refresh={refreshAll}
           onCreateModelRegistryClick={() => {
             setCreateModalOpen(true);
-            return Promise.resolve();
           }}
         />
       </ApplicationsPage>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-10026
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Please verify that the MR selector shows a new registered model, without the need of refreshing a page

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on the UI

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I had to rewrite a couple of tests to match the new logic

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
