### PR TITLE
MR fixes identified during architecture review

### DIFF
--- a/backend/src/routes/api/modelRegistries/index.ts
+++ b/backend/src/routes/api/modelRegistries/index.ts
@@ -162,7 +162,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         const { modelRegistryName } = request.params;
         try {
           const modelRegistryNamespace = getModelRegistryNamespace(fastify);
-          deleteModelRegistryAndSecret(
+          return deleteModelRegistryAndSecret(
             fastify,
             modelRegistryName,
             modelRegistryNamespace,

--- a/backend/src/routes/api/modelRegistryRoleBindings/modelRegistryRolebindingsUtils.ts
+++ b/backend/src/routes/api/modelRegistryRoleBindings/modelRegistryRolebindingsUtils.ts
@@ -27,12 +27,19 @@ export const createModelRegistryRoleBinding = async (
   rbRequest: V1RoleBinding,
   mrNamespace: string,
 ): Promise<V1RoleBinding> => {
+  // Re-inject the namespace value that was omitted by the client
+  //   (see createModelRegistryRoleBinding in frontend/src/services/modelRegistrySettingsService.ts)
+  // This will be unnecessary when we remove the backend service as part of https://issues.redhat.com/browse/RHOAIENG-12077
+  const roleBindingWithNamespace = {
+    ...rbRequest,
+    metadata: { ...rbRequest.metadata, namespace: mrNamespace },
+  };
   const response = await (fastify.kube.customObjectsApi.createNamespacedCustomObject(
     MODEL_REGISTRY_ROLE_BINDING_API_GROUP,
     MODEL_REGISTRY_ROLE_BINDING_API_VERSION,
     mrNamespace,
     MODEL_REGISTRY_ROLE_BINDING_PLURAL,
-    rbRequest,
+    roleBindingWithNamespace,
   ) as Promise<{ body: V1RoleBinding }>);
   return response.body;
 };

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -430,7 +430,6 @@ describe('MR Permissions', () => {
       cy.interceptOdh(
         'POST /api/modelRegistryRoleBindings',
         mockRoleBindingK8sResource({
-          namespace: MODEL_REGISTRY_DEFAULT_NAMESPACE,
           subjects: projectSubjects,
           roleRefName: 'registry-user-example-mr',
           modelRegistryName: 'example-mr',
@@ -443,9 +442,6 @@ describe('MR Permissions', () => {
 
       cy.wait('@addProject').then((interception) => {
         expect(interception.request.body).to.containSubset({
-          metadata: {
-            namespace: 'odh-model-registries',
-          },
           roleRef: {
             apiGroup: 'rbac.authorization.k8s.io',
             kind: 'Role',
@@ -484,9 +480,6 @@ describe('MR Permissions', () => {
 
       cy.wait('@editProject').then((interception) => {
         expect(interception.request.body).to.containSubset({
-          metadata: {
-            namespace: 'odh-model-registries',
-          },
           roleRef: {
             apiGroup: 'rbac.authorization.k8s.io',
             kind: 'Role',

--- a/frontend/src/api/modelRegistry/errorUtils.ts
+++ b/frontend/src/api/modelRegistry/errorUtils.ts
@@ -18,7 +18,6 @@ export const handleModelRegistryFailures = <T>(promise: Promise<T>): Promise<T> 
       }
       if (isCommonStateError(e)) {
         // Common state errors are handled by useFetchState at storage level, let them deal with it
-        // TODO: check whether we need this or not
         throw e;
       }
       // eslint-disable-next-line no-console


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Followup to https://github.com/opendatahub-io/odh-dashboard/pull/3252 and https://github.com/opendatahub-io/odh-dashboard/pull/3249 as well as some misc discussion points from arch review (https://issues.redhat.com/browse/RHOAIENG-13439).

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

* After #3249 was rebased on the changes from #3252, testing it revealed that because we removed the model registry namespace from the checks in `backend/src/utils/route-security.ts` and rolebindings we create in MR settings include that namespace in the request body, creation of rolebindings failed due to the namespace checking in `requestSecurityGuard`. We do not want to modify route-security because it is a fragile workaround and modifying it involves high risk. The fix instead is to simply not include a namespace in the rolebinding object when we send it to the backend and instead inject it just before calling the cluster API.
* When deleting a registry in the backend, we were not returning the promise from the `deleteModelRegistryAndSecret` util which means we weren't catching errors that came up in this deletion.
* There was a TODO comment asking if we needed some code in our error handler util. That code is also present in `frontend/src/api/pipelines/errorUtils.ts`, and it is needed because some requests in MR throw a NotReadyError which should be ignored by this handler. Removed the TODO comment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on modelregistry-ui cluster, we can now create rolebindings in MR settings again

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, no tests in the backend

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
