### PR TITLE
Add P0 OOTB connection types

### DIFF
--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -151,6 +151,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
             {
               title: 'Edit',
               onClick: () => navigate(`/connectionTypes/edit/${obj.metadata.name}`),
+              isDisabled: ownedByDSC(obj),
             },
             {
               title: 'Duplicate',
@@ -160,6 +161,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
             {
               title: 'Delete',
               onClick: () => handleDelete(obj),
+              isDisabled: ownedByDSC(obj),
             },
           ]}
         />

--- a/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
 import { useParams } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { useConnectionType } from '~/concepts/connectionTypes/useConnectionType';
 import { updateConnectionType } from '~/services/connectionTypesService';
+import { ownedByDSC } from '~/concepts/k8s/utils';
 import ManageConnectionTypePage from './ManageConnectionTypePage';
 
 const EditConnectionTypePage: React.FC = () => {
+  const navigate = useNavigate();
   const { name } = useParams();
   const [existingConnectionType, isLoaded, error] = useConnectionType(name);
+
+  if (existingConnectionType && ownedByDSC(existingConnectionType)) {
+    navigate('/connectionTypes');
+    return null;
+  }
 
   if (!isLoaded || error) {
     return <ApplicationsPage loaded={isLoaded} loadError={error} empty />;

--- a/manifests/common/connection-types/kustomization.yaml
+++ b/manifests/common/connection-types/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./crd
-  - ./apps
-  - ./connection-types
+  - ./oci-compliant-registry-v1.yaml
+  - ./s3.yaml
+  - ./uri-v1.yaml

--- a/manifests/common/connection-types/oci-compliant-registry-v1.yaml
+++ b/manifests/common/connection-types/oci-compliant-registry-v1.yaml
@@ -1,0 +1,13 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: oci-compliant-registry-v1
+  labels:
+    opendatahub.io/connection-type: 'true'
+    opendatahub.io/dashboard: 'true'
+  annotations:
+    openshift.io/description: 'Connect to an OCI-compliant container registry, enabling integration with containerized applications and services. Use this connection type to pull and manage container images and artifacts that adhere to the Open Container Initiative (OCI) standards, ensuring compatibility with OCI-compliant tools and workflows.'
+    openshift.io/display-name: OCI compliant registry - v1
+data:
+  category: '["URI"]'
+  fields: '[{"type":"uri","name":"URI","envVar":"URI","required":true,"properties":{}}]'

--- a/manifests/common/connection-types/s3.yaml
+++ b/manifests/common/connection-types/s3.yaml
@@ -1,0 +1,13 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: s3
+  labels:
+    opendatahub.io/connection-type: 'true'
+    opendatahub.io/dashboard: 'true'
+  annotations:
+    openshift.io/description: 'Connect to storage systems that are compatible with Amazon S3, enabling integration with other S3-compatible services and applications.'
+    openshift.io/display-name: S3 compatible object storage - v1
+data:
+  category: '["Object storage"]'
+  fields: '[{"type":"short-text","name":"Access key","envVar":"AWS_ACCESS_KEY_ID","properties":{},"required":true},{"type":"hidden","name":"Secret key","envVar":"AWS_SECRET_ACCESS_KEY","required":true,"properties":{}},{"type":"short-text","name":"Endpoint","envVar":"AWS_S3_ENDPOINT","required":true,"properties":{}},{"type":"short-text","name":"Region","envVar":"AWS_DEFAULT_REGION","required":false,"properties":{}},{"type":"short-text","name":"Bucket","envVar":"AWS_S3_BUCKET","required":false,"properties":{}}]'

--- a/manifests/common/connection-types/uri-v1.yaml
+++ b/manifests/common/connection-types/uri-v1.yaml
@@ -1,0 +1,13 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: uri-v1
+  labels:
+    opendatahub.io/connection-type: 'true'
+    opendatahub.io/dashboard: 'true'
+  annotations:
+    openshift.io/description: Establish connections by using Uniform Resource Identifiers (URIs) to access various data sources.
+    openshift.io/display-name: URI - v1
+data:
+  category: '["URI"]'
+  fields: '[{"type":"uri","name":"URI","envVar":"URI","required":true,"properties":{}}]'


### PR DESCRIPTION
[RHOAIENG-13105](https://issues.redhat.com/browse/RHOAIENG-13105)

## Description
Adds yaml files for OOTB connection types. Updates the connection type page to not allow editing of the OOTB connection types. Fixes an issue where the connection types table does not update when new connections are added or modified.

## How Has This Been Tested?
- Run the UI and navigate to Settings -> Connection types
- Install the connection types:
  - Set the project to opendatahub: `oc project opendatahub`
  - oc apply -f manifests/common/connection-types/s3.yaml
  - oc apply -f manifests/common/connection-types/oci-compliant-registry-v1.yaml
  - oc apply -f manifests/common/connection-types/uri-v1.yaml
- Verify the connection types are shown in the UI without needing to refresh the page within 30 seconds

- From the OpenShift Console, go to Administrator -> Home -> Search
  - Select the opendatahub project
  - Select Resource = OdhApplication
  - Find the `jupyter` OdhApplication and copy its `ownerReference` section of the Yaml file
  - Go back to the Search page and Select the ConfigMap Resource
  - Edit the s3, oci-compliant-registry-v1, and uri-v1 configmaps:
    -  Add the copied `ownerReference` section to each of them
  - Check the UI and see that each now has `Pre-installed` for the `creator` column
  - Verify the `Edit` action in the kebab is disabled for each.

## Test Impact
None, test already covered this functionality

## Screen shots

![image](https://github.com/user-attachments/assets/6fb9f312-a8e4-4329-9401-6118b8573888)

![image](https://github.com/user-attachments/assets/db80e24e-4724-4523-b4f7-ca83cedb6f78)

![image](https://github.com/user-attachments/assets/8f79acf7-65cf-4faf-9802-f9731bd3d0d3)

![image](https://github.com/user-attachments/assets/7f54f4a3-bb07-4874-8aa5-0ff46ba40315)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)


/cc @simrandhaliw 