### PR TITLE
Update empty pipeline server page button variant

### DIFF
--- a/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
@@ -10,6 +10,7 @@ import {
   EmptyStateBody,
   Button,
   EmptyStateIcon,
+  ButtonVariant,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import ExternalLink from '~/components/ExternalLink';
@@ -39,7 +40,7 @@ const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerPro
   }
 
   if (!pipelinesServer.installed) {
-    return <NoPipelineServer variant="secondary" />;
+    return <NoPipelineServer variant={ButtonVariant.primary} />;
   }
 
   if (!pipelinesServer.compatible) {

--- a/frontend/src/pages/pipelines/global/PipelineCoreApplicationPage.tsx
+++ b/frontend/src/pages/pipelines/global/PipelineCoreApplicationPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ButtonVariant } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import NoPipelineServer from '~/concepts/pipelines/NoPipelineServer';
 import PipelineCoreProjectSelector from '~/pages/pipelines/global/PipelineCoreProjectSelector';
@@ -26,7 +27,7 @@ const PipelineCoreApplicationPage: React.FC<PipelineCoreApplicationPageProps> = 
       {...pageProps}
       loaded={!pipelinesAPi.pipelinesServer.initializing}
       empty={!pipelinesAPi.pipelinesServer.installed}
-      emptyStatePage={<NoPipelineServer />}
+      emptyStatePage={<NoPipelineServer variant={ButtonVariant.primary} />}
       headerContent={<PipelineCoreProjectSelector getRedirectPath={getRedirectPath} />}
       provideChildrenPadding={!overrideChildPadding}
     >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-9209

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updated the configure server button variant on pipelines page to make it primary.

<img width="1512" alt="Screenshot 2024-10-04 at 11 43 28 AM" src="https://github.com/user-attachments/assets/f65ef3a6-dbe5-4a56-94de-5dd7489966e2">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the project that doesn't have a pipeline server configured, make sure the configure server button is the primary style on both the projects page and the pipelines global page.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, minor UX update.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
