### PR TITLE
add doc for dev feature flags

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -58,6 +58,12 @@ Run the tests.
 
 For in-depth testing guidance review the [testing guidelines](./testing.md)
 
+### Dev Feature Flags
+
+Feature flags are defined in the [dashboard config](./dashboard-config.md#features). When testing on a live cluster, changing feature flags via the config affects all users on the cluster. It is also possible to personally control the enablement of feature flags within the browser session. Simply append `?devFeatureFlags` to the dashboard URL. A blue banner will appear at the top of the page where a modal can be opened, allowing one to adjust the enablement of feature flags. These settings will persist for the length of the browser session.
+
+With the dev feature flags modal opened, the browser URL will update to include the current feature flag enablement settings. The URL can then be bookmarked or shared.
+
 ## Deploying the ODH Dashbard
 
 ### Official Image Builds


### PR DESCRIPTION
Adds a small blurb to our documents about dev feature flags and how to enable them in the browser using `?devFeatureFlags` query string.