### PR TITLE
test: Storage Classes e2e cypress tests

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -8,4 +8,4 @@ ODH_FAVICON=odh-favicon.svg
 ODH_NOTEBOOK_REPO=opendatahub
 
 ########## Change this version with each dashboard release ###########
-INTERNAL_DASHBOARD_VERSION=v2.26.0
+INTERNAL_DASHBOARD_VERSION=v2.27.0

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/storage_class.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/storage_class.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: os-sc-{{SC_NAME}}
+  annotations:
+    description: description
+    opendatahub.io/sc-config: '{"isDefault":{{SC_IS_DEFAULT}},"isEnabled":{{SC_IS_ENABLED}},"displayName":"{{SC_NAME}}","lastModified":"2024-10-01T15:22:42.480Z"}'
+provisioner: cinder.csi.openstack.org
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/storage_class.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/storage_class.yaml
@@ -1,7 +1,7 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: os-sc-{{SC_NAME}}
+  name: {{SC_NAME}}
   annotations:
     description: description
     opendatahub.io/sc-config: '{"isDefault":{{SC_IS_DEFAULT}},"isEnabled":{{SC_IS_ENABLED}},"displayName":"{{SC_NAME}}","lastModified":"2024-10-01T15:22:42.480Z"}'

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -157,6 +157,10 @@ class ClusterStorage {
   findCreateButton() {
     return cy.findByTestId('cluster-storage-button');
   }
+
+  findCreateButtonFromActions() {
+    return cy.findByTestId('actions-cluster-storage-button');
+  }
 }
 
 export const clusterStorage = new ClusterStorage();

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -172,6 +172,10 @@ class ProjectDetails {
     this.wait(section);
   }
 
+  findSectionTab(sectionId: string) {
+    return cy.findByTestId(`${sectionId}-tab`);
+  }
+
   private wait(section = 'overview') {
     cy.findByTestId(`section-${section}`);
     cy.testA11y();

--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -12,6 +12,11 @@ class StorageClassesPage {
     this.wait();
   }
 
+  navigate() {
+    this.findNavItem().click();
+    this.wait();
+  }
+
   private wait() {
     cy.findByTestId('app-page-title').contains('Storage classes');
     cy.testA11y();

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -3,112 +3,21 @@ import {
   provisionClusterStorageSCFeature,
   tearDownClusterStorageSCFeature,
 } from '~/__tests__/cypress/cypress/utils/storageClass';
-import {
-  clusterStorage,
-  addClusterStorageModal,
-} from '~/__tests__/cypress/cypress/pages/clusterStorage';
+import { addClusterStorageModal } from '~/__tests__/cypress/cypress/pages/clusterStorage';
 import { projectListPage, projectDetails } from '~/__tests__/cypress/cypress/pages/projects';
 import { findAddClusterStorageButton } from '~/__tests__/cypress/cypress/utils/clusterStorage';
-import {
-  getDefaultEnabledStorageClass,
-  updateStorageClass,
-  disableNonDefaultStorageClasses,
-} from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
-import type { SCReplacements } from '~/__tests__/cypress/cypress/types';
+import { disableNonDefaultStorageClasses } from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
 
-const scName = 'qe-cs-sc';
 const dspName = 'qe-cluster-storage-sc-dsp';
 
 describe('Regular Users can make use of the Storage Classes in the Cluster Storage tab from DSP ', () => {
-  let createdStorageClasses: string[];
-  before(() => {
-    // Provision different SCs
-    createdStorageClasses = provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME, scName);
-  });
+  // before(() => {
+  //   provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME);
+  // });
 
-  after(() => {
-    tearDownClusterStorageSCFeature(dspName, createdStorageClasses);
-  });
-
-  it('Regular user can create a cluster storage using a new storage class', () => {
-    cy.visitWithLogin('/projects', TEST_USER);
-    // Open the project
-    projectListPage.filterProjectByName(dspName);
-    projectListPage.findProjectLink(dspName).click();
-    // Go to cluster storage tab
-    projectDetails.findSectionTab('cluster-storages').click();
-
-    // Create a cluster storage using the new Storage Class
-    const scEnabledName = `${scName}-enabled`;
-    const scDisabledName = `${scName}-disabled`;
-    const clusterStorageName = `cs-${scEnabledName}`;
-    clusterStorage.findCreateButton().click();
-    addClusterStorageModal.findNameInput().fill(clusterStorageName);
-    // Verify that the sc selected by default is the default one
-    getDefaultEnabledStorageClass().then((storageClassName) => {
-      cy.findByTestId('storage-classes-selector')
-        .invoke('text')
-        .then((text) => {
-          const trimmedText = text.trim();
-          expect(trimmedText).to.equal(storageClassName);
-        });
-      // Verify that the default one has the label
-      addClusterStorageModal.findStorageClassSelect().click();
-      cy.findByTestId(storageClassName).within(() => {
-        cy.findByTestId('is-default-label').should('exist').and('have.text', 'Default class');
-      });
-    });
-    // Verify that the enabled SC is shown in the dropdown and the disabled one is not
-    addClusterStorageModal
-      .findStorageClassSelect()
-      .findSelectOption(scDisabledName)
-      .should('not.exist');
-    addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).should('exist');
-    // Select the enabled SC and submit
-    addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).click();
-    addClusterStorageModal.findSubmitButton().click();
-    // Verify it's now in the grid
-    const clusterStorageRow = clusterStorage.getClusterStorageRow(clusterStorageName);
-    clusterStorageRow.findStorageClassColumn().should('exist');
-  });
-
-  it('A Cluster Storage with a disabled SC shows the deprecated warning', () => {
-    cy.visitWithLogin('/projects', TEST_USER);
-    // Open the project
-    projectListPage.filterProjectByName(dspName);
-    projectListPage.findProjectLink(dspName).click();
-    // Go to cluster storage tab
-    projectDetails.findSectionTab('cluster-storages').click();
-
-    // Create a cluster storage using the new Storage Class
-    const scEnabledName = `${scName}-enabled`;
-    const clusterStorageName = `cs-deprecated`;
-    findAddClusterStorageButton().click();
-    addClusterStorageModal.findNameInput().fill(clusterStorageName);
-    // Select the enabled SC and submit
-    addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).click();
-    addClusterStorageModal.findSubmitButton().click();
-    // Verify it's now in the grid
-    let clusterStorageRow = clusterStorage.getClusterStorageRow(clusterStorageName);
-    clusterStorageRow.findStorageClassColumn().should('exist');
-
-    // patch: Disable the SC
-    const SCReplacement: SCReplacements = {
-      SC_NAME: scEnabledName,
-      SC_IS_DEFAULT: 'false',
-      SC_IS_ENABLED: 'false',
-    };
-    updateStorageClass(SCReplacement);
-
-    // Reload the view in order to force the warnings
-    cy.reload();
-    // Verify the deprecated Label
-    clusterStorageRow = clusterStorage.getClusterStorageRow(clusterStorageName);
-    clusterStorageRow.findDeprecatedLabel().should('exist');
-    // Verify warning message
-    clusterStorage.shouldHaveDeprecatedAlertMessage();
-    clusterStorage.closeDeprecatedAlert();
-  });
+  // after(() => {
+  //   tearDownClusterStorageSCFeature(dspName);
+  // });
 
   it('If all SC are disabled except one, the SC dropdown should be disabled', () => {
     cy.visitWithLogin('/projects', TEST_USER);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -28,14 +28,14 @@ const dspName = 'qe-cluster-storage-sc-dsp';
 // describe('An admin user can manage Storage Classes', { testIsolation: false }, () => {
 describe('An admin user can manage Storage Classes from Settings -> Storage classes view', () => {
   let createdStorageClasses: string[];
-  // before(() => {
-  //   // Provision different SCs
-  //   createdStorageClasses = provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME, scName);
-  // });
+  before(() => {
+    // Provision different SCs
+    createdStorageClasses = provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME, scName);
+  });
 
-  // after(() => {
-  //   tearDownClusterStorageSCFeature(dspName, createdStorageClasses);
-  // });
+  after(() => {
+    tearDownClusterStorageSCFeature(dspName, createdStorageClasses);
+  });
 
   it.only('Regular user can create a cluster storage using a new storage class', () => {
     // Login as a regular user and try to land in storage classes view
@@ -66,19 +66,22 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
         cy.findByTestId('is-default-label').should('exist').and('have.text', 'Default class');
       });
     });
-
     // Verify that the enabled SC is shown in the dropdown and the disabled one is not
     addClusterStorageModal
       .findStorageClassSelect()
       .findSelectOption(scDisabledName)
       .should('not.exist');
     addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).should('exist');
+    // Select the enabled SC and submit
     addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).click();
+    addClusterStorageModal.findSubmitButton().click();
+    // Verify it's now in the grid
+    const clusterStorageRow = clusterStorage.getClusterStorageRow(clusterStorageName);
+    clusterStorageRow.findStorageClassColumn().should('exist');
   });
 });
 
 /**
- * disabled ones does not appears
  * All except one are disabled -> dropdown disabled
  *
  */

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -1,0 +1,84 @@
+import { TEST_USER, ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
+import {
+  verifyStorageClassConfig,
+  provisionClusterStorageSCFeature,
+  tearDownClusterStorageSCFeature,
+} from '~/__tests__/cypress/cypress/utils/storageClass';
+import {
+  clusterStorage,
+  addClusterStorageModal,
+  updateClusterStorageModal,
+} from '~/__tests__/cypress/cypress/pages/clusterStorage';
+import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
+import { projectListPage, projectDetails } from '~/__tests__/cypress/cypress/pages/projects';
+import {
+  storageClassEditModal,
+  storageClassesPage,
+  storageClassesTable,
+} from '~/__tests__/cypress/cypress/pages/storageClasses';
+import { getDefaultEnabledStorageClass } from '../../../utils/oc_commands/storageClass';
+
+const scName = 'qe-cs-sc';
+const scDefaultName = 'standard-csi';
+const dspName = 'qe-cluster-storage-sc-dsp';
+// const dspName = 'fede';
+
+// Using testIsolation will reuse the login (cache)
+// describe('An admin user can manage Storage Classes', { testIsolation: false }, () => {
+describe('An admin user can manage Storage Classes from Settings -> Storage classes view', () => {
+  let createdStorageClasses: string[];
+  // before(() => {
+  //   // Provision different SCs
+  //   createdStorageClasses = provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME, scName);
+  // });
+
+  // after(() => {
+  //   tearDownClusterStorageSCFeature(dspName, createdStorageClasses);
+  // });
+
+  it.only('Regular user can create a cluster storage using a new storage class', () => {
+    // Login as a regular user and try to land in storage classes view
+    cy.visitWithLogin('/projects', TEST_USER);
+    // Open the project
+    projectListPage.filterProjectByName(dspName);
+    projectListPage.findProjectLink(dspName).click();
+    // Go to cluster storage tab
+    projectDetails.findSectionTab('cluster-storages').click();
+
+    // Create a cluster storage using the new Storage Class
+    const scEnabledName = `${scName}-enabled`;
+    const scDisabledName = `${scName}-disabled`;
+    const clusterStorageName = `cs-${scEnabledName}`;
+    clusterStorage.findCreateButton().click();
+    addClusterStorageModal.findNameInput().fill(clusterStorageName);
+    // Verify that the sc selected by default is the default one
+    getDefaultEnabledStorageClass().then((storageClassName) => {
+      cy.findByTestId('storage-classes-selector')
+        .invoke('text')
+        .then((text) => {
+          const trimmedText = text.trim();
+          expect(trimmedText).to.equal(storageClassName);
+        });
+      // Verify that the default one has the label
+      addClusterStorageModal.findStorageClassSelect().click();
+      cy.findByTestId(storageClassName).within(() => {
+        cy.findByTestId('is-default-label').should('exist').and('have.text', 'Default class');
+      });
+    });
+
+    // Verify that the enabled SC is shown in the dropdown and the disabled one is not
+    addClusterStorageModal
+      .findStorageClassSelect()
+      .findSelectOption(scDisabledName)
+      .should('not.exist');
+    addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).should('exist');
+    addClusterStorageModal.findStorageClassSelect().findSelectOption(scEnabledName).click();
+  });
+});
+
+/**
+ * disabled ones does not appears
+ * All except one are disabled -> dropdown disabled
+ *
+ */

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -11,13 +11,13 @@ import { disableNonDefaultStorageClasses } from '~/__tests__/cypress/cypress/uti
 const dspName = 'qe-cluster-storage-sc-dsp';
 
 describe('Regular Users can make use of the Storage Classes in the Cluster Storage tab from DSP ', () => {
-  // before(() => {
-  //   provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME);
-  // });
+  before(() => {
+    provisionClusterStorageSCFeature(dspName, TEST_USER.USERNAME);
+  });
 
-  // after(() => {
-  //   tearDownClusterStorageSCFeature(dspName);
-  // });
+  after(() => {
+    tearDownClusterStorageSCFeature(dspName);
+  });
 
   it('If all SC are disabled except one, the SC dropdown should be disabled', () => {
     cy.visitWithLogin('/projects', TEST_USER);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
@@ -1,8 +1,3 @@
-import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  createStorageClass,
-  deleteStorageClass,
-} from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
 import { TEST_USER, ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
 import {
@@ -15,9 +10,7 @@ import {
   storageClassesPage,
   storageClassesTable,
 } from '~/__tests__/cypress/cypress/pages/storageClasses';
-import type { SCReplacements } from '~/__tests__/cypress/cypress/types';
 
-const projectName = 'test-settings-storage-classes-dsp';
 const scName = 'qe-settings-sc';
 const scDefaultName = 'standard-csi';
 
@@ -35,13 +28,13 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     tearDownStorageClassFeature(createdStorageClasses);
   });
 
-  it.skip('A non admin user can not acccess to Settings -> Storage classes view', () => {
+  it('A non admin user can not acccess to Settings -> Storage classes view', () => {
     // Login as a regular user and try to land in storage classes view
     cy.visitWithLogin('/storageClasses', TEST_USER);
     pageNotfound.findPage().should('be.visible');
   });
 
-  it.skip('The Default label is present in the grid', () => {
+  it('The Default label is present in the grid', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
     const scDisabledRow = storageClassesTable.getRowByConfigName(scDefaultName);
@@ -49,10 +42,10 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     scDisabledRow.findOpenshiftDefaultLabel().should('exist');
   });
 
-  it.skip('An admin user can enable a disabled Storage Class', () => {
+  it('An admin user can enable a disabled Storage Class', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
-    const scDisabledName = scName + '-disabled-non-default';
+    const scDisabledName = `${scName}-disabled-non-default`;
     // SC row exist
     storageClassesTable.findRowByName(scDisabledName).should('be.visible');
     const scDisabledRow = storageClassesTable.getRowByConfigName(scDisabledName);
@@ -74,10 +67,10 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     verifyStorageClassConfig(scDisabledName, false, true);
   });
 
-  it.skip('An admin user can disable an enabled Storage Class', () => {
+  it('An admin user can disable an enabled Storage Class', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
-    const scEnabledName = scName + '-enabled-non-default';
+    const scEnabledName = `${scName}-enabled-non-default`;
     // SC row exist
     storageClassesTable.findRowByName(scEnabledName).should('be.visible');
     const scEnabledRow = storageClassesTable.getRowByConfigName(scEnabledName);
@@ -99,10 +92,10 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     verifyStorageClassConfig(scEnabledName, false, false);
   });
 
-  it.skip('An admin user can set an enabled Storage Class as the default one', () => {
+  it('An admin user can set an enabled Storage Class as the default one', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
-    const scToDefaultName = scName + '-enabled-to-default';
+    const scToDefaultName = `${scName}-enabled-to-default`;
     const scToDefaultRow = storageClassesTable.getRowByConfigName(scToDefaultName);
     // There's no Default label
     scToDefaultRow.findOpenshiftDefaultLabel().should('not.exist');
@@ -123,10 +116,10 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
   it('An admin user can edit an Storage Class', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
-    const scEnabledName = scName + '-enabled-non-default';
+    const scEnabledName = `${scName}-enabled-non-default`;
     storageClassesTable.getRowByConfigName(scEnabledName).findKebabAction('Edit').click();
     // Edit DisplayName and Description
-    const scNameEdited = scName + '-edited';
+    const scNameEdited = `${scName}-edited`;
     const scEditedDescription = 'Edited Description';
     storageClassEditModal.fillDisplayNameInput(scNameEdited);
     storageClassEditModal.fillDescriptionInput(scEditedDescription);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
@@ -1,18 +1,15 @@
-import { TEST_USER, ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
+import { ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import {
   verifyStorageClassConfig,
   provisionStorageClassFeature,
   tearDownStorageClassFeature,
 } from '~/__tests__/cypress/cypress/utils/storageClass';
 import {
-  storageClassEditModal,
   storageClassesPage,
   storageClassesTable,
 } from '~/__tests__/cypress/cypress/pages/storageClasses';
 
 const scName = 'qe-settings-sc';
-const scDefaultName = 'standard-csi';
 
 // Using testIsolation will reuse the login (cache)
 // describe('An admin user can manage Storage Classes', { testIsolation: false }, () => {
@@ -26,20 +23,6 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
   after(() => {
     // Delete provisioned SCs
     tearDownStorageClassFeature(createdStorageClasses);
-  });
-
-  it('A non admin user can not acccess to Settings -> Storage classes view', () => {
-    // Login as a regular user and try to land in storage classes view
-    cy.visitWithLogin('/storageClasses', TEST_USER);
-    pageNotfound.findPage().should('be.visible');
-  });
-
-  it('The Default label is shown in the grid', () => {
-    cy.visitWithLogin('/', ADMIN_USER);
-    storageClassesPage.navigate();
-    const scDisabledRow = storageClassesTable.getRowByConfigName(scDefaultName);
-    // There's the Default label
-    scDisabledRow.findOpenshiftDefaultLabel().should('exist');
   });
 
   it('An admin user can enable a disabled Storage Class', () => {
@@ -111,29 +94,5 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     // The Enable switch is disabled
     scToDefaultRow.findEnableSwitchInput().should('be.disabled');
     verifyStorageClassConfig(scToDefaultName, true, true);
-  });
-
-  it('An admin user can edit an Storage Class', () => {
-    cy.visitWithLogin('/', ADMIN_USER);
-    storageClassesPage.navigate();
-    const scEnabledName = `${scName}-enabled-non-default`;
-    storageClassesTable.getRowByConfigName(scEnabledName).findKebabAction('Edit').click();
-    // Edit DisplayName and Description
-    const scNameEdited = `${scName}-edited`;
-    const scEditedDescription = 'Edited Description';
-    storageClassEditModal.fillDisplayNameInput(scNameEdited);
-    storageClassEditModal.fillDescriptionInput(scEditedDescription);
-    storageClassEditModal.findSaveButton().click();
-    // Verify new values
-    const scEditedRow = storageClassesTable.getRowByConfigName(scNameEdited);
-    scEditedRow.find().should('contain.text', scNameEdited);
-    scEditedRow.find().should('contain.text', scEditedDescription);
-    verifyStorageClassConfig(
-      scEnabledName,
-      undefined,
-      undefined,
-      scNameEdited,
-      scEditedDescription,
-    );
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
@@ -34,7 +34,7 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     pageNotfound.findPage().should('be.visible');
   });
 
-  it('The Default label is present in the grid', () => {
+  it('The Default label is shown in the grid', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
     const scDisabledRow = storageClassesTable.getRowByConfigName(scDefaultName);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
@@ -49,7 +49,7 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     scDisabledRow.findOpenshiftDefaultLabel().should('exist');
   });
 
-  it('An admin user can enable a disabled Storage Class', () => {
+  it.skip('An admin user can enable a disabled Storage Class', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
     const scDisabledName = scName + '-disabled-non-default';
@@ -74,7 +74,7 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     verifyStorageClassConfig(scDisabledName, false, true);
   });
 
-  it('An admin user can disable an enabled Storage Class', () => {
+  it.skip('An admin user can disable an enabled Storage Class', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
     const scEnabledName = scName + '-enabled-non-default';
@@ -99,7 +99,7 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     verifyStorageClassConfig(scEnabledName, false, false);
   });
 
-  it('An admin user can set an enabled Storage Class as the default one', () => {
+  it.skip('An admin user can set an enabled Storage Class as the default one', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
     const scToDefaultName = scName + '-enabled-to-default';
@@ -120,44 +120,27 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
     verifyStorageClassConfig(scToDefaultName, true, true);
   });
 
-  it.skip('An admin user can edit an Storage Class', () => {
+  it('An admin user can edit an Storage Class', () => {
     cy.visitWithLogin('/', ADMIN_USER);
     storageClassesPage.navigate();
-
-    // /**
-    //  * Import Pipeline by URL from Project Details view
-    //  */
-    // projectListPage.navigate();
-    // // Open the project
-    // projectListPage.filterProjectByName(projectName);
-    // projectListPage.findProjectLink(projectName).click();
-    // // Increasing the timeout to ~3mins so the DSPA can be loaded
-    // projectDetails.findImportPipelineButton(180000).click();
-    // // Fill tue Import Pipeline modal
-    // pipelineImportModal.findPipelineNameInput().type(testPipelineName);
-    // pipelineImportModal.findPipelineDescriptionInput().type('Pipeline Description');
-    // pipelineImportModal.findImportPipelineRadio().click();
-    // pipelineImportModal
-    //   .findPipelineUrlInput()
-    //   //TODO: modify this URL once the PR is merged
-    //   .type(
-    //     'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/caab82536b4dd5d39fb7a06a6c3248f10c183417/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
-    //   );
-    // pipelineImportModal.submit();
-    // // Verify that we are at the details page of the pipeline by checking the title
-    // // It can take a little longer to load
-    // pipelineDetails.findPageTitle(60000).should('have.text', testPipelineName);
-    // /**
-    //  * Run the Pipeline using the Actions button in the pipeline detail view
-    //  */
-    // pipelineDetails.selectActionDropdownItem('Create run');
-    // //Fill the Create run fields
-    // createRunPage.experimentSelect.findToggleButton().click();
-    // createRunPage.selectExperimentByName('Default');
-    // createRunPage.fillName(testRunName);
-    // createRunPage.fillDescription('Run Description');
-    // createRunPage.findSubmitButton().click();
-    // //Redirected to the Graph view of the created run
-    // pipelineRunDetails.expectStatusLabelToBe('Succeeded', 180000);
+    const scEnabledName = scName + '-enabled-non-default';
+    storageClassesTable.getRowByConfigName(scEnabledName).findKebabAction('Edit').click();
+    // Edit DisplayName and Description
+    const scNameEdited = scName + '-edited';
+    const scEditedDescription = 'Edited Description';
+    storageClassEditModal.fillDisplayNameInput(scNameEdited);
+    storageClassEditModal.fillDescriptionInput(scEditedDescription);
+    storageClassEditModal.findSaveButton().click();
+    // Verify new values
+    const scEditedRow = storageClassesTable.getRowByConfigName(scNameEdited);
+    scEditedRow.find().should('contain.text', scNameEdited);
+    scEditedRow.find().should('contain.text', scEditedDescription);
+    verifyStorageClassConfig(
+      scEnabledName,
+      undefined,
+      undefined,
+      scNameEdited,
+      scEditedDescription,
+    );
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -59,6 +59,19 @@ export type DspaReplacements = {
   AWS_S3_BUCKET: string;
 };
 
+export type StorageClassConfig = {
+  isDefault: boolean;
+  isEnabled: boolean;
+  displayName: string;
+  description?: string;
+};
+
+export type SCReplacements = {
+  SC_NAME: string;
+  SC_IS_DEFAULT: string;
+  SC_IS_ENABLED: string;
+};
+
 export type CommandLineResult = {
   code: number;
   stdout: string;

--- a/frontend/src/__tests__/cypress/cypress/utils/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/clusterStorage.ts
@@ -1,0 +1,17 @@
+import { clusterStorage } from '~/__tests__/cypress/cypress/pages/clusterStorage';
+
+/**
+ * Find the "Add cluster storage" button in the DSP details Cluster Storage tab.
+ * It can be in two different positions:
+ * 1. When there are no Cluster Storage
+ * 2. When there are already at least 1 Cluster Storage
+ *
+ */
+export const findAddClusterStorageButton = (): Cypress.Chainable<JQuery<HTMLElement>> => {
+  return cy.get('body').then(($body) => {
+    if ($body.find('[data-testid="cluster-storage-button"]').length > 0) {
+      return clusterStorage.findCreateButton();
+    }
+    return clusterStorage.findCreateButtonFromActions();
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -19,3 +19,35 @@ export const applyOpenShiftYaml = (yamlContent: string): Cypress.Chainable<Comma
     return result;
   });
 };
+
+/**
+ * Patches an OpenShift resource using the `oc patch` command.
+ *
+ * @param resourceType The type of resource to patch (e.g., 'storageclass')
+ * @param resourceName The name of the resource to patch
+ * @param patchContent The patch content as a JSON string
+ * @returns Cypress Chainable
+ */
+export const patchOpenShiftResource = (
+  resourceType: string,
+  resourceName: string,
+  patchContent: string,
+): Cypress.Chainable<CommandLineResult> => {
+  // Escape single quotes in the patch content
+  const escapedPatchContent = patchContent.replace(/'/g, "'\\''");
+
+  const ocCommand = `oc patch ${resourceType} ${resourceName} --type=merge -p '${escapedPatchContent}'`;
+
+  cy.log(ocCommand);
+
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      // If there is an error, log the error and fail the test
+      cy.log(`ERROR patching ${resourceType} ${resourceName}
+              stdout: ${result.stdout}
+              stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -46,3 +46,28 @@ export const deleteOpenShiftProject = (
     return result;
   });
 };
+
+/**
+ * Assign a role to a user for an specific Project
+ *
+ * @param projectName OpenShift Project name
+ * @param userName User
+ * @param role OpenShift Role (edit, admin, view)
+ * @returns Result Object of the operation
+ */
+export const addUserToProject = (
+  projectName: string,
+  userName: string,
+  role: string = 'edit',
+): Cypress.Chainable<CommandLineResult> => {
+  const ocCommand = `oc adm policy add-role-to-user ${role} ${userName} -n ${projectName}`;
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
+    if (result.code !== 0) {
+      cy.log(`ERROR Assigning role ${role} to user ${userName} in ${projectName} Project
+                stdout: ${result.stdout}
+                stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -58,7 +58,7 @@ export const deleteOpenShiftProject = (
 export const addUserToProject = (
   projectName: string,
   userName: string,
-  role: string = 'edit',
+  role = 'edit',
 ): Cypress.Chainable<CommandLineResult> => {
   const ocCommand = `oc adm policy add-role-to-user ${role} ${userName} -n ${projectName}`;
   return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
@@ -1,8 +1,4 @@
-import type {
-  SCReplacements,
-  CommandLineResult,
-  StorageClassConfig,
-} from '~/__tests__/cypress/cypress/types';
+import type { SCReplacements, CommandLineResult } from '~/__tests__/cypress/cypress/types';
 import { replacePlaceholdersInYaml } from '~/__tests__/cypress/cypress/utils/yaml_files';
 import { applyOpenShiftYaml } from './baseCommands';
 

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
@@ -1,0 +1,101 @@
+import type {
+  SCReplacements,
+  CommandLineResult,
+  StorageClassConfig,
+} from '~/__tests__/cypress/cypress/types';
+import { replacePlaceholdersInYaml } from '~/__tests__/cypress/cypress/utils/yaml_files';
+import { applyOpenShiftYaml } from './baseCommands';
+
+/**
+ * Try to create an Storage Class based on the storageClassReplacements config
+ * @param storageClassReplacements Dictionary with the config values
+ *      Dict Structure:
+ *              storageClassReplacements = {
+ *                  SC_NAME: <STORAGE CLASS NAME>,
+ *                  SC_IS_DEFAULT: <STR CAST BOOL>,
+ *                  SC_IS_ENABLED: <STR CAST BOOL>
+ *               }
+ * @param yamlFilePath
+ */
+export const createStorageClass = (
+  storageClassReplacements: SCReplacements,
+  yamlFilePath = 'resources/yaml/storage_class.yaml',
+): Cypress.Chainable<CommandLineResult> => {
+  return cy.fixture(yamlFilePath).then((yamlContent) => {
+    const modifiedYamlContent = replacePlaceholdersInYaml(yamlContent, storageClassReplacements);
+    return applyOpenShiftYaml(modifiedYamlContent);
+  });
+};
+
+/**
+ * Delete an Storage Class given its name
+ *
+ * @param scName Storage Class name
+ * @returns Result Object of the operation
+ */
+export const deleteStorageClass = (scName: string): Cypress.Chainable<CommandLineResult> => {
+  const ocCommand = `oc delete storageclass ${scName}`;
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
+    if (result.code !== 0) {
+      cy.log(`ERROR deleting ${scName} Storage Class
+                stdout: ${result.stdout}
+                stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};
+
+/**
+ * Get Storage Class Configuration
+ *
+ * @param scName Storage Class name
+ * @returns Result Object of the operation
+ */
+export const getStorageClassConfig = (scName: string): Cypress.Chainable<CommandLineResult> => {
+  const ocCommand = `oc get storageclass os-sc-${scName} -o jsonpath='{.metadata.annotations.opendatahub\\.io/sc-config}'`;
+  cy.log(ocCommand);
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
+    if (result.code !== 0) {
+      cy.log(`ERROR Getting ${scName} Storage Class Config
+                stdout: ${result.stdout}
+                stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};
+
+// /**
+//  * Get and delete Storage Classes that match a given prefix
+//  *
+//  * @param prefix The prefix to match Storage Class names against
+//  * @returns Promise<void>
+//  */
+// export const deleteStorageClassesByPrefix = (prefix: string): Cypress.Chainable<void> => {
+//   const getCommand = `oc get storageclass -o jsonpath='{.items[?(@.metadata.name=~"^${prefix}.*")].metadata.name}'`;
+
+//   return cy.exec(getCommand, { failOnNonZeroExit: false }).then((result) => {
+//     if (result.code !== 0) {
+//       cy.log(`ERROR getting Storage Classes with prefix ${prefix}
+//               stdout: ${result.stdout}
+//               stderr: ${result.stderr}`);
+//       throw new Error(`Command failed with code ${result.code}`);
+//     }
+
+//     const storageClasses = result.stdout.split(' ').filter(Boolean);
+
+//     if (storageClasses.length === 0) {
+//       cy.log(`No Storage Classes found with prefix ${prefix}`);
+//       return;
+//     }
+
+//     // Use cy.wrap() to create a Cypress chain
+//     return cy.wrap(storageClasses).each((scName) => {
+//       cy.log(`Deleting Storage Class: ${scName}`);
+//       return deleteStorageClass(scName);
+//     });
+//   });
+// };
+
+// // oc get storageclass | grep '^os-sc-test-settings-storage-classes' | awk '{print $1}' | xargs oc delete storageclass

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
@@ -49,7 +49,7 @@ export const deleteStorageClass = (scName: string): Cypress.Chainable<CommandLin
  * @returns Result Object of the operation
  */
 export const getStorageClassConfig = (scName: string): Cypress.Chainable<CommandLineResult> => {
-  const ocCommand = `oc get storageclass os-sc-${scName} -o jsonpath='{.metadata.annotations.opendatahub\.io/sc-config}'`;
+  const ocCommand = `oc get storageclass os-sc-${scName} -o jsonpath='{.metadata.annotations.opendatahub\\.io/sc-config}'`;
   cy.log(ocCommand);
   return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
     if (result.code !== 0) {

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
@@ -87,8 +87,10 @@ export const getOpenshiftDefaultStorageClass = (): Cypress.Chainable<CommandLine
  * @returns List of Storage Class names
  */
 export const getStorageClassNames = (): Cypress.Chainable<string[]> => {
+  const command = "oc get storageclass -o jsonpath='{.items[*].metadata.name}'";
+  cy.log(`Executing command: ${command}`);
   return cy
-    .exec("oc get storageclass -o jsonpath='{.items[*].metadata.name}'", {
+    .exec(command, {
       failOnNonZeroExit: false,
     })
     .then((result: CommandLineResult) => {
@@ -114,11 +116,10 @@ export const getDefaultEnabledStorageClass = (): Cypress.Chainable<string> => {
         return cy.wrap('No storage class found that is both default and enabled');
       }
 
+      const command = `oc get storageclass ${scNames[index]} -o jsonpath='{.metadata.annotations.opendatahub\\.io/sc-config}'`;
+      cy.log(`Executing command: ${command}`);
       return cy
-        .exec(
-          `oc get storageclass ${scNames[index]} -o jsonpath='{.metadata.annotations.opendatahub\\.io/sc-config}'`,
-          { failOnNonZeroExit: false },
-        )
+        .exec(command, { failOnNonZeroExit: false })
         .then((result: Cypress.Exec) => {
           if (result.code !== 0) {
             cy.log(`ERROR Getting ${scNames[index]} Storage Class Config

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -95,26 +95,29 @@ export const parseStorageClassConfig = (result: CommandLineResult): StorageClass
  * Verify Storage Class Configuration retrieving the info using OC
  *
  * @param scName - Storage Class to verify
- * @param expectedIsDefault expected isDefault
- * @param expectedIsEnabled expected isEnabled
+ * @param expectedIsDefault (Optional) expected isDefault
+ * @param expectedIsEnabled (Optional) expected isEnabled
  * @param expectedDisplayName (Optional) expected Display Name
  * @param expectedDescription (Optional) expected Description
  */
 export const verifyStorageClassConfig = (
   scName: string,
-  expectedIsDefault: boolean,
-  expectedIsEnabled: boolean,
+  expectedIsDefault?: boolean,
+  expectedIsEnabled?: boolean,
   expectedDisplayName?: string,
   expectedDescription?: string,
 ): Cypress.Chainable<CommandLineResult> => {
   return getStorageClassConfig(scName).then((result) => {
     const config = parseStorageClassConfig(result);
 
-    // Check mandatory fields
-    cy.wrap(config.isDefault).should('equal', expectedIsDefault);
-    cy.wrap(config.isEnabled).should('equal', expectedIsEnabled);
+    if (expectedIsDefault !== undefined) {
+      cy.wrap(config.isDefault).should('equal', expectedIsDefault);
+    }
 
-    // Check optional fields if provided
+    if (expectedIsEnabled !== undefined) {
+      cy.wrap(config.isEnabled).should('equal', expectedIsEnabled);
+    }
+
     if (expectedDisplayName !== undefined) {
       cy.wrap(config.displayName).should('equal', expectedDisplayName);
     }

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -1,14 +1,13 @@
-import { createOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import { createDataConnection } from '~/__tests__/cypress/cypress/utils/oc_commands/dataConnection';
-import { createDSPASecret, createDSPA } from '~/__tests__/cypress/cypress/utils/oc_commands/dspa';
-import { AWS_BUCKETS } from '~/__tests__/cypress/cypress/utils/s3Buckets';
-import type { CommandLineResult, StorageClassConfig } from '~/__tests__/cypress/cypress/types';
+import type {
+  CommandLineResult,
+  StorageClassConfig,
+  SCReplacements,
+} from '~/__tests__/cypress/cypress/types';
 import {
   createStorageClass,
   deleteStorageClass,
   getStorageClassConfig,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
-import type { SCReplacements } from '~/__tests__/cypress/cypress/types';
 
 /**
  * Provision (using oc) all necessary resources for the Storage Class testing feature
@@ -19,7 +18,7 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
   const createdStorageClasses: string[] = [];
 
   //Provision a disabled non-default sc
-  const scNameDisabledNonDefault = scName + '-disabled-non-default';
+  const scNameDisabledNonDefault = `${scName}-disabled-non-default`;
   let SCReplacement: SCReplacements = {
     SC_NAME: scNameDisabledNonDefault,
     SC_IS_DEFAULT: 'false',
@@ -29,7 +28,7 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
   createdStorageClasses.push(scNameDisabledNonDefault);
 
   //Provision an enabled non-default sc
-  const scNameEnabledNonDefault = scName + '-enabled-non-default';
+  const scNameEnabledNonDefault = `${scName}-enabled-non-default`;
   SCReplacement = {
     SC_NAME: scNameEnabledNonDefault,
     SC_IS_DEFAULT: 'false',
@@ -39,7 +38,7 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
   createdStorageClasses.push(scNameEnabledNonDefault);
 
   //Provision an enabled non-default sc in order to set it as default
-  const scNameEnabledToDefault = scName + '-enabled-to-default';
+  const scNameEnabledToDefault = `${scName}-enabled-to-default`;
   SCReplacement = {
     SC_NAME: scNameEnabledToDefault,
     SC_IS_DEFAULT: 'false',
@@ -49,7 +48,7 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
   createdStorageClasses.push(scNameEnabledToDefault);
 
   //Provision an enabled non-default sc in order to set it as default
-  const scNameEnabledAndDefault = scName + '-enabled-and-default';
+  const scNameEnabledAndDefault = `${scName}-enabled-and-default`;
   SCReplacement = {
     SC_NAME: scNameEnabledAndDefault,
     SC_IS_DEFAULT: 'false',
@@ -64,7 +63,7 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
 export const tearDownStorageClassFeature = (createdSC: string[]): void => {
   createdSC.forEach((scName) => {
     cy.log(`Deleting storage class: os-sc-${scName}`);
-    deleteStorageClass('os-sc-' + scName);
+    deleteStorageClass(`os-sc-${scName}`);
   });
 };
 

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -1,0 +1,164 @@
+import { createOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
+import { createDataConnection } from '~/__tests__/cypress/cypress/utils/oc_commands/dataConnection';
+import { createDSPASecret, createDSPA } from '~/__tests__/cypress/cypress/utils/oc_commands/dspa';
+import { AWS_BUCKETS } from '~/__tests__/cypress/cypress/utils/s3Buckets';
+import type { CommandLineResult, StorageClassConfig } from '~/__tests__/cypress/cypress/types';
+import {
+  createStorageClass,
+  deleteStorageClass,
+  getStorageClassConfig,
+} from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
+import type { SCReplacements } from '~/__tests__/cypress/cypress/types';
+
+/**
+ * Provision (using oc) all necessary resources for the Storage Class testing feature
+ *
+ * @param scName Project Name
+ */
+export const provisionStorageClassFeature = (scName: string): string[] => {
+  const createdStorageClasses: string[] = [];
+
+  //Provision a disabled non-default sc
+  const scNameDisabledNonDefault = scName + '-disabled-non-default';
+  let SCReplacement: SCReplacements = {
+    SC_NAME: scNameDisabledNonDefault,
+    SC_IS_DEFAULT: 'false',
+    SC_IS_ENABLED: 'false',
+  };
+  createStorageClass(SCReplacement);
+  createdStorageClasses.push(scNameDisabledNonDefault);
+
+  //Provision an enabled non-default sc
+  const scNameEnabledNonDefault = scName + '-enabled-non-default';
+  SCReplacement = {
+    SC_NAME: scNameEnabledNonDefault,
+    SC_IS_DEFAULT: 'false',
+    SC_IS_ENABLED: 'true',
+  };
+  createStorageClass(SCReplacement);
+  createdStorageClasses.push(scNameEnabledNonDefault);
+
+  //Provision an enabled non-default sc in order to set it as default
+  const scNameEnabledToDefault = scName + '-enabled-to-default';
+  SCReplacement = {
+    SC_NAME: scNameEnabledToDefault,
+    SC_IS_DEFAULT: 'false',
+    SC_IS_ENABLED: 'true',
+  };
+  createStorageClass(SCReplacement);
+  createdStorageClasses.push(scNameEnabledToDefault);
+
+  //Provision an enabled non-default sc in order to set it as default
+  const scNameEnabledAndDefault = scName + '-enabled-and-default';
+  SCReplacement = {
+    SC_NAME: scNameEnabledAndDefault,
+    SC_IS_DEFAULT: 'false',
+    SC_IS_ENABLED: 'true',
+  };
+  createStorageClass(SCReplacement);
+  createdStorageClasses.push(scNameEnabledAndDefault);
+
+  return createdStorageClasses;
+};
+
+export const tearDownStorageClassFeature = (createdSC: string[]): void => {
+  createdSC.forEach((scName) => {
+    cy.log(`Deleting storage class: os-sc-${scName}`);
+    deleteStorageClass('os-sc-' + scName);
+  });
+};
+
+/**
+ * Parse Storage Class Configuration
+ *
+ * @param result Output from getStorageClassConfig
+ * @returns StorageClassConfig object
+ */
+export const parseStorageClassConfig = (result: CommandLineResult): StorageClassConfig => {
+  const rawConfig = JSON.parse(result.stdout);
+  const config: StorageClassConfig = {
+    isDefault: rawConfig.isDefault,
+    isEnabled: rawConfig.isEnabled,
+    displayName: rawConfig.displayName,
+    description: rawConfig.description,
+  };
+
+  // If description is undefined, remove it from the final object
+  if (config.description === undefined) {
+    delete config.description;
+  }
+
+  return config;
+};
+
+/**
+ * Verify Storage Class Configuration retrieving the info using OC
+ *
+ * @param scName - Storage Class to verify
+ * @param expectedIsDefault expected isDefault
+ * @param expectedIsEnabled expected isEnabled
+ * @param expectedDisplayName (Optional) expected Display Name
+ * @param expectedDescription (Optional) expected Description
+ */
+export const verifyStorageClassConfig = (
+  scName: string,
+  expectedIsDefault: boolean,
+  expectedIsEnabled: boolean,
+  expectedDisplayName?: string,
+  expectedDescription?: string,
+): Cypress.Chainable<CommandLineResult> => {
+  return getStorageClassConfig(scName).then((result) => {
+    const config = parseStorageClassConfig(result);
+
+    // Check mandatory fields
+    cy.wrap(config.isDefault).should('equal', expectedIsDefault);
+    cy.wrap(config.isEnabled).should('equal', expectedIsEnabled);
+
+    // Check optional fields if provided
+    if (expectedDisplayName !== undefined) {
+      cy.wrap(config.displayName).should('equal', expectedDisplayName);
+    }
+
+    if (expectedDescription !== undefined) {
+      if (expectedDescription === '') {
+        cy.wrap(config.description).should('be.undefined');
+      } else {
+        cy.wrap(config.description).should('equal', expectedDescription);
+      }
+    }
+    cy.log('Storage Class Config:', JSON.stringify(config));
+    return cy.wrap(result);
+  });
+};
+
+// // Provision a Project
+// createOpenShiftProject(projectName);
+
+// // Create a pipeline compatible Data Connection
+// const dataConnectionReplacements: DataConnectionReplacements = {
+//   NAMESPACE: projectName,
+//   AWS_ACCESS_KEY_ID: Buffer.from(AWS_BUCKETS.AWS_ACCESS_KEY_ID).toString('base64'),
+//   AWS_DEFAULT_REGION: Buffer.from(AWS_BUCKETS.BUCKET_2.REGION).toString('base64'),
+//   AWS_S3_BUCKET: Buffer.from(AWS_BUCKETS.BUCKET_2.NAME).toString('base64'),
+//   AWS_S3_ENDPOINT: Buffer.from(AWS_BUCKETS.BUCKET_2.ENDPOINT).toString('base64'),
+//   AWS_SECRET_ACCESS_KEY: Buffer.from(AWS_BUCKETS.AWS_SECRET_ACCESS_KEY).toString('base64'),
+// };
+// createDataConnection(dataConnectionReplacements);
+
+// // Configure Pipeline server: Create DSPA Secret
+// const dspaSecretReplacements: DspaSecretReplacements = {
+//   DSPA_SECRET_NAME: dspaSecretName,
+//   NAMESPACE: projectName,
+//   AWS_ACCESS_KEY_ID: Buffer.from(AWS_BUCKETS.AWS_ACCESS_KEY_ID).toString('base64'),
+//   AWS_SECRET_ACCESS_KEY: Buffer.from(AWS_BUCKETS.AWS_SECRET_ACCESS_KEY).toString('base64'),
+// };
+// createDSPASecret(dspaSecretReplacements);
+
+// // Configure Pipeline server: Create DSPA
+// const dspaReplacements: DspaReplacements = {
+//   DSPA_SECRET_NAME: dspaSecretName,
+//   NAMESPACE: projectName,
+//   AWS_S3_BUCKET: AWS_BUCKETS.BUCKET_2.NAME,
+// };
+// createDSPA(dspaReplacements);
+// };

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -79,37 +79,10 @@ export const tearDownStorageClassFeature = (createdSC: string[]): void => {
  *
  * @param scName Project Name
  */
-export const provisionClusterStorageSCFeature = (
-  projectName: string,
-  userName: string,
-  scName: string,
-): string[] => {
+export const provisionClusterStorageSCFeature = (projectName: string, userName: string): void => {
   // Provision a Project
   createOpenShiftProject(projectName);
   addUserToProject(projectName, userName);
-
-  const createdStorageClasses: string[] = [];
-  // Provision an enabled SC
-  const scNameEnabledToDefault = `${scName}-enabled`;
-  let SCReplacement: SCReplacements = {
-    SC_NAME: scNameEnabledToDefault,
-    SC_IS_DEFAULT: 'false',
-    SC_IS_ENABLED: 'true',
-  };
-  createStorageClass(SCReplacement);
-  createdStorageClasses.push(scNameEnabledToDefault);
-
-  // Provision an enabled SC
-  const scNameDisabledToDefault = `${scName}-disabled`;
-  SCReplacement = {
-    SC_NAME: scNameDisabledToDefault,
-    SC_IS_DEFAULT: 'false',
-    SC_IS_ENABLED: 'false',
-  };
-  createStorageClass(SCReplacement);
-  createdStorageClasses.push(scNameDisabledToDefault);
-
-  return createdStorageClasses;
 };
 
 /**
@@ -118,14 +91,9 @@ export const provisionClusterStorageSCFeature = (
  *
  * @param scName Project Name
  */
-export const tearDownClusterStorageSCFeature = (projectName: string, createdSC: string[]): void => {
+export const tearDownClusterStorageSCFeature = (projectName: string): void => {
   // Delete provisioned projectName
   deleteOpenShiftProject(projectName);
-  // Delete provisioned SCs
-  createdSC.forEach((scName) => {
-    cy.log(`Deleting storage class:${scName}`);
-    deleteStorageClass(scName);
-  });
 };
 
 /**

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -68,8 +68,8 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
 
 export const tearDownStorageClassFeature = (createdSC: string[]): void => {
   createdSC.forEach((scName) => {
-    cy.log(`Deleting storage class: os-sc-${scName}`);
-    deleteStorageClass(`os-sc-${scName}`);
+    cy.log(`Deleting storage class: ${scName}`);
+    deleteStorageClass(scName);
   });
 };
 
@@ -123,8 +123,8 @@ export const tearDownClusterStorageSCFeature = (projectName: string, createdSC: 
   deleteOpenShiftProject(projectName);
   // Delete provisioned SCs
   createdSC.forEach((scName) => {
-    cy.log(`Deleting storage class: os-sc-${scName}`);
-    deleteStorageClass(`os-sc-${scName}`);
+    cy.log(`Deleting storage class:${scName}`);
+    deleteStorageClass(scName);
   });
 };
 

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -53,16 +53,6 @@ export const provisionStorageClassFeature = (scName: string): string[] => {
   createStorageClass(SCReplacement);
   createdStorageClasses.push(scNameEnabledToDefault);
 
-  //Provision an enabled non-default sc in order to set it as default
-  const scNameEnabledAndDefault = `${scName}-enabled-and-default`;
-  SCReplacement = {
-    SC_NAME: scNameEnabledAndDefault,
-    SC_IS_DEFAULT: 'false',
-    SC_IS_ENABLED: 'true',
-  };
-  createStorageClass(SCReplacement);
-  createdStorageClasses.push(scNameEnabledAndDefault);
-
   return createdStorageClasses;
 };
 

--- a/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
+++ b/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
@@ -55,6 +55,7 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({ activeKey, 
               key={section.id}
               eventKey={section.id}
               tabContentId={section.id}
+              data-testid={`${section.id}-tab`}
               title={
                 <>
                   {section.icon && <TabTitleIcon>{section.icon}</TabTitleIcon>}

--- a/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
@@ -42,6 +42,7 @@ const StorageList: React.FC = () => {
             onClick={() => setOpen(true)}
             key={`action-${ProjectSectionID.CLUSTER_STORAGES}`}
             variant="primary"
+            data-testid="actions-cluster-storage-button"
           >
             Add cluster storage
           </Button>,

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -67,7 +67,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
           <SplitItem isFilled />
           <SplitItem>
             {config?.isDefault && (
-              <Label isCompact color="green">
+              <Label isCompact color="green" data-testid="is-default-label">
                 Default class
               </Label>
             )}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-11613

## Description
e2e Cypress test cases for Storage Class Feature

Settings->Storage class view:
- A non admin user can not acccess to Settings -> Storage classes view
- The Default label is shown in the grid
- An admin user can enable a disabled Storage Class
- An admin user can disable an enabled Storage Class
- An admin user can set an enabled Storage Class as the default one
- An admin user can edit an Storage Class

Cluster Storage view from the Cluster Storage DSP tab:
- Regular user can create a cluster storage using a new storage class
- A Cluster Storage with a disabled SC shows the deprecated warning
- If all SC are disabled except one, the SC dropdown should be disabled

## How Has This Been Tested?
As there were some UI changes, the tests ran against the local UI and a 2.14 cluster as the backend

![image](https://github.com/user-attachments/assets/ce2a43f3-fe3f-4f74-b82c-dc176f6fa65d)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
