### PR TITLE
Don't show empty connected models when deleting a connection

### DIFF
--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsDeleteModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsDeleteModal.tsx
@@ -123,38 +123,42 @@ export const ConnectionsDeleteModal: React.FC<Props> = ({
                   ) : null}
                 </>
               ) : null}
-              <ExpandableSectionToggle
-                isExpanded={modelsExpanded}
-                onToggle={setModelsExpanded}
-                id="expand-connected-models-toggle"
-                contentId="expanded-connected-models"
-                data-testid="connections-delete-models-toggle"
-              >
-                <span>Model deployments </span>
-                <Badge isRead data-testid="connections-delete-models-count">
-                  {connectedModels.length}
-                </Badge>
-              </ExpandableSectionToggle>
-              {modelsExpanded ? (
-                <ExpandableSection
-                  isExpanded
-                  isDetached
-                  toggleId="expand-connected-models-toggle"
-                  contentId="expanded-connected-models"
-                >
-                  <TextContent>
-                    <TextList>
-                      {connectedModels.map((model) => (
-                        <TextListItem
-                          key={model.metadata.name}
-                          data-testid="connections-delete-models-item"
-                        >
-                          {getDisplayNameFromK8sResource(model)}
-                        </TextListItem>
-                      ))}
-                    </TextList>
-                  </TextContent>
-                </ExpandableSection>
+              {connectedModels.length ? (
+                <>
+                  <ExpandableSectionToggle
+                    isExpanded={modelsExpanded}
+                    onToggle={setModelsExpanded}
+                    id="expand-connected-models-toggle"
+                    contentId="expanded-connected-models"
+                    data-testid="connections-delete-models-toggle"
+                  >
+                    <span>Model deployments </span>
+                    <Badge isRead data-testid="connections-delete-models-count">
+                      {connectedModels.length}
+                    </Badge>
+                  </ExpandableSectionToggle>
+                  {modelsExpanded ? (
+                    <ExpandableSection
+                      isExpanded
+                      isDetached
+                      toggleId="expand-connected-models-toggle"
+                      contentId="expanded-connected-models"
+                    >
+                      <TextContent>
+                        <TextList>
+                          {connectedModels.map((model) => (
+                            <TextListItem
+                              key={model.metadata.name}
+                              data-testid="connections-delete-models-item"
+                            >
+                              {getDisplayNameFromK8sResource(model)}
+                            </TextListItem>
+                          ))}
+                        </TextList>
+                      </TextContent>
+                    </ExpandableSection>
+                  ) : null}
+                </>
               ) : null}
             </>
           )}

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsDeleteModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsDeleteModal.spec.tsx
@@ -90,4 +90,28 @@ describe('Delete connection modal', () => {
     expect(modelsItems[0]).toHaveTextContent('Deployed model 1');
     expect(modelsItems[1]).toHaveTextContent('Deployed model 2');
   });
+
+  it('should not show empty related resources', async () => {
+    const deleteConnection = mockConnection({ displayName: 'connection1', description: 'desc1' });
+
+    useRelatedNotebooksMock.mockReturnValue({
+      notebooks: [],
+      loaded: true,
+    });
+    useInferenceServicesForConnectionMock.mockReturnValue([]);
+    render(
+      <ConnectionsDeleteModal
+        namespace={deleteConnection.metadata.namespace}
+        deleteConnection={deleteConnection}
+        onClose={onClose}
+        onDelete={onDelete}
+      />,
+    );
+
+    const notebooksCountBadge = screen.queryByTestId('connections-delete-notebooks-toggle');
+    expect(notebooksCountBadge).toBeFalsy();
+
+    const modelsCountBadge = screen.queryByTestId('connections-delete-models-toggle');
+    expect(modelsCountBadge).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Fixes [RHOAIENG-11558](https://issues.redhat.com/browse/RHOAIENG-11558)

## Description
When deleting a connection, do not show the related models section if there are no related models

## How Has This Been Tested?
Delete a Connection that has no related deployed models.
Verify the `Model deployments` section is not shown.

## Test Impact
Added RTL test for empty workbenches and model deployments

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
