### PR TITLE
update fastify maxParamLength to 253 for support max k8s names

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,8 @@ const transport =
     : undefined;
 
 const app = fastify({
+  // set to kubernetes max name length
+  maxParamLength: 253,
   logger: pino(
     {
       level: LOG_LEVEL,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12443

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

fastify default `maxParamLength` is 100.
Some of our URLs contain k8s resource names and since a k8s resource name can be up to 253 characters, we get invalid routes:

![image](https://github.com/user-attachments/assets/0e92d92e-2694-41da-9d38-dc36cd508564)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a connection type with a name longer than 100 characters
Attempt to edit the connection type.

Same thing can be tested with accelerator profiles.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
