### PR TITLE
Fix to show complete edge highlight on selection in topology views

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -44,7 +44,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
 
   const [isDeletionOpen, setDeletionOpen] = React.useState(false);
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(PipelineDetailsTab.GRAPH);
-  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = React.useState<string[] | undefined>();
 
   const { namespace } = usePipelinesAPI();
 
@@ -61,8 +61,8 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
     if (isInvalidPipelineVersion) {
       return null;
     }
-    return nodes.find((n) => n.id === selectedId);
-  }, [isInvalidPipelineVersion, nodes, selectedId]);
+    return selectedIds ? nodes.find((n) => n.id === selectedIds[0]) : undefined;
+  }, [isInvalidPipelineVersion, nodes, selectedIds]);
 
   const isLoaded = isPipelineVersionLoaded && isPipelineLoaded && !!pipelineVersion?.pipeline_spec;
 
@@ -89,7 +89,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
   const panelContent = selectedNode ? (
     <SelectedTaskDrawerContent
       task={selectedNode.data.pipelineTask}
-      onClose={() => setSelectedId(null)}
+      onClose={() => setSelectedIds(undefined)}
     />
   ) : null;
 
@@ -183,7 +183,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
                   activeKey={activeTabKey}
                   onSelect={(e, tabIndex) => {
                     setActiveTabKey(tabIndex);
-                    setSelectedId(null);
+                    setSelectedIds(undefined);
                   }}
                   aria-label="Pipeline Details tabs"
                   role="region"
@@ -229,15 +229,8 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
                   ) : (
                     <PipelineTopology
                       nodes={nodes}
-                      selectedIds={selectedId ? [selectedId] : []}
-                      onSelectionChange={(ids) => {
-                        const firstId = ids[0];
-                        if (ids.length === 0) {
-                          setSelectedId(null);
-                        } else {
-                          setSelectedId(firstId);
-                        }
-                      }}
+                      selectedIds={selectedIds}
+                      onSelectionChange={setSelectedIds}
                       sidePanel={panelContent}
                     />
                   )}

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRecurringRun/PipelineRecurringRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRecurringRun/PipelineRecurringRunDetails.tsx
@@ -40,7 +40,7 @@ const PipelineRecurringRunDetails: PipelineCoreDetailsPageComponent = ({
     recurringRun?.pipeline_version_reference.pipeline_version_id,
   );
   const [deleting, setDeleting] = React.useState(false);
-  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = React.useState<string[]>();
 
   const nodes = usePipelineTaskTopology(version?.pipeline_spec);
   const isInvalidPipelineVersion = isArgoWorkflow(version?.pipeline_spec);
@@ -49,15 +49,8 @@ const PipelineRecurringRunDetails: PipelineCoreDetailsPageComponent = ({
     if (isInvalidPipelineVersion) {
       return null;
     }
-    return nodes.find((n) => n.id === selectedId);
-  }, [isInvalidPipelineVersion, selectedId, nodes]);
-
-  const getFirstNode = (firstId: string) => {
-    if (isInvalidPipelineVersion) {
-      return null;
-    }
-    return nodes.find((n) => n.id === firstId)?.data?.pipelineTask;
-  };
+    return selectedIds ? nodes.find((n) => n.id === selectedIds[0]) : undefined;
+  }, [isInvalidPipelineVersion, selectedIds, nodes]);
 
   const loaded = versionLoaded && recurringRunLoaded;
   const error = versionError || recurringRunError;
@@ -85,7 +78,7 @@ const PipelineRecurringRunDetails: PipelineCoreDetailsPageComponent = ({
   const panelContent = selectedNode ? (
     <SelectedTaskDrawerContent
       task={selectedNode.data.pipelineTask}
-      onClose={() => setSelectedId(null)}
+      onClose={() => setSelectedIds(undefined)}
     />
   ) : null;
 
@@ -124,15 +117,8 @@ const PipelineRecurringRunDetails: PipelineCoreDetailsPageComponent = ({
             graphContent={
               <PipelineTopology
                 nodes={nodes}
-                selectedIds={selectedId ? [selectedId] : []}
-                onSelectionChange={(ids) => {
-                  const firstId = ids[0];
-                  if (ids.length === 0) {
-                    setSelectedId(null);
-                  } else if (getFirstNode(firstId)) {
-                    setSelectedId(firstId);
-                  }
-                }}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
                 sidePanel={panelContent}
               />
             }

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -49,7 +49,7 @@ const PipelineRunDetails: React.FC<
   const pipelineSpec = version?.pipeline_spec ?? run?.pipeline_spec;
   const [deleting, setDeleting] = React.useState(false);
   const [archiving, setArchiving] = React.useState(false);
-  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = React.useState<string[] | undefined>();
 
   const [executions, executionsLoaded, executionsError] = useExecutionsForPipelineRun(run);
   const [artifacts] = usePipelineRunArtifacts(run);
@@ -69,8 +69,8 @@ const PipelineRunDetails: React.FC<
     if (isInvalidPipelineVersion) {
       return null;
     }
-    return nodes.find((n) => n.id === selectedId);
-  }, [isInvalidPipelineVersion, selectedId, nodes]);
+    return selectedIds ? nodes.find((n) => n.id === selectedIds[0]) : undefined;
+  }, [isInvalidPipelineVersion, selectedIds, nodes]);
 
   const loaded = runLoaded && (versionLoaded || !!run?.pipeline_spec || !!versionError);
   const error = runError;
@@ -100,7 +100,7 @@ const PipelineRunDetails: React.FC<
     <PipelineRunDrawerRightContent
       task={selectedNode.data.pipelineTask}
       upstreamTaskName={selectedNode.runAfterTasks?.[0]}
-      onClose={() => setSelectedId(null)}
+      onClose={() => setSelectedIds(undefined)}
       executions={executions}
     />
   ) : null;
@@ -157,15 +157,8 @@ const PipelineRunDetails: React.FC<
               <PipelineTopology
                 nodes={nodes}
                 versionError={versionError}
-                selectedIds={selectedId ? [selectedId] : []}
-                onSelectionChange={(ids) => {
-                  const firstId = ids[0];
-                  if (ids.length === 0) {
-                    setSelectedId(null);
-                  } else if (nodes.find((node) => node.id === firstId)) {
-                    setSelectedId(firstId);
-                  }
-                }}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
                 sidePanel={panelContent}
               />
             }


### PR DESCRIPTION
Fixes [RHOAIENG-13164](https://issues.redhat.com/browse/RHOAIENG-13164)

## Description
When spacer nodes are created for edges due to multiple sources going to the same multiple targets, only the edge between the spacer node and source (or target) was being highlighted.

Added code to include the edge between the spacer node and targets (or sources) in the selection list.

## How Has This Been Tested?
Tested locally.

Can reproduce using:
https://redhat.enterprise.slack.com/files/UQN4S2YQJ/F07P71R7NSU/fraud_detection.yaml

## Screen shot ##
![image](https://github.com/user-attachments/assets/7651c2b6-bf73-444a-8e78-200bfe13c7ba)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
