### PR TITLE
fix(vllm metrics): error stack trace

### DIFF
--- a/frontend/src/__mocks__/mockKserveMetricsConfigMap.ts
+++ b/frontend/src/__mocks__/mockKserveMetricsConfigMap.ts
@@ -62,6 +62,51 @@ export const MOCK_KSERVE_METRICS_CONFIG_1 = `
   ]
 }`;
 
+export const MOCK_KSERVE_METRICS_CONFIG_MISSING_QUERY = `{
+    "config": [
+			{
+				"title": "Requests per 5 minutes",
+				"type": "REQUEST_COUNT",
+				"queries": [
+					{
+						"title": "Number of successful incoming requests",
+						"query": "round(sum(increase(vllm:request_success_total{namespace='test-project',model_name='test vllm'}[5m])))"
+					}
+				]
+			},
+			{
+				"title": "Average response time (ms)",
+				"type": "MEAN_LATENCY",
+				"queries": [
+					{
+						"title": "Average e2e latency",
+						"query": "histogram_quantile(0.5, sum(rate(vllm:e2e_request_latency_seconds_bucket{namespace='test-project', model_name='test-vllm'}[1m])) by (le, model_name))"
+					}
+				]
+			},
+			{
+				"title": "CPU utilization %",
+				"type": "CPU_USAGE",
+				"queries": [
+					{
+						"title": "CPU usage",
+						"query":  "sum(pod:container_cpu_usage:sum{namespace='test-project', pod=~'test-vllm-predictor-.*'})/sum(kube_pod_resource_limit{resource='cpu', pod=~'test-vllm-predictor-.*', namespace='test-project'})"
+					}
+				]
+			},
+			{
+				"title": "Memory utilization %",
+				"type": "MEMORY_USAGE",
+				"queries": [
+					{
+						"title": "Memory usage",
+						"query":  "sum(container_memory_working_set_bytes{namespace='test-project', pod=~'test-vllm-predictor-.*'})/sum(kube_pod_resource_limit{resource='memory', pod=~'test-vllm-predictor-.*', namespace='test-project'})"
+					}
+				]
+			}
+		]
+  }`;
+
 export const MOCK_KSERVE_METRICS_CONFIG_2 =
   '{ I am malformed JSON and I am here to ruin your day }';
 

--- a/frontend/src/api/prometheus/kservePerformanceMetrics.ts
+++ b/frontend/src/api/prometheus/kservePerformanceMetrics.ts
@@ -23,8 +23,8 @@ export const useFetchKserveRequestCountData = (
 ): RequestCountData => {
   const active = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
 
-  const successQuery = metricsDef.queries[0].query;
-  const failedQuery = metricsDef.queries[1].query;
+  const successQuery = metricsDef.queries[0]?.query;
+  const failedQuery = metricsDef.queries[1]?.query;
 
   const successCount = useQueryRangeResourceData(
     active,
@@ -76,7 +76,7 @@ export const useFetchKserveMeanLatencyData = (
 
   const inferenceLatency = useQueryRangeResourceData(
     active,
-    metricsDef.queries[0].query,
+    metricsDef.queries[0]?.query,
     endInMs,
     timeframe,
     defaultResponsePredicate,
@@ -85,7 +85,7 @@ export const useFetchKserveMeanLatencyData = (
 
   const requestLatency = useQueryRangeResourceData(
     active,
-    metricsDef.queries[1].query,
+    metricsDef.queries[1]?.query,
     endInMs,
     timeframe,
     defaultResponsePredicate,
@@ -123,7 +123,7 @@ export const useFetchKserveCpuUsageData = (
 
   const cpuUsage = useQueryRangeResourceData(
     active,
-    metricsDef.queries[0].query,
+    metricsDef.queries[0]?.query,
     endInMs,
     timeframe,
     defaultResponsePredicate,
@@ -159,7 +159,7 @@ export const useFetchKserveMemoryUsageData = (
 
   const memoryUsage = useQueryRangeResourceData(
     active,
-    metricsDef.queries[0].query,
+    metricsDef.queries[0]?.query,
     endInMs,
     timeframe,
     defaultResponsePredicate,

--- a/frontend/src/concepts/metrics/kserve/content/KserveMeanLatencyGraph.tsx
+++ b/frontend/src/concepts/metrics/kserve/content/KserveMeanLatencyGraph.tsx
@@ -32,13 +32,17 @@ const KserveMeanLatencyGraph: React.FC<KserveMeanLatencyGraphProps> = ({
             data: convertPrometheusNaNToZero(inferenceLatency.data),
           },
         },
-        {
-          name: graphDefinition.queries[1].title,
-          metric: {
-            ...requestLatency,
-            data: convertPrometheusNaNToZero(requestLatency.data),
-          },
-        },
+        ...(graphDefinition.queries[1]
+          ? [
+              {
+                name: graphDefinition.queries[1].title,
+                metric: {
+                  ...requestLatency,
+                  data: convertPrometheusNaNToZero(requestLatency.data),
+                },
+              },
+            ]
+          : []),
       ]}
       color="green"
       title={graphDefinition.title}


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-11522

this is a situation that would result in the error stack and ui crash without this change:
![image](https://github.com/user-attachments/assets/a3aad35a-4e20-4e57-864e-ce247423fa86)


## Description
prevent ui from crashing. let the query be undefined if it doesn't exist, which will result in an empty data and no errors. vince said he did not want an error message at all as it might convey to the user that it might resolve with a refresh or something.

## How Has This Been Tested?
tested code on a previous deploy that would crash the ui on metrics page, it no longer crashes. used MR cluster to test. existing tests still pass.

## Test Impact
added a new test using mock data that only contains 1 query and made sure that the 4 charts show up (instead of an error stack page). i also updated the test mock for `prometheus/serving` to return empty results if the request body includes `query=undefined\b` as it would in the real endpoint. Here's a screenshot from a test with a missing query resulting in no data for one of the serving endpoints (it still shows the data):
![image](https://github.com/user-attachments/assets/f3e18370-11b2-43e9-8dfb-9fd0ab86e31c)


## Request review criteria:
test a vllm deploy, view the metrics. also view metrics of other types.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
