### PR TITLE
[RHOAIENG-13320] Storage class duplication isDefault edge cases

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -140,7 +140,7 @@ class ClusterStorage {
       .findByTestId('storage-class-deprecated-alert')
       .should(
         'contain.text',
-        'Warning alert:Deprecated storage classA storage class has been deprecated by your administrator, but the cluster storage using it is still active. If you want to migrate your data to cluster storage instance using a different storage class, contact your administrator.',
+        'Warning alert:Deprecated storage classA storage class has been deprecated by your administrator, but the cluster storage using it is still active. If you want to migrate your data to a cluster storage instance using a different storage class, contact your administrator.',
       );
   }
 

--- a/frontend/src/components/table/TableRowTitleDescription.tsx
+++ b/frontend/src/components/table/TableRowTitleDescription.tsx
@@ -9,7 +9,7 @@ type TableRowTitleDescriptionProps = {
   boldTitle?: boolean;
   resource?: K8sResourceCommon;
   subtitle?: React.ReactNode;
-  description?: string;
+  description?: React.ReactNode;
   descriptionAsMarkdown?: boolean;
   truncateDescriptionLines?: number;
   label?: React.ReactNode;
@@ -29,20 +29,21 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
 }) => {
   let descriptionNode: React.ReactNode;
   if (description) {
-    descriptionNode = descriptionAsMarkdown ? (
-      <MarkdownView conciseDisplay markdown={description} />
-    ) : (
-      <span
-        data-testid="table-row-title-description"
-        style={{ color: 'var(--pf-v5-global--Color--200)' }}
-      >
-        {truncateDescriptionLines !== undefined ? (
-          <TruncatedText maxLines={truncateDescriptionLines} content={description} />
-        ) : (
-          description
-        )}
-      </span>
-    );
+    descriptionNode =
+      descriptionAsMarkdown && typeof description === 'string' ? (
+        <MarkdownView conciseDisplay markdown={description} />
+      ) : (
+        <span
+          data-testid="table-row-title-description"
+          style={{ color: 'var(--pf-v5-global--Color--200)' }}
+        >
+          {truncateDescriptionLines !== undefined && typeof description === 'string' ? (
+            <TruncatedText maxLines={truncateDescriptionLines} content={description} />
+          ) : (
+            description
+          )}
+        </span>
+      );
   }
 
   return (

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -62,7 +62,7 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
           }
         >
           A storage class has been deprecated by your administrator, but the cluster storage using
-          it is still active. If you want to migrate your data to cluster storage instance using a
+          it is still active. If you want to migrate your data to a cluster storage instance using a
           different storage class, contact your administrator.
         </Alert>
       )}

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   TextVariants,
   Tooltip,
+  Truncate,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, HddIcon } from '@patternfly/react-icons';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
@@ -100,17 +101,20 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
         </Td>
 
         {isStorageClassesAvailable && (
-          <Td dataLabel="Storage class">
+          <Td modifier="truncate" dataLabel="Storage class">
             <Flex
               spaceItems={{ default: 'spaceItemsSm' }}
               alignItems={{ default: 'alignItemsCenter' }}
             >
               <FlexItem>
-                <Text>
-                  {storageClassConfig?.displayName ??
+                <Truncate
+                  content={
+                    storageClassConfig?.displayName ??
                     obj.storageClass?.metadata.name ??
-                    obj.pvc.spec.storageClassName}
-                </Text>
+                    obj.pvc.spec.storageClassName ??
+                    ''
+                  }
+                />
               </FlexItem>
               {storageClassesLoaded && (
                 <FlexItem>

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -28,6 +28,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
   menuAppendTo,
 }) => {
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
+  const hasStorageClassConfigs = storageClasses.some((sc) => !!getStorageClassConfig(sc));
 
   const enabledStorageClasses = storageClasses
     .filter((sc) => getStorageClassConfig(sc)?.isEnabled)
@@ -76,7 +77,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
     };
   });
 
-  return (
+  return hasStorageClassConfigs ? (
     <FormGroup label="Storage class" fieldId="storage-class">
       <SimpleSelect
         dataTestId="storage-classes-selector"
@@ -88,7 +89,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
           setStorageClassName(selection);
         }}
         isDisabled={
-          disableStorageClassSelect || !storageClassesLoaded || storageClasses.length <= 1
+          disableStorageClassSelect || !storageClassesLoaded || enabledStorageClasses.length <= 1
         }
         placeholder="Select storage class"
         popperProps={{ appendTo: menuAppendTo }}
