### PR TITLE
[RHOAIENG-13781] Storage classes grid not sorting by Display Name

### DIFF
--- a/frontend/src/pages/storageClasses/constants.ts
+++ b/frontend/src/pages/storageClasses/constants.ts
@@ -14,7 +14,16 @@ export const columns: SortableData<StorageClassKind>[] = [
   {
     field: 'displayName',
     label: ColumnLabel.DisplayName,
-    sortable: (a, b) => a.metadata.name.localeCompare(b.metadata.name),
+    sortable: (a: StorageClassKind, b: StorageClassKind): number => {
+      const configDisplayNameA = getStorageClassConfig(a)?.displayName;
+      const configDisplayNameB = getStorageClassConfig(b)?.displayName;
+
+      if (configDisplayNameA && configDisplayNameB) {
+        return configDisplayNameA.localeCompare(configDisplayNameB);
+      }
+
+      return -1;
+    },
     info: {
       popoverProps: { headerContent: 'Display name' },
       popover:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13781

## Description
Fixing sort that was previously using the storage class name instead of the storage class config display name.

https://github.com/user-attachments/assets/19dee695-3b6d-4c25-b893-fd5e767732db


## How Has This Been Tested?
Verify using storage class names that differ from their config display names that the Display name column sort is based on those displayName values versus the storage class name.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
