### PR TITLE
Conditionally render pipeline modals

### DIFF
--- a/frontend/src/concepts/pipelines/content/ArchiveModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ArchiveModal.tsx
@@ -10,7 +10,6 @@ interface ArchiveModalProps {
   onCancel: () => void;
   onSubmit: () => Promise<void[]>;
   children: React.ReactNode;
-  isOpen: boolean;
   testId: string;
 }
 
@@ -21,7 +20,6 @@ export const ArchiveModal: React.FC<ArchiveModalProps> = ({
   title,
   alertTitle,
   children,
-  isOpen,
   testId,
 }) => {
   const { refreshAllAPI } = usePipelinesAPI();
@@ -53,7 +51,7 @@ export const ArchiveModal: React.FC<ArchiveModalProps> = ({
 
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       title={title}
       titleIconVariant="warning"
       variant="small"

--- a/frontend/src/concepts/pipelines/content/PipelineServerActions.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineServerActions.tsx
@@ -114,7 +114,7 @@ const PipelineServerActions: React.FC<PipelineServerActionsProps> = ({ variant, 
           }}
         />
       ) : null}
-      <ViewServerModal isOpen={viewOpen} onClose={() => setViewOpen(false)} />
+      {viewOpen ? <ViewServerModal onClose={() => setViewOpen(false)} /> : null}
       {deletePipelinesOpen ? (
         <DeletePipelinesModal
           toDeletePipelines={pipelines}

--- a/frontend/src/concepts/pipelines/content/RestoreModal.tsx
+++ b/frontend/src/concepts/pipelines/content/RestoreModal.tsx
@@ -9,7 +9,6 @@ interface RestoreModalProps {
   title: string;
   alertTitle: string;
   children: React.ReactNode;
-  isOpen: boolean;
   testId: string;
 }
 
@@ -18,7 +17,6 @@ export const RestoreModal: React.FC<RestoreModalProps> = ({
   onSubmit,
   title,
   children,
-  isOpen,
   testId,
   alertTitle,
 }) => {
@@ -43,7 +41,7 @@ export const RestoreModal: React.FC<RestoreModalProps> = ({
 
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       title={title}
       variant="small"
       onClose={onCancel}

--- a/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
@@ -15,13 +15,11 @@ import { ExternalDatabaseSecret } from '~/concepts/pipelines/content/configurePi
 import { DSPipelineKind } from '~/k8sTypes';
 
 type ViewPipelineServerModalProps = {
-  isOpen: boolean;
   onClose: () => void;
   pipelineNamespaceCR: DSPipelineKind | null;
 };
 
 const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
-  isOpen,
   onClose,
   pipelineNamespaceCR,
 }) => {
@@ -35,7 +33,7 @@ const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
   const databaseSecret = dataEntryToRecord(result?.values?.data ?? []);
 
   return (
-    <Modal title="View pipeline server" isOpen={isOpen} onClose={onClose} variant="small">
+    <Modal title="View pipeline server" isOpen onClose={onClose} variant="small">
       {pipelineNamespaceCR && (
         <DescriptionList termWidth="20ch" isHorizontal>
           {!!pipelineNamespaceCR.spec.objectStorage.externalStorage?.s3CredentialsSecret

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -16,7 +16,6 @@ import { configureDSPipelineResourceSpec, objectStorageIsValid } from './utils';
 import { PipelineServerConfigType } from './types';
 
 type ConfigurePipelinesServerModalProps = {
-  open: boolean;
   onClose: () => void;
 };
 
@@ -27,19 +26,12 @@ const FORM_DEFAULTS: PipelineServerConfigType = {
 
 export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerModalProps> = ({
   onClose,
-  open,
 }) => {
   const { project, namespace } = usePipelinesAPI();
-  const [dataConnections, loaded, , refresh] = useDataConnections(namespace);
+  const [dataConnections, loaded] = useDataConnections(namespace);
   const [fetching, setFetching] = React.useState(false);
   const [error, setError] = React.useState<Error>();
   const [config, setConfig] = React.useState<PipelineServerConfigType>(FORM_DEFAULTS);
-
-  React.useEffect(() => {
-    if (open) {
-      refresh();
-    }
-  }, [open, refresh]);
 
   const databaseIsValid = config.database.useDefault
     ? true
@@ -101,7 +93,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
       title="Configure pipeline server"
       variant="medium"
       description="Configuring a pipeline server enables you to create and manage pipelines."
-      isOpen={open}
+      isOpen
       onClose={onBeforeClose}
       footer={
         <DashboardModalFooter

--- a/frontend/src/concepts/pipelines/content/experiment/CreateExperimentButton.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/CreateExperimentButton.tsx
@@ -25,18 +25,19 @@ const CreateExperimentButton: React.FC<CreateExperimentButtonProps> = ({
       >
         {children || 'Create experiment'}
       </Button>
-      <CreateExperimentModal
-        isOpen={open}
-        onClose={(experiment) => {
-          setOpen(false);
-          if (experiment) {
-            if (onCreate) {
-              onCreate(experiment);
+      {open ? (
+        <CreateExperimentModal
+          onClose={(experiment) => {
+            setOpen(false);
+            if (experiment) {
+              if (onCreate) {
+                onCreate(experiment);
+              }
+              refreshAllAPI();
             }
-            refreshAllAPI();
-          }
-        }}
-      />
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
@@ -20,11 +20,10 @@ import {
 import { CharLimitHelperText } from '~/components/CharLimitHelperText';
 
 type CreateExperimentModalProps = {
-  isOpen: boolean;
   onClose: (experiment?: ExperimentKFv2) => void;
 };
 
-const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ isOpen, onClose }) => {
+const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }) => {
   const { project, api, apiAvailable } = usePipelinesAPI();
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
@@ -41,7 +40,7 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ isOpen, o
 
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       title="Create experiment"
       onClose={() => onBeforeClose()}
       actions={[

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineButton.tsx
@@ -28,19 +28,20 @@ const ImportPipelineButton: React.FC<ImportPipelineButtonProps> = ({
       >
         {children || 'Import pipeline'}
       </Button>
-      <PipelineImportModal
-        isOpen={open}
-        redirectAfterImport={redirectAfterImport}
-        onClose={(pipeline) => {
-          setOpen(false);
-          if (pipeline) {
-            if (onCreate) {
-              onCreate(pipeline);
+      {open ? (
+        <PipelineImportModal
+          redirectAfterImport={redirectAfterImport}
+          onClose={(pipeline) => {
+            setOpen(false);
+            if (pipeline) {
+              if (onCreate) {
+                onCreate(pipeline);
+              }
+              refreshAllAPI();
             }
-            refreshAllAPI();
-          }
-        }}
-      />
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineSplitButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineSplitButton.tsx
@@ -82,18 +82,19 @@ const ImportPipelineSplitButton: React.FC<ImportPipelineSplitButtonProps> = ({
           </DropdownItem>
         </DropdownList>
       </Dropdown>
-      <PipelineImportModal
-        isOpen={isPipelineModalOpen}
-        onClose={(pipeline) => {
-          setPipelineModalOpen(false);
-          if (pipeline) {
-            if (onImportPipeline) {
-              onImportPipeline(pipeline);
+      {isPipelineModalOpen ? (
+        <PipelineImportModal
+          onClose={(pipeline) => {
+            setPipelineModalOpen(false);
+            if (pipeline) {
+              if (onImportPipeline) {
+                onImportPipeline(pipeline);
+              }
+              refreshAllAPI();
             }
-            refreshAllAPI();
-          }
-        }}
-      />
+          }}
+        />
+      ) : null}
       {isPipelineVersionModalOpen && (
         <PipelineVersionImportModal
           onClose={(pipelineVersion) => {

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportModal.tsx
@@ -29,13 +29,11 @@ import PipelineUploadRadio from './PipelineUploadRadio';
 import { PipelineUploadOption, extractKindFromPipelineYAML } from './utils';
 
 type PipelineImportModalProps = {
-  isOpen: boolean;
   onClose: (pipeline?: PipelineKFv2) => void;
   redirectAfterImport?: boolean;
 };
 
 const PipelineImportModal: React.FC<PipelineImportModalProps> = ({
-  isOpen,
   redirectAfterImport = true,
   onClose,
 }) => {
@@ -152,7 +150,7 @@ const PipelineImportModal: React.FC<PipelineImportModalProps> = ({
   return (
     <Modal
       title="Import pipeline"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose()}
       actions={[
         <Button

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDetails.tsx
@@ -176,11 +176,9 @@ const PipelineRunDetails: React.FC<
           }
         }}
       />
-      <ArchiveRunModal
-        isOpen={archiving}
-        runs={run ? [run] : []}
-        onCancel={() => setArchiving(false)}
-      />
+      {archiving ? (
+        <ArchiveRunModal runs={run ? [run] : []} onCancel={() => setArchiving(false)} />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ActiveExperimentTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ActiveExperimentTable.tsx
@@ -46,11 +46,12 @@ const ActiveExperimentTable: React.FC<ActiveExperimentTableProps> = ({ ...baseTa
           />
         )}
       />
-      <ArchiveExperimentModal
-        isOpen={isArchiveModalOpen}
-        experiments={archiveExperiments}
-        onCancel={() => setIsArchiveModalOpen(false)}
-      />
+      {isArchiveModalOpen ? (
+        <ArchiveExperimentModal
+          experiments={archiveExperiments}
+          onCancel={() => setIsArchiveModalOpen(false)}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ArchivedExperimentTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ArchivedExperimentTable.tsx
@@ -55,11 +55,12 @@ const ArchivedExperimentTable: React.FC<ArchivedExperimentTableProps> = ({ ...ba
           />
         )}
       />
-      <RestoreExperimentModal
-        isOpen={isRestoreModalOpen}
-        experiments={restoreExperiments}
-        onCancel={() => setIsRestoreModalOpen(false)}
-      />
+      {isRestoreModalOpen ? (
+        <RestoreExperimentModal
+          experiments={restoreExperiments}
+          onCancel={() => setIsRestoreModalOpen(false)}
+        />
+      ) : null}
       {deleteExperiment ? (
         <DeleteExperimentModal
           onCancel={() => setDeleteExperiment(undefined)}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -295,22 +295,24 @@ const PipelineRunTableInternal: React.FC<PipelineRunTableInternalProps> = ({
         data-testid={`${runType}-runs-table`}
         id={`${runType}-runs-table`}
       />
-      <ArchiveRunModal
-        isOpen={isArchiveModalOpen}
-        runs={selectedRuns}
-        onCancel={() => {
-          setIsArchiveModalOpen(false);
-          setSelectedIds([]);
-        }}
-      />
-      <RestoreRunModal
-        isOpen={isRestoreModalOpen}
-        runs={selectedRuns}
-        onCancel={() => {
-          setIsRestoreModalOpen(false);
-          setSelectedIds([]);
-        }}
-      />
+      {isArchiveModalOpen ? (
+        <ArchiveRunModal
+          runs={selectedRuns}
+          onCancel={() => {
+            setIsArchiveModalOpen(false);
+            setSelectedIds([]);
+          }}
+        />
+      ) : null}
+      {isRestoreModalOpen ? (
+        <RestoreRunModal
+          runs={selectedRuns}
+          onCancel={() => {
+            setIsRestoreModalOpen(false);
+            setSelectedIds([]);
+          }}
+        />
+      ) : null}
       {isDeleteModalOpen && (
         <DeletePipelineRunsModal
           toDeleteResources={selectedRuns}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -171,16 +171,12 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
             items={actions}
             popperProps={{ appendTo: getDashboardMainContainer, position: 'right' }}
           />
-          <RestoreRunModal
-            isOpen={isRestoreModalOpen}
-            runs={[run]}
-            onCancel={() => setIsRestoreModalOpen(false)}
-          />
-          <ArchiveRunModal
-            isOpen={isArchiveModalOpen}
-            runs={[run]}
-            onCancel={() => setIsArchiveModalOpen(false)}
-          />
+          {isRestoreModalOpen ? (
+            <RestoreRunModal runs={[run]} onCancel={() => setIsRestoreModalOpen(false)} />
+          ) : null}
+          {isArchiveModalOpen ? (
+            <ArchiveRunModal runs={[run]} onCancel={() => setIsArchiveModalOpen(false)} />
+          ) : null}
         </Td>
       )}
     </Tr>

--- a/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
+++ b/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
@@ -238,13 +238,14 @@ export const CreatePipelineServerButton: React.FC<CreatePipelineServerButtonProp
           </Button>
         </StackItem>
       </Stack>
-      <ConfigurePipelinesServerModal
-        open={configureModalVisible}
-        onClose={() => {
-          setConfigureModalVisible(false);
-          refreshState();
-        }}
-      />
+      {configureModalVisible ? (
+        <ConfigurePipelinesServerModal
+          onClose={() => {
+            setConfigureModalVisible(false);
+            refreshState();
+          }}
+        />
+      ) : null}
     </>
   );
 };
@@ -264,23 +265,11 @@ export const DeleteServerModal = ({ onClose }: { onClose: () => void }): React.J
   );
 };
 
-export const ViewServerModal = ({
-  isOpen,
-  onClose,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-}): React.JSX.Element => {
+export const ViewServerModal = ({ onClose }: { onClose: () => void }): React.JSX.Element => {
   const { namespace } = React.useContext(PipelinesContext);
   const [pipelineNamespaceCR] = usePipelineNamespaceCR(namespace);
 
-  return (
-    <ViewPipelineServerModal
-      isOpen={isOpen}
-      onClose={onClose}
-      pipelineNamespaceCR={pipelineNamespaceCR}
-    />
-  );
+  return <ViewPipelineServerModal onClose={onClose} pipelineNamespaceCR={pipelineNamespaceCR} />;
 };
 
 export const PipelineServerTimedOut: React.FC = () => {

--- a/frontend/src/pages/pipelines/global/experiments/ArchiveExperimentModal.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/ArchiveExperimentModal.tsx
@@ -6,13 +6,11 @@ import { ArchiveModal } from '~/concepts/pipelines/content/ArchiveModal';
 import { BulkActionExpandableSection } from '~/pages/projects/components/BulkActionExpandableSection';
 
 interface ArchiveExperimentModalProps {
-  isOpen: boolean;
   experiments: ExperimentKFv2[];
   onCancel: () => void;
 }
 
 export const ArchiveExperimentModal: React.FC<ArchiveExperimentModalProps> = ({
-  isOpen,
   experiments,
   onCancel,
 }) => {
@@ -28,7 +26,6 @@ export const ArchiveExperimentModal: React.FC<ArchiveExperimentModalProps> = ({
 
   return (
     <ArchiveModal
-      isOpen={isOpen}
       title={`Archiving experiment${isSingleArchiving ? '' : 's'}?`}
       alertTitle={`Error archiving ${
         isSingleArchiving ? experiments[0].display_name : 'experiments'

--- a/frontend/src/pages/pipelines/global/experiments/RestoreExperimentModal.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/RestoreExperimentModal.tsx
@@ -10,13 +10,11 @@ import { BulkActionExpandableSection } from '~/pages/projects/components/BulkAct
 interface RestoreExperimentModalProps {
   experiments: ExperimentKFv2[];
   onCancel: () => void;
-  isOpen: boolean;
 }
 
 export const RestoreExperimentModal: React.FC<RestoreExperimentModalProps> = ({
   experiments,
   onCancel,
-  isOpen,
 }) => {
   const isSingleRestoring = experiments.length === 1;
 
@@ -30,7 +28,6 @@ export const RestoreExperimentModal: React.FC<RestoreExperimentModalProps> = ({
   );
   return (
     <RestoreModal
-      isOpen={isOpen}
       onCancel={onCancel}
       onSubmit={onSubmit}
       title={`Restore experiment${isSingleRestoring ? '' : 's'}?`}

--- a/frontend/src/pages/pipelines/global/runs/ArchiveRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/runs/ArchiveRunModal.tsx
@@ -7,12 +7,11 @@ import { PipelineRunTabTitle } from '~/pages/pipelines/global/runs/types';
 import { BulkActionExpandableSection } from '~/pages/projects/components/BulkActionExpandableSection';
 
 interface ArchiveRunModalProps {
-  isOpen: boolean;
   runs: PipelineRunKFv2[];
   onCancel: () => void;
 }
 
-export const ArchiveRunModal: React.FC<ArchiveRunModalProps> = ({ isOpen, runs, onCancel }) => {
+export const ArchiveRunModal: React.FC<ArchiveRunModalProps> = ({ runs, onCancel }) => {
   const isSingleArchiving = runs.length === 1;
   const { api } = usePipelinesAPI();
   const onSubmit = React.useCallback(
@@ -22,7 +21,6 @@ export const ArchiveRunModal: React.FC<ArchiveRunModalProps> = ({ isOpen, runs, 
 
   return (
     <ArchiveModal
-      isOpen={isOpen}
       title={`Archiving run${isSingleArchiving ? '' : 's'}?`}
       alertTitle={`Error archiving ${isSingleArchiving ? runs[0].display_name : 'runs'}`}
       confirmMessage={

--- a/frontend/src/pages/pipelines/global/runs/RestoreRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/runs/RestoreRunModal.tsx
@@ -7,12 +7,11 @@ import { BulkActionExpandableSection } from '~/pages/projects/components/BulkAct
 import { PipelineRunTabTitle } from './types';
 
 interface RestoreRunModalProps {
-  isOpen: boolean;
   runs: PipelineRunKFv2[];
   onCancel: () => void;
 }
 
-export const RestoreRunModal: React.FC<RestoreRunModalProps> = ({ isOpen, runs, onCancel }) => {
+export const RestoreRunModal: React.FC<RestoreRunModalProps> = ({ runs, onCancel }) => {
   const isSingleRestoring = runs.length === 1;
   const { api } = usePipelinesAPI();
   const onSubmit = React.useCallback(
@@ -24,7 +23,6 @@ export const RestoreRunModal: React.FC<RestoreRunModalProps> = ({ isOpen, runs, 
       title={`Restore run${isSingleRestoring ? '' : 's'}?`}
       onCancel={onCancel}
       onSubmit={onSubmit}
-      isOpen={isOpen}
       testId="restore-run-modal"
       alertTitle={`Error restoring ${isSingleRestoring ? runs[0].display_name : 'runs'}`}
     >


### PR DESCRIPTION
Towards [RHOAIENG-12117](https://issues.redhat.com/browse/RHOAIENG-12117)

## Description
Update usage of pipeline Archive, Restore, and View server modals to render them only when they would be shown rather than having them be rendered but hidden.

## How Has This Been Tested?
Run thru the UI and check that then modals are shown only when they should be shown.

- From a project details page
  - select the `Pipelines` tab
  - expand a pipeline that has pipeline versions
  - select a pipeline version
  - from the pipelines page, select the `Pipeline server actions` menu and choose `View pipeline server configuration`
  - verify the `View pipeline server` modal is shown
- From a project details page
  - select the `Pipelines` tab
  - expand a pipeline that has pipeline versions
  - from a pipeline version, use the kebab and select `View runs`
  - from the pipeline rus page, select the `Actions` menu and choose `Archive`
  - verify the `Archiving run` modal is shown
- Select the `Experiments` nav item, then `Experiments and Runs`
  - for an experiment, select the kebab menu and select `Archive`
  - verify the `Archiving experiment?` modal is shown.
- Select the `Experiments` nav item, then `Experiments and Runs`
  - select the `Archive` tab
  - for an experiment, select the kebab menu and select `Restore`
  - verify the `Restore experiment?` modal is shown.
- Select the `Data Science Pipelines` nav item
  - for a project without a configured pipeline server, select the `Configure pipeline server` button
  - verify the `Configure pipeline server` modal is shown.
- Select the `Data Science Pipelines` nav item
  - for a project with a configured pipeline server, select the `Import pipeline` button
  - verify the `Import pipeline` modal is shown.
- Select the `Experiments` nav item, then `Experiments and Runs`
  - select the `Create experiment` button
  - verify the `Create experiment` modal is shown.

## Test Impact
Current tests already test these modals.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
