### PR TITLE
[WIP] RHOAIENG-1109 Select Storage Classes in add cluster storage sections

### DIFF
--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -17,11 +17,11 @@ export const assemblePvc = (
   data: CreatingStorageObject,
   namespace: string,
   editName?: string,
-  storageClassName?: string,
 ): PersistentVolumeClaimKind => {
   const {
     nameDesc: { name: pvcName, description },
     size,
+    storageClassName,
   } = data;
 
   const name = editName || translateDisplayNameForK8s(pvcName);
@@ -68,10 +68,9 @@ export const getDashboardPvcs = (projectName: string): Promise<PersistentVolumeC
 export const createPvc = (
   data: CreatingStorageObject,
   namespace: string,
-  storageClassName?: string,
   opts?: K8sAPIOptions,
 ): Promise<PersistentVolumeClaimKind> => {
-  const pvc = assemblePvc(data, namespace, undefined, storageClassName);
+  const pvc = assemblePvc(data, namespace, undefined);
 
   return k8sCreateResource<PersistentVolumeClaimKind>(
     applyK8sAPIOptions({ model: PVCModel, resource: pvc }, opts),

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -242,11 +242,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
         ? [dataConnection.existing]
         : [];
 
-    const pvcDetails = await createPvcDataForNotebook(
-      projectName,
-      storageData,
-      storageClass?.metadata.name,
-    ).catch(handleError);
+    const pvcDetails = await createPvcDataForNotebook(projectName, storageData).catch(handleError);
     const envFrom = await createConfigMapsAndSecretsForNotebook(projectName, [
       ...envVariables,
       ...newDataConnection,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -45,6 +45,7 @@ import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVa
 import DataConnectionField from './dataConnection/DataConnectionField';
 import { useNotebookDataConnection } from './dataConnection/useNotebookDataConnection';
 import { useNotebookSizeState } from './useNotebookSizeState';
+import useDefaultStorageClass from './storage/useDefaultStorageClass';
 
 type SpawnerPageProps = {
   existingNotebook?: NotebookKind;
@@ -68,7 +69,14 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     string[] | undefined
   >();
   const [storageDataWithoutDefault, setStorageData] = useStorageDataObject(existingNotebook);
-  const storageData = useMergeDefaultPVCName(storageDataWithoutDefault, nameDesc.name);
+
+  const defaultStorageClass = useDefaultStorageClass();
+  const storageData = useMergeDefaultPVCName(
+    storageDataWithoutDefault,
+    nameDesc.name,
+    defaultStorageClass?.metadata.name,
+  );
+
   const [envVariables, setEnvVariables] = useNotebookEnvVariables(existingNotebook);
   const [dataConnectionData, setDataConnectionData] = useNotebookDataConnection(
     dataConnections.data,

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -30,14 +30,13 @@ import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnv
 export const createPvcDataForNotebook = async (
   projectName: string,
   storageData: StorageData,
-  storageClassName?: string,
 ): Promise<{ volumes: Volume[]; volumeMounts: VolumeMount[] }> => {
   const { storageType } = storageData;
 
   const { volumes, volumeMounts } = getVolumesByStorageData(storageData);
 
   if (storageType === StorageType.NEW_PVC) {
-    const pvc = await createPvc(storageData.creating, projectName, storageClassName);
+    const pvc = await createPvc(storageData.creating, projectName);
     const newPvcName = pvc.metadata.name;
     volumes.push({ name: newPvcName, persistentVolumeClaim: { claimName: newPvcName } });
     volumeMounts.push({ mountPath: ROOT_MOUNT_PATH, name: newPvcName });
@@ -70,7 +69,7 @@ export const replaceRootVolumesForNotebook = async (
     };
     replacedVolumeMount = { name: existingName, mountPath: ROOT_MOUNT_PATH };
   } else {
-    const pvc = await createPvc(storageData.creating, projectName, storageClassName, { dryRun });
+    const pvc = await createPvc(storageData.creating, projectName, { dryRun });
     const newPvcName = pvc.metadata.name;
     replacedVolume = { name: newPvcName, persistentVolumeClaim: { claimName: newPvcName } };
     replacedVolumeMount = { mountPath: ROOT_MOUNT_PATH, name: newPvcName };

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -32,6 +32,7 @@ import { FAILED_PHASES, PENDING_PHASES, IMAGE_ANNOTATIONS } from './const';
 export const useMergeDefaultPVCName = (
   storageData: StorageData,
   defaultPVCName: string,
+  defaultStorageClassName?: string,
 ): StorageData => {
   const modifiedRef = React.useRef(false);
 
@@ -48,6 +49,7 @@ export const useMergeDefaultPVCName = (
         ...storageData.creating.nameDesc,
         name: storageData.creating.nameDesc.name || defaultPVCName,
       },
+      storageClassName: defaultStorageClassName ?? '',
     },
   };
 };

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { FormGroup, Stack, StackItem } from '@patternfly/react-core';
 import { CreatingStorageObject, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import PVSizeField from '~/pages/projects/components/PVSizeField';
 import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
+import SimpleSelect from '~/components/SimpleSelect';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
+import { getStorageClassConfig } from '~/pages/storageClasses/utils';
 
 type CreateNewStorageSectionProps = {
   data: CreatingStorageObject;
@@ -10,6 +13,7 @@ type CreateNewStorageSectionProps = {
   currentSize?: string;
   autoFocusName?: boolean;
   menuAppendTo?: HTMLElement;
+  isEdit?: boolean;
 };
 
 const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
@@ -18,27 +22,52 @@ const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
   currentSize,
   menuAppendTo,
   autoFocusName,
-}) => (
-  <Stack hasGutter>
-    <StackItem>
-      <NameDescriptionField
-        nameFieldId="create-new-storage-name"
-        descriptionFieldId="create-new-storage-description"
-        data={data.nameDesc}
-        setData={(newData) => setData('nameDesc', newData)}
-        autoFocusName={autoFocusName}
-      />
-    </StackItem>
-    <StackItem>
-      <PVSizeField
-        menuAppendTo={menuAppendTo}
-        fieldID="create-new-storage-size"
-        currentSize={currentSize}
-        size={data.size}
-        setSize={(size) => setData('size', size)}
-      />
-    </StackItem>
-  </Stack>
-);
+  isEdit,
+}) => {
+  const [storageClasses, storageClassesLoaded] = useStorageClasses();
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <NameDescriptionField
+          nameFieldId="create-new-storage-name"
+          descriptionFieldId="create-new-storage-description"
+          data={data.nameDesc}
+          setData={(newData) => setData('nameDesc', newData)}
+          autoFocusName={autoFocusName}
+        />
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Storage class" fieldId="storage-class" isRequired>
+          <SimpleSelect
+            id="storage-classes-selector"
+            isFullWidth
+            value={data.storageClassName}
+            options={storageClasses.map((sc) => {
+              const { name } = sc.metadata;
+              const desc = getStorageClassConfig(sc)?.description;
+              return { key: name, label: name, description: desc };
+            })}
+            onChange={(selection) => {
+              setData('storageClassName', selection);
+            }}
+            isDisabled={isEdit || !storageClassesLoaded}
+            placeholder={isEdit && !storageClassesLoaded ? data.storageClassName : 'Select one'}
+            popperProps={{ appendTo: menuAppendTo }}
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <PVSizeField
+          menuAppendTo={menuAppendTo}
+          fieldID="create-new-storage-size"
+          currentSize={currentSize}
+          size={data.size}
+          setSize={(size) => setData('size', size)}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
 
 export default CreateNewStorageSection;

--- a/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
+import { StorageClassKind } from '~/k8sTypes';
+import {
+  getStorageClassConfig,
+  isOpenshiftDefaultStorageClass,
+} from '~/pages/storageClasses/utils';
+
+const useDefaultStorageClass = (): StorageClassKind | undefined => {
+  const [storageClasses, storageClassesLoaded] = useStorageClasses();
+  const [defaultStorageClass, setDefaultStorageClass] = React.useState<
+    StorageClassKind | undefined
+  >();
+
+  React.useEffect(() => {
+    if (!storageClassesLoaded) {
+      return;
+    }
+
+    const defaultSc = storageClasses.find(
+      (sc) => isOpenshiftDefaultStorageClass(sc) || getStorageClassConfig(sc)?.isDefault,
+    );
+    setDefaultStorageClass(defaultSc);
+  }, [storageClasses, storageClassesLoaded]);
+
+  return defaultStorageClass;
+};
+
+export default useDefaultStorageClass;

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -26,6 +26,7 @@ export type NameDescType = {
 export type CreatingStorageObject = {
   nameDesc: NameDescType;
   size: string;
+  storageClassName?: string;
 };
 
 export type MountPath = {

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -16,3 +16,12 @@ export const getStorageClassConfig = (
 
 export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>
   storageClass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
+
+export const getDefaultStorageClass = (
+  storageClasses: StorageClassKind[],
+): StorageClassKind | undefined =>
+  storageClasses.find(
+    (storageClass) =>
+      isOpenshiftDefaultStorageClass(storageClass) ||
+      getStorageClassConfig(storageClass)?.isDefault,
+  );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-1109](https://issues.redhat.com/browse/RHOAIENG-1109)

## Description
Added new field to select storage class to create pvc.

Available inside workbenches when creating new cluster storage.
![Screenshot 2024-09-10 at 6 32 47 PM](https://github.com/user-attachments/assets/d32a7381-5e50-466f-894e-1269913ac046)

When editing cluster storage storage class field will be disabled. 
![Screenshot 2024-09-10 at 6 22 39 PM](https://github.com/user-attachments/assets/d54ade49-c533-465a-b648-1879d88ad093)

Default will be selected initially.
![Screenshot 2024-09-10 at 6 22 20 PM](https://github.com/user-attachments/assets/5c8cb42e-1fb0-4013-ae16-cfa4b5a89078)

## How Has This Been Tested?
Create a new cluster storage and you check list of storage classes in the field.
Create new workbench and select storage class in cluster storage.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@xianli123 