### PR TITLE
Add support for external routes to proxyService, use for model registry

### DIFF
--- a/backend/src/routes/api/service/mlmd/index.ts
+++ b/backend/src/routes/api/service/mlmd/index.ts
@@ -9,7 +9,7 @@ export default proxyService<DSPipelineKind>(
     plural: 'datasciencepipelinesapplications',
   },
   {
-    constructUrl: (resource) => resource.status?.components.mlmdProxy.url,
+    constructUrl: (resource: DSPipelineKind) => resource.status?.components.mlmdProxy.url,
   },
   {
     // Use port forwarding for local development:

--- a/backend/src/routes/api/service/modelregistry/index.ts
+++ b/backend/src/routes/api/service/modelregistry/index.ts
@@ -1,10 +1,12 @@
+import { ServiceAddressAnnotation } from '../../../../types';
 import { MODEL_REGISTRY_NAMESPACE } from '../../../../utils/constants';
 import { proxyService } from '../../../../utils/proxy';
 
 export default proxyService(
   null,
   {
-    port: 8080,
+    addressAnnotation: ServiceAddressAnnotation.EXTERNAL_REST,
+    internalPort: 8080,
     namespace: MODEL_REGISTRY_NAMESPACE,
   },
   {
@@ -14,5 +16,4 @@ export default proxyService(
     port: process.env.MODEL_REGISTRY_SERVICE_PORT,
   },
   null,
-  false,
 );

--- a/backend/src/routes/api/service/pipelines/index.ts
+++ b/backend/src/routes/api/service/pipelines/index.ts
@@ -9,7 +9,7 @@ export default proxyService<DSPipelineKind>(
     plural: 'datasciencepipelinesapplications',
   },
   {
-    constructUrl: (resource) => resource.status?.components.apiServer.url,
+    constructUrl: (resource: DSPipelineKind) => resource.status?.components.apiServer.url,
   },
   {
     // Use port forwarding for local development:

--- a/backend/src/routes/api/service/trustyai/index.ts
+++ b/backend/src/routes/api/service/trustyai/index.ts
@@ -9,7 +9,7 @@ export default proxyService<TrustyAIKind>(
     plural: 'trustyaiservices',
   },
   {
-    port: 443,
+    internalPort: 443,
     suffix: '-tls',
   },
   {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1215,3 +1215,8 @@ export type ResponseStatus = {
   success: boolean;
   error: string;
 };
+
+export enum ServiceAddressAnnotation {
+  EXTERNAL_REST = 'routing.opendatahub.io/external-address-rest',
+  EXTERNAL_GRPC = 'routing.opendatahub.io/external-address-grpc',
+}

--- a/backend/src/utils/proxy.ts
+++ b/backend/src/utils/proxy.ts
@@ -143,6 +143,9 @@ export const proxyService =
           done();
         };
 
+        // If `model` is passed, we first check if the user is able to get a resource with that model and the given namespace/name.
+        // We can use this to only proxy for users that can access some resource that manages the service.
+        // If `statusCheck` is also passed, we can also make sure that resource passes some check before we proxy to the service.
         const doServiceRequestWithGatingResource = async () => {
           try {
             // Retreive the gating resource by name and namespace

--- a/backend/src/utils/proxy.ts
+++ b/backend/src/utils/proxy.ts
@@ -1,11 +1,12 @@
 import { FastifyRequest } from 'fastify';
 import httpProxy from '@fastify/http-proxy';
-import { K8sResourceCommon, KubeFastifyInstance } from '../types';
+import { K8sResourceCommon, KubeFastifyInstance, ServiceAddressAnnotation } from '../types';
 import { isK8sStatus, passThroughResource } from '../routes/api/k8s/pass-through';
 import { DEV_MODE } from './constants';
 import { createCustomError } from './requestUtils';
 import { getAccessToken, getDirectCallOptions } from './directCallUtils';
 import { EitherNotBoth } from '../typeHelpers';
+import { V1Service } from '@kubernetes/client-node';
 
 export const getParam = <F extends FastifyRequest<any, any>>(req: F, name: string): string =>
   (req.params as { [key: string]: string })[name];
@@ -26,12 +27,14 @@ const notFoundError = (kind: string, name: string, e?: any, overrideMessage?: st
     404,
   );
 };
+
 export const proxyService =
   <K extends K8sResourceCommon = never>(
     model: { apiGroup: string; apiVersion: string; plural: string; kind: string } | null,
     service: EitherNotBoth<
       {
-        port: number | string;
+        addressAnnotation?: ServiceAddressAnnotation;
+        internalPort: number | string;
         prefix?: string;
         suffix?: string;
         namespace?: string;
@@ -74,56 +77,93 @@ export const proxyService =
         // see `prefix` for named params
         const namespace = service.namespace ?? getParam(request, 'namespace');
         const name = getParam(request, 'name');
+        const serviceName = `${service.prefix ?? ''}${name}${service.suffix ?? ''}`;
+        const scheme = tls ? 'https' : 'http';
+        const kc = fastify.kube.config;
+        const cluster = kc.getCurrentCluster();
 
-        const doServiceRequest = (resource?: K) => {
-          const scheme = tls ? 'https' : 'http';
+        const getServiceAddress = async (
+          serviceName: string,
+          resource?: K,
+        ): Promise<string | null> => {
+          if (DEV_MODE) {
+            // Use port forwarding for local development:
+            // kubectl port-forward -n <namespace> svc/<service-name> <local.port>:<service.port>
+            return `${scheme}://${local.host}:${local.port}`;
+          }
+          if (service.constructUrl) {
+            return service.constructUrl(resource);
+          }
+          if (service.addressAnnotation) {
+            try {
+              const k8sService = await passThroughResource<V1Service>(fastify, request, {
+                url: `${cluster.server}/api/v1/namespaces/${namespace}/services/${serviceName}`,
+                method: 'GET',
+              });
+              if (isK8sStatus(k8sService)) {
+                fastify.log.error(
+                  `Proxy failed to read k8s service ${serviceName} in namespace ${namespace}.`,
+                );
+                return null;
+              }
+              const address = k8sService.metadata?.annotations?.[service.addressAnnotation];
+              if (address) {
+                return `${scheme}://${address}`;
+              }
+              fastify.log.error(
+                `Proxy could not find address annotation on k8s service ${serviceName} in namespace ${namespace}, falling back to internal address. Annotation expected: ${service.addressAnnotation}`,
+              );
+            } catch (e) {
+              fastify.log.error(
+                e,
+                `Proxy failed to read k8s service ${serviceName} in namespace ${namespace}.`,
+              );
+              return null;
+            }
+          }
+          // For services configured for internal addresses (no annotation), construct the URL
+          // or if annotation is expected but missing, fall back to internal address for compatibility
+          return `${scheme}://${serviceName}.${namespace}.svc.cluster.local:${service.internalPort}`;
+        };
 
-          const upstream = DEV_MODE
-            ? // Use port forwarding for local development:
-              // kubectl port-forward -n <namespace> svc/<service-name> <local.port>:<service.port>
-              `${scheme}://${local.host}:${local.port}`
-            : // Construct service URL
-            service.constructUrl
-            ? service.constructUrl(resource)
-            : `${scheme}://${service.prefix || ''}${name}${
-                service.suffix ?? ''
-              }.${namespace}.svc.cluster.local:${service.port}`;
-
-          // assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
+        const doServiceRequest = async (resource?: K) => {
+          const upstream = await getServiceAddress(serviceName, resource);
+          if (!upstream) {
+            done(notFoundError('Service', serviceName, undefined, 'service unavailable'));
+            return;
+          }
+          // Assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
           setParam(request, 'upstream', upstream);
-
+          if (tls) {
+            const requestOptions = await getDirectCallOptions(fastify, request, '');
+            const token = getAccessToken(requestOptions);
+            request.headers.authorization = `Bearer ${token}`;
+          }
           fastify.log.info(`Proxy ${request.method} request ${request.url} to ${upstream}`);
           done();
         };
 
-        if (model) {
-          const kc = fastify.kube.config;
-          const cluster = kc.getCurrentCluster();
-
-          // retreive the gating resource by name and namespace
-          passThroughResource<K>(fastify, request, {
-            url: `${cluster.server}/apis/${model.apiGroup}/${model.apiVersion}/namespaces/${namespace}/${model.plural}/${name}`,
-            method: 'GET',
-          })
-            .then((resource) => {
-              return getDirectCallOptions(fastify, request, request.url).then((requestOptions) => {
-                if (isK8sStatus(resource)) {
-                  done(notFoundError(model.kind, name));
-                } else if (!statusCheck || statusCheck(resource)) {
-                  if (tls) {
-                    const token = getAccessToken(requestOptions);
-                    request.headers.authorization = `Bearer ${token}`;
-                  }
-
-                  doServiceRequest(resource);
-                } else {
-                  done(notFoundError(model.kind, name, undefined, 'service unavailable'));
-                }
-              });
-            })
-            .catch((e) => {
-              done(notFoundError(model.kind, name, e));
+        const doServiceRequestWithGatingResource = async () => {
+          try {
+            // Retreive the gating resource by name and namespace
+            const resource = await passThroughResource<K>(fastify, request, {
+              url: `${cluster.server}/apis/${model.apiGroup}/${model.apiVersion}/namespaces/${namespace}/${model.plural}/${name}`,
+              method: 'GET',
             });
+            if (isK8sStatus(resource)) {
+              done(notFoundError(model.kind, name));
+            } else if (!statusCheck || statusCheck(resource)) {
+              doServiceRequest(resource);
+            } else {
+              done(notFoundError(model.kind, name, undefined, 'service unavailable'));
+            }
+          } catch (e) {
+            done(notFoundError(model.kind, name, e));
+          }
+        };
+
+        if (model) {
+          doServiceRequestWithGatingResource();
         } else {
           doServiceRequest();
         }

--- a/frontend/src/__mocks__/mockModelRegistry.ts
+++ b/frontend/src/__mocks__/mockModelRegistry.ts
@@ -18,8 +18,13 @@ export const mockModelRegistry = ({
     namespace,
   },
   spec: {
-    grpc: {
-      port: 9090,
+    grpc: {},
+    rest: {},
+    istio: {
+      gateway: {
+        grpc: { tls: {} },
+        rest: { tls: {} },
+      },
     },
     postgres: {
       database: 'model-registry',
@@ -32,10 +37,6 @@ export const mockModelRegistry = ({
       skipDBCreation: false,
       sslMode: 'disable',
       username: 'mlmduser',
-    },
-    rest: {
-      port: 8080,
-      serviceRoute: 'disabled',
     },
   },
   status: {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1379,12 +1379,17 @@ export type ModelRegistryKind = K8sResourceCommon & {
     annotations?: DisplayNameAnnotations;
   };
   spec: {
-    grpc: {
-      port: number;
-    };
-    rest: {
-      port: number;
-      serviceRoute: string;
+    grpc: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
+    rest: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
+    istio: {
+      gateway: {
+        grpc: {
+          tls: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
+        };
+        rest: {
+          tls: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
+        };
+      };
     };
   } & EitherNotBoth<
     {

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -82,18 +82,20 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, refresh }) =
         },
       },
       spec: {
-        grpc: {
-          port: 9090,
-        },
-        rest: {
-          port: 8080,
-          serviceRoute: 'disabled',
+        grpc: {},
+        rest: {},
+        istio: {
+          gateway: {
+            grpc: { tls: {} },
+            rest: { tls: {} },
+          },
         },
         mysql: {
           host,
           port: Number(port),
           database,
           username,
+          skipDBCreation: false,
         },
       },
     };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Closes https://issues.redhat.com/browse/RHOAIENG-10133 and https://issues.redhat.com/browse/RHOAIENG-9037

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates `proxyService` to support configuring services with an optional `addressAnnotation`. If the `addressAnnotation` is omitted, the existing behavior will apply, so this PR should not affect the behavior of proxied services other than model registry. If the `addressAnnotation` is `EXTERNAL_REST` or `EXTERNAL_GRPC`, the proxy will fetch the k8s Service named in the request URL and look for a corresponding annotation. If present, the proxy will use that annotation's value as the upstream URL. If it's missing, the proxy will fall back to the existing behavior (constructing an internal `.svc.cluster.local` URL), which will provide compatibility with non-Istio model registry services that don't require the external URL.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On ods-qe-psi-08, we deployed a model registry [from the istio TLS samples](https://github.com/opendatahub-io/model-registry-operator/tree/main/config/samples/istio/mysql-tls) and observed that the Service has the `routing.opendatahub.io/external-address-rest` annotation on it. We then deployed the image for this PR using a devFlag and saw that the model registry page works when proxying requests through this new route.

We then also created a new registry using the settings page and reused the database details from the sample registry, and saw that the new istio spec provided on creation works correctly. That registry also became available and worked with the new proxy logic.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No tests for backend code, unfortunately.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
