### PR TITLE
Config map nim model name fetch

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AlertActionCloseButton,
   Form,
+  getUniqueId,
   Modal,
   Stack,
   StackItem,
@@ -50,7 +51,6 @@ import { getServingRuntimeFromTemplate } from '~/pages/modelServing/customServin
 
 const NIM_SECRET_NAME = 'nvidia-nim-secrets';
 const NIM_NGC_SECRET_NAME = 'ngc-secret';
-const NIM_PVC_NAME = 'nim-pvc';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'rbac.authorization.k8s.io',
@@ -95,6 +95,7 @@ const DeployNIMServiceModal: React.FC<DeployNIMServiceModalProps> = ({
   const isAuthorinoEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status;
   const currentProjectName = projectContext?.currentProject.metadata.name;
   const namespace = currentProjectName || createDataInferenceService.project;
+  const nimPVCName = getUniqueId('nim-pvc');
 
   const [translatedName] = translateDisplayNameForK8sAndReport(createDataInferenceService.name, {
     maxLength: 253,
@@ -202,6 +203,7 @@ const DeployNIMServiceModal: React.FC<DeployNIMServiceModalProps> = ({
       projectContext?.currentProject,
       servingRuntimeName,
       true,
+      nimPVCName,
     );
 
     const submitInferenceServiceResource = getSubmitInferenceServiceResourceFn(
@@ -226,7 +228,7 @@ const DeployNIMServiceModal: React.FC<DeployNIMServiceModalProps> = ({
           submitInferenceServiceResource({ dryRun: false }),
           createNIMSecret(namespace, NIM_SECRET_NAME, false, false),
           createNIMSecret(namespace, NIM_NGC_SECRET_NAME, true, false),
-          createNIMPVC(namespace, NIM_PVC_NAME, pvcSize, false),
+          createNIMPVC(namespace, nimPVCName, pvcSize, false),
         ]),
       )
       .then(() => onSuccess())

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -32,7 +32,7 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
   useEffect(() => {
     const getModelNames = async () => {
       try {
-        const modelInfos = await fetchNIMModelNames(dashboardNamespace);
+        const modelInfos = await fetchNIMModelNames();
         if (modelInfos && modelInfos.length > 0) {
           const fetchedOptions = modelInfos.flatMap((modelInfo) =>
             modelInfo.tags.map((tag) => ({

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -343,9 +343,9 @@ describe('fetchNIMModelNames', () => {
   it('should return model infos when configMap has data', async () => {
     (getConfigMap as jest.Mock).mockResolvedValueOnce(configMapMock);
 
-    const result = await fetchNIMModelNames(dashboardNamespace);
+    const result = await fetchNIMModelNames();
 
-    expect(getConfigMap).toHaveBeenCalledWith(dashboardNamespace, NIM_CONFIGMAP_NAME);
+    expect(getConfigMap).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
     expect(result).toEqual([
       {
         name: 'model1',
@@ -371,18 +371,18 @@ describe('fetchNIMModelNames', () => {
   it('should return undefined if configMap has no data', async () => {
     (getConfigMap as jest.Mock).mockResolvedValueOnce({ data: {} });
 
-    const result = await fetchNIMModelNames(dashboardNamespace);
+    const result = await fetchNIMModelNames();
 
-    expect(getConfigMap).toHaveBeenCalledWith(dashboardNamespace, NIM_CONFIGMAP_NAME);
+    expect(getConfigMap).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
     expect(result).toBeUndefined();
   });
 
   it('should return undefined if configMap.data is not defined', async () => {
     (getConfigMap as jest.Mock).mockResolvedValueOnce({ data: undefined });
 
-    const result = await fetchNIMModelNames(dashboardNamespace);
+    const result = await fetchNIMModelNames();
 
-    expect(getConfigMap).toHaveBeenCalledWith(dashboardNamespace, NIM_CONFIGMAP_NAME);
+    expect(getConfigMap).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
     expect(result).toBeUndefined();
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -12,20 +12,24 @@ import {
 import { LabeledDataConnection, ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
 import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
-import { createPvc, createSecret, getConfigMap } from '~/api';
+import { createPvc, createSecret } from '~/api';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
-import { getNGCSecretType, getNIMData } from '~/pages/modelServing/screens/projects/nimUtils';
+import {
+  getNGCSecretType,
+  getNIMData,
+  getNIMResource,
+} from '~/pages/modelServing/screens/projects/nimUtils';
 
 jest.mock('~/api', () => ({
   getSecret: jest.fn(),
   createSecret: jest.fn(),
-  getConfigMap: jest.fn(),
   createPvc: jest.fn(),
 }));
 
 jest.mock('~/pages/modelServing/screens/projects/nimUtils', () => ({
   getNIMData: jest.fn(),
   getNGCSecretType: jest.fn(),
+  getNIMResource: jest.fn(),
 }));
 
 describe('filterOutConnectionsWithoutBucket', () => {
@@ -312,7 +316,6 @@ describe('createNIMSecret', () => {
   });
 });
 describe('fetchNIMModelNames', () => {
-  const dashboardNamespace = 'test-namespace';
   const NIM_CONFIGMAP_NAME = 'nvidia-nim-images-data';
 
   const configMapMock = {
@@ -341,11 +344,11 @@ describe('fetchNIMModelNames', () => {
   });
 
   it('should return model infos when configMap has data', async () => {
-    (getConfigMap as jest.Mock).mockResolvedValueOnce(configMapMock);
+    (getNIMResource as jest.Mock).mockResolvedValueOnce(configMapMock);
 
     const result = await fetchNIMModelNames();
 
-    expect(getConfigMap).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
+    expect(getNIMResource).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
     expect(result).toEqual([
       {
         name: 'model1',
@@ -369,20 +372,20 @@ describe('fetchNIMModelNames', () => {
   });
 
   it('should return undefined if configMap has no data', async () => {
-    (getConfigMap as jest.Mock).mockResolvedValueOnce({ data: {} });
+    (getNIMResource as jest.Mock).mockResolvedValueOnce({ data: {} });
 
     const result = await fetchNIMModelNames();
 
-    expect(getConfigMap).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
+    expect(getNIMResource).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
     expect(result).toBeUndefined();
   });
 
   it('should return undefined if configMap.data is not defined', async () => {
-    (getConfigMap as jest.Mock).mockResolvedValueOnce({ data: undefined });
+    (getNIMResource as jest.Mock).mockResolvedValueOnce({ data: undefined });
 
     const result = await fetchNIMModelNames();
 
-    expect(getConfigMap).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
+    expect(getNIMResource).toHaveBeenCalledWith(NIM_CONFIGMAP_NAME);
     expect(result).toBeUndefined();
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nimUtils.ts
@@ -9,9 +9,9 @@ const NIM_NGC_SECRET_NAME = 'nvidia-nim-image-pull';
 export const getNGCSecretType = (isNGC: boolean): string =>
   isNGC ? 'kubernetes.io/dockerconfigjson' : 'Opaque';
 
-const getNIMSecretData = async (secretName: string): Promise<SecretKind> => {
+export const getNIMResource = async (resourceName: string): Promise<SecretKind> => {
   try {
-    const response = await fetch(`/api/nim-serving/${secretName}`, {
+    const response = await fetch(`/api/nim-serving/${resourceName}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -21,16 +21,16 @@ const getNIMSecretData = async (secretName: string): Promise<SecretKind> => {
     if (!response.ok) {
       throw new Error(`Error fetching secret: ${response.statusText}`);
     }
-    const secretData = await response.json();
-    return secretData.body;
+    const resourceData = await response.json();
+    return resourceData.body;
   } catch (error) {
-    throw new Error(`Failed to fetch secret: ${secretName}.`);
+    throw new Error(`Failed to fetch the resource: ${resourceName}.`);
   }
 };
 export const getNIMData = async (isNGC: boolean): Promise<Record<string, string> | undefined> => {
   const nimSecretData: SecretKind = isNGC
-    ? await getNIMSecretData(NIM_NGC_SECRET_NAME)
-    : await getNIMSecretData(NIM_SECRET_NAME);
+    ? await getNIMResource(NIM_NGC_SECRET_NAME)
+    : await getNIMResource(NIM_SECRET_NAME);
 
   if (!nimSecretData.data) {
     throw new Error(`Error retrieving NIM ${isNGC ? 'NGC' : ''} secret data`);

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -452,6 +452,7 @@ export const getSubmitServingRuntimeResourcesFn = (
   currentProject?: ProjectKind,
   name?: string,
   isModelMesh?: boolean,
+  nimPVCName?: string,
 ): ((opts: { dryRun?: boolean }) => Promise<void | (string | void | ServingRuntimeKind)[]>) => {
   if (!servingRuntimeSelected) {
     return () =>
@@ -501,6 +502,7 @@ export const getSubmitServingRuntimeResourcesFn = (
               selectedAcceleratorProfile: controlledState,
               initialAcceleratorProfile,
               isModelMesh,
+              nimPVCName,
             }),
             setUpTokenAuth(
               servingRuntimeData,
@@ -527,6 +529,7 @@ export const getSubmitServingRuntimeResourcesFn = (
               selectedAcceleratorProfile: controlledState,
               initialAcceleratorProfile,
               isModelMesh,
+              nimPVCName,
             }).then((servingRuntime) =>
               setUpTokenAuth(
                 servingRuntimeData,

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -40,7 +40,6 @@ import {
   createPvc,
   createSecret,
   createServingRuntime,
-  getConfigMap,
   updateInferenceService,
   updateServingRuntime,
 } from '~/api';
@@ -48,7 +47,11 @@ import { isDataConnectionAWS } from '~/pages/projects/screens/detail/data-connec
 import { removeLeadingSlash } from '~/utilities/string';
 import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
 import { AcceleratorProfileSelectFieldState } from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
-import { getNGCSecretType, getNIMData } from '~/pages/modelServing/screens/projects/nimUtils';
+import {
+  getNGCSecretType,
+  getNIMData,
+  getNIMResource,
+} from '~/pages/modelServing/screens/projects/nimUtils';
 
 const NIM_CONFIGMAP_NAME = 'nvidia-nim-images-data';
 
@@ -579,10 +582,8 @@ export interface ModelInfo {
   updatedDate: string;
 }
 
-export const fetchNIMModelNames = async (
-  dashboardNamespace: string,
-): Promise<ModelInfo[] | undefined> => {
-  const configMap = await getConfigMap(dashboardNamespace, NIM_CONFIGMAP_NAME);
+export const fetchNIMModelNames = async (): Promise<ModelInfo[] | undefined> => {
+  const configMap = await getNIMResource(NIM_CONFIGMAP_NAME);
   if (configMap.data && Object.keys(configMap.data).length > 0) {
     const modelInfos: ModelInfo[] = [];
     for (const [key, value] of Object.entries(configMap.data)) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Retrieving ConfigMap using service account and added ${uid} to PVC name to avoid waiting for resource termination after deletion

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Deployed a NIM model, deleted it, and deployed another model while the PVC was still in the 'Terminating' state. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
