### PR TITLE
fix(12787): fix 20 qty limit on registered models

### DIFF
--- a/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
+++ b/frontend/src/api/modelRegistry/__tests__/custom.spec.ts
@@ -279,7 +279,7 @@ describe('getListRegisteredModels', () => {
     expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
       'hostPath',
-      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models`,
+      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models?pageSize=99999`,
       {},
       K8sAPIOptionsMock,
     );
@@ -294,7 +294,7 @@ describe('getListModelArtifacts', () => {
     expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
       'hostPath',
-      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_artifacts`,
+      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_artifacts?pageSize=99999`,
       {},
       K8sAPIOptionsMock,
     );
@@ -309,7 +309,7 @@ describe('getListModelVersions', () => {
     expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
       'hostPath',
-      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions`,
+      `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions?pageSize=99999`,
       {},
       K8sAPIOptionsMock,
     );

--- a/frontend/src/api/modelRegistry/custom.ts
+++ b/frontend/src/api/modelRegistry/custom.ts
@@ -122,37 +122,40 @@ export const getModelArtifact =
       ),
     );
 
+// TODO: the pageSize value here is temporary until we implement filter/sort on serverside, https://issues.redhat.com/browse/RHOAIENG-12800
 export const getListModelArtifacts =
   (hostpath: string) =>
   (opts: K8sAPIOptions): Promise<ModelArtifactList> =>
     handleModelRegistryFailures(
       proxyGET(
         hostpath,
-        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_artifacts`,
+        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_artifacts?pageSize=99999`,
         {},
         opts,
       ),
     );
 
+// TODO: the pageSize value here is temporary until we implement filter/sort on serverside, https://issues.redhat.com/browse/RHOAIENG-12800
 export const getListModelVersions =
   (hostpath: string) =>
   (opts: K8sAPIOptions): Promise<ModelVersionList> =>
     handleModelRegistryFailures(
       proxyGET(
         hostpath,
-        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions`,
+        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/model_versions?pageSize=99999`,
         {},
         opts,
       ),
     );
 
+// TODO: the pageSize value here is temporary until we implement filter/sort on serverside, https://issues.redhat.com/browse/RHOAIENG-12800
 export const getListRegisteredModels =
   (hostpath: string) =>
   (opts: K8sAPIOptions): Promise<RegisteredModelList> =>
     handleModelRegistryFailures(
       proxyGET(
         hostpath,
-        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models`,
+        `/api/model_registry/${MODEL_REGISTRY_API_VERSION}/registered_models?pageSize=99999`,
         {},
         opts,
       ),


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/RHOAIENG-12787

showing with 26 total.

live
![image](https://github.com/user-attachments/assets/e7910b59-d456-49b1-bb40-9dab10fff0b1)
archived
![image](https://github.com/user-attachments/assets/6cbd1548-2e08-44ab-87d4-bd4dac6837b8)


## Description
changed model registry list limit (via API call) to 99999 as the default was 20 and when we reached 20 we would not see any new model registries. there is a spike to followup by implementing server side filter/sort/pagination https://issues.redhat.com/browse/RHOAIENG-12800

## How Has This Been Tested?
tested locally by adding more than 20 (combo of live and archived) model registries and making sure they are still visible and behavior properly in the table.

## Test Impact
updated a test to make sure that the pageSize is included in the call. can't really test beyond that as we mock the data that comes as a response.

## Request review criteria:
see more than 20 registered models in the table

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
