### PR TITLE
fix alignment of text for connection type form elements

### DIFF
--- a/frontend/src/components/TruncatedText.tsx
+++ b/frontend/src/components/TruncatedText.tsx
@@ -14,6 +14,7 @@ const TruncatedText: React.FC<TruncatedTextProps> = ({ maxLines, content, ...res
         overflow: 'hidden',
         WebkitBoxOrient: 'vertical',
         WebkitLineClamp: maxLines,
+        overflowWrap: 'anywhere',
       }}
       {...rest}
     >

--- a/frontend/src/concepts/connectionTypes/ConnectionTypePreview.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypePreview.tsx
@@ -46,7 +46,7 @@ const ConnectionTypePreview: React.FC<Props> = ({ obj }) => {
         />
         <HelperText>
           {connectionTypeDescription ? (
-            <HelperTextItem style={{ overflowWrap: 'anywhere' }}>
+            <HelperTextItem>
               <TruncatedText maxLines={2} content={connectionTypeDescription} />
             </HelperTextItem>
           ) : undefined}

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableToolbar.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableToolbar.tsx
@@ -1,4 +1,4 @@
-import { Button, TextInput, ToolbarItem } from '@patternfly/react-core';
+import { Button, SearchInput, ToolbarItem } from '@patternfly/react-core';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import FilterToolbar from '~/components/FilterToolbar';
@@ -27,7 +27,7 @@ const ConnectionTypesTableToolbar: React.FC<Props> = ({
       filterOptions={options}
       filterOptionRenders={{
         [ConnectionTypesOptions.keyword]: ({ onChange, ...props }) => (
-          <TextInput
+          <SearchInput
             {...props}
             aria-label="Filter by keyword"
             placeholder="Filter by keyword"
@@ -35,7 +35,7 @@ const ConnectionTypesTableToolbar: React.FC<Props> = ({
           />
         ),
         [ConnectionTypesOptions.category]: ({ onChange, ...props }) => (
-          <TextInput
+          <SearchInput
             {...props}
             aria-label="Filter by category"
             placeholder="Filter by category"
@@ -43,7 +43,7 @@ const ConnectionTypesTableToolbar: React.FC<Props> = ({
           />
         ),
         [ConnectionTypesOptions.createdBy]: ({ onChange, ...props }) => (
-          <TextInput
+          <SearchInput
             {...props}
             aria-label="Created by"
             placeholder="Created by"

--- a/frontend/src/pages/connectionTypes/EmptyConnectionTypes.tsx
+++ b/frontend/src/pages/connectionTypes/EmptyConnectionTypes.tsx
@@ -16,7 +16,7 @@ const EmptyConnectionTypes: React.FC = () => (
   <PageSection isFilled>
     <EmptyState variant={EmptyStateVariant.full} data-testid="connection-types-empty-state">
       <EmptyStateHeader
-        titleText="No connection types found."
+        titleText="No connection types"
         icon={<EmptyStateIcon icon={PlusCircleIcon} />}
         headingLevel="h1"
       />

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -66,7 +66,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
             id: `draggable-row-${props.id}`,
           }}
         />
-        <Td colSpan={4} dataLabel={columns[0].label} data-testid="field-name">
+        <Td dataLabel={columns[0].label} data-testid="field-name">
           <div>
             {row.name}{' '}
             <Label color="blue" data-testid="section-heading">
@@ -77,7 +77,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
             </div>
           </div>
         </Td>
-        <Td />
+        <Td colSpan={4} />
         <Td isActionCell modifier="nowrap">
           <Button variant="secondary" onClick={() => onAddField(row)}>
             Add field

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -164,17 +164,17 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
                   }}
                 />
               </FormGroup>
-              <FormGroup label="Enable" fieldId="connection-type-enable">
-                <Checkbox
-                  label="Enable users in your organization to use this connection type when adding connections."
-                  id="connection-type-enable"
-                  name="connection-type-enable"
-                  data-testid="connection-type-enable"
-                  isChecked={connectionEnabled}
-                  onChange={(_e, value) => setConnectionEnabled(value)}
-                />
-              </FormGroup>
             </FormSection>
+            <FormGroup label="Enable" fieldId="connection-type-enable">
+              <Checkbox
+                label="Enable users in your organization to use this connection type when adding connections."
+                id="connection-type-enable"
+                name="connection-type-enable"
+                data-testid="connection-type-enable"
+                isChecked={connectionEnabled}
+                onChange={(_e, value) => setConnectionEnabled(value)}
+              />
+            </FormGroup>
             <FormSection title="Fields" className="pf-v5-u-mt-0">
               <FormGroup>
                 {isEnvVarConflict ? (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-12573

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Removed the enable checkbox from the type details section which allows it more room to display without text wrapping.
![image](https://github.com/user-attachments/assets/3756baaa-f1d0-4486-9bb7-22b62434f111)

Removed the col span from the section title cell in order to constrain the text to its column.
![image](https://github.com/user-attachments/assets/21ee73aa-c690-4df6-993a-04a3c09eb09f)

Added missing icon to search inputs:
![image](https://github.com/user-attachments/assets/7a6bf8ec-46ce-4b7a-9764-4e076dbe3717)


cc @simrandhaliw 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.
Visual only changes.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
