### PR TITLE
Soft disable the biasMetrics feature flag

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -64,8 +64,52 @@ const DASHBOARD_CONFIG = {
 };
 
 const fetchDashboardCR = async (fastify: KubeFastifyInstance): Promise<DashboardConfig[]> => {
-  return fetchOrCreateDashboardCR(fastify).then((dashboardCR) => [dashboardCR]);
+  return fetchOrCreateDashboardCR(fastify)
+    .then(softDisableBiasMetrics(fastify))
+    .then((dashboardCR) => [dashboardCR]);
 };
+
+/**
+ * TODO: Support Bias Metrics https://issues.redhat.com/browse/RHOAIENG-13084
+ * For RHOAI Only
+ * Always disable bias metrics until we can properly support the new UI flow.
+ * Note: This does no changes to the on-cluster value -- there can be a de-sync
+ */
+const softDisableBiasMetrics =
+  (fastify: KubeFastifyInstance) =>
+  (dashboardConfig: DashboardConfig): DashboardConfig & { status?: object } => {
+    if (!isRHOAI(fastify)) {
+      return dashboardConfig;
+    }
+
+    fastify.log.info(
+      'Trusty Bias Metrics are explicitly disabled in the cached odh-dashboard-config',
+    );
+    return {
+      ...dashboardConfig,
+      spec: {
+        ...dashboardConfig.spec,
+        dashboardConfig: {
+          ...dashboardConfig.spec.dashboardConfig,
+          disableBiasMetrics: true,
+        },
+      },
+      // NOTE: This is a fake status to help show in the UI that we are overriding the value
+      // The CRD does not support a status property today and should not have existing statuses here
+      // No code should use this -- this is purely for debugging in the UI
+      // To be removed as soon as we can support trusty properly
+      status: {
+        conditions: [
+          {
+            message: 'This feature flag state is being ignored',
+            reason: 'IgnoredFeatureFlag',
+            status: 'False',
+            type: 'disableBiasMetricsAvailable',
+          },
+        ],
+      },
+    };
+  };
 
 const fetchOrCreateDashboardCR = async (fastify: KubeFastifyInstance): Promise<DashboardConfig> => {
   return fastify.kube.customObjectsApi


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13107

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
(soft) Disable trusty bias metrics feature flag as the cache loads in the OdhDashboardConfig

Get dashboard config... `GET /api/config`
```json
{
  "apiVersion": "opendatahub.io/v1alpha",
  "kind": "OdhDashboardConfig",
  "metadata": "...",
  "spec": {
    "dashboardConfig": {
       "disableBiasMetrics": true,
       "other-properties": "...",
    },
    "other-properties": "...",
  },
  "status": {
    "conditions": [
      {
        "message": "This feature flag state is being ignored",
        "reason": "IgnoredFeatureFlag",
        "status": "False",
        "type": "disableBiasMetricsAvailable"
      }
    ]
  }
```
For RHOAI installations, biasMetrics will always be disable when fetching the status to the client.

[Arch docs are being added in support to explain this design](https://github.com/opendatahub-io/architecture-decision-records/pull/65). We are no4 bubble -- when the cache is updated, we update our internal version to have this. It is not reflected on the cluster.

Note: Client feature flags feature can still enable it if needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Doing a call to `GET /api/config`.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
