### PR TITLE
Fix misleading label after creating model registry

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -67,7 +67,10 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
         : [];
 
     // Unavailable
-    if (availableCondition?.status === ConditionStatus.False) {
+    if (
+      availableCondition?.status === ConditionStatus.False &&
+      !popoverMessages.some((message) => message.includes('ContainerCreating'))
+    ) {
       statusLabel = ModelRegistryStatusLabel.Unavailable;
       icon = <ExclamationCircleIcon />;
       color = 'red';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-12278

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Without this change the MR showed `Unavailable` immediately after creating model registry, when the reason was `ContainerCreating`, which was misleading to the user.

Before:
<img width="862" alt="Screenshot 2024-10-11 at 8 04 06 PM" src="https://github.com/user-attachments/assets/d3987a5e-06ad-4c5a-8892-2b2c7046a656">

<img width="1090" alt="Screenshot 2024-10-11 at 8 08 40 PM" src="https://github.com/user-attachments/assets/b5c40b81-faca-4fa4-bd5b-f041b870ceac">

After:
<img width="855" alt="Screenshot 2024-10-11 at 7 54 42 PM" src="https://github.com/user-attachments/assets/12a320ca-4943-4056-91e8-494d0a89f983">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to model registry setting page
2. Try creating model registry, if the reason is `ContainerCreating` the status of Model registry shows `Progressing` instead of `Unavailable`.
3. Show `Unavailable` otherwise.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
