### PR TITLE
preserve sort and filter when loading more experiments

### DIFF
--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -6,10 +6,7 @@ import { TableBase, getTableColumnSort } from '~/components/table';
 import { ExperimentKFv2 } from '~/concepts/pipelines/kfTypes';
 import PipelineViewMoreFooterRow from '~/concepts/pipelines/content/tables/PipelineViewMoreFooterRow';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
-import {
-  useActiveExperimentSelector,
-  useAllExperimentSelector,
-} from '~/concepts/pipelines/content/pipelineSelector/useCreateSelectors';
+import { useActiveExperimentSelector } from '~/concepts/pipelines/content/pipelineSelector/useCreateSelectors';
 import { experimentSelectorColumns } from '~/concepts/pipelines/content/experiment/columns';
 import SearchSelector from '~/components/searchSelector/SearchSelector';
 
@@ -19,7 +16,7 @@ type ExperimentSelectorProps = {
 };
 
 const InnerExperimentSelector: React.FC<
-  ReturnType<typeof useAllExperimentSelector> & ExperimentSelectorProps
+  ReturnType<typeof useActiveExperimentSelector> & ExperimentSelectorProps
 > = ({
   fetchedSize,
   totalSize,
@@ -93,11 +90,6 @@ const InnerExperimentSelector: React.FC<
     )}
   </SearchSelector>
 );
-
-export const AllExperimentSelector: React.FC<ExperimentSelectorProps> = (props) => {
-  const selectorProps = useAllExperimentSelector();
-  return <InnerExperimentSelector {...props} {...selectorProps} />;
-};
 
 export const ActiveExperimentSelector: React.FC<ExperimentSelectorProps> = (props) => {
   const selectorProps = useActiveExperimentSelector();

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/useCreateSelectors.ts
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/useCreateSelectors.ts
@@ -2,13 +2,11 @@ import {
   useSelectorSearch,
   UseSelectorSearchValue,
 } from '~/concepts/pipelines/content/pipelineSelector/utils';
-import useExperimentTable, {
-  useActiveExperimentTable,
-} from '~/concepts/pipelines/content/tables/experiment/useExperimentTable';
+import { useActiveExperimentTable } from '~/concepts/pipelines/content/tables/experiment/useExperimentTable';
 import usePipelinesTable from '~/concepts/pipelines/content/tables/pipeline/usePipelinesTable';
 import {
   LoadMoreProps,
-  useExperimentLoadMore,
+  useActiveExperimentLoadMore,
   usePipelineLoadMore,
 } from '~/concepts/pipelines/content/tables/usePipelineLoadMore';
 import {
@@ -20,8 +18,6 @@ import {
   ExperimentKFv2,
   PipelineCoreResourceKFv2,
   PipelineKFv2,
-  PipelinesFilterOp,
-  StorageStateKF,
 } from '~/concepts/pipelines/kfTypes';
 import { PipelineListPaged } from '~/concepts/pipelines/types';
 import { FetchState } from '~/utilities/useFetchState';
@@ -38,40 +34,18 @@ type UsePipelineSelectorData<DataType> = {
   searchProps: Omit<UseSelectorSearchValue, 'onClear' | 'totalSize'>;
 } & Pick<UseSelectorSearchValue, 'totalSize'>;
 
-export const getExperimentSelector =
-  (useTable: typeof useExperimentTable, storageState?: StorageStateKF) =>
-  (): UsePipelineSelectorData<ExperimentKFv2> => {
-    const experimentsTable = useTable();
-    const [[{ items: initialData, nextPageToken: initialPageToken }, loaded]] = experimentsTable;
-
-    return useCreateSelector<ExperimentKFv2>(experimentsTable, () =>
-      useExperimentLoadMore({
-        initialData,
-        initialPageToken,
-        loaded,
-      })({
-        ...(storageState && {
-          filter: {
-            predicates: [
-              {
-                key: 'storage_state',
-                operation: PipelinesFilterOp.EQUALS,
-                // eslint-disable-next-line camelcase
-                string_value: storageState,
-              },
-            ],
-          },
-        }),
-      }),
-    );
-  };
-
-export const useAllExperimentSelector = getExperimentSelector(useExperimentTable);
-
-export const useActiveExperimentSelector = getExperimentSelector(
-  useActiveExperimentTable,
-  StorageStateKF.AVAILABLE,
-);
+export const useActiveExperimentSelector = (): UsePipelineSelectorData<ExperimentKFv2> => {
+  const experimentsTable = useActiveExperimentTable();
+  const [[{ items: initialData, nextPageToken: initialPageToken }, loaded]] = experimentsTable;
+  return useCreateSelector<ExperimentKFv2>(
+    experimentsTable,
+    useActiveExperimentLoadMore({
+      initialData,
+      initialPageToken,
+      loaded,
+    }),
+  );
+};
 
 export const usePipelineSelector = (): UsePipelineSelectorData<PipelineKFv2> => {
   const pipelinesTable = usePipelinesTable();

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineLoadMore.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineLoadMore.ts
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { ExperimentKFv2, PipelineKFv2, PipelineVersionKFv2 } from '~/concepts/pipelines/kfTypes';
+import {
+  ExperimentKFv2,
+  PipelineKFv2,
+  PipelinesFilterOp,
+  PipelineVersionKFv2,
+  StorageStateKF,
+} from '~/concepts/pipelines/kfTypes';
 import { PipelineParams, PipelinesFilter } from '~/concepts/pipelines/types';
 import { NotReadyError } from '~/utilities/useFetchState';
 
@@ -10,7 +16,7 @@ export type LoadMoreProps = {
   filter?: PipelinesFilter;
 };
 
-export const useExperimentLoadMore = (
+export const useActiveExperimentLoadMore = (
   initialState: UsePipelineDataRefProps<ExperimentKFv2>,
 ): ((props: LoadMoreProps) => [ExperimentKFv2[], () => Promise<void>]) => {
   const { api } = usePipelinesAPI();
@@ -22,10 +28,22 @@ export const useExperimentLoadMore = (
         if (!pageTokenRef.current) {
           return;
         }
-        const result = await api.listExperiments(
-          {},
-          getLoadMorePipelineParams({ pageTokenRef, ...loadMoreProps }),
-        );
+        const loadMorePipelineParams = getLoadMorePipelineParams({
+          pageTokenRef,
+          ...loadMoreProps,
+          filter: {
+            predicates: [
+              {
+                key: 'storage_state',
+                operation: PipelinesFilterOp.EQUALS,
+                // eslint-disable-next-line camelcase
+                string_value: StorageStateKF.AVAILABLE,
+              },
+              ...(loadMoreProps.filter?.predicates || []),
+            ],
+          },
+        });
+        const result = await api.listExperiments({}, loadMorePipelineParams);
         showMoreData((flag) => !flag);
         dataRef.current = [...dataRef.current, ...(result.experiments || [])];
         pageTokenRef.current = result.next_page_token;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-12843

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix experiment selector error when loading more results with active filters

This PR addresses an issue where clicking "View more" in the experiment selector would throw an error if sort or search filters were applied. The fix ensures that pagination works correctly while preserving the current filter state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Create more than 10 experiments in the system.
2. Navigate to the create run page.
3. Open the experiment selector.
4. Apply a sort filter to the experiments.
5. Click the "View more" button.
6. Verify that additional experiments load without errors.
7. Apply a search filter to the experiments.
8. Click the "View more" button again.
9. Confirm that more experiments load correctly, respecting both sort and search filters.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
covered by existing tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
