### PR TITLE
Get rid of imagePullSecrets field in RHOAI deployment

### DIFF
--- a/manifests/rhoai/shared/base/anaconda-ce-validator-cron.yaml
+++ b/manifests/rhoai/shared/base/anaconda-ce-validator-cron.yaml
@@ -19,8 +19,6 @@ spec:
             parent: "anaconda-ce-periodic-validator"
         spec:
           serviceAccount: "rhods-dashboard"
-          imagePullSecrets:
-            - name: addon-managed-odh-pullsecret
           containers:
           - name: anaconda-ce-validator
             image: registry.redhat.io/openshift4/ose-cli@sha256:75bf9b911b6481dcf29f7942240d1555adaa607eec7fc61bedb7f624f87c36d4

--- a/manifests/rhoai/shared/base/deployment.yaml
+++ b/manifests/rhoai/shared/base/deployment.yaml
@@ -20,7 +20,3 @@
 - op: replace
   path: /spec/template/spec/serviceAccount
   value: rhods-dashboard
-- op: replace
-  path: /spec/template/spec/imagePullSecrets
-  value:
-    - name: addon-managed-odh-pullsecret

--- a/manifests/rhoai/shared/base/nvidia-nim-validator-cron.yaml
+++ b/manifests/rhoai/shared/base/nvidia-nim-validator-cron.yaml
@@ -19,8 +19,6 @@ spec:
             parent: "nvidia-nim-periodic-validator"
         spec:
           serviceAccount: "rhods-dashboard"
-          imagePullSecrets:
-            - name: addon-managed-odh-pullsecret
           containers:
           - name: nvidia-nim-validator
             image: registry.redhat.io/openshift4/ose-cli@sha256:75bf9b911b6481dcf29f7942240d1555adaa607eec7fc61bedb7f624f87c36d4


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-10782](https://issues.redhat.com/browse/RHOAIENG-10782)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This field was probably an old value and could be removed not to avoid the warnings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Get a 4.15+ OpenShift cluster
2. Install RHOAI operator on it and create the DSC
3. Check the warning events on the cluster, you should be able to see `Unable to retrieve some image pull secrets (addon-managed-odh-pullsecret);`
4. Go to DSC, edit dashboard entry to
```
dashboard:
  devFlags:
    manifests:
      - contextDir: manifests
        sourcePath: ''
        uri: 'https://github.com/DaoDaoNoCode/odh-dashboard/tarball/jira-rhoaieng-10782'
```
5. The deployment will start to rollout
6. Make sure there is no warning event above
7. Make sure the dashboard can still running normally

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, manifest change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
