### PR TITLE
Improve update call in editing workbench

### DIFF
--- a/backend/src/routes/api/k8s/index.ts
+++ b/backend/src/routes/api/k8s/index.ts
@@ -40,6 +40,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         url,
         method: req.method,
         requestData: data,
+        overrideContentType: req.headers['content-type'],
       };
 
       let promise: Promise<unknown>;

--- a/backend/src/routes/api/k8s/pass-through.ts
+++ b/backend/src/routes/api/k8s/pass-through.ts
@@ -12,6 +12,8 @@ export type PassThroughData = {
   method: string;
   requestData?: string;
   url: string;
+  /** Option to substitute your own content type for the API call -- defaults to JSON */
+  overrideContentType?: string;
 };
 
 export const isK8sStatus = (data: unknown): data is K8sStatus =>

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -33,6 +33,21 @@ const app = fastify({
   pluginTimeout: 10000,
 });
 
+// Allow the fastify server to parse the merge-patch/json content type
+app.addContentTypeParser(
+  'application/merge-patch+json',
+  { parseAs: 'string' },
+  function (req, body, done) {
+    try {
+      const json = JSON.parse(String(body));
+      done(null, json);
+    } catch (err) {
+      err.statusCode = 400;
+      done(err, undefined);
+    }
+  },
+);
+
 app.register(initializeApp);
 
 app.listen({ port: PORT, host: IP }, (err) => {

--- a/frontend/src/__mocks__/mockStartNotebookData.ts
+++ b/frontend/src/__mocks__/mockStartNotebookData.ts
@@ -4,12 +4,18 @@ import { mockK8sNameDescriptionFieldData } from '~/__mocks__/mockK8sNameDescript
 
 type MockResourceConfigType = {
   volumeName?: string;
+  notebookId?: string;
 };
 export const mockStartNotebookData = ({
+  notebookId,
   volumeName = 'test-volume',
 }: MockResourceConfigType): StartNotebookData => ({
   projectName: 'test-project',
-  notebookData: mockK8sNameDescriptionFieldData({ name: 'test-notebook', description: '' }),
+  notebookData: mockK8sNameDescriptionFieldData({
+    name: 'test-notebook',
+    description: '',
+    k8sName: { value: notebookId },
+  }),
   image: {
     imageStream: {
       metadata: {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -556,9 +556,10 @@ describe('Workbench page', () => {
     editSpawnerPage.findSubmitButton().should('be.enabled');
     editSpawnerPage.k8sNameDescription.findDisplayNameInput().fill('Updated Notebook');
 
-    cy.interceptK8s('PUT', NotebookModel, mockNotebookK8sResource({})).as('editWorkbench');
+    cy.interceptK8s('PUT', NotebookModel, mockNotebookK8sResource({})).as('editWorkbenchDryRun');
+    cy.interceptK8s('PATCH', NotebookModel, mockNotebookK8sResource({})).as('editWorkbench');
     editSpawnerPage.findSubmitButton().click();
-    cy.wait('@editWorkbench').then((interception) => {
+    cy.wait('@editWorkbenchDryRun').then((interception) => {
       expect(interception.request.url).to.include('?dryRun=All');
       expect(interception.request.body).to.containSubset({
         metadata: {
@@ -580,14 +581,9 @@ describe('Workbench page', () => {
         },
       });
     });
-
     // Actual request
     cy.wait('@editWorkbench').then((interception) => {
       expect(interception.request.url).not.to.include('?dryRun=All');
-    });
-
-    cy.get('@editWorkbench.all').then((interceptions) => {
-      expect(interceptions).to.have.length(2); // 1 dry run request and 1 actual request
     });
   });
 

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -4,9 +4,9 @@ import {
   k8sGetResource,
   k8sListResource,
   k8sPatchResource,
-  k8sUpdateResource,
   Patch,
   K8sStatus,
+  k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import * as _ from 'lodash-es';
 import { NotebookModel } from '~/api/models';
@@ -26,6 +26,7 @@ import {
 } from '~/concepts/pipelines/elyra/utils';
 import { Volume, VolumeMount } from '~/types';
 import { getImageStreamDisplayName } from '~/pages/projects/screens/spawner/spawnerUtils';
+import { k8sMergePatchResource } from '~/api/k8sUtils';
 import { assemblePodSpecOptions, getshmVolume, getshmVolumeMount } from './utils';
 
 export const assembleNotebook = (
@@ -300,6 +301,21 @@ export const updateNotebook = (
     ),
   );
 };
+
+export const mergePatchUpdateNotebook = (
+  assignableData: StartNotebookData,
+  username: string,
+  opts?: K8sAPIOptions,
+): Promise<NotebookKind> =>
+  k8sMergePatchResource<NotebookKind>(
+    applyK8sAPIOptions(
+      {
+        model: NotebookModel,
+        resource: assembleNotebook(assignableData, username),
+      },
+      opts,
+    ),
+  );
 
 export const deleteNotebook = (notebookName: string, namespace: string): Promise<K8sStatus> =>
   k8sDeleteResource<NotebookKind, K8sStatus>({

--- a/frontend/src/api/k8sUtils.ts
+++ b/frontend/src/api/k8sUtils.ts
@@ -1,7 +1,11 @@
+import { applyOverrides } from '@openshift/dynamic-plugin-sdk';
 import {
+  commonFetchJSON,
+  getK8sResourceURL,
   K8sGroupVersionKind,
   K8sModelCommon,
   K8sResourceCommon,
+  K8sResourceUpdateOptions,
 } from '@openshift/dynamic-plugin-sdk-utils';
 
 export const addOwnerReference = <R extends K8sResourceCommon>(
@@ -40,3 +44,30 @@ export const groupVersionKind = (model: K8sModelCommon): K8sGroupVersionKind => 
   version: model.apiVersion,
   kind: model.kind,
 });
+
+export const k8sMergePatchResource = <
+  TResource extends K8sResourceCommon,
+  TUpdatedResource extends TResource = TResource,
+>({
+  model,
+  resource,
+  queryOptions = {},
+  fetchOptions = {},
+}: K8sResourceUpdateOptions<TResource>): Promise<TUpdatedResource> => {
+  if (!resource.metadata?.name) {
+    return Promise.reject(new Error('Resource payload name not specified'));
+  }
+
+  return commonFetchJSON<TUpdatedResource>(
+    getK8sResourceURL(model, resource, queryOptions),
+    applyOverrides(fetchOptions.requestInit, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+      },
+      body: JSON.stringify(resource),
+    }),
+    fetchOptions.timeout,
+    true,
+  );
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-1157

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
After discussions within the eng team, we decided not to go with the UX design and simply create some actions in the alert to allow the user to override the value and force update the workbench or abandon the value and refresh the page.

The PR does the following things:
1. Added a merge patch method to the k8s API so we can merge patch a resource
2. Create a new method called `mergePatchUpdateNotebook` to override the values in the workbench using merge-patch
3. Dry-run the current method `updateNotebook` (which will use `PUT` method instead of `PATCH`), if it generates a 409 conflict because the workbench is updated on the cluster, then prompt 2 actions to allow users to force update the workbench or refresh the page
<img width="1512" alt="Screenshot 2024-09-06 at 4 29 02 PM" src="https://github.com/user-attachments/assets/605c7ed4-f55c-4152-8733-d5e699d96a86">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a workbench
2. Open the workbench editing page (Tab 1)
3. Open a new browser tab (Tab 2)
4. Edit the workbench in Tab 2 and save
5. Get back to Tab 1 and click "Update" and you can see the error
6. Test the `Force update` and `Refresh` buttons, the first one will push all your changes in Tab 1 through and override the changes you made in Tab 2, and `Refresh` will refresh the whole page and fetch the latest notebook values

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Update some test cases

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