@@ -114,7 +115,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
         )}
       </FormHelperText>
     </FormGroup>
-  );
+  ) : null;
 };
 
 export default StorageClassSelect;

--- a/frontend/src/pages/storageClasses/ResetCorruptConfigValueAlert.tsx
+++ b/frontend/src/pages/storageClasses/ResetCorruptConfigValueAlert.tsx
@@ -10,7 +10,7 @@ import { CorruptedMetadataAlert } from './CorruptedMetadataAlert';
 interface ResetCorruptConfigValueAlertProps extends Pick<AlertProps, 'variant'> {
   storageClassName: string;
   storageClassConfig: StorageClassConfig;
-  refresh: () => Promise<void | StorageClassKind[]>;
+  onSuccess: () => Promise<void | StorageClassKind[]>;
   popoverText?: string;
 }
 
@@ -19,7 +19,7 @@ export const ResetCorruptConfigValueAlert: React.FC<ResetCorruptConfigValueAlert
   storageClassConfig,
   variant,
   popoverText = 'Refresh the field to correct the corrupted metadata.',
-  refresh,
+  onSuccess,
 }) => {
   const [error, setError] = React.useState<string>();
   const [isUpdating, setIsUpdating] = React.useState(false);
@@ -29,13 +29,13 @@ export const ResetCorruptConfigValueAlert: React.FC<ResetCorruptConfigValueAlert
 
     try {
       await updateStorageClassConfig(storageClassName, storageClassConfig);
-      await refresh();
+      await onSuccess();
     } catch {
       setError('Failed to refresh the field. Try again later.');
     } finally {
       setIsUpdating(false);
     }
-  }, [storageClassName, storageClassConfig, refresh]);
+  }, [storageClassName, storageClassConfig, onSuccess]);
 
   return (
     <CorruptedMetadataAlert

--- a/frontend/src/pages/storageClasses/StorageClassConfigValue.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassConfigValue.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+type StrorageClassConfigValueProps = React.PropsWithChildren & { alert: React.ReactNode };
+
+export const StrorageClassConfigValue: React.FC<StrorageClassConfigValueProps> = ({
+  alert,
+  children,
+}) => {
+  if (!children) {
+    return alert;
+  }
+
+  return children;
+};

--- a/frontend/src/pages/storageClasses/StorageClassEnableSwitch.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEnableSwitch.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Flex, FlexItem, Switch, Tooltip } from '@patternfly/react-core';
 import { updateStorageClassConfig } from '~/services/StorageClassService';
