### PR TITLE
List connected deployed models for each connection table row

### DIFF
--- a/frontend/src/pages/projects/__tests__/useInferenceServicesForConnection.spec.ts
+++ b/frontend/src/pages/projects/__tests__/useInferenceServicesForConnection.spec.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import { mockInferenceServiceK8sResource } from '~/__mocks__';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { useInferenceServicesForConnection } from '~/pages/projects/useInferenceServicesForConnection';
+import { mockConnection } from '~/__mocks__/mockConnection';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(),
+}));
+
+const useContextMock = React.useContext as jest.Mock;
+
+const connection = mockConnection({
+  name: 'connection1',
+  displayName: 'Connection 1',
+  description: 'desc1',
+});
+
+const mockInferenceServices = [
+  mockInferenceServiceK8sResource({
+    name: 'item-1',
+    displayName: 'Item 1',
+    secretName: 'connection1',
+  }),
+  mockInferenceServiceK8sResource({
+    name: 'item-2',
+    displayName: 'Item 2',
+    secretName: 'connection2',
+  }),
+];
+
+describe('useInferenceServicesForConnection', () => {
+  beforeEach(() => {
+    useContextMock.mockReturnValue({ inferenceServices: { data: mockInferenceServices } });
+  });
+
+  it('should return matching inference services', () => {
+    const renderResult = testHook(useInferenceServicesForConnection)(connection);
+    expect(renderResult.result.current).toHaveLength(1);
+  });
+});

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
@@ -8,6 +8,7 @@ import { Connection } from '~/concepts/connectionTypes/types';
 import { ProjectObjectType } from '~/concepts/design/utils';
 import ResourceLabel from '~/pages/projects/screens/detail/connections/ResourceLabel';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { useInferenceServicesForConnection } from '~/pages/projects/useInferenceServicesForConnection';
 
 type Props = {
   connection: Connection;
@@ -18,6 +19,7 @@ const ConnectedResources: React.FC<Props> = ({ connection }) => {
     ConnectedNotebookContext.EXISTING_DATA_CONNECTION,
     connection.metadata.name,
   );
+  const connectedModels = useInferenceServicesForConnection(connection);
 
   if (!notebooksLoaded) {
     return <Spinner size="sm" />;
@@ -34,6 +36,13 @@ const ConnectedResources: React.FC<Props> = ({ connection }) => {
           key={notebook.metadata.name}
           resourceType={ProjectObjectType.notebook}
           title={getDisplayNameFromK8sResource(notebook)}
+        />
+      ))}
+      {connectedModels.map((model) => (
+        <ResourceLabel
+          key={model.metadata.name}
+          resourceType={ProjectObjectType.deployedModels}
+          title={getDisplayNameFromK8sResource(model)}
         />
       ))}
     </LabelGroup>

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsTable.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsTable.spec.tsx
@@ -5,17 +5,30 @@ import { mockConnectionTypeConfigMapObj } from '~/__mocks__/mockConnectionType';
 import { mockConnection } from '~/__mocks__/mockConnection';
 import { mockNotebookK8sResource } from '~/__mocks__/mockNotebookK8sResource';
 import { useRelatedNotebooks } from '~/pages/projects/notebook/useRelatedNotebooks';
+import { useInferenceServicesForConnection } from '~/pages/projects/useInferenceServicesForConnection';
+import { mockInferenceServiceK8sResource } from '~/__mocks__';
 
 jest.mock('~/pages/projects/notebook/useRelatedNotebooks', () => ({
   ...jest.requireActual('~/pages/projects/notebook/useRelatedNotebooks'),
   useRelatedNotebooks: jest.fn(),
 }));
 
+jest.mock('~/pages/projects/useInferenceServicesForConnection', () => ({
+  useInferenceServicesForConnection: jest.fn(),
+}));
+
 const useRelatedNotebooksMock = useRelatedNotebooks as jest.Mock;
+const useInferenceServicesForConnectionMock = useInferenceServicesForConnection as jest.Mock;
+
+const mockInferenceServices = [
+  mockInferenceServiceK8sResource({ name: 'deployed-model-1', displayName: 'Deployed model 1' }),
+  mockInferenceServiceK8sResource({ name: 'deployed-model-2', displayName: 'Deployed model 2' }),
+];
 
 describe('ConnectionsTable', () => {
   beforeEach(() => {
     useRelatedNotebooksMock.mockReturnValue({ notebooks: [], loaded: true });
+    useInferenceServicesForConnectionMock.mockReturnValue([]);
   });
 
   it('should render table', () => {
@@ -61,6 +74,7 @@ describe('ConnectionsTable', () => {
       notebooks: [mockNotebookK8sResource({ displayName: 'Connected notebook' })],
       loaded: true,
     });
+    useInferenceServicesForConnectionMock.mockReturnValue(mockInferenceServices);
 
     const connection = mockConnection({ displayName: 'connection1', description: 'desc1' });
     render(
@@ -81,5 +95,7 @@ describe('ConnectionsTable', () => {
     expect(screen.queryByText('s3')).toBeFalsy();
     expect(screen.getByText('S3 Buckets')).toBeTruthy();
     expect(screen.getByText('Connected notebook')).toBeTruthy();
+    expect(screen.getByText('Deployed model 1')).toBeTruthy();
+    expect(screen.getByText('Deployed model 2')).toBeTruthy();
   });
 });

--- a/frontend/src/pages/projects/useInferenceServicesForConnection.ts
+++ b/frontend/src/pages/projects/useInferenceServicesForConnection.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { InferenceServiceKind } from '~/k8sTypes';
+import { Connection } from '~/concepts/connectionTypes/types';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+
+export const useInferenceServicesForConnection = (
+  connection: Connection,
+): InferenceServiceKind[] => {
+  const {
+    inferenceServices: { data: inferenceServices },
+  } = React.useContext(ProjectDetailsContext);
+  const connectionName = connection.metadata.name;
+
+  return inferenceServices.filter(
+    (inferenceService) => inferenceService.spec.predictor.model?.storage?.key === connectionName,
+  );
+};


### PR DESCRIPTION
Closes [RHOAIENG-11558](https://issues.redhat.com/browse/RHOAIENG-11558)

## Description
Adds connected deployed models to the connection table rows.
Lists connected deployed models when deleting a connection.

## How Has This Been Tested?
Tested manually.
Added test scenarios

## Test Impact
Test the connection table to verify the related models show up in each row
Test the delete connection modal to verify the related models are listed.

## Screen shots
![image](https://github.com/user-attachments/assets/f55a6397-66df-425c-a059-bd4706553670)


![image](https://github.com/user-attachments/assets/e28ef31e-3da3-4f91-8a6e-66719c37c415)


![image](https://github.com/user-attachments/assets/7033b68f-a145-411c-803b-c831da9a52e1)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw 