### PR TITLE
MR Permissions - Group and Project dropdown issues 

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -295,7 +295,7 @@ describe('MR Permissions', () => {
       usersTab.findAddGroupButton().click();
 
       groupTable.findNameSelect().fill('new-example-mr-group');
-      cy.findByText('Create "new-example-mr-group"').click();
+      cy.findByText('Select "new-example-mr-group"').click();
       groupTable.findSaveNewButton().click();
 
       cy.wait('@addGroup').then((interception) => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -295,7 +295,7 @@ describe('MR Permissions', () => {
       usersTab.findAddGroupButton().click();
 
       groupTable.findNameSelect().fill('new-example-mr-group');
-      cy.findByText('Select "new-example-mr-group"').click();
+      cy.findByText('Create "new-example-mr-group"').click();
       groupTable.findSaveNewButton().click();
 
       cy.wait('@addGroup').then((interception) => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -296,10 +296,10 @@ describe('MR Permissions', () => {
 
       // Type the group name into the input
       groupTable.findNameSelect().type('new-example-mr-group');
-      
+
       // Wait for the dropdown to appear and select the option
       cy.contains('new-example-mr-group', { timeout: 10000 }).should('be.visible').click();
-      
+
       groupTable.findSaveNewButton().click();
 
       cy.wait('@addGroup').then((interception) => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -294,8 +294,12 @@ describe('MR Permissions', () => {
 
       usersTab.findAddGroupButton().click();
 
-      groupTable.findNameSelect().fill('new-example-mr-group');
-      cy.findByText('Create "new-example-mr-group"').click();
+      // Type the group name into the input
+      groupTable.findNameSelect().type('new-example-mr-group');
+      
+      // Wait for the dropdown to appear and select the option
+      cy.contains('new-example-mr-group', { timeout: 10000 }).should('be.visible').click();
+      
       groupTable.findSaveNewButton().click();
 
       cy.wait('@addGroup').then((interception) => {

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -250,12 +250,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     if (onInputChange) {
       onInputChange(value);
     }
-    if (selected && value !== selected.content) {
-      // Clear the selection when the input value changes
-      if (onSelect) {
-        onSelect(undefined, '');
-      }
-    }
+
     resetActiveAndFocusedItem();
   };
 

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -69,7 +69,7 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
-const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
+const defaultSelectOptionMessage = (newValue: string) => `Select "${newValue}"`;
 
 const defaultFilterFunction = (filterValue: string, options: TypeaheadSelectOption[]) =>
   options.filter((o) => String(o.content).toLowerCase().includes(filterValue.toLowerCase()));
@@ -88,7 +88,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   noOptionsFoundMessage = defaultNoOptionsFoundMessage,
   isCreatable = false,
   isCreateOptionOnTop = false,
-  createOptionMessage = defaultCreateOptionMessage,
+  createOptionMessage = defaultSelectOptionMessage,
   isDisabled,
   toggleWidth,
   toggleProps,
@@ -212,12 +212,10 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   const onInputClick = () => {
     if (!isOpen) {
       openMenu();
-      setTimeout(() => {
-        textInputRef.current?.focus();
-      }, 100);
-    } else if (isFiltering) {
-      closeMenu();
     }
+    setTimeout(() => {
+      textInputRef.current?.focus();
+    }, 100);
   };
 
   const selectOption = (
@@ -248,12 +246,17 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   };
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
-    setFilterValue(value || '');
+    setFilterValue(value);
     setIsFiltering(true);
     if (onInputChange) {
       onInputChange(value);
     }
-
+    if (selected && value !== selected.content) {
+      // Clear the selection when the input value changes
+      if (onSelect) {
+        onSelect(undefined, '');
+      }
+    }
     resetActiveAndFocusedItem();
   };
 
@@ -371,7 +374,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
-          value={isFiltering ? filterValue : selected?.content ?? ''}
+          value={isFiltering ? filterValue : (selected?.content ?? '')}
           onClick={onInputClick}
           onChange={onTextInputChange}
           onKeyDown={onInputKeyDown}

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -69,8 +69,7 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
-const defaultSelectOptionMessage = (newValue: string) => `Select "${newValue}"`;
-
+const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
 const defaultFilterFunction = (filterValue: string, options: TypeaheadSelectOption[]) =>
   options.filter((o) => String(o.content).toLowerCase().includes(filterValue.toLowerCase()));
 
@@ -88,7 +87,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   noOptionsFoundMessage = defaultNoOptionsFoundMessage,
   isCreatable = false,
   isCreateOptionOnTop = false,
-  createOptionMessage = defaultSelectOptionMessage,
+  createOptionMessage = defaultCreateOptionMessage,
   isDisabled,
   toggleWidth,
   toggleProps,
@@ -246,7 +245,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   };
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
-    setFilterValue(value);
+    setFilterValue(value || '');
     setIsFiltering(true);
     if (onInputChange) {
       onInputChange(value);
@@ -404,6 +403,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       onSelect={handleSelect}
       onOpenChange={(open) => !open && closeMenu()}
       toggle={toggle}
+      shouldFocusFirstItemOnOpen={false}
       ref={innerRef}
       {...props}
     >

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -374,7 +374,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
-          value={isFiltering ? filterValue : (selected?.content ?? '')}
+          value={isFiltering ? filterValue : selected?.content ?? ''}
           onClick={onInputClick}
           onChange={onTextInputChange}
           onKeyDown={onInputKeyDown}

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -52,10 +52,6 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
     return { value: displayName, content: displayName };
   });
 
-  if (value && !typeAhead.includes(value)) {
-    selectOptions.push({ value, content: value });
-  }
-
   return (
     <TypeaheadSelect
       selectOptions={selectOptions}
@@ -68,6 +64,18 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
         }
       }}
       placeholder={placeholderText}
+      createOptionMessage={(newValue) => `Select "${newValue}"`}
+      filterFunction={(filterValue, options) => {
+        const filteredOptions = options.filter((option) =>
+          String(option.content).toLowerCase().includes(filterValue.toLowerCase()),
+        );
+
+        if (filteredOptions.length === 0 && filterValue.trim() !== '') {
+          return [{ value: filterValue, content: filterValue }];
+        }
+
+        return filteredOptions;
+      }}
     />
   );
 };

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -65,17 +65,6 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
       }}
       placeholder={placeholderText}
       createOptionMessage={(newValue) => `Select "${newValue}"`}
-      filterFunction={(filterValue, options) => {
-        const filteredOptions = options.filter((option) =>
-          String(option.content).toLowerCase().includes(filterValue.toLowerCase()),
-        );
-
-        if (filteredOptions.length === 0 && filterValue.trim() !== '') {
-          return [{ value: filterValue, content: filterValue }];
-        }
-
-        return filteredOptions;
-      }}
     />
   );
 };

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -51,7 +51,10 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
     const displayName = isProjectSubject ? namespaceToProjectDisplayName(option, projects) : option;
     return { value: displayName, content: displayName };
   });
