### PR TITLE
Fix to show tooltip on explore card badges

### DIFF
--- a/frontend/src/components/OdhCard.scss
+++ b/frontend/src/components/OdhCard.scss
@@ -40,6 +40,10 @@
       visibility: hidden;
     }
 
+    &.odh-m-selectable {
+      z-index: 1;
+      cursor: pointer;
+    }
     &.odh-m-doc {
       border-color: var(--pf-v5-global--BackgroundColor--light-300);
       display: flex;

--- a/frontend/src/components/OdhExploreCard.tsx
+++ b/frontend/src/components/OdhExploreCard.tsx
@@ -39,6 +39,7 @@ const OdhExploreCard: React.FC<OdhExploreCardProps> = ({
   const cardClasses = classNames('odh-card', { 'm-disabled': disabled });
   const badgeClasses = classNames('odh-card__partner-badge', {
     'm-hidden': odhApp.spec.support === ODH_PRODUCT_NAME,
+    'odh-m-selectable': !disabled,
   });
 
   return (
@@ -64,7 +65,7 @@ const OdhExploreCard: React.FC<OdhExploreCardProps> = ({
                   <FlexItem className="odh-card__coming-soon">Coming soon</FlexItem>
                 )}
                 {!odhApp.spec.comingSoon && odhApp.spec.category && (
-                  <FlexItem className={badgeClasses}>
+                  <FlexItem className={badgeClasses} onClick={disabled ? undefined : onSelect}>
                     <OdhExploreCardTypeBadge category={odhApp.spec.category} />
                   </FlexItem>
                 )}


### PR DESCRIPTION
Fixes [RHOAIENG-7709](https://issues.redhat.com/browse/RHOAIENG-7709)

## Description
Adds z-index to the partner badge for selectable cards so that it shows above the card overlay and displays the tooltip on hover. Adds the pointer cursor and handles the click event when the card is not disabled (so that click on the badge still selects the card).

## How Has This Been Tested?
- On the `Explore` page, for an enabled card:
  -  hover over the badge, verify the tooltip for the badge is shown and the cursor remains the pointer cursor
  - click on the badge, verify the card becomes selected and the side panel shows its details
- On the `Explore` page, for disabled card  (I tested by forcing cards to be disabled):
  - hover over the badge, verify the tooltip for the badge is shown
  - click on the badge, verify nothing happens

## Test Impact
Automated testing is not feasible since it is hover state visuals that have changed

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
