### PR TITLE
Display storage class selected in workbenches

### DIFF
--- a/frontend/src/__mocks__/mockPVCK8sResource.ts
+++ b/frontend/src/__mocks__/mockPVCK8sResource.ts
@@ -5,6 +5,7 @@ type MockResourceConfigType = {
   name?: string;
   namespace?: string;
   storage?: string;
+  storageClassName?: string;
   displayName?: string;
   uid?: string;
 };
@@ -13,6 +14,7 @@ export const mockPVCK8sResource = ({
   name = 'test-storage',
   namespace = 'test-project',
   storage = '5Gi',
+  storageClassName = 'gp3',
   displayName = 'Test Storage',
   uid = genUID('pvc'),
 }: MockResourceConfigType): PersistentVolumeClaimKind => ({
@@ -38,7 +40,7 @@ export const mockPVCK8sResource = ({
       },
     },
     volumeName: 'pvc-8644e33b-a710-45a3-9d54-7f987494643a',
-    storageClassName: 'gp3',
+    storageClassName,
     volumeMode: 'Filesystem',
   },
   status: {

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -15,6 +15,19 @@ class ClusterStorageRow extends TableRow {
     this.find().findByRole('button', { name: 'Details' }).click();
   }
 
+  findDeprecatedLabel() {
+    return this.find().findByTestId('storage-class-deprecated');
+  }
+
+  shouldHaveDeprecatedTooltip() {
+    cy.findByTestId('storage-class-deprecated-tooltip').should('be.visible');
+    return this;
+  }
+
+  findStorageClassColumn() {
+    return this.find().find('[data-label="Storage class"]');
+  }
+
   shouldHaveStorageSize(name: string) {
     this.find().siblings().find('[data-label=Size]').contains(name).should('exist');
     return this;
@@ -116,6 +129,19 @@ class ClusterStorage {
 
   findClusterStorageTableHeaderButton(name: string) {
     return this.findClusterStorageTable().find('thead').findByRole('button', { name });
+  }
+
+  shouldHaveDeprecatedAlertMessage() {
+    return cy
+      .findByTestId('storage-class-deprecated-alert')
+      .should(
+        'contain.text',
+        'Warning alert:Deprecated storage classA storage class has been deprecated by your administrator, but the cluster storage using it is still active. If you want to migrate your data to cluster storage instance using a different storage class, contact your administrator.',
+      );
+  }
+
+  closeDeprecatedAlert() {
+    cy.findByTestId('storage-class-deprecated-alert-close-button').click();
   }
 
   getClusterStorageRow(name: string) {

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -1,8 +1,9 @@
 import { SortableData } from '~/components/table';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
-import { PersistentVolumeClaimKind } from '~/k8sTypes';
+import { getStorageClassConfig } from '~/pages/storageClasses/utils';
+import { StorageTableData } from './types';
 
-export const columns: SortableData<PersistentVolumeClaimKind>[] = [
+export const columns: SortableData<StorageTableData>[] = [
   {
     field: 'expand',
     label: '',
@@ -13,18 +14,32 @@ export const columns: SortableData<PersistentVolumeClaimKind>[] = [
     label: 'Name',
     width: 30,
     sortable: (a, b) =>
-      getDisplayNameFromK8sResource(a).localeCompare(getDisplayNameFromK8sResource(b)),
+      getDisplayNameFromK8sResource(a.pvc).localeCompare(getDisplayNameFromK8sResource(b.pvc)),
+  },
+  {
+    field: 'storage',
+    label: 'Storage class',
+    width: 30,
+    sortable: (a, b) =>
+      (a.storageClass
+        ? getStorageClassConfig(a.storageClass)?.displayName ?? a.storageClass.metadata.name
+        : a.pvc.spec.storageClassName ?? ''
+      ).localeCompare(
+        b.storageClass
+          ? getStorageClassConfig(b.storageClass)?.displayName ?? b.storageClass.metadata.name
+          : b.pvc.spec.storageClassName ?? '',
+      ),
   },
   {
     field: 'type',
     label: 'Type',
-    width: 25,
+    width: 20,
     sortable: false,
   },
   {
     field: 'connected',
     label: 'Connected workbenches',
-    width: 25,
+    width: 20,
     sortable: false,
   },
   {

--- a/frontend/src/pages/projects/screens/detail/storage/types.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/types.ts
@@ -1,0 +1,6 @@
+import { PersistentVolumeClaimKind, StorageClassKind } from '~/k8sTypes';
+
+export type StorageTableData = {
+  pvc: PersistentVolumeClaimKind;
+  storageClass: StorageClassKind | undefined;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-1110

## Description

1. Added a new column for the storage class in the cluster storage table when the feature flag is enabled
2. shows class display name and description and sortable
3. shows the deprecated storage class alert when atleast one of the storage class is disabled and attached to cluster storage and added a label 

Cluster storage page

<img width="1171" alt="Screenshot 2024-09-17 at 1 04 34 PM" src="https://github.com/user-attachments/assets/a4d15d62-a20f-4701-95a9-d09650a87d79">


when storage class is deprecated/disabled
[
<img width="1256" alt="Screenshot 2024-09-16 at 5 31 10 PM" src="https://github.com/user-attachments/assets/4f176dae-0627-4d18-9723-ea31659706b4">
](url)

when storage class is deleted

<img width="1256" alt="Screenshot 2024-09-16 at 5 29 28 PM" src="https://github.com/user-attachments/assets/3ad2ebfc-1ded-4f90-94aa-6610137322dc">



<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
When feature flag is off

1. Check the functionality remains same 

When feature flag is on

1. Go to the cluster storage tab from the Data science project Page
2. Check for the new storage column
3. Check whether its sortable
4. Check when the storage class is disabled for the attached cluster storage the deprecated label along with the alert message is shown
5. Check when the storage class is deleted for the attached cluster storage the deleted label is shown

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added cypress test to it
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
