### PR TITLE
workaround PF bug with modals causing cypress selectors to fail

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/Modal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/Modal.ts
@@ -12,7 +12,10 @@ export class Modal {
   }
 
   find(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('dialog', { name: this.title });
+    // FIXME Remove `hidden: true` once issue with PF modals is fixed.
+    // https://issues.redhat.com/browse/RHOAIENG-11946
+    // https://github.com/patternfly/patternfly-react/issues/11041
+    return cy.findByRole('dialog', { name: this.title, hidden: true });
   }
 
   findCloseButton(): Cypress.Chainable<JQuery<HTMLElement>> {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-11946

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
A bug in PF `Modal` is causing the modal DOM node container to have `aria-hidden="true"` when running in our dev server which uses `React.StrictMode`. As a result, the cypress selector fails to find the modal.

The workaround here is to supply `hidden: true` to the selector. As per the documentation, this will include the hidden element in the result:
```
  /**
   * If true includes elements in the query set that are usually excluded from
   * the accessibility tree. `role="none"` or `role="presentation"` are included
   * in either case.
   */
  hidden?: boolean
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run cypress:server:dev`
`npm run cypress:open:mock`

Run the `connectionTypes.cy.ts` test suite. Specifically the delete test.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
