### PR TITLE
Fix validation in the storage modal mount path

### DIFF
--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash-es';
 import { KnownLabels, NotebookKind } from '~/k8sTypes';
 import { DEFAULT_NOTEBOOK_SIZES } from '~/pages/projects/screens/spawner/const';
-import { ContainerResources, TolerationEffect, TolerationOperator } from '~/types';
+import { ContainerResources, TolerationEffect, TolerationOperator, VolumeMount } from '~/types';
 import { genUID } from '~/__mocks__/mockUtils';
 import { RecursivePartial } from '~/typeHelpers';
 
@@ -17,6 +17,7 @@ type MockResourceConfigType = {
   lastImageSelection?: string;
   opts?: RecursivePartial<NotebookKind>;
   uid?: string;
+  additionalVolumeMounts?: VolumeMount[];
 };
 
 export const mockNotebookK8sResource = ({
@@ -31,6 +32,7 @@ export const mockNotebookK8sResource = ({
   lastImageSelection = 's2i-minimal-notebook:py3.8-v1',
   opts = {},
   uid = genUID('notebook'),
+  additionalVolumeMounts = [],
 }: MockResourceConfigType): NotebookKind =>
   _.merge(
     {
@@ -144,6 +146,7 @@ export const mockNotebookK8sResource = ({
                     mountPath: '/opt/app-root/src',
                     name,
                   },
+                  ...additionalVolumeMounts,
                 ],
                 workingDir: '/opt/app-root/src',
               },

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -49,6 +49,10 @@ class ClusterStorageModal extends Modal {
     return this.find().findByTestId('mount-path-folder-value');
   }
 
+  findMountFieldHelperText() {
+    return this.find().findByTestId('mount-path-folder-helper-text');
+  }
+
   findWorkbenchRestartAlert() {
     return this.find().findByTestId('notebook-restart-alert');
   }

--- a/frontend/src/pages/projects/pvc/MountPathField.tsx
+++ b/frontend/src/pages/projects/pvc/MountPathField.tsx
@@ -37,11 +37,11 @@ const MountPathField: React.FC<MountPathFieldProps> = ({
           onChange={(e, value) => {
             let error = '';
             if (value.length === 0) {
-              error = 'Required';
-            } else if (!/^[a-z-]+$/.test(value)) {
-              error = 'Must only consist of lower case letters and dashes';
+              error = 'Enter a path to a model or folder. This path cannot point to a root folder.';
+            } else if (!/^[a-z-]+\/?$/.test(value)) {
+              error = 'Must only consist of lower case letters and dashes.';
             } else if (inUseMountPaths.includes(`/${value}`)) {
-              error = 'Mount folder is already in use for this workbench';
+              error = 'Mount folder is already in use for this workbench.';
             }
             setMountPath({ value, error });
           }}
@@ -50,10 +50,11 @@ const MountPathField: React.FC<MountPathFieldProps> = ({
     </InputGroup>
     <FormHelperText>
       <HelperText>
-        <HelperTextItem variant={mountPath.error ? 'error' : 'default'}>
-          {mountPath.error
-            ? 'Enter a path to a model or folder. This path cannot point to a root folder.'
-            : 'Must consist of lower case letters and dashes.'}
+        <HelperTextItem
+          variant={mountPath.error ? 'error' : 'default'}
+          data-testid="mount-path-folder-helper-text"
+        >
+          {mountPath.error || 'Must consist of lower case letters and dashes.'}
         </HelperTextItem>
       </HelperText>
     </FormHelperText>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-7680

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There is something wrong with the logic in the helper text and what error text we should show. I made some changes to that to correct the logic. Also, change the regex to allow a trailing `/` in the path.

Initial state:

<img width="1512" alt="Screenshot 2024-09-20 at 3 12 01 PM" src="https://github.com/user-attachments/assets/cdde7fc2-87a6-4fea-be1f-4d49bf69c707">

Trailing slash:

<img width="1512" alt="Screenshot 2024-09-20 at 3 12 24 PM" src="https://github.com/user-attachments/assets/5b4b9bc0-2174-40c3-bf77-76734cf9abdc">

Duplicate path:

<img width="1512" alt="Screenshot 2024-09-20 at 3 12 47 PM" src="https://github.com/user-attachments/assets/b3bab42e-6e74-4376-8f63-8b129b7f570d">

Empty input:

<img width="1512" alt="Screenshot 2024-09-20 at 3 13 05 PM" src="https://github.com/user-attachments/assets/d6b6c0b4-855e-4ba6-b79c-d06d59545c7e">

Invalid value (contains number):

<img width="1512" alt="Screenshot 2024-09-20 at 3 13 30 PM" src="https://github.com/user-attachments/assets/b7a0a404-ccaf-4986-a072-ae2ba3ad40fb">

Invalid value (slash is not the trailing slash):

<img width="1512" alt="Screenshot 2024-09-20 at 3 14 32 PM" src="https://github.com/user-attachments/assets/b5a8908e-6089-43cf-b6cd-eec95af5ae22">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a cluster storage
2. Attach it to a workbench
3. Input in the mouth path field, check if it's allowing a trailing slash
4. Check all the error states as listed above

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated the cypress test to check the error cases.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
