### PR TITLE
View pipeline server dialog shows access key and secret key

### DIFF
--- a/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
@@ -45,13 +45,23 @@ const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
               <DescriptionListGroup>
                 <DescriptionListTerm>Access key</DescriptionListTerm>
                 <DescriptionListDescription data-testid="access-key-field">
-                  {pipelineSecret.AWS_ACCESS_KEY_ID || ''}
+                  {pipelineSecret[
+                    pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
+                      .accessKey
+                  ] || ''}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>Secret key</DescriptionListTerm>
                 <DescriptionListDescription data-testid="secret-key-field">
-                  <PasswordHiddenText password={pipelineSecret.AWS_SECRET_ACCESS_KEY ?? ''} />
+                  <PasswordHiddenText
+                    password={
+                      pipelineSecret[
+                        pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
+                          .secretKey
+                      ] ?? ''
+                    }
+                  />
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-9819

## Description
View pipeline server dialog displays Access key and Secret key when the values are from a secret

![Screenshot 2024-09-18 at 7 20 32 PM](https://github.com/user-attachments/assets/23d356db-97fe-4967-b584-02b9cb40394d)


<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Create a dspa using the following yaml mentioned in the jira issue
2. Check whether the view pipeline server dialog displays the access key and secret key
3. Check whether othetr dspa created from dashboard works same

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
The cypress test are already present
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
