### PR TITLE
Project Details Page - Allow Edit and View Details

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -195,6 +195,34 @@ class ProjectDetails {
     );
   }
 
+  showProjectResourceDetails() {
+    return cy.findByTestId('resource-name-icon-button').click();
+  }
+
+  findProjectResourceNameText() {
+    return cy.findByTestId('resource-name-text');
+  }
+
+  findProjectResourceKindText() {
+    return cy.findByTestId('resource-kind-text');
+  }
+
+  findProjectActions() {
+    return cy.findByTestId('project-actions');
+  }
+
+  showProjectActions() {
+    cy.findByTestId('project-actions').click();
+  }
+
+  findEditProjectAction() {
+    return cy.findByTestId('edit-project-action');
+  }
+
+  findDeleteProjectAction() {
+    return cy.findByTestId('delete-project-action');
+  }
+
   findImportPipelineButton(timeout?: number) {
     return cy.findByTestId('import-pipeline-button', { timeout });
   }

--- a/frontend/src/components/ResourceNameTooltip.tsx
+++ b/frontend/src/components/ResourceNameTooltip.tsx
@@ -5,6 +5,8 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Flex,
+  FlexItem,
   Popover,
   Stack,
   StackItem,
@@ -26,9 +28,9 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({
   wrap = true,
 }) => (
   <div style={{ display: wrap ? 'block' : 'inline-flex' }}>
-    <span>{children}</span>
-    {resource.metadata?.name && (
-      <div style={{ display: 'inline-block', marginLeft: 'var(--pf-v5-global--spacer--xs)' }}>
+    <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>{children}</FlexItem>
+      {resource.metadata?.name && (
         <Popover
           position="right"
           bodyContent={
@@ -41,24 +43,35 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({
                   <DescriptionListGroup>
                     <DescriptionListTerm>Resource name</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
+                      <ClipboardCopy
+                        hoverTip="Copy"
+                        clickTip="Copied"
+                        variant="inline-compact"
+                        data-testid="resource-name-text"
+                      >
                         {resource.metadata.name}
                       </ClipboardCopy>
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                   <DescriptionListGroup>
                     <DescriptionListTerm>Resource type</DescriptionListTerm>
-                    <DescriptionListDescription>{resource.kind}</DescriptionListDescription>
+                    <DescriptionListDescription data-testid="resource-kind-text">
+                      {resource.kind}
+                    </DescriptionListDescription>
                   </DescriptionListGroup>
                 </DescriptionList>
               </StackItem>
             </Stack>
           }
         >
-          <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+          <DashboardPopupIconButton
+            data-testid="resource-name-icon-button"
+            icon={<OutlinedQuestionCircleIcon />}
+            aria-label="More info"
+          />
         </Popover>
-      </div>
-    )}
+      )}
+    </Flex>
   </div>
 );
 

--- a/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { Dropdown, DropdownItem, MenuToggle, DropdownList } from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import { getDashboardMainContainer } from '~/utilities/utils';
+import { AccessReviewResourceAttributes, ProjectKind } from '~/k8sTypes';
+import { useAccessReview } from '~/api';
+import DeleteProjectModal from '~/pages/projects/screens/projects/DeleteProjectModal';
+import ManageProjectModal from '~/pages/projects/screens/projects/ManageProjectModal';
+
+const projectEditAccessReview: AccessReviewResourceAttributes = {
+  group: 'project.openshift.io',
+  resource: 'projectrequests',
+  verb: 'update',
+};
+
+const projectDeleteAccessReview: AccessReviewResourceAttributes = {
+  group: 'project.openshift.io',
+  resource: 'projectrequests',
+  verb: 'delete',
+};
+
+type Props = {
+  project: ProjectKind;
+};
+
+const ProjectActions: React.FC<Props> = ({ project }) => {
+  const navigate = useNavigate();
+  const [canEdit, editRbacLoaded] = useAccessReview({
+    ...projectEditAccessReview,
+    namespace: project.metadata.name,
+  });
+  const [canDelete, deleteRbacLoaded] = useAccessReview({
+    ...projectDeleteAccessReview,
+    namespace: project.metadata.name,
+  });
+  const [open, setOpen] = React.useState(false);
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
+  const [editOpen, setEditOpen] = React.useState(false);
+
+  if (!editRbacLoaded || !deleteRbacLoaded || (!canEdit && !canDelete)) {
+    return null;
+  }
+
+  const DropdownComponent = (
+    <Dropdown
+      onOpenChange={setOpen}
+      onSelect={() => setOpen(false)}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          aria-label="Actions"
+          data-testid="project-actions"
+          variant="secondary"
+          ref={toggleRef}
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Actions
+        </MenuToggle>
+      )}
+      isOpen={open}
+      popperProps={{ position: 'right', appendTo: getDashboardMainContainer() }}
+    >
+      <DropdownList>
+        {canEdit ? (
+          <DropdownItem data-testid="edit-project-action" onClick={() => setEditOpen(true)}>
+            Edit project
+          </DropdownItem>
+        ) : null}
+        {canDelete ? (
+          <DropdownItem data-testid="delete-project-action" onClick={() => setDeleteOpen(true)}>
+            Delete project
+          </DropdownItem>
+        ) : null}
+      </DropdownList>
+    </Dropdown>
+  );
+
+  return (
+    <>
+      {DropdownComponent}
+      {editOpen ? (
+        <ManageProjectModal editProjectData={project} onClose={() => setEditOpen(false)} />
+      ) : null}
+      {deleteOpen ? (
+        <DeleteProjectModal
+          deleteData={project}
+          onClose={(deleted) => {
+            setDeleteOpen(false);
+            if (deleted) {
+              navigate('/projects');
+            }
+          }}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default ProjectActions;

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -16,6 +16,7 @@ import { AccessReviewResourceAttributes } from '~/k8sTypes';
 import { useAccessReview } from '~/api';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import useConnectionTypesEnabled from '~/concepts/connectionTypes/useConnectionTypesEnabled';
+import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import useCheckLogoutParams from './useCheckLogoutParams';
 import ProjectOverview from './overview/ProjectOverview';
 import NotebookList from './notebooks/NotebookList';
@@ -23,6 +24,7 @@ import StorageList from './storage/StorageList';
 import DataConnectionsList from './data-connections/DataConnectionsList';
 import ConnectionsList from './connections/ConnectionsList';
 import PipelinesSection from './pipelines/PipelinesSection';
+import ProjectActions from './ProjectActions';
 
 import './ProjectDetails.scss';
 
@@ -123,7 +125,11 @@ const ProjectDetails: React.FC = () => {
           alignItems={{ default: 'alignItemsFlexStart' }}
         >
           <img style={{ height: 32 }} src={typedObjectImage(ProjectObjectType.project)} alt="" />
-          <FlexItem>{displayName}</FlexItem>
+          <FlexItem>
+            <ResourceNameTooltip resource={currentProject} wrap={false}>
+              {displayName}
+            </ResourceNameTooltip>
+          </FlexItem>
         </Flex>
       }
       description={<div style={{ marginLeft: 40 }}>{description}</div>}
@@ -135,6 +141,7 @@ const ProjectDetails: React.FC = () => {
       }
       loaded={rbacLoaded}
       empty={false}
+      headerAction={<ProjectActions project={currentProject} />}
     >
       {content()}
     </ApplicationsPage>


### PR DESCRIPTION
Closes [RHOAIENG-8571](https://issues.redhat.com/browse/RHOAIENG-8571)

## Description
In the project details page, add a popover to show users the project's resource name and kind.
Also, add actions to allow a provisioned user to edit or delete the project.

## How Has This Been Tested?
As a provisioned user, navigate to a project page.
Verify there is a popover indicator next to the project name.
Clicking the indicator shows a popover that shows the project's resource name and show `Project` for the resource type.
Click on the actions menu to the far right, verify both `Edit project` and `Delete project` actions are shown.
Verify that `Edit project` bring up the `Edit project` modal.
Verify that `Delete project` brings up the `Delete project` modal.

As a non-provisioning user, navigate to a project page.
Verify there is a popover indicator next to the project name.
Clicking the indicator shows a popover that shows the project's resource name and show `Project` for the resource type.
Verify there is no actions menu shown to the far right.

## Test Impact
Added cypress e2e tests.

## Mocks
Ref: [Figma prototype](https://www.figma.com/proto/ANpg8c6Ltq2sCVNCAyXzOR/Project-Enhancements?page-id=355%3A32349&node-id=355-32350&viewport=334%2C247%2C0.34&t=cu3i51XnVnoIzTvW-1&scaling=scale-down-width&content-scaling=fixed&starting-point-node-id=355%3A32350)

![image](https://github.com/user-attachments/assets/157bc912-f680-4b17-b2f9-159815f0989b)

![image](https://github.com/user-attachments/assets/61408540-42b2-45b7-954a-b48fae26ec35)

## Screen shots
![image](https://github.com/user-attachments/assets/85a9012e-5ba4-4fb7-8d80-84f0d8ba9314)

![image](https://github.com/user-attachments/assets/fb7f13de-9059-4af5-9cda-65715a5fdaeb)



## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

/cc  @jgiardino