### PR TITLE
Connection card update

### DIFF
--- a/frontend/src/pages/home/aiFlows/ProjectsGallery.tsx
+++ b/frontend/src/pages/home/aiFlows/ProjectsGallery.tsx
@@ -69,14 +69,16 @@ const ProjectsGallery: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     <InfoGalleryItem
       key="connections"
       data-testid="ai-flows-connections-info"
-      title="Data connections"
+      title="Connections"
       imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
       sectionType={SectionType.organize}
       description={
         <TextContent>
           <Text component="small">
-            You can add data connections to link your project and its workbenches to data sources,
-            and to object storage buckets which save data and models that you want to deploy.
+            Connections enable you to store and retrieve information that typically should not be
+            stored in code. For example, you can store details (including credentials) for object
+            storage, databases, and more. You can then attach the connections to artifacts in your
+            project, such as workbenches and model servers.
           </Text>
         </TextContent>
       }

--- a/frontend/src/pages/home/aiFlows/ProjectsGallery.tsx
+++ b/frontend/src/pages/home/aiFlows/ProjectsGallery.tsx
@@ -5,6 +5,7 @@ import InfoGalleryItem from '~/concepts/design/InfoGalleryItem';
 import { SupportedArea } from '~/concepts/areas';
 import useIsAreaAvailable from '~/concepts/areas/useIsAreaAvailable';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
