### PR TITLE
[RHOAIENG-11010] Use a more secure role for KServe InferenceService access

### DIFF
--- a/backend/src/plugins/kube.ts
+++ b/backend/src/plugins/kube.ts
@@ -88,6 +88,8 @@ export default fp(async (fastify: FastifyInstance) => {
         }`,
       ),
     );
+
+    // TODO call new cleanup fn
   }
 });
 

--- a/backend/src/plugins/kube.ts
+++ b/backend/src/plugins/kube.ts
@@ -5,7 +5,11 @@ import * as jsYaml from 'js-yaml';
 import * as k8s from '@kubernetes/client-node';
 import { errorHandler, isKubeFastifyInstance } from '../utils';
 import { DEV_MODE } from '../utils/constants';
-import { cleanupGPU, initializeWatchedResources } from '../utils/resourceUtils';
+import {
+  cleanupGPU,
+  cleanupKserveRoleBindings,
+  initializeWatchedResources,
+} from '../utils/resourceUtils';
 
 const CONSOLE_CONFIG_YAML_FIELD = 'console-config.yaml';
 
@@ -89,7 +93,13 @@ export default fp(async (fastify: FastifyInstance) => {
       ),
     );
 
-    // TODO call new cleanup fn
+    cleanupKserveRoleBindings(fastify).catch((e) =>
+      fastify.log.error(
+        `Unable to fully convert kserve rolebindings to use secure role. ${
+          e.response?.body?.message || e.message || e
+        }`,
+      ),
+    );
   }
 });
 

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -682,9 +682,20 @@ export const getConsoleLinks = (): ConsoleLinkKind[] => {
   return consoleLinksWatcher.getResources();
 };
 
+// TODO
+// * List all RoleBindings in all namespaces filtered with labelselector for opendatahub.io/dashboard: 'true'
+// * Filter by RoleRef kind = ClusterRole and name = view
+// * Filter that by ones that have ownerReferences with kind InferenceService, Subject kind ServiceAccount
+// * Delete and replace with new RoleBinding to new role with the same subject and ownerReferences
+// Note: bring ownerReference util into backend
+// export const cleanupKserveRoleBindings = ...;
+
+// TODO test with RB llama-gem-view in kserve namespace
+
 /**
  * Converts GPU usage to use accelerator by adding an accelerator profile CRD to the cluster if GPU usage is detected
  */
+// TODO copy this approach for migrating for https://issues.redhat.com/browse/RHOAIENG-11010
 export const cleanupGPU = async (fastify: KubeFastifyInstance): Promise<void> => {
   // When we startup — in kube.ts we can handle a migration (catch ALL promise errors — exit gracefully and use fastify logging)
   // Check for migration-gpu-status configmap in dashboard namespace — if found, exit early

--- a/frontend/src/__mocks__/mockRoleK8sResource.ts
+++ b/frontend/src/__mocks__/mockRoleK8sResource.ts
@@ -1,0 +1,32 @@
+import { genUID } from '~/__mocks__/mockUtils';
+import { KnownLabels, ResourceRule, RoleKind } from '~/k8sTypes';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+  rules?: ResourceRule[];
+  roleRefName?: string;
+  uid?: string;
+  modelRegistryName?: string;
+  isProjectSubject?: boolean;
+};
+
+export const mockRoleK8sResource = ({
+  name = 'test-name-view',
+  namespace = 'test-project',
+  rules = [],
+  uid = genUID('role'),
+}: MockResourceConfigType): RoleKind => ({
+  kind: 'Role',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name,
+    namespace,
+    uid,
+    creationTimestamp: '2023-02-14T21:43:59Z',
+    labels: {
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    },
+  },
+  rules,
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -8,6 +8,7 @@ export * from './k8s/notebooks';
 export * from './k8s/pods';
 export * from './k8s/projects';
 export * from './k8s/pvcs';
+export * from './k8s/roles';
 export * from './k8s/roleBindings';
 export * from './k8s/routes';
 export * from './k8s/secrets';

--- a/frontend/src/api/k8s/__tests__/roleBindings.spec.ts
+++ b/frontend/src/api/k8s/__tests__/roleBindings.spec.ts
@@ -14,7 +14,7 @@ import {
   createRoleBinding,
   deleteRoleBinding,
   generateRoleBindingPermissions,
-  generateRoleBindingServingRuntime,
+  generateRoleBindingServiceAccount,
   getRoleBinding,
   listRoleBindings,
   patchRoleBindingOwnerRef,
@@ -73,7 +73,12 @@ const createRoleBindingObject = (roleRefName: string, subjects: RoleBindingSubje
 
 describe('generateRoleBindingServingRuntime', () => {
   it('should generate serving runtime role binding ', () => {
-    const result = generateRoleBindingServingRuntime('rbName', 'serviceAccountName', namespace);
+    const result = generateRoleBindingServiceAccount(
+      'rbName',
+      'serviceAccountName',
+      { kind: 'ClusterRole', name: 'view' },
+      namespace,
+    );
     const subjects = [
       {
         kind: 'ServiceAccount',

--- a/frontend/src/api/k8s/__tests__/roles.spec.ts
+++ b/frontend/src/api/k8s/__tests__/roles.spec.ts
@@ -1,0 +1,92 @@
+import { k8sCreateResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { mockRoleK8sResource } from '~/__mocks__/mockRoleK8sResource';
+import { KnownLabels, RoleKind } from '~/k8sTypes';
+import { createRole, generateRoleInferenceService, getRole } from '~/api/k8s/roles';
+import { RoleModel } from '~/api/models/k8s';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+  k8sCreateResource: jest.fn(),
+  k8sDeleteResource: jest.fn(),
+}));
+
+const k8sGetResourceMock = jest.mocked(k8sGetResource);
+const k8sCreateResourceMock = jest.mocked(k8sCreateResource);
+
+const namespace = 'namespace';
+const roleMock = mockRoleK8sResource({ name: 'roleName', namespace });
+
+describe('generateRoleInferenceService', () => {
+  it('should generate role for inference service', () => {
+    const result = generateRoleInferenceService('roleName', 'inferenceServiceName', namespace);
+    expect(result).toStrictEqual({
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: 'roleName',
+        namespace,
+        labels: {
+          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        },
+      },
+      rules: [
+        {
+          verbs: ['get'],
+          apiGroups: ['serving.kserve.io'],
+          resources: ['inferenceservices'],
+          resourceNames: ['inferenceServiceName'],
+        },
+      ],
+    } satisfies RoleKind);
+  });
+});
+
+describe('getRole', () => {
+  it('should fetch role', async () => {
+    k8sGetResourceMock.mockResolvedValue(roleMock);
+    const result = await getRole('projectName', 'roleName');
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: RoleModel,
+      queryOptions: { name: 'roleName', ns: 'projectName' },
+    });
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(roleMock);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(getRole('projectName', 'roleName')).rejects.toThrow('error1');
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: RoleModel,
+      queryOptions: { name: 'roleName', ns: 'projectName' },
+    });
+  });
+});
+
+describe('createRole', () => {
+  it('should create role', async () => {
+    k8sCreateResourceMock.mockResolvedValue(roleMock);
+    const result = await createRole(roleMock);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: RoleModel,
+      queryOptions: { queryParams: {} },
+      resource: roleMock,
+    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(roleMock);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sCreateResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(createRole(roleMock)).rejects.toThrow('error1');
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: RoleModel,
+      queryOptions: { queryParams: {} },
+      resource: roleMock,
+    });
+  });
+});

--- a/frontend/src/api/k8s/roleBindings.ts
+++ b/frontend/src/api/k8s/roleBindings.ts
@@ -21,9 +21,10 @@ import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 import { RoleBindingPermissionsRoleType } from '~/concepts/roleBinding/types';
 import { addOwnerReference } from '~/api/k8sUtils';
 
-export const generateRoleBindingServingRuntime = (
+export const generateRoleBindingServiceAccount = (
   name: string,
   serviceAccountName: string,
+  roleRef: Omit<RoleBindingRoleRef, 'apiGroup'>,
   namespace: string,
 ): RoleBindingKind => {
   const roleBindingObject: RoleBindingKind = {
@@ -38,8 +39,7 @@ export const generateRoleBindingServingRuntime = (
     },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'ClusterRole',
-      name: 'view',
+      ...roleRef,
     },
     subjects: [
       {

--- a/frontend/src/api/k8s/roles.ts
+++ b/frontend/src/api/k8s/roles.ts
@@ -1,0 +1,40 @@
+import { k8sCreateResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sAPIOptions, KnownLabels, RoleKind } from '~/k8sTypes';
+import { RoleModel } from '~/api/models';
+import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
+
+export const generateRoleInferenceService = (
+  roleName: string,
+  inferenceServiceName: string,
+  namespace: string,
+): RoleKind => {
+  const role: RoleKind = {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'Role',
+    metadata: {
+      name: roleName,
+      namespace,
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+      },
+    },
+    rules: [
+      {
+        verbs: ['get'],
+        apiGroups: ['serving.kserve.io'],
+        resources: ['inferenceservices'],
+        resourceNames: [inferenceServiceName],
+      },
+    ],
+  };
+  return role;
+};
+
+export const getRole = (namespace: string, roleName: string): Promise<RoleKind> =>
+  k8sGetResource({
+    model: RoleModel,
+    queryOptions: { name: roleName, ns: namespace },
+  });
+
+export const createRole = (data: RoleKind, opts?: K8sAPIOptions): Promise<RoleKind> =>
+  k8sCreateResource(applyK8sAPIOptions({ model: RoleModel, resource: data }, opts));

--- a/frontend/src/api/models/k8s.ts
+++ b/frontend/src/api/models/k8s.ts
@@ -44,6 +44,13 @@ export const NamespaceModel: K8sModelCommon = {
   plural: 'namespaces',
 };
 
+export const RoleModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'rbac.authorization.k8s.io',
+  kind: 'Role',
+  plural: 'roles',
+};
+
 export const RoleBindingModel: K8sModelCommon = {
   apiVersion: 'v1',
   apiGroup: 'rbac.authorization.k8s.io',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -539,6 +539,14 @@ export type RoleBindingRoleRef = {
   name: string;
 };
 
+export type RoleKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  rules: ResourceRule[];
+};
+
 export type RoleBindingKind = K8sResourceCommon & {
   metadata: {
     name: string;
@@ -1047,6 +1055,13 @@ export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
   };
 };
 
+export type ResourceRule = {
+  verbs: string[];
+  apiGroups?: string[];
+  resourceNames?: string[];
+  resources?: string[];
+};
+
 export type SelfSubjectRulesReviewKind = K8sResourceCommon & {
   spec: {
     namespace: string;
@@ -1057,12 +1072,7 @@ export type SelfSubjectRulesReviewKind = K8sResourceCommon & {
       verbs: string[];
       nonResourceURLs?: string[];
     }[];
-    resourceRules: {
-      verbs: string[];
-      apiGroups?: string[];
-      resourceNames?: string[];
-      resources?: string[];
-    }[];
+    resourceRules: ResourceRule[];
     evaluationError?: string;
   };
 };

--- a/frontend/src/pages/modelServing/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/utils.spec.ts
@@ -92,12 +92,12 @@ describe('setUpTokenAuth', () => {
         );
       jest
         .mocked(getRole)
-        .mockImplementation((name: string, namespace: string) =>
+        .mockImplementation((namespace: string, name: string) =>
           Promise.resolve(mockRoleK8sResource({ name, namespace })),
         );
       jest
         .mocked(getRoleBinding)
-        .mockImplementation((name: string, namespace: string) =>
+        .mockImplementation((namespace: string, name: string) =>
           Promise.resolve(mockRoleBindingK8sResource({ name, namespace })),
         );
     } else {

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -419,6 +419,7 @@ export const getSubmitInferenceServiceResourceFn = (
         createData.project,
         createTokenAuth,
         inferenceService,
+        isModelMesh,
         secrets || [],
         {
           dryRun,
@@ -504,6 +505,7 @@ export const getSubmitServingRuntimeResourcesFn = (
               namespace,
               createTokenAuth,
               editInfo.servingRuntime,
+              isModelMesh,
               editInfo.secrets,
               {
                 dryRun,
@@ -529,6 +531,7 @@ export const getSubmitServingRuntimeResourcesFn = (
                 namespace,
                 createTokenAuth,
                 servingRuntime,
+                isModelMesh,
                 editInfo?.secrets,
                 {
                   dryRun,

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -145,7 +145,7 @@ export const createRoleIfMissing = async (
   namespace: string,
   opts?: K8sAPIOptions,
 ): Promise<RoleKind> =>
-  getRole(role.metadata.name, namespace).catch((e) => {
+  getRole(namespace, role.metadata.name).catch((e) => {
     if (e.statusObject?.code === 404) {
       return createRole(role, opts);
     }

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -188,6 +188,14 @@ rules:
     resources:
       - dscinitializations
   - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - modelregistry.opendatahub.io
     verbs:
       - get


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Resolves https://issues.redhat.com/browse/RHOAIENG-11010

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

See comments on Jira issue for implementation details. When setting up token auth for KServe models, instead of giving their ServiceAccounts a binding to the ClusterRole "view", we create a new role for them to get only InferenceServices in their own namespace. This PR also adds logic to replace the old rolebindings on users' clusters with the replaced more secure ones.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by @lucferbux, [steps outlined in this doc](https://docs.google.com/document/d/1N1UvwESTHo6fTsNSkjojuExakUzKKU0fxB4LXY_Kty4/edit#heading=h.cv9nyz82zwzi)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

* New unit tests for new frontend utils for managing roles
* Updated tests for `setUpTokenAuth` to account for creating / not creating the new role
* Backend code unfortunately has no unit testing currently, only manual testing here.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`