### PR TITLE
Fixes to connection type field modal

### DIFF
--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -43,7 +43,6 @@ const isConnectionTypeFieldType = (
 
 type Props = {
   field?: ConnectionTypeDataField;
-  isOpen?: boolean;
   onClose: () => void;
   onSubmit: (field: ConnectionTypeDataField) => void;
   isEdit?: boolean;
@@ -52,7 +51,6 @@ type Props = {
 
 export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
   field,
-  isOpen,
   onClose,
   onSubmit,
   isEdit,
@@ -107,7 +105,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
 
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       variant="medium"
       title={isEdit ? 'Edit field' : 'Add field'}
       onClose={onClose}

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -107,7 +107,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
 
   return (
     <Modal
-      isOpen
+      isOpen={isOpen}
       variant="medium"
       title={isEdit ? 'Edit field' : 'Add field'}
       onClose={onClose}
@@ -234,7 +234,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
                 onClick={() => {
                   setIsTypeSelectOpen((open) => !open);
                 }}
-                isExpanded={isOpen}
+                isExpanded={isTypeSelectOpen}
               >
                 {fieldType ? fieldTypeToString(fieldType) : ''}
               </MenuToggle>

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -66,7 +66,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
       ? // Cast from specific type to generic type
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-explicit-any
         (field.type as ConnectionTypeFieldType)
-      : undefined,
+      : ConnectionTypeFieldType.ShortText,
   );
   const [required, setRequired] = React.useState<boolean | undefined>(field?.required);
   const [isTypeSelectOpen, setIsTypeSelectOpen] = React.useState<boolean>(false);

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -121,6 +121,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
         />
       }
       data-testid="archive-model-version-modal"
+      elementToFocus="#name"
     >
       <Form>
         <FormGroup fieldId="name" label="Name" isRequired>

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -115,7 +115,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
         <DashboardModalFooter
           onCancel={onClose}
           onSubmit={handleSubmit}
-          submitLabel={isEdit ? 'Edit' : 'Add'}
+          submitLabel={isEdit ? 'Save' : 'Add'}
           isSubmitDisabled={!isValid}
           alertTitle="Error"
         />

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -123,7 +123,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
       data-testid="archive-model-version-modal"
     >
       <Form>
-        <FormGroup fieldId="name" label="Field name" isRequired>
+        <FormGroup fieldId="name" label="Name" isRequired>
           <TextInput
             id="name"
             value={name}
@@ -138,12 +138,12 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
         </FormGroup>
         <FormGroup
           fieldId="description"
-          label="Field description"
+          label="Description"
           labelIcon={
             <Popover
-              aria-label="field description help"
-              headerContent="Field description"
-              bodyContent="Use the field description to provide users in your organization with additional information about a field, or instructions for completing the field. Your input will appear in a popover, like this one."
+              aria-label="description help"
+              headerContent="Description"
+              bodyContent="Use the description to provide users in your organization with additional information about a field, or instructions for completing the field. Your input will appear in a popover, like this one."
             >
               <DashboardPopupIconButton
                 icon={<OutlinedQuestionCircleIcon />}
@@ -166,7 +166,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
             <Popover
               aria-label="environment variable help"
               headerContent="Environment variable"
-              bodyContent="Environment variables grant you access to the value provided when attaching the connection to your workbench."
+              bodyContent="Environment variables are how the system references the field value in a workbench or model server. Your input will appear in a popover, like this one. "
             >
               <DashboardPopupIconButton
                 icon={<OutlinedQuestionCircleIcon />}
@@ -211,12 +211,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
             ) : undefined}
           </FormHelperText>
         </FormGroup>
-        <FormGroup
-          fieldId="fieldType"
-          label="Field type"
-          isRequired
-          data-testid="field-type-select"
-        >
+        <FormGroup fieldId="fieldType" label="Type" isRequired data-testid="field-type-select">
           <Select
             id="fieldType"
             isOpen={isTypeSelectOpen}

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldModal.tsx
@@ -5,7 +5,6 @@ import ConnectionTypeSectionModal from './ConnectionTypeSectionModal';
 
 type Props = {
   field?: ConnectionTypeField;
-  isOpen?: boolean;
   onClose: () => void;
   onSubmit: (field: ConnectionTypeField) => void;
   isEdit?: boolean;

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
@@ -45,6 +45,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({
           alertTitle=""
         />
       }
+      elementToFocus="#section-name"
     >
       <Form>
         <FormGroup

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
@@ -33,7 +33,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({
       variant="medium"
       footer={
         <DashboardModalFooter
-          submitLabel={isEdit ? 'Edit' : 'Add'}
+          submitLabel={isEdit ? 'Save' : 'Add'}
           onCancel={onClose}
           onSubmit={() => {
             if (isValid) {

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
@@ -7,19 +7,12 @@ import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconBut
 
 type Props = {
   field?: SectionField;
-  isOpen?: boolean;
   onClose: () => void;
   onSubmit: (field: SectionField) => void;
   isEdit?: boolean;
 };
 
-const ConnectionTypeSectionModal: React.FC<Props> = ({
-  field,
-  isOpen,
-  onClose,
-  onSubmit,
-  isEdit,
-}) => {
+const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit, isEdit }) => {
   const [name, setName] = React.useState(field?.name || '');
   const [description, setDescription] = React.useState(field?.description || '');
 
@@ -27,7 +20,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({
 
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       title={isEdit ? 'Edit section heading' : 'Add section heading'}
       onClose={onClose}
       variant="medium"

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -160,7 +160,6 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
           field={modalField.field}
           isEdit={modalField.isEdit}
           onClose={() => setModalField(undefined)}
-          isOpen
           onSubmit={(field) => {
             if (modalField.field && modalField.isEdit && modalField.index !== undefined) {
               // update

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
@@ -15,7 +15,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should render the modal', () => {
-    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
 
     const addButton = screen.getByTestId('modal-submit-button');
     expect(addButton).toBeDisabled();
@@ -24,7 +24,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should add a short text field', async () => {
-    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
     const fieldNameInput = screen.getByTestId('field-name-input');
     const fieldDescriptionInput = screen.getByTestId('field-description-input');
     const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
@@ -69,7 +69,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should auto generate env var if not entered', async () => {
-    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
     const fieldNameInput = screen.getByTestId('field-name-input');
     const fieldDescriptionInput = screen.getByTestId('field-description-input');
     const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
@@ -129,7 +129,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should add a numeric field', async () => {
-    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
     const fieldNameInput = screen.getByTestId('field-name-input');
     const fieldDescriptionInput = screen.getByTestId('field-description-input');
     const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
@@ -247,6 +247,7 @@ describe('ConnectionTypeDataFieldModal', () => {
     };
     render(
       <ConnectionTypeDataFieldModal
+        isOpen
         onClose={onClose}
         onSubmit={onSubmit}
         field={field}

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
@@ -15,7 +15,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should render the modal', () => {
-    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
 
     const addButton = screen.getByTestId('modal-submit-button');
     expect(addButton).toBeDisabled();
@@ -24,7 +24,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should add a short text field', async () => {
-    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
     const fieldNameInput = screen.getByTestId('field-name-input');
     const fieldDescriptionInput = screen.getByTestId('field-description-input');
     const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
@@ -69,7 +69,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should auto generate env var if not entered', async () => {
-    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
     const fieldNameInput = screen.getByTestId('field-name-input');
     const fieldDescriptionInput = screen.getByTestId('field-description-input');
     const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
@@ -129,7 +129,7 @@ describe('ConnectionTypeDataFieldModal', () => {
   });
 
   it('should add a numeric field', async () => {
-    render(<ConnectionTypeDataFieldModal isOpen onClose={onClose} onSubmit={onSubmit} />);
+    render(<ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} />);
     const fieldNameInput = screen.getByTestId('field-name-input');
     const fieldDescriptionInput = screen.getByTestId('field-description-input');
     const fieldEnvVarInput = screen.getByTestId('field-env-var-input');
@@ -247,7 +247,6 @@ describe('ConnectionTypeDataFieldModal', () => {
     };
     render(
       <ConnectionTypeDataFieldModal
-        isOpen
         onClose={onClose}
         onSubmit={onSubmit}
         field={field}

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeSectionModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeSectionModal.spec.tsx
@@ -8,9 +8,7 @@ describe('ConnectionTypeSectionModal', () => {
   it('should disable submit until valid', () => {
     const closeFn = jest.fn();
     const submitFn = jest.fn();
-    const result = render(
-      <ConnectionTypeSectionModal isOpen onClose={closeFn} onSubmit={submitFn} />,
-    );
+    const result = render(<ConnectionTypeSectionModal onClose={closeFn} onSubmit={submitFn} />);
 
     const nameInput = result.getByTestId('section-name');
     const descriptionInput = result.getByTestId('section-description');
@@ -36,7 +34,6 @@ describe('ConnectionTypeSectionModal', () => {
     const submitFn = jest.fn();
     const result = render(
       <ConnectionTypeSectionModal
-        isOpen
         onClose={closeFn}
         onSubmit={submitFn}
         field={{


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Auto selects the name field
- update labels that no longer have "field"
- "Text - Short" is auto selected
- field type dropdown no longer has focused styling
- button is now "Save" and not "Edit"

Initial load render screenshot:
![image](https://github.com/user-attachments/assets/4d96487d-4936-47ab-a135-b0a0f9217598)
![image](https://github.com/user-attachments/assets/6fb9ef7d-3901-49a6-8be4-d08aae5ed766)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, mainly visual changes

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

The field labels have been changed so the test-id's could also be updated, but I haven't (they still have "field")

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
