### PR TITLE
Use a ResourceWatcher for DSC status in the backend instead of fetching it once at app startup to resolve model registries namespace

### DIFF
--- a/backend/src/routes/api/dsc/index.ts
+++ b/backend/src/routes/api/dsc/index.ts
@@ -1,6 +1,6 @@
 import { KubeFastifyInstance } from '../../../types';
 import { secureRoute } from '../../../utils/route-security';
-import { getClusterStatus } from '../../../utils/dsc';
+import { getClusterStatus } from '../../../utils/resourceUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get(

--- a/backend/src/routes/api/modelRegistries/index.ts
+++ b/backend/src/routes/api/modelRegistries/index.ts
@@ -18,8 +18,6 @@ type ModelRegistryAndDBPassword = {
 
 // Lists ModelRegistries directly (does not look up passwords from associated Secrets, you must make a direct request to '/:modelRegistryName' for that)
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  const modelRegistryNamespace = await getModelRegistryNamespace(fastify);
-
   fastify.get(
     '/',
     secureAdminRoute(fastify)(
@@ -29,6 +27,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       ) => {
         const { labelSelector } = request.query;
         try {
+          const modelRegistryNamespace = getModelRegistryNamespace(fastify);
           return listModelRegistries(fastify, modelRegistryNamespace, labelSelector);
         } catch (e) {
           fastify.log.error(
@@ -55,6 +54,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         const { dryRun } = request.query;
         const { modelRegistry, databasePassword } = request.body;
         try {
+          const modelRegistryNamespace = getModelRegistryNamespace(fastify);
           return createModelRegistryAndSecret(
             fastify,
             modelRegistry,
@@ -84,6 +84,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       ) => {
         const { modelRegistryName } = request.params;
         try {
+          const modelRegistryNamespace = getModelRegistryNamespace(fastify);
           const modelRegistry = await getModelRegistry(
             fastify,
             modelRegistryName,
@@ -124,6 +125,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         const { modelRegistryName } = request.params;
         const { modelRegistry: patchBody, databasePassword } = request.body;
         try {
+          const modelRegistryNamespace = getModelRegistryNamespace(fastify);
           const modelRegistry = await patchModelRegistryAndUpdatePassword(
             fastify,
             modelRegistryName,
@@ -159,6 +161,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         const { dryRun } = request.query;
         const { modelRegistryName } = request.params;
         try {
+          const modelRegistryNamespace = getModelRegistryNamespace(fastify);
           deleteModelRegistryAndSecret(
             fastify,
             modelRegistryName,

--- a/backend/src/routes/api/modelRegistries/modelRegistryUtils.ts
+++ b/backend/src/routes/api/modelRegistries/modelRegistryUtils.ts
@@ -1,23 +1,16 @@
 import { KubeFastifyInstance, ModelRegistryKind, RecursivePartial } from '../../../types';
 import { PatchUtils, V1Secret, V1Status } from '@kubernetes/client-node';
-import { getClusterStatus } from '../../../utils/dsc';
+import { getClusterStatus } from '../../../utils/resourceUtils';
 
 const MODEL_REGISTRY_API_GROUP = 'modelregistry.opendatahub.io';
 const MODEL_REGISTRY_API_VERSION = 'v1alpha1';
 const MODEL_REGISTRY_PLURAL = 'modelregistries';
 
-export const getModelRegistryNamespace = async (
-  fastify: KubeFastifyInstance,
-): Promise<string | undefined> => {
-  let registriesNamespace: string | undefined;
-  try {
-    const clusterStatus = await getClusterStatus(fastify);
-    registriesNamespace = clusterStatus.components?.modelregistry?.registriesNamespace;
-  } catch (e) {
-    fastify.log.error(e, 'Failed to fetch DSC status');
-  }
+export const getModelRegistryNamespace = (fastify: KubeFastifyInstance): string => {
+  const clusterStatus = getClusterStatus(fastify);
+  const registriesNamespace = clusterStatus.components?.modelregistry?.registriesNamespace;
   if (!registriesNamespace) {
-    fastify.log.warn('Model registry namespace not found in DSC status');
+    throw new Error('Model registry namespace not found in DSC status');
   }
   return registriesNamespace;
 };

--- a/backend/src/utils/dsc.ts
+++ b/backend/src/utils/dsc.ts
@@ -6,7 +6,7 @@ import {
 } from '../types';
 import { createCustomError } from './requestUtils';
 
-export const getClusterStatus = async (
+export const fetchClusterStatus = async (
   fastify: KubeFastifyInstance,
 ): Promise<DataScienceClusterKindStatus> => {
   const result: DataScienceClusterKind | null = await fastify.kube.customObjectsApi

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -73,12 +73,21 @@ const requestSecurityGuard = async (
   const translatedUsername = usernameTranslate(userInfo.userName);
   const isReadRequest = request.method.toLowerCase() === 'get';
 
+  let modelRegistryNamespace: string | undefined;
+  try {
+    modelRegistryNamespace = getModelRegistryNamespace(fastify);
+  } catch (e) {
+    fastify.log.warn(
+      'Model registry secure routes will be unavailable, cannot read model registry namespace from DSC',
+    );
+  }
+
+  const namespacesToCheck = [notebookNamespace, dashboardNamespace, modelRegistryNamespace].filter(
+    Boolean,
+  );
+
   // Check to see if a request was made against one of our namespaces
-  if (
-    ![notebookNamespace, dashboardNamespace, await getModelRegistryNamespace(fastify)].includes(
-      namespace,
-    )
-  ) {
+  if (!namespacesToCheck.includes(namespace)) {
     // Not a valid namespace -- cannot make direct calls to just any namespace no matter who you are
     fastify.log.error(
       `User requested a resource that was not in our namespaces. Namespace: ${namespace}`,

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -12,7 +12,6 @@ import {
   NotebookState,
   OauthFastifyRequest,
 } from '../types';
-import { getModelRegistryNamespace } from '../routes/api/modelRegistries/modelRegistryUtils';
 
 const testAdmin = async (
   fastify: KubeFastifyInstance,
@@ -73,21 +72,8 @@ const requestSecurityGuard = async (
   const translatedUsername = usernameTranslate(userInfo.userName);
   const isReadRequest = request.method.toLowerCase() === 'get';
 
-  let modelRegistryNamespace: string | undefined;
-  try {
-    modelRegistryNamespace = getModelRegistryNamespace(fastify);
-  } catch (e) {
-    fastify.log.warn(
-      'Model registry secure routes will be unavailable, cannot read model registry namespace from DSC',
-    );
-  }
-
-  const namespacesToCheck = [notebookNamespace, dashboardNamespace, modelRegistryNamespace].filter(
-    Boolean,
-  );
-
   // Check to see if a request was made against one of our namespaces
-  if (!namespacesToCheck.includes(namespace)) {
+  if (![notebookNamespace, dashboardNamespace].includes(namespace)) {
     // Not a valid namespace -- cannot make direct calls to just any namespace no matter who you are
     fastify.log.error(
       `User requested a resource that was not in our namespaces. Namespace: ${namespace}`,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Followup to #3248 and #3239.
Closes https://issues.redhat.com/browse/RHOAIENG-12311

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

A potential problem with the implementation in #3239 is that it depends on the registriesNamespace being present in the DSC status immediately when the dashboard pod starts. In theory on a fresh install it is possible for the dashboard to start before the operator has reconciled the DSC and put the registriesNamespace into its status, in which case we would never refetch it and all model registry API calls would fail until the dashboard pods were restarted.

To fix this, we can use a ResourceWatcher so that the server is regularly refetching the DSC and any usage of `getModelRegistryNamespace` will use its latest value. This means that function is no longer async, and also should now be called during each fastify request instead of at app startup time. However, it still throws errors so it should only be called within a `try` block. Any clusters that do not have model registry enabled will have an error thrown by `getModelRegistryNamespace` and must handle that appropriately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in modelregistry-ui cluster - we can still access and interact with both the admin-side MR settings page and the user-side Model Registry page.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, no unit tests on the backend :(

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
