### PR TITLE
Model registry deploy modal has faulty submit button disable detection

### DIFF
--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/usePrefillDeployModalFromModelRegistry.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/usePrefillDeployModalFromModelRegistry.spec.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import usePrefillDeployModalFromModelRegistry from '~/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry';
+import { ProjectKind } from '~/k8sTypes';
+import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
+import { mockInferenceServiceModalData } from '~/__mocks__/mockInferenceServiceModalData';
+import { DataConnection } from '~/pages/projects/types';
+
+describe('usePrefillDeployModalFromModelRegistry', () => {
+  const mockProjectContext = {
+    currentProject: {
+      apiVersion: 'v1',
+      kind: 'Project',
+      metadata: {
+        name: 'test-project',
+        namespace: 'test-namespace',
+      },
+    } as ProjectKind,
+    dataConnections: [] as DataConnection[],
+  };
+
+  const data = mockInferenceServiceModalData({});
+
+  const mockSetCreateData = jest.fn();
+
+  const mockRegisteredModelDeployInfo: RegisteredModelDeployInfo = {
+    modelName: 'test-model',
+    modelArtifactUri: 's3://bucket/path',
+    modelArtifactStorageKey: 'test-key',
+  };
+
+  it('should ensure awsData array never has more than one element per key', () => {
+    renderHook(() =>
+      usePrefillDeployModalFromModelRegistry(
+        mockProjectContext,
+        data,
+        mockSetCreateData,
+        mockRegisteredModelDeployInfo,
+      ),
+    );
+
+    const { awsData } = mockSetCreateData.mock.calls.find(([key]) => key === 'storage')[1];
+
+    const keys = awsData.map((item: { key: string }) => item.key);
+    const uniqueKeys = new Set(keys);
+
+    expect(keys.length).toBe(uniqueKeys.size);
+  });
+});

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -41,23 +41,18 @@ const usePrefillDeployModalFromModelRegistry = (
           type: InferenceServiceStorageType.EXISTING_STORAGE,
         });
       } else {
-        const prefilledKeys = [
+        const prefilledKeys: (typeof EMPTY_AWS_SECRET_DATA)[number]['key'][] = [
           AwsKeys.NAME,
           AwsKeys.AWS_S3_BUCKET,
           AwsKeys.S3_ENDPOINT,
           AwsKeys.DEFAULT_REGION,
         ];
-        const filteredEmptyAwsSecretData = EMPTY_AWS_SECRET_DATA.filter(
-          (item): item is (typeof EMPTY_AWS_SECRET_DATA)[number] =>
-            !prefilledKeys.includes(item.key),
-        );
-
         const prefilledAWSData = [
           { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
           { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.bucket },
           { key: AwsKeys.S3_ENDPOINT, value: storageFields.endpoint },
           { key: AwsKeys.DEFAULT_REGION, value: storageFields.region || '' },
-          ...filteredEmptyAwsSecretData,
+          ...EMPTY_AWS_SECRET_DATA.filter((item) => !prefilledKeys.includes(item.key)),
         ];
         if (recommendedDataConnections.length === 0) {
           setCreateData('storage', {

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -41,12 +41,23 @@ const usePrefillDeployModalFromModelRegistry = (
           type: InferenceServiceStorageType.EXISTING_STORAGE,
         });
       } else {
+        const prefilledKeys = [
+          AwsKeys.NAME,
+          AwsKeys.AWS_S3_BUCKET,
+          AwsKeys.S3_ENDPOINT,
+          AwsKeys.DEFAULT_REGION,
+        ];
+        const filteredEmptyAwsSecretData = EMPTY_AWS_SECRET_DATA.filter(
+          (item): item is (typeof EMPTY_AWS_SECRET_DATA)[number] =>
+            !prefilledKeys.includes(item.key),
+        );
+
         const prefilledAWSData = [
           { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
           { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.bucket },
           { key: AwsKeys.S3_ENDPOINT, value: storageFields.endpoint },
           { key: AwsKeys.DEFAULT_REGION, value: storageFields.region || '' },
-          ...EMPTY_AWS_SECRET_DATA,
+          ...filteredEmptyAwsSecretData,
         ];
         if (recommendedDataConnections.length === 0) {
           setCreateData('storage', {

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -165,7 +165,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   // Inference Service Validation
   const storageCanCreate = (): boolean => {
     if (createDataInferenceService.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
-      return createDataInferenceService.storage.dataConnection !== '';
+      return (
+        createDataInferenceService.storage.dataConnection !== '' ||
+        (dataConnections.length > 0 && createDataInferenceService.storage.path !== '')
+      );
     }
     return isAWSValid(createDataInferenceService.storage.awsData, [AwsKeys.AWS_S3_BUCKET]);
   };

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -165,10 +165,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   // Inference Service Validation
   const storageCanCreate = (): boolean => {
     if (createDataInferenceService.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
-      return (
-        createDataInferenceService.storage.dataConnection !== '' ||
-        (dataConnections.length > 0 && createDataInferenceService.storage.path !== '')
-      );
+      return createDataInferenceService.storage.dataConnection !== '';
     }
     return isAWSValid(createDataInferenceService.storage.awsData, [AwsKeys.AWS_S3_BUCKET]);
   };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->

(https://issues.redhat.com/browse/RHOAIENG-12116)
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updated the UI to enable the Deploy button once all the required fields are filled, without the need to update the pre-filled fields/ 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the UI in - try to deploy a version of a model with pre-existing connection fields
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a unit test that makes sure the awsData array never has more than one element per key, as this was the issues that was causing the buggy behavior. ## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
