### PR TITLE
Model name dropdown not retaining user selection for 'Register new version'

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisteredModelSelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisteredModelSelector.tsx
@@ -21,8 +21,9 @@ const RegisteredModelSelector: React.FC<RegisteredModelSelectorProps> = ({
       registeredModels.map(({ name, id }) => ({
         content: name,
         value: id,
+        isSelected: id === registeredModelId,
       })),
-    [registeredModels],
+    [registeredModels, registeredModelId],
   );
 
   if (isDisabled && registeredModelId) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-12777


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The selection from the drop down is now preserved and displayed
<img width="918" alt="Screenshot 2024-09-18 at 11 25 33 AM" src="https://github.com/user-attachments/assets/ec376625-7bd0-46c8-abaa-589be821a025">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on the UI
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
