### PR TITLE
adjust resource name form spacing and help icon

### DIFF
--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -3,10 +3,9 @@ import {
   Button,
   FormGroup,
   FormHelperText,
+  FormSection,
   HelperText,
   HelperTextItem,
-  Stack,
-  StackItem,
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
@@ -61,65 +60,61 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
   const { name, description, k8sName } = data;
 
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
-          <TextInput
-            aria-readonly={!onDataChange}
-            data-testid={`${dataTestId}-name`}
-            id={`${dataTestId}-name`}
-            name={`${dataTestId}-name`}
-            autoFocus={autoFocusName}
-            isRequired
-            value={name}
-            onChange={(event, value) => onDataChange?.('name', value)}
-          />
-          {!showK8sField && !!onDataChange && !k8sName.state.immutable && (
-            <FormHelperText>
-              {k8sName.value && (
-                <HelperText>
-                  <HelperTextItem>
-                    The resource name will be <b>{k8sName.value}</b>.
-                  </HelperTextItem>
-                </HelperText>
-              )}
+    <FormSection style={{ margin: 0 }}>
+      <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
+        <TextInput
+          aria-readonly={!onDataChange}
+          data-testid={`${dataTestId}-name`}
+          id={`${dataTestId}-name`}
+          name={`${dataTestId}-name`}
+          autoFocus={autoFocusName}
+          isRequired
+          value={name}
+          onChange={(event, value) => onDataChange?.('name', value)}
+        />
+        {!showK8sField && !!onDataChange && !k8sName.state.immutable && (
+          <FormHelperText>
+            {k8sName.value && (
               <HelperText>
                 <HelperTextItem>
-                  <Button
-                    data-testid={`${dataTestId}-editResourceLink`}
-                    variant="link"
-                    isInline
-                    onClick={() => setShowK8sField(true)}
-                  >
-                    Edit resource name
-                  </Button>{' '}
-                  <ResourceNameDefinitionTooltip />
+                  The resource name will be <b>{k8sName.value}</b>.
                 </HelperTextItem>
               </HelperText>
-            </FormHelperText>
-          )}
-        </FormGroup>
-      </StackItem>
+            )}
+            <HelperText>
+              <HelperTextItem>
+                <Button
+                  data-testid={`${dataTestId}-editResourceLink`}
+                  variant="link"
+                  isInline
+                  onClick={() => setShowK8sField(true)}
+                >
+                  Edit resource name
+                </Button>{' '}
+                <ResourceNameDefinitionTooltip />
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
+      </FormGroup>
       <ResourceNameField
         allowEdit={showK8sField}
         dataTestId={dataTestId}
         k8sName={k8sName}
         onDataChange={onDataChange}
       />
-      <StackItem>
-        <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
-          <TextArea
-            aria-readonly={!onDataChange}
-            data-testid={`${dataTestId}-description`}
-            id={`${dataTestId}-description`}
-            name={`${dataTestId}-description`}
-            value={description}
-            onChange={(event, value) => onDataChange?.('description', value)}
-            resizeOrientation="vertical"
-          />
-        </FormGroup>
-      </StackItem>
-    </Stack>
+      <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
+        <TextArea
+          aria-readonly={!onDataChange}
+          data-testid={`${dataTestId}-description`}
+          id={`${dataTestId}-description`}
+          name={`${dataTestId}-description`}
+          value={description}
+          onChange={(event, value) => onDataChange?.('description', value)}
+          resizeOrientation="vertical"
+        />
+      </FormGroup>
+    </FormSection>
   );
 };
 

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  FormGroup,
-  HelperText,
-  StackItem,
-  TextInput,
-  ValidatedOptions,
-} from '@patternfly/react-core';
+import { FormGroup, HelperText, TextInput, ValidatedOptions } from '@patternfly/react-core';
 import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTooltip';
 import {
   HelperTextItemMaxLength,
@@ -37,11 +31,7 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
   };
 
   if (k8sName.state.immutable) {
-    return (
-      <StackItem>
-        <FormGroup {...formGroupProps}>{k8sName.value}</FormGroup>
-      </StackItem>
-    );
+    return <FormGroup {...formGroupProps}>{k8sName.value}</FormGroup>;
   }
 
   if (!allowEdit || !onDataChange) {
@@ -56,22 +46,20 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
   }
 
   return (
-    <StackItem>
-      <FormGroup {...formGroupProps} isRequired>
-        <TextInput
-          data-testid={`${dataTestId}-resourceName`}
-          name={`${dataTestId}-resourceName`}
-          isRequired
-          value={k8sName.value}
-          onChange={(event, value) => onDataChange('k8sName', value)}
-          validated={validated}
-        />
-        <HelperText>
-          <HelperTextItemMaxLength k8sName={k8sName} />
-          <HelperTextItemValidCharacters k8sName={k8sName} />
-        </HelperText>
-      </FormGroup>
-    </StackItem>
+    <FormGroup {...formGroupProps} isRequired>
+      <TextInput
+        data-testid={`${dataTestId}-resourceName`}
+        name={`${dataTestId}-resourceName`}
+        isRequired
+        value={k8sName.value}
+        onChange={(event, value) => onDataChange('k8sName', value)}
+        validated={validated}
+      />
+      <HelperText>
+        <HelperTextItemMaxLength k8sName={k8sName} />
+        <HelperTextItemValidCharacters k8sName={k8sName} />
+      </HelperText>
+    </FormGroup>
   );
 };
 

