### PR TITLE
Bug/rhoaieng 13197 workbench creation screen no longer keeps none f

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -324,6 +324,10 @@ class EditSpawnerPage extends CreateSpawnerPage {
   findCancelButton() {
     return cy.findByTestId('workbench-cancel-button');
   }
+
+  findAcceleratorProfileSelect() {
+    return cy.findByTestId('accelerator-profile-select');
+  }
 }
 
 class NotFoundSpawnerPage {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -176,6 +176,7 @@ const initIntercepts = ({
     mockK8sResourceList([
       mockAcceleratorProfile({
         name: 'test-accelerator',
+        namespace: 'opendatahub',
         displayName: 'Test Accelerator',
         description: 'A test accelerator profile',
         enabled: true,
@@ -575,7 +576,7 @@ describe('Workbench page', () => {
 
     // Add a test for editing accelerator profile
     editSpawnerPage.findAcceleratorProfileSelect().click();
-    editSpawnerPage.findAcceleratorProfileSelect().findSelectOption('none').click();
+    editSpawnerPage.findAcceleratorProfileSelect().findSelectOption('None').click();
     editSpawnerPage.findAcceleratorProfileSelect().should('contain', 'None');
 
     cy.interceptK8s('PUT', NotebookModel, mockNotebookK8sResource({})).as('editWorkbenchDryRun');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -33,9 +33,11 @@ import {
   RouteModel,
   SecretModel,
   StorageClassModel,
+  AcceleratorProfileModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mock200Status } from '~/__mocks__/mockK8sStatus';
 import type { NotebookSize } from '~/types';
+import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
 
 const configYamlPath = '../../__mocks__/mock-upload-configmap.yaml';
 
@@ -168,7 +170,21 @@ const initIntercepts = ({
   cy.interceptK8s('POST', ConfigMapModel, mockConfigMap({})).as('createConfigMap');
 
   cy.interceptK8s('POST', NotebookModel, mockNotebookK8sResource({})).as('createWorkbench');
+
+  cy.interceptK8sList(
+    AcceleratorProfileModel,
+    mockK8sResourceList([
+      mockAcceleratorProfile({
+        name: 'test-accelerator',
+        displayName: 'Test Accelerator',
+        description: 'A test accelerator profile',
+        enabled: true,
+        identifier: 'test.com/accelerator',
+      }),
+    ]),
+  );
 };
+
 describe('Workbench page', () => {
   it('Empty state', () => {
     initIntercepts({ isEmpty: true });
@@ -556,6 +572,11 @@ describe('Workbench page', () => {
     editSpawnerPage.shouldHavePersistentStorage('Test Storage');
     editSpawnerPage.findSubmitButton().should('be.enabled');
     editSpawnerPage.k8sNameDescription.findDisplayNameInput().fill('Updated Notebook');
+
+    // Add a test for editing accelerator profile
+    editSpawnerPage.findAcceleratorProfileSelect().click();
+    editSpawnerPage.findAcceleratorProfileSelect().findSelectOption('none').click();
+    editSpawnerPage.findAcceleratorProfileSelect().should('contain', 'None');
 
     cy.interceptK8s('PUT', NotebookModel, mockNotebookK8sResource({})).as('editWorkbenchDryRun');
     cy.interceptK8s('PATCH', NotebookModel, mockNotebookK8sResource({})).as('editWorkbench');

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -218,6 +218,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 );
               }
             }}
+            data-testid="accelerator-profile-select"
           />
         </FormGroup>
       </StackItem>

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -145,9 +145,8 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
 
   // add none option
   options.push({
-    key: '',
+    key: 'none',
     label: 'None',
-    isPlaceholder: true,
   });
 
   if (acceleratorProfileState.unknownProfileDetected) {
@@ -194,10 +193,10 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
             value={
               selectedAcceleratorProfile.useExistingSettings
                 ? 'use-existing'
-                : selectedAcceleratorProfile.profile?.metadata.name ?? ''
+                : selectedAcceleratorProfile.profile?.metadata.name ?? 'none'
             }
-            onChange={(key, isPlaceholder) => {
-              if (isPlaceholder) {
+            onChange={(key) => {
+              if (key === 'none') {
                 // none
                 setSelectedAcceleratorProfile('useExistingSettings', false);
                 setSelectedAcceleratorProfile('profile', undefined);

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -218,7 +218,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 );
               }
             }}
-            data-testid="accelerator-profile-select"
+            dataTestId="accelerator-profile-select"
           />
         </FormGroup>
       </StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13197

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
made it so none was able to be selected and added a test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create a accelerator profile
2. create workbench and verify that None is able to be selected for the accelerator selector

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added a test to ensure that None can be selected and is shown as None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
