### PR TITLE
NIM storage size field update

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMPVCSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMPVCSizeSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HelperText, HelperTextItem, StackItem } from '@patternfly/react-core';
 import PVSizeField from '~/pages/projects/components/PVSizeField';
+import { MEMORY_UNITS_FOR_SELECTION } from '~/utilities/valueUnits';
 
 type NIMPVCSizeSectionProps = {
   pvcSize: string;
@@ -14,11 +15,15 @@ const NIMPVCSizeSection: React.FC<NIMPVCSizeSectionProps> = ({ pvcSize, setPvcSi
       size={pvcSize}
       setSize={(value: string) => setPvcSize(value)}
       label="NVIDIA NIM storage size"
+      options={MEMORY_UNITS_FOR_SELECTION.filter((option) => option.unit !== 'Mi')} // Filtering out 'Mi'
     />
     <HelperText>
       <HelperTextItem>
         Specify the size of the cluster storage instance that will be created to store the
         downloaded NVIDIA NIM.
+      </HelperTextItem>
+      <HelperTextItem>
+        Make sure your storage size is greater than the NIM size specified by NVIDIA.
       </HelperTextItem>
     </HelperText>
   </StackItem>

--- a/frontend/src/pages/projects/components/PVSizeField.tsx
+++ b/frontend/src/pages/projects/components/PVSizeField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import ValueUnitField from '~/components/ValueUnitField';
-import { MEMORY_UNITS_FOR_SELECTION } from '~/utilities/valueUnits';
+import { MEMORY_UNITS_FOR_SELECTION, UnitOption } from '~/utilities/valueUnits';
 
 type PVSizeFieldProps = {
   fieldID: string;
@@ -11,6 +11,7 @@ type PVSizeFieldProps = {
   setSize: (size: string) => void;
   currentSize?: string;
   label?: string;
+  options?: UnitOption[];
 };
 
 const PVSizeField: React.FC<PVSizeFieldProps> = ({
@@ -20,6 +21,7 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({
   setSize,
   currentSize,
   label = 'Persistent storage size',
+  options = MEMORY_UNITS_FOR_SELECTION,
 }) => (
   <FormGroup label={label} fieldId={fieldID} data-testid={fieldID}>
     <ValueUnitField
@@ -28,7 +30,7 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({
       menuAppendTo={menuAppendTo}
       onChange={(value) => setSize(value)}
       validated={currentSize ? 'warning' : 'default'}
-      options={MEMORY_UNITS_FOR_SELECTION}
+      options={options}
       value={size}
     />
     {currentSize && (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14037

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added another line of helper text and removed 'Mi' option.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested to make sure 'Mi' does not show up as an option for NIM.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