--- a/frontend/src/concepts/k8s/ResourceNameDefinitionTooltip.tsx
+++ b/frontend/src/concepts/k8s/ResourceNameDefinitionTooltip.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
-import { Stack, StackItem, Tooltip } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
+import { Popover, Stack, StackItem } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 
 const ResourceNameDefinitionTooltip: React.FC = () => (
-  <Tooltip
-    position="right"
-    content={
+  <Popover
+    bodyContent={
       <Stack hasGutter>
         <StackItem>Resource names are what your resources are labeled in OpenShift.</StackItem>
         <StackItem>Resource names are not editable after creation.</StackItem>
       </Stack>
     }
   >
-    <HelpIcon aria-label="More info" />
-  </Tooltip>
+    <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+  </Popover>
 );
 
 export default ResourceNameDefinitionTooltip;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
It was observed while reviewing the new [create connection modal](https://github.com/opendatahub-io/odh-dashboard/pull/3217) that the k8s name / description component didn't fit exactly the UX for connection types.

Two differences observed:
- The spacing between form elements is 16px as oppose to 24px. PF `Form` and PF `FormSection` provide specific spacing between elements of the form. This component was using a stack layout with a different gap.
- The help icon and tooltip vs popover differed from those in the connection type form for form field descriptions.

The change here replaces the stack layout with a `FormSection`. Since there is no title to this section, the margin is eliminated to allow for these form elements to fit into existing forms.

The 2nd change is to use a popover and `OutlinedQuestionCircleIcon` icon. There's a lot of inconsistencies in our product today for using tooltips vs popovers and `HelpIcon` vs `OutlinedQuestionCircleIcon` in many of our forms. While both methods could be considered correct, it looks inconsistent within the connection form. The `K8sNameDescriptionField` component currently is not used in a form which has another `?` icon therefore this change does not produce further inconsistency within a single form.

Before:
![image](https://github.com/user-attachments/assets/a788b68e-22df-4358-8ff8-b9d4c01e59b0)
![image](https://github.com/user-attachments/assets/0495be2d-53df-48c2-a7d6-f5c302050e84)
![image](https://github.com/user-attachments/assets/eb6750d2-ecfb-48b5-8499-a9b9e23a9645)
Gap is 16px:
![image](https://github.com/user-attachments/assets/ecc6ca08-6e43-4c97-9b3b-ae4fd5f0b68e)

After:
![image](https://github.com/user-attachments/assets/571957f8-412b-4d75-b300-2b5efc571e99)
![image](https://github.com/user-attachments/assets/24ebb5f1-1ad7-4edd-b693-9fc0ec6a739d)
![image](https://github.com/user-attachments/assets/8291a2c8-1ad4-4c7f-9f71-bdf46301dde8)
Gap is 24px as prescribed by PF forms:
![image](https://github.com/user-attachments/assets/9bf0202e-0805-4a5f-9526-f25ed491d8a4)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
From the project list view page, click to create a new project to open the modal.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, visual change only

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @andrewballantyne @simrandhaliw 