### PR TITLE
Display internal addresses even when models are external

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -311,6 +311,14 @@ class InferenceServiceRow extends TableRow {
   findInternalServicePopover() {
     return cy.findByTestId('internal-service-popover');
   }
+
+  findExternalServiceButton() {
+    return this.find().findByTestId('internal-external-service-button');
+  }
+
+  findExternalServicePopover() {
+    return cy.findByTestId('external-service-popover');
+  }
 }
 class ServingPlatformCard extends Contextual<HTMLElement> {
   findDeployModelButton() {

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceEndpoint.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceEndpoint.tsx
@@ -2,6 +2,12 @@ import * as React from 'react';
 import {
   Button,
   ClipboardCopy,
+  ClipboardCopyVariant,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Divider,
   HelperText,
   HelperTextItem,
   Popover,
@@ -40,14 +46,15 @@ const InferenceServiceEndpoint: React.FC<InferenceServiceEndpointProps> = ({
     return (
       <Popover
         data-testid="internal-service-popover"
-        headerContent="Internal Service can be accessed inside the cluster"
+        headerContent="Inference endpoints"
         aria-label="Internal Service Info"
+        hasAutoWidth
         bodyContent={
           <InternalServicePopoverContent inferenceService={inferenceService} isKserve={isKserve} />
         }
       >
         <Button data-testid="internal-service-button" isInline variant="link">
-          Internal Service
+          Endpoint details (internal)
         </Button>
       </Popover>
     );
@@ -68,9 +75,38 @@ const InferenceServiceEndpoint: React.FC<InferenceServiceEndpointProps> = ({
   }
 
   return (
-    <ClipboardCopy hoverTip="Copy" clickTip="Copied" isReadOnly>
-      {isKserve ? routeLink : `${routeLink}/infer`}
-    </ClipboardCopy>
+    <Popover
+      data-testid="external-service-popover"
+      headerContent="Inference endpoints"
+      aria-label="External Service Info"
+      hasAutoWidth
+      bodyContent={
+        <InternalServicePopoverContent inferenceService={inferenceService} isKserve={isKserve} />
+      }
+      footerContent={
+        <DescriptionList>
+          <DescriptionListGroup>
+            <Divider />
+            <DescriptionListTerm>
+              External (can be accessed from inside or outside the cluster)
+            </DescriptionListTerm>
+            <DescriptionListDescription style={{ paddingLeft: 'var(--pf-v5-global--spacer--md)' }}>
+              <ClipboardCopy
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant={ClipboardCopyVariant.inlineCompact}
+              >
+                {isKserve ? routeLink : `${routeLink}/infer`}
+              </ClipboardCopy>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      }
+    >
+      <Button data-testid="internal-external-service-button" isInline variant="link">
+        Endpoint details (internal and external)
+      </Button>
+    </Popover>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  ListItem,
 } from '@patternfly/react-core';
 import { InferenceServiceKind } from '~/k8sTypes';
 
@@ -47,20 +48,27 @@ const InternalServicePopoverContent: React.FC<InternalServicePopoverContentProps
 
   return (
     <DescriptionList isCompact>
-      {Object.entries(isInternalServiceEnabled).map(([route, value]) => (
-        <DescriptionListGroup key={route}>
-          <DescriptionListTerm>{route}</DescriptionListTerm>
-          <DescriptionListDescription>
-            <ClipboardCopy
-              hoverTip="Copy"
-              clickTip="Copied"
-              variant={ClipboardCopyVariant.inlineCompact}
-            >
-              {value}
-            </ClipboardCopy>
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-      ))}
+      <DescriptionListTerm>
+        Internal (can only be accessed from inside the cluster)
+      </DescriptionListTerm>
+      {Object.entries(isInternalServiceEnabled)
+        .slice(0, 2)
+        .map(([route, value]) => (
+          <DescriptionListGroup key={route}>
+            <DescriptionListTerm>
+              <ListItem>{route}</ListItem>
+            </DescriptionListTerm>
+            <DescriptionListDescription style={{ paddingLeft: 'var(--pf-v5-global--spacer--md)' }}>
+              <ClipboardCopy
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant={ClipboardCopyVariant.inlineCompact}
+              >
+                {value}
+              </ClipboardCopy>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        ))}
     </DescriptionList>
   );
 };


### PR DESCRIPTION
Closes: [RHOAIENG-7579](https://issues.redhat.com/browse/RHOAIENG-7579)

## Description
This PR aims to display internal addresses even when models are external.

<img width="696" alt="Screenshot 2024-10-15 at 5 03 33 PM" src="https://github.com/user-attachments/assets/275bc359-7882-4319-901d-d1bd7c82f7a8">

<img width="879" alt="Screenshot 2024-10-15 at 5 03 51 PM" src="https://github.com/user-attachments/assets/1cf8510f-6539-46e2-898c-2e4c303d6414">


## How Has This Been Tested?
check the inference endpoint:
when external route is enabled: 
  - it should display both internal and external address
  
when external route is not enabled
  - it should only show internal address

## Test Impact
Added cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
