### PR TITLE
fix(5463): fix axe issue in model version detail

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -85,7 +85,11 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
           >
             <InlineTruncatedClipboardCopy testId="model-version-id" textToCopy={mv.id} />
           </DashboardDescriptionListGroup>
-          <Title headingLevel={TextVariants.h3}>Model location</Title>
+        </DescriptionList>
+        <Title style={{ marginTop: '1em' }} headingLevel={TextVariants.h3}>
+          Model location
+        </Title>
+        <DescriptionList isFillColumns>
           {storageFields && (
             <>
               <DashboardDescriptionListGroup


### PR DESCRIPTION
This section will be looked at again by UX for style post MVP according to this comment by Haley: https://github.com/opendatahub-io/odh-dashboard/pull/3139#issuecomment-2327882720

For now, fixing an issue that was introduced in https://github.com/opendatahub-io/odh-dashboard/pull/3139 which results in an a11y warning. The a11y issue was due to a non datalist element as a child of a datalist. To fix this, I split up the datalist into two and put the heading in between. Had to add some space that was lost after pulling the heading out of the datalist, but this should be temporary with some refresh post-MVP.

## Test Impact
no difference, just a small DOM change.

## Request review criteria:
make sure everything looks good and AXE doesn't complain about header being in DL

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
