### PR TITLE
Conditionally render model serving modals

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -61,11 +61,35 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
     [onCancel, onSubmit],
   );
 
+  const projectSection = (
+    <ProjectSelector
+      selectedProject={selectedProject}
+      setSelectedProject={setSelectedProject}
+      error={error}
+      isOpen={isProjectSelectorOpen}
+      setOpen={setProjectSelectorOpen}
+    />
+  );
+
   if (
     (platform === ServingRuntimePlatform.MULTI && !projectDeployStatusLoaded) ||
     !selectedProject ||
     !platform
   ) {
+    const modalForm = (
+      <Form>
+        {deployInfoError ? (
+          <Alert variant="danger" isInline title={deployInfoError.name}>
+            {deployInfoError.message}
+          </Alert>
+        ) : !deployInfoLoaded ? (
+          <Spinner />
+        ) : (
+          <FormSection title="Model deployment">{projectSection}</FormSection>
+        )}
+      </Form>
+    );
+
     return (
       <Modal
         title="Deploy model"
@@ -83,25 +107,7 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
         ]}
         showClose
       >
-        <Form>
-          {deployInfoError ? (
-            <Alert variant="danger" isInline title={deployInfoError.name}>
-              {deployInfoError.message}
-            </Alert>
-          ) : !deployInfoLoaded ? (
-            <Spinner />
-          ) : (
-            <FormSection title="Model deployment">
-              <ProjectSelector
-                selectedProject={selectedProject}
-                setSelectedProject={setSelectedProject}
-                error={error}
-                isOpen={isProjectSelectorOpen}
-                setOpen={setProjectSelectorOpen}
-              />
-            </FormSection>
-          )}
-        </Form>
+        {modalForm}
       </Modal>
     );
   }
@@ -110,20 +116,11 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
     return (
       <ManageKServeModal
         onClose={onClose}
-        isOpen
         servingRuntimeTemplates={getKServeTemplates(templates, templateOrder, templateDisablement)}
         shouldFormHidden={!!error}
         registeredModelDeployInfo={registeredModelDeployInfo}
         projectContext={{ currentProject: selectedProject, dataConnections }}
-        projectSection={
-          <ProjectSelector
-            selectedProject={selectedProject}
-            setSelectedProject={setSelectedProject}
-            error={error}
-            isOpen={isProjectSelectorOpen}
-            setOpen={setProjectSelectorOpen}
-          />
-        }
+        projectSection={projectSection}
       />
     );
   }
@@ -131,19 +128,10 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
   return (
     <ManageInferenceServiceModal
       onClose={onClose}
-      isOpen
       shouldFormHidden={!!error}
       registeredModelDeployInfo={registeredModelDeployInfo}
       projectContext={{ currentProject: selectedProject, dataConnections }}
-      projectSection={
-        <ProjectSelector
-          selectedProject={selectedProject}
-          setSelectedProject={setSelectedProject}
-          error={error}
-          isOpen={isProjectSelectorOpen}
-          setOpen={setProjectSelectorOpen}
-        />
-      }
+      projectSection={projectSection}
     />
   );
 };

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -20,12 +20,11 @@ import FormSection from '~/components/pf-overrides/FormSection';
 import { AreaContext } from '~/concepts/areas/AreaContext';
 
 type CreateModalProps = {
-  isOpen: boolean;
   onClose: () => void;
   refresh: () => Promise<unknown>;
 };
 
-const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, refresh }) => {
+const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<Error>();
   const [nameDesc, setNameDesc] = React.useState<NameDescType>({
@@ -125,7 +124,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, refresh }) =
 
   return (
     <Modal
-      isOpen={isOpen}
+      isOpen
       title="Create model registry"
       onClose={onBeforeClose}
       actions={[

--- a/frontend/src/pages/modelRegistrySettings/DeleteModelRegistryModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/DeleteModelRegistryModal.tsx
@@ -6,14 +6,12 @@ import { deleteModelRegistryBackend } from '~/services/modelRegistrySettingsServ
 
 type DeleteModelRegistryModalProps = {
   modelRegistry: ModelRegistryKind;
-  isOpen: boolean;
   onClose: () => void;
   refresh: () => Promise<unknown>;
 };
 
 const DeleteModelRegistryModal: React.FC<DeleteModelRegistryModalProps> = ({
   modelRegistry: mr,
-  isOpen,
   onClose,
   refresh,
 }) => {
@@ -49,7 +47,7 @@ const DeleteModelRegistryModal: React.FC<DeleteModelRegistryModalProps> = ({
       data-testid="delete-mr-modal"
       titleIconVariant="warning"
       title="Delete model registry?"
-      isOpen={isOpen}
+      isOpen
       onClose={onClose}
       variant="medium"
       footer={

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
@@ -57,17 +57,19 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
           />
         </Td>
       </Tr>
-      <ViewDatabaseConfigModal
-        modelRegistry={mr}
-        isOpen={isDatabaseConfigModalOpen}
-        onClose={() => setIsDatabaseConfigModalOpen(false)}
-      />
-      <DeleteModelRegistryModal
-        modelRegistry={mr}
-        isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
-        refresh={refresh}
-      />
+      {isDatabaseConfigModalOpen ? (
+        <ViewDatabaseConfigModal
+          modelRegistry={mr}
+          onClose={() => setIsDatabaseConfigModalOpen(false)}
+        />
+      ) : null}
+      {isDeleteModalOpen ? (
+        <DeleteModelRegistryModal
+          modelRegistry={mr}
+          onClose={() => setIsDeleteModalOpen(false)}
+          refresh={refresh}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -71,11 +71,9 @@ const ModelRegistrySettings: React.FC = () => {
           }}
         />
       </ApplicationsPage>
-      <CreateModal
-        isOpen={createModalOpen}
-        onClose={() => setCreateModalOpen(false)}
-        refresh={refreshAll}
-      />
+      {createModalOpen ? (
+        <CreateModal onClose={() => setCreateModalOpen(false)} refresh={refreshAll} />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelRegistrySettings/ViewDatabaseConfigModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ViewDatabaseConfigModal.tsx
@@ -11,19 +11,17 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { ModelRegistryKind } from '~/k8sTypes';
-import useFetchState, { NotReadyError } from '~/utilities/useFetchState';
+import useFetchState from '~/utilities/useFetchState';
 import { getModelRegistryBackend } from '~/services/modelRegistrySettingsService';
 import ModelRegistryDatabasePassword from './ModelRegistryDatabasePassword';
 
 type ViewDatabaseConfigModalProps = {
   modelRegistry: ModelRegistryKind;
-  isOpen: boolean;
   onClose: () => void;
 };
 
 const ViewDatabaseConfigModal: React.FC<ViewDatabaseConfigModalProps> = ({
   modelRegistry: mr,
-  isOpen,
   onClose,
 }) => {
   const dbSpec = mr.spec.mysql || mr.spec.postgres;
@@ -34,12 +32,9 @@ const ViewDatabaseConfigModal: React.FC<ViewDatabaseConfigModalProps> = ({
 
   const [password, passwordLoaded, passwordLoadError] = useFetchState(
     React.useCallback(async () => {
-      if (!isOpen) {
-        throw new NotReadyError('Defer load until modal opened');
-      }
       const { databasePassword } = await getModelRegistryBackend(mr.metadata.name);
       return databasePassword;
-    }, [mr, isOpen]),
+    }, [mr]),
     undefined,
   );
 
@@ -47,7 +42,7 @@ const ViewDatabaseConfigModal: React.FC<ViewDatabaseConfigModalProps> = ({
     <Modal
       title="View database configuration"
       description="Database configuration cannot be edited after registry creation. To change the database configuration, you must delete the registry and create a new one."
-      isOpen={isOpen}
+      isOpen
       onClose={onClose}
       variant="medium"
       actions={[

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -104,41 +104,41 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
           }}
         />
       ) : null}
-      <ManageInferenceServiceModal
-        isOpen={!!editInferenceService && isModelMesh(editInferenceService)}
-        editInfo={editInferenceService}
-        onClose={(edited) => {
-          fireFormTrackingEvent('Model Updated', {
-            outcome: edited ? TrackingOutcome.submit : TrackingOutcome.cancel,
-            type: 'multi',
-          });
-          if (edited) {
-            refresh?.();
-          }
-          setEditInferenceService(undefined);
-        }}
-      />
-      <ManageKServeModal
-        isOpen={!!editInferenceService && !isModelMesh(editInferenceService)}
-        editInfo={{
-          inferenceServiceEditInfo: editInferenceService,
-          servingRuntimeEditInfo: {
-            servingRuntime: editInferenceService
-              ? servingRuntimes.find(
-                  (sr) => sr.metadata.name === editInferenceService.spec.predictor.model?.runtime,
-                )
-              : undefined,
-            secrets: [],
-          },
-          secrets: filterTokens ? filterTokens(editInferenceService?.metadata.name) : [],
-        }}
-        onClose={(edited) => {
-          if (edited) {
-            refresh?.();
-          }
-          setEditInferenceService(undefined);
-        }}
-      />
+      {!!editInferenceService && isModelMesh(editInferenceService) ? (
+        <ManageInferenceServiceModal
+          editInfo={editInferenceService}
+          onClose={(edited) => {
+            fireFormTrackingEvent('Model Updated', {
+              outcome: edited ? TrackingOutcome.submit : TrackingOutcome.cancel,
+              type: 'multi',
+            });
+            if (edited) {
+              refresh?.();
+            }
+            setEditInferenceService(undefined);
+          }}
+        />
+      ) : null}
+      {!!editInferenceService && !isModelMesh(editInferenceService) ? (
+        <ManageKServeModal
+          editInfo={{
+            inferenceServiceEditInfo: editInferenceService,
+            servingRuntimeEditInfo: {
+              servingRuntime: servingRuntimes.find(
+                (sr) => sr.metadata.name === editInferenceService.spec.predictor.model?.runtime,
+              ),
+              secrets: [],
+            },
+            secrets: filterTokens ? filterTokens(editInferenceService.metadata.name) : [],
+          }}
+          onClose={(edited) => {
+            if (edited) {
+              refresh?.();
+            }
+            setEditInferenceService(undefined);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx
@@ -66,42 +66,42 @@ const ServeModelButton: React.FC = () => {
     </Button>
   );
 
+  if (!project) {
+    return (
+      <Tooltip data-testid="deploy-model-tooltip" content="To deploy a model, select a project.">
+        {deployButton}
+      </Tooltip>
+    );
+  }
+
   return (
     <>
-      {!project ? (
-        <Tooltip data-testid="deploy-model-tooltip" content="To deploy a model, select a project.">
-          {deployButton}
-        </Tooltip>
-      ) : (
-        deployButton
-      )}
-      {project && (
-        <>
-          <ManageInferenceServiceModal
-            isOpen={platformSelected === ServingRuntimePlatform.MULTI}
-            projectContext={{
-              currentProject: project,
-              dataConnections,
-            }}
-            onClose={(submit: boolean) => {
-              onSubmit(submit);
-            }}
-          />
-          <ManageKServeModal
-            isOpen={platformSelected === ServingRuntimePlatform.SINGLE}
-            projectContext={{
-              currentProject: project,
-              dataConnections,
-            }}
-            servingRuntimeTemplates={templatesEnabled.filter((template) =>
-              getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-            )}
-            onClose={(submit: boolean) => {
-              onSubmit(submit);
-            }}
-          />
-        </>
-      )}
+      {deployButton}
+      {platformSelected === ServingRuntimePlatform.MULTI ? (
+        <ManageInferenceServiceModal
+          projectContext={{
+            currentProject: project,
+            dataConnections,
+          }}
+          onClose={(submit: boolean) => {
+            onSubmit(submit);
+          }}
+        />
+      ) : null}
+      {platformSelected === ServingRuntimePlatform.SINGLE ? (
+        <ManageKServeModal
+          projectContext={{
+            currentProject: project,
+            dataConnections,
+          }}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+          )}
+          onClose={(submit: boolean) => {
+            onSubmit(submit);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -16,14 +16,12 @@ import MetricTypeField from './MetricTypeField';
 
 type ManageBiasConfigurationModalProps = {
   existingConfiguration?: BiasMetricConfig;
-  isOpen: boolean;
   onClose: (submit: boolean) => void;
   inferenceService: InferenceServiceKind;
 };
 
 const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> = ({
   existingConfiguration,
-  isOpen,
   onClose,
   inferenceService,
 }) => {
@@ -67,7 +65,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
     <Modal
       variant="medium"
       title="Configure bias metric"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose(false)}
       footer={
         <DashboardModalFooter

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationPage.tsx
@@ -73,16 +73,17 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
           onConfigure={() => setOpen(true)}
         />
       </ApplicationsPage>
-      <ManageBiasConfigurationModal
-        isOpen={isOpen}
-        onClose={(submit) => {
-          if (submit) {
-            refresh();
-          }
-          setOpen(false);
-        }}
-        inferenceService={inferenceService}
-      />
+      {isOpen ? (
+        <ManageBiasConfigurationModal
+          onClose={(submit) => {
+            if (submit) {
+              refresh();
+            }
+            setOpen(false);
+          }}
+          inferenceService={inferenceService}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationTable.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationTable.tsx
@@ -96,17 +96,18 @@ const BiasConfigurationTable: React.FC<BiasConfigurationTableProps> = ({
           </>
         }
       />
-      <ManageBiasConfigurationModal
-        existingConfiguration={cloneConfiguration}
-        isOpen={!!cloneConfiguration}
-        onClose={(submit) => {
-          if (submit) {
-            refresh();
-          }
-          setCloneConfiguration(undefined);
-        }}
-        inferenceService={inferenceService}
-      />
+      {cloneConfiguration ? (
+        <ManageBiasConfigurationModal
+          existingConfiguration={cloneConfiguration}
+          onClose={(submit) => {
+            if (submit) {
+              refresh();
+            }
+            setCloneConfiguration(undefined);
+          }}
+          inferenceService={inferenceService}
+        />
+      ) : null}
       {deleteConfiguration ? (
         <DeleteBiasConfigurationModal
           configurationToDelete={deleteConfiguration}

--- a/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
@@ -78,17 +78,18 @@ const EmptyMultiModelServingCard: React.FC = () => {
           </Bullseye>
         </CardFooter>
       </Card>
-      <ManageServingRuntimeModal
-        isOpen={open}
-        currentProject={currentProject}
-        servingRuntimeTemplates={templatesEnabled.filter((template) =>
-          getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
-        )}
-        onClose={(submit: boolean) => {
-          setOpen(false);
-          onSubmit(submit);
-        }}
-      />
+      {open ? (
+        <ManageServingRuntimeModal
+          currentProject={currentProject}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
+          )}
+          onClose={(submit: boolean) => {
+            setOpen(false);
+            onSubmit(submit);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
@@ -81,7 +81,6 @@ const EmptyNIMModelServingCard: React.FC = () => {
       </Card>
       {open && (
         <DeployNIMServiceModal
-          isOpen={open}
           projectContext={{
             currentProject,
             dataConnections,

--- a/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
@@ -80,20 +80,21 @@ const EmptySingleModelServingCard: React.FC = () => {
           </Bullseye>
         </CardFooter>
       </Card>
-      <ManageKServeModal
-        isOpen={open}
-        projectContext={{
-          currentProject,
-          dataConnections,
-        }}
-        servingRuntimeTemplates={templatesEnabled.filter((template) =>
-          getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-        )}
-        onClose={(submit) => {
-          onSubmit(submit);
-          setOpen(false);
-        }}
-      />
+      {open ? (
+        <ManageKServeModal
+          projectContext={{
+            currentProject,
+            dataConnections,
+          }}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+          )}
+          onClose={(submit) => {
+            onSubmit(submit);
+            setOpen(false);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -23,7 +23,6 @@ import InferenceServiceServingRuntimeSection from './InferenceServiceServingRunt
 import InferenceServiceNameSection from './InferenceServiceNameSection';
 
 type ManageInferenceServiceModalProps = {
-  isOpen: boolean;
   onClose: (submit: boolean) => void;
   registeredModelDeployInfo?: RegisteredModelDeployInfo;
   shouldFormHidden?: boolean;
@@ -40,7 +39,6 @@ type ManageInferenceServiceModalProps = {
 >;
 
 const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = ({
-  isOpen,
   onClose,
   editInfo,
   projectContext,
@@ -129,7 +127,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
       title={editInfo ? 'Edit model' : 'Deploy model'}
       description="Configure properties for deploying your model"
       variant="medium"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose(false)}
       footer={
         <DashboardModalFooter

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -43,7 +43,6 @@ describe('ManageInferenceServiceModal', () => {
     const currentProject = mockProjectK8sResource({});
     const wrapper = render(
       <ManageInferenceServiceModal
-        isOpen
         projectContext={{
           currentProject,
           dataConnections: [],
@@ -67,7 +66,6 @@ describe('ManageInferenceServiceModal', () => {
     await act(async () => {
       wrapper.rerender(
         <ManageInferenceServiceModal
-          isOpen
           projectContext={{
             currentProject: projectChange,
             dataConnections: [],

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -70,26 +70,27 @@ const KServeInferenceServiceTable: React.FC = () => {
           }}
         />
       ) : null}
-      <ManageKServeModal
-        isOpen={!!editKserveResources}
-        editInfo={{
-          servingRuntimeEditInfo: {
-            servingRuntime: editKserveResources?.servingRuntime,
-            secrets: [],
-          },
-          inferenceServiceEditInfo: editKserveResources?.inferenceService,
-          secrets: filterTokens(editKserveResources?.inferenceService.metadata.name),
-        }}
-        onClose={(submit: boolean) => {
-          setEditKServeResources(undefined);
-          if (submit) {
-            refreshServingRuntime();
-            refreshInferenceServices();
-            refreshDataConnections();
-            refreshServerSecrets();
-          }
-        }}
-      />
+      {editKserveResources ? (
+        <ManageKServeModal
+          editInfo={{
+            servingRuntimeEditInfo: {
+              servingRuntime: editKserveResources.servingRuntime,
+              secrets: [],
+            },
+            inferenceServiceEditInfo: editKserveResources.inferenceService,
+            secrets: filterTokens(editKserveResources.inferenceService.metadata.name),
+          }}
+          onClose={(submit: boolean) => {
+            setEditKServeResources(undefined);
+            if (submit) {
+              refreshServingRuntime();
+              refreshInferenceServices();
+              refreshDataConnections();
+              refreshServerSecrets();
+            }
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTable.tsx
@@ -74,25 +74,25 @@ const ServingRuntimeTable: React.FC = () => {
           }}
         />
       ) : null}
-      <ManageServingRuntimeModal
-        isOpen={editServingRuntime !== undefined}
-        currentProject={currentProject}
-        editInfo={{
-          servingRuntime: editServingRuntime,
-          secrets: filterTokens(editServingRuntime?.metadata.name),
-        }}
-        onClose={(submit: boolean) => {
-          setEditServingRuntime(undefined);
-          if (submit) {
-            refreshServingRuntime();
-            refreshInferenceServices();
-            setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-          }
-        }}
-      />
+      {editServingRuntime ? (
+        <ManageServingRuntimeModal
+          currentProject={currentProject}
+          editInfo={{
+            servingRuntime: editServingRuntime,
+            secrets: filterTokens(editServingRuntime.metadata.name),
+          }}
+          onClose={(submit: boolean) => {
+            setEditServingRuntime(undefined);
+            if (submit) {
+              refreshServingRuntime();
+              refreshInferenceServices();
+              setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
+            }
+          }}
+        />
+      ) : null}
       {deployServingRuntime && (
         <ManageInferenceServiceModal
-          isOpen={!!deployServingRuntime}
           onClose={(submit: boolean) => {
             setDeployServingRuntime(undefined);
             if (submit) {

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -132,6 +132,43 @@ const ModelServingPlatform: React.FC = () => {
     return <EmptyModelServingPlatform />;
   };
 
+  const renderSelectedPlatformModal = () => {
+    if (!platformSelected) {
+      return null;
+    }
+
+    if (platformSelected === ServingRuntimePlatform.MULTI) {
+      return (
+        <ManageServingRuntimeModal
+          currentProject={currentProject}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
+          )}
+          onClose={onSubmit}
+        />
+      );
+    }
+
+    if (isKServeNIMEnabled) {
+      return (
+        <DeployNIMServiceModal
+          projectContext={{ currentProject, dataConnections }}
+          onClose={onSubmit}
+        />
+      );
+    }
+
+    return (
+      <ManageKServeModal
+        projectContext={{ currentProject, dataConnections }}
+        servingRuntimeTemplates={templatesEnabled.filter((template) =>
+          getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+        )}
+        onClose={onSubmit}
+      />
+    );
+  };
+
   return (
     <>
       <DetailsSection
@@ -253,42 +290,7 @@ const ModelServingPlatform: React.FC = () => {
           <KServeInferenceServiceTable />
         )}
       </DetailsSection>
-      <ManageServingRuntimeModal
-        isOpen={platformSelected === ServingRuntimePlatform.MULTI}
-        currentProject={currentProject}
-        servingRuntimeTemplates={templatesEnabled.filter((template) =>
-          getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
-        )}
-        onClose={(submit: boolean) => {
-          onSubmit(submit);
-        }}
-      />
-      {!isKServeNIMEnabled ? (
-        <ManageKServeModal
-          isOpen={platformSelected === ServingRuntimePlatform.SINGLE}
-          projectContext={{
-            currentProject,
-            dataConnections,
-          }}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-          )}
-          onClose={(submit: boolean) => {
-            onSubmit(submit);
-          }}
-        />
-      ) : (
-        <DeployNIMServiceModal
-          isOpen={platformSelected === ServingRuntimePlatform.SINGLE}
-          projectContext={{
-            currentProject,
-            dataConnections,
-          }}
-          onClose={(submit: boolean) => {
-            onSubmit(submit);
-          }}
-        />
-      )}
+      {renderSelectedPlatformModal()}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal.tsx
@@ -59,7 +59,6 @@ const accessReviewResource: AccessReviewResourceAttributes = {
 };
 
 type DeployNIMServiceModalProps = {
-  isOpen: boolean;
   onClose: (submit: boolean) => void;
 } & EitherOrNone<
   {
@@ -78,7 +77,6 @@ type DeployNIMServiceModalProps = {
 >;
 
 const DeployNIMServiceModal: React.FC<DeployNIMServiceModalProps> = ({
-  isOpen,
   onClose,
   projectContext,
   editInfo,
@@ -130,10 +128,10 @@ const DeployNIMServiceModal: React.FC<DeployNIMServiceModalProps> = ({
   const [pvcSize, setPvcSize] = React.useState<string>('30Gi');
 
   React.useEffect(() => {
-    if (currentProjectName && isOpen) {
+    if (currentProjectName) {
       setCreateDataInferenceService('project', currentProjectName);
     }
-  }, [currentProjectName, setCreateDataInferenceService, isOpen]);
+  }, [currentProjectName, setCreateDataInferenceService]);
 
   // Serving Runtime Validation
   const isDisabledServingRuntime =
@@ -249,7 +247,7 @@ const DeployNIMServiceModal: React.FC<DeployNIMServiceModalProps> = ({
       title="Deploy model with NVIDIA NIM"
       description="Configure properties for deploying your model using an NVIDIA NIM."
       variant="medium"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose(false)}
       footer={
         <DashboardModalFooter

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -32,7 +32,6 @@ import ServingRuntimeNameSection from './ServingRuntimeNameSection';
 import AuthServingRuntimeSection from './AuthServingRuntimeSection';
 
 type ManageServingRuntimeModalProps = {
-  isOpen: boolean;
   onClose: (submit: boolean) => void;
   currentProject: ProjectKind;
 } & EitherOrNone<
@@ -51,7 +50,6 @@ const accessReviewResource: AccessReviewResourceAttributes = {
 const modelServerAddedName = 'Model Server Added';
 const modelServerEditName = 'Model Server Modified';
 const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
-  isOpen,
   onClose,
   currentProject,
   servingRuntimeTemplates,
@@ -171,7 +169,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
       title={`${editInfo ? 'Edit' : 'Add'} model server`}
       description="A model server specifies resources available for use by one or more supported models, and includes a serving runtime."
       variant="medium"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose(false)}
       showClose
       footer={

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -64,7 +64,6 @@ const accessReviewResource: AccessReviewResourceAttributes = {
 };
 
 type ManageKServeModalProps = {
-  isOpen: boolean;
   onClose: (submit: boolean) => void;
   servingRuntimeTemplates?: TemplateKind[];
   registeredModelDeployInfo?: RegisteredModelDeployInfo;
@@ -87,7 +86,6 @@ type ManageKServeModalProps = {
 >;
 
 const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
-  isOpen,
   onClose,
   servingRuntimeTemplates,
   projectContext,
@@ -142,10 +140,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const [alertVisible, setAlertVisible] = React.useState(true);
 
   React.useEffect(() => {
-    if (currentProjectName && isOpen) {
+    if (currentProjectName) {
       setCreateDataInferenceService('project', currentProjectName);
     }
-  }, [currentProjectName, setCreateDataInferenceService, isOpen]);
+  }, [currentProjectName, setCreateDataInferenceService]);
 
   // Refresh model format selection when changing serving runtime template selection
   // Don't affect the edit modal
@@ -295,7 +293,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       title={editInfo ? 'Edit model' : 'Deploy model'}
       description="Configure properties for deploying your model"
       variant="medium"
-      isOpen={isOpen}
+      isOpen
       onClose={() => onBeforeClose(false)}
       footer={
         <DashboardModalFooter

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
@@ -71,7 +71,6 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
       />
       {modalShown && isProjectModelMesh && !isNIM ? (
         <ManageServingRuntimeModal
-          isOpen
           currentProject={currentProject}
           servingRuntimeTemplates={templatesEnabled.filter((template) =>
             getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
@@ -81,7 +80,6 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
       ) : null}
       {modalShown && !isProjectModelMesh && !isNIM ? (
         <ManageKServeModal
-          isOpen
           projectContext={{ currentProject, dataConnections }}
           servingRuntimeTemplates={templatesEnabled.filter((template) =>
             getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
@@ -91,7 +89,6 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
       ) : null}
       {modalShown && isNIM ? (
         <DeployNIMServiceModal
-          isOpen
           projectContext={{ currentProject, dataConnections }}
           onClose={onSubmit}
         />


### PR DESCRIPTION
Towards [RHOAIENG-12117](https://issues.redhat.com/browse/RHOAIENG-12117)

## Description
Update usage of modals in the model serving section to render them only when they would be shown rather than having them be rendered but hidden.

## How Has This Been Tested?
Run thru the UI and check that then modals are shown only when they should be shown.

- From the `Model Serving` page
  - For a project with KServe enabled, select the `Deploy model` button
  - verify the `Deploy model` modal is shown
- From the `Model Serving` page
  - For a project with ModelMesh enabled, select the `Deploy model` button
  - verify the `Deploy model` modal is shown
- From the `Model Serving` page
  - For a project with ModelMesh enabled, select the kebab for an existing model and select `Delete`
  - verify the `Delete deployed model?` modal is shown
- From the `Model Serving` page
  - For a project with ModelMesh enabled, select the kebab for an existing model and select `Edit`
  - verify the `Edit model` modal is shown
- On a cluster with no model registries (shared Model Serving cluster), from the `Model registry settings` page
  - Click the `Create model registry` button
  - verify the `Create model registry` modal is shown
- On a cluster with model registries (shared Model Registry cluster), from the `Model registry settings` page
  - For an existing model registry, select the kebab menu then `View database configuration`
  - verify the `View database configuration` modal is shown
- On a cluster with model registries (shared Model Registry cluster), from the `Model registry settings` page
  - For an existing model registry, select the kebab menu then `Delete model registry`
  - verify the `Delete model registry?` modal is shown
- On a cluster with model registries (shared Model Registry cluster), from the `Model registry settings` page
  - Click the `Create model registry` button
  - verify the `Create model registry` modal is shown
- For a project with model serving type not selected, navigate to the project details page and chose the `Models` tab
  - Select `Deploy model` from the `Single-model serving platform` card
  - verify the `Deploy model` modal is shown
- For a project with model serving type not selected, navigate to the project details page and chose the `Models` tab
  - Select `Add model server` from the `Multi-model serving platform` card
  - verify the `Add model server` modal is shown

## Test Impact
Current tests already test these modals.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