-import { StorageClassKind } from '~/k8sTypes';
+import { ResponseStatus } from '~/types';
 
 interface StorageClassEnableSwitchProps {
   storageClassName: string;
   isChecked: boolean;
   isDisabled: boolean;
-  onChange: () => Promise<void | StorageClassKind[]>;
+  onChange: (update: () => Promise<ResponseStatus>) => Promise<void>;
 }
 
 export const StorageClassEnableSwitch: React.FC<StorageClassEnableSwitchProps> = ({
@@ -29,8 +29,7 @@ export const StorageClassEnableSwitch: React.FC<StorageClassEnableSwitchProps> =
       setIsUpdating(true);
 
       try {
-        await updateStorageClassConfig(storageClassName, { isEnabled: checked });
-        await onChange();
+        await onChange(() => updateStorageClassConfig(storageClassName, { isEnabled: checked }));
       } finally {
         setIsUpdating(false);
       }

--- a/frontend/src/pages/storageClasses/StorageClassesContext.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesContext.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+
+import { StorageClassConfig, StorageClassKind } from '~/k8sTypes';
+import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
+import { ResponseStatus } from '~/types';
+import { updateStorageClassConfig } from '~/services/StorageClassService';
+import { allSettledPromises } from '~/utilities/allSettledPromises';
+import { getStorageClassConfig, isOpenshiftDefaultStorageClass } from './utils';
+
+export interface StorageClassContextProps {
+  storageClasses: StorageClassKind[];
+  storageClassConfigs: Record<string, StorageClassConfig | undefined>;
+  refresh: FetchStateRefreshPromise<StorageClassKind[]>;
+  isUpdatingConfigs: boolean;
+  isLoadingDefault: boolean;
+  setIsLoadingDefault: (isUpdating: boolean) => void;
+}
+
+const defaultContextValues = {
+  storageClasses: [],
+  storageClassConfigs: {},
+  refresh: () => Promise.resolve(undefined),
+  isUpdatingConfigs: false,
+  isLoadingDefault: false,
+  setIsLoadingDefault: () => undefined,
+};
+
+export const StorageClassContext =
+  React.createContext<StorageClassContextProps>(defaultContextValues);
+
+export interface StorageClassContextProviderProps {
+  storageClasses: StorageClassKind[];
+  loaded: boolean;
+  refresh: FetchStateRefreshPromise<StorageClassKind[]>;
+  children: (
+    isAlertOpen: boolean,
+    setIsAlertOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  ) => React.ReactNode;
+}
+
+export const StorageClassContextProvider: React.FC<StorageClassContextProviderProps> = ({
+  storageClasses,
+  refresh,
+  loaded,
+  children,
+}) => {
+  const [isUpdatingConfigs, setIsUpdatingConfigs] = React.useState(true);
+  const [isLoadingDefault, setIsLoadingDefault] = React.useState(false);
+  const [isAutoDefaultAlertOpen, setIsAutoDefaultAlertOpen] = React.useState(false);
+
+  const storageClassConfigs = React.useMemo(
+    () =>
+      storageClasses.reduce((acc: Record<string, StorageClassConfig | undefined>, storageClass) => {
+        acc[storageClass.metadata.name] = getStorageClassConfig(storageClass);
+
+        return acc;
+      }, {}),
+    [storageClasses],
+  );
+
+  const [defaultStorageClassName] =
+    Object.entries(storageClassConfigs).find(([, config]) => config?.isDefault) || [];
+
+  const openshiftDefaultScName = storageClasses.find((storageClass) =>
+    isOpenshiftDefaultStorageClass(storageClass),
+  )?.metadata.name;
+
+  const updateConfigs = React.useCallback(async () => {
+    let hasDefaultConfig = false;
+
+    const updateRequests = Object.entries(storageClassConfigs).reduce(
+      (acc: Promise<ResponseStatus>[], [name, config], index) => {
+        const isFirstConfig = index === 0;
+        const isOpenshiftDefault = openshiftDefaultScName === name;
+
+        // Add a default config annotation when one doesn't exist
+        if (!config) {
+          let isDefault = isOpenshiftDefault;
+          let isEnabled = isDefault;
+
+          if (!openshiftDefaultScName) {
+            isDefault = isFirstConfig;
+            isEnabled = true;
+          }
+
+          acc.push(
+            updateStorageClassConfig(name, {
+              isDefault,
+              isEnabled,
+              displayName: name,
+            }),
+          );
+        }
+        // If multiple defaults are set via OpenShift's dashboard,
+        // unset all except the first indexed storage class
+        else {
+          if (config.isDefault) {
+            if (!hasDefaultConfig) {
+              hasDefaultConfig = true;
+            } else {
+              acc.push(updateStorageClassConfig(name, { isDefault: false }));
+            }
+          }
+
+          // Set a default storage class (OpenShift default or first indexed storage class)
+          // if none exists and notify the user
+          if (
+            !defaultStorageClassName &&
+            ((isFirstConfig && !openshiftDefaultScName) || isOpenshiftDefault)
+          ) {
+            acc.push(
+              updateStorageClassConfig(name, {
+                isDefault: true,
+                isEnabled: true,
+              }),
+            );
+          }
+
+          // If the default storage class coming from OpenShift is disabled, update to enable
+          if (defaultStorageClassName && !storageClassConfigs[defaultStorageClassName]?.isEnabled) {
+            acc.push(
+              updateStorageClassConfig(defaultStorageClassName, {
+                isEnabled: true,
+              }),
+            );
+          }
+        }
+
+        return acc;
+      },
+      [],
+    );
+
+    if (loaded) {
+      try {
+        const [successResponses] = await allSettledPromises(updateRequests);
+
+        if (successResponses.length) {
+          await refresh();
+
+          if (!defaultStorageClassName) {
+            setIsAutoDefaultAlertOpen(true);
+          }
+        }
+      } finally {
+        setIsUpdatingConfigs(false);
+      }
+    }
+  }, [storageClassConfigs, loaded, openshiftDefaultScName, defaultStorageClassName, refresh]);
+
+  // Initialize storage class configs
+  React.useEffect(() => {
+    updateConfigs();
+  }, [defaultStorageClassName, openshiftDefaultScName, storageClassConfigs, updateConfigs]);
+
+  const value: StorageClassContextProps = React.useMemo(
+    () => ({
+      storageClasses,
+      storageClassConfigs,
+      refresh,
+      isUpdatingConfigs,
+      isLoadingDefault,
+      setIsLoadingDefault,
+    }),
+    [storageClasses, storageClassConfigs, refresh, isUpdatingConfigs, isLoadingDefault],
+  );
+
+  return (
+    <StorageClassContext.Provider value={value}>
+      {children(isAutoDefaultAlertOpen, setIsAutoDefaultAlertOpen)}
+    </StorageClassContext.Provider>
+  );
+};
+
+export const useStorageClassContext = (): StorageClassContextProps =>
+  React.useContext(StorageClassContext);

--- a/frontend/src/pages/storageClasses/StorageClassesPage.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesPage.tsx
@@ -10,128 +10,92 @@ import {
   AlertActionCloseButton,
 } from '@patternfly/react-core';
 
-import { MetadataAnnotation } from '~/k8sTypes';
-import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import ApplicationsPage from '~/pages/ApplicationsPage';
-import { updateStorageClassConfig } from '~/services/StorageClassService';
-import { ResponseStatus } from '~/types';
+import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import { StorageClassesTable } from './StorageClassesTable';
-import { getStorageClassConfig, isOpenshiftDefaultStorageClass } from './utils';
+import { StorageClassContextProvider, useStorageClassContext } from './StorageClassesContext';
 
-const StorageClassesPage: React.FC = () => {
-  const [isAlertOpen, setIsAlertOpen] = React.useState(false);
-  const [isUpdating, setIsUpdating] = React.useState(false);
-  const [storageClasses, storageClassesLoaded, storageClassesError, refreshStorageClasses] =
-    useStorageClasses();
-  const storageClassesWithoutConfigs = React.useMemo(
-    () =>
-      storageClasses.filter(
-        (storageClass) =>
-          !storageClass.metadata.annotations?.[MetadataAnnotation.OdhStorageClassConfig],
-      ),
-    [storageClasses],
-  );
+interface StorageClassesPageInternalProps {
+  loaded: boolean;
+  error: Error | undefined;
+  alert: React.ReactNode;
+}
 
-  const defaultStorageClass = storageClasses.find(
-    (storageClass) =>
-      isOpenshiftDefaultStorageClass(storageClass) ||
-      getStorageClassConfig(storageClass)?.isDefault,
-  );
-
-  const updateStorageClasses = React.useCallback(
-    async (updateRequests: Promise<ResponseStatus>[]) => {
-      setIsUpdating(true);
-
-      try {
-        const updateResponses = await Promise.all(updateRequests);
-        if (updateResponses.some((response) => response.success)) {
-          await refreshStorageClasses();
-        }
-
-        if (!defaultStorageClass) {
-          setIsAlertOpen(true);
-        }
-      } finally {
-        setIsUpdating(false);
-      }
-    },
-    [defaultStorageClass, refreshStorageClasses],
-  );
-
-  // Add storage class config annotations automatically for all storage classes without them
-  React.useEffect(() => {
-    if (storageClassesWithoutConfigs.length > 0) {
-      const updateRequests = storageClassesWithoutConfigs.map((storageClass, index) => {
-        const { metadata } = storageClass;
-        const { name: storageClassName } = metadata;
-
-        let isDefault = defaultStorageClass?.metadata.uid === metadata.uid;
-        let isEnabled = isDefault;
-
-        if (!defaultStorageClass) {
-          isDefault = index === 0;
-          isEnabled = true;
-        }
-
-        return updateStorageClassConfig(storageClassName, {
-          isDefault,
-          isEnabled,
-          displayName: storageClassName,
-        });
-      });
-
-      updateStorageClasses(updateRequests);
-    }
-  }, [defaultStorageClass, storageClassesWithoutConfigs, updateStorageClasses]);
-
-  const emptyStatePage = (
-    <PageSection isFilled>
-      <EmptyState variant={EmptyStateVariant.lg} data-testid="storage-classes-empty-state">
-        <img
-          width="60px"
-          height="60px"
-          src={typedEmptyImage(ProjectObjectType.storageClasses)}
-          alt=""
-          className="pf-v5-u-mb-sm"
-        />
-
-        <Title headingLevel="h5" size="lg">
-          Configure storage classes
-        </Title>
-        <EmptyStateBody>
-          At least one OpenShift storage class is required to use OpenShift AI. Configure a storage
-          class in OpenShift, or request that your admin configure one.
-        </EmptyStateBody>
-      </EmptyState>
-    </PageSection>
-  );
+const StorageClassesPageInternal: React.FC<StorageClassesPageInternalProps> = ({
+  loaded,
+  error,
+  alert,
+}) => {
+  const { isUpdatingConfigs, storageClasses } = useStorageClassContext();
 
   return (
     <ApplicationsPage
       title="Storage classes"
       description="Manage your organization's OpenShift cluster storage class settings for usage within OpenShift AI. These settings do not impact the storage classes within OpenShift."
-      loaded={storageClassesLoaded && !isUpdating}
+      loaded={loaded && !isUpdatingConfigs}
       empty={storageClasses.length === 0}
-      loadError={storageClassesError}
+      loadError={error}
       errorMessage="Unable to load storage classes."
-      emptyStatePage={emptyStatePage}
+      emptyStatePage={
+        <PageSection isFilled>
+          <EmptyState variant={EmptyStateVariant.lg} data-testid="storage-classes-empty-state">
+            <img
+              width="60px"
+              height="60px"
+              src={typedEmptyImage(ProjectObjectType.storageClasses)}
+              alt=""
+              className="pf-v5-u-mb-sm"
+            />
+
+            <Title headingLevel="h5" size="lg">
+              Configure storage classes
+            </Title>
+            <EmptyStateBody>
+              At least one OpenShift storage class is required to use OpenShift AI. Configure a
+              storage class in OpenShift, or request that your admin configure one.
+            </EmptyStateBody>
+          </EmptyState>
+        </PageSection>
+      }
       provideChildrenPadding
     >
-      {isAlertOpen && (
-        <Alert
-          variant="warning"
-          isInline
-          title="Review default storage class"
-          actionClose={<AlertActionCloseButton onClose={() => setIsAlertOpen(false)} />}
-        >
-          Some OpenShift AI features won&apos;t work without a default storage class. No OpenShift
-          default exists, so an OpenShift AI default was set automatically. Review the default
-          storage class, and set a new one if needed.
-        </Alert>
-      )}
-      <StorageClassesTable storageClasses={storageClasses} refresh={refreshStorageClasses} />
+      {alert}
+      <StorageClassesTable />
     </ApplicationsPage>
+  );
+};
+
+const StorageClassesPage: React.FC = () => {
+  const [storageClasses, storageClassesLoaded, error, refresh] = useStorageClasses();
+
+  return (
+    <StorageClassContextProvider
+      storageClasses={storageClasses}
+      loaded={storageClassesLoaded}
+      refresh={refresh}
+    >
+      {(isAlertOpen, setIsAlertOpen) => (
+        <StorageClassesPageInternal
+          loaded={storageClassesLoaded}
+          error={error}
+          alert={
+            isAlertOpen && (
+              <Alert
+                variant="warning"
+                isInline
+                title="Review default storage class"
+                actionClose={<AlertActionCloseButton onClose={() => setIsAlertOpen(false)} />}
+              >
+                Some OpenShift AI features won&apos;t work without a default storage class. No
+                OpenShift default exists, so an OpenShift AI default was set automatically. Review
+                the default storage class, and set a new one if needed.
+              </Alert>
+            )
+          }
+        />
+      )}
+    </StorageClassContextProvider>
   );
 };
 

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -15,8 +15,10 @@ export const getStorageClassConfig = (
   }
 };
 
-export const isOpenshiftDefaultStorageClass = (storageClass: StorageClassKind): boolean =>
-  storageClass.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
+export const isOpenshiftDefaultStorageClass = (
+  storageClass: StorageClassKind | undefined,
+): boolean =>
+  storageClass?.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
 
 export const isValidConfigValue = (
   configKey: keyof StorageClassConfig,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13320
https://issues.redhat.com/browse/RHOAIENG-13401

## Description
Added new logic to account for edge cases where users manually update storage classes from the OpenShift dashboard. The situations accounted for include:

**Storage class table:**
1. If isEnabled is false & isDefault is true (set from OpenShift dashboard), then set isEnabled to true.
2. When all configs exist but no ODH default is defined, update to set the OpenShift default or the first found storage class as the ODH default and show the same alert as when configs are initialized.
3. Disable corresponding IsDefault while Enabling is ongoing.

**Storage class dropdown:**
1. Disable storage class dropdown when only 1 value exists.
2. Hide the dropdown when no storage class configs are defined.

## How Has This Been Tested?
By forcing the scenarios listed in the description above between OpenShift dashboard and the ODH dashboard.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
