### PR TITLE
ImagePullBackOff is not handled as error during workbench start

### DIFF
--- a/frontend/src/pages/projects/notebook/utils.ts
+++ b/frontend/src/pages/projects/notebook/utils.ts
@@ -239,6 +239,9 @@ export const useNotebookStatus = (
         if (!gracePeriod && lastItem.reason === 'FailedScheduling') {
           currentEvent = 'Insufficient resources to start';
           status = EventStatus.ERROR;
+        } else if (!gracePeriod && lastItem.reason === 'BackOff') {
+          currentEvent = 'ImagePullBackOff';
+          status = EventStatus.ERROR;
         } else if (lastItem.type === 'Warning') {
           currentEvent = 'Issue creating notebook container';
           status = EventStatus.WARNING;

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -435,6 +435,9 @@ export const useNotebookStatus = (
         if (!gracePeriod && lastItem.reason === 'FailedScheduling') {
           currentEvent = 'Insufficient resources to start';
           status = EventStatus.ERROR;
+        } else if (!gracePeriod && lastItem.reason === 'BackOff') {
+          currentEvent = 'ImagePullBackOff';
+          status = EventStatus.ERROR;
         } else if (lastItem.type === 'Warning') {
           currentEvent = 'Issue creating notebook container';
           status = EventStatus.WARNING;


### PR DESCRIPTION
Closes: [RHOAIENG-1132](https://issues.redhat.com/browse/RHOAIENG-1132)

## Description
Added case to handle notebook failure when reason === "BackOff"

![Screenshot 2024-09-26 at 5 42 18 PM](https://github.com/user-attachments/assets/ed021634-b4c2-4890-8e51-1acc3aaa1247)

![Screenshot 2024-09-26 at 2 01 29 PM](https://github.com/user-attachments/assets/6801c20b-1ca4-4c54-95b3-2364b749b00c)


## How Has This Been Tested?
1. Create a custom image from Settings > Notebook images (e.g., quay.io/myfakeimages/myimage:1234)
2. create a workbench and select the custom image as notebook image
3. compare the pod and workbench status

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@xianli123 