### PR TITLE
Make Label Cursor Hoverable 

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -30,7 +30,6 @@ enum ConditionStatus {
   True = 'True',
   False = 'False',
 }
-
 interface ModelRegistryTableRowStatusProps {
   conditions: K8sCondition[] | undefined;
 }
@@ -118,9 +117,13 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     }
   }
 
+  const isClickable =
+    statusLabel === ModelRegistryStatusLabel.Unavailable ||
+    statusLabel === ModelRegistryStatusLabel.Degrading;
+
   const label = (
     <Label
-      onClick={() => void 0}
+      {...(isClickable ? { onClick: () => {} } : {})}
       data-testid="model-registry-label"
       icon={icon}
       color={color}

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -119,7 +119,14 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
   }
 
   const label = (
-    <Label data-testid="model-registry-label" icon={icon} color={color} isCompact>
+    <Label
+      onClick={() => void 0}
+      data-testid="model-registry-label"
+      icon={icon}
+      color={color}
+      isCompact
+      className="pf-m-link"
+    >
       {statusLabel}
     </Label>
   );

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -123,7 +123,13 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
 
   const label = (
     <Label
-      {...(isClickable ? { onClick: () => {} } : {})}
+      {...(isClickable
+        ? {
+            onClick: () => {
+              /* intentional no-op */
+            },
+          }
+        : {})}
       data-testid="model-registry-label"
       icon={icon}
       color={color}

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -125,7 +125,6 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
       icon={icon}
       color={color}
       isCompact
-      className="pf-m-link"
     >
       {statusLabel}
     </Label>

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -117,16 +117,15 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     }
   }
 
-  const isClickable =
-    statusLabel === ModelRegistryStatusLabel.Unavailable ||
-    statusLabel === ModelRegistryStatusLabel.Degrading;
+  const isClickable = popoverTitle && popoverMessages.length;
 
   const label = (
     <Label
       {...(isClickable
         ? {
             onClick: () => {
-              /* intentional no-op */
+              /* intentional no-op - Click event is handled by the Popover parent, 
+              this prop enables clickable styles in the PatternFly Label" */
             },
           }
         : {})}

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -125,7 +125,7 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
         ? {
             onClick: () => {
               /* intentional no-op - Click event is handled by the Popover parent, 
-              this prop enables clickable styles in the PatternFly Label" */
+              this prop enables clickable styles in the PatternFly Label */
             },
           }
         : {})}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13047

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Made the labels indicate they are hoverable in Settings page

https://github.com/user-attachments/assets/31648c76-ee87-4b39-80b8-316f4e594ced


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the UI
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
