### PR TITLE
Nim double window

### DIFF
--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -10,6 +10,7 @@ import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import ServeModelButton from '~/pages/modelServing/screens/global/ServeModelButton';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nimUtils';
 
 const EmptyModelServing: React.FC = () => {
   const navigate = useNavigate();
@@ -18,10 +19,12 @@ const EmptyModelServing: React.FC = () => {
     project,
   } = React.useContext(ModelServingContext);
   const servingPlatformStatuses = useServingPlatformStatuses();
+  const isKServeNIMEnabled = project ? isProjectNIMSupported(project) : false;
 
   if (
-    getProjectModelServingPlatform(project, servingPlatformStatuses).platform !==
-      ServingRuntimePlatform.SINGLE &&
+    (getProjectModelServingPlatform(project, servingPlatformStatuses).platform !==
+      ServingRuntimePlatform.SINGLE ||
+      isKServeNIMEnabled) &&
     servingRuntimes.length === 0
   ) {
     return (

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -33,10 +33,10 @@ import EmptyMultiModelServingCard from '~/pages/modelServing/screens/projects/Em
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import EmptyModelServingPlatform from '~/pages/modelServing/screens/projects/EmptyModelServingPlatform';
 import EmptyNIMModelServingCard from '~/pages/modelServing/screens/projects/EmptyNIMModelServingCard';
-import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nimUtils';
-import { useDashboardNamespace } from '~/redux/selectors';
 import DeployNIMServiceModal from '~/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal';
+import { useDashboardNamespace } from '~/redux/selectors';
+import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 import ModelMeshServingRuntimeTable from './ModelMeshSection/ServingRuntimeTable';
 import ModelServingPlatformButtonAction from './ModelServingPlatformButtonAction';
@@ -263,23 +263,27 @@ const ModelServingPlatform: React.FC = () => {
           onSubmit(submit);
         }}
       />
-      <ManageKServeModal
-        isOpen={platformSelected === ServingRuntimePlatform.SINGLE}
-        projectContext={{
-          currentProject,
-          dataConnections,
-        }}
-        servingRuntimeTemplates={templatesEnabled.filter((template) =>
-          getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-        )}
-        onClose={(submit: boolean) => {
-          onSubmit(submit);
-        }}
-      />
-      {isNIMAvailable && (
+      {!isKServeNIMEnabled ? (
+        <ManageKServeModal
+          isOpen={platformSelected === ServingRuntimePlatform.SINGLE}
+          projectContext={{
+            currentProject,
+            dataConnections,
+          }}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+          )}
+          onClose={(submit: boolean) => {
+            onSubmit(submit);
+          }}
+        />
+      ) : (
         <DeployNIMServiceModal
           isOpen={platformSelected === ServingRuntimePlatform.SINGLE}
-          projectContext={{ currentProject, dataConnections }}
+          projectContext={{
+            currentProject,
+            dataConnections,
+          }}
           onClose={(submit: boolean) => {
             onSubmit(submit);
           }}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Resolved double window and NIM modal showing for KServe. Added a link to EmptyModelServing for NIM project. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
