### PR TITLE
rename trusty flag to disableTrustyBiasMetrics

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -29,7 +29,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableProjectSharing: boolean;
       disableCustomServingRuntimes: boolean;
       disablePipelines: boolean;
-      disableBiasMetrics: boolean;
+      disableTrustyBiasMetrics: boolean;
       disablePerformanceMetrics: boolean;
       disableKServe: boolean;
       disableKServeAuth: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -53,7 +53,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableModelServing: false,
       disableProjectSharing: false,
       disableCustomServingRuntimes: false,
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disablePipelines: false,
       disableKServe: false,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -30,7 +30,7 @@ The following are a list of features that are supported, along with there defaul
 | disableKServeMetrics         | false   | Disables the ability to see KServe Metrics.                                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
-| disableBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
+| disableTrustyBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
@@ -62,7 +62,7 @@ spec:
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: false
     disableKServeMetrics: false
-    disableBiasMetrics: false
+    disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
     disableDistributedWorkloads: false
     disableConnectionTypes: false
@@ -159,7 +159,7 @@ spec:
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: true
     disableKServeMetrics: true
-    disableBiasMetrics: false
+    disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
     disableNIMModelServing: true
   notebookController:

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -21,7 +21,7 @@ type MockDashboardConfigType = {
   disableModelMesh?: boolean;
   disableAcceleratorProfiles?: boolean;
   disablePerformanceMetrics?: boolean;
-  disableBiasMetrics?: boolean;
+  disableTrustyBiasMetrics?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
   disableConnectionTypes?: boolean;
@@ -51,7 +51,7 @@ export const mockDashboardConfig = ({
   disableModelMesh = false,
   disableAcceleratorProfiles = false,
   disablePerformanceMetrics = false,
-  disableBiasMetrics = false,
+  disableTrustyBiasMetrics = false,
   disableDistributedWorkloads = false,
   disableModelRegistry = false,
   disableConnectionTypes = true,
@@ -152,7 +152,7 @@ export const mockDashboardConfig = ({
       disableCustomServingRuntimes,
       disablePipelines,
       disableProjectSharing: false,
-      disableBiasMetrics,
+      disableTrustyBiasMetrics,
       disablePerformanceMetrics,
       disableKServe,
       disableKServeAuth,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
@@ -53,7 +53,7 @@ import {
 
 type HandlersProps = {
   disablePerformanceMetrics?: boolean;
-  disableBiasMetrics?: boolean;
+  disableTrustyBiasMetrics?: boolean;
   disableKServeMetrics?: boolean;
   servingRuntimes?: ServingRuntimeKind[];
   inferenceServices?: InferenceServiceKind[];
@@ -81,7 +81,7 @@ const mockTrustyDBSecret = (): SecretKind =>
 
 const initIntercepts = ({
   disablePerformanceMetrics,
-  disableBiasMetrics,
+  disableTrustyBiasMetrics,
   disableKServeMetrics,
   servingRuntimes = [mockServingRuntimeK8sResource({})],
   inferenceServices = [mockInferenceServiceK8sResource({ isModelMesh: true })],
@@ -100,7 +100,7 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({
-      disableBiasMetrics,
+      disableTrustyBiasMetrics,
       disablePerformanceMetrics,
       disableKServeMetrics,
     }),
@@ -210,7 +210,7 @@ const initIntercepts = ({
 describe('Model Metrics', () => {
   it('Empty State No Serving Data Available', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -222,7 +222,7 @@ describe('Model Metrics', () => {
 
   it('Serving Chart Shows Data', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: true,
       hasBiasData: false,
@@ -234,7 +234,7 @@ describe('Model Metrics', () => {
 
   it('Empty State No Bias Data Available', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -264,7 +264,7 @@ describe('Model Metrics', () => {
 
   it('Bias Charts Show Data', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: true,
@@ -294,7 +294,7 @@ describe('Model Metrics', () => {
 
   it('Server metrics show no data available', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -309,7 +309,7 @@ describe('Model Metrics', () => {
 
   it('Server metrics show data', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: true,
       hasBiasData: false,
@@ -324,7 +324,7 @@ describe('Model Metrics', () => {
 
   it('Bias metrics is not configured', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -339,7 +339,7 @@ describe('Model Metrics', () => {
 
   it('Performance Metrics Tab Hidden', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: true,
       hasServingData: false,
       hasBiasData: false,
@@ -351,7 +351,7 @@ describe('Model Metrics', () => {
 
   it('Bias Metrics Tab Hidden', () => {
     initIntercepts({
-      disableBiasMetrics: true,
+      disableTrustyBiasMetrics: true,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -363,7 +363,7 @@ describe('Model Metrics', () => {
 
   it('Disable Trusty AI', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -393,7 +393,7 @@ describe('Model Metrics', () => {
 
   it('Enable Trusty AI', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -461,7 +461,7 @@ describe('Model Metrics', () => {
 
   it('Trusty AI enable service error', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: false,
@@ -510,7 +510,7 @@ describe('Model Metrics', () => {
 
   it('Bias Metrics Show In Table', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: true,
@@ -537,7 +537,7 @@ describe('Model Metrics', () => {
 
   it('Configure Bias Metric', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       hasServingData: false,
       hasBiasData: true,
@@ -603,7 +603,7 @@ describe('Model Metrics', () => {
 describe('KServe performance metrics', () => {
   it('should inform user when area disabled', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: true,
       hasServingData: false,
@@ -616,7 +616,7 @@ describe('KServe performance metrics', () => {
 
   it('should show error when ConfigMap is missing', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: true,
@@ -639,7 +639,7 @@ describe('KServe performance metrics', () => {
 
   it('should inform user when serving runtime is unsupported', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: true,
@@ -655,7 +655,7 @@ describe('KServe performance metrics', () => {
 
   it('should handle a malformed graph definition gracefully', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: true,
@@ -674,7 +674,7 @@ describe('KServe performance metrics', () => {
 
   it('should display only 2 graphs, when the config specifies', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: true,
@@ -695,7 +695,7 @@ describe('KServe performance metrics', () => {
 
   it('charts should not error out if a query is missing and there is other data', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: true,
@@ -718,7 +718,7 @@ describe('KServe performance metrics', () => {
 
   it('charts should not error out if a query is missing and there is no data', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: false,
@@ -741,7 +741,7 @@ describe('KServe performance metrics', () => {
 
   it('charts should show data when serving data is available', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: true,
@@ -761,7 +761,7 @@ describe('KServe performance metrics', () => {
 
   it('charts should show empty state when no serving data is available', () => {
     initIntercepts({
-      disableBiasMetrics: false,
+      disableTrustyBiasMetrics: false,
       disablePerformanceMetrics: false,
       disableKServeMetrics: false,
       hasServingData: false,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -17,7 +17,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableProjectSharing: false,
   disableCustomServingRuntimes: false,
   disablePipelines: false,
-  disableBiasMetrics: false,
+  disableTrustyBiasMetrics: false,
   disablePerformanceMetrics: false,
   disableKServe: false,
   disableKServeAuth: false,
@@ -94,7 +94,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.DS_PROJECTS_VIEW],
   },
   [SupportedArea.BIAS_METRICS]: {
-    featureFlags: ['disableBiasMetrics'],
+    featureFlags: ['disableTrustyBiasMetrics'],
     requiredComponents: [StackComponent.TRUSTY_AI],
     reliantAreas: [SupportedArea.MODEL_SERVING],
   },

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1316,7 +1316,7 @@ export type DashboardCommonConfig = {
   disableProjectSharing: boolean;
   disableCustomServingRuntimes: boolean;
   disablePipelines: boolean;
-  disableBiasMetrics: boolean;
+  disableTrustyBiasMetrics: boolean;
   disablePerformanceMetrics: boolean;
   disableKServe: boolean;
   disableKServeAuth: boolean;

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -53,7 +53,7 @@ spec:
                       type: boolean
                     disablePipelines:
                       type: boolean
-                    disableBiasMetrics:
+                    disableTrustyBiasMetrics:
                       type: boolean
                     disablePerformanceMetrics:
                       type: boolean

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -19,7 +19,7 @@ spec:
     disableModelServing: false
     disableProjectSharing: false
     disableCustomServingRuntimes: false
-    disableBiasMetrics: false
+    disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
     disableAcceleratorProfiles: false
     disableKServe: false


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14126

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
renames trusty flag to disableTrustyBiasMetrics and removed logic in the resourceUtils that prevents RHOAI from using the feature flag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Make sure enable trusty is visible in the permissions tab

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no test impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
