### PR TITLE
Add delete modal for project connections

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connections.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connections.ts
@@ -1,0 +1,15 @@
+import { TableRow } from './components/table';
+
+class ConnectionsPage {
+  findTable() {
+    return cy.findByTestId('connection-table');
+  }
+
+  getConnectionRow(name: string) {
+    return new TableRow(() =>
+      this.findTable().findAllByTestId(`table-row-title`).contains(name).parents('tr'),
+    );
+  }
+}
+
+export const connectionsPage = new ConnectionsPage();

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -102,6 +102,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
   const notebookRefresh = notebooks.refresh;
   const pvcRefresh = pvcs.refresh;
   const dataConnectionRefresh = dataConnections.refresh;
+  const connectionRefresh = connections.refresh;
   const servingRuntimeRefresh = servingRuntimes.refresh;
   const servingRuntimeTemplateOrderRefresh = servingRuntimeTemplateOrder.refresh;
   const servingRuntimeTemplateDisablementRefresh = servingRuntimeTemplateDisablement.refresh;
@@ -112,6 +113,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
     setTimeout(notebookRefresh, 2000);
     pvcRefresh();
     dataConnectionRefresh();
+    connectionRefresh();
     servingRuntimeRefresh();
     inferenceServiceRefresh();
     projectSharingRefresh();
@@ -122,6 +124,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
     notebookRefresh,
     pvcRefresh,
     dataConnectionRefresh,
+    connectionRefresh,
     servingRuntimeRefresh,
     servingRuntimeTemplateOrderRefresh,
     servingRuntimeTemplateDisablementRefresh,

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsDeleteModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsDeleteModal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { Connection } from '~/concepts/connectionTypes/types';
+import DeleteModal from '~/pages/projects/components/DeleteModal';
+
+type Props = {
+  deleteConnection: Connection;
+  onClose: (deleted?: boolean) => void;
+  onDelete: () => Promise<K8sStatus>;
+};
+
+export const ConnectionsDeleteModal: React.FC<Props> = ({
+  deleteConnection,
+  onClose,
+  onDelete,
+}) => {
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+
+  return (
+    <DeleteModal
+      title="Delete connection?"
+      isOpen
+      onClose={onClose}
+      submitButtonLabel="Delete"
+      onDelete={() => {
+        setIsDeleting(true);
+        setError(undefined);
+
+        onDelete()
+          .then(() => {
+            onClose(true);
+          })
+          .catch((e) => {
+            setError(e);
+            setIsDeleting(false);
+          });
+      }}
+      deleting={isDeleting}
+      error={error}
+      deleteName={getDisplayNameFromK8sResource(deleteConnection)}
+    >
+      The <b>{getDisplayNameFromK8sResource(deleteConnection)}</b> connection will be deleted, and
+      its dependent resources will stop working.
+    </DeleteModal>
+  );
+};

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
@@ -16,7 +16,7 @@ const ConnectionsDescription =
 
 const ConnectionsList: React.FC = () => {
   const {
-    connections: { data: connections, loaded, error },
+    connections: { data: connections, loaded, error, refresh: refreshConnections },
   } = React.useContext(ProjectDetailsContext);
   const [connectionTypes, connectionTypesLoaded, connectionTypesError] = useWatchConnectionTypes();
 
@@ -60,7 +60,11 @@ const ConnectionsList: React.FC = () => {
         />
       }
     >
-      <ConnectionsTable connections={connections} connectionTypes={connectionTypes} />
+      <ConnectionsTable
+        connections={connections}
+        connectionTypes={connectionTypes}
+        refreshConnections={refreshConnections}
+      />
     </DetailsSection>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
@@ -1,29 +1,56 @@
 import * as React from 'react';
 import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+import { deleteSecret } from '~/api';
 import { Table } from '~/components/table';
 import ConnectionsTableRow from './ConnectionsTableRow';
 import { columns } from './connectionsTableColumns';
+import { ConnectionsDeleteModal } from './ConnectionsDeleteModal';
 
 type ConnectionsTableProps = {
   connections: Connection[];
   connectionTypes?: ConnectionTypeConfigMapObj[];
+  refreshConnections: () => void;
 };
 
-const ConnectionsTable: React.FC<ConnectionsTableProps> = ({ connections, connectionTypes }) => (
-  <Table
-    data={connections}
-    data-testid="connection-table"
-    columns={columns}
-    rowRenderer={(connection) => (
-      <ConnectionsTableRow
-        key={connection.metadata.name}
-        obj={connection}
-        connectionTypes={connectionTypes}
-        onEditConnection={() => undefined}
-        onDeleteConnection={() => undefined}
+const ConnectionsTable: React.FC<ConnectionsTableProps> = ({
+  connections,
+  connectionTypes,
+  refreshConnections,
+}) => {
+  const [deleteConnection, setDeleteConnection] = React.useState<Connection>();
+
+  return (
+    <>
+      <Table
+        data={connections}
+        data-testid="connection-table"
+        columns={columns}
+        rowRenderer={(connection) => (
+          <ConnectionsTableRow
+            key={connection.metadata.name}
+            obj={connection}
+            connectionTypes={connectionTypes}
+            onEditConnection={() => undefined}
+            onDeleteConnection={() => setDeleteConnection(connection)}
+          />
+        )}
+        isStriped
       />
-    )}
-    isStriped
-  />
-);
+      {deleteConnection && (
+        <ConnectionsDeleteModal
+          deleteConnection={deleteConnection}
+          onClose={(deleted) => {
+            setDeleteConnection(undefined);
+            if (deleted) {
+              refreshConnections();
+            }
+          }}
+          onDelete={() =>
+            deleteSecret(deleteConnection.metadata.namespace, deleteConnection.metadata.name)
+          }
+        />
+      )}
+    </>
+  );
+};
 export default ConnectionsTable;

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsTable.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsTable.spec.tsx
@@ -9,6 +9,7 @@ describe('ConnectionsTable', () => {
     render(
       <ConnectionsTable
         connections={[mockConnection({ displayName: 'connection1', description: 'desc1' })]}
+        refreshConnections={() => undefined}
       />,
     );
 
@@ -25,6 +26,7 @@ describe('ConnectionsTable', () => {
         connectionTypes={[
           mockConnectionTypeConfigMapObj({ name: 's3', displayName: 'S3 Buckets' }),
         ]}
+        refreshConnections={() => undefined}
       />,
     );
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-11557

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fairly straightforward implementation of the delete modal for the new connections page inside a project. 

![image](https://github.com/user-attachments/assets/0dc42b8f-2230-4318-96fc-b1623b2cf81c)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To test: if there are existing data connections on a project, you can delete those. otherwise you have to add new secrets from openshift console for that project

Has been tested locally

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Cypress test added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
