### PR TITLE
RHOAIENG-13608 Inconsistent Default Storage Class when corrupting isDefault value

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
 import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import { getStorageClassConfig } from '~/pages/storageClasses/utils';
+import useDefaultStorageClass from './useDefaultStorageClass';
 
 type StorageClassSelectProps = {
   storageClassName?: string;
@@ -29,9 +30,10 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
 }) => {
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
   const hasStorageClassConfigs = storageClasses.some((sc) => !!getStorageClassConfig(sc));
+  const defaultSc = useDefaultStorageClass();
 
   const enabledStorageClasses = storageClasses
-    .filter((sc) => getStorageClassConfig(sc)?.isEnabled)
+    .filter((sc) => getStorageClassConfig(sc)?.isEnabled === true)
     .toSorted((a, b) => {
       const aConfig = getStorageClassConfig(a);
       const bConfig = getStorageClassConfig(b);
@@ -66,7 +68,9 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
           <SplitItem>{config?.displayName || sc.metadata.name}</SplitItem>
           <SplitItem isFilled />
           <SplitItem>
-            {config?.isDefault && (
+            {/* If multiple storage classes have `isDefault` set to true, 
+            prioritize the one returned by useDefaultStorageClass() as the default class */}
+            {sc.metadata.name === defaultSc?.metadata.name && (
               <Label isCompact color="green">
                 Default class
               </Label>

--- a/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
@@ -17,10 +17,12 @@ const useDefaultStorageClass = (): StorageClassKind | undefined => {
     }
 
     const enabledStorageClasses = storageClasses.filter(
-      (sc) => getStorageClassConfig(sc)?.isEnabled,
+      (sc) => getStorageClassConfig(sc)?.isEnabled === true,
     );
 
-    const defaultSc = enabledStorageClasses.find((sc) => getStorageClassConfig(sc)?.isDefault);
+    const defaultSc = enabledStorageClasses.find(
+      (sc) => getStorageClassConfig(sc)?.isDefault === true,
+    );
 
     if (!defaultSc && enabledStorageClasses.length > 0) {
       setDefaultStorageClass(enabledStorageClasses[0]);

--- a/frontend/src/pages/storageClasses/StorageClassesContext.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesContext.tsx
@@ -59,7 +59,7 @@ export const StorageClassContextProvider: React.FC<StorageClassContextProviderPr
   );
 
   const [defaultStorageClassName] =
-    Object.entries(storageClassConfigs).find(([, config]) => config?.isDefault) || [];
+    Object.entries(storageClassConfigs).find(([, config]) => config?.isDefault === true) || [];
 
   const openshiftDefaultScName = storageClasses.find((storageClass) =>
     isOpenshiftDefaultStorageClass(storageClass),
@@ -94,7 +94,7 @@ export const StorageClassContextProvider: React.FC<StorageClassContextProviderPr
         // If multiple defaults are set via OpenShift's dashboard,
         // unset all except the first indexed storage class
         else {
-          if (config.isDefault) {
+          if (config.isDefault === true) {
             if (!hasDefaultConfig) {
               hasDefaultConfig = true;
             } else {

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -255,7 +255,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({ 
             {isValidConfigValue('isDefault', storageClassConfig.isDefault) && (
               <StorageClassDefaultRadio
                 storageClassName={metadata.name}
-                isChecked={storageClassConfig.isDefault}
+                isChecked={storageClassConfig.isDefault === true}
                 isDisabled={isDefaultRadioDisabled}
                 onChange={onDefaultRadioChange}
               />


### PR DESCRIPTION
Closes: [RHOAIENG-13608](https://issues.redhat.com/browse/RHOAIENG-13608)

## Description
This PR resolves inconsistencies when handling corrupted or multiple storage classes marked as default (isDefault: true).

a) If a corrupted class is detected and no valid default is found, the first storage class in the list is automatically selected.
<img width="450px" src="https://github.com/user-attachments/assets/1370d2d6-144d-44db-99f9-2b0bbe60bd05" />

b) Improved the logic in `StorageClassSelect` to properly manage scenarios with multiple default storage classes.

Before
<img width="450px" src="https://github.com/user-attachments/assets/802904ce-b091-47cc-bff3-d64c6307fbc6" />

After
<img width="450px" src="https://github.com/user-attachments/assets/9dcd74f9-f3ed-43cd-9eba-41779ba82e88" />

c) Enhanced error handling for corrupted default values within `StorageClassesContext`.
https://github.com/user-attachments/assets/61b8d37a-ffa9-43cb-8ad6-7f00f93097d6

## How Has This Been Tested?

To test default inconsistency on Storage class select.
1. Add isDefault: 1 in annotations of any one storage class.
2. On the cluster storage page create new storage, the default will be selected first storage class (by name) in the list.

To test multiple storage class with default.
1. Add two storage class with isDefault: true
2. On the cluster storage page create new storage. Only one will be selected as default.

To test default inconsistency on Storage class page.
1. Add isDefault: 1 in annotations of any one storage class.
2. On the storage class page in dashboard, you can see "Corrupted metadata" mention in that row.
4. Click on "Corrupted metadata"
5. The default is updated, verify the annotation on openshift.

## Test Impact
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
