### PR TITLE
allow for pvc to be added to multiple workbenches

### DIFF
--- a/frontend/src/pages/projects/notebook/ConnectedNotebookNames.tsx
+++ b/frontend/src/pages/projects/notebook/ConnectedNotebookNames.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge, List, ListItem, Spinner } from '@patternfly/react-core';
+import { Badge, Label, LabelGroup, List, ListItem, Spinner } from '@patternfly/react-core';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import useRelatedNotebooks, { ConnectedNotebookContext } from './useRelatedNotebooks';
 
@@ -32,13 +32,11 @@ const ConnectedNotebookNames: React.FC<ConnectedNotebookNamesProps> = ({
   }
 
   return (
-    <List isPlain>
+    <LabelGroup isCompact>
       {connectedNotebooks.map((notebook) => (
-        <ListItem key={notebook.metadata.uid}>
-          <Badge isRead>{getDisplayNameFromK8sResource(notebook)}</Badge>
-        </ListItem>
+          <Label isCompact key={notebook.metadata.uid}>{getDisplayNameFromK8sResource(notebook)}</Label>
       ))}
-    </List>
+    </LabelGroup>
   );
 };
 

--- a/frontend/src/pages/projects/notebook/ConnectedNotebookNames.tsx
+++ b/frontend/src/pages/projects/notebook/ConnectedNotebookNames.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge, Label, LabelGroup, List, ListItem, Spinner } from '@patternfly/react-core';
+import { Label, LabelGroup, Spinner } from '@patternfly/react-core';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import useRelatedNotebooks, { ConnectedNotebookContext } from './useRelatedNotebooks';
 
@@ -34,7 +34,9 @@ const ConnectedNotebookNames: React.FC<ConnectedNotebookNamesProps> = ({
   return (
     <LabelGroup isCompact>
       {connectedNotebooks.map((notebook) => (
-          <Label isCompact key={notebook.metadata.uid}>{getDisplayNameFromK8sResource(notebook)}</Label>
+        <Label isCompact key={notebook.metadata.uid}>
+          {getDisplayNameFromK8sResource(notebook)}
+        </Label>
       ))}
     </LabelGroup>
   );

--- a/frontend/src/pages/projects/notebook/ConnectedNotebookNames.tsx
+++ b/frontend/src/pages/projects/notebook/ConnectedNotebookNames.tsx
@@ -32,7 +32,7 @@ const ConnectedNotebookNames: React.FC<ConnectedNotebookNamesProps> = ({
   }
 
   return (
-    <LabelGroup isCompact>
+    <LabelGroup>
       {connectedNotebooks.map((notebook) => (
         <Label isCompact key={notebook.metadata.uid}>
           {getDisplayNameFromK8sResource(notebook)}

--- a/frontend/src/pages/projects/notebook/StorageNotebookConnections.tsx
+++ b/frontend/src/pages/projects/notebook/StorageNotebookConnections.tsx
@@ -3,19 +3,20 @@ import { Alert } from '@patternfly/react-core';
 import { ForNotebookSelection } from '~/pages/projects/types';
 import MountPathField from '~/pages/projects/pvc/MountPathField';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NotebookKind } from '~/k8sTypes';
 import { getNotebookMountPaths } from './utils';
 import ConnectedNotebookField from './ConnectedNotebookField';
 
 type StorageNotebookConnectionsProps = {
   forNotebookData: ForNotebookSelection;
   setForNotebookData: (value: ForNotebookSelection) => void;
-  isDisabled: boolean;
+  connectedNotebooks: NotebookKind[];
 };
 
 const StorageNotebookConnections: React.FC<StorageNotebookConnectionsProps> = ({
   forNotebookData,
   setForNotebookData,
-  isDisabled,
+  connectedNotebooks,
 }) => {
   const {
     notebooks: { data, loaded, error },
@@ -34,12 +35,17 @@ const StorageNotebookConnections: React.FC<StorageNotebookConnectionsProps> = ({
     notebooks.find((notebook) => notebook.metadata.name === forNotebookData.name),
   );
 
+  const connectedNotebookNames = connectedNotebooks.map((notebook) => notebook.metadata.name);
+  const availableNotebooks = notebooks.filter(
+    (notebook) => !connectedNotebookNames.includes(notebook.metadata.name),
+  );
+
   return (
     <>
       <ConnectedNotebookField
-        isDisabled={isDisabled}
+        isDisabled={availableNotebooks.length === 0}
         loaded={loaded}
-        notebooks={notebooks}
+        notebooks={availableNotebooks}
         selections={[forNotebookData.name]}
         onSelect={(selectionItems) => {
           const selection = selectionItems[0];

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -75,12 +75,8 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
     ? !!createData.forNotebook.mountPath.value && !createData.forNotebook.mountPath.error
     : true;
 
-  const storageClassSelected = isStorageClassesAvailable ? createData.storageClassName : true;
   const canCreate =
-    !actionInProgress &&
-    createData.nameDesc.name.trim() &&
-    hasValidNotebookRelationship &&
-    storageClassSelected;
+    !actionInProgress && createData.nameDesc.name.trim() && hasValidNotebookRelationship;
 
   const runPromiseActions = async (dryRun: boolean) => {
     const {
@@ -191,7 +187,7 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
                 setCreateData('forNotebook', forNotebookData);
               }}
               forNotebookData={createData.forNotebook}
-              isDisabled={connectedNotebooks.length !== 0 && removedNotebooks.length === 0}
+              connectedNotebooks={connectedNotebooks}
             />
           </StackItem>
           {restartNotebooks.length !== 0 && (

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -34,12 +34,17 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
   const [error, setError] = React.useState<Error | undefined>();
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const namespace = currentProject.metadata.name;
-  const {
-    notebooks: connectedNotebooks,
-    loaded: notebookLoaded,
-    error: notebookError,
-  } = useRelatedNotebooks(ConnectedNotebookContext.EXISTING_PVC, existingData?.metadata.name);
+  const { notebooks: connectedNotebooks } = useRelatedNotebooks(
+    ConnectedNotebookContext.EXISTING_PVC,
+    existingData?.metadata.name,
+  );
   const [removedNotebooks, setRemovedNotebooks] = React.useState<string[]>([]);
+
+  const {
+    notebooks: removableNotebooks,
+    loaded: removableNotebookLoaded,
+    error: removableNotebookError,
+  } = useRelatedNotebooks(ConnectedNotebookContext.REMOVABLE_PVC, existingData?.metadata.name);
 
   const restartNotebooks = useWillNotebooksRestart([
     ...removedNotebooks,
@@ -172,12 +177,12 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
           {createData.hasExistingNotebookConnections && (
             <StackItem>
               <ExistingConnectedNotebooks
-                connectedNotebooks={connectedNotebooks}
+                connectedNotebooks={removableNotebooks}
                 onNotebookRemove={(notebook: NotebookKind) =>
                   setRemovedNotebooks([...removedNotebooks, notebook.metadata.name])
                 }
-                loaded={notebookLoaded}
-                error={notebookError}
+                loaded={removableNotebookLoaded}
+                error={removableNotebookError}
               />
             </StackItem>
           )}

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -39,11 +39,7 @@ import ContainerSizeSelector from './deploymentSize/ContainerSizeSelector';
 import StorageField from './storage/StorageField';
 import EnvironmentVariables from './environmentVariables/EnvironmentVariables';
 import { useStorageDataObject } from './storage/utils';
-import {
-  getCompatibleAcceleratorIdentifiers,
-  getRootVolumeName,
-  useMergeDefaultPVCName,
-} from './spawnerUtils';
+import { getCompatibleAcceleratorIdentifiers, useMergeDefaultPVCName } from './spawnerUtils';
 import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVariables';
 import DataConnectionField from './dataConnection/DataConnectionField';
 import { useNotebookDataConnection } from './dataConnection/useNotebookDataConnection';
@@ -220,11 +216,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                 isInline
                 title="Cluster storage will mount to /"
               />
-              <StorageField
-                storageData={storageData}
-                setStorageData={setStorageData}
-                editStorage={getRootVolumeName(existingNotebook)}
-              />
+              <StorageField storageData={storageData} setStorageData={setStorageData} />
             </FormSection>
             <FormSection
               title={SpawnerPageSectionTitles[SpawnerPageSectionID.DATA_CONNECTIONS]}

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -408,8 +408,7 @@ export const checkRequiredFieldsForNotebookStart = (
     image.imageVersion
   );
 
-  const newStorageFieldInvalid =
-    storageType === StorageType.NEW_PVC && (!creating.nameDesc.name || !creating.storageClassName);
+  const newStorageFieldInvalid = storageType === StorageType.NEW_PVC && !creating.nameDesc.name;
   const existingStorageFieldInvalid = storageType === StorageType.EXISTING_PVC && !existing.storage;
   const isStorageDataValid = !newStorageFieldInvalid && !existingStorageFieldInvalid;
 

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -4,12 +4,11 @@ import { ExistingStorageObject } from '~/pages/projects/types';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import TypeaheadSelect from '~/components/TypeaheadSelect';
-import useAvailablePvcs from './useAvailablePvcs';
+import useProjectPvcs from '~/pages/projects/screens/detail/storage/useProjectPvcs';
 
 type AddExistingStorageFieldProps = {
   data: ExistingStorageObject;
   setData: (data: ExistingStorageObject) => void;
-  editStorage?: string;
   selectDirection?: 'up' | 'down';
   menuAppendTo?: HTMLElement;
 };
@@ -17,19 +16,11 @@ type AddExistingStorageFieldProps = {
 const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
   data,
   setData,
-  editStorage,
   selectDirection,
   menuAppendTo,
 }) => {
-  const {
-    currentProject,
-    notebooks: { data: allNotebooks },
-  } = React.useContext(ProjectDetailsContext);
-  const [storages, loaded, loadError] = useAvailablePvcs(
-    currentProject.metadata.name,
-    allNotebooks,
-    editStorage,
-  );
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const [storages, loaded, loadError] = useProjectPvcs(currentProject.metadata.name);
 
   const selectOptions = React.useMemo(
     () =>

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -77,7 +77,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
   });
 
   return (
-    <FormGroup label="Storage class" fieldId="storage-class" isRequired>
+    <FormGroup label="Storage class" fieldId="storage-class">
       <SimpleSelect
         dataTestId="storage-classes-selector"
         id="storage-classes-selector"

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageField.tsx
@@ -8,10 +8,9 @@ import AddExistingStorageField from './AddExistingStorageField';
 type StorageFieldType = {
   storageData: StorageData;
   setStorageData: UpdateObjectAtPropAndValue<StorageData>;
-  editStorage: string;
 };
 
-const StorageField: React.FC<StorageFieldType> = ({ storageData, setStorageData, editStorage }) => {
+const StorageField: React.FC<StorageFieldType> = ({ storageData, setStorageData }) => {
   const { storageType, creating, existing } = storageData;
 
   return (
@@ -53,7 +52,6 @@ const StorageField: React.FC<StorageFieldType> = ({ storageData, setStorageData,
                 <AddExistingStorageField
                   data={existing}
                   setData={(data) => setStorageData('existing', data)}
-                  editStorage={editStorage}
                   selectDirection="up"
                   menuAppendTo={getDashboardMainContainer()}
                 />

--- a/frontend/src/pages/projects/screens/spawner/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/utils.ts
@@ -51,6 +51,7 @@ export const useCreateStorageObjectForNotebook = (
     ConnectedNotebookContext.REMOVABLE_PVC,
     existingData ? existingData.metadata.name : undefined,
   );
+
   const hasExistingNotebookConnections = relatedNotebooks.length > 0;
 
   React.useEffect(() => {

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -6,6 +6,15 @@ rules:
   - verbs:
       - get
       - list
+      - update
+      - patch
+    apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+  - verbs:
+      - get
+      - list
     apiGroups:
       - ''
     resources:

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -4,8 +4,6 @@ metadata:
   name: odh-dashboard
 rules:
   - verbs:
-      - get
-      - list
       - update
       - patch
     apiGroups:

--- a/manifests/core-bases/base/role.yaml
+++ b/manifests/core-bases/base/role.yaml
@@ -4,15 +4,6 @@ metadata:
   name: odh-dashboard
 rules:
   - verbs:
-      - get
-      - list
-      - update
-      - patch
-    apiGroups:
-      - storage.k8s.io
-    resources:
-      - storageclasses
-  - verbs:
       - create
       - get
       - list


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12803

## Description

This PR implements the functionality to allow a PVC to be added to multiple workbenches. The changes include:
- Updating the UI to allow selection of multiple workbenches when adding or editing a PVC.
- Modifying the logic to handle attaching a PVC to multiple workbenches.

I also updated some storage class logic and manifests

https://github.com/user-attachments/assets/a25b7f9a-7bef-4eb4-b5e2-b1531aba3805


## How Has This Been Tested?

1. create two workbenches
   - one with its own new pvc
   - the second one should be able to use the previous pvc
2. go to cluster storage tab
3. create a new pvc and connect one workbench
4. save and re edit pvc and add another workbench 

## Test Impact
- Cypress tests for adding a new PVC and attaching it to multiple workbenches

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
