### PR TITLE
[RHOAIENG-1107] Storage Class Filter

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -26,7 +26,7 @@ import {
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mock200Status } from '~/__mocks__/mockK8sStatus';
 import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
-import { storageClassesTable } from '~/__tests__/cypress/cypress/pages/storageClasses';
+import { storageClassesPage } from '~/__tests__/cypress/cypress/pages/storageClasses';
 
 type HandlersProps = {
   isEmpty?: boolean;
@@ -106,7 +106,7 @@ describe('ClusterStorage', () => {
 
   it('Add cluster storage', () => {
     initInterceptors({ isEmpty: true });
-    storageClassesTable.mockGetStorageClasses([
+    storageClassesPage.mockGetStorageClasses([
       openshiftDefaultStorageClass,
       buildMockStorageClass(otherStorageClass, { isEnabled: true }),
     ]);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -1,7 +1,6 @@
 import {
   buildMockStorageClass,
   buildMockStorageClassConfig,
-  mockStorageClassList,
   mockStorageClasses,
 } from '~/__mocks__';
 import { asProductAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
@@ -27,22 +26,14 @@ describe('Storage classes', () => {
     });
 
     it('shows empty state when the returned storage class list is empty', () => {
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList([]),
-      );
+      storageClassesPage.mockGetStorageClasses([]);
       storageClassesPage.visit();
       storageClassesPage.findNavItem().should('be.visible');
       storageClassesPage.findEmptyState().should('be.visible');
     });
 
     it('renders table with data', () => {
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList(),
-      );
+      storageClassesPage.mockGetStorageClasses();
       storageClassesPage.visit();
 
       storageClassesTable.findRowByName('Test SC 1').should('be.visible');
@@ -50,11 +41,7 @@ describe('Storage classes', () => {
     });
 
     it('table rows allow for toggling of Enable and Default values', () => {
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList(),
-      );
+      storageClassesPage.mockGetStorageClasses();
       storageClassesPage.visit();
 
       const openshiftDefaultTableRow =
@@ -77,7 +64,7 @@ describe('Storage classes', () => {
       storageClassesTable
         .mockUpdateStorageClass(otherStorageClass.metadata.name, 1)
         .as('updateStorageClass-1');
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses(
           [
             openshiftDefaultStorageClass,
@@ -101,7 +88,7 @@ describe('Storage classes', () => {
       storageClassesTable
         .mockUpdateStorageClass(openshiftDefaultStorageClass.metadata.name, 1)
         .as('updateStorageClass-3');
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses(
           [
             buildMockStorageClass(openshiftDefaultStorageClass, { isDefault: false }),
@@ -122,11 +109,7 @@ describe('Storage classes', () => {
     });
 
     it('can edit storage class display name and description', () => {
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList(),
-      );
+      storageClassesPage.mockGetStorageClasses();
       storageClassesPage.visit();
 
       storageClassesTable
@@ -144,7 +127,7 @@ describe('Storage classes', () => {
       storageClassEditModal.fillDescriptionInput('Updated description');
 
       storageClassEditModal.mockUpdateStorageClass('test-storage-class-1', 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           openshiftDefaultStorageClass,
           buildMockStorageClass(otherStorageClass, {
@@ -169,12 +152,7 @@ describe('Storage classes', () => {
       };
       const unreadableConfigStorageClass = buildMockStorageClass(storageClass, '{“FAIL:}');
 
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList([unreadableConfigStorageClass]),
-      );
-
+      storageClassesPage.mockGetStorageClasses([unreadableConfigStorageClass]);
       storageClassesPage.visit();
 
       const storageClassTableRow = storageClassesTable.getRowByName(storageClassName);
@@ -189,7 +167,7 @@ describe('Storage classes', () => {
       storageClassEditModal.fillDisplayNameInput('Readable config');
 
       storageClassEditModal.mockUpdateStorageClass(storageClassName, 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(storageClass, {
             displayName: 'Readable config',
@@ -218,12 +196,7 @@ describe('Storage classes', () => {
       );
       const existingConfig = JSON.parse(storageClassConfig);
 
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList([storageClass]),
-      );
-
+      storageClassesPage.mockGetStorageClasses([storageClass]);
       storageClassesPage.visit();
 
       const storageClassTableRow = storageClassesTable.getRowByName(storageClassName);
@@ -242,7 +215,7 @@ describe('Storage classes', () => {
 
       // Reset enable
       storageClassesTable.mockUpdateStorageClass(storageClassName, 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(storageClass, {
             ...existingConfig,
@@ -261,7 +234,7 @@ describe('Storage classes', () => {
 
       // Reset default
       storageClassesTable.mockUpdateStorageClass(storageClassName, 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(storageClass, {
             ...existingConfig,
@@ -281,7 +254,7 @@ describe('Storage classes', () => {
 
       // Reset last modified
       storageClassesTable.mockUpdateStorageClass(storageClassName, 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(storageClass, {
             ...existingConfig,
@@ -307,12 +280,7 @@ describe('Storage classes', () => {
         '{"isDefault":false,"isEnabled":false,"displayName":{},"lastModified":"2024-09-09T17:45:05.299Z","description":"Test malformed displayName"}',
       );
 
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList([storageClass]),
-      );
-
+      storageClassesPage.mockGetStorageClasses([storageClass]);
       storageClassesPage.visit();
 
       const storageClassTableRow = storageClassesTable.getRowByName('invalid-name');
@@ -328,7 +296,7 @@ describe('Storage classes', () => {
       storageClassEditModal.fillDisplayNameInput('New name');
 
       storageClassEditModal.mockUpdateStorageClass('invalid-name', 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(
             storageClass,
@@ -351,12 +319,7 @@ describe('Storage classes', () => {
         '{"isDefault":false,"isEnabled":false,"displayName":"Test malformed description","lastModified":"2024-09-09T17:45:05.299Z","description":{}}',
       );
 
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList([storageClass]),
-      );
-
+      storageClassesPage.mockGetStorageClasses([storageClass]);
       storageClassesPage.visit();
 
       const storageClassTableRow = storageClassesTable.getRowByName('invalid-description');
@@ -371,7 +334,7 @@ describe('Storage classes', () => {
       storageClassEditModal.findInfoAlert().should('contain.text', 'Edit the invalid field');
 
       storageClassEditModal.mockUpdateStorageClass('invalid-description', 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(
             storageClass,
@@ -394,12 +357,7 @@ describe('Storage classes', () => {
         '{"isDefault":false,"isEnabled":false,"displayName":{},"description":{},"lastModified":"2024-09-09T17:45:05.299Z"}',
       );
 
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList([storageClass]),
-      );
-
+      storageClassesPage.mockGetStorageClasses([storageClass]);
       storageClassesPage.visit();
 
       const storageClassTableRow = storageClassesTable.getRowByName('invalid-name-and-desc');
@@ -414,7 +372,7 @@ describe('Storage classes', () => {
       storageClassEditModal.fillDescriptionInput('New description');
 
       storageClassEditModal.mockUpdateStorageClass('invalid-name-and-desc', 1);
-      storageClassesTable
+      storageClassesPage
         .mockGetStorageClasses([
           buildMockStorageClass(
             storageClass,
@@ -431,6 +389,47 @@ describe('Storage classes', () => {
       cy.wait('@refreshStorageClasses');
       storageClassTableRow.findDisplayNameValue().should('contain.text', 'New name');
       storageClassTableRow.findDisplayNameValue().should('contain.text', 'New description');
+    });
+
+    it('can filter table by displayName and/or OpenShift storage class name', () => {
+      const storageClasses = [
+        ...mockStorageClasses,
+        buildMockStorageClass(
+          { ...mockStorageClasses[0], metadata: { ...mockStorageClasses[0], name: 'sc-2' } },
+          { displayName: 'Test SC 2' },
+        ),
+      ];
+
+      storageClassesPage.mockGetStorageClasses(storageClasses);
+      storageClassesPage.visit();
+      storageClassesTable.findRows().should('have.length', 3);
+
+      // Filter only by display name
+      const toolbar = storageClassesTable.getTableToolbar();
+      toolbar.fillSearchInput('Test');
+      storageClassesTable.findRows().should('have.length', 2);
+      toolbar.findSearchInput().clear();
+      storageClassesTable.findRows().should('have.length', 3);
+
+      // Filter only by OpenShift class
+      toolbar.findFilterMenuItem('OpenShift storage class').click();
+      toolbar.fillSearchInput('sc-2');
+      storageClassesTable.findRows().should('have.length', 1);
+      toolbar.findSearchInput().clear();
+      storageClassesTable.findRows().should('have.length', 3);
+
+      // Filter by a value that doesn't exist in any row
+      toolbar.fillSearchInput('not found');
+      storageClassesTable.findEmptyState().should('be.visible');
+      storageClassesTable.findClearFiltersButton().click();
+      storageClassesTable.findRows().should('have.length', 3);
+      toolbar.findSearchInput().clear();
+
+      // Filter by both display name and OpenShift class
+      toolbar.fillSearchInput('test');
+      toolbar.findFilterMenuItem('Display name').click();
+      toolbar.fillSearchInput('test');
+      storageClassesTable.findRows().should('have.length', 1);
     });
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -1,7 +1,7 @@
 import type { CommandLineResult } from '~/__tests__/cypress/cypress/types';
 
 /**
- * Create an Openshift Project
+ * Create an OpenShift Project
  *
  * @param projectName Project Name
  * @param displayName Project Display Name
@@ -27,7 +27,7 @@ export const createOpenShiftProject = (
 };
 
 /**
- * Delete an Openshift Project given its name
+ * Delete an OpenShift Project given its name
  *
  * @param projectName OpenShift Project name
  * @returns Result Object of the operation

--- a/frontend/src/concepts/dashboard/DashboardEmptyTableView.tsx
+++ b/frontend/src/concepts/dashboard/DashboardEmptyTableView.tsx
@@ -23,7 +23,7 @@ const DashboardEmptyTableView: React.FC<DashboardEmptyTableViewProps> = ({
   variant,
 }) => (
   <Bullseye>
-    <EmptyState variant={variant}>
+    <EmptyState variant={variant} data-testid="dashboard-empty-table-state">
       <EmptyStateHeader
         data-testid="no-result-found-title"
         titleText="No results found"
@@ -32,7 +32,7 @@ const DashboardEmptyTableView: React.FC<DashboardEmptyTableViewProps> = ({
       />
       <EmptyStateBody>Adjust your filters and try again.</EmptyStateBody>
       <EmptyStateFooter>
-        <Button variant="link" onClick={onClearFilters}>
+        <Button variant="link" onClick={onClearFilters} data-testid="clear-filters-button">
           Clear all filters
         </Button>
       </EmptyStateFooter>

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -59,6 +59,7 @@ export enum MetadataAnnotation {
   StorageClassIsDefault = 'storageclass.kubernetes.io/is-default-class',
   K8sDescription = 'kubernetes.io/description',
   OdhStorageClassConfig = 'opendatahub.io/sc-config',
+  Description = 'description',
 }
 
 type StorageClassAnnotations = Partial<{

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfiles.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfiles.tsx
@@ -39,7 +39,7 @@ const AcceleratorProfiles: React.FC = () => {
         <EmptyStateBody>
           You don&apos;t have any accelerator profiles yet. To get started, please ask your cluster
           administrator about the accelerator availability in your cluster and create corresponding
-          profiles in Openshift Data Science.
+          profiles in OpenShift Data Science.
         </EmptyStateBody>
         <EmptyStateFooter>
           <EmptyStateActions>

--- a/frontend/src/pages/storageClasses/ResetCorruptConfigValueAlert.tsx
+++ b/frontend/src/pages/storageClasses/ResetCorruptConfigValueAlert.tsx
@@ -11,12 +11,14 @@ interface ResetCorruptConfigValueAlertProps extends Pick<AlertProps, 'variant'> 
   storageClassName: string;
   storageClassConfig: StorageClassConfig;
   refresh: () => Promise<void | StorageClassKind[]>;
+  popoverText?: string;
 }
 
 export const ResetCorruptConfigValueAlert: React.FC<ResetCorruptConfigValueAlertProps> = ({
   storageClassName,
   storageClassConfig,
   variant,
+  popoverText = 'Refresh the field to correct the corrupted metadata.',
   refresh,
 }) => {
   const [error, setError] = React.useState<string>();
@@ -38,7 +40,7 @@ export const ResetCorruptConfigValueAlert: React.FC<ResetCorruptConfigValueAlert
   return (
     <CorruptedMetadataAlert
       variant={variant}
-      popoverText="Refresh the field to correct the corrupted metadata."
+      popoverText={popoverText}
       errorText={error}
       action={
         <Button

--- a/frontend/src/pages/storageClasses/StorageClassFilterToolbar.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassFilterToolbar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { SearchInput } from '@patternfly/react-core';
+import FilterToolbar from '~/components/FilterToolbar';
+import {
+  StorageClassFilterData,
+  StorageClassFilterOption,
+  storageClassFilterOptions,
+} from './constants';
+
+interface StorageClassFilterToolbarProps {
+  filterData: StorageClassFilterData;
+  setFilterData: React.Dispatch<React.SetStateAction<StorageClassFilterData>>;
+}
+
+export const StorageClassFilterToolbar: React.FC<StorageClassFilterToolbarProps> = ({
+  filterData,
+  setFilterData,
+}) => {
+  const onFilterUpdate = React.useCallback(
+    (key: string, value: string | { label: string; value: string } | undefined) =>
+      setFilterData((prevValues: StorageClassFilterData) => ({ ...prevValues, [key]: value })),
+    [setFilterData],
+  );
+
+  return (
+    <FilterToolbar<keyof typeof storageClassFilterOptions>
+      data-testid="sc-table-toolbar"
+      filterOptions={storageClassFilterOptions}
+      filterOptionRenders={{
+        [StorageClassFilterOption.DisplayName]: ({ onChange, ...props }) => (
+          <SearchInput
+            {...props}
+            placeholder="Filter by display name"
+            onChange={(_event, value) => onChange(value)}
+          />
+        ),
+        [StorageClassFilterOption.OpenshiftScName]: ({ onChange, ...props }) => (
+          <SearchInput
+            {...props}
+            placeholder="Filter by OpenShift storage class"
+            onChange={(_event, value) => onChange(value)}
+          />
+        ),
+      }}
+      filterData={filterData}
+      onFilterUpdate={onFilterUpdate}
+    />
+  );
+};

--- a/frontend/src/pages/storageClasses/StorageClassesPage.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesPage.tsx
@@ -44,15 +44,15 @@ const StorageClassesPage: React.FC = () => {
       setIsUpdating(true);
 
       try {
-        await Promise.all(updateRequests);
-        await refreshStorageClasses();
+        const updateResponses = await Promise.all(updateRequests);
+        if (updateResponses.some((response) => response.success)) {
+          await refreshStorageClasses();
+        }
 
         if (!defaultStorageClass) {
           setIsAlertOpen(true);
         }
-
-        setIsUpdating(false);
-      } catch {
+      } finally {
         setIsUpdating(false);
       }
     },

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -14,7 +14,7 @@ import {
 import { Tr, Td, ActionsColumn, TableText } from '@patternfly/react-table';
 import { PencilAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
+import { MetadataAnnotation, StorageClassConfig, StorageClassKind } from '~/k8sTypes';
 import { TableRowTitleDescription } from '~/components/table';
 import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
 import { updateStorageClassConfig } from '~/services/StorageClassService';
@@ -52,7 +52,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
   const storageClassInfoItems = [
     {
       label: 'OpenShift storage class',
-      value: storageClassConfig?.displayName,
+      value: metadata.name,
     },
     {
       label: 'Provisioner',
@@ -60,7 +60,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
     },
     {
       label: 'Description',
-      value: storageClassConfig?.description ?? <NoValue />,
+      value: metadata.annotations?.[MetadataAnnotation.Description] ?? <NoValue />,
     },
     {
       label: 'Reclaim policy',

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -199,6 +199,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({
                   isEnabled: false,
                 }}
                 variant="danger"
+                popoverText="This storage class is temporarily unavailable for use in new cluster storage. Refresh the field to correct the corrupted metadata."
                 refresh={refresh}
               />
             }

--- a/frontend/src/pages/storageClasses/constants.ts
+++ b/frontend/src/pages/storageClasses/constants.ts
@@ -4,7 +4,7 @@ import { getStorageClassConfig } from './utils';
 
 export enum ColumnLabel {
   DisplayName = 'Display name',
-  OpenshiftStorageClass = 'Openshift storage class',
+  OpenshiftStorageClass = 'OpenShift storage class',
   Enable = 'Enable',
   Default = 'Default',
   LastModified = 'Last modified',
@@ -60,3 +60,20 @@ export const columns: SortableData<StorageClassKind>[] = [
   },
   kebabTableColumn(),
 ];
+
+export enum StorageClassFilterOption {
+  DisplayName = 'displayName',
+  OpenshiftScName = 'openshiftScName',
+}
+
+export const storageClassFilterOptions = {
+  [StorageClassFilterOption.DisplayName]: 'Display name',
+  [StorageClassFilterOption.OpenshiftScName]: 'OpenShift storage class',
+};
+
+export type StorageClassFilterData = Record<StorageClassFilterOption, string>;
+
+export const initialScFilterData: StorageClassFilterData = {
+  [StorageClassFilterOption.DisplayName]: '',
+  [StorageClassFilterOption.OpenshiftScName]: '',
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-1107

## Description
Added filter toolbar and pagination to the storage classes table page. Users can filter by display name and/or Openshift class name.

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/0d521244-3c4c-49e8-85c2-374c23ed87a9">
<img width="461" alt="image" src="https://github.com/user-attachments/assets/190f8d3f-68cf-49da-a966-2d801287abff">
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/c3d418b0-c64b-4fc7-91a5-ac6abf1546fc">

**Demo:** 
https://github.com/user-attachments/assets/6d86fe29-a3c8-46f1-badc-e459dce17123

(cc @xianli123)

## How Has This Been Tested?
1. With the feature flag enabled, visit the storage class table's page; `/storageClasses?devFeatureFlags=disableStorageClasses`
2. Verify pagination exists
3. Verify the toolbar filter exists and matches the design
4. Verify you can filter by both display name and openshift class name
5. Verify empty state when filter yields no results and can reset filters via the action in that empty state ("Clear filters")

## Test Impact
Added catch-all filter cypress test for storage classes

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
