### PR TITLE
Only fetch serving runtime templates with dashboard label

### DIFF
--- a/frontend/src/api/k8s/__tests__/templates.spec.ts
+++ b/frontend/src/api/k8s/__tests__/templates.spec.ts
@@ -113,6 +113,11 @@ describe('useTemplates', () => {
         isList: true,
         groupVersionKind: groupVersionKind(TemplateModel),
         namespace,
+        selector: {
+          matchLabels: {
+            'opendatahub.io/dashboard': 'true',
+          },
+        },
       },
       TemplateModel,
     );
@@ -165,6 +170,11 @@ describe('useTemplates', () => {
         isList: true,
         groupVersionKind: groupVersionKind(TemplateModel),
         namespace,
+        selector: {
+          matchLabels: {
+            'opendatahub.io/dashboard': 'true',
+          },
+        },
       },
       TemplateModel,
     );

--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -1,7 +1,7 @@
 import YAML from 'yaml';
 import React from 'react';
 import { WatchK8sResource, k8sDeleteResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
+import { KnownLabels, ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import { TemplateModel } from '~/api/models';
 import { genRandomChars } from '~/utilities/string';
 import { CustomWatchK8sResult, ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
@@ -54,6 +54,7 @@ export const useTemplates = (namespace?: string): CustomWatchK8sResult<TemplateK
           isList: true,
           groupVersionKind: groupVersionKind(TemplateModel),
           namespace,
+          selector: { matchLabels: { [KnownLabels.DASHBOARD_RESOURCE]: 'true' } },
         }
       : null;
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-12799

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added back the label selector for `'opendatahub.io/dashboard': 'true'` when fetching the templates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the serving runtimes page in the settings
2. Duplicate a serving runtime template
3. Go to the OpenShift console and find that template
4. Remove the label `'opendatahub.io/dashboard': 'true'` from the template
5. Refresh the serving runtimes page in the dashboard
6. Make sure the template without the label is not listed

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
There is no way to test the WebSocket watch API, the only way is to make sure the hook has been called with the selector option, so I updated that.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
