### PR TITLE
Use K8sNameDescriptionField in connection type page

### DIFF
--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/__tests__/utils.spec.ts
@@ -51,6 +51,29 @@ describe('setupDefaults', () => {
       }),
     );
   });
+
+  it('should allow prefilling of displayName and description', () => {
+    expect(
+      setupDefaults({
+        initialData: mockProjectK8sResource({
+          displayName: 'Display Name',
+          k8sName: '',
+          description: 'my description',
+        }),
+      }),
+    ).toEqual(
+      mockK8sNameDescriptionFieldData({
+        name: 'Display Name',
+        description: 'my description',
+        k8sName: {
+          value: 'display-name',
+          state: {
+            immutable: false,
+          },
+        },
+      }),
+    );
+  });
 });
 
 describe('handleUpdateLogic', () => {

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -52,7 +52,7 @@ export const setupDefaults = ({
     configuredMaxLength = ROUTE_BASED_NAME_LENGTH;
   }
 
-  return {
+  return handleUpdateLogic({
     name: initialName,
     description: initialDescription,
     k8sName: {
@@ -66,7 +66,7 @@ export const setupDefaults = ({
         touched: false,
       },
     },
-  } satisfies K8sNameDescriptionFieldData;
+  })('name', initialName) satisfies K8sNameDescriptionFieldData;
 };
 
 export const handleUpdateLogic =

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -7,7 +7,8 @@ export const PreInstalledName = 'Pre-installed';
 export const ownedByDSC = (resource: K8sResourceCommon): boolean =>
   !!resource.metadata?.ownerReferences?.find((owner) => owner.kind === 'DataScienceCluster');
 
-export const isK8sDSGResource = (x?: K8sResourceCommon): x is K8sDSGResource => !!x?.metadata?.name;
+export const isK8sDSGResource = (x?: K8sResourceCommon): x is K8sDSGResource =>
+  x?.metadata?.name != null;
 export const getDisplayNameFromK8sResource = (resource: K8sDSGResource): string =>
   resource.metadata.annotations?.['openshift.io/display-name'] || resource.metadata.name;
 export const getResourceNameFromK8sResource = (resource: K8sDSGResource): string =>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-13400

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Use the new `K8sNameDescriptionField` component. This prevents the user from entering a too long of a name which causes a resource name error when saving. 

![image](https://github.com/user-attachments/assets/ad4b1568-7b05-4654-8063-fa46a10d8969)
![image](https://github.com/user-attachments/assets/a1d30d91-a54e-4986-8e75-c335150a46c9)
![image](https://github.com/user-attachments/assets/e3833652-d0d9-4dbe-a8b9-ac992f6189db)
![image](https://github.com/user-attachments/assets/03dec3f3-b986-4519-b423-3a20f828213d)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally by running through the different connection type operations. 
For the bug referenced in the jira issue, paste a lot of text https://www.lipsum.com/feed/html and click save. It will now truncate the resource name

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No updates, existing tests cover the previous functionality. (and the long name is a server side error)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
