### PR TITLE
Disable manage permissions when no rolebinding present for the default group

### DIFF
--- a/frontend/src/__mocks__/mockModelRegistry.ts
+++ b/frontend/src/__mocks__/mockModelRegistry.ts
@@ -1,13 +1,30 @@
-import { ModelRegistryKind } from '~/k8sTypes';
+import { K8sCondition, ModelRegistryKind } from '~/k8sTypes';
 
 type MockModelRegistryType = {
   name?: string;
   namespace?: string;
+  conditions?: K8sCondition[];
 };
 
 export const mockModelRegistry = ({
   name = 'modelregistry-sample',
   namespace = 'odh-model-registries',
+  conditions = [
+    {
+      lastTransitionTime: '2024-03-22T09:30:02Z',
+      message: 'Deployment for custom resource modelregistry-sample was successfully created',
+      reason: 'CreatedDeployment',
+      status: 'True',
+      type: 'Progressing',
+    },
+    {
+      lastTransitionTime: '2024-03-14T08:11:26Z',
+      message: 'Deployment for custom resource modelregistry-sample is available',
+      reason: 'DeploymentAvailable',
+      status: 'True',
+      type: 'Available',
+    },
+  ],
 }: MockModelRegistryType): ModelRegistryKind => ({
   apiVersion: 'modelregistry.opendatahub.io/v1alpha1',
   kind: 'ModelRegistry',
@@ -39,21 +56,6 @@ export const mockModelRegistry = ({
     },
   },
   status: {
-    conditions: [
-      {
-        lastTransitionTime: '2024-03-22T09:30:02Z',
-        message: 'Deployment for custom resource modelregistry-sample was successfully created',
-        reason: 'CreatedDeployment',
-        status: 'True',
-        type: 'Progressing',
-      },
-      {
-        lastTransitionTime: '2024-03-14T08:11:26Z',
-        message: 'Deployment for custom resource modelregistry-sample is available',
-        reason: 'DeploymentAvailable',
-        status: 'True',
-        type: 'Available',
-      },
-    ],
+    conditions,
   },
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
@@ -90,6 +90,10 @@ class ModelRegistrySettings {
     return cy.findByTestId('modal-submit-button');
   }
 
+  findManagePermissionsTooltip() {
+    return cy.findByRole('tooltip');
+  }
+
   findTable() {
     return cy.findByTestId('model-registries-table');
   }

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesTable.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesTable.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import { Button, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { Table } from '~/components/table';
-import { ModelRegistryKind } from '~/k8sTypes';
+import { ModelRegistryKind, RoleBindingKind } from '~/k8sTypes';
+import { ContextResourceData } from '~/types';
 import { modelRegistryColumns } from './columns';
 import ModelRegistriesTableRow from './ModelRegistriesTableRow';
 
 type ModelRegistriesTableProps = {
   modelRegistries: ModelRegistryKind[];
   refresh: () => Promise<unknown>;
+  roleBindings: ContextResourceData<RoleBindingKind>;
   onCreateModelRegistryClick: () => void;
 };
 
 const ModelRegistriesTable: React.FC<ModelRegistriesTableProps> = ({
   modelRegistries,
+  roleBindings,
   refresh,
   onCreateModelRegistryClick,
 }) => (
@@ -36,7 +39,12 @@ const ModelRegistriesTable: React.FC<ModelRegistriesTableProps> = ({
       </Toolbar>
     }
     rowRenderer={(mr) => (
-      <ModelRegistriesTableRow key={mr.metadata.name} modelRegistry={mr} refresh={refresh} />
+      <ModelRegistriesTableRow
+        key={mr.metadata.name}
+        modelRegistry={mr}
+        roleBindings={roleBindings}
+        refresh={refresh}
+      />
     )}
     variant="compact"
   />

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -15,13 +15,19 @@ import useModelRegistriesBackend from '~/concepts/modelRegistrySettings/useModel
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
+import { useContextResourceData } from '~/utilities/useContextResourceData';
+import { RoleBindingKind } from '~/k8sTypes';
 import ModelRegistriesTable from './ModelRegistriesTable';
 import CreateModal from './CreateModal';
+import useModelRegistryRoleBindings from './useModelRegistryRoleBindings';
 
 const ModelRegistrySettings: React.FC = () => {
   const [createModalOpen, setCreateModalOpen] = React.useState(false);
-  const [modelRegistries, loaded, loadError, refreshModelRegistries] = useModelRegistriesBackend();
+  const [modelRegistries, mrloaded, loadError, refreshModelRegistries] =
+    useModelRegistriesBackend();
+  const roleBindings = useContextResourceData<RoleBindingKind>(useModelRegistryRoleBindings());
   const { refreshRulesReview } = React.useContext(ModelRegistrySelectorContext);
+  const loaded = mrloaded && roleBindings.loaded;
 
   const refreshAll = React.useCallback(
     () => Promise.all([refreshModelRegistries(), refreshRulesReview()]),
@@ -65,6 +71,7 @@ const ModelRegistrySettings: React.FC = () => {
       >
         <ModelRegistriesTable
           modelRegistries={modelRegistries}
+          roleBindings={roleBindings}
           refresh={refreshAll}
           onCreateModelRegistryClick={() => {
             setCreateModalOpen(true);


### PR DESCRIPTION
Closes: [RHOAIENG-13091](https://issues.redhat.com/browse/RHOAIENG-13091)

## Description
This PR aims to disable the Manage Permissions when model registry is in not ready state.
<img width="339" alt="Screenshot 2024-10-04 at 8 02 54 PM" src="https://github.com/user-attachments/assets/3fc2098f-8c26-4752-9c98-33fd4534d42d">

<img width="1314" alt="Screenshot 2024-10-10 at 8 53 55 PM" src="https://github.com/user-attachments/assets/c34b076a-5569-4b0e-a67b-04b422a0f2e1">



## How Has This Been Tested?
Create a model registry
when Model registry is in progressing state, Manage permissions on the model registry table will be disabled.

## Test Impact
Updated cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
