### PR TITLE
NO-JIRA: chore(quality): add `data-testid` for the Launch standalone notebook server button

### DIFF
--- a/frontend/src/pages/projects/screens/projects/LaunchJupyterButton.tsx
+++ b/frontend/src/pages/projects/screens/projects/LaunchJupyterButton.tsx
@@ -17,6 +17,7 @@ const LaunchJupyterButton: React.FC = () => {
       content="Launch a notebook server to create a standalone notebook outside of a project."
     >
       <Button
+        data-testid="launch-standalone-notebook-server"
         href="/notebookController"
         component="a"
         variant={ButtonVariant.secondary}


### PR DESCRIPTION
## Description

* https://github.com/red-hat-data-services/ods-ci/pull/1880#issuecomment-2387950341

## How Has This Been Tested?

PR checks

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges: quay.io/opendatahub/odh-dashboard:pr-3294
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
