### PR TITLE
Conditionally render delete modals

### DIFF
--- a/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
@@ -81,7 +81,7 @@ const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerPro
             </EmptyStateFooter>
           </EmptyState>
         </Bullseye>
-        <DeleteServerModal isOpen={isDeleting} onClose={() => setIsDeleting(false)} />
+        {isDeleting ? <DeleteServerModal onClose={() => setIsDeleting(false)} /> : null}
       </>
     );
   }

--- a/frontend/src/concepts/pipelines/content/DeletePipelineRunsModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelineRunsModal.tsx
@@ -33,10 +33,13 @@ const DeletePipelineRunsModal: React.FC<DeletePipelineRunsModalProps> = ({
   const resourceCount = toDeleteResources.length;
   const typeCategory = runTypeCategory[type];
 
+  if (!resourceCount) {
+    return null;
+  }
+
   return (
     <DeleteModal
       title={`Delete ${typeCategory}${resourceCount > 1 ? 's' : ''}?`}
-      isOpen={resourceCount !== 0}
       onClose={() => onBeforeClose(false)}
       deleting={deleting}
       error={error}

--- a/frontend/src/concepts/pipelines/content/DeletePipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelineServerModal.tsx
@@ -5,14 +5,10 @@ import { deleteServer } from '~/concepts/pipelines/utils';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 
 type DeletePipelineServerModalProps = {
-  isOpen: boolean;
   onClose: (deleted: boolean) => void;
 };
 
-const DeletePipelineServerModal: React.FC<DeletePipelineServerModalProps> = ({
-  isOpen,
-  onClose,
-}) => {
+const DeletePipelineServerModal: React.FC<DeletePipelineServerModalProps> = ({ onClose }) => {
   const [deleting, setDeleting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
   const { project, namespace, pipelinesServer } = usePipelinesAPI();
@@ -26,7 +22,6 @@ const DeletePipelineServerModal: React.FC<DeletePipelineServerModalProps> = ({
   return (
     <DeleteModal
       title="Delete pipeline server?"
-      isOpen={isOpen}
       onClose={() => onBeforeClose(false)}
       deleting={deleting}
       error={error}

--- a/frontend/src/concepts/pipelines/content/DeletePipelinesModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelinesModal.tsx
@@ -8,14 +8,12 @@ import DeletePipelineModalExpandableSection from '~/concepts/pipelines/content/D
 import { getPipelineAndVersionDeleteString } from '~/concepts/pipelines/content/utils';
 
 type DeletePipelinesModalProps = {
-  isOpen: boolean;
   toDeletePipelines?: PipelineKFv2[];
   toDeletePipelineVersions?: { pipelineName: string; version: PipelineVersionKFv2 }[];
   onClose: (deleted?: boolean) => void;
 };
 
 const DeletePipelinesModal: React.FC<DeletePipelinesModalProps> = ({
-  isOpen,
   toDeletePipelines = [],
   toDeletePipelineVersions = [],
   onClose,
@@ -79,7 +77,6 @@ const DeletePipelinesModal: React.FC<DeletePipelinesModalProps> = ({
   return (
     <DeleteModal
       title={deleteTitle}
-      isOpen={isOpen}
       onClose={() => onBeforeClose(false)}
       deleting={deleting}
       error={error}

--- a/frontend/src/concepts/pipelines/content/PipelineServerActions.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineServerActions.tsx
@@ -107,25 +107,27 @@ const PipelineServerActions: React.FC<PipelineServerActionsProps> = ({ variant, 
   return (
     <>
       {DropdownComponent}
-      <DeleteServerModal
-        isOpen={deleteOpen}
-        onClose={() => {
-          setDeleteOpen(false);
-        }}
-      />
+      {deleteOpen ? (
+        <DeleteServerModal
+          onClose={() => {
+            setDeleteOpen(false);
+          }}
+        />
+      ) : null}
       <ViewServerModal isOpen={viewOpen} onClose={() => setViewOpen(false)} />
-      <DeletePipelinesModal
-        isOpen={deletePipelinesOpen}
-        toDeletePipelines={pipelines}
-        toDeletePipelineVersions={versions}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshAllAPI();
-            clearAfterDeletion();
-          }
-          setDeletePipelinesOpen(false);
-        }}
-      />
+      {deletePipelinesOpen ? (
+        <DeletePipelinesModal
+          toDeletePipelines={pipelines}
+          toDeletePipelineVersions={versions}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshAllAPI();
+              clearAfterDeletion();
+            }
+            setDeletePipelinesOpen(false);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipeline/PipelineDetails.tsx
@@ -257,9 +257,8 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
           </PageSection>
         )}
       </ApplicationsPage>
-      {pipeline && (
+      {pipeline && isDeletionOpen ? (
         <DeletePipelinesModal
-          isOpen={isDeletionOpen}
           toDeletePipelineVersions={
             pipelineVersion
               ? [{ pipelineName: pipeline.display_name, version: pipelineVersion }]
@@ -272,7 +271,7 @@ const PipelineDetails: PipelineCoreDetailsPageComponent = ({ breadcrumbPath }) =
             }
           }}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ArchivedExperimentTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ArchivedExperimentTable.tsx
@@ -60,10 +60,12 @@ const ArchivedExperimentTable: React.FC<ArchivedExperimentTableProps> = ({ ...ba
         experiments={restoreExperiments}
         onCancel={() => setIsRestoreModalOpen(false)}
       />
-      <DeleteExperimentModal
-        onCancel={() => setDeleteExperiment(undefined)}
-        experiment={deleteExperiment}
-      />
+      {deleteExperiment ? (
+        <DeleteExperimentModal
+          onCancel={() => setDeleteExperiment(undefined)}
+          experiment={deleteExperiment}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTable.tsx
@@ -95,16 +95,17 @@ const PipelinesTable: React.FC<PipelinesTableProps> = ({
         })}
         data-testid="pipelines-table"
       />
-      <DeletePipelinesModal
-        isOpen={deletePipelines.length !== 0}
-        toDeletePipelines={deletePipelines}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshAllAPI();
-          }
-          setDeletePipelines([]);
-        }}
-      />
+      {deletePipelines.length ? (
+        <DeletePipelinesModal
+          toDeletePipelines={deletePipelines}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshAllAPI();
+            }
+            setDeletePipelines([]);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTable.tsx
@@ -98,16 +98,17 @@ const PipelineVersionTable: React.FC<PipelineVersionTableProps> = ({
         }
         data-testid="pipeline-versions-table"
       />
-      <DeletePipelinesModal
-        isOpen={deleteVersions.length !== 0}
-        toDeletePipelineVersions={deleteVersions}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshAllAPI();
-          }
-          setDeleteVersions([]);
-        }}
-      />
+      {deleteVersions.length ? (
+        <DeletePipelinesModal
+          toDeletePipelineVersions={deleteVersions}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshAllAPI();
+            }
+            setDeleteVersions([]);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
+++ b/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
@@ -249,17 +249,10 @@ export const CreatePipelineServerButton: React.FC<CreatePipelineServerButtonProp
   );
 };
 
-export const DeleteServerModal = ({
-  isOpen,
-  onClose,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-}): React.JSX.Element => {
+export const DeleteServerModal = ({ onClose }: { onClose: () => void }): React.JSX.Element => {
   const { refreshState } = React.useContext(PipelinesContext);
   return (
     <DeletePipelineServerModal
-      isOpen={isOpen}
       onClose={(deleted) => {
         if (deleted) {
           refreshState().then(onClose);

--- a/frontend/src/concepts/trustyai/content/DeleteTrustyAIModal.tsx
+++ b/frontend/src/concepts/trustyai/content/DeleteTrustyAIModal.tsx
@@ -2,19 +2,17 @@ import React from 'react';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
 
 type DeleteTrustyAIModalProps = {
-  isOpen: boolean;
   onDelete: () => Promise<unknown>;
   onClose: (deleted: boolean) => void;
 };
 
-const DeleteTrustyAIModal: React.FC<DeleteTrustyAIModalProps> = ({ isOpen, onDelete, onClose }) => {
+const DeleteTrustyAIModal: React.FC<DeleteTrustyAIModalProps> = ({ onDelete, onClose }) => {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [error, setError] = React.useState<Error>();
 
   return (
     <DeleteModal
       title="Uninstall TrustyAI"
-      isOpen={isOpen}
       onClose={() => {
         setIsDeleting(false);
         setError(undefined);

--- a/frontend/src/concepts/trustyai/content/InstallTrustyAICheckbox.tsx
+++ b/frontend/src/concepts/trustyai/content/InstallTrustyAICheckbox.tsx
@@ -47,13 +47,14 @@ const InstallTrustyAICheckbox: React.FC<InstallTrustyAICheckboxProps> = ({
         data-testid="trustyai-service-installation"
         name="TrustyAI service installation status"
       />
-      <DeleteTrustyAIModal
-        isOpen={open}
-        onDelete={onDelete}
-        onClose={() => {
-          setOpen(false);
-        }}
-      />
+      {open ? (
+        <DeleteTrustyAIModal
+          onDelete={onDelete}
+          onClose={() => {
+            setOpen(false);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/BYONImages/BYONImageModal/DeleteBYONImageModal.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageModal/DeleteBYONImageModal.tsx
@@ -4,7 +4,7 @@ import { BYONImage } from '~/types';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
 
 export type DeleteBYONImageModalProps = {
-  image?: BYONImage;
+  image: BYONImage;
   onClose: (deleted: boolean) => void;
 };
 
@@ -18,26 +18,23 @@ const DeleteBYONImageModal: React.FC<DeleteBYONImageModalProps> = ({ image, onCl
     setError(undefined);
   };
 
-  const deleteName = image?.display_name || 'this notebook image';
+  const deleteName = image.display_name;
 
   return (
     <DeleteModal
       title="Delete notebook image?"
-      isOpen={!!image}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete notebook image"
       onDelete={() => {
-        if (image) {
-          setIsDeleting(true);
-          deleteBYONImage(image)
-            .then(() => {
-              onBeforeClose(true);
-            })
-            .catch((e) => {
-              setError(e);
-              setIsDeleting(false);
-            });
-        }
+        setIsDeleting(true);
+        deleteBYONImage(image)
+          .then(() => {
+            onBeforeClose(true);
+          })
+          .catch((e) => {
+            setError(e);
+            setIsDeleting(false);
+          });
       }}
       deleting={isDeleting}
       error={error}

--- a/frontend/src/pages/BYONImages/BYONImagesTable.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTable.tsx
@@ -94,15 +94,17 @@ export const BYONImagesTable: React.FC<BYONImagesTableProps> = ({ images, refres
           </>
         }
       />
-      <DeleteBYONImageModal
-        image={deleteImage}
-        onClose={(deleted) => {
-          if (deleted) {
-            refresh();
-          }
-          setDeleteImage(undefined);
-        }}
-      />
+      {deleteImage ? (
+        <DeleteBYONImageModal
+          image={deleteImage}
+          onClose={(deleted) => {
+            if (deleted) {
+              refresh();
+            }
+            setDeleteImage(undefined);
+          }}
+        />
+      ) : null}
       <ManageBYONImageModal
         isOpen={!!editImage}
         onClose={(updated) => {

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTable.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTable.tsx
@@ -83,15 +83,17 @@ const AcceleratorProfilesTable: React.FC<AcceleratorProfilesTableProps> = ({
           </>
         }
       />
-      <DeleteAcceleratorProfileModal
-        acceleratorProfile={deleteAcceleratorProfile}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshAcceleratorProfiles();
-          }
-          setDeleteAcceleratorProfile(undefined);
-        }}
-      />
+      {deleteAcceleratorProfile ? (
+        <DeleteAcceleratorProfileModal
+          acceleratorProfile={deleteAcceleratorProfile}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshAcceleratorProfiles();
+            }
+            setDeleteAcceleratorProfile(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/acceleratorProfiles/screens/list/DeleteAcceleratorProfileModal.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/DeleteAcceleratorProfileModal.tsx
@@ -4,7 +4,7 @@ import { AcceleratorProfileKind } from '~/k8sTypes';
 import { deleteAcceleratorProfile } from '~/services/acceleratorProfileService';
 
 type DeleteAcceleratorProfileModalProps = {
-  acceleratorProfile?: AcceleratorProfileKind;
+  acceleratorProfile: AcceleratorProfileKind;
   onClose: (deleted: boolean) => void;
 };
 
@@ -21,26 +21,23 @@ const DeleteAcceleratorProfileModal: React.FC<DeleteAcceleratorProfileModalProps
     setError(undefined);
   };
 
-  const deleteName = acceleratorProfile?.spec.displayName || 'this accelerator profile';
+  const deleteName = acceleratorProfile.spec.displayName;
 
   return (
     <DeleteModal
       title="Delete accelerator profile?"
-      isOpen={!!acceleratorProfile}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete"
       onDelete={() => {
-        if (acceleratorProfile) {
-          setIsDeleting(true);
-          deleteAcceleratorProfile(acceleratorProfile.metadata.name)
-            .then(() => {
-              onBeforeClose(true);
-            })
-            .catch((e) => {
-              setError(e);
-              setIsDeleting(false);
-            });
-        }
+        setIsDeleting(true);
+        deleteAcceleratorProfile(acceleratorProfile.metadata.name)
+          .then(() => {
+            onBeforeClose(true);
+          })
+          .catch((e) => {
+            setError(e);
+            setIsDeleting(false);
+          });
       }}
       deleting={isDeleting}
       error={error}

--- a/frontend/src/pages/connectionTypes/DeleteConnectionTypeModal.tsx
+++ b/frontend/src/pages/connectionTypes/DeleteConnectionTypeModal.tsx
@@ -27,7 +27,6 @@ const DeleteConnectionTypeModal: React.FC<DeleteConnectionTypeModalProps> = ({
   return (
     <DeleteModal
       title="Delete connection type?"
-      isOpen={!!connectionType}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete"
       onDelete={() => {

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeListView.tsx
@@ -70,15 +70,17 @@ const CustomServingRuntimeListView: React.FC = () => {
           </ToolbarItem>
         }
       />
-      <DeleteCustomServingRuntimeModal
-        template={deleteTemplate}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshData();
-          }
-          setDeleteTemplate(undefined);
-        }}
-      />
+      {deleteTemplate ? (
+        <DeleteCustomServingRuntimeModal
+          template={deleteTemplate}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshData();
+            }
+            setDeleteTemplate(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/customServingRuntimes/DeleteCustomServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/DeleteCustomServingRuntimeModal.tsx
@@ -12,7 +12,7 @@ import {
 import { CustomServingRuntimeContext } from './CustomServingRuntimeContext';
 
 type DeleteCustomServingRuntimeModalProps = {
-  template?: TemplateKind;
+  template: TemplateKind;
   onClose: (deleted: boolean) => void;
 };
 
@@ -36,45 +36,40 @@ const DeleteCustomServingRuntimeModal: React.FC<DeleteCustomServingRuntimeModalP
     setError(undefined);
   };
 
-  const deleteName = template
-    ? getServingRuntimeDisplayNameFromTemplate(template)
-    : 'this serving runtime';
+  const deleteName = getServingRuntimeDisplayNameFromTemplate(template);
 
   return (
     <DeleteModal
       title="Delete serving runtime?"
-      isOpen={!!template}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete serving runtime"
       onDelete={() => {
-        if (template) {
-          setIsDeleting(true);
-          // TODO: Revert back to pass through api once we migrate admin panel
-          const templateDisablemetUpdated = setListDisabled(
-            template,
-            templates,
-            templateDisablement,
-            false,
-          );
-          Promise.all([
-            ...(!getTemplateEnabled(template, templateDisablement)
-              ? [
-                  patchDashboardConfigTemplateDisablementBackend(
-                    templateDisablemetUpdated,
-                    dashboardNamespace,
-                  ),
-                ]
-              : []),
-            deleteTemplateBackend(template.metadata.name, template.metadata.namespace),
-          ])
-            .then(() => {
-              onBeforeClose(true);
-            })
-            .catch((e) => {
-              setError(e);
-              setIsDeleting(false);
-            });
-        }
+        setIsDeleting(true);
+        // TODO: Revert back to pass through api once we migrate admin panel
+        const templateDisablemetUpdated = setListDisabled(
+          template,
+          templates,
+          templateDisablement,
+          false,
+        );
+        Promise.all([
+          ...(!getTemplateEnabled(template, templateDisablement)
+            ? [
+                patchDashboardConfigTemplateDisablementBackend(
+                  templateDisablemetUpdated,
+                  dashboardNamespace,
+                ),
+              ]
+            : []),
+          deleteTemplateBackend(template.metadata.name, template.metadata.namespace),
+        ])
+          .then(() => {
+            onBeforeClose(true);
+          })
+          .catch((e) => {
+            setError(e);
+            setIsDeleting(false);
+          });
       }}
       deleting={isDeleting}
       error={error}

--- a/frontend/src/pages/modelServing/screens/global/DeleteInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/global/DeleteInferenceServiceModal.tsx
@@ -10,14 +10,12 @@ type DeleteInferenceServiceModalProps = {
   inferenceService?: InferenceServiceKind;
   servingRuntime?: ServingRuntimeKind;
   onClose: (deleted: boolean) => void;
-  isOpen?: boolean;
 };
 
 const DeleteInferenceServiceModal: React.FC<DeleteInferenceServiceModalProps> = ({
   inferenceService,
   servingRuntime,
   onClose,
-  isOpen = false,
 }) => {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
@@ -39,7 +37,6 @@ const DeleteInferenceServiceModal: React.FC<DeleteInferenceServiceModalProps> = 
   return (
     <DeleteModal
       title="Delete deployed model?"
-      isOpen={isOpen}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete deployed model"
       onDelete={() => {

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -82,27 +82,28 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
           </ResourceTr>
         )}
       />
-      <DeleteInferenceServiceModal
-        isOpen={!!deleteInferenceService}
-        inferenceService={deleteInferenceService}
-        servingRuntime={
-          deleteInferenceService && !isModelMesh(deleteInferenceService)
-            ? servingRuntimes.find(
-                (sr) => sr.metadata.name === deleteInferenceService.spec.predictor.model?.runtime,
-              )
-            : undefined
-        }
-        onClose={(deleted) => {
-          fireFormTrackingEvent('Model Deleted', {
-            outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
-            type: 'multi',
-          });
-          if (deleted) {
-            refresh?.();
+      {deleteInferenceService ? (
+        <DeleteInferenceServiceModal
+          inferenceService={deleteInferenceService}
+          servingRuntime={
+            !isModelMesh(deleteInferenceService)
+              ? servingRuntimes.find(
+                  (sr) => sr.metadata.name === deleteInferenceService.spec.predictor.model?.runtime,
+                )
+              : undefined
           }
-          setDeleteInferenceService(undefined);
-        }}
-      />
+          onClose={(deleted) => {
+            fireFormTrackingEvent('Model Deleted', {
+              outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
+              type: 'multi',
+            });
+            if (deleted) {
+              refresh?.();
+            }
+            setDeleteInferenceService(undefined);
+          }}
+        />
+      ) : null}
       <ManageInferenceServiceModal
         isOpen={!!editInferenceService && isModelMesh(editInferenceService)}
         editInfo={editInferenceService}

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/DeleteBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/DeleteBiasConfigurationModal.tsx
@@ -5,7 +5,7 @@ import { BiasMetricConfig } from '~/concepts/trustyai/types';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
 
 type DeleteBiasConfigurationModalProps = {
-  configurationToDelete?: BiasMetricConfig;
+  configurationToDelete: BiasMetricConfig;
   onClose: (deleted: boolean) => void;
 };
 
@@ -25,31 +25,27 @@ const DeleteBiasConfigurationModal: React.FC<DeleteBiasConfigurationModalProps> 
     setError(undefined);
   };
 
-  const displayName = configurationToDelete ? configurationToDelete.name : 'this bias metric';
   return (
     <DeleteModal
       title="Delete bias metric?"
-      isOpen={!!configurationToDelete}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete bias metric"
       onDelete={() => {
-        if (configurationToDelete) {
-          setDeleting(true);
-          const deleteFunc =
-            configurationToDelete.metricType === BiasMetricType.DIR
-              ? api.deleteDirRequest
-              : api.deleteSpdRequest;
-          deleteFunc({}, configurationToDelete.id)
-            .then(() => onBeforeClose(true))
-            .catch((e) => {
-              setError(e);
-              setDeleting(false);
-            });
-        }
+        setDeleting(true);
+        const deleteFunc =
+          configurationToDelete.metricType === BiasMetricType.DIR
+            ? api.deleteDirRequest
+            : api.deleteSpdRequest;
+        deleteFunc({}, configurationToDelete.id)
+          .then(() => onBeforeClose(true))
+          .catch((e) => {
+            setError(e);
+            setDeleting(false);
+          });
       }}
       deleting={isDeleting}
       error={error}
-      deleteName={displayName}
+      deleteName={configurationToDelete.name}
     >
       This action cannot be undone.
     </DeleteModal>

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationTable.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationTable.tsx
@@ -107,15 +107,17 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({
         }}
         inferenceService={inferenceService}
       />
-      <DeleteBiasConfigurationModal
-        configurationToDelete={deleteConfiguration}
-        onClose={(deleted) => {
-          if (deleted) {
-            refresh();
-          }
-          setDeleteConfiguration(undefined);
-        }}
-      />
+      {deleteConfiguration ? (
+        <DeleteBiasConfigurationModal
+          configurationToDelete={deleteConfiguration}
+          onClose={(deleted) => {
+            if (deleted) {
+              refresh();
+            }
+            setDeleteConfiguration(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -53,22 +53,23 @@ const KServeInferenceServiceTable: React.FC = () => {
           />
         )}
       />
-      <DeleteInferenceServiceModal
-        isOpen={!!deleteKserveResources}
-        inferenceService={deleteKserveResources?.inferenceService}
-        servingRuntime={deleteKserveResources?.servingRuntime}
-        onClose={(deleted) => {
-          fireFormTrackingEvent('Model Deleted', {
-            outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
-            type: 'single',
-          });
-          if (deleted) {
-            refreshServingRuntime();
-            refreshInferenceServices();
-          }
-          setDeleteKServeResources(undefined);
-        }}
-      />
+      {deleteKserveResources ? (
+        <DeleteInferenceServiceModal
+          inferenceService={deleteKserveResources.inferenceService}
+          servingRuntime={deleteKserveResources.servingRuntime}
+          onClose={(deleted) => {
+            fireFormTrackingEvent('Model Deleted', {
+              outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
+              type: 'single',
+            });
+            if (deleted) {
+              refreshServingRuntime();
+              refreshInferenceServices();
+            }
+            setDeleteKServeResources(undefined);
+          }}
+        />
+      ) : null}
       <ManageKServeModal
         isOpen={!!editKserveResources}
         editInfo={{

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
@@ -59,7 +59,7 @@ const ServingRuntimeTable: React.FC = () => {
           />
         )}
       />
-      {allowDelete && (
+      {allowDelete && deleteServingRuntime ? (
         <DeleteServingRuntimeModal
           servingRuntime={deleteServingRuntime}
           inferenceServices={inferenceServices}
@@ -73,7 +73,7 @@ const ServingRuntimeTable: React.FC = () => {
             setDeleteServingRuntime(undefined);
           }}
         />
-      )}
+      ) : null}
       <ManageServingRuntimeModal
         isOpen={editServingRuntime !== undefined}
         currentProject={currentProject}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/DeleteServingRuntimeModal.tsx
@@ -12,7 +12,7 @@ import { getTokenNames } from '~/pages/modelServing/utils';
 import { allSettledPromises } from '~/utilities/allSettledPromises';
 
 type DeleteServingRuntimeModalProps = {
-  servingRuntime?: ServingRuntimeKind;
+  servingRuntime: ServingRuntimeKind;
   inferenceServices: InferenceServiceKind[];
   onClose: (deleted: boolean) => void;
 };
@@ -34,47 +34,44 @@ const DeleteServingRuntimeModal: React.FC<DeleteServingRuntimeModalProps> = ({
   return (
     <DeleteModal
       title="Delete model server?"
-      isOpen={!!servingRuntime}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete model server"
       onDelete={() => {
-        if (servingRuntime) {
-          setIsDeleting(true);
+        setIsDeleting(true);
 
-          const { serviceAccountName, roleBindingName } = getTokenNames(
-            servingRuntime.metadata.name,
-            servingRuntime.metadata.namespace,
-          );
+        const { serviceAccountName, roleBindingName } = getTokenNames(
+          servingRuntime.metadata.name,
+          servingRuntime.metadata.namespace,
+        );
 
-          allSettledPromises<ServingRuntimeKind | K8sStatus>([
-            deleteServingRuntime(servingRuntime.metadata.name, servingRuntime.metadata.namespace),
-            ...inferenceServices
-              .filter(
-                (inferenceService) =>
-                  inferenceService.spec.predictor.model?.runtime === servingRuntime.metadata.name,
-              )
-              .map((inferenceService) =>
-                deleteInferenceService(
-                  inferenceService.metadata.name,
-                  inferenceService.metadata.namespace,
-                ),
+        allSettledPromises<ServingRuntimeKind | K8sStatus>([
+          deleteServingRuntime(servingRuntime.metadata.name, servingRuntime.metadata.namespace),
+          ...inferenceServices
+            .filter(
+              (inferenceService) =>
+                inferenceService.spec.predictor.model?.runtime === servingRuntime.metadata.name,
+            )
+            .map((inferenceService) =>
+              deleteInferenceService(
+                inferenceService.metadata.name,
+                inferenceService.metadata.namespace,
               ),
-            // for compatibility continue to delete related resources
-            deleteServiceAccount(serviceAccountName, servingRuntime.metadata.namespace),
-            deleteRoleBinding(roleBindingName, servingRuntime.metadata.namespace),
-          ])
-            .then(() => {
-              onBeforeClose(true);
-            })
-            .catch((e) => {
-              setError(e);
-              setIsDeleting(false);
-            });
-        }
+            ),
+          // for compatibility continue to delete related resources
+          deleteServiceAccount(serviceAccountName, servingRuntime.metadata.namespace),
+          deleteRoleBinding(roleBindingName, servingRuntime.metadata.namespace),
+        ])
+          .then(() => {
+            onBeforeClose(true);
+          })
+          .catch((e) => {
+            setError(e);
+            setIsDeleting(false);
+          });
       }}
       deleting={isDeleting}
       error={error}
-      deleteName={servingRuntime?.metadata.name || 'this model server'}
+      deleteName={servingRuntime.metadata.name || 'this model server'}
     >
       This action cannot be undone.
     </DeleteModal>

--- a/frontend/src/pages/pipelines/global/experiments/DeleteExperimentModal.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/DeleteExperimentModal.tsx
@@ -4,7 +4,7 @@ import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { ExperimentKFv2 } from '~/concepts/pipelines/kfTypes';
 
 type DeleteExperimentModalProps = {
-  experiment?: ExperimentKFv2;
+  experiment: ExperimentKFv2;
   onCancel: () => void;
 };
 
@@ -13,14 +13,9 @@ const DeleteExperimentModal: React.FC<DeleteExperimentModalProps> = ({ experimen
   const [error, setError] = React.useState<Error | undefined>();
   const { api, refreshAllAPI } = usePipelinesAPI();
 
-  if (!experiment) {
-    return null;
-  }
-
   return (
     <DeleteModal
       title="Delete experiment?"
-      isOpen={!!experiment}
       onClose={onCancel}
       deleting={isDeleting}
       error={error}

--- a/frontend/src/pages/pipelines/global/pipelines/GlobalPipelinesTableToolbar.tsx
+++ b/frontend/src/pages/pipelines/global/pipelines/GlobalPipelinesTableToolbar.tsx
@@ -75,18 +75,19 @@ const GlobalPipelinesTableToolbar: React.FC<GlobalPipelinesTableToolbarProps> = 
           />
         </ToolbarItem>
       </PipelineFilterBar>
-      <DeletePipelinesModal
-        isOpen={isDeletionOpen}
-        toDeletePipelines={pipelines}
-        toDeletePipelineVersions={versions}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshAllAPI();
-            clearAfterDeletion();
-          }
-          setDeletionOpen(false);
-        }}
-      />
+      {isDeletionOpen ? (
+        <DeletePipelinesModal
+          toDeletePipelines={pipelines}
+          toDeletePipelineVersions={versions}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshAllAPI();
+              clearAfterDeletion();
+            }
+            setDeletionOpen(false);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -12,7 +12,6 @@ import {
 
 type DeleteModalProps = {
   title: string;
-  isOpen: boolean;
   onClose: () => void;
   deleting: boolean;
   onDelete: () => void;
@@ -26,7 +25,6 @@ type DeleteModalProps = {
 const DeleteModal: React.FC<DeleteModalProps> = ({
   children,
   title,
-  isOpen,
   onClose,
   deleting,
   onDelete,
@@ -50,17 +48,11 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
     }
   };
 
-  React.useEffect(() => {
-    if (!isOpen) {
-      setValue('');
-    }
-  }, [isOpen]);
-
   return (
     <Modal
       title={title}
       titleIconVariant="warning"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose(false)}
       actions={[
         <Button

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -8,7 +8,7 @@ import { ConfigMapRef, SecretRef } from '~/pages/projects/types';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 
 type DeleteNotebookModalProps = {
-  notebook?: NotebookKind;
+  notebook: NotebookKind;
   onClose: (deleted: boolean) => void;
 };
 
@@ -22,44 +22,41 @@ const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onC
     setError(undefined);
   };
 
-  const displayName = notebook ? getDisplayNameFromK8sResource(notebook) : 'this workbench';
+  const displayName = getDisplayNameFromK8sResource(notebook);
 
   return (
     <DeleteModal
       title="Delete workbench?"
-      isOpen={!!notebook}
       onClose={() => onBeforeClose(false)}
       submitButtonLabel="Delete workbench"
       onDelete={() => {
-        if (notebook) {
-          setIsDeleting(true);
+        setIsDeleting(true);
 
-          const nonDataConnectionVariables = getEnvFromList(notebook).filter(
-            (envFrom) => !envFrom.secretRef?.name.includes(DATA_CONNECTION_PREFIX),
-          );
-          const configMapNames = nonDataConnectionVariables
-            .filter((envName): envName is ConfigMapRef => !!envName.configMapRef)
-            .map((data) => data.configMapRef.name);
-          const secretNames = nonDataConnectionVariables
-            .filter((envName): envName is SecretRef => !!envName.secretRef)
-            .map((data) => data.secretRef.name);
+        const nonDataConnectionVariables = getEnvFromList(notebook).filter(
+          (envFrom) => !envFrom.secretRef?.name.includes(DATA_CONNECTION_PREFIX),
+        );
+        const configMapNames = nonDataConnectionVariables
+          .filter((envName): envName is ConfigMapRef => !!envName.configMapRef)
+          .map((data) => data.configMapRef.name);
+        const secretNames = nonDataConnectionVariables
+          .filter((envName): envName is SecretRef => !!envName.secretRef)
+          .map((data) => data.secretRef.name);
 
-          const { namespace } = notebook.metadata;
+        const { namespace } = notebook.metadata;
 
-          const resourcesToDelete: Promise<K8sStatus>[] = [
-            deleteNotebook(notebook.metadata.name, namespace),
-            ...secretNames.map((name) => deleteSecret(namespace, name)),
-            ...configMapNames.map((name) => deleteConfigMap(namespace, name)),
-          ];
-          Promise.all(resourcesToDelete)
-            .then(() => {
-              onBeforeClose(true);
-            })
-            .catch((e) => {
-              setError(e);
-              setIsDeleting(false);
-            });
-        }
+        const resourcesToDelete: Promise<K8sStatus>[] = [
+          deleteNotebook(notebook.metadata.name, namespace),
+          ...secretNames.map((name) => deleteSecret(namespace, name)),
+          ...configMapNames.map((name) => deleteConfigMap(namespace, name)),
+        ];
+        Promise.all(resourcesToDelete)
+          .then(() => {
+            onBeforeClose(true);
+          })
+          .catch((e) => {
+            setError(e);
+            setIsDeleting(false);
+          });
       }}
       deleting={isDeleting}
       error={error}

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsDeleteModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsDeleteModal.tsx
@@ -56,7 +56,6 @@ export const ConnectionsDeleteModal: React.FC<Props> = ({
   return (
     <DeleteModal
       title="Delete connection?"
-      isOpen
       onClose={onClose}
       submitButtonLabel="Delete"
       onDelete={() => {

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTable.tsx
@@ -48,15 +48,17 @@ const DataConnectionsTable: React.FC<DataConnectionsTableProps> = ({
           setEditDataConnection(undefined);
         }}
       />
-      <DeleteDataConnectionModal
-        dataConnection={deleteDataConnection}
-        onClose={(deleted) => {
-          if (deleted) {
-            refreshData();
-          }
-          setDeleteDataConnection(undefined);
-        }}
-      />
+      {deleteDataConnection ? (
+        <DeleteDataConnectionModal
+          dataConnection={deleteDataConnection}
+          onClose={(deleted) => {
+            if (deleted) {
+              refreshData();
+            }
+            setDeleteDataConnection(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTable.tsx
@@ -57,15 +57,17 @@ const NotebookTable: React.FC<NotebookTableProps> = ({ notebookStates, refresh }
           setAddNotebookStorage(undefined);
         }}
       />
-      <DeleteNotebookModal
-        notebook={notebookToDelete}
-        onClose={(deleted) => {
-          if (deleted) {
-            refresh();
-          }
-          setNotebookToDelete(undefined);
-        }}
-      />
+      {notebookToDelete ? (
+        <DeleteNotebookModal
+          notebook={notebookToDelete}
+          onClose={(deleted) => {
+            if (deleted) {
+              refresh();
+            }
+            setNotebookToDelete(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -94,15 +94,17 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
           setEditPVC(undefined);
         }}
       />
-      <DeletePVCModal
-        pvcToDelete={deleteStorage}
-        onClose={(deleted) => {
-          if (deleted) {
-            refresh();
-          }
-          setDeleteStorage(undefined);
-        }}
-      />
+      {deleteStorage ? (
+        <DeletePVCModal
+          pvcToDelete={deleteStorage}
+          onClose={(deleted) => {
+            if (deleted) {
+              refresh();
+            }
+            setDeleteStorage(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/projects/DeleteProjectModal.tsx
+++ b/frontend/src/pages/projects/screens/projects/DeleteProjectModal.tsx
@@ -8,7 +8,7 @@ import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUti
 
 type DeleteProjectModalProps = {
   onClose: (deleted: boolean) => void;
-  deleteData?: ProjectKind;
+  deleteData: ProjectKind;
 };
 
 const deleteProjectEventType = 'Project Deleted';
@@ -30,30 +30,27 @@ const DeleteProjectModal: React.FC<DeleteProjectModalProps> = ({ deleteData, onC
     setError(undefined);
   };
 
-  const displayName = deleteData ? getDisplayNameFromK8sResource(deleteData) : 'this project';
+  const displayName = getDisplayNameFromK8sResource(deleteData);
 
   return (
     <DeleteModal
       title="Delete project?"
-      isOpen={!!deleteData}
       onClose={() => onBeforeClose(false)}
       deleting={deleting}
       submitButtonLabel="Delete project"
       onDelete={() => {
-        if (deleteData) {
-          setDeleting(true);
-          deleteProject(deleteData.metadata.name)
-            .then(() => onBeforeClose(true))
-            .catch((e) => {
-              fireFormTrackingEvent(deleteProjectEventType, {
-                outcome: TrackingOutcome.submit,
-                success: false,
-                error: e,
-              });
-              setError(e);
-              setDeleting(false);
+        setDeleting(true);
+        deleteProject(deleteData.metadata.name)
+          .then(() => onBeforeClose(true))
+          .catch((e) => {
+            fireFormTrackingEvent(deleteProjectEventType, {
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: e,
             });
-        }
+            setError(e);
+            setDeleting(false);
+          });
       }}
       deleteName={displayName}
       error={error}

--- a/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectListView.tsx
@@ -111,12 +111,14 @@ const ProjectListView: React.FC<ProjectListViewProps> = ({ allowCreate }) => {
           editProjectData={editData}
         />
       )}
-      <DeleteProjectModal
-        deleteData={deleteData}
-        onClose={() => {
-          setDeleteData(undefined);
-        }}
-      />
+      {deleteData ? (
+        <DeleteProjectModal
+          deleteData={deleteData}
+          onClose={() => {
+            setDeleteData(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
Towards [RHOAIENG-12117](https://issues.redhat.com/browse/RHOAIENG-12117)

## Description
Update usage of delete modals to render them only when they would be shown rather than having them be rendered but hidden.

## How Has This Been Tested?
Run thru the UI and check that delete modals are shown only when they should be shown.

- From the `Data science Projects` page.
  - use a kebab menu for a project and select `Delete project`
  - verify the delete modal is shown
- From a project details page
  - select the `Workbenches` tab
  - use a kebab menu for a project and select `Delete workbench`
  - verify the delete modal is shown
- From a project details page
  - select the `Pipelines` tab
  - use the top level kebab menu for a pipeline version and select `Delete pipeline server`
  - verify the delete modal is shown
- From a project details page
  - select the `Pipelines` tab
  - expand a pipeline that has pipeline versions
  - use a kebab menu for a pipeline version and select `Delete pipeline version`
  - verify the delete modal is shown
- From a project details page
  - select the `Pipelines` tab
  - expand a pipeline that has pipeline versions
  - and select a pipeline version
  - from the pipeline version page, use the actions menu and select `Delete pipeline version`
  - verify the delete modal is shown
- From a project details page
  - select the `Pipelines` tab
  - expand a pipeline that has pipeline versions
  - select a pipeline run
  - from the pipeline run page, use thee actions menu and select `Delete pipeline version`
  - verify the delete modal is shown
- From a project details page
  - select the `Pipelines` tab
  - for a that has no pipeline versions, use a kebab menu for the pipeline and select `Delete pipeline`
  - verify the delete modal is shown
- From a project details page
  - select the `Models` tab
  - from a models server in the list, use the kebab menu and select 'Delete model server'
  - verify the delete modal is shown.
- From a project details page
  - select the `Models` tab
  - expand the deployed models of a model server
  - from the deployed models list,  use the kebab menu and select 'Delete'
  - verify the delete modal is shown.
- From a project details page
  - select the `Cluster storage` tab
  - from a connection in the list, use the kebab menu and select 'Delete storage'
  - verify the delete modal is shown.
- From a project details page
  - select the `Connections` tab
  - from a connection in the list, use the kebab menu and select 'Delete'
  - verify the delete modal is shown.
- From a project details page
  - select the `Data connections` tab
  - from a data connection in the list, use the kebab menu and select 'Delete data connection'
  - verify the delete modal is shown.


## Test Impact
Current tests already test the delete modals.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
