### PR TITLE
Swap the order of Model Registry and Model Serving in left navigation

### DIFF
--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -218,8 +218,8 @@ export const useBuildNavData = (): NavDataItem[] => [
   ...useDSProjectsNav(),
   ...useDSPipelinesNav(),
   ...useDistributedWorkloadsNav(),
-  ...useModelServingNav(),
   ...useModelRegistrySectionNav(),
+  ...useModelServingNav(),
   ...useResourcesNav(),
   ...useSettingsNav(),
 ];


### PR DESCRIPTION
Closes: [RHOAIENG-12253](https://issues.redhat.com/browse/RHOAIENG-12253)

## Description
This PR aims to show the Model Registry above the Model Serving in left navigation.
<img width="456" alt="Screenshot 2024-09-09 at 8 51 27 PM" src="https://github.com/user-attachments/assets/d838dd6f-0376-4ff1-943c-9caf661c6081">


## How Has This Been Tested?
1. Run `npm run start:dev:ext` in the frontend and see that the Model Registry is above the Model Serving.

## Test Impact
NA

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