-
+  // If we've selected an option that doesn't exist via isCreatable, include it in the options so it remains selected
+  if (value && !selectOptions.some((option) => option.value === value)) {
+    selectOptions.push({ value, content: value });
+  }
   return (
     <TypeaheadSelect
       selectOptions={selectOptions}

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRow.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRow.tsx
@@ -92,7 +92,8 @@ const RoleBindingPermissionsTableRow: React.FC<RoleBindingPermissionsTableRowPro
                 <Tooltip
                   content={
                     <div>
-                      This group is created by default. You can add users to this group via the API.
+                      This group is created by default. You can add users to this group in OpenShift
+                      user management, or ask the cluster admin to do so.
                     </div>
                   }
                 >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
[RHOAIENG-12025](https://issues.redhat.com/browse/RHOAIENG-12025)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
 1.  Verify that once you've selected an item in the dropdown, if you then open the dropdown, you can NOW focus the typeahead text field without the need to close the dropdown( it was blocking the user from doing it) - try typing something in the typeahead in addition to the selected option 
 2. The Option in the bottom of the dropdown list is now Select and not Create 
 3. After you choose an option in the drop down, try deleting it in the typeahead and verify that it's not creating duplicate entries of that field in the dropdown(see screenshot in the issue) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the UI 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
One test change to update the Create to Select . Also When changing the label to select I didn't change all the variable names of that label so they are still mostly shown as "create ...." in the code and not as select (except at the original line) 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x
<img width="681" alt="Screenshot 2024-09-18 at 10 40 12 AM" src="https://github.com/user-attachments/assets/9d01ed74-e529-46e3-81a7-20cc03af57be">
<img width="890" alt="Screenshot 2024-09-18 at 10 40 29 AM" src="https://github.com/user-attachments/assets/57047965-86e5-4c4d-b462-bfd3a43ec473">
] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
