### PR TITLE
Search - 'Clear all Filters' doesn't work

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -155,14 +155,14 @@ describe('ClusterStorage', () => {
     addClusterStorageModal.findMountField().fill('test2');
     addClusterStorageModal
       .findMountFieldHelperText()
-      .should('have.text', 'Must only consist of lower case letters and dashes.');
+      .should('have.text', 'Must only consist of lowercase letters and dashes.');
 
     // Allow trailing slash
     addClusterStorageModal.findMountField().clear();
     addClusterStorageModal.findMountField().fill('test/');
     addClusterStorageModal
       .findMountFieldHelperText()
-      .should('have.text', 'Must consist of lower case letters and dashes.');
+      .should('have.text', 'Must consist of lowercase letters and dashes.');
 
     addClusterStorageModal.findMountField().clear();
     addClusterStorageModal

--- a/frontend/src/concepts/k8s/NameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/NameDescriptionField.tsx
@@ -121,7 +121,7 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
                       variant: 'error',
                     })}
                   >
-                    {`Must consist of lower case alphanumeric characters or '-', and must start and
+                    {`Must consist of lowercase alphanumeric characters or '-', and must start and
                     end with an alphanumeric character`}
                   </HelperTextItem>
                 </HelperText>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
@@ -26,6 +26,7 @@ const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
     toolbarContent={toolbarContent}
     defaultSortColumn={3}
     enablePagination
+    onClearFilters={clearFilters}
     emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
     rowRenderer={(mv) => (
       <ModelVersionsTableRow

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveTable.tsx
@@ -23,6 +23,7 @@ const ModelVersionsArchiveTable: React.FC<ModelVersionsArchiveTableProps> = ({
     columns={mvColumns}
     toolbarContent={toolbarContent}
     enablePagination
+    onClearFilters={clearFilters}
     emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
     defaultSortColumn={1}
     rowRenderer={(mv) => (

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelListView.tsx
@@ -105,12 +105,19 @@ const RegisteredModelListView: React.FC<RegisteredModelListViewProps> = ({
     </ToolbarGroup>
   );
 
+  const clearAllFilters = resetFilters;
+
   return (
     <RegisteredModelTable
       refresh={refresh}
-      clearFilters={resetFilters}
+      clearFilters={clearAllFilters}
       registeredModels={filteredRegisteredModels}
-      toolbarContent={<RegisteredModelsTableToolbar toggleGroupItems={toggleGroupItems} />}
+      toolbarContent={
+        <RegisteredModelsTableToolbar
+          toggleGroupItems={toggleGroupItems}
+          onClearAllFilters={clearAllFilters}
+        />
+      }
     />
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTable.tsx
@@ -23,6 +23,7 @@ const RegisteredModelTable: React.FC<RegisteredModelTableProps> = ({
     columns={rmColumns}
     toolbarContent={toolbarContent}
     defaultSortColumn={2}
+    onClearFilters={clearFilters}
     enablePagination
     emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
     rowRenderer={(rm) => (

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableToolbar.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableToolbar.tsx
@@ -22,10 +22,12 @@ import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/M
 
 type RegisteredModelsTableToolbarProps = {
   toggleGroupItems?: React.ReactNode;
+  onClearAllFilters?: () => void;
 };
 
 const RegisteredModelsTableToolbar: React.FC<RegisteredModelsTableToolbarProps> = ({
   toggleGroupItems: tableToggleGroupItems,
+  onClearAllFilters,
 }) => {
   const navigate = useNavigate();
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
@@ -35,7 +37,7 @@ const RegisteredModelsTableToolbar: React.FC<RegisteredModelsTableToolbarProps> 
   const tooltipRef = React.useRef<HTMLButtonElement>(null);
 
   return (
-    <Toolbar data-testid="registered-models-table-toolbar">
+    <Toolbar data-testid="registered-models-table-toolbar" clearAllFilters={onClearAllFilters}>
       <ToolbarContent>
         <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
           {tableToggleGroupItems}

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelsArchiveTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModelsArchive/RegisteredModelsArchiveTable.tsx
@@ -23,6 +23,7 @@ const RegisteredModelsArchiveTable: React.FC<RegisteredModelsArchiveTableProps> 
     columns={rmColumns}
     toolbarContent={toolbarContent}
     defaultSortColumn={2}
+    onClearFilters={clearFilters}
     enablePagination
     emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
     rowRenderer={(rm) => (

--- a/frontend/src/pages/projects/pvc/MountPathField.tsx
+++ b/frontend/src/pages/projects/pvc/MountPathField.tsx
@@ -39,7 +39,7 @@ const MountPathField: React.FC<MountPathFieldProps> = ({
             if (value.length === 0) {
               error = 'Enter a path to a model or folder. This path cannot point to a root folder.';
             } else if (!/^[a-z-]+\/?$/.test(value)) {
-              error = 'Must only consist of lower case letters and dashes.';
+              error = 'Must only consist of lowercase letters and dashes.';
             } else if (inUseMountPaths.includes(`/${value}`)) {
               error = 'Mount folder is already in use for this workbench.';
             }
@@ -54,7 +54,7 @@ const MountPathField: React.FC<MountPathFieldProps> = ({
           variant={mountPath.error ? 'error' : 'default'}
           data-testid="mount-path-folder-helper-text"
         >
-          {mountPath.error || 'Must consist of lower case letters and dashes.'}
+          {mountPath.error || 'Must consist of lowercase letters and dashes.'}
         </HelperTextItem>
       </HelperText>
     </FormHelperText>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-12861 -->
https://issues.redhat.com/browse/RHOAIENG-12861

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
1. Clear all filters button is now working on all existing screens 
2.  Changed label that was mentioned in RHOAI sprint demos.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on the UI

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated tests to pass after the label change. In order to test the change, verify that now "Clear all Filters' button is now working everywhere it exists 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
