### PR TITLE
[RHOAIENG-12310] Error cases for storage class admin table

### DIFF
--- a/frontend/src/__mocks__/mockStorageClasses.ts
+++ b/frontend/src/__mocks__/mockStorageClasses.ts
@@ -19,19 +19,28 @@ export const mockStorageClassList = (
   items: storageClasses,
 });
 
-export const buildMockStorageClass = (
+export const buildMockStorageClassConfig = (
   mockStorageClass: MockStorageClass,
   config: Partial<StorageClassConfig>,
+): string =>
+  JSON.stringify({
+    ...JSON.parse(
+      String(mockStorageClass.metadata.annotations?.['opendatahub.io/sc-config'] ?? null),
+    ),
+    ...config,
+  });
+
+export const buildMockStorageClass = (
+  mockStorageClass: MockStorageClass,
+  config: Partial<StorageClassConfig> | string,
 ): MockStorageClass => ({
   ...mockStorageClass,
   metadata: {
     ...mockStorageClass.metadata,
     annotations: {
       ...mockStorageClass.metadata.annotations,
-      'opendatahub.io/sc-config': JSON.stringify({
-        ...JSON.parse(String(mockStorageClass.metadata.annotations?.['opendatahub.io/sc-config'])),
-        ...config,
-      }),
+      'opendatahub.io/sc-config':
+        typeof config !== 'string' ? buildMockStorageClassConfig(mockStorageClass, config) : config,
     },
   },
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -29,16 +29,32 @@ class StorageClassesTableRow extends TableRow {
     return this.find().findByTestId('openshift-sc-default-label');
   }
 
-  findEnableSwitch() {
+  findEnableSwitchInput() {
     return this.find().findByTestId('enable-switch');
   }
 
-  findDefaultRadio() {
+  findDefaultRadioInput() {
     return this.find().findByTestId('set-default-radio');
   }
 
-  findOpenshiftScName() {
-    return this.find().find(`[data-label="Openshift storage class"]`);
+  findDisplayNameValue() {
+    return this.find().find(`[data-label="Display name"]`);
+  }
+
+  findEnableValue() {
+    return this.find().find(`[data-label="Enable"]`);
+  }
+
+  findDefaultValue() {
+    return this.find().find(`[data-label="Default"]`);
+  }
+
+  findLastModifiedValue() {
+    return this.find().find(`[data-label="Last modified"]`);
+  }
+
+  findCorruptedMetadataAlert() {
+    return cy.findByTestId('corrupted-metadata-alert');
   }
 }
 
@@ -49,12 +65,18 @@ class StorageClassesTable {
 
   getRowByName(name: string) {
     return new StorageClassesTableRow(() =>
+      this.find().find(`[data-label="Openshift storage class"]`).contains(name).parents('tr'),
+    );
+  }
+
+  getRowByConfigName(name: string) {
+    return new StorageClassesTableRow(() =>
       this.find().find(`[data-label="Display name"]`).contains(name).parents('tr'),
     );
   }
 
   findRowByName(name: string) {
-    return this.getRowByName(name).find();
+    return this.getRowByConfigName(name).find();
   }
 
   mockUpdateStorageClass(storageClassName: string, times?: number) {
@@ -117,6 +139,10 @@ class StorageClassEditModal extends Modal {
 
   findSaveButton() {
     return this.findFooter().findByTestId('modal-submit-button');
+  }
+
+  findInfoAlert() {
+    return this.find().findByTestId('edit-sc-modal-info-alert');
   }
 
   mockUpdateStorageClass(storageClassName: string, times?: number) {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -1,4 +1,9 @@
-import { buildMockStorageClass, mockStorageClassList, mockStorageClasses } from '~/__mocks__';
+import {
+  buildMockStorageClass,
+  buildMockStorageClassConfig,
+  mockStorageClassList,
+  mockStorageClasses,
+} from '~/__mocks__';
 import { asProductAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
 import {
@@ -52,19 +57,22 @@ describe('Storage classes', () => {
       );
       storageClassesPage.visit();
 
-      const openshiftDefaultTableRow = storageClassesTable.getRowByName('openshift-default-sc');
+      const openshiftDefaultTableRow =
+        storageClassesTable.getRowByConfigName('openshift-default-sc');
       openshiftDefaultTableRow.findOpenshiftDefaultLabel().should('be.visible');
-      openshiftDefaultTableRow.findEnableSwitch().should('have.attr', 'aria-checked', 'true');
-      openshiftDefaultTableRow.findEnableSwitch().should('have.attr', 'disabled');
-      openshiftDefaultTableRow.findDefaultRadio().should('have.attr', 'checked');
-      openshiftDefaultTableRow.findDefaultRadio().should('not.have.attr', 'disabled');
+      openshiftDefaultTableRow.findEnableSwitchInput().should('have.attr', 'aria-checked', 'true');
+      openshiftDefaultTableRow.findEnableSwitchInput().should('have.attr', 'disabled');
+      openshiftDefaultTableRow.findDefaultRadioInput().should('have.attr', 'checked');
+      openshiftDefaultTableRow.findDefaultRadioInput().should('not.have.attr', 'disabled');
 
-      const otherStorageClassTableRow = storageClassesTable.getRowByName('Test SC 1');
+      const otherStorageClassTableRow = storageClassesTable.getRowByConfigName('Test SC 1');
       otherStorageClassTableRow.findOpenshiftDefaultLabel().should('not.exist');
-      otherStorageClassTableRow.findEnableSwitch().should('have.attr', 'aria-checked', 'false');
-      otherStorageClassTableRow.findEnableSwitch().should('not.have.attr', 'disabled');
-      otherStorageClassTableRow.findDefaultRadio().should('not.have.attr', 'checked');
-      otherStorageClassTableRow.findDefaultRadio().should('have.attr', 'disabled');
+      otherStorageClassTableRow
+        .findEnableSwitchInput()
+        .should('have.attr', 'aria-checked', 'false');
+      otherStorageClassTableRow.findEnableSwitchInput().should('not.have.attr', 'disabled');
+      otherStorageClassTableRow.findDefaultRadioInput().should('not.have.attr', 'checked');
+      otherStorageClassTableRow.findDefaultRadioInput().should('have.attr', 'disabled');
 
       storageClassesTable
         .mockUpdateStorageClass(otherStorageClass.metadata.name, 1)
@@ -80,12 +88,12 @@ describe('Storage classes', () => {
         .as('refreshStorageClasses-1');
 
       // Enable the other storage class so that the RHOAI default can be toggled
-      otherStorageClassTableRow.findEnableSwitch().click({ force: true });
+      otherStorageClassTableRow.findEnableSwitchInput().click({ force: true });
       cy.wait('@updateStorageClass-1');
       cy.wait('@refreshStorageClasses-1');
 
-      otherStorageClassTableRow.findEnableSwitch().should('have.attr', 'aria-checked', 'true');
-      otherStorageClassTableRow.findDefaultRadio().should('not.have.attr', 'disabled');
+      otherStorageClassTableRow.findEnableSwitchInput().should('have.attr', 'aria-checked', 'true');
+      otherStorageClassTableRow.findDefaultRadioInput().should('not.have.attr', 'disabled');
 
       storageClassesTable
         .mockUpdateStorageClass(otherStorageClass.metadata.name, 1)
@@ -104,13 +112,13 @@ describe('Storage classes', () => {
         .as('refreshStorageClasses-2');
 
       // Set the other storage class as the RHOAI default
-      otherStorageClassTableRow.findDefaultRadio().click();
+      otherStorageClassTableRow.findDefaultRadioInput().click();
       cy.wait('@updateStorageClass-2');
       cy.wait('@updateStorageClass-3');
       cy.wait('@refreshStorageClasses-2');
 
-      openshiftDefaultTableRow.findEnableSwitch().should('not.have.attr', 'disabled');
-      openshiftDefaultTableRow.findDefaultRadio().should('have.attr', 'checked');
+      openshiftDefaultTableRow.findEnableSwitchInput().should('not.have.attr', 'disabled');
+      openshiftDefaultTableRow.findDefaultRadioInput().should('have.attr', 'checked');
     });
 
     it('can edit storage class display name and description', () => {
@@ -121,11 +129,14 @@ describe('Storage classes', () => {
       );
       storageClassesPage.visit();
 
-      storageClassesTable.getRowByName('openshift-default-sc').findKebabAction('Edit').click();
+      storageClassesTable
+        .getRowByConfigName('openshift-default-sc')
+        .findKebabAction('Edit')
+        .click();
       storageClassEditModal.findOpenshiftDefaultLabel().should('be.visible');
       storageClassEditModal.findCloseButton().click();
 
-      storageClassesTable.getRowByName('Test SC 1').findKebabAction('Edit').click();
+      storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
       storageClassEditModal.findOpenshiftScName().should('have.text', 'test-storage-class-1');
       storageClassEditModal.findProvisioner().should('have.text', 'manila.csi.openstack.org');
       storageClassEditModal.findOpenshiftDefaultLabel().should('not.exist');
@@ -145,9 +156,281 @@ describe('Storage classes', () => {
       storageClassEditModal.findSaveButton().click();
 
       cy.wait('@updateStorageClass');
-      const updatedRow = storageClassesTable.getRowByName('Updated name');
+      const updatedRow = storageClassesTable.getRowByConfigName('Updated name');
       updatedRow.find().should('contain.text', 'Updated name');
       updatedRow.find().should('contain.text', 'Updated description');
+    });
+
+    it('can reset an unreadable storage class config', () => {
+      const storageClassName = 'unreadable-config';
+      const storageClass = {
+        ...otherStorageClass,
+        metadata: { ...otherStorageClass.metadata, name: storageClassName },
+      };
+      const unreadableConfigStorageClass = buildMockStorageClass(storageClass, '{“FAIL:}');
+
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList([unreadableConfigStorageClass]),
+      );
+
+      storageClassesPage.visit();
+
+      const storageClassTableRow = storageClassesTable.getRowByName(storageClassName);
+      storageClassTableRow.findDisplayNameValue().should('have.text', '-');
+      storageClassTableRow.findEnableValue().should('have.text', '-');
+      storageClassTableRow.findDefaultValue().should('have.text', '-');
+      storageClassTableRow.findLastModifiedValue().should('have.text', '-');
+      storageClassTableRow.findEnableValue().should('have.text', '-');
+      storageClassTableRow.find().findByTestId('corrupted-metadata-alert').should('be.visible');
+      storageClassTableRow.findKebabAction('Edit').click();
+      storageClassEditModal.findInfoAlert().should('contain.text', 'Reset the metadata');
+      storageClassEditModal.fillDisplayNameInput('Readable config');
+
+      storageClassEditModal.mockUpdateStorageClass(storageClassName, 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(storageClass, {
+            displayName: 'Readable config',
+            isEnabled: false,
+            isDefault: false,
+          }),
+        ])
+        .as('updateStorageClass');
+      storageClassEditModal.findSaveButton().click();
+
+      cy.wait('@updateStorageClass');
+
+      storageClassTableRow.findDisplayNameValue().should('have.text', 'Readable config');
+      storageClassTableRow.findEnableSwitchInput().should('have.attr', 'aria-checked', 'false');
+      storageClassTableRow.findDefaultRadioInput().should('not.have.attr', 'checked');
+      storageClassTableRow.findLastModifiedValue().should('not.have.text', '-');
+    });
+
+    it('can reset individual config non-name fields when invalid', () => {
+      const storageClassName = 'invalid-non-name-fields';
+      const storageClassConfig =
+        '{"isDefault":"","isEnabled":"","displayName":"Test malformed default, enable, lastmodified","lastModified":"","description":""}';
+      const storageClass = buildMockStorageClass(
+        { ...otherStorageClass, metadata: { name: storageClassName } },
+        storageClassConfig,
+      );
+      const existingConfig = JSON.parse(storageClassConfig);
+
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList([storageClass]),
+      );
+
+      storageClassesPage.visit();
+
+      const storageClassTableRow = storageClassesTable.getRowByName(storageClassName);
+      storageClassTableRow
+        .findEnableValue()
+        .findByTestId('corrupted-metadata-alert')
+        .should('be.visible');
+      storageClassTableRow
+        .findDefaultValue()
+        .findByTestId('corrupted-metadata-alert')
+        .should('be.visible');
+      storageClassTableRow
+        .findLastModifiedValue()
+        .findByTestId('corrupted-metadata-alert')
+        .should('be.visible');
+
+      // Reset enable
+      storageClassesTable.mockUpdateStorageClass(storageClassName, 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(storageClass, {
+            ...existingConfig,
+            isEnabled: false,
+          }),
+        ])
+        .as('resetEnable');
+
+      storageClassTableRow
+        .findEnableValue()
+        .findByTestId('corrupted-metadata-alert-action')
+        .click();
+
+      cy.wait('@resetEnable');
+      storageClassTableRow.findEnableSwitchInput().should('have.attr', 'aria-checked', 'false');
+
+      // Reset default
+      storageClassesTable.mockUpdateStorageClass(storageClassName, 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(storageClass, {
+            ...existingConfig,
+            isEnabled: false,
+            isDefault: false,
+          }),
+        ])
+        .as('resetDefault');
+
+      storageClassTableRow
+        .findDefaultValue()
+        .findByTestId('corrupted-metadata-alert-action')
+        .click();
+
+      cy.wait('@resetDefault');
+      storageClassTableRow.findDefaultRadioInput().should('not.have.attr', 'checked');
+
+      // Reset last modified
+      storageClassesTable.mockUpdateStorageClass(storageClassName, 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(storageClass, {
+            ...existingConfig,
+            lastModified: '2023-08-22T15:42:53.101Z',
+            isEnabled: false,
+            isDefault: false,
+          }),
+        ])
+        .as('resetLastModified');
+
+      storageClassTableRow
+        .findLastModifiedValue()
+        .findByTestId('corrupted-metadata-alert-action')
+        .click();
+
+      cy.wait('@resetLastModified');
+      storageClassTableRow.findLastModifiedValue().should('contain.text', '8/22/2023');
+    });
+
+    it('can reset invalid config display name', () => {
+      const storageClass = buildMockStorageClass(
+        { ...otherStorageClass, metadata: { name: 'invalid-name' } },
+        '{"isDefault":false,"isEnabled":false,"displayName":{},"lastModified":"2024-09-09T17:45:05.299Z","description":"Test malformed displayName"}',
+      );
+
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList([storageClass]),
+      );
+
+      storageClassesPage.visit();
+
+      const storageClassTableRow = storageClassesTable.getRowByName('invalid-name');
+      storageClassTableRow
+        .findDisplayNameValue()
+        .findByTestId('corrupted-metadata-alert-action')
+        .click();
+      storageClassEditModal.findDisplayNameInput().should('be.empty');
+      storageClassEditModal
+        .findDescriptionInput()
+        .should('have.value', 'Test malformed displayName');
+      storageClassEditModal.findInfoAlert().should('contain.text', 'Edit the invalid field');
+      storageClassEditModal.fillDisplayNameInput('New name');
+
+      storageClassEditModal.mockUpdateStorageClass('invalid-name', 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(
+            storageClass,
+            buildMockStorageClassConfig(storageClass, {
+              displayName: 'New name',
+            }),
+          ),
+        ])
+        .as('refreshStorageClasses');
+
+      storageClassEditModal.findSaveButton().click();
+
+      cy.wait('@refreshStorageClasses');
+      storageClassTableRow.findDisplayNameValue().should('contain.text', 'New name');
+    });
+
+    it('can reset invalid config description', () => {
+      const storageClass = buildMockStorageClass(
+        { ...otherStorageClass, metadata: { name: 'invalid-description' } },
+        '{"isDefault":false,"isEnabled":false,"displayName":"Test malformed description","lastModified":"2024-09-09T17:45:05.299Z","description":{}}',
+      );
+
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList([storageClass]),
+      );
+
+      storageClassesPage.visit();
+
+      const storageClassTableRow = storageClassesTable.getRowByName('invalid-description');
+      storageClassTableRow
+        .findDisplayNameValue()
+        .findByTestId('corrupted-metadata-alert-action')
+        .click();
+      storageClassEditModal
+        .findDisplayNameInput()
+        .should('have.value', 'Test malformed description');
+      storageClassEditModal.findDescriptionInput().should('be.empty');
+      storageClassEditModal.findInfoAlert().should('contain.text', 'Edit the invalid field');
+
+      storageClassEditModal.mockUpdateStorageClass('invalid-description', 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(
+            storageClass,
+            buildMockStorageClassConfig(storageClass, {
+              description: '',
+            }),
+          ),
+        ])
+        .as('refreshStorageClasses');
+
+      storageClassEditModal.findSaveButton().click();
+
+      cy.wait('@refreshStorageClasses');
+      storageClassTableRow.findDisplayNameValue().should('have.text', 'Test malformed description');
+    });
+
+    it('can reset invalid config display name & description', () => {
+      const storageClass = buildMockStorageClass(
+        { ...otherStorageClass, metadata: { name: 'invalid-name-and-desc' } },
+        '{"isDefault":false,"isEnabled":false,"displayName":{},"description":{},"lastModified":"2024-09-09T17:45:05.299Z"}',
+      );
+
+      cy.interceptOdh(
+        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
+        {},
+        mockStorageClassList([storageClass]),
+      );
+
+      storageClassesPage.visit();
+
+      const storageClassTableRow = storageClassesTable.getRowByName('invalid-name-and-desc');
+      storageClassTableRow
+        .findDisplayNameValue()
+        .findByTestId('corrupted-metadata-alert-action')
+        .click();
+      storageClassEditModal.findDisplayNameInput().should('be.empty');
+      storageClassEditModal.findDescriptionInput().should('be.empty');
+      storageClassEditModal.findInfoAlert().should('contain.text', 'Edit the invalid field');
+      storageClassEditModal.fillDisplayNameInput('New name');
+      storageClassEditModal.fillDescriptionInput('New description');
+
+      storageClassEditModal.mockUpdateStorageClass('invalid-name-and-desc', 1);
+      storageClassesTable
+        .mockGetStorageClasses([
+          buildMockStorageClass(
+            storageClass,
+            buildMockStorageClassConfig(storageClass, {
+              displayName: 'New name',
+              description: 'New description',
+            }),
+          ),
+        ])
+        .as('refreshStorageClasses');
+
+      storageClassEditModal.findSaveButton().click();
+
+      cy.wait('@refreshStorageClasses');
+      storageClassTableRow.findDisplayNameValue().should('contain.text', 'New name');
+      storageClassTableRow.findDisplayNameValue().should('contain.text', 'New description');
     });
   });
 });

--- a/frontend/src/pages/storageClasses/CorruptedMetadataAlert.tsx
+++ b/frontend/src/pages/storageClasses/CorruptedMetadataAlert.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Alert, AlertProps, Flex, FlexItem, Icon, Popover, Tooltip } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+interface CorruptedMetadataAlertProps extends Pick<AlertProps, 'variant'> {
+  popoverText: React.ReactNode;
+  action?: React.ReactNode;
+  errorText?: React.ReactNode;
+}
+
+export const CorruptedMetadataAlert: React.FC<CorruptedMetadataAlertProps> = ({
+  variant = 'warning',
+  action,
+  errorText,
+  popoverText,
+}) => (
+  <Flex
+    alignItems={{ default: 'alignItemsCenter' }}
+    spaceItems={{ default: 'spaceItemsNone' }}
+    data-testid="corrupted-metadata-alert"
+  >
+    <FlexItem>
+      <Popover aria-label="Corrupted metadata popover" bodyContent={popoverText}>
+        <Alert
+          variant={variant}
+          isInline
+          isPlain
+          title="Corrupted metadata"
+          className="pf-v5-u-text-nowrap"
+        />
+      </Popover>
+    </FlexItem>
+
+    {action && <FlexItem data-testid="corrupted-metadata-alert-action">{action}</FlexItem>}
+
+    {errorText && (
+      <FlexItem>
+        <Tooltip content={errorText}>
+          <Icon status="danger" data-testid="corrupted-metadata-alert-error-icon">
+            <ExclamationCircleIcon />
+          </Icon>
+        </Tooltip>
+      </FlexItem>
+    )}
+  </Flex>
+);

--- a/frontend/src/pages/storageClasses/ResetCorruptConfigValueAlert.tsx
+++ b/frontend/src/pages/storageClasses/ResetCorruptConfigValueAlert.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { AlertProps, Button } from '@patternfly/react-core';
+import { SyncAltIcon } from '@patternfly/react-icons';
+
+import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+import { CorruptedMetadataAlert } from './CorruptedMetadataAlert';
+
+interface ResetCorruptConfigValueAlertProps extends Pick<AlertProps, 'variant'> {
+  storageClassName: string;
+  storageClassConfig: StorageClassConfig;
+  refresh: () => Promise<void | StorageClassKind[]>;
+}
+
+export const ResetCorruptConfigValueAlert: React.FC<ResetCorruptConfigValueAlertProps> = ({
+  storageClassName,
+  storageClassConfig,
+  variant,
+  refresh,
+}) => {
+  const [error, setError] = React.useState<string>();
+  const [isUpdating, setIsUpdating] = React.useState(false);
+
+  const onClick = React.useCallback(async () => {
+    setIsUpdating(true);
+
+    try {
+      await updateStorageClassConfig(storageClassName, storageClassConfig);
+      await refresh();
+    } catch {
+      setError('Failed to refresh the field. Try again later.');
+    } finally {
+      setIsUpdating(false);
+    }
+  }, [storageClassName, storageClassConfig, refresh]);
+
+  return (
+    <CorruptedMetadataAlert
+      variant={variant}
+      popoverText="Refresh the field to correct the corrupted metadata."
+      errorText={error}
+      action={
+        <Button
+          variant="plain"
+          aria-label="Corrupt metadata default reset button"
+          isDisabled={isUpdating}
+          onClick={onClick}
+        >
+          <SyncAltIcon />
+        </Button>
+      }
+    />
+  );
+};

--- a/frontend/src/pages/storageClasses/StorageClassDefaultRadio.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassDefaultRadio.tsx
@@ -30,8 +30,7 @@ export const StorageClassDefaultRadio: React.FC<StorageClassDefaultRadioProps> =
     try {
       await updateStorageClassConfig(storageClassName, { isDefault: true });
       await onChange();
-      setIsUpdating(false);
-    } catch {
+    } finally {
       setIsUpdating(false);
     }
 

--- a/frontend/src/pages/storageClasses/StorageClassEnableSwitch.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEnableSwitch.tsx
@@ -31,8 +31,7 @@ export const StorageClassEnableSwitch: React.FC<StorageClassEnableSwitchProps> =
       try {
         await updateStorageClassConfig(storageClassName, { isEnabled: checked });
         await onChange();
-        setIsUpdating(false);
-      } catch {
+      } finally {
         setIsUpdating(false);
       }
 

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -9,9 +9,10 @@ import {
   DescriptionListTerm,
   DescriptionListDescription,
   Timestamp,
+  Button,
 } from '@patternfly/react-core';
 import { Tr, Td, ActionsColumn, TableText } from '@patternfly/react-table';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
 import { TableRowTitleDescription } from '~/components/table';
@@ -20,11 +21,13 @@ import { updateStorageClassConfig } from '~/services/StorageClassService';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import { NoValue } from '~/components/NoValue';
 import { ColumnLabel } from './constants';
-import { isOpenshiftDefaultStorageClass } from './utils';
+import { isOpenshiftDefaultStorageClass, isValidConfigValue } from './utils';
 import { StorageClassEnableSwitch } from './StorageClassEnableSwitch';
 import { StorageClassDefaultRadio } from './StorageClassDefaultRadio';
 import { StorageClassEditModal } from './StorageClassEditModal';
 import { OpenshiftDefaultLabel } from './OpenshiftDefaultLabel';
+import { CorruptedMetadataAlert } from './CorruptedMetadataAlert';
+import { ResetCorruptConfigValueAlert } from './ResetCorruptConfigValueAlert';
 
 interface StorageClassesTableRowProps {
   storageClass: StorageClassKind;
@@ -38,10 +41,13 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
   refresh,
 }) => {
   const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
-  const storageClassConfig = storageClassConfigMap[storageClass.metadata.name];
   const isOpenshiftDefault = isOpenshiftDefaultStorageClass(storageClass);
   const { metadata, provisioner, reclaimPolicy, volumeBindingMode, allowVolumeExpansion } =
     storageClass;
+  const storageClassConfig = storageClassConfigMap[metadata.name];
+  const hasReadableConfig = storageClassConfig !== undefined;
+  const editModalAlertRef =
+    React.useRef<React.ComponentProps<typeof StorageClassEditModal>['alert']>();
 
   const storageClassInfoItems = [
     {
@@ -72,8 +78,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
 
   const isEnableSwitchDisabled = React.useMemo(() => {
     const hasOtherStorageClassesEnabled = Object.entries(storageClassConfigMap).some(
-      ([storageClassName, config]) =>
-        storageClassName !== storageClass.metadata.name && config?.isEnabled,
+      ([storageClassName, config]) => storageClassName !== metadata.name && config?.isEnabled,
     );
 
     // Prevent disabling when the storage class is enabled and all
@@ -87,7 +92,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
 
     return false;
   }, [
-    storageClass.metadata.name,
+    metadata.name,
     storageClassConfig?.isDefault,
     storageClassConfig?.isEnabled,
     storageClassConfigMap,
@@ -95,7 +100,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
 
   const onDefaultRadioChange = React.useCallback(async () => {
     const existingDefaultConfigMap = Object.entries(storageClassConfigMap).find(
-      ([name, config]) => storageClass.metadata.name !== name && config?.isDefault,
+      ([name, config]) => metadata.name !== name && config?.isDefault,
     );
 
     if (existingDefaultConfigMap) {
@@ -103,15 +108,48 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
       await updateStorageClassConfig(name, { ...config, isDefault: false });
       refresh();
     }
-  }, [storageClass.metadata.name, storageClassConfigMap, refresh]);
+  }, [metadata.name, storageClassConfigMap, refresh]);
 
   return (
     <Tr>
       <Td dataLabel={ColumnLabel.DisplayName}>
-        <TableRowTitleDescription
-          title={<TableText wrapModifier="truncate">{storageClassConfig?.displayName}</TableText>}
-          description={storageClassConfig?.description}
-        />
+        {hasReadableConfig ? (
+          <StrorageClassConfigValue
+            alert={
+              <CorruptedMetadataAlert
+                popoverText="Edit the invalid field(s) and save your changes to correct the corrupted metadata."
+                action={
+                  <Button
+                    variant="plain"
+                    aria-label="Corrupt metadata name/description edit button"
+                    onClick={() => {
+                      editModalAlertRef.current = {
+                        title:
+                          'Edit the invalid field(s) and save your changes to correct the corrupted metadata.',
+                      };
+                      setIsEditModalOpen(true);
+                    }}
+                  >
+                    <PencilAltIcon />
+                  </Button>
+                }
+              />
+            }
+          >
+            {isValidConfigValue('displayName', storageClassConfig.displayName) &&
+              (!storageClassConfig.description ||
+                isValidConfigValue('description', storageClassConfig.description)) && (
+                <TableRowTitleDescription
+                  title={
+                    <TableText wrapModifier="truncate">{storageClassConfig.displayName}</TableText>
+                  }
+                  description={storageClassConfig.description}
+                />
+              )}
+          </StrorageClassConfigValue>
+        ) : (
+          '-'
+        )}
       </Td>
 
       <Td dataLabel={ColumnLabel.OpenshiftStorageClass}>
@@ -151,40 +189,114 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
       </Td>
 
       <Td dataLabel={ColumnLabel.Enable}>
-        <StorageClassEnableSwitch
-          storageClassName={metadata.name}
-          isChecked={!!storageClassConfig?.isEnabled}
-          isDisabled={isEnableSwitchDisabled}
-          onChange={refresh}
-        />
+        {hasReadableConfig ? (
+          <StrorageClassConfigValue
+            alert={
+              <ResetCorruptConfigValueAlert
+                storageClassName={metadata.name}
+                storageClassConfig={{
+                  ...storageClassConfig,
+                  isEnabled: false,
+                }}
+                variant="danger"
+                refresh={refresh}
+              />
+            }
+          >
+            {isValidConfigValue('isEnabled', storageClassConfig.isEnabled) && (
+              <StorageClassEnableSwitch
+                storageClassName={metadata.name}
+                isChecked={storageClassConfig.isEnabled}
+                isDisabled={isEnableSwitchDisabled}
+                onChange={refresh}
+              />
+            )}
+          </StrorageClassConfigValue>
+        ) : (
+          '-'
+        )}
       </Td>
 
       <Td dataLabel={ColumnLabel.Default}>
-        <StorageClassDefaultRadio
-          storageClassName={metadata.name}
-          isChecked={!!storageClassConfig?.isDefault}
-          isDisabled={!storageClassConfig?.isDefault && !storageClassConfig?.isEnabled}
-          onChange={onDefaultRadioChange}
-        />
+        {hasReadableConfig ? (
+          <StrorageClassConfigValue
+            alert={
+              <ResetCorruptConfigValueAlert
+                storageClassName={metadata.name}
+                storageClassConfig={{
+                  ...storageClassConfig,
+                  isDefault: false,
+                }}
+                refresh={refresh}
+              />
+            }
+          >
+            {isValidConfigValue('isDefault', storageClassConfig.isDefault) && (
+              <StorageClassDefaultRadio
+                storageClassName={metadata.name}
+                isChecked={storageClassConfig.isDefault}
+                isDisabled={!storageClassConfig.isDefault && !storageClassConfig.isEnabled}
+                onChange={onDefaultRadioChange}
+              />
+            )}
+          </StrorageClassConfigValue>
+        ) : (
+          '-'
+        )}
       </Td>
 
       <Td dataLabel={ColumnLabel.LastModified}>
-        {storageClassConfig?.lastModified ? (
-          <Timestamp date={new Date(storageClassConfig.lastModified)} />
+        {hasReadableConfig ? (
+          <StrorageClassConfigValue
+            alert={
+              <ResetCorruptConfigValueAlert
+                storageClassName={metadata.name}
+                storageClassConfig={storageClassConfig}
+                refresh={refresh}
+              />
+            }
+          >
+            {isValidConfigValue('lastModified', storageClassConfig.lastModified) && (
+              <Timestamp date={new Date(storageClassConfig.lastModified)} />
+            )}
+          </StrorageClassConfigValue>
         ) : (
-          'Unknown'
+          '-'
         )}
       </Td>
 
       <Td isActionCell>
-        <ActionsColumn
-          items={[
-            {
-              title: 'Edit',
-              onClick: () => setIsEditModalOpen(true),
-            },
-          ]}
-        />
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          flexWrap={{ default: 'nowrap' }}
+          spaceItems={{ default: 'spaceItemsNone' }}
+          justifyContent={{ default: 'justifyContentFlexEnd' }}
+        >
+          {!hasReadableConfig && (
+            <CorruptedMetadataAlert
+              variant="danger"
+              popoverText="This storage class is unavailable because its metadata is corrupted. Edit the storage class to correct its metadata."
+            />
+          )}
+
+          <ActionsColumn
+            items={[
+              {
+                title: 'Edit',
+                onClick: () => {
+                  editModalAlertRef.current = !hasReadableConfig
+                    ? {
+                        title: 'Reset the metadata',
+                        children:
+                          'Correct any invalid fields and save your changes to reset the corrupted metadata. Upon saving, Display name and Last modified will receive valid values, and the Enable and Default parameters will be reset to their default values.',
+                      }
+                    : undefined;
+                  setIsEditModalOpen(true);
+                },
+              },
+            ]}
+          />
+        </Flex>
       </Td>
 
       {isEditModalOpen && (
@@ -192,8 +304,20 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
           storageClass={storageClass}
           onSuccess={refresh}
           onClose={() => setIsEditModalOpen(false)}
+          alert={editModalAlertRef.current}
         />
       )}
     </Tr>
   );
+};
+
+const StrorageClassConfigValue: React.FC<React.PropsWithChildren & { alert: React.ReactNode }> = ({
+  alert,
+  children,
+}) => {
+  if (!children) {
+    return alert;
+  }
+
+  return children;
 };

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -1,3 +1,4 @@
+import { isValidDate } from '@patternfly/react-core';
 import { MetadataAnnotation, StorageClassConfig, StorageClassKind } from '~/k8sTypes';
 
 export const getStorageClassConfig = (
@@ -16,3 +17,21 @@ export const getStorageClassConfig = (
 
 export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>
   storageClass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
+
+export const isValidConfigValue = (
+  configKey: keyof StorageClassConfig,
+  value: string | boolean | undefined,
+): boolean => {
+  switch (configKey) {
+    case 'displayName':
+    case 'description':
+      return !!value && typeof value === 'string';
+    case 'isEnabled':
+    case 'isDefault':
+      return typeof value === 'boolean';
+    case 'lastModified':
+      return typeof value === 'string' && isValidDate(new Date(value));
+    default:
+      return false;
+  }
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-12310

## Description
Show error/warning alerts for scenarios where individual storage class config values or the entire config are malformed in some way. Introduce abilities to correct those mistakes possibly made via the Openshift UI within the ODH dashboard's storage class table.

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/7ef334e0-1ca8-4990-8f26-aba64ed04a4c">

**Unreadable config demo:**
https://github.com/user-attachments/assets/86b3cda6-f5c4-41cf-bcdc-92f8787f9b61

**Invalid data, default, enable config values:**
https://github.com/user-attachments/assets/35a9d29c-f889-4101-a2f2-690fe4a8afbb

**Invalid Display name demo:**
https://github.com/user-attachments/assets/af5d969f-450c-4303-a1e5-3057554d114d

**Invalid Description demo:**
https://github.com/user-attachments/assets/8f4b14a3-b97f-4035-b24c-0f8d28a885b7

**Invalid Display name and description demo:**
https://github.com/user-attachments/assets/9fd6f80f-5590-42e9-b524-3c7db61c7b16

(cc @xianli123)

## How Has This Been Tested?
1. Edit storage classes within in Openshift via `/search/ns/opendatahub?q=&kind=storage.k8s.io~v1~StorageClass` by clicking on individual row actions, `Edit annotations`, then update the `opendatahub.io/sc-config` value to force invalid data.

With the feature flag enabled, visit the storage class table's page; `/storageClasses?devFeatureFlags=disableStorageClasses`

2. Verify the cases outlined in the JIRA issue are covered and match the referenced designs.
3. Verify all storage class edit modals are updated according to how/where they were opened from.
4. Verify once updating a given row or individual cell that the data is reset and no longer considered "Corrupted".

## Test Impact
Added cypress test covering multiple error cases

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
