### PR TITLE
Add storage class support for notebook PVCs

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -838,6 +838,7 @@ export type NotebookData = {
   envVars: EnvVarReducedTypeKeyValues;
   state: NotebookState;
   username?: string;
+  storageClassName?: string;
 };
 
 export type AcceleratorProfileState = {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -65,7 +65,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
       disableConnectionTypes: true,
-      disableStorageClasses: true,
+      disableStorageClasses: false,
       disableNIMModelServing: true,
     },
     notebookController: {

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -611,7 +611,7 @@ const generateNotebookResources = async (
     await fastify.kube.coreV1Api.readNamespacedPersistentVolumeClaim(pvcName, namespace);
   } catch (e) {
     if (e.statusCode === 404) {
-      await createPvc(fastify, namespace, pvcName);
+      await createPvc(fastify, namespace, pvcName, notebookData.storageClassName);
     } else {
       throw e;
     }
@@ -636,10 +636,12 @@ const createPvc = async (
   fastify: KubeFastifyInstance,
   namespace: string,
   pvcName: string,
+  storageClassName?: string,
 ): Promise<V1PersistentVolumeClaim> => {
   const pvcSize = getDashboardConfig().spec?.notebookController?.pvcSize ?? DEFAULT_PVC_SIZE;
-  const storageClassName = getDashboardConfig().spec.notebookController?.storageClassName;
-  const pvc = assemblePvc(pvcName, namespace, pvcSize, storageClassName);
+  const preferredStorageClassName =
+    getDashboardConfig().spec.notebookController?.storageClassName ?? storageClassName;
+  const pvc = assemblePvc(pvcName, namespace, pvcSize, preferredStorageClassName);
 
   try {
     const pvcResponse = await fastify.kube.coreV1Api.createNamespacedPersistentVolumeClaim(

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -35,7 +35,7 @@ The following are a list of features that are supported, along with there defaul
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
 | disableConnectionTypes       | true    | Disables creating custom data connection types from the dashboard.                                   |
-| disableStorageClasses        | true    | Disables storage classes settings nav item from the dashboard.                                       |
+| disableStorageClasses        | false    | Disables storage classes settings nav item from the dashboard.                                       |
 | disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.   
 
 ## Defaults
@@ -67,7 +67,7 @@ spec:
     disablePipelineExperiments: true
     disableDistributedWorkloads: false
     disableConnectionTypes: false
-    disableStorageClasses: true
+    disableStorageClasses: false
     disableNIMModelServing: true
 ```
 

--- a/frontend/src/__mocks__/mockStorageClasses.ts
+++ b/frontend/src/__mocks__/mockStorageClasses.ts
@@ -1,26 +1,19 @@
 import { K8sResourceListResult, StorageClassConfig, StorageClassKind } from '~/k8sTypes';
 
-export type MockStorageClass = Omit<StorageClassKind, 'apiVersion' | 'kind'>;
-
-export type MockStorageClassList = Omit<K8sResourceListResult<MockStorageClass>, 'metadata'> & {
-  metadata: {
-    resourceVersion: string;
-  };
-};
-
 export const mockStorageClassList = (
-  storageClasses: MockStorageClass[] = mockStorageClasses,
-): MockStorageClassList => ({
+  storageClasses: StorageClassKind[] = mockStorageClasses,
+): K8sResourceListResult<StorageClassKind> => ({
   kind: 'StorageClassList',
   apiVersion: 'storage.k8s.io/v1',
   metadata: {
     resourceVersion: '55571379',
+    continue: '',
   },
   items: storageClasses,
 });
 
 export const buildMockStorageClassConfig = (
-  mockStorageClass: MockStorageClass,
+  mockStorageClass: StorageClassKind,
   config: Partial<StorageClassConfig>,
 ): string =>
   JSON.stringify({
@@ -31,9 +24,9 @@ export const buildMockStorageClassConfig = (
   });
 
 export const buildMockStorageClass = (
-  mockStorageClass: MockStorageClass,
+  mockStorageClass: StorageClassKind,
   config: Partial<StorageClassConfig> | string,
-): MockStorageClass => ({
+): StorageClassKind => ({
   ...mockStorageClass,
   metadata: {
     ...mockStorageClass.metadata,
@@ -45,8 +38,10 @@ export const buildMockStorageClass = (
   },
 });
 
-export const mockStorageClasses: MockStorageClass[] = [
+export const mockStorageClasses: StorageClassKind[] = [
   {
+    apiVersion: 'storage.k8s.io/v1',
+    kind: 'StorageClass',
     metadata: {
       name: 'openshift-default-sc',
       uid: '5de188ae-aa8e-43d1-a714-4d60ecc5c6da',
@@ -99,6 +94,8 @@ export const mockStorageClasses: MockStorageClass[] = [
     volumeBindingMode: 'WaitForFirstConsumer',
   },
   {
+    apiVersion: 'storage.k8s.io/v1',
+    kind: 'StorageClass',
     metadata: {
       name: 'test-storage-class-1',
       uid: 'c3c05a4a-c1b7-4358-a246-da6b6dfd12cd',

--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -1,7 +1,8 @@
-import type { MockStorageClass } from '~/__mocks__';
-import { mockStorageClassList } from '~/__mocks__';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+import { mockStorageClassList } from '~/__mocks__';
+import type { StorageClassKind } from '~/k8sTypes';
+import { StorageClassModel } from '~/__tests__/cypress/cypress/utils/models';
 import { Modal } from './components/Modal';
 import { TableToolbar } from './components/TableToolbar';
 
@@ -24,10 +25,12 @@ class StorageClassesPage {
     return cy.findByTestId('storage-classes-empty-state');
   }
 
-  mockGetStorageClasses(storageClasses?: MockStorageClass[], times?: number) {
-    return cy.interceptOdh(
-      'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-      { times },
+  mockGetStorageClasses(storageClasses?: StorageClassKind[], times?: number) {
+    return cy.interceptK8sList(
+      {
+        model: StorageClassModel,
+        times,
+      },
       mockStorageClassList(storageClasses),
     );
   }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -51,7 +51,7 @@ import type {
   PipelineVersionKFv2,
 } from '~/concepts/pipelines/kfTypes';
 import type { GrpcResponse } from '~/__mocks__/mlmd/utils';
-import type { BuildMockPipelinveVersionsType, MockStorageClassList } from '~/__mocks__';
+import type { BuildMockPipelinveVersionsType } from '~/__mocks__';
 import type { ArtifactStorage } from '~/concepts/pipelines/types';
 import type { ConnectionTypeConfigMap } from '~/concepts/connectionTypes/types';
 
@@ -193,11 +193,6 @@ declare global {
           type: 'POST /api/servingRuntimes/',
           options: { query: { dryRun: 'All' } } | null,
           response: OdhResponse<ServingRuntimeKind>,
-        ) => Cypress.Chainable<null>) &
-        ((
-          type: 'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-          options: { times?: number },
-          response: OdhResponse<MockStorageClassList>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'PUT /api/storage-class/:name/config',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -1,5 +1,10 @@
 import { mockRoleBindingK8sResource } from '~/__mocks__/mockRoleBindingK8sResource';
-import { mockK8sResourceList, mockNotebookK8sResource } from '~/__mocks__';
+import {
+  mockK8sResourceList,
+  mockNotebookK8sResource,
+  mockDashboardConfig,
+  mockStorageClassList,
+} from '~/__mocks__';
 import type { RoleBindingSubject } from '~/k8sTypes';
 import { mockAllowedUsers } from '~/__mocks__/mockAllowedUsers';
 import { mockNotebookImageInfo } from '~/__mocks__/mockNotebookImageInfo';
@@ -11,6 +16,7 @@ import {
   stopNotebookModal,
 } from '~/__tests__/cypress/cypress/pages/administration';
 import { homePage } from '~/__tests__/cypress/cypress/pages/home/home';
+import { StorageClassModel } from '~/__tests__/cypress/cypress/utils/models';
 
 const groupSubjects: RoleBindingSubject[] = [
   {
@@ -33,6 +39,14 @@ const initIntercepts = () => {
   );
   cy.interceptOdh('GET /api/images/:type', { path: { type: 'jupyter' } }, mockNotebookImageInfo());
   cy.interceptOdh('GET /api/status/openshift-ai-notebooks/allowedUsers', mockAllowedUsers({}));
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableStorageClasses: false,
+    }),
+  );
+
+  cy.interceptK8sList(StorageClassModel, mockStorageClassList());
 };
 
 it('Administration tab should not be accessible for non-project admins', () => {
@@ -64,6 +78,7 @@ describe('NotebookServer', () => {
         acceleratorProfile: { acceleratorProfiles: [], count: 0, unknownProfileDetected: false },
         envVars: { configMap: {}, secrets: {} },
         state: 'started',
+        storageClassName: 'openshift-default-sc',
       });
     });
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -10,7 +10,7 @@ import { mockAllowedUsers } from '~/__mocks__/mockAllowedUsers';
 import { mockNotebookImageInfo } from '~/__mocks__/mockNotebookImageInfo';
 import { mockStartNotebookData } from '~/__mocks__/mockStartNotebookData';
 import { notebookServer } from '~/__tests__/cypress/cypress/pages/notebookServer';
-import { asProductAdminUser, asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
+import { asClusterAdminUser, asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import {
   notebookController,
   stopNotebookModal,
@@ -60,8 +60,8 @@ it('Administration tab should not be accessible for non-project admins', () => {
 
 describe('NotebookServer', () => {
   beforeEach(() => {
+    asClusterAdminUser();
     initIntercepts();
-    asProductAdminUser();
   });
 
   it('should start notebook server', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -23,6 +23,7 @@ import {
   PVCModel,
   PodModel,
   ProjectModel,
+  StorageClassModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mock200Status } from '~/__mocks__/mockK8sStatus';
 import { mockPrometheusQueryResponse } from '~/__mocks__/mockPrometheusQueryResponse';
@@ -80,11 +81,7 @@ describe('ClusterStorage', () => {
         }),
       );
 
-      cy.interceptOdh(
-        'GET /api/k8s/apis/storage.k8s.io/v1/storageclasses',
-        {},
-        mockStorageClassList(),
-      );
+      cy.interceptK8sList(StorageClassModel, mockStorageClassList());
     });
 
     it('Check whether the Storage class column is present', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -32,6 +32,7 @@ import {
   ProjectModel,
   RouteModel,
   SecretModel,
+  StorageClassModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mock200Status } from '~/__mocks__/mockK8sStatus';
 import type { NotebookSize } from '~/types';
@@ -61,7 +62,7 @@ const initIntercepts = ({
     },
   ],
 }: HandlersProps) => {
-  cy.interceptOdh('GET /api/k8s/apis/storage.k8s.io/v1/storageclasses', {}, mockStorageClassList());
+  cy.interceptK8sList(StorageClassModel, mockStorageClassList());
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -47,6 +47,7 @@ import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
+import useDefaultStorageClass from '~/pages/projects/screens/spawner/storage/useDefaultStorageClass';
 import SizeSelectField from './SizeSelectField';
 import useSpawnerNotebookModalState from './useSpawnerNotebookModalState';
 import BrowserTabPreferenceCheckbox from './BrowserTabPreferenceCheckbox';
@@ -82,6 +83,8 @@ const SpawnerPage: React.FC = () => {
   const acceleratorProfile = useNotebookAcceleratorProfile(currentUserNotebook);
   const [variableRows, setVariableRows] = React.useState<VariableRow[]>([]);
   const [submitError, setSubmitError] = React.useState<Error | null>(null);
+
+  const defaultStorageClass = useDefaultStorageClass();
 
   const [selectedAcceleratorProfile, setSelectedAcceleratorProfile] =
     useGenericObjectState<AcceleratorProfileSelectFieldState>({
@@ -278,6 +281,7 @@ const SpawnerPage: React.FC = () => {
       envVars,
       state: NotebookState.Started,
       username: impersonatedUsername || undefined,
+      storageClassName: defaultStorageClass?.metadata.name,
     })
       .then(() => {
         fireStartServerEvent();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -601,6 +601,7 @@ export type NotebookData = {
   state: NotebookState;
   // only used for admin calls, regular users cannot use this field
   username?: string;
+  storageClassName?: string;
 };
 
 export type UsernameMap<V> = { [username: string]: V };

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -29,7 +29,7 @@ spec:
     disableDistributedWorkloads: false
     disableModelRegistry: false
     disableConnectionTypes: true
-    disableStorageClasses: true
+    disableStorageClasses: false
     disableNIMModelServing: true
   groupsConfig:
     adminGroups: "$(admin_groups)"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13395

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR adds support for setting the default storage class for the jupyter tile. 
Key changes:
* Added storageClassName field to NotebookData type in both frontend and backend.
* fix test mocks that where creating a new type

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. enable storage class feature flag
2. set storage class in dashboard config
3. spawn a notebook in jupyter tile
4. check that notebook created is using the storage class in the dashboard config
5. remove the storage class from the dashboard config
6. spawn it again and check that it uses the default set in the storage class admin page
7. turn off the feature flag
8. spawn it again, check that it uses the default openshift storage class

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated test mocks and added test to make sure default storage class was passed to the backend

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