+import useConnectionTypesEnabled from '~/concepts/connectionTypes/useConnectionTypesEnabled';
 import InfoGallery from './InfoGallery';
 
 const ProjectsGallery: React.FC<{ onClose: () => void }> = ({ onClose }) => {
@@ -12,6 +13,7 @@ const ProjectsGallery: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { status: modelServingAvailable } = useIsAreaAvailable(SupportedArea.MODEL_SERVING);
   const servingPlatformStatuses = useServingPlatformStatuses();
   const modelMeshEnabled = servingPlatformStatuses.modelMesh.enabled;
+  const connectionTypesEnabled = useConnectionTypesEnabled();
 
   const getProjectDescriptionAdditionalText = () => {
     if (pipelinesAvailable && modelServingAvailable) {
@@ -66,24 +68,43 @@ const ProjectsGallery: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       }
       isOpen
     />,
-    <InfoGalleryItem
-      key="connections"
-      data-testid="ai-flows-connections-info"
-      title="Connections"
-      imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
-      sectionType={SectionType.organize}
-      description={
-        <TextContent>
-          <Text component="small">
-            Connections enable you to store and retrieve information that typically should not be
-            stored in code. For example, you can store details (including credentials) for object
-            storage, databases, and more. You can then attach the connections to artifacts in your
-            project, such as workbenches and model servers.
-          </Text>
-        </TextContent>
-      }
-      isOpen
-    />,
+    connectionTypesEnabled ? (
+      <InfoGalleryItem
+        key="connections"
+        data-testid="ai-flows-connections-info"
+        title="Connections"
+        imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
+        sectionType={SectionType.organize}
+        description={
+          <TextContent>
+            <Text component="small">
+              Connections enable you to store and retrieve information that typically should not be
+              stored in code. For example, you can store details (including credentials) for object
+              storage, databases, and more. You can then attach the connections to artifacts in your
+              project, such as workbenches and model servers.
+            </Text>
+          </TextContent>
+        }
+        isOpen
+      />
+    ) : (
+      <InfoGalleryItem
+        key="data-connections"
+        data-testid="ai-flows-connections-info"
+        title="Data connections"
+        imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
+        sectionType={SectionType.organize}
+        description={
+          <TextContent>
+            <Text component="small">
+              You can add data connections to link your project and its workbenches to data sources,
+              and to object storage buckets which save data and models that you want to deploy.
+            </Text>
+          </TextContent>
+        }
+        isOpen
+      />
+    ),
     <InfoGalleryItem
       key="storage"
       data-testid="ai-flows-storage-info"

--- a/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
@@ -72,20 +72,21 @@ const ConfigurationSection: React.FC = () => {
         <InfoGalleryItem
           sectionType={SectionType.setup}
           imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
-          title="Data connections"
+          title="Connections"
           description={
             <TextContent>
               <Text component="small">
-                You can add data connections to workbenches to connect your project to data inputs
-                and object storage buckets. You can also use data connections to specify the
-                location of your models during deployment.
+                Connections enable you to store and retrieve information that typically should not
+                be stored in code. For example, you can store details (including credentials) for
+                object storage, databases, and more. You can then attach the connections to
+                artifacts in your project, such as workbenches and model servers.
               </Text>
             </TextContent>
           }
           isOpen={open}
           onClick={() =>
             navigate(
-              `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.DATA_CONNECTIONS}`,
+              `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.CONNECTIONS}`,
             )
           }
         />

--- a/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/configuration/ConfigurationSection.tsx
@@ -15,6 +15,7 @@ import DividedGallery from '~/concepts/design/DividedGallery';
 import InfoGalleryItem from '~/concepts/design/InfoGalleryItem';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import useConnectionTypesEnabled from '~/concepts/connectionTypes/useConnectionTypesEnabled';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'rbac.authorization.k8s.io',
@@ -27,6 +28,7 @@ const ConfigurationSection: React.FC = () => {
   const [open, setOpen] = React.useState<boolean>(true);
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const projectSharingEnabled = useIsAreaAvailable(SupportedArea.DS_PROJECTS_PERMISSIONS).status;
+  const connectionTypesEnabled = useConnectionTypesEnabled();
   const [allowCreate, rbacLoaded] = useAccessReview({
     ...accessReviewResource,
     namespace: currentProject.metadata.name,
@@ -69,27 +71,50 @@ const ConfigurationSection: React.FC = () => {
             )
           }
         />
-        <InfoGalleryItem
-          sectionType={SectionType.setup}
-          imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
-          title="Connections"
-          description={
-            <TextContent>
-              <Text component="small">
-                Connections enable you to store and retrieve information that typically should not
-                be stored in code. For example, you can store details (including credentials) for
-                object storage, databases, and more. You can then attach the connections to
-                artifacts in your project, such as workbenches and model servers.
-              </Text>
-            </TextContent>
-          }
-          isOpen={open}
-          onClick={() =>
-            navigate(
-              `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.CONNECTIONS}`,
-            )
-          }
-        />
+        {connectionTypesEnabled ? (
+          <InfoGalleryItem
+            sectionType={SectionType.setup}
+            imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
+            title="Connections"
+            description={
+              <TextContent>
+                <Text component="small">
+                  Connections enable you to store and retrieve information that typically should not
+                  be stored in code. For example, you can store details (including credentials) for
+                  object storage, databases, and more. You can then attach the connections to
+                  artifacts in your project, such as workbenches and model servers.
+                </Text>
+              </TextContent>
+            }
+            isOpen={open}
+            onClick={() =>
+              navigate(
+                `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.CONNECTIONS}`,
+              )
+            }
+          />
+        ) : (
+          <InfoGalleryItem
+            sectionType={SectionType.setup}
+            imgSrc={typedObjectImage(ProjectObjectType.dataConnection)}
+            title="Data connections"
+            description={
+              <TextContent>
+                <Text component="small">
+                  You can add data connections to workbenches to connect your project to data inputs
+                  and object storage buckets. You can also use data connections to specify the
+                  location of your models during deployment.
+                </Text>
+              </TextContent>
+            }
+            isOpen={open}
+            onClick={() =>
+              navigate(
+                `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.DATA_CONNECTIONS}`,
+              )
+            }
+          />
+        )}
         {showPermissions ? (
           <InfoGalleryItem
             sectionType={SectionType.setup}


### PR DESCRIPTION
Closes: [RHOAIENG-13140](https://issues.redhat.com/browse/RHOAIENG-13140)

## Description
Updates the data connections card with new contents on both the home page and the data science projects page. The Connections card on the data science projects page now links to the connections tab.

## How Has This Been Tested?
Tested locally

## Test Impact
No tests added

## Screenshots
<img width="1228" alt="Screenshot 2024-10-07 at 3 37 15 PM" src="https://github.com/user-attachments/assets/68a11caf-9b56-4c0e-a4f7-ccebff4ddffa">

_----------------------_

<img width="1191" alt="Screenshot 2024-10-07 at 3 38 49 PM" src="https://github.com/user-attachments/assets/9a44b300-6b95-4317-9af2-558fb2101ca8">


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
