### PR TITLE
Don't crash if modelregistries namespace is not present in the DSC

### DIFF
--- a/backend/src/routes/api/modelRegistries/modelRegistryUtils.ts
+++ b/backend/src/routes/api/modelRegistries/modelRegistryUtils.ts
@@ -6,9 +6,20 @@ const MODEL_REGISTRY_API_GROUP = 'modelregistry.opendatahub.io';
 const MODEL_REGISTRY_API_VERSION = 'v1alpha1';
 const MODEL_REGISTRY_PLURAL = 'modelregistries';
 
-export const getModelRegistryNamespace = async (fastify: KubeFastifyInstance): Promise<string> => {
-  const modelRegistryNamespace = await getClusterStatus(fastify);
-  return modelRegistryNamespace.components.modelregistry.registriesNamespace;
+export const getModelRegistryNamespace = async (
+  fastify: KubeFastifyInstance,
+): Promise<string | undefined> => {
+  let registriesNamespace: string | undefined;
+  try {
+    const clusterStatus = await getClusterStatus(fastify);
+    registriesNamespace = clusterStatus.components?.modelregistry?.registriesNamespace;
+  } catch (e) {
+    fastify.log.error(e, 'Failed to fetch DSC status');
+  }
+  if (!registriesNamespace) {
+    fastify.log.warn('Model registry namespace not found in DSC status');
+  }
+  return registriesNamespace;
 };
 
 const base64encode = (value?: string): string => {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1004,11 +1004,11 @@ type ComponentNames =
   | 'workbenches';
 
 export type DataScienceClusterKindStatus = {
-  components: {
-    modelregistry: {
-      registriesNamespace: string
-    }
-  }
+  components?: {
+    modelregistry?: {
+      registriesNamespace?: string;
+    };
+  };
   conditions: K8sCondition[];
   installedComponents: { [key in ComponentNames]?: boolean };
   phase?: string;

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -48,7 +48,7 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<
     isLoaded,
     error,
     refreshRulesReview,
-  } = useModelRegistryServices(dscStatus?.components.modelregistry.registriesNamespace || '');
+  } = useModelRegistryServices(dscStatus?.components?.modelregistry?.registriesNamespace || '');
   const [preferredModelRegistry, setPreferredModelRegistry] = React.useState<
     ServiceKind | undefined
   >(undefined);

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1356,9 +1356,9 @@ export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> 
 
 /** We don't need or should ever get the full kind, this is the status section */
 export type DataScienceClusterKindStatus = {
-  components: {
-    modelregistry: {
-      registriesNamespace: string;
+  components?: {
+    modelregistry?: {
+      registriesNamespace?: string;
     };
   };
   conditions: K8sCondition[];

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -76,7 +76,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, refresh }) =
       kind: 'ModelRegistry',
       metadata: {
         name: nameDesc.k8sName || translateDisplayNameForK8s(nameDesc.name),
-        namespace: dscStatus?.components.modelregistry.registriesNamespace || '',
+        namespace: dscStatus?.components?.modelregistry?.registriesNamespace || '',
         annotations: {
           'openshift.io/description': nameDesc.description,
           'openshift.io/display-name': nameDesc.name.trim(),

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
@@ -24,7 +24,7 @@ import ProjectsSettingsTab from './ProjectsTab/ProjectsSettingsTab';
 
 const ModelRegistriesManagePermissions: React.FC = () => {
   const { dscStatus } = React.useContext(AreaContext);
-  const modelRegistryNamespace = dscStatus?.components.modelregistry.registriesNamespace;
+  const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace;
   const [activeTabKey, setActiveTabKey] = React.useState('users');
   const [ownerReference, setOwnerReference] = React.useState<ModelRegistryKind>();
   const [groups] = useGroups();

--- a/frontend/src/pages/modelRegistrySettings/useModelRegistryRoleBindings.ts
+++ b/frontend/src/pages/modelRegistrySettings/useModelRegistryRoleBindings.ts
@@ -10,7 +10,7 @@ const useModelRegistryRoleBindings = (): FetchState<RoleBindingKind[]> => {
   const getRoleBindings = React.useCallback(
     () =>
       listRoleBindings(
-        dscStatus?.components.modelregistry.registriesNamespace,
+        dscStatus?.components?.modelregistry?.registriesNamespace,
         KnownLabels.LABEL_SELECTOR_MODEL_REGISTRY,
       ).catch((e) => {
         if (e.statusObject?.code === 404) {
@@ -18,7 +18,7 @@ const useModelRegistryRoleBindings = (): FetchState<RoleBindingKind[]> => {
         }
         throw e;
       }),
-    [dscStatus?.components.modelregistry.registriesNamespace],
+    [dscStatus?.components?.modelregistry?.registriesNamespace],
   );
 
   return useFetchState<RoleBindingKind[]>(getRoleBindings, []);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Followup to https://github.com/opendatahub-io/odh-dashboard/pull/3239
Needed for https://issues.redhat.com/browse/RHOAIENG-12311

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

[See slack thread here](https://redhat-internal.slack.com/archives/C07C0447EAV/p1727200812929609). The above PR creates a situation where if model registry is not enabled on a cluster, the dashboard will crash on server start. This PR is an immediate fix for the crash, and I'll follow up with a second PR to switch us to using a ResourceWatcher so we make sure the namespace value is current in case it is not available yet when the dashboard starts.

This PR also fixes the same type in the frontend to make sure we are always being defensive when we try to read this value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on https://console-openshift-console.apps.ods-qe-psi-01.osp.rh-ods.com/ which is old enough that its DSC has no modelregistry spec or status. Running the backend locally on main, verified that it crashes when using this cluster's API. Running the same way on this branch there is no crash.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, no tests in the backend.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
