### PR TITLE
address UX items with connection types

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -70,3 +70,7 @@ body,
   min-height: 0;
 }
 
+.pf-v5-c-truncate {
+  --pf-v5-c-truncate--MinWidth: 0;
+  --pf-v5-c-truncate__start--MinWidth: 0;
+}

--- a/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
@@ -19,18 +19,24 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
   const hasValidOption = field.properties.items?.find((f) => f.value || f.label);
 
   const menuToggleText = () => {
-    let text = field.name ? `Select ${field.name} ` : 'No values defined yet ';
-    if (!isMulti && isPreview) {
-      const defaultOption = field.properties.items?.find(
-        (i) => i.value === field.properties.defaultValue?.[0],
-      );
-      if (defaultOption) {
-        text = defaultOption.label || defaultOption.value;
-      }
-    } else if (!isMulti && !isPreview) {
-      const currentSelection = field.properties.items?.find((i) => value?.includes(i.value));
-      if (currentSelection) {
-        text = currentSelection.label || currentSelection.value;
+    let text = field.properties.items?.some((i) => i.label || i.value)
+      ? field.name
+        ? `Select ${field.name} `
+        : 'Select'
+      : 'No values defined';
+    if (!isMulti) {
+      if (isPreview) {
+        const defaultOption = field.properties.items?.find(
+          (i) => i.value === field.properties.defaultValue?.[0],
+        );
+        if (defaultOption) {
+          text = defaultOption.label || defaultOption.value;
+        }
+      } else {
+        const currentSelection = field.properties.items?.find((i) => value?.includes(i.value));
+        if (currentSelection) {
+          text = currentSelection.label || currentSelection.value;
+        }
       }
     }
     return text;
@@ -74,7 +80,7 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
             <>
               {menuToggleText()}
               {isMulti && (
-                <Badge>
+                <Badge className="pf-v5-u-ml-xs">
                   {(isPreview ? field.properties.defaultValue?.length : value?.length) ?? 0}{' '}
                   selected
                 </Badge>

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) => {
   const [filterData, setFilterData] = React.useState<FilterDataType>(initialFilterData);
-  const onClearFilters = React.useCallback(() => setFilterData(initialFilterData), [setFilterData]);
+  const onClearFilters = React.useCallback(() => setFilterData(initialFilterData), []);
 
   const [deleteConnectionType, setDeleteConnectionType] = React.useState<
     ConnectionTypeConfigMapObj | undefined
@@ -30,7 +30,7 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
     () =>
       connectionTypes.filter((connectionType) => {
         const keywordFilter = filterData.Keyword?.toLowerCase();
-        const createFilter = filterData['Created by']?.toLowerCase();
+        const createFilter = filterData.Creator?.toLowerCase();
         const categoryFilter = filterData.Category?.toLowerCase();
 
         if (
@@ -58,10 +58,6 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
     [connectionTypes, filterData],
   );
 
-  const resetFilters = () => {
-    setFilterData(initialFilterData);
-  };
-
   return (
     <>
       <Table
@@ -88,7 +84,7 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
           />
         }
         disableItemCount
-        emptyTableView={<DashboardEmptyTableView onClearFilters={resetFilters} />}
+        emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
         id="connectionTypes-list-table"
       />
       {deleteConnectionType ? (

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableToolbar.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableToolbar.tsx
@@ -42,11 +42,11 @@ const ConnectionTypesTableToolbar: React.FC<Props> = ({
             onChange={(_event, value) => onChange(value)}
           />
         ),
-        [ConnectionTypesOptions.createdBy]: ({ onChange, ...props }) => (
+        [ConnectionTypesOptions.creator]: ({ onChange, ...props }) => (
           <SearchInput
             {...props}
-            aria-label="Created by"
-            placeholder="Created by"
+            aria-label="Creator"
+            placeholder="Creator"
             onChange={(_event, value) => onChange(value)}
           />
         ),

--- a/frontend/src/pages/connectionTypes/const.ts
+++ b/frontend/src/pages/connectionTypes/const.ts
@@ -1,13 +1,13 @@
 export enum ConnectionTypesOptions {
   keyword = 'Keyword',
   category = 'Category',
-  createdBy = 'Created by',
+  creator = 'Creator',
 }
 
 export const options = {
   [ConnectionTypesOptions.keyword]: 'Keyword',
   [ConnectionTypesOptions.category]: 'Category',
-  [ConnectionTypesOptions.createdBy]: 'Created By',
+  [ConnectionTypesOptions.creator]: 'Creator',
 };
 
 export type FilterDataType = Record<ConnectionTypesOptions, string | undefined>;
@@ -15,7 +15,7 @@ export type FilterDataType = Record<ConnectionTypesOptions, string | undefined>;
 export const initialFilterData: Record<ConnectionTypesOptions, string | undefined> = {
   [ConnectionTypesOptions.keyword]: '',
   [ConnectionTypesOptions.category]: '',
-  [ConnectionTypesOptions.createdBy]: '',
+  [ConnectionTypesOptions.creator]: '',
 };
 
 export const categoryOptions = ['Object storage', 'Database', 'Model registry', 'URI'];

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
@@ -57,8 +57,10 @@ export const ConnectionTypeMoveFieldToSectionModal: React.FC<Props> = ({
         />
       }
     >
-      Select the section heading that <b>{row.field.name}</b> will be moved to.
       <Form>
+        <div>
+          Select the section heading that <b>{row.field.name}</b> will be moved to.
+        </div>
         <FormGroup fieldId="sectionHeading" label="Section heading" isRequired>
           <SimpleSelect
             id="sectionHeading"

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
-import { Button, Icon, Label, Switch } from '@patternfly/react-core';
+import { ActionsColumn, TableText, Td, Tr } from '@patternfly/react-table';
+import { Button, Flex, FlexItem, Icon, Label, Switch, Truncate } from '@patternfly/react-core';
 import {
   ConnectionTypeField,
   ConnectionTypeFieldType,
@@ -90,7 +90,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
               },
               {
                 title: 'Duplicate',
-                onClick: () => onDuplicate({ ...row, name: `Duplicate of ${row.name}` }),
+                onClick: () => onDuplicate({ ...row, name: `Copy of ${row.name}` }),
               },
               {
                 title: 'Remove',
@@ -133,19 +133,26 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
       <Td dataLabel={columns[1].label} data-testid="field-type">
         {fieldTypeToString(row.type)}
       </Td>
-      <Td dataLabel={columns[2].label} data-testid="field-default" modifier="truncate">
-        {defaultValueToString(row) || '-'}
+      <Td dataLabel={columns[2].label} data-testid="field-default">
+        <TableText wrapModifier="truncate">{defaultValueToString(row) || '-'}</TableText>
       </Td>
       <Td dataLabel={columns[3].label} data-testid="field-env">
-        {row.envVar || '-'}
-        {isEnvVarConflict ? (
-          <>
-            <Icon status="danger" size="sm" className="pf-v5-u-ml-xs">
-              <ExclamationCircleIcon />
-            </Icon>
-            <span className="pf-v5-u-screen-reader">This environment variable is in conflict.</span>
-          </>
-        ) : undefined}
+        <Flex gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }}>
+          <FlexItem>
+            <Truncate content={row.envVar || '-'} />
+          </FlexItem>
+          {isEnvVarConflict ? (
+            <FlexItem>
+              <Icon
+                status="danger"
+                size="sm"
+                aria-label="This environment variable is in conflict."
+              >
+                <ExclamationCircleIcon />
+              </Icon>
+            </FlexItem>
+          ) : undefined}
+        </Flex>
       </Td>
       <Td dataLabel={columns[4].label}>
         <Switch
@@ -164,7 +171,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
             },
             {
               title: 'Duplicate',
-              onClick: () => onDuplicate(row),
+              onClick: () => onDuplicate({ ...row, name: `Copy of ${row.name}` }),
             },
             ...(showMoveToSection
               ? [

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
@@ -48,9 +48,9 @@ describe('ManageConnectionTypeFieldsTableRow', () => {
     };
 
     const result = render(renderRow({ row: field, fields: [field] }));
-    expect(screen.getByTestId('field-env')).not.toHaveTextContent('conflict');
+    expect(screen.queryByLabelText(/conflict/)).not.toBeInTheDocument();
 
     result.rerender(renderRow({ row: field, fields: [field, field2] }));
-    expect(screen.getByTestId('field-env')).toHaveTextContent('conflict');
+    expect(screen.queryByLabelText(/conflict/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/connectionTypes/manage/fieldTableColumns.ts
+++ b/frontend/src/pages/connectionTypes/manage/fieldTableColumns.ts
@@ -1,7 +1,7 @@
 import { ThProps } from '@patternfly/react-table';
 
 export const columns: ThProps[] = [
-  { label: 'Section heading/field name', width: 30 },
+  { label: 'Section heading / field name', width: 30 },
   { label: 'Type', width: 10 },
   { label: 'Default value', width: 30 },
   { label: 'Environment variable', width: 20 },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12827

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Addresses the following UX items for connection types:

Connection type filter changed from `Created By` to `Creator`:
![image](https://github.com/user-attachments/assets/fdd49e2f-4721-45d5-962d-2e67a388b875)

Microcopy of fields name header updated with spacing around the `/`:
![image](https://github.com/user-attachments/assets/464b59fe-8a3d-4776-9d23-5a3c9237c196)

Long env var names get truncated in table. Include screenshots for when env var names are in conflict.
![image](https://github.com/user-attachments/assets/9139bd93-3e90-46a1-b6a3-b2e3d7804867)
![image](https://github.com/user-attachments/assets/5fdec525-44d9-439c-88cb-a6e05000a032)
![image](https://github.com/user-attachments/assets/4cc4bcce-038c-4339-ace5-227f81979adc)

When duplicating a section or data field, the name starts with `Copy of`:
![image](https://github.com/user-attachments/assets/9a0835e2-2f28-4271-a1ca-2d9b1af61db9)
![image](https://github.com/user-attachments/assets/ced9b46e-59de-4dd9-a51b-5f9ea9f04f64)

Dropdown field updates.
When no items are defined:
![image](https://github.com/user-attachments/assets/bd601dc5-4a5e-4322-a374-6949da0a4d77)

When items are defined but no field name:
![image](https://github.com/user-attachments/assets/b739dfe9-b597-4407-8f56-3c844fc14387)
![image](https://github.com/user-attachments/assets/d77b940d-2aa2-472a-a38a-c6b971eabb67)

When field name is defined (eg. `testing`):
![image](https://github.com/user-attachments/assets/13f8ab50-8898-454e-b798-735c6e834f5c)
![image](https://github.com/user-attachments/assets/684e8757-bcd4-4fcd-863a-64227e86008d)

Added spacing between modal description and form by moving the text inside the form which applies the default spacing between form elements:
![image](https://github.com/user-attachments/assets/dadb7e2c-8078-4b52-8d67-2b8fb16eff90)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual verification
- Enable the connection types feature flag and navigate to Settings => Connection types

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A visual impacts only

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 