### PR TITLE
Fix: Cypress Pipeline e2e test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -19,7 +19,7 @@ class ProjectListToolbar extends Contextual<HTMLElement> {
   }
 
   findSearchInput(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findByLabelText('Search input');
+    return this.find().findByTestId('filter-toolbar-text-field');
   }
 }
 
@@ -138,7 +138,7 @@ class ProjectListPage {
    */
   filterProjectByName = (projectName: string) => {
     const projectListToolbar = projectListPage.getTableToolbar();
-    projectListToolbar.findFilterMenuOption('filter-dropdown-select', 'Name').click();
+    projectListToolbar.findFilterMenuOption('filter-toolbar-dropdown', 'Name').click();
     projectListToolbar.findSearchInput().type(projectName);
   };
 }

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/pipelines/pipelines.cy.ts
@@ -47,9 +47,8 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
     pipelineImportModal.findImportPipelineRadio().click();
     pipelineImportModal
       .findPipelineUrlInput()
-      //TODO: modify this URL once the PR is merged
       .type(
-        'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/caab82536b4dd5d39fb7a06a6c3248f10c183417/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
+        'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
       );
     pipelineImportModal.submit();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13384

## Description
After some changes in the DSProjects view search toolbar, the Pipelines  e2e test was failing.
Also I've updated the URL used to import the pipeline.

## How Has This Been Tested?
cypress/job/dashboard-tests/18
![image](https://github.com/user-attachments/assets/a8f29b6f-0e62-4bb1-a5e3-ab8c1aa9c9f0)


After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
