### PR TITLE
Update mlmd and pipelines service to use constructUrl for URL generation

### DIFF
--- a/backend/src/routes/api/service/mlmd/index.ts
+++ b/backend/src/routes/api/service/mlmd/index.ts
@@ -9,8 +9,7 @@ export default proxyService<DSPipelineKind>(
     plural: 'datasciencepipelinesapplications',
   },
   {
-    port: 8443,
-    prefix: 'ds-pipeline-md-',
+    constructUrl: (resource) => resource.status.components.mlmdProxy.url,
   },
   {
     // Use port forwarding for local development:

--- a/backend/src/routes/api/service/mlmd/index.ts
+++ b/backend/src/routes/api/service/mlmd/index.ts
@@ -9,7 +9,7 @@ export default proxyService<DSPipelineKind>(
     plural: 'datasciencepipelinesapplications',
   },
   {
-    constructUrl: (resource) => resource.status.components.mlmdProxy.url,
+    constructUrl: (resource) => resource.status?.components.mlmdProxy.url,
   },
   {
     // Use port forwarding for local development:

--- a/backend/src/routes/api/service/pipelines/index.ts
+++ b/backend/src/routes/api/service/pipelines/index.ts
@@ -9,7 +9,7 @@ export default proxyService<DSPipelineKind>(
     plural: 'datasciencepipelinesapplications',
   },
   {
-    constructUrl: (resource) => resource.status.components.apiServer.url,
+    constructUrl: (resource) => resource.status?.components.apiServer.url,
   },
   {
     // Use port forwarding for local development:

--- a/backend/src/routes/api/service/pipelines/index.ts
+++ b/backend/src/routes/api/service/pipelines/index.ts
@@ -9,8 +9,7 @@ export default proxyService<DSPipelineKind>(
     plural: 'datasciencepipelinesapplications',
   },
   {
-    port: 8443,
-    prefix: 'ds-pipeline-',
+    constructUrl: (resource) => resource.status.components.apiServer.url,
   },
   {
     // Use port forwarding for local development:

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1145,6 +1145,16 @@ export type DSPipelineKind = K8sResourceCommon & {
   };
   status?: {
     conditions?: K8sCondition[];
+    components: {
+      apiServer: {
+        externalUrl: string;
+        url: string;
+      };
+      mlmdProxy: {
+        externalUrl: string;
+        url: string;
+      };
+    };
   };
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12000

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds a constructUrl option that can be used instead of manually entering service info for backend proxy helper
uses this for mlmd and pipelines

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make sure a pipelines server and mlmd server can fetch data
create a new pipeline server and verify backend is not crashing

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none backend 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
