### PR TITLE
update breadcrumb title for edit connection type page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -53,7 +53,7 @@ class CreateConnectionTypePage {
 
   visitEditPage(name = 'existing') {
     cy.visitWithLogin(`/connectionTypes/edit/${name}`);
-    cy.findAllByText('Create connection type').should('exist');
+    cy.findAllByText('Edit connection type').should('exist');
   }
 
   findConnectionTypeName() {

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeBreadcrumbs.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeBreadcrumbs.tsx
@@ -2,12 +2,16 @@ import * as React from 'react';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
-const ManageConnectionTypeBreadcrumbs: React.FunctionComponent = () => (
+type Props = {
+  name: string;
+};
+
+const ManageConnectionTypeBreadcrumbs: React.FC<Props> = ({ name }) => (
   <Breadcrumb ouiaId="BasicBreadcrumb">
     <BreadcrumbItem>
       <Link to="/connectionTypes">Connection types</Link>
     </BreadcrumbItem>
-    <BreadcrumbItem isActive>Create connection type</BreadcrumbItem>
+    <BreadcrumbItem isActive>{name}</BreadcrumbItem>
   </Breadcrumb>
 );
 

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -103,6 +103,7 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
     navigate('/connectionTypes');
   };
 
+  const pageName = isEdit ? 'Edit connection type' : 'Create connection type';
   return (
     <ConnectionTypePreviewDrawer
       isExpanded={isDrawerExpanded}
@@ -110,11 +111,11 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
       obj={connectionTypeObj}
     >
       <ApplicationsPage
-        title={isEdit ? 'Edit connection type' : 'Create connection type'}
+        title={pageName}
         loaded
         empty={false}
         errorMessage="Unable to load connection types"
-        breadcrumb={<ManageConnectionTypeBreadcrumbs />}
+        breadcrumb={<ManageConnectionTypeBreadcrumbs name={pageName} />}
         headerAction={
           isDrawerExpanded ? undefined : (
             <Button


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12827


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes the breadcrumb of the edit connection type page which use to say `Create connection type`.

Updated screenshot:
![image](https://github.com/user-attachments/assets/ca9581cd-bbb5-4aa1-b40f-aa3be6e68aa0)

cc @simrandhaliw 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by editing a connection type.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A copy change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
