### PR TITLE
[RHOAIENG-11326] Creating new pipeline from Create Run Page redirects to the pipeline detail page

### DIFF
--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -60,6 +60,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
               variant="link"
               icon={<PlusCircleIcon />}
               onCreate={onPipelineChange}
+              redirectAfterImport={false}
             >
               Create new pipeline
             </ImportPipelineButton>

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineButton.tsx
@@ -6,11 +6,13 @@ import { PipelineKFv2 } from '~/concepts/pipelines/kfTypes';
 
 type ImportPipelineButtonProps = {
   onCreate?: (pipeline: PipelineKFv2) => void;
+  redirectAfterImport?: boolean;
 } & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
 
 const ImportPipelineButton: React.FC<ImportPipelineButtonProps> = ({
   onCreate,
   children,
+  redirectAfterImport,
   ...buttonProps
 }) => {
   const { apiAvailable, refreshAllAPI, pipelinesServer } = usePipelinesAPI();
@@ -28,6 +30,7 @@ const ImportPipelineButton: React.FC<ImportPipelineButtonProps> = ({
       </Button>
       <PipelineImportModal
         isOpen={open}
+        redirectAfterImport={redirectAfterImport}
         onClose={(pipeline) => {
           setOpen(false);
           if (pipeline) {

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
@@ -31,9 +31,14 @@ import { PipelineUploadOption, extractKindFromPipelineYAML } from './utils';
 type PipelineImportModalProps = {
   isOpen: boolean;
   onClose: (pipeline?: PipelineKFv2) => void;
+  redirectAfterImport?: boolean;
 };
 
-const PipelineImportModal: React.FC<PipelineImportModalProps> = ({ isOpen, onClose }) => {
+const PipelineImportModal: React.FC<PipelineImportModalProps> = ({
+  isOpen,
+  redirectAfterImport = true,
+  onClose,
+}) => {
   const navigate = useNavigate();
   const { project, api, apiAvailable, namespace } = usePipelinesAPI();
   const [importing, setImporting] = React.useState(false);
@@ -73,11 +78,11 @@ const PipelineImportModal: React.FC<PipelineImportModalProps> = ({ isOpen, onClo
       );
       const versionId = versions?.[0].pipeline_version_id;
 
-      if (versionId) {
+      if (redirectAfterImport && versionId) {
         navigate(pipelineVersionDetailsRoute(namespace, pipeline.pipeline_id, versionId));
       }
     },
-    [api, namespace, navigate, onBeforeClose],
+    [api, namespace, redirectAfterImport, navigate, onBeforeClose],
   );
 
   const checkForDuplicateName = useDebounceCallback(


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-11326

## Description
Add condition to pipeline import modal to only redirect when not located in the `/create` path associated with runs/schedules

**Demo:**
https://github.com/user-attachments/assets/28f10956-9b84-465e-8db6-bf9fda2d5f6d

## How Has This Been Tested?
1. Import a pipeline from the Pipelines list page and verify you're redirected to the pipeline version details page after creation
2. Import a pipeline from the Create run page and verify you are not redirected to the pipeline version details page
3. Repeat step 2 for the Create schedule page

## Test Impact
No new tests added

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
