### PR TITLE
label group truncation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -1,4 +1,4 @@
-import type { K8sResourceListResult } from '@openshift/dynamic-plugin-sdk-utils';
+import type { K8sResourceListResult, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import type { GenericStaticResponse, RouteHandlerController } from 'cypress/types/net-stubbing';
 import type { BaseMetricCreationResponse, BaseMetricListResponse } from '~/api';
 import type {
@@ -637,7 +637,7 @@ declare global {
         ((
           type: 'DELETE /api/modelRegistryRoleBindings/:name',
           options: { path: { name: string } },
-          response: OdhResponse<SuccessErrorResponse>,
+          response: OdhResponse<K8sStatus>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'POST /api/modelRegistryRoleBindings',

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -78,3 +78,14 @@ body,
   --pf-v5-c-truncate--MinWidth: 0;
   --pf-v5-c-truncate__start--MinWidth: 0;
 }
+
+// FIXME https://github.com/patternfly/patternfly/issues/7104
+.pf-v5-c-label-group {
+  max-width: 100%;
+
+  &__main,
+  &__list,
+  &__list-item {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12443

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This works around an issue with PF: https://github.com/patternfly/patternfly/issues/7104

`Label` components within a `LabelGroup` do not truncate when placed within a confined container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a connection type with a very long named category.
- Observe the category truncation on the connection type table.

Before:
![image](https://github.com/user-attachments/assets/15eb1a62-c9c2-4f4d-8a25-e6bae364ea5a)

After:
![image](https://github.com/user-attachments/assets/ebdb93bc-defd-4557-bcdf-d70d1487497a)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A
Visual change only.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 