### PR TITLE
Fix layout issues on notebook controller

### DIFF
--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Alert, Stack, StackItem, Title } from '@patternfly/react-core';
+import {
+  Alert,
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateVariant,
+  Spinner,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
 import { Table } from '~/components/table';
 import ExternalLink from '~/components/ExternalLink';
@@ -38,61 +47,65 @@ const NotebookAdminControl: React.FC = () => {
   );
 
   return (
-    <div className="odh-notebook-controller__page-content">
-      <ApplicationsPage
-        title="Administration"
-        description="Manage notebook servers."
-        provideChildrenPadding
-        loaded={loaded}
-        loadError={loadError}
-        empty={false}
-        headerAction={<StopAllServersButton users={users} />}
-      >
-        <Stack hasGutter>
-          <StackItem>
-            <Alert
-              title="Manage users in OpenShift"
-              component="h2"
-              isInline
-              data-testid="manage-users-alert"
-            >
-              Create, delete, and manage permissions for {ODH_PRODUCT_NAME} users in OpenShift.{' '}
-              <ExternalLink
-                text="Learn more about OpenShift user management"
-                to="https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/index"
-              />
-            </Alert>
-          </StackItem>
-          <StackItem>
-            <Title headingLevel="h2">Users</Title>
-          </StackItem>
-          <StackItem>
-            <Table
-              aria-label="Users table"
-              variant="compact"
-              data={users}
-              data-testid="administration-users-table"
-              enablePagination
-              columns={columns}
-              rowRenderer={(user) => (
-                <Tr key={user.name}>
-                  {columns.map((column) => (
-                    <Td
-                      key={column.field}
-                      dataLabel={column.field}
-                      isActionCell={column.field === 'actions'}
-                    >
-                      <UserTableCellTransform user={user} userProperty={column.field} />
-                    </Td>
-                  ))}
-                </Tr>
-              )}
+    <ApplicationsPage
+      title="Administration"
+      description="Manage notebook servers."
+      provideChildrenPadding
+      loaded={loaded}
+      loadingContent={
+        <EmptyState variant={EmptyStateVariant.lg} data-id="loading-empty-state">
+          <Spinner size="xl" />
+          <EmptyStateHeader titleText="Loading" headingLevel="h1" />
+        </EmptyState>
+      }
+      loadError={loadError}
+      empty={false}
+      headerAction={<StopAllServersButton users={users} />}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <Alert
+            title="Manage users in OpenShift"
+            component="h2"
+            isInline
+            data-testid="manage-users-alert"
+          >
+            Create, delete, and manage permissions for {ODH_PRODUCT_NAME} users in OpenShift.{' '}
+            <ExternalLink
+              text="Learn more about OpenShift user management"
+              to="https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/index"
             />
-          </StackItem>
-        </Stack>
-        <StopServerModal notebooksToStop={notebooksToStop} onNotebooksStop={onNotebooksStop} />
-      </ApplicationsPage>
-    </div>
+          </Alert>
+        </StackItem>
+        <StackItem>
+          <Title headingLevel="h2">Users</Title>
+        </StackItem>
+        <StackItem>
+          <Table
+            aria-label="Users table"
+            variant="compact"
+            data={users}
+            data-testid="administration-users-table"
+            enablePagination
+            columns={columns}
+            rowRenderer={(user) => (
+              <Tr key={user.name}>
+                {columns.map((column) => (
+                  <Td
+                    key={column.field}
+                    dataLabel={column.field}
+                    isActionCell={column.field === 'actions'}
+                  >
+                    <UserTableCellTransform user={user} userProperty={column.field} />
+                  </Td>
+                ))}
+              </Tr>
+            )}
+          />
+        </StackItem>
+      </Stack>
+      <StopServerModal notebooksToStop={notebooksToStop} onNotebooksStop={onNotebooksStop} />
+    </ApplicationsPage>
   );
 };
 

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -3,11 +3,15 @@ import {
   ActionGroup,
   Alert,
   Button,
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateVariant,
   Form,
   FormGroup,
   FormSection,
   Grid,
   GridItem,
+  Spinner,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
@@ -305,6 +309,12 @@ const SpawnerPage: React.FC = () => {
         description="Select options for your notebook server."
         provideChildrenPadding
         loaded={loaded}
+        loadingContent={
+          <EmptyState variant={EmptyStateVariant.lg} data-id="loading-empty-state">
+            <Spinner size="xl" />
+            <EmptyStateHeader titleText="Loading" headingLevel="h1" />
+          </EmptyState>
+        }
         loadError={loadError}
         empty={images.length === 0}
       >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-1202](https://issues.redhat.com/browse/RHOAIENG-1202)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Remove the div on the administration page to make it use the full width:

<img width="1512" alt="Screenshot 2024-09-25 at 5 19 04 PM" src="https://github.com/user-attachments/assets/477b78da-3998-46e2-8b69-86653ae68f64">

Fix the loading state by adding the `loadingContent` to the applications page to remove the background.

<img width="1512" alt="Screenshot 2024-09-25 at 5 20 52 PM" src="https://github.com/user-attachments/assets/cd53af29-0d30-4f74-b06f-1e038f635790">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the notebook controller page and switch between the Notebook Server and Administration tab. See how the loading state renders, Make sure there is no layout issue.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, layout fix.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
