### PR TITLE
Make accelorators field not required on workbench spawner page and model deployment modals

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -187,7 +187,6 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
               </Popover>
             ) : undefined
           }
-          isRequired
         >
           <SimpleSelect
             isFullWidth
@@ -235,7 +234,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
       )}
       {selectedAcceleratorProfile.profile && (
         <StackItem>
-          <FormGroup label="Number of accelerators" fieldId="number-of-accelerators" isRequired>
+          <FormGroup label="Number of accelerators" fieldId="number-of-accelerators">
             <InputGroup>
               <NumberInput
                 inputAriaLabel="Number of accelerators"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-12694

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Revert the changes made in https://github.com/opendatahub-io/odh-dashboard/pull/3102/files#diff-47693ad1cdd3bf50cbf06a60b941d5af0c9b0478f43311f7eca3e4f7d7972df8 to make the accelerator field non-required as discussed in https://redhat-internal.slack.com/archives/C07CQ4R4HMY/p1725973980856419?thread_ts=1725972888.178819&cid=C07CQ4R4HMY

<img width="839" alt="Screenshot 2024-09-10 at 12 47 07 PM" src="https://github.com/user-attachments/assets/aaa20c91-1083-4908-96e8-2f44022265d4">

<img width="1511" alt="Screenshot 2024-09-10 at 12 47 41 PM" src="https://github.com/user-attachments/assets/834a9ed6-e69c-47ef-b337-49f2db41e5e7">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verify both the workbench spawner page and model deployment modals, the accelerator field should not be required now.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, one-liner fix on UX, not sure if it is worth the effort to detect the `*` symbol exists...

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
