### PR TITLE
Don't show tooltip on truncated text that isn't truncated

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -148,7 +148,7 @@ class ConnectionTypeRow extends TableRow {
   }
 
   shouldHaveDescription(description: string) {
-    return this.findConnectionTypeDescription().should('have.text', description);
+    return this.findConnectionTypeDescription().should('contain.text', description);
   }
 
   shouldHaveCreator(creator: string) {

--- a/frontend/src/components/TruncatedText.tsx
+++ b/frontend/src/components/TruncatedText.tsx
@@ -6,21 +6,47 @@ type TruncatedTextProps = {
   content: string;
 } & React.HTMLProps<HTMLSpanElement>;
 
-const TruncatedText: React.FC<TruncatedTextProps> = ({ maxLines, content, ...rest }) => (
-  <Tooltip content={content}>
+const TruncatedText: React.FC<TruncatedTextProps> = ({ maxLines, content, ...props }) => {
+  const outerElementRef = React.useRef<HTMLElement>(null);
+  const textElementRef = React.useRef<HTMLElement>(null);
+  const [isTruncated, setIsTruncated] = React.useState<boolean>(false);
+
+  const updateTruncation = React.useCallback(() => {
+    if (textElementRef.current && outerElementRef.current) {
+      setIsTruncated(textElementRef.current.offsetHeight > outerElementRef.current.offsetHeight);
+    }
+  }, []);
+
+  const truncateBody = (
     <span
+      {...props}
       style={{
         display: '-webkit-box',
-        overflow: 'hidden',
         WebkitBoxOrient: 'vertical',
-        WebkitLineClamp: maxLines,
         overflowWrap: 'anywhere',
+        overflow: 'hidden',
+        WebkitLineClamp: maxLines,
+        ...(props.style || {}),
       }}
-      {...rest}
+      ref={outerElementRef}
+      onMouseEnter={(e) => {
+        props.onMouseEnter?.(e);
+        updateTruncation();
+      }}
+      onFocus={(e) => {
+        props.onFocus?.(e);
+        updateTruncation();
+      }}
     >
-      {content}
+      <span ref={textElementRef}>{content}</span>
     </span>
-  </Tooltip>
-);
+  );
+
+  return (
+    <Tooltip hidden={!isTruncated ? true : undefined} content={content}>
+      {truncateBody}
+    </Tooltip>
+  );
+};
 
 export default TruncatedText;

--- a/frontend/src/components/table/TableRowTitleDescription.tsx
+++ b/frontend/src/components/table/TableRowTitleDescription.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Text } from '@patternfly/react-core';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import MarkdownView from '~/components/MarkdownView';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
@@ -29,7 +28,7 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
     descriptionNode = descriptionAsMarkdown ? (
       <MarkdownView conciseDisplay markdown={description} />
     ) : (
-      <Text
+      <span
         data-testid="table-row-title-description"
         style={{ color: 'var(--pf-v5-global--Color--200)' }}
       >
@@ -38,7 +37,7 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
         ) : (
           description
         )}
-      </Text>
+      </span>
     );
   }
 


### PR DESCRIPTION
Closes [RHOAIENG-12566](https://issues.redhat.com/browse/RHOAIENG-12566)

## Description
Determine if the text to be displayed will be truncated and if so wrap it with the tooltip otherwise just show the text.
Also fixes an issue causing a `validateDomNesting` issue for the Connection Types list page.

## How Has This Been Tested?
Tested Home page project cards, documentation cards, and connection type descriptions (in table and in preview pane).

## Test Impact
None, visual change only.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

