### PR TITLE
Change models tooltip to popover

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -285,7 +285,7 @@ class InferenceServiceRow extends TableRow {
   findStatusTooltip() {
     return this.find()
       .findByTestId('status-tooltip')
-      .trigger('mouseenter')
+      .click()
       .then(() => {
         cy.findByTestId('model-status-tooltip');
       });
@@ -296,7 +296,7 @@ class InferenceServiceRow extends TableRow {
       .invoke('text')
       .should('contain', msg)
       .then(() => {
-        this.findStatusTooltip().trigger('mouseleave');
+        this.findStatusTooltip().find('button').click();
       });
   }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -528,7 +528,7 @@ describe('Serving Runtime List', () => {
         .click();
       modelServingSection.findInferenceServiceTable().should('exist');
       let inferenceServiceRow = modelServingSection.getInferenceServiceRow('OVMS ONNX');
-      inferenceServiceRow.findStatusTooltip().should('be.visible');
+      inferenceServiceRow.findStatusTooltip();
       inferenceServiceRow.findStatusTooltipValue('Failed to pull model from storage due to error');
 
       // Check status of deployed model which loaded successfully after an error

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, Icon, Tooltip } from '@patternfly/react-core';
+import { Text, Icon, Popover } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -45,6 +45,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
+            style={{ cursor: 'pointer' }}
           >
             <CheckCircleIcon />
           </Icon>
@@ -59,6 +60,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
+            style={{ cursor: 'pointer' }}
           >
             <ExclamationCircleIcon />
           </Icon>
@@ -80,6 +82,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
+            style={{ cursor: 'pointer' }}
           >
             <OutlinedQuestionCircleIcon />
           </Icon>
@@ -94,6 +97,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
+            style={{ cursor: 'pointer' }}
           >
             <OutlinedQuestionCircleIcon />
           </Icon>
@@ -102,10 +106,9 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
   };
 
   return (
-    <Tooltip
-      role="none"
-      data-testid="model-status-tooltip"
-      content={
+    <Popover
+      position="right"
+      bodyContent={
         modelStatus?.failedToSchedule ? (
           <Text>Insufficient resources</Text>
         ) : (
@@ -114,7 +117,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
       }
     >
       {statusIcon()}
-    </Tooltip>
+    </Popover>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, Icon, Popover } from '@patternfly/react-core';
+import { Icon, Popover, Button } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -45,7 +45,6 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
-            style={{ cursor: 'pointer' }}
           >
             <CheckCircleIcon />
           </Icon>
@@ -60,7 +59,6 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
-            style={{ cursor: 'pointer' }}
           >
             <ExclamationCircleIcon />
           </Icon>
@@ -82,7 +80,6 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
-            style={{ cursor: 'pointer' }}
           >
             <OutlinedQuestionCircleIcon />
           </Icon>
@@ -97,7 +94,6 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
             isInline
             tabIndex={0}
             iconSize={iconSize}
-            style={{ cursor: 'pointer' }}
           >
             <OutlinedQuestionCircleIcon />
           </Icon>
@@ -105,18 +101,18 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
     }
   };
 
+  const bodyContent = modelStatus?.failedToSchedule
+    ? 'Insufficient resources'
+    : getInferenceServiceStatusMessage(inferenceService);
+
   return (
     <Popover
-      position="right"
-      bodyContent={
-        modelStatus?.failedToSchedule ? (
-          <Text>Insufficient resources</Text>
-        ) : (
-          <Text>{getInferenceServiceStatusMessage(inferenceService)}</Text>
-        )
-      }
+      data-testid="model-status-tooltip"
+      position="top"
+      bodyContent={bodyContent}
+      isVisible={bodyContent ? undefined : false}
     >
-      {statusIcon()}
+      <Button variant="link" isInline icon={statusIcon()} />
     </Popover>
   );
 };

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -37,31 +37,31 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
       case InferenceServiceModelState.LOADED:
       case InferenceServiceModelState.STANDBY:
         return (
-          <Icon
-            data-testid="status-tooltip"
-            role="button"
-            aria-label="success icon"
-            status="success"
+          <Button
+            aria-label="success status"
+            variant="link"
             isInline
-            tabIndex={0}
-            iconSize={iconSize}
-          >
-            <CheckCircleIcon />
-          </Icon>
+            data-testid="status-tooltip"
+            icon={
+              <Icon status="success" isInline iconSize={iconSize}>
+                <CheckCircleIcon />
+              </Icon>
+            }
+          />
         );
       case InferenceServiceModelState.FAILED_TO_LOAD:
         return (
-          <Icon
-            data-testid="status-tooltip"
-            role="button"
-            aria-label="error icon"
-            status="danger"
+          <Button
+            aria-label="danger status"
+            variant="link"
             isInline
-            tabIndex={0}
-            iconSize={iconSize}
-          >
-            <ExclamationCircleIcon />
-          </Icon>
+            data-testid="status-tooltip"
+            icon={
+              <Icon status="danger" isInline iconSize={iconSize}>
+                <ExclamationCircleIcon />
+              </Icon>
+            }
+          />
         );
       case InferenceServiceModelState.PENDING:
       case InferenceServiceModelState.LOADING:
@@ -72,31 +72,31 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
         );
       case InferenceServiceModelState.UNKNOWN:
         return (
-          <Icon
-            data-testid="status-tooltip"
-            role="button"
-            aria-label="warning icon"
-            status="warning"
+          <Button
+            aria-label="warning status"
+            variant="link"
             isInline
-            tabIndex={0}
-            iconSize={iconSize}
-          >
-            <OutlinedQuestionCircleIcon />
-          </Icon>
+            data-testid="status-tooltip"
+            icon={
+              <Icon status="warning" isInline iconSize={iconSize}>
+                <OutlinedQuestionCircleIcon />
+              </Icon>
+            }
+          />
         );
       default:
         return (
-          <Icon
-            data-testid="status-tooltip"
-            role="button"
-            aria-label="warning icon"
-            status="warning"
+          <Button
+            aria-label="warning status"
+            variant="link"
             isInline
-            tabIndex={0}
-            iconSize={iconSize}
-          >
-            <OutlinedQuestionCircleIcon />
-          </Icon>
+            data-testid="status-tooltip"
+            icon={
+              <Icon status="warning" isInline iconSize={iconSize}>
+                <OutlinedQuestionCircleIcon />
+              </Icon>
+            }
+          />
         );
     }
   };
@@ -112,7 +112,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
       bodyContent={bodyContent}
       isVisible={bodyContent ? undefined : false}
     >
-      <Button variant="link" isInline icon={statusIcon()} />
+      {statusIcon()}
     </Popover>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: [RHOAIENG-10992](https://issues.redhat.com/browse/RHOAIENG-10992)

## Description
Updates the data science projects models page to use a popover instead of a tooltip for the status. The message will no longer disappear when trying to select the text, and removes the issue of the screen shaking if the message is too long.


## How Has This Been Tested?
Tested locally

## Test Impact
Adjusted cypress tests to check for popover instead of tooltip

## Screenshots 
Before (hover for tooltip):
<img width="522" alt="Screenshot 2024-10-16 at 3 47 40 PM" src="https://github.com/user-attachments/assets/a9bb92f5-a2ee-439b-bc1f-d158f0a0c59b">

After (click for popover)"
![Screenshot 2024-10-16 at 3 47 13 PM](https://github.com/user-attachments/assets/a91ff06c-5c66-42e8-9145-f10745363912)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
