### PR TITLE
Refactor useDefaultStorageClass hook to use FetchState

### DIFF
--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -84,7 +84,7 @@ const SpawnerPage: React.FC = () => {
   const [variableRows, setVariableRows] = React.useState<VariableRow[]>([]);
   const [submitError, setSubmitError] = React.useState<Error | null>(null);
 
-  const defaultStorageClass = useDefaultStorageClass();
+  const [defaultStorageClass, defaultStorageClassLoaded] = useDefaultStorageClass();
 
   const [selectedAcceleratorProfile, setSelectedAcceleratorProfile] =
     useGenericObjectState<AcceleratorProfileSelectFieldState>({
@@ -99,7 +99,8 @@ const SpawnerPage: React.FC = () => {
       ({ errors, variables }) =>
         Object.keys(errors).length > 0 ||
         variables.find((variable) => !variable.name || variable.name === EMPTY_KEY),
-    );
+    ) ||
+    !defaultStorageClassLoaded;
 
   React.useEffect(() => {
     const setFirstValidImage = () => {

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -28,7 +28,7 @@ type AddStorageModalProps = {
 const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, isOpen, onClose }) => {
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const preferredStorageClass = usePreferredStorageClass();
-  const defaultStorageClass = useDefaultStorageClass();
+  const [defaultStorageClass] = useDefaultStorageClass();
 
   const [createData, setCreateData, resetData] = useCreateStorageObjectForNotebook(existingData);
   const [actionInProgress, setActionInProgress] = React.useState(false);

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -70,7 +70,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   >();
   const [storageDataWithoutDefault, setStorageData] = useStorageDataObject(existingNotebook);
 
-  const defaultStorageClass = useDefaultStorageClass();
+  const [defaultStorageClass] = useDefaultStorageClass();
   const preferredStorageClass = usePreferredStorageClass();
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const defaultStorageClassName = isStorageClassesAvailable

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -30,7 +30,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
 }) => {
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
   const hasStorageClassConfigs = storageClasses.some((sc) => !!getStorageClassConfig(sc));
-  const defaultSc = useDefaultStorageClass();
+  const [defaultSc] = useDefaultStorageClass();
 
   const enabledStorageClasses = storageClasses
     .filter((sc) => getStorageClassConfig(sc)?.isEnabled === true)

--- a/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useDefaultStorageClass.ts
@@ -3,35 +3,50 @@ import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import { StorageClassKind } from '~/k8sTypes';
 import { getStorageClassConfig } from '~/pages/storageClasses/utils';
+import useFetchState, {
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '~/utilities/useFetchState';
 
-const useDefaultStorageClass = (): StorageClassKind | undefined => {
+const useDefaultStorageClass = (): FetchState<StorageClassKind | null> => {
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
-  const [storageClasses, storageClassesLoaded] = useStorageClasses();
-  const [defaultStorageClass, setDefaultStorageClass] = React.useState<
-    StorageClassKind | undefined
-  >();
+  const [storageClasses, storageClassesLoaded, storageClassesError] = useStorageClasses();
 
-  React.useEffect(() => {
-    if (!storageClassesLoaded || !isStorageClassesAvailable) {
-      return;
-    }
+  const fetchDefaultStorageClass: FetchStateCallbackPromise<StorageClassKind | null> =
+    React.useCallback(
+      () =>
+        new Promise((resolve, reject) => {
+          if (!isStorageClassesAvailable) {
+            resolve(null);
+          }
+          if (!storageClassesLoaded) {
+            reject(new NotReadyError('Storage classes are not loaded'));
+          }
+          if (storageClassesError) {
+            resolve(null);
+          }
 
-    const enabledStorageClasses = storageClasses.filter(
-      (sc) => getStorageClassConfig(sc)?.isEnabled === true,
+          const enabledStorageClasses = storageClasses.filter(
+            (sc) => getStorageClassConfig(sc)?.isEnabled === true,
+          );
+
+          const defaultSc = enabledStorageClasses.find(
+            (sc) => getStorageClassConfig(sc)?.isDefault === true,
+          );
+
+          if (!defaultSc && enabledStorageClasses.length > 0) {
+            resolve(enabledStorageClasses[0]);
+          } else if (defaultSc) {
+            resolve(defaultSc);
+          } else {
+            resolve(null);
+          }
+        }),
+      [storageClasses, storageClassesLoaded, storageClassesError, isStorageClassesAvailable],
     );
 
-    const defaultSc = enabledStorageClasses.find(
-      (sc) => getStorageClassConfig(sc)?.isDefault === true,
-    );
-
-    if (!defaultSc && enabledStorageClasses.length > 0) {
-      setDefaultStorageClass(enabledStorageClasses[0]);
-    } else {
-      setDefaultStorageClass(defaultSc);
-    }
-  }, [storageClasses, storageClassesLoaded, isStorageClassesAvailable]);
-
-  return defaultStorageClass;
+  return useFetchState(fetchDefaultStorageClass, null);
 };
 
 export default useDefaultStorageClass;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14219

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR refactors the `useDefaultStorageClass` hook to use the `useFetchState` utility, improving error handling and loading state management. The changes affect several components that use this hook, updating their implementations to handle the new return value format.

Key changes:
- Rewrote `useDefaultStorageClass` to use `useFetchState`
- Updated components using `useDefaultStorageClass` to destructure the new return value
- Added error handling and improved loading state management in `SpawnerPage`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Navigate to the Spawner page and verify that the storage class selection works as expected.

1. Verify that the ManageStorageModal in the project details page still functions correctly.
2. Check the StorageClassSelect component to ensure it still displays the correct default storage class.
3. Test the application's behavior during the loading state of storage classes, ensuring no errors occur and the UI handles the loading state appropriately.
4. Verify that the SpawnerPage component sets default properly

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
fixes flaky test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
