### PR TITLE
address truncation of names in connection type tables

### DIFF
--- a/frontend/src/components/ResourceNameTooltip.tsx
+++ b/frontend/src/components/ResourceNameTooltip.tsx
@@ -17,13 +17,18 @@ import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconBut
 type ResourceNameTooltipProps = {
   resource: K8sResourceCommon;
   children: React.ReactNode;
+  wrap?: boolean;
 };
 
-const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({ children, resource }) => (
-  <div>
-    {children}{' '}
+const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({
+  children,
+  resource,
+  wrap = true,
+}) => (
+  <div style={{ display: wrap ? 'block' : 'inline-flex' }}>
+    <span>{children}</span>
     {resource.metadata?.name && (
-      <div style={{ display: 'inline-block' }}>
+      <div style={{ display: 'inline-block', marginLeft: 'var(--pf-v5-global--spacer--xs)' }}>
         <Popover
           position="right"
           bodyContent={

--- a/frontend/src/components/table/TableRowTitleDescription.tsx
+++ b/frontend/src/components/table/TableRowTitleDescription.tsx
@@ -13,6 +13,7 @@ type TableRowTitleDescriptionProps = {
   descriptionAsMarkdown?: boolean;
   truncateDescriptionLines?: number;
   label?: React.ReactNode;
+  wrapResourceTitle?: boolean;
 };
 
 const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
@@ -24,6 +25,7 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
   descriptionAsMarkdown,
   truncateDescriptionLines,
   label,
+  wrapResourceTitle = true,
 }) => {
   let descriptionNode: React.ReactNode;
   if (description) {
@@ -46,7 +48,13 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
   return (
     <>
       <div data-testid="table-row-title" className={boldTitle ? 'pf-v5-u-font-weight-bold' : ''}>
-        {resource ? <ResourceNameTooltip resource={resource}>{title}</ResourceNameTooltip> : title}
+        {resource ? (
+          <ResourceNameTooltip resource={resource} wrap={wrapResourceTitle}>
+            {title}
+          </ResourceNameTooltip>
+        ) : (
+          title
+        )}
       </div>
       {subtitle}
       {descriptionNode}

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTable.tsx
@@ -62,7 +62,6 @@ const ConnectionTypesTable: React.FC<Props> = ({ connectionTypes, onUpdate }) =>
     <>
       <Table
         isStriped
-        variant="compact"
         style={{ tableLayout: 'fixed' }}
         data={filteredConnectionTypes}
         columns={connectionTypeColumns}

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -7,6 +7,7 @@ import {
   Switch,
   Timestamp,
   TimestampTooltipVariant,
+  Truncate,
 } from '@patternfly/react-core';
 import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { relativeTime } from '~/utilities/time';
@@ -81,7 +82,8 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
     <Tr>
       <Td dataLabel={connectionTypeColumns[0].label}>
         <TableRowTitleDescription
-          title={getDisplayNameFromK8sResource(obj)}
+          boldTitle={false}
+          title={<Truncate content={getDisplayNameFromK8sResource(obj)} />}
           description={getDescriptionFromK8sResource(obj)}
           truncateDescriptionLines={2}
         />

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -10,9 +10,9 @@ import {
 } from '~/concepts/connectionTypes/types';
 import { defaultValueToString, fieldTypeToString } from '~/concepts/connectionTypes/utils';
 import type { RowProps } from '~/utilities/useDraggableTableControlled';
-import TruncatedText from '~/components/TruncatedText';
 import { columns } from '~/pages/connectionTypes/manage/fieldTableColumns';
 import { ConnectionTypeFieldRemoveModal } from '~/pages/connectionTypes/manage/ConnectionTypeFieldRemoveModal';
+import { TableRowTitleDescription } from '~/components/table';
 
 type Props = {
   row: ConnectionTypeField;
@@ -67,15 +67,23 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
           }}
         />
         <Td dataLabel={columns[0].label} data-testid="field-name">
-          <div>
-            {row.name}{' '}
-            <Label color="blue" data-testid="section-heading">
-              Section heading
-            </Label>
-            <div className="pf-v5-u-color-200">
-              <TruncatedText content={row.description ?? ''} maxLines={2} />
-            </div>
-          </div>
+          <TableRowTitleDescription
+            boldTitle={false}
+            title={
+              <Flex gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }}>
+                <FlexItem>
+                  <Truncate content={row.name} />
+                </FlexItem>
+                <FlexItem>
+                  <Label color="blue" data-testid="section-heading">
+                    Section heading
+                  </Label>
+                </FlexItem>
+              </Flex>
+            }
+            description={row.description}
+            truncateDescriptionLines={2}
+          />
         </Td>
         <Td colSpan={4} />
         <Td isActionCell modifier="nowrap">
@@ -123,12 +131,12 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
         }}
       />
       <Td dataLabel={columns[0].label} data-testid="field-name">
-        <div>
-          {row.name}
-          <div className="pf-v5-u-color-200">
-            <TruncatedText content={row.description ?? ''} maxLines={2} />
-          </div>
-        </div>
+        <TableRowTitleDescription
+          boldTitle={false}
+          title={<Truncate content={row.name} />}
+          description={row.description}
+          truncateDescriptionLines={2}
+        />
       </Td>
       <Td dataLabel={columns[1].label} data-testid="field-type">
         {fieldTypeToString(row.type)}

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTableRow.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { Truncate } from '@patternfly/react-core';
 import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { TableRowTitleDescription } from '~/components/table';
+import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 
 type ConnectionsTableRowProps = {
   obj: Connection;
@@ -30,10 +32,12 @@ const ConnectionsTableRow: React.FC<ConnectionsTableRowProps> = ({
     <Tr>
       <Td dataLabel="Name">
         <TableRowTitleDescription
-          title={obj.metadata.annotations['openshift.io/display-name'] || obj.metadata.name}
+          title={<Truncate content={getDisplayNameFromK8sResource(obj)} />}
           boldTitle={false}
           resource={obj}
-          description={obj.metadata.annotations['openshift.io/description']}
+          description={getDescriptionFromK8sResource(obj)}
+          truncateDescriptionLines={2}
+          wrapResourceTitle={false}
         />
       </Td>
       <Td dataLabel="Type">{connectionTypeDisplayName}</Td>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12827

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Changed table variant to not be compact and truncates long names:
![image](https://github.com/user-attachments/assets/66aa66fb-de97-47b0-a80d-e42cd5c94a49)

Added name truncation to fields table:
![image](https://github.com/user-attachments/assets/9d0743aa-75e1-4243-97a8-8eccc7d1601d)

Added name and description truncation to connections table:
![image](https://github.com/user-attachments/assets/6ddb5846-751f-421e-aa3a-7cce14774eb8)


For reference. The serving runtimes admin table uses the `ResourceNameTooltip` component and it still looks the same as before vs after
![image](https://github.com/user-attachments/assets/23f2e41f-7fdd-40ec-bb61-17ea3a8aa1e9)
![image](https://github.com/user-attachments/assets/0ab0fde1-2a05-4f74-b85b-cd33f4bfab62)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested by creating resources with long names in the various UI areas.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A. Visual only changes.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 