### PR TITLE
Storage class dropdown select

### DIFF
--- a/frontend/src/__mocks__/mockStorageClasses.ts
+++ b/frontend/src/__mocks__/mockStorageClasses.ts
@@ -1,4 +1,4 @@
-import { K8sResourceListResult, StorageClassKind } from '~/k8sTypes';
+import { K8sResourceListResult, StorageClassConfig, StorageClassKind } from '~/k8sTypes';
 
 export type MockStorageClass = Omit<StorageClassKind, 'apiVersion' | 'kind'>;
 
@@ -17,6 +17,23 @@ export const mockStorageClassList = (
     resourceVersion: '55571379',
   },
   items: storageClasses,
+});
+
+export const buildMockStorageClass = (
+  mockStorageClass: MockStorageClass,
+  config: Partial<StorageClassConfig>,
+): MockStorageClass => ({
+  ...mockStorageClass,
+  metadata: {
+    ...mockStorageClass.metadata,
+    annotations: {
+      ...mockStorageClass.metadata.annotations,
+      'opendatahub.io/sc-config': JSON.stringify({
+        ...JSON.parse(String(mockStorageClass.metadata.annotations?.['opendatahub.io/sc-config'])),
+        ...config,
+      }),
+    },
+  },
 });
 
 export const mockStorageClasses: MockStorageClass[] = [

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -85,6 +85,14 @@ class ClusterStorageModal extends Modal {
   findPVSizePlusButton() {
     return this.findPVSizeField().findByRole('button', { name: 'Plus' });
   }
+
+  findStorageClassSelect() {
+    return this.find().findByTestId('storage-classes-selector');
+  }
+
+  findStorageClassDeprecatedWarning() {
+    return this.find().findByTestId('deprecated-storage-warning');
+  }
 }
 
 class ClusterStorage {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -6,6 +6,7 @@ import {
   mockProjectK8sResource,
   mockRouteK8sResource,
   mockSecretK8sResource,
+  mockStorageClassList,
 } from '~/__mocks__';
 import { mockConfigMap } from '~/__mocks__/mockConfigMap';
 import { mockImageStreamK8sResource } from '~/__mocks__/mockImageStreamK8sResource';
@@ -60,6 +61,7 @@ const initIntercepts = ({
     },
   ],
 }: HandlersProps) => {
+  cy.interceptOdh('GET /api/k8s/apis/storage.k8s.io/v1/storageclasses', {}, mockStorageClassList());
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -1,5 +1,4 @@
-import type { MockStorageClass } from '~/__mocks__';
-import { mockStorageClassList, mockStorageClasses } from '~/__mocks__';
+import { buildMockStorageClass, mockStorageClassList, mockStorageClasses } from '~/__mocks__';
 import { asProductAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
 import {
@@ -7,7 +6,6 @@ import {
   storageClassesPage,
   storageClassesTable,
 } from '~/__tests__/cypress/cypress/pages/storageClasses';
-import type { StorageClassConfig } from '~/k8sTypes';
 
 describe('Storage classes', () => {
   it('shows "page not found" and does not show nav item as a non-admin user', () => {
@@ -152,21 +150,4 @@ describe('Storage classes', () => {
       updatedRow.find().should('contain.text', 'Updated description');
     });
   });
-});
-
-const buildMockStorageClass = (
-  mockStorageClass: MockStorageClass,
-  config: Partial<StorageClassConfig>,
-) => ({
-  ...mockStorageClass,
-  metadata: {
-    ...mockStorageClass.metadata,
-    annotations: {
-      ...mockStorageClass.metadata.annotations,
-      'opendatahub.io/sc-config': JSON.stringify({
-        ...JSON.parse(String(mockStorageClass.metadata.annotations?.['opendatahub.io/sc-config'])),
-        ...config,
-      }),
-    },
-  },
 });

--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -17,11 +17,11 @@ export const assemblePvc = (
   data: CreatingStorageObject,
   namespace: string,
   editName?: string,
-  storageClassName?: string,
 ): PersistentVolumeClaimKind => {
   const {
     nameDesc: { name: pvcName, description },
     size,
+    storageClassName,
   } = data;
 
   const name = editName || translateDisplayNameForK8s(pvcName);
@@ -68,10 +68,9 @@ export const getDashboardPvcs = (projectName: string): Promise<PersistentVolumeC
 export const createPvc = (
   data: CreatingStorageObject,
   namespace: string,
-  storageClassName?: string,
   opts?: K8sAPIOptions,
 ): Promise<PersistentVolumeClaimKind> => {
-  const pvc = assemblePvc(data, namespace, undefined, storageClassName);
+  const pvc = assemblePvc(data, namespace, undefined);
 
   return k8sCreateResource<PersistentVolumeClaimKind>(
     applyK8sAPIOptions({ model: PVCModel, resource: pvc }, opts),

--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -70,7 +70,7 @@ export const createPvc = (
   namespace: string,
   opts?: K8sAPIOptions,
 ): Promise<PersistentVolumeClaimKind> => {
-  const pvc = assemblePvc(data, namespace, undefined);
+  const pvc = assemblePvc(data, namespace);
 
   return k8sCreateResource<PersistentVolumeClaimKind>(
     applyK8sAPIOptions({ model: PVCModel, resource: pvc }, opts),

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -13,6 +13,9 @@ import NotebookRestartAlert from '~/pages/projects/components/NotebookRestartAle
 import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksRestart';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import usePreferredStorageClass from '~/pages/projects/screens/spawner/storage/usePreferredStorageClass';
+import useDefaultStorageClass from '~/pages/projects/screens/spawner/storage/useDefaultStorageClass';
 import ExistingConnectedNotebooks from './ExistingConnectedNotebooks';
 
 type AddStorageModalProps = {
@@ -22,6 +25,10 @@ type AddStorageModalProps = {
 };
 
 const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOpen, onClose }) => {
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
+  const preferredStorageClass = usePreferredStorageClass();
+  const defaultStorageClass = useDefaultStorageClass();
+
   const [createData, setCreateData, resetData] = useCreateStorageObjectForNotebook(existingData);
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
@@ -39,6 +46,23 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
     createData.forNotebook.name,
   ]);
 
+  React.useEffect(() => {
+    if (!existingData && isOpen) {
+      if (isStorageClassesAvailable) {
+        setCreateData('storageClassName', defaultStorageClass?.metadata.name);
+      } else {
+        setCreateData('storageClassName', preferredStorageClass?.metadata.name);
+      }
+    }
+  }, [
+    isStorageClassesAvailable,
+    defaultStorageClass,
+    preferredStorageClass,
+    existingData,
+    isOpen,
+    setCreateData,
+  ]);
+
   const onBeforeClose = (submitted: boolean) => {
     onClose(submitted);
     setActionInProgress(false);
@@ -50,8 +74,13 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
   const hasValidNotebookRelationship = createData.forNotebook.name
     ? !!createData.forNotebook.mountPath.value && !createData.forNotebook.mountPath.error
     : true;
+
+  const storageClassSelected = isStorageClassesAvailable ? createData.storageClassName : true;
   const canCreate =
-    !actionInProgress && createData.nameDesc.name.trim() && hasValidNotebookRelationship;
+    !actionInProgress &&
+    createData.nameDesc.name.trim() &&
+    hasValidNotebookRelationship &&
+    storageClassSelected;
 
   const runPromiseActions = async (dryRun: boolean) => {
     const {
@@ -141,7 +170,7 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
               setData={(key, value) => setCreateData(key, value)}
               currentSize={existingData?.status?.capacity?.storage}
               autoFocusName
-              isEdit={!!existingData}
+              disableStorageClassSelect={!!existingData}
             />
           </StackItem>
           {createData.hasExistingNotebookConnections && (

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -18,7 +18,6 @@ import {
 import { useUser } from '~/redux/selectors';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { AppContext } from '~/app/AppContext';
-import usePreferredStorageClass from '~/pages/projects/screens/spawner/storage/usePreferredStorageClass';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import {
@@ -57,7 +56,6 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     },
   } = React.useContext(AppContext);
   const tolerationSettings = notebookController?.notebookTolerationSettings;
-  const storageClass = usePreferredStorageClass();
   const {
     notebooks: { data },
     dataConnections: { data: existingDataConnections },
@@ -158,7 +156,6 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
           projectName,
           editNotebook,
           storageData,
-          storageClass?.metadata.name,
           dryRun,
         ).catch(handleError);
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -242,11 +242,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
         ? [dataConnection.existing]
         : [];
 
-    const pvcDetails = await createPvcDataForNotebook(
-      projectName,
-      storageData,
-      storageClass?.metadata.name,
-    ).catch(handleError);
+    const pvcDetails = await createPvcDataForNotebook(projectName, storageData).catch(handleError);
     const envFrom = await createConfigMapsAndSecretsForNotebook(projectName, [
       ...envVariables,
       ...newDataConnection,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -47,6 +47,7 @@ import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVa
 import DataConnectionField from './dataConnection/DataConnectionField';
 import { useNotebookDataConnection } from './dataConnection/useNotebookDataConnection';
 import { useNotebookSizeState } from './useNotebookSizeState';
+import useDefaultStorageClass from './storage/useDefaultStorageClass';
 
 type SpawnerPageProps = {
   existingNotebook?: NotebookKind;
@@ -70,10 +71,14 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     string[] | undefined
   >();
   const [storageDataWithoutDefault, setStorageData] = useStorageDataObject(existingNotebook);
+
+  const defaultStorageClass = useDefaultStorageClass();
   const storageData = useMergeDefaultPVCName(
     storageDataWithoutDefault,
     k8sNameDescriptionData.data.name,
+    defaultStorageClass?.metadata.name,
   );
+
   const [envVariables, setEnvVariables] = useNotebookEnvVariables(existingNotebook);
   const [dataConnectionData, setDataConnectionData] = useNotebookDataConnection(
     dataConnections.data,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -26,6 +26,7 @@ import useNotebookAcceleratorProfile from '~/pages/projects/screens/detail/noteb
 import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
@@ -48,6 +49,7 @@ import DataConnectionField from './dataConnection/DataConnectionField';
 import { useNotebookDataConnection } from './dataConnection/useNotebookDataConnection';
 import { useNotebookSizeState } from './useNotebookSizeState';
 import useDefaultStorageClass from './storage/useDefaultStorageClass';
+import usePreferredStorageClass from './storage/usePreferredStorageClass';
 
 type SpawnerPageProps = {
   existingNotebook?: NotebookKind;
@@ -73,10 +75,15 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   const [storageDataWithoutDefault, setStorageData] = useStorageDataObject(existingNotebook);
 
   const defaultStorageClass = useDefaultStorageClass();
+  const preferredStorageClass = usePreferredStorageClass();
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
+  const defaultStorageClassName = isStorageClassesAvailable
+    ? defaultStorageClass?.metadata.name
+    : preferredStorageClass?.metadata.name;
   const storageData = useMergeDefaultPVCName(
     storageDataWithoutDefault,
     k8sNameDescriptionData.data.name,
-    defaultStorageClass?.metadata.name,
+    defaultStorageClassName,
   );
 
   const [envVariables, setEnvVariables] = useNotebookEnvVariables(existingNotebook);

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -30,14 +30,13 @@ import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnv
 export const createPvcDataForNotebook = async (
   projectName: string,
   storageData: StorageData,
-  storageClassName?: string,
 ): Promise<{ volumes: Volume[]; volumeMounts: VolumeMount[] }> => {
   const { storageType } = storageData;
 
   const { volumes, volumeMounts } = getVolumesByStorageData(storageData);
 
   if (storageType === StorageType.NEW_PVC) {
-    const pvc = await createPvc(storageData.creating, projectName, storageClassName);
+    const pvc = await createPvc(storageData.creating, projectName);
     const newPvcName = pvc.metadata.name;
     volumes.push({ name: newPvcName, persistentVolumeClaim: { claimName: newPvcName } });
     volumeMounts.push({ mountPath: ROOT_MOUNT_PATH, name: newPvcName });
@@ -70,7 +69,7 @@ export const replaceRootVolumesForNotebook = async (
     };
     replacedVolumeMount = { name: existingName, mountPath: ROOT_MOUNT_PATH };
   } else {
-    const pvc = await createPvc(storageData.creating, projectName, storageClassName, { dryRun });
+    const pvc = await createPvc(storageData.creating, projectName, { dryRun });
     const newPvcName = pvc.metadata.name;
     replacedVolume = { name: newPvcName, persistentVolumeClaim: { claimName: newPvcName } };
     replacedVolumeMount = { mountPath: ROOT_MOUNT_PATH, name: newPvcName };

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -48,7 +48,6 @@ export const replaceRootVolumesForNotebook = async (
   projectName: string,
   notebook: NotebookKind,
   storageData: StorageData,
-  storageClassName?: string,
   dryRun?: boolean,
 ): Promise<{ volumes: Volume[]; volumeMounts: VolumeMount[] }> => {
   const {

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -33,6 +33,7 @@ import { FAILED_PHASES, PENDING_PHASES, IMAGE_ANNOTATIONS } from './const';
 export const useMergeDefaultPVCName = (
   storageData: StorageData,
   defaultPVCName: string,
+  defaultStorageClassName?: string,
 ): StorageData => {
   const modifiedRef = React.useRef(false);
 
@@ -49,6 +50,7 @@ export const useMergeDefaultPVCName = (
         ...storageData.creating.nameDesc,
         name: storageData.creating.nameDesc.name || defaultPVCName,
       },
+      storageClassName: defaultStorageClassName ?? '',
     },
   };
 };

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -50,7 +50,7 @@ export const useMergeDefaultPVCName = (
         ...storageData.creating.nameDesc,
         name: storageData.creating.nameDesc.name || defaultPVCName,
       },
-      storageClassName: defaultStorageClassName ?? '',
+      storageClassName: storageData.creating.storageClassName || defaultStorageClassName,
     },
   };
 };
@@ -408,7 +408,8 @@ export const checkRequiredFieldsForNotebookStart = (
     image.imageVersion
   );
 
-  const newStorageFieldInvalid = storageType === StorageType.NEW_PVC && !creating.nameDesc.name;
+  const newStorageFieldInvalid =
+    storageType === StorageType.NEW_PVC && (!creating.nameDesc.name || !creating.storageClassName);
   const existingStorageFieldInvalid = storageType === StorageType.EXISTING_PVC && !existing.storage;
   const isStorageDataValid = !newStorageFieldInvalid && !existingStorageFieldInvalid;
 

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { FormGroup, Stack, StackItem } from '@patternfly/react-core';
+import { Stack, StackItem } from '@patternfly/react-core';
 import { CreatingStorageObject, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import PVSizeField from '~/pages/projects/components/PVSizeField';
 import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
-import SimpleSelect from '~/components/SimpleSelect';
-import useStorageClasses from '~/concepts/k8s/useStorageClasses';
-import { getStorageClassConfig } from '~/pages/storageClasses/utils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import StorageClassSelect from './StorageClassSelect';
 
 type CreateNewStorageSectionProps = {
   data: CreatingStorageObject;
@@ -13,7 +12,7 @@ type CreateNewStorageSectionProps = {
   currentSize?: string;
   autoFocusName?: boolean;
   menuAppendTo?: HTMLElement;
-  isEdit?: boolean;
+  disableStorageClassSelect?: boolean;
 };
 
 const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
@@ -22,9 +21,9 @@ const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
   currentSize,
   menuAppendTo,
   autoFocusName,
-  isEdit,
+  disableStorageClassSelect,
 }) => {
-  const [storageClasses, storageClassesLoaded] = useStorageClasses();
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
 
   return (
     <Stack hasGutter>
@@ -38,24 +37,14 @@ const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
         />
       </StackItem>
       <StackItem>
-        <FormGroup label="Storage class" fieldId="storage-class" isRequired>
-          <SimpleSelect
-            id="storage-classes-selector"
-            isFullWidth
-            value={data.storageClassName}
-            options={storageClasses.map((sc) => {
-              const { name } = sc.metadata;
-              const desc = getStorageClassConfig(sc)?.description;
-              return { key: name, label: name, description: desc };
-            })}
-            onChange={(selection) => {
-              setData('storageClassName', selection);
-            }}
-            isDisabled={isEdit || !storageClassesLoaded}
-            placeholder={isEdit && !storageClassesLoaded ? data.storageClassName : 'Select one'}
-            popperProps={{ appendTo: menuAppendTo }}
+        {isStorageClassesAvailable && (
+          <StorageClassSelect
+            storageClassName={data.storageClassName}
+            setStorageClassName={(name) => setData('storageClassName', name)}
+            disableStorageClassSelect={disableStorageClassSelect}
+            menuAppendTo={menuAppendTo}
           />
-        </FormGroup>
+        )}
       </StackItem>
       <StackItem>
         <PVSizeField

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { FormGroup, Stack, StackItem } from '@patternfly/react-core';
 import { CreatingStorageObject, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import PVSizeField from '~/pages/projects/components/PVSizeField';
 import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
+import SimpleSelect from '~/components/SimpleSelect';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
+import { getStorageClassConfig } from '~/pages/storageClasses/utils';
 
 type CreateNewStorageSectionProps = {
   data: CreatingStorageObject;
@@ -10,6 +13,7 @@ type CreateNewStorageSectionProps = {
   currentSize?: string;
   autoFocusName?: boolean;
   menuAppendTo?: HTMLElement;
+  isEdit?: boolean;
 };
 
 const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
@@ -18,27 +22,52 @@ const CreateNewStorageSection: React.FC<CreateNewStorageSectionProps> = ({
   currentSize,
   menuAppendTo,
   autoFocusName,
-}) => (
-  <Stack hasGutter>
-    <StackItem>
-      <NameDescriptionField
-        nameFieldId="create-new-storage-name"
-        descriptionFieldId="create-new-storage-description"
-        data={data.nameDesc}
-        setData={(newData) => setData('nameDesc', newData)}
-        autoFocusName={autoFocusName}
-      />
-    </StackItem>
-    <StackItem>
-      <PVSizeField
-        menuAppendTo={menuAppendTo}
-        fieldID="create-new-storage-size"
-        currentSize={currentSize}
-        size={data.size}
-        setSize={(size) => setData('size', size)}
-      />
-    </StackItem>
-  </Stack>
-);
+  isEdit,
+}) => {
+  const [storageClasses, storageClassesLoaded] = useStorageClasses();
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <NameDescriptionField
+          nameFieldId="create-new-storage-name"
+          descriptionFieldId="create-new-storage-description"
+          data={data.nameDesc}
+          setData={(newData) => setData('nameDesc', newData)}
+          autoFocusName={autoFocusName}
+        />
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Storage class" fieldId="storage-class" isRequired>
+          <SimpleSelect
+            id="storage-classes-selector"
+            isFullWidth
+            value={data.storageClassName}
+            options={storageClasses.map((sc) => {
+              const { name } = sc.metadata;
+              const desc = getStorageClassConfig(sc)?.description;
+              return { key: name, label: name, description: desc };
+            })}
+            onChange={(selection) => {
+              setData('storageClassName', selection);
+            }}
+            isDisabled={isEdit || !storageClassesLoaded}
+            placeholder={isEdit && !storageClassesLoaded ? data.storageClassName : 'Select one'}
+            popperProps={{ appendTo: menuAppendTo }}
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <PVSizeField
+          menuAppendTo={menuAppendTo}
+          fieldID="create-new-storage-size"
+          currentSize={currentSize}
+          size={data.size}
+          setSize={(size) => setData('size', size)}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
 
 export default CreateNewStorageSection;

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -94,7 +94,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
         popperProps={{ appendTo: menuAppendTo }}
       />
       <FormHelperText>
-        {selectedStorageClassConfig?.isEnabled === false ? (
+        {selectedStorageClassConfig && !selectedStorageClassConfig.isEnabled ? (
           <HelperText>
             <HelperTextItem
               data-testid="deprecated-storage-warning"

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -1,0 +1,120 @@
+import {
+  Split,
+  SplitItem,
+  Label,
+  FormGroup,
+  Alert,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import React from 'react';
+import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
+import { getStorageClassConfig } from '~/pages/storageClasses/utils';
+
+type StorageClassSelectProps = {
+  storageClassName?: string;
+  setStorageClassName: (name: string) => void;
+  disableStorageClassSelect?: boolean;
+  menuAppendTo?: HTMLElement;
+};
+
+const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
+  storageClassName,
+  setStorageClassName,
+  disableStorageClassSelect,
+  menuAppendTo,
+}) => {
+  const [storageClasses, storageClassesLoaded] = useStorageClasses();
+
+  const enabledStorageClasses = storageClasses
+    .filter((sc) => getStorageClassConfig(sc)?.isEnabled)
+    .toSorted((a, b) => {
+      const aConfig = getStorageClassConfig(a);
+      const bConfig = getStorageClassConfig(b);
+      if (aConfig?.isDefault) {
+        return -1;
+      }
+      if (bConfig?.isDefault) {
+        return 1;
+      }
+      return (aConfig?.displayName || a.metadata.name).localeCompare(
+        bConfig?.displayName || b.metadata.name,
+      );
+    });
+
+  const selectedStorageClass = storageClasses.find((sc) => sc.metadata.name === storageClassName);
+  const selectedStorageClassConfig = selectedStorageClass
+    ? getStorageClassConfig(selectedStorageClass)
+    : undefined;
+
+  const options: SimpleSelectOption[] = (
+    disableStorageClassSelect ? storageClasses : enabledStorageClasses
+  ).map((sc) => {
+    const config = getStorageClassConfig(sc);
+
+    return {
+      key: sc.metadata.name,
+      label: config?.displayName || sc.metadata.name,
+      description: config?.description,
+      isDisabled: !config?.isEnabled,
+      dropdownLabel: (
+        <Split>
+          <SplitItem>{config?.displayName || sc.metadata.name}</SplitItem>
+          <SplitItem isFilled />
+          <SplitItem>
+            {config?.isDefault && (
+              <Label isCompact color="green">
+                Default class
+              </Label>
+            )}
+          </SplitItem>
+        </Split>
+      ),
+    };
+  });
+
+  return (
+    <FormGroup label="Storage class" fieldId="storage-class" isRequired>
+      <SimpleSelect
+        dataTestId="storage-classes-selector"
+        id="storage-classes-selector"
+        isFullWidth
+        value={storageClassName}
+        options={options}
+        onChange={(selection) => {
+          setStorageClassName(selection);
+        }}
+        isDisabled={
+          disableStorageClassSelect || !storageClassesLoaded || storageClasses.length <= 1
+        }
+        placeholder="Select storage class"
+        popperProps={{ appendTo: menuAppendTo }}
+      />
+      <FormHelperText>
+        {selectedStorageClassConfig?.isEnabled === false ? (
+          <HelperText>
+            <HelperTextItem
+              data-testid="deprecated-storage-warning"
+              variant="warning"
+              icon={<ExclamationTriangleIcon />}
+            >
+              The selected storage class is deprecated.
+            </HelperTextItem>
+          </HelperText>
+        ) : (
+          <Alert
+            variant="info"
+            title="The storage class cannot be changed after creation."
+            isInline
+            isPlain
+          />
+        )}
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default StorageClassSelect;

--- a/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
+import { StorageClassKind } from '~/k8sTypes';
+import {
+  getStorageClassConfig,
+  isOpenshiftDefaultStorageClass,
+} from '~/pages/storageClasses/utils';
+
+const useDefaultStorageClass = (): StorageClassKind | undefined => {
+  const [storageClasses, storageClassesLoaded] = useStorageClasses();
+  const [defaultStorageClass, setDefaultStorageClass] = React.useState<
+    StorageClassKind | undefined
+  >();
+
+  React.useEffect(() => {
+    if (!storageClassesLoaded) {
+      return;
+    }
+
+    const defaultSc = storageClasses.find(
+      (sc) => isOpenshiftDefaultStorageClass(sc) || getStorageClassConfig(sc)?.isDefault,
+    );
+    setDefaultStorageClass(defaultSc);
+  }, [storageClasses, storageClassesLoaded]);
+
+  return defaultStorageClass;
+};
+
+export default useDefaultStorageClass;

--- a/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
@@ -1,27 +1,29 @@
 import * as React from 'react';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import { StorageClassKind } from '~/k8sTypes';
-import {
-  getStorageClassConfig,
-  isOpenshiftDefaultStorageClass,
-} from '~/pages/storageClasses/utils';
+import { getStorageClassConfig } from '~/pages/storageClasses/utils';
 
 const useDefaultStorageClass = (): StorageClassKind | undefined => {
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
   const [defaultStorageClass, setDefaultStorageClass] = React.useState<
     StorageClassKind | undefined
   >();
 
   React.useEffect(() => {
-    if (!storageClassesLoaded) {
+    if (!storageClassesLoaded || !isStorageClassesAvailable) {
       return;
     }
 
-    const defaultSc = storageClasses.find(
-      (sc) => isOpenshiftDefaultStorageClass(sc) || getStorageClassConfig(sc)?.isDefault,
-    );
-    setDefaultStorageClass(defaultSc);
-  }, [storageClasses, storageClassesLoaded]);
+    const defaultSc = storageClasses.find((sc) => getStorageClassConfig(sc)?.isDefault);
+
+    if (!defaultSc && storageClasses.length > 0) {
+      setDefaultStorageClass(storageClasses[0]);
+    } else {
+      setDefaultStorageClass(defaultSc);
+    }
+  }, [storageClasses, storageClassesLoaded, isStorageClassesAvailable]);
 
   return defaultStorageClass;
 };

--- a/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
@@ -16,10 +16,14 @@ const useDefaultStorageClass = (): StorageClassKind | undefined => {
       return;
     }
 
-    const defaultSc = storageClasses.find((sc) => getStorageClassConfig(sc)?.isDefault);
+    const enabledStorageClasses = storageClasses.filter(
+      (sc) => getStorageClassConfig(sc)?.isEnabled,
+    );
 
-    if (!defaultSc && storageClasses.length > 0) {
-      setDefaultStorageClass(storageClasses[0]);
+    const defaultSc = enabledStorageClasses.find((sc) => getStorageClassConfig(sc)?.isDefault);
+
+    if (!defaultSc && enabledStorageClasses.length > 0) {
+      setDefaultStorageClass(enabledStorageClasses[0]);
     } else {
       setDefaultStorageClass(defaultSc);
     }

--- a/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/usePreferredStorageClass.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { AppContext } from '~/app/AppContext';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { MetadataAnnotation, StorageClassKind } from '~/k8sTypes';
 
 const usePreferredStorageClass = (): StorageClassKind | undefined => {
@@ -10,16 +9,13 @@ const usePreferredStorageClass = (): StorageClassKind | undefined => {
     },
     storageClasses,
   } = React.useContext(AppContext);
-  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
 
   const defaultClusterStorageClasses = storageClasses.filter(
     (storageclass) =>
       storageclass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true',
   );
 
-  const configStorageClassName = !isStorageClassesAvailable
-    ? notebookController?.storageClassName ?? ''
-    : '';
+  const configStorageClassName = notebookController?.storageClassName ?? '';
 
   if (defaultClusterStorageClasses.length !== 0) {
     return undefined;

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -27,6 +27,7 @@ export type NameDescType = {
 export type CreatingStorageObject = {
   nameDesc: NameDescType;
   size: string;
+  storageClassName?: string;
 };
 
 export type MountPath = {

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -16,12 +16,3 @@ export const getStorageClassConfig = (
 
 export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>
   storageClass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
-
-export const getDefaultStorageClass = (
-  storageClasses: StorageClassKind[],
-): StorageClassKind | undefined =>
-  storageClasses.find(
-    (storageClass) =>
-      isOpenshiftDefaultStorageClass(storageClass) ||
-      getStorageClassConfig(storageClass)?.isDefault,
-  );

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -16,3 +16,12 @@ export const getStorageClassConfig = (
 
 export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>
   storageClass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
+
+export const getDefaultStorageClass = (
+  storageClasses: StorageClassKind[],
+): StorageClassKind | undefined =>
+  storageClasses.find(
+    (storageClass) =>
+      isOpenshiftDefaultStorageClass(storageClass) ||
+      getStorageClassConfig(storageClass)?.isDefault,
+  );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-1109](https://issues.redhat.com/browse/RHOAIENG-1109)

## Description
This is a continuation of @dpanshug PR
- added default selection
- added default label
- corrected autofill for default
- added alerts for select

> Added new field to select storage class to create pvc.

![Screenshot 2024-09-13 at 2 17 21 PM](https://github.com/user-attachments/assets/2d430e09-cba6-4d96-898e-914d14de9c10)
![Screenshot 2024-09-13 at 2 17 07 PM](https://github.com/user-attachments/assets/4e041466-0edd-48ba-a459-ac9ea72d739e)
![Screenshot 2024-09-13 at 2 17 00 PM](https://github.com/user-attachments/assets/e6cfa21c-ac70-4e7c-8610-5394722d4f4d)



## How Has This Been Tested?
Create a new cluster storage and you check list of storage classes in the field.
Create new workbench and select storage class in cluster storage.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added test for default being set

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@xianli123 