### PR TITLE
change description format within tables

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/experiments.ts
@@ -91,6 +91,10 @@ class ExperimentsRow extends TableRow {
     return this.find().find(`[data-label=Checkbox]`).find('input');
   }
 
+  findDescription() {
+    return this.find().findByTestId('table-row-title-description');
+  }
+
   findExperimentCreatedTime() {
     return this.find().find(`[data-label="Created"]`);
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
@@ -39,6 +39,7 @@ const mockExperiments = [
   buildMockExperimentKF({
     display_name: 'Test experiment 1',
     experiment_id: '1',
+    description: 'Test experiment 1',
     last_run_created_at: currentTime.toISOString(),
   }),
   buildMockExperimentKF({
@@ -86,6 +87,10 @@ describe('Experiments', () => {
     it('experiments table time', () => {
       experimentsTabs.findActiveTab().click();
       const activeExperimentsTable = experimentsTabs.getActiveExperimentsTable();
+      activeExperimentsTable
+        .getRowByName('Test experiment 1')
+        .findDescription()
+        .should('have.text', 'Test experiment 1');
       activeExperimentsTable
         .getRowByName('Test experiment 1')
         .findExperimentLastRunTime()

--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -65,26 +65,25 @@ export const experimentColumns: SortableData<ExperimentKFv2>[] = [
     label: 'Experiment',
     field: 'display_name',
     sortable: true,
-  },
-  {
-    label: 'Description',
-    field: 'description',
-    sortable: true,
+    width: 40,
   },
   {
     label: 'Created',
     field: 'created_at',
     sortable: true,
+    width: 20,
   },
   {
     label: 'Last run started',
     field: 'last_run_created_at',
     sortable: true,
+    width: 20,
   },
   {
     label: 'Last 5 runs',
     field: 'last_5_runs',
     sortable: false,
+    width: 20,
   },
   kebabTableColumn(),
 ];

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import { Truncate } from '@patternfly/react-core';
 import { ExperimentKFv2, StorageStateKF } from '~/concepts/pipelines/kfTypes';
-import { CheckboxTd } from '~/components/table';
+import { CheckboxTd, TableRowTitleDescription } from '~/components/table';
 import { experimentArchivedRunsRoute, experimentRunsRoute } from '~/routes';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { ExperimentCreated, LastExperimentRuns, LastExperimentRunsStarted } from './renderUtils';
@@ -29,19 +29,25 @@ const ExperimentTableRow: React.FC<ExperimentTableRowProps> = ({
     <Tr>
       <CheckboxTd id={experiment.experiment_id} isChecked={isChecked} onToggle={onToggleCheck} />
       <Td dataLabel="Experiment">
-        <Link
-          to={
-            isArchived
-              ? experimentArchivedRunsRoute(namespace, experiment.experiment_id)
-              : experimentRunsRoute(namespace, experiment.experiment_id)
+        <TableRowTitleDescription
+          title={
+            <Link
+              to={
+                isArchived
+                  ? experimentArchivedRunsRoute(namespace, experiment.experiment_id)
+                  : experimentRunsRoute(namespace, experiment.experiment_id)
+              }
+              state={{ experiment }}
+            >
+              {/* TODO: Remove the custom className after upgrading to PFv6 */}
+              <Truncate content={experiment.display_name} className="truncate-no-min-width" />
+            </Link>
           }
-          state={{ experiment }}
-        >
-          {/* TODO: Remove the custom className after upgrading to PFv6 */}
-          <Truncate content={experiment.display_name} className="truncate-no-min-width" />
-        </Link>
+          description={experiment.description}
+          truncateDescriptionLines={2}
+        />
       </Td>
-      <Td dataLabel="Description">{experiment.description}</Td>
+
       <Td dataLabel="Created">
         <ExperimentCreated experiment={experiment} />
       </Td>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-11499

## Description
Removed the separate description column and  have the description underneath the resource name for the experiments table. and archive experiment table

<img width="1355" alt="Screenshot 2024-09-11 at 10 54 50 AM" src="https://github.com/user-attachments/assets/22743589-ad9d-4c59-b817-508f1c3f1568">

<img width="1355" alt="Screenshot 2024-09-11 at 10 54 30 AM" src="https://github.com/user-attachments/assets/21768793-a978-42f9-bf6e-e9f6546ea029">

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Go to the experiment Page 
2. Check whether the description column is not present
3. check whether the description is present underneath the resource name and gets truncated when > 2 lines

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added cypress test
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
