### PR TITLE
Restart all connected notebooks when the pvc size changes

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -30,6 +30,7 @@ import {
   getStopPatch,
   startPatch,
   mergePatchUpdateNotebook,
+  restartNotebook,
 } from '~/api/k8s/notebooks';
 
 import {
@@ -941,5 +942,32 @@ describe('removeNotebookSecret', () => {
       ],
       queryOptions: { name, ns: namespace },
     });
+  });
+});
+
+describe('restartNotebook', () => {
+  it('should add restart notebook annotation', async () => {
+    const name = 'test-notebook';
+    const namespace = 'test-project';
+    const notebookMock = mockNotebookK8sResource({ uid });
+
+    k8sGetResourceMock.mockResolvedValue(notebookMock);
+    k8sPatchResourceMock.mockResolvedValue(notebookMock);
+
+    const renderResult = await restartNotebook(name, namespace);
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: NotebookModel,
+      patches: [
+        {
+          op: 'add',
+          path: '/metadata/annotations/notebooks.opendatahub.io~1notebook-restart',
+          value: 'true',
+        },
+      ],
+      queryOptions: { name, ns: namespace, queryParams: {} },
+    });
+    expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).toStrictEqual(notebookMock);
   });
 });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -506,3 +506,28 @@ export const removeNotebookSecret = (
       })
       .catch(reject);
   });
+
+export const restartNotebook = (
+  notebookName: string,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<NotebookKind> => {
+  const patches: Patch[] = [
+    {
+      op: 'add',
+      path: '/metadata/annotations/notebooks.opendatahub.io~1notebook-restart',
+      value: 'true',
+    },
+  ];
+
+  return k8sPatchResource<NotebookKind>(
+    applyK8sAPIOptions(
+      {
+        model: NotebookModel,
+        queryOptions: { name: notebookName, ns: namespace },
+        patches,
+      },
+      opts,
+    ),
+  );
+};

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Form, Modal, Stack, StackItem } from '@patternfly/react-core';
-import { attachNotebookPVC, createPvc, removeNotebookPVC, updatePvc } from '~/api';
+import { attachNotebookPVC, createPvc, removeNotebookPVC, restartNotebook, updatePvc } from '~/api';
 import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { useCreateStorageObjectForNotebook } from '~/pages/projects/screens/spawner/storage/utils';
@@ -97,6 +97,11 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOp
         existingData.spec.storageClassName !== createData.storageClassName
       ) {
         pvcPromises.push(updatePvc(createData, existingData, namespace, { dryRun }));
+      }
+      if (existingData.spec.resources.requests.storage !== createData.size) {
+        connectedNotebooks.map((connectedNotebook) =>
+          pvcPromises.push(restartNotebook(connectedNotebook.metadata.name, namespace, { dryRun })),
+        );
       }
       if (removedNotebooks.length > 0) {
         // Remove connected pvcs


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-147](https://issues.redhat.com/browse/RHOAIENG-147)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Find all the connected notebooks to the PVC, and when detects the PVC size changes, add the `notebooks.opendatahub.io/notebook-restart=true` annotation to the workbench to trigger a restart.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a workbench
2. Make sure it's running
3. Find the attached PVC to that workbench
4. Update that PVC, increase the size by 1 GB
5. Make sure the workbench restarts
6. You can try to attach the PVC to more workbenches and make sure the size increase could trigger the restart of all the attached workbenches

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a unit test to verify the restart notebook function triggers the correct patch method.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
