### PR TITLE
run eslint on backend src folder

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,14 +26,13 @@
     "build": "run-s build:clean tsc:prod",
     "build:clean": "rimraf ./dist",
     "test": "run-s test:lint test:type-check test:jest",
-    "test:lint": "eslint --max-warnings 0 --ext .json,.js,.ts src/plugins src/routes src/utils",
-    "test:fix": "eslint --ext .json,.js,.ts src/plugins src/routes src/utils --fix",
+    "test:lint": "eslint --max-warnings 0 --ext .json,.js,.ts ./src",
+    "test:fix": "eslint --ext .json,.js,.ts ./src --fix",
     "test:type-check": "tsc --noEmit",
     "test:jest": "jest",
     "server": "NODE_ENV=production node ./dist/server.js",
     "tsc": "tsc -p .",
     "tsc:prod": "tsc -p tsconfig.prod.json",
-    "lint": "eslint ./src/",
     "watch": "tsc -p . -w"
   },
   "dependencies": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,8 +7,12 @@ import fastifySensible from '@fastify/sensible';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyAccepts from '@fastify/accepts';
 import { FastifyInstance } from 'fastify/types/instance';
+import { FastifyRegisterOptions } from 'fastify';
 
-export const initializeApp = async (fastify: FastifyInstance, opts: any): Promise<void> => {
+export const initializeApp = async (
+  fastify: FastifyInstance,
+  opts: FastifyRegisterOptions<unknown>,
+): Promise<void> => {
   if (!fs.existsSync(LOG_DIR)) {
     fastify.log.info(`${LOG_DIR} does not exist. Creating`);
     fs.mkdirSync(LOG_DIR);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updated lint script to target the `backend/src` folder because not all files were being assessed by eslint.
Fixed any errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test:lint

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
