### PR TITLE
[RHOAIENG-1108] Edit for Storage Class Table Row

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -2,6 +2,7 @@ import type { MockStorageClass } from '~/__mocks__';
 import { mockStorageClassList } from '~/__mocks__';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+import { Modal } from './components/Modal';
 
 class StorageClassesPage {
   visit() {
@@ -73,5 +74,60 @@ class StorageClassesTable {
   }
 }
 
+class StorageClassEditModal extends Modal {
+  constructor() {
+    super('Edit storage class details');
+  }
+
+  find() {
+    return cy.findByTestId('edit-sc-modal').parents('div[role="dialog"]');
+  }
+
+  findOpenshiftScName() {
+    return this.find().findByTestId('edit-sc-openshift-class-name');
+  }
+
+  findOpenshiftDefaultLabel() {
+    return this.findOpenshiftScName().findByTestId('openshift-sc-default-label');
+  }
+
+  findProvisioner() {
+    return this.find().findByTestId('edit-sc-provisioner');
+  }
+
+  findDisplayNameInput() {
+    return this.find().findByTestId('edit-sc-display-name');
+  }
+
+  fillDisplayNameInput(value: string) {
+    this.findDisplayNameInput().clear().fill(value);
+  }
+
+  findDescriptionInput() {
+    return this.find().findByTestId('edit-sc-description');
+  }
+
+  fillDescriptionInput(value: string) {
+    this.findDescriptionInput().clear().fill(value);
+  }
+
+  findCloseButton() {
+    return this.findFooter().findByTestId('modal-cancel-button');
+  }
+
+  findSaveButton() {
+    return this.findFooter().findByTestId('modal-submit-button');
+  }
+
+  mockUpdateStorageClass(storageClassName: string, times?: number) {
+    return cy.interceptOdh(
+      `PUT /api/storage-class/:name/config`,
+      { path: { name: storageClassName }, times },
+      { success: true, error: '' },
+    );
+  }
+}
+
 export const storageClassesPage = new StorageClassesPage();
 export const storageClassesTable = new StorageClassesTable();
+export const storageClassEditModal = new StorageClassEditModal();

--- a/frontend/src/pages/storageClasses/OpenshiftDefaultLabel.tsx
+++ b/frontend/src/pages/storageClasses/OpenshiftDefaultLabel.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Label, Tooltip } from '@patternfly/react-core';
+
+export const OpenshiftDefaultLabel: React.FC = () => (
+  <Tooltip content="This is the default storage class in OpenShift.">
+    <Label color="green" isCompact data-testid="openshift-sc-default-label">
+      Default
+    </Label>
+  </Tooltip>
+);

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+
+import {
+  Modal,
+  ModalVariant,
+  Form,
+  FormGroup,
+  TextInput,
+  Alert,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  TextArea,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+
+import { StorageClassKind } from '~/k8sTypes';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import { getStorageClassConfig, isOpenshiftDefaultStorageClass } from './utils';
+import { OpenshiftDefaultLabel } from './OpenshiftDefaultLabel';
+
+interface StorageClassEditModalProps {
+  storageClass: StorageClassKind;
+  onSuccess: () => Promise<StorageClassKind[] | void>;
+  onClose: () => void;
+}
+
+export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
+  storageClass,
+  onSuccess,
+  onClose,
+}) => {
+  const { name: storageClassName } = storageClass.metadata;
+  const storageClassConfig = getStorageClassConfig(storageClass);
+  const [displayName, setDisplayName] = React.useState(storageClassConfig?.displayName ?? '');
+  const [description, setDescription] = React.useState(storageClassConfig?.description ?? '');
+  const [updateError, setUpdateError] = React.useState<Error>();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const onSave = async () => {
+    setIsSubmitting(true);
+
+    try {
+      await updateStorageClassConfig(storageClassName, { displayName, description });
+      await onSuccess();
+      onClose();
+    } catch (error) {
+      if (error instanceof Error) {
+        setUpdateError(error);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen
+      variant={ModalVariant.small}
+      title="Edit storage class details"
+      onClose={onClose}
+      footer={
+        <DashboardModalFooter
+          onCancel={onClose}
+          onSubmit={onSave}
+          submitLabel="Save"
+          isSubmitLoading={isSubmitting}
+          isSubmitDisabled={!displayName || isSubmitting}
+          error={updateError}
+          alertTitle="Error updating storage class"
+        />
+      }
+      data-testid="edit-sc-modal"
+    >
+      <Alert
+        isInline
+        variant="info"
+        title="Editing these details will not affect the storage class in OpenShift."
+        className="pf-v5-u-mb-lg"
+      />
+
+      <Form id="edit-sc-form">
+        <DescriptionList>
+          <DescriptionListGroup>
+            <DescriptionListTerm>OpenShift storage class</DescriptionListTerm>
+            <DescriptionListDescription data-testid="edit-sc-openshift-class-name">
+              <Flex
+                spaceItems={{ default: 'spaceItemsSm' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+              >
+                <FlexItem>{storageClassName}</FlexItem>
+                {isOpenshiftDefaultStorageClass(storageClass) && <OpenshiftDefaultLabel />}
+              </Flex>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          <DescriptionListGroup>
+            <DescriptionListTerm>Provisioner</DescriptionListTerm>
+            <DescriptionListDescription data-testid="edit-sc-provisioner">
+              {storageClass.provisioner}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+
+        <FormGroup label="Display name" isRequired fieldId="edit-sc-display-name">
+          <TextInput
+            isRequired
+            value={displayName}
+            onChange={(_, value) => setDisplayName(value)}
+            id="edit-sc-display-name"
+            data-testid="edit-sc-display-name"
+          />
+        </FormGroup>
+
+        <FormGroup label="Description" fieldId="edit-sc-description">
+          <TextArea
+            value={description}
+            onChange={(_, value) => setDescription(value)}
+            resizeOrientation="vertical"
+            autoResize
+            id="edit-sc-description"
+            data-testid="edit-sc-description"
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -8,11 +8,9 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   DescriptionListDescription,
-  Tooltip,
-  Label,
   Timestamp,
 } from '@patternfly/react-core';
-import { Tr, Td, ActionsColumn } from '@patternfly/react-table';
+import { Tr, Td, ActionsColumn, TableText } from '@patternfly/react-table';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
@@ -25,6 +23,8 @@ import { ColumnLabel } from './constants';
 import { isOpenshiftDefaultStorageClass } from './utils';
 import { StorageClassEnableSwitch } from './StorageClassEnableSwitch';
 import { StorageClassDefaultRadio } from './StorageClassDefaultRadio';
+import { StorageClassEditModal } from './StorageClassEditModal';
+import { OpenshiftDefaultLabel } from './OpenshiftDefaultLabel';
 
 interface StorageClassesTableRowProps {
   storageClass: StorageClassKind;
@@ -37,6 +37,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
   storageClassConfigMap,
   refresh,
 }) => {
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
   const storageClassConfig = storageClassConfigMap[storageClass.metadata.name];
   const isOpenshiftDefault = isOpenshiftDefaultStorageClass(storageClass);
   const { metadata, provisioner, reclaimPolicy, volumeBindingMode, allowVolumeExpansion } =
@@ -108,7 +109,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
     <Tr>
       <Td dataLabel={ColumnLabel.DisplayName}>
         <TableRowTitleDescription
-          title={storageClassConfig?.displayName}
+          title={<TableText wrapModifier="truncate">{storageClassConfig?.displayName}</TableText>}
           description={storageClassConfig?.description}
         />
       </Td>
@@ -143,11 +144,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
 
           {isOpenshiftDefault && (
             <FlexItem>
-              <Tooltip content="This is the default storage class in OpenShift.">
-                <Label color="green" isCompact data-testid="openshift-sc-default-label">
-                  Default
-                </Label>
-              </Tooltip>
+              <OpenshiftDefaultLabel />
             </FlexItem>
           )}
         </Flex>
@@ -183,12 +180,20 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
         <ActionsColumn
           items={[
             {
-              // TODO, https://issues.redhat.com/browse/RHOAIENG-1108
               title: 'Edit',
+              onClick: () => setIsEditModalOpen(true),
             },
           ]}
         />
       </Td>
+
+      {isEditModalOpen && (
+        <StorageClassEditModal
+          storageClass={storageClass}
+          onSuccess={refresh}
+          onClose={() => setIsEditModalOpen(false)}
+        />
+      )}
     </Tr>
   );
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-1108

## Description
Edit modal accessed from row actions for the storage class table

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/749831c6-9293-4cb2-b3c3-703de55b87b8">

**Demo**
https://github.com/user-attachments/assets/5da9dc1f-c141-4bce-9f65-d938c154b435

(cc @xianli123)

## How Has This Been Tested?
1. Run the dev environment via the root directory of the project (npm run dev) and navigating to `/storageClasses?devFeatureFlags=disableStorageClasses` should lead to the storage classes table
2. For 1 or many rows, access row actions from the last column value menu, select "Edit", verify the modal matches the design, verify you cannot submit the modal without a display name
3. Edit the display name & description and submit. Verify the table data is updated with the new name and description

## Test Impact
Added cypress test

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
