### PR TITLE
Provide the functionality to search models and model version by "labels"

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersions.cy.ts
@@ -200,6 +200,12 @@ describe('Model Versions', () => {
     modelRegistry.findModelVersionsTableRows().contains('new model version');
     modelRegistry.findModelVersionsTableSearch().focused().clear();
 
+    // filtering by label
+    modelRegistry.findModelVersionsTableSearch().type('Financial');
+    modelRegistry.findModelVersionsTableRows().should('have.length', 1);
+    modelRegistry.findModelVersionsTableRows().contains('new model version');
+    modelRegistry.findModelVersionsTableSearch().focused().clear();
+
     // filtering by model version author
     modelRegistry.findModelVersionsTableFilter().findSelectOption('Author').click();
     modelRegistry.findModelVersionsTableSearch().type('Test author');

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -107,6 +107,7 @@ export type ModelVersion = ModelRegistryBase & {
   state?: ModelState;
   author?: string;
   registeredModelId: string;
+  labels?: string[];
 };
 
 export type RegisteredModel = ModelRegistryBase & {

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -297,14 +297,15 @@ describe('filterModelVersions', () => {
 
 describe('filterRegisteredModels', () => {
   const registeredModels: RegisteredModel[] = [
-    mockRegisteredModel({ name: 'Test 1', state: ModelState.ARCHIVED }),
+    mockRegisteredModel({ name: 'Test 1', state: ModelState.ARCHIVED, owner: 'Alice' }),
     mockRegisteredModel({
       name: 'Test 2',
       description: 'Description2',
+      owner: 'Bob',
     }),
-    mockRegisteredModel({ name: 'Test 3', state: ModelState.ARCHIVED }),
-    mockRegisteredModel({ name: 'Test 4', state: ModelState.ARCHIVED }),
-    mockRegisteredModel({ name: 'Test 5' }),
+    mockRegisteredModel({ name: 'Test 3', state: ModelState.ARCHIVED, owner: 'Charlie' }),
+    mockRegisteredModel({ name: 'Test 4', state: ModelState.ARCHIVED, owner: 'Alice' }),
+    mockRegisteredModel({ name: 'Test 5', owner: 'Bob' }),
   ];
 
   test('filters by name', () => {
@@ -315,6 +316,11 @@ describe('filterRegisteredModels', () => {
   test('filters by description', () => {
     const filtered = filterRegisteredModels(registeredModels, 'Description2', SearchType.KEYWORD);
     expect(filtered).toEqual([registeredModels[1]]);
+  });
+
+  test('filters by owner', () => {
+    const filtered = filterRegisteredModels(registeredModels, 'Alice', SearchType.OWNER);
+    expect(filtered).toEqual([registeredModels[0], registeredModels[3]]);
   });
 
   test('does not filter when search is empty', () => {

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -88,13 +88,12 @@ export const filterModelVersions = (
     }
 
     switch (searchType) {
-      case SearchType.KEYWORD: {
+      case SearchType.KEYWORD:
         return (
           mv.name.toLowerCase().includes(searchLower) ||
           (mv.description && mv.description.toLowerCase().includes(searchLower)) ||
           getLabels(mv.customProperties).some((label) => label.toLowerCase().includes(searchLower))
         );
-      }
 
       case SearchType.AUTHOR: {
         return mv.author && mv.author.toLowerCase().includes(searchLower);

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -89,29 +89,15 @@ export const filterModelVersions = (
 
     switch (searchType) {
       case SearchType.KEYWORD: {
-        const nameMatch = mv.name.toLowerCase().includes(searchLower);
-        const descriptionMatch =
-          mv.description && mv.description.toLowerCase().includes(searchLower);
-
-        let labelMatch = false;
-        labelMatch = Object.keys(mv.customProperties).some((key) => {
-          const prop = mv.customProperties[key];
-          return (
-            key.toLowerCase().includes(searchLower) ||
-            (prop.metadataType === ModelRegistryMetadataType.STRING &&
-              prop.string_value.toLowerCase().includes(searchLower))
-          );
-        });
-
-        return nameMatch || descriptionMatch || labelMatch;
+        return (
+          mv.name.toLowerCase().includes(searchLower) ||
+          (mv.description && mv.description.toLowerCase().includes(searchLower)) ||
+          getLabels(mv.customProperties).some((label) => label.toLowerCase().includes(searchLower))
+        );
       }
 
       case SearchType.AUTHOR: {
-        return (
-          mv.author &&
-          (mv.author.toLowerCase().includes(search.toLowerCase()) ||
-            (mv.author && mv.author.toLowerCase().includes(search.toLowerCase())))
-        );
+        return mv.author && mv.author.toLowerCase().includes(searchLower);
       }
 
       default:
@@ -141,21 +127,11 @@ export const filterRegisteredModels = (
 
     switch (searchType) {
       case SearchType.KEYWORD: {
-        const nameMatch = rm.name.toLowerCase().includes(searchLower);
-        const descriptionMatch =
-          rm.description && rm.description.toLowerCase().includes(searchLower);
-
-        let labelMatch = false;
-        labelMatch = Object.keys(rm.customProperties).some((key) => {
-          const prop = rm.customProperties[key];
-          return (
-            key.toLowerCase().includes(searchLower) ||
-            (prop.metadataType === ModelRegistryMetadataType.STRING &&
-              prop.string_value.toLowerCase().includes(searchLower))
-          );
-        });
-
-        return nameMatch || descriptionMatch || labelMatch;
+        return (
+          rm.name.toLowerCase().includes(searchLower) ||
+          (rm.description && rm.description.toLowerCase().includes(searchLower)) ||
+          getLabels(rm.customProperties).some((label) => label.toLowerCase().includes(searchLower))
+        );
       }
 
       case SearchType.OWNER: {

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -79,30 +79,46 @@ export const filterModelVersions = (
   unfilteredModelVersions: ModelVersion[],
   search: string,
   searchType: SearchType,
-): ModelVersion[] =>
-  unfilteredModelVersions.filter((mv: ModelVersion) => {
+): ModelVersion[] => {
+  const searchLower = search.toLowerCase();
+
+  return unfilteredModelVersions.filter((mv: ModelVersion) => {
     if (!search) {
       return true;
     }
 
     switch (searchType) {
-      case SearchType.KEYWORD:
-        return (
-          mv.name.toLowerCase().includes(search.toLowerCase()) ||
-          (mv.description && mv.description.toLowerCase().includes(search.toLowerCase()))
-        );
+      case SearchType.KEYWORD: {
+        const nameMatch = mv.name.toLowerCase().includes(searchLower);
+        const descriptionMatch =
+          mv.description && mv.description.toLowerCase().includes(searchLower);
 
-      case SearchType.AUTHOR:
+        let labelMatch = false;
+        labelMatch = Object.keys(mv.customProperties).some((key) => {
+          const prop = mv.customProperties[key];
+          return (
+            key.toLowerCase().includes(searchLower) ||
+            (prop.metadataType === ModelRegistryMetadataType.STRING &&
+              prop.string_value.toLowerCase().includes(searchLower))
+          );
+        });
+
+        return nameMatch || descriptionMatch || labelMatch;
+      }
+
+      case SearchType.AUTHOR: {
         return (
           mv.author &&
           (mv.author.toLowerCase().includes(search.toLowerCase()) ||
             (mv.author && mv.author.toLowerCase().includes(search.toLowerCase())))
         );
+      }
 
       default:
         return true;
     }
   });
+};
 
 export const sortModelVersionsByCreateTime = (registeredModels: ModelVersion[]): ModelVersion[] =>
   registeredModels.toSorted((a, b) => {
@@ -115,23 +131,39 @@ export const filterRegisteredModels = (
   unfilteredRegisteredModels: RegisteredModel[],
   search: string,
   searchType: SearchType,
-): RegisteredModel[] =>
-  unfilteredRegisteredModels.filter((rm: RegisteredModel) => {
+): RegisteredModel[] => {
+  const searchLower = search.toLowerCase();
+
+  return unfilteredRegisteredModels.filter((rm: RegisteredModel) => {
     if (!search) {
       return true;
     }
 
     switch (searchType) {
-      case SearchType.KEYWORD:
-        return (
-          rm.name.toLowerCase().includes(search.toLowerCase()) ||
-          (rm.description && rm.description.toLowerCase().includes(search.toLowerCase()))
-        );
+      case SearchType.KEYWORD: {
+        const nameMatch = rm.name.toLowerCase().includes(searchLower);
+        const descriptionMatch =
+          rm.description && rm.description.toLowerCase().includes(searchLower);
 
-      case SearchType.OWNER:
-        return rm.owner && rm.owner.toLowerCase().includes(search.toLowerCase());
+        let labelMatch = false;
+        labelMatch = Object.keys(rm.customProperties).some((key) => {
+          const prop = rm.customProperties[key];
+          return (
+            key.toLowerCase().includes(searchLower) ||
+            (prop.metadataType === ModelRegistryMetadataType.STRING &&
+              prop.string_value.toLowerCase().includes(searchLower))
+          );
+        });
+
+        return nameMatch || descriptionMatch || labelMatch;
+      }
+
+      case SearchType.OWNER: {
+        return rm.owner && rm.owner.toLowerCase().includes(searchLower);
+      }
 
       default:
         return true;
     }
   });
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12589

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change --> 
When using the Keyword filtering option, it will now query the labels as well. This should be in both models and versions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on The UI  
![Screenshot 2024-10-01 at 3 45 38 PM](https://github.com/user-attachments/assets/91111ff3-1470-41da-b7d3-dd22cfde2922)


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
