### PR TITLE
import act from react

### DIFF
--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import axios from '~/utilities/axios';
 import { mockPrometheusQueryVectorResponse } from '~/__mocks__/mockPrometheusQueryVectorResponse';
 import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';

--- a/frontend/src/api/prometheus/__tests__/pvcs.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/pvcs.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import axios from '~/utilities/axios';
 import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';

--- a/frontend/src/api/prometheus/__tests__/usePrometheusQuery.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/usePrometheusQuery.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import axios from '~/utilities/axios';
 import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';

--- a/frontend/src/api/prometheus/__tests__/usePrometheusQueryRange.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/usePrometheusQueryRange.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import axios from '~/utilities/axios';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockPrometheusServing } from '~/__mocks__/mockPrometheusServing';

--- a/frontend/src/app/__tests__/DevFeatureFlagsBanner.spec.tsx
+++ b/frontend/src/app/__tests__/DevFeatureFlagsBanner.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DevFeatureFlagsBanner from '~/app/DevFeatureFlagsBanner';
 

--- a/frontend/src/app/__tests__/useDevFeatureFlags.spec.ts
+++ b/frontend/src/app/__tests__/useDevFeatureFlags.spec.ts
@@ -1,5 +1,5 @@
 import { merge } from 'lodash-es';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import useDevFeatureFlags from '~/app/useDevFeatureFlags';

--- a/frontend/src/components/error/__tests__/ErrorBoundary.spec.tsx
+++ b/frontend/src/components/error/__tests__/ErrorBoundary.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { act } from 'react';
 import '@testing-library/jest-dom';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ErrorBoundary from '~/components/error/ErrorBoundary';
 
 class ChunkLoadError extends Error {

--- a/frontend/src/components/table/__tests__/useCheckboxTable.spec.ts
+++ b/frontend/src/components/table/__tests__/useCheckboxTable.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { useCheckboxTable } from '~/components/table';
 

--- a/frontend/src/concepts/areas/__tests__/useFetchDscStatus.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/useFetchDscStatus.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import axios from '~/utilities/axios';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';

--- a/frontend/src/concepts/areas/__tests__/useFetchDsciStatus.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/useFetchDsciStatus.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import axios from '~/utilities/axios';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockDsciStatus } from '~/__mocks__/mockDsciStatus';

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/BooleanFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/BooleanFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { BooleanField } from '~/concepts/connectionTypes/types';
 import BooleanFormField from '~/concepts/connectionTypes/fields/BooleanFormField';
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/DropdownFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/DropdownFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { DropdownField } from '~/concepts/connectionTypes/types';
 import DropdownFormField from '~/concepts/connectionTypes/fields/DropdownFormField';
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/FileFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/FileFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { FileField } from '~/concepts/connectionTypes/types';
 import FileFormField from '~/concepts/connectionTypes/fields/FileFormField';
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/HiddenFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/HiddenFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { HiddenField } from '~/concepts/connectionTypes/types';
 import HiddenFormField from '~/concepts/connectionTypes/fields/HiddenFormField';
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/NumericFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/NumericFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { NumericField } from '~/concepts/connectionTypes/types';
 import NumericFormField from '~/concepts/connectionTypes/fields/NumericFormField';
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/ShortTextFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/ShortTextFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { ShortTextField } from '~/concepts/connectionTypes/types';
 import ShortTextFormField from '~/concepts/connectionTypes/fields/ShortTextFormField';
 

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/TextFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/TextFormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { TextField } from '~/concepts/connectionTypes/types';
 import TextFormField from '~/concepts/connectionTypes/fields/TextFormField';
 

--- a/frontend/src/concepts/distributedWorkloads/__tests__/useClusterQueues.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/useClusterQueues.spec.ts
@@ -1,5 +1,5 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { mockClusterQueueK8sResource } from '~/__mocks__/mockClusterQueueK8sResource';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';

--- a/frontend/src/concepts/distributedWorkloads/__tests__/useLocalQueues.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/useLocalQueues.spec.ts
@@ -1,5 +1,5 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { mockLocalQueueK8sResource } from '~/__mocks__/mockLocalQueueK8sResource';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';

--- a/frontend/src/concepts/distributedWorkloads/__tests__/useWorkloads.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/useWorkloads.spec.ts
@@ -1,5 +1,5 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { mockWorkloadK8sResource } from '~/__mocks__/mockWorkloadK8sResource';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import useDistributedWorkloadsEnabled from '~/concepts/distributedWorkloads/useDistributedWorkloadsEnabled';

--- a/frontend/src/concepts/k8s/pods/__tests__/usePod.spec.ts
+++ b/frontend/src/concepts/k8s/pods/__tests__/usePod.spec.ts
@@ -1,5 +1,5 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { PodKind } from '~/k8sTypes';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import usePod from '~/concepts/k8s/pods/usePod';

--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
@@ -1,5 +1,6 @@
+import { act } from 'react';
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { act, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { useAccessReview, useRulesReview, listServices } from '~/api';
 import { ServiceKind } from '~/k8sTypes';
 import {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/__tests__/PipelineRunDrawerRightContent.spec.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-
 import { Drawer } from '@patternfly/react-core';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import PipelineRunDrawerRightContent from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightContent';
 import { PipelineTask } from '~/concepts/pipelines/topology';
 import { Artifact } from '~/third_party/mlmd';

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/ArtifactNodeDrawerContent.spec.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
+import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
-
 import { Drawer } from '@patternfly/react-core';
 import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { PipelineTask } from '~/concepts/pipelines/topology';
 import { Artifact, Value } from '~/third_party/mlmd';
 import { ArtifactNodeDrawerContent } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/ArtifactNodeDrawerContent';

--- a/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.ts
+++ b/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import usePipelineFilter, {
   FilterOptions,

--- a/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineTable.spec.ts
+++ b/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineTable.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import * as React from 'react';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import createUsePipelineTable from '~/concepts/pipelines/content/tables/usePipelineTable';

--- a/frontend/src/concepts/pipelines/elyra/__tests__/useElyraSecret.spec.ts
+++ b/frontend/src/concepts/pipelines/elyra/__tests__/useElyraSecret.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import useElyraSecret from '~/concepts/pipelines/elyra/useElyraSecret';

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { ConnectionTypeDataFieldModal } from '~/pages/connectionTypes/manage/ConnectionTypeDataFieldModal';
 import { ShortTextField, TextField } from '~/concepts/connectionTypes/types';
 

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { ConnectionTypeFieldType, DropdownField } from '~/concepts/connectionTypes/types';
 import DropdownAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm';
 

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/FileUploadAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/FileUploadAdvancedPropertiesForm.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { ConnectionTypeFieldType, FileField } from '~/concepts/connectionTypes/types';
 import FileUploadAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm';
 

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/NumericAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/NumericAdvancedPropertiesForm.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import NumericAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/NumericAdvancedPropertiesForm';
 import { ConnectionTypeFieldType, NumericField } from '~/concepts/connectionTypes/types';
 

--- a/frontend/src/pages/modelServing/__tests__/useInferenceServices.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useInferenceServices.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import useModelServingEnabled from '~/pages/modelServing/useModelServingEnabled';

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { render, act, fireEvent } from '@testing-library/react';
+import { act } from 'react';
+import { render, fireEvent } from '@testing-library/react';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import { mockProjectK8sResource } from '~/__mocks__/mockProjectK8sResource';
 import useServingRuntimes from '~/pages/modelServing/useServingRuntimes';

--- a/frontend/src/pages/notebookController/screens/server/__tests__/useAcceleratorProfiles.spec.ts
+++ b/frontend/src/pages/notebookController/screens/server/__tests__/useAcceleratorProfiles.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactDetails.spec.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactDetails.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { Artifact } from '~/third_party/mlmd';
 import { artifactsBaseRoute } from '~/routes';
 import { ArtifactDetails } from '~/pages/pipelines/global/experiments/artifacts/ArtifactDetails';

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactsTable.spec.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/__tests__/ArtifactsTable.spec.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { Artifact } from '~/third_party/mlmd';
 import * as useGetArtifactsList from '~/concepts/pipelines/apiHooks/mlmd/useGetArtifactsList';
 import * as MlmdListContext from '~/concepts/pipelines/context/MlmdListContext';

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/useProjectPvcs.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/useProjectPvcs.spec.ts
@@ -1,5 +1,5 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { PVCModel } from '~/api';

--- a/frontend/src/pages/projects/screens/spawner/__tests__/useImageStreams.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/useImageStreams.spec.ts
@@ -1,5 +1,5 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { mockImageStreamK8sResource } from '~/__mocks__/mockImageStreamK8sResource';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 import { ImageStreamKind } from '~/k8sTypes';

--- a/frontend/src/utilities/__tests__/useDetectUser.spec.ts
+++ b/frontend/src/utilities/__tests__/useDetectUser.spec.ts
@@ -1,4 +1,5 @@
-import { act, waitFor, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { waitFor, renderHook } from '@testing-library/react';
 import axios from '~/utilities/axios';
 import { StatusResponse } from '~/redux/types';
 import { useAppDispatch } from '~/redux/hooks';

--- a/frontend/src/utilities/__tests__/useDraggableTable.spec.ts
+++ b/frontend/src/utilities/__tests__/useDraggableTable.spec.ts
@@ -1,5 +1,5 @@
-import React from 'react';
-import { act } from '@testing-library/react';
+import * as React from 'react';
+import { act } from 'react';
 import useDraggableTable from '~/utilities/useDraggableTable';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 

--- a/frontend/src/utilities/__tests__/useFetchState.spec.ts
+++ b/frontend/src/utilities/__tests__/useFetchState.spec.ts
@@ -1,4 +1,5 @@
-import { act, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { waitFor } from '@testing-library/react';
 import useFetchState, { FetchState } from '~/utilities/useFetchState';
 import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
 

--- a/frontend/src/utilities/__tests__/useWatchGroups.spec.tsx
+++ b/frontend/src/utilities/__tests__/useWatchGroups.spec.tsx
@@ -1,4 +1,4 @@
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { GroupsConfig } from '~/pages/groupSettings/groupTypes';
 import { fetchGroupsSettings, updateGroupsSettings } from '~/services/groupSettingsService';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12665

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Warnings are console logged for any import of `act` that isn't coming from `react.

This PR updates all imports of `act` to be from `react`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test:jest`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
