### PR TITLE
support editing connection with unmatched connection type

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/BooleanFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/BooleanFormField.tsx
@@ -12,16 +12,6 @@ const BooleanFormField: React.FC<FieldProps<BooleanField>> = ({
   'data-testid': dataTestId,
 }) => {
   const isPreview = mode === 'preview';
-
-  // ensure the value is not undefined
-  React.useEffect(() => {
-    if (value == null) {
-      onChange?.(field.properties.defaultValue ?? false);
-    }
-    // do not run when callback changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
-
   return (
     <Checkbox
       aria-readonly={isPreview}

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -130,7 +130,7 @@ export const getDefaultValues = (
 
 export const assembleConnectionSecret = (
   project: ProjectKind,
-  type: ConnectionTypeConfigMapObj,
+  connectionTypeName: string,
   nameDesc: K8sNameDescriptionFieldData,
   values: {
     [key: string]: ConnectionTypeValueType;
@@ -155,7 +155,7 @@ export const assembleConnectionSecret = (
         'opendatahub.io/managed': 'true',
       },
       annotations: {
-        'opendatahub.io/connection-type': type.metadata.name,
+        'opendatahub.io/connection-type': connectionTypeName,
         'openshift.io/display-name': nameDesc.name,
         'openshift.io/description': nameDesc.description,
       },
@@ -215,3 +215,10 @@ export const getConnectionTypeDisplayName = (
     connection.metadata.annotations['opendatahub.io/connection-type']
   );
 };
+
+export const filterEnabledConnectionTypes = <
+  T extends ConnectionTypeConfigMap | ConnectionTypeConfigMapObj,
+>(
+  connectionTypes: T[],
+): T[] =>
+  connectionTypes.filter((t) => t.metadata.annotations?.['opendatahub.io/enabled'] === 'true');

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
@@ -11,6 +11,7 @@ import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
 import { createSecret, replaceSecret } from '~/api';
+import { filterEnabledConnectionTypes } from '~/concepts/connectionTypes/utils';
 import ConnectionsTable from './ConnectionsTable';
 import { ManageConnectionModal } from './ManageConnectionsModal';
 
@@ -23,6 +24,10 @@ const ConnectionsList: React.FC = () => {
     currentProject,
   } = React.useContext(ProjectDetailsContext);
   const [connectionTypes, connectionTypesLoaded, connectionTypesError] = useWatchConnectionTypes();
+  const enabledConnectionTypes = React.useMemo(
+    () => filterEnabledConnectionTypes(connectionTypes),
+    [connectionTypes],
+  );
 
   const [manageConnectionModal, setManageConnectionModal] = React.useState<{
     connection?: Connection;
@@ -47,6 +52,7 @@ const ConnectionsList: React.FC = () => {
           onClick={() => {
             setManageConnectionModal({});
           }}
+          isDisabled={enabledConnectionTypes.length === 0}
         >
           Add connection
         </Button>,
@@ -65,6 +71,10 @@ const ConnectionsList: React.FC = () => {
               key={`action-${ProjectSectionID.CONNECTIONS}`}
               variant="primary"
               data-testid="create-connection-button"
+              onClick={() => {
+                setManageConnectionModal({});
+              }}
+              isDisabled={enabledConnectionTypes.length === 0}
             >
               Create connection
             </Button>

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
@@ -496,7 +496,7 @@ describe('Edit connection modal', () => {
           connectionType: 's3',
           data: {
             UNMATCHED_1: window.btoa('unmatched1!'),
-            env1: window.btoa('saved data'),
+            env1: window.btoa('true'),
             UNMATCHED_2: window.btoa('unmatched2!'),
           },
         })}
@@ -505,8 +505,8 @@ describe('Edit connection modal', () => {
             name: 's3',
             fields: [
               {
-                type: 'short-text',
-                name: 'Short text',
+                type: 'boolean',
+                name: 'Checkbox field',
                 envVar: 'env1',
                 properties: {},
               },
@@ -517,8 +517,35 @@ describe('Edit connection modal', () => {
     );
 
     expect(screen.getByRole('combobox')).toHaveValue('s3');
-    expect(screen.getByRole('textbox', { name: 'Short text' })).toHaveValue('saved data');
+    expect(screen.getByRole('checkbox', { name: 'Checkbox field' })).toBeChecked();
     expect(screen.getByRole('textbox', { name: 'UNMATCHED_1' })).toHaveValue('unmatched1!');
+    expect(screen.getByRole('textbox', { name: 'UNMATCHED_2' })).toHaveValue('unmatched2!');
+  });
+
+  it('should list non matching values as short text with missing connection type', async () => {
+    render(
+      <ManageConnectionModal
+        isEdit
+        project={mockProjectK8sResource({})}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connection={mockConnection({
+          name: 's3-connection',
+          description: 's3 desc',
+          connectionType: 's3',
+          data: {
+            UNMATCHED_1: window.btoa('unmatched1!'),
+            env1: window.btoa('true'),
+            UNMATCHED_2: window.btoa('unmatched2!'),
+          },
+        })}
+        connectionTypes={[]}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('s3');
+    expect(screen.getByRole('textbox', { name: 'UNMATCHED_1' })).toHaveValue('unmatched1!');
+    expect(screen.getByRole('textbox', { name: 'env1' })).toHaveValue('true');
     expect(screen.getByRole('textbox', { name: 'UNMATCHED_2' })).toHaveValue('unmatched2!');
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14274
https://issues.redhat.com/browse/RHOAIENG-14273

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updates the empty state `Add connection` button to open the modal. Also disables the `Add connection` buttons when no connection types are present (note that this should not happen when we install OOTB types).

The annotation `opendatahub.io/connection-type` value from the `Secret` is used to reference a connection type. When no matching connection type is found now this reference is displayed as the connection type in the disabled drop down and all fields are displayed in their default state (env vars as labels and fields are all text inputs).
![image](https://github.com/user-attachments/assets/76f37794-c2ed-4729-b8cb-1c89f9769d95)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Toggle the `disableConnectionsTypes` feature flag to `false`.
- Navigate to the `Data connections` tab of the project details.
- Create a new data connection.
- Navigate to the `Connections` tab and edit the data connection.
- Observe the connection type in the disabled dropdown reads `s3`.
- Observe the form is open and fields are editable and can be saved.
- Install the `s3` connection type (until we have OOTB types) and use the admin page. It can be enabled or disabled (test both).
<details>
  <summary>S3 connection type</summary>
  
  ```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: s3
  namespace: opendatahub
  labels:
    opendatahub.io/connection-type: 'true'
    opendatahub.io/dashboard: 'true'
  annotations:
    opendatahub.io/enabled: 'true'
    openshift.io/description: 'Connect to storage systems that are compatible with Amazon S3, enabling integration with other S3-compatible services and applications.'
    openshift.io/display-name: S3 compatible object storage - v1
data:
  category: '["Object storage"]'
  fields: '[{"type":"short-text","name":"Access Key","envVar":"AWS_ACCESS_KEY_ID","required":true,"properties":{}},{"type":"hidden","name":"Secret Key","envVar":"AWS_SECRET_ACCESS_KEY","required":true,"properties":{}},{"type":"short-text","name":"Endpoint","envVar":"AWS_S3_ENDPOINT","required":true,"properties":{}},{"name":"Region","description":"","envVar":"AWS_DEFAULT_REGION","type":"short-text","required":false,"properties":{}},{"type":"short-text","name":"Bucket","envVar":"AWS_S3_BUCKET","required":false,"properties":{}}]'

  }
  ```
</details>

- Navigate back to the `Connections` tab and edit the same connection.
- Observe the fields now have proper labels and the connection type selected in the disabled dropdown reads `S3 compatible object storage - v1`. This time the connection type was used to generate the form.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Add unit test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 