### PR TITLE
Fix stack chart issue when there is no data for one area

### DIFF
--- a/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/MetricsChart.tsx
@@ -213,7 +213,13 @@ const MetricsChart: React.FC<MetricsChartProps> = ({
                 {graphLines.map((line, i) => {
                   switch (type) {
                     case MetricsChartTypes.AREA:
-                      return <ChartArea key={i} data={line.points} name={line.name} />;
+                      return (
+                        <ChartArea
+                          key={i}
+                          data={line.points.length === 0 ? [null] : line.points}
+                          name={line.name}
+                        />
+                      );
                     case MetricsChartTypes.LINE:
                       return <ChartLine key={i} data={line.points} name={line.name} />;
                     default:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-11048

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is a known issue in Victory chart, and I am taking the workaround as suggested by the PF team here https://github.com/patternfly/patternfly-react/issues/10978#issuecomment-2346917642. If there is no data, we render it as `[null]` instead of `[]`, which fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I met some problems with generating the real data points, but you can go to the cypress test server and check the test case `Serving Chart Shows Data`

Way to compare:
1. Run `cypress:server` and `cypress:open:mock` in 2 terminals
2. Add `it.only` to the `Serving Chart Shows Data` test so we can check the screenshot
3. Go to `modelMetrics` test to check if it renders incorrectly
4. Run `cypress:server:build` and re-run step 1-3
5. You can see the data renders correctly

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Update the test cases to see the mocked data better.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
