### PR TITLE
Cleanup the existing secret field functionality

### DIFF
--- a/frontend/src/concepts/trustyai/content/TrustyDBExistingSecretField.tsx
+++ b/frontend/src/concepts/trustyai/content/TrustyDBExistingSecretField.tsx
@@ -62,11 +62,14 @@ const TrustyDBExistingSecretField: React.FC<TrustyDBExistingSecretFieldProps> = 
         value={data}
         onChange={(e, value) => {
           delayCheckState();
-          onDataChange(value);
+          onDataChange(value.trim());
         }}
         onBlur={() => {
-          delayCheckState.cancel();
-          onCheckState();
+          if (state !== TrustyInstallModalFormExistingState.EXISTING) {
+            // If you're not already validated, cancel exiting efforts and check now
+            delayCheckState.cancel();
+            onCheckState();
+          }
         }}
         validated={inputState}
       />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14314

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Couple PR followups to the previous effort to add DB field to trusty startup

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See https://github.com/opendatahub-io/odh-dashboard/pull/3305 for setup. Basically this is all frontend so you just need trusty enabled and to interact with the UI modal for configuring it.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None, UI quirks.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
