### PR TITLE
Update project list view to readily show active notebooks

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -46,6 +46,14 @@ class ProjectNotebookRow extends TableRow {
   findNotebookStatusText() {
     return this.find().findByTestId('notebook-status-text');
   }
+
+  findNotebookStart() {
+    return this.find().findByTestId('notebook-start-action');
+  }
+
+  findNotebookStop() {
+    return this.find().findByTestId('notebook-stop-action');
+  }
 }
 
 class ProjectRow extends TableRow {
@@ -57,8 +65,16 @@ class ProjectRow extends TableRow {
     return this.find().findByTestId('notebook-column-expand');
   }
 
+  findNotebookColumnExpander() {
+    return this.find().findByTestId('notebook-column-count');
+  }
+
   findNotebookTable() {
     return this.find().parents('tbody').findByTestId('project-notebooks-table');
+  }
+
+  getNotebookRows() {
+    return this.findNotebookTable().findByTestId('project-notebooks-table-row');
   }
 
   getNotebookRow(notebookName: string) {

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -169,6 +169,14 @@ class NotebookRow extends TableRow {
     return this.find().findByTestId('notebook-status-text');
   }
 
+  findNotebookStart() {
+    return this.find().findByTestId('notebook-start-action');
+  }
+
+  findNotebookStop() {
+    return this.find().findByTestId('notebook-stop-action');
+  }
+
   findNotebookStatusPopover(name: string) {
     return cy.findByTestId('notebook-status-popover').contains(name);
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
@@ -272,8 +272,9 @@ describe('Data science projects details', () => {
     );
     projectListPage.visit();
     const projectTableRow = projectListPage.getProjectRow('Test Project');
-    projectTableRow.findNotebookColumn().click();
-    cy.wait('@getWorkbench');
+    projectTableRow.findNotebookColumnExpander().click();
+    const notebookRows = projectTableRow.getNotebookRows();
+    notebookRows.should('have.length', 1);
   });
 
   it('should open the modal to stop workbench when user stops the workbench', () => {
@@ -316,13 +317,14 @@ describe('Data science projects details', () => {
     );
     projectListPage.visit();
     const projectTableRow = projectListPage.getProjectRow('Test Project');
-    projectTableRow.findNotebookColumn().click();
+    projectTableRow.findNotebookColumnExpander().click();
+    const notebookRows = projectTableRow.getNotebookRows();
+    notebookRows.should('have.length', 1);
 
     const notebookRow = projectTableRow.getNotebookRow('Test Notebook');
     notebookRow.findNotebookRouteLink().should('have.attr', 'aria-disabled', 'false');
 
-    notebookRow.findKebabAction('Start').should('be.disabled');
-    notebookRow.findKebabAction('Stop').click();
+    notebookRow.findNotebookStop().click();
 
     //stop workbench
     notebookConfirmModal.findStopWorkbenchButton().should('be.enabled');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -534,7 +534,7 @@ describe('Workbench page', () => {
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
 
     //stop Workbench
-    notebookRow.findKebabAction('Stop').click();
+    notebookRow.findNotebookStop().click();
     notebookConfirmModal.findStopWorkbenchButton().should('be.enabled');
     cy.interceptK8s(
       NotebookModel,
@@ -584,7 +584,7 @@ describe('Workbench page', () => {
       }),
     );
 
-    notebookRow.findKebabAction('Start').click();
+    notebookRow.findNotebookStart().click();
     notebookRow.findHaveNotebookStatusText().should('have.text', 'Starting');
     notebookRow.findHaveNotebookStatusText().click();
 

--- a/frontend/src/pages/projects/notebook/NotebookActionsColumn.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookActionsColumn.tsx
@@ -3,140 +3,40 @@ import { ActionsColumn } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { NotebookKind, ProjectKind } from '~/k8sTypes';
 import { NotebookState } from '~/pages/projects/notebook/types';
-import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
-import { startNotebook, stopNotebook } from '~/api';
-import useNotebookAcceleratorProfile from '~/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfile';
-import useNotebookDeploymentSize from '~/pages/projects/screens/detail/notebooks/useNotebookDeploymentSize';
-import useStopNotebookModalAvailability from '~/pages/projects/notebook/useStopNotebookModalAvailability';
-import { useAppContext } from '~/app/AppContext';
-import { computeNotebooksTolerations } from '~/utilities/tolerations';
-import { currentlyHasPipelines } from '~/concepts/pipelines/elyra/utils';
-import StopNotebookConfirmModal from '~/pages/projects/notebook/StopNotebookConfirmModal';
-import useNotebookImage from '~/pages/projects/screens/detail/notebooks/useNotebookImage';
-import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
 
-export const useNotebookActionsColumn = (
-  project: ProjectKind,
-  notebookState: NotebookState,
-  enablePipelines: boolean,
-  onNotebookDelete: (notebook: NotebookKind) => void,
-): [React.ReactNode, () => void] => {
+type Props = {
+  project: ProjectKind;
+  notebookState: NotebookState;
+  onNotebookDelete: (notebook: NotebookKind) => void;
+};
+
+export const NotebookActionsColumn: React.FC<Props> = ({
+  project,
+  notebookState,
+  onNotebookDelete,
+}) => {
   const navigate = useNavigate();
-  const { notebook, isStarting, isRunning, isStopping, refresh } = notebookState;
-  const acceleratorProfile = useNotebookAcceleratorProfile(notebook);
-  const { size } = useNotebookDeploymentSize(notebook);
-  const [isOpenConfirm, setOpenConfirm] = React.useState(false);
-  const [inProgress, setInProgress] = React.useState(false);
-  const [notebookImage] = useNotebookImage(notebookState.notebook);
-  const [dontShowModalValue] = useStopNotebookModalAvailability();
-  const { dashboardConfig } = useAppContext();
-  const notebookName = notebook.metadata.name;
-  const notebookNamespace = notebook.metadata.namespace;
-  const isDisabled =
-    isStopping ||
-    inProgress ||
-    (notebookImage?.imageAvailability === NotebookImageAvailability.DELETED && !isRunning);
-  const isRunningOrStarting = isStarting || isRunning;
+  const { isStarting, isStopping } = notebookState;
 
-  const fireNotebookTrackingEvent = React.useCallback(
-    (action: 'started' | 'stopped') => {
-      fireFormTrackingEvent(`Workbench ${action === 'started' ? 'Started' : 'Stopped'}`, {
-        outcome: TrackingOutcome.submit,
-        acceleratorCount: acceleratorProfile.unknownProfileDetected
-          ? undefined
-          : acceleratorProfile.count,
-        accelerator: acceleratorProfile.acceleratorProfile
-          ? `${acceleratorProfile.acceleratorProfile.spec.displayName} (${acceleratorProfile.acceleratorProfile.metadata.name}): ${acceleratorProfile.acceleratorProfile.spec.identifier}`
-          : acceleratorProfile.unknownProfileDetected
-          ? 'Unknown'
-          : 'None',
-        lastSelectedSize:
-          size?.name ||
-          notebook.metadata.annotations?.['notebooks.opendatahub.io/last-size-selection'],
-        lastSelectedImage:
-          notebook.metadata.annotations?.['notebooks.opendatahub.io/last-image-selection'],
-        projectName: notebook.metadata.namespace,
-        notebookName: notebook.metadata.name,
-        ...(action === 'stopped' && {
-          lastActivity: notebook.metadata.annotations?.['notebooks.kubeflow.org/last-activity'],
-        }),
-      });
-    },
-    [acceleratorProfile, notebook, size],
+  return (
+    <ActionsColumn
+      items={[
+        {
+          isDisabled: isStarting || isStopping,
+          title: 'Edit workbench',
+          onClick: () => {
+            navigate(
+              `/projects/${project.metadata.name}/spawner/${notebookState.notebook.metadata.name}`,
+            );
+          },
+        },
+        {
+          title: 'Delete workbench',
+          onClick: () => {
+            onNotebookDelete(notebookState.notebook);
+          },
+        },
+      ]}
+    />
   );
-
-  const handleStop = React.useCallback(() => {
-    fireNotebookTrackingEvent('stopped');
-    setInProgress(true);
-    stopNotebook(notebookName, notebookNamespace).then(() => {
-      refresh().then(() => setInProgress(false));
-    });
-  }, [fireNotebookTrackingEvent, notebookName, notebookNamespace, refresh]);
-
-  return [
-    <>
-      <ActionsColumn
-        items={[
-          {
-            isDisabled: isDisabled || isRunningOrStarting,
-            title: 'Start',
-            onClick: () => {
-              setInProgress(true);
-              const tolerationSettings = computeNotebooksTolerations(
-                dashboardConfig,
-                notebookState.notebook,
-              );
-              startNotebook(
-                notebook,
-                tolerationSettings,
-                enablePipelines && !currentlyHasPipelines(notebook),
-              ).then(() => {
-                fireNotebookTrackingEvent('started');
-                refresh().then(() => setInProgress(false));
-              });
-            },
-          },
-          {
-            isDisabled: isDisabled || !isRunningOrStarting,
-            title: 'Stop',
-            onClick: () => {
-              if (dontShowModalValue) {
-                handleStop();
-              } else {
-                setOpenConfirm(true);
-              }
-            },
-          },
-          {
-            isDisabled: isStarting || isStopping,
-            title: 'Edit workbench',
-            onClick: () => {
-              navigate(
-                `/projects/${project.metadata.name}/spawner/${notebookState.notebook.metadata.name}`,
-              );
-            },
-          },
-          {
-            title: 'Delete workbench',
-            onClick: () => {
-              onNotebookDelete(notebookState.notebook);
-            },
-          },
-        ]}
-      />
-      {isOpenConfirm ? (
-        <StopNotebookConfirmModal
-          notebookState={notebookState}
-          onClose={(confirmStatus) => {
-            if (confirmStatus) {
-              handleStop();
-            }
-            setOpenConfirm(false);
-          }}
-        />
-      ) : null}
-    </>,
-    handleStop,
-  ];
 };

--- a/frontend/src/pages/projects/notebook/NotebookStateAction.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateAction.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
+import useNotebookImage from '~/pages/projects/screens/detail/notebooks/useNotebookImage';
+import { NotebookState } from './types';
+
+type Props = {
+  notebookState: NotebookState;
+  onStart: () => void;
+  onStop: () => void;
+  isDisabled?: boolean;
+};
+
+const NotebookStateAction: React.FC<Props> = ({ notebookState, onStart, onStop, isDisabled }) => {
+  const { notebook, isStarting, isRunning, isStopping } = notebookState;
+  const [notebookImage] = useNotebookImage(notebook);
+
+  const actionDisabled =
+    isDisabled ||
+    isStopping ||
+    (notebookImage?.imageAvailability === NotebookImageAvailability.DELETED && !isRunning);
+
+  return isStarting || isRunning ? (
+    <Button
+      data-testid="notebook-stop-action"
+      variant="link"
+      isInline
+      isDisabled={actionDisabled}
+      onClick={onStop}
+    >
+      Stop
+    </Button>
+  ) : (
+    <Button
+      data-testid="notebook-start-action"
+      variant="link"
+      isInline
+      isDisabled={actionDisabled}
+      onClick={onStart}
+    >
+      Start
+    </Button>
+  );
+};
+
+export default NotebookStateAction;

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Button, Label, LabelProps, Popover, Tooltip } from '@patternfly/react-core';
 import {
-  BanIcon,
   ExclamationCircleIcon,
   InProgressIcon,
-  RunningIcon,
+  OffIcon,
+  PlayIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
 import { EventStatus } from '~/types';
@@ -52,9 +52,9 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
       };
     }
     if (isRunning) {
-      return { label: 'Running', color: 'green', icon: <RunningIcon /> };
+      return { label: 'Running', color: 'green', icon: <PlayIcon /> };
     }
-    return { label: 'Stopped', color: 'grey', icon: <BanIcon /> };
+    return { label: 'Stopped', color: 'grey', icon: <OffIcon /> };
   }, [isError, isRunning, isStarting, isStopping]);
 
   const StatusLabel = (

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookList.tsx
@@ -5,30 +5,35 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '~/pages/projects/screens/detail/const';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { FAST_POLL_INTERVAL } from '~/utilities/const';
+import { FAST_POLL_INTERVAL, POLL_INTERVAL } from '~/utilities/const';
 import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
 import EmptyDetailsView from '~/components/EmptyDetailsView';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
+import useRefreshInterval from '~/utilities/useRefreshInterval';
 import NotebookTable from './NotebookTable';
 
 const NotebookList: React.FC = () => {
   const {
     currentProject,
-    notebooks: { data: notebookStates, loaded, error: loadError, refresh: refreshNotebooks },
+    notebooks: { data: notebookStates, loaded, error: loadError },
     refreshAllProjectData: refresh,
   } = React.useContext(ProjectDetailsContext);
   const navigate = useNavigate();
   const projectName = currentProject.metadata.name;
   const isNotebooksEmpty = notebookStates.length === 0;
 
-  React.useEffect(() => {
-    let interval: ReturnType<typeof setInterval>;
-    if (notebookStates.some((notebookState) => notebookState.isStarting)) {
-      interval = setInterval(() => refreshNotebooks(), FAST_POLL_INTERVAL);
-    }
-    return () => clearInterval(interval);
-  }, [notebookStates, refreshNotebooks]);
+  useRefreshInterval(FAST_POLL_INTERVAL, () =>
+    notebookStates
+      .filter((notebookState) => notebookState.isStarting || notebookState.isStopping)
+      .forEach((notebookState) => notebookState.refresh()),
+  );
+
+  useRefreshInterval(POLL_INTERVAL, () =>
+    notebookStates
+      .filter((notebookState) => !notebookState.isStarting && !notebookState.isStopping)
+      .forEach((notebookState) => notebookState.refresh()),
+  );
 
   return (
     <DetailsSection

--- a/frontend/src/pages/projects/screens/detail/notebooks/data.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/data.ts
@@ -12,7 +12,7 @@ export const columns: SortableData<NotebookState>[] = [
   {
     field: 'name',
     label: 'Name',
-    width: 30,
+    width: 25,
     sortable: (a, b) =>
       getDisplayNameFromK8sResource(a.notebook).localeCompare(
         getDisplayNameFromK8sResource(b.notebook),
@@ -34,6 +34,12 @@ export const columns: SortableData<NotebookState>[] = [
     field: 'status',
     label: 'Status',
     sortable: (a, b) => getNotebookStatusPriority(a) - getNotebookStatusPriority(b),
+    modifier: 'fitContent',
+  },
+  {
+    field: '',
+    label: '',
+    sortable: false,
   },
   {
     field: 'open',

--- a/frontend/src/pages/projects/screens/projects/ProjectTableRowNotebookTable.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectTableRowNotebookTable.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
 import { Table } from '~/components/table';
 import { NotebookKind, ProjectKind } from '~/k8sTypes';
-import { useNotebooksStates } from '~/pages/projects/notebook/useNotebooksStates';
 import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableElyraPipelinesCheck';
 import ProjectTableRowNotebookTableRow from '~/pages/projects/screens/projects/ProjectTableRowNotebookTableRow';
 import DeleteNotebookModal from '~/pages/projects/notebook/DeleteNotebookModal';
+import { NotebookState } from '~/pages/projects/notebook/types';
+import { FetchStateRefreshPromise } from '~/utilities/useFetchState';
 import { columns } from './notebookTableData';
 
 type ProjectTableRowNotebookTableProps = {
-  notebooks: NotebookKind[];
+  notebookStates: NotebookState[];
   obj: ProjectKind;
+  refresh: FetchStateRefreshPromise<NotebookState[]>;
 };
 const ProjectTableRowNotebookTable: React.FC<ProjectTableRowNotebookTableProps> = ({
-  notebooks,
+  notebookStates,
   obj: project,
+  refresh,
 }) => {
-  const [notebookStates, loaded, , refresh] = useNotebooksStates(notebooks, project.metadata.name);
   const [notebookToDelete, setNotebookToDelete] = React.useState<NotebookKind | undefined>();
 
   return (
@@ -24,9 +26,6 @@ const ProjectTableRowNotebookTable: React.FC<ProjectTableRowNotebookTableProps> 
         <>
           <Table
             className="odh-project-table-row--notebook-table"
-            loading={!loaded}
-            skeletonRowCount={notebooks.length}
-            skeletonRowProps={{ style: { border: 'none' } }}
             variant="compact"
             defaultSortColumn={0}
             data={notebookStates}

--- a/frontend/src/pages/projects/screens/projects/notebookTableData.tsx
+++ b/frontend/src/pages/projects/screens/projects/notebookTableData.tsx
@@ -32,7 +32,13 @@ export const columns: SortableData<NotebookState>[] = [
     field: 'status',
     label: 'Status',
     sortable: (a, b) => getNotebookStatusValue(a) - getNotebookStatusValue(b),
-    width: 40,
+    modifier: 'fitContent',
+  },
+  {
+    field: '',
+    label: '',
+    sortable: false,
+    width: 20,
   },
   {
     field: 'kebab',

--- a/frontend/src/pages/projects/screens/projects/tableData.tsx
+++ b/frontend/src/pages/projects/screens/projects/tableData.tsx
@@ -1,7 +1,22 @@
+import { OffIcon, PlayIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { SortableData } from '~/components/table';
 import { ProjectKind } from '~/k8sTypes';
 import { getProjectCreationTime } from '~/concepts/projects/utils';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+
+const WorkBenchDescription = (
+  <div>
+    <div>
+      <PlayIcon className="pf-v5-u-mr-xs" />
+      Indicates number of running or starting workbenches.
+    </div>
+    <div>
+      <OffIcon className="pf-v5-u-mr-xs" />
+      Indicates number of stopped workbenches.
+    </div>
+  </div>
+);
 
 export const columns: SortableData<ProjectKind>[] = [
   {
@@ -22,6 +37,10 @@ export const columns: SortableData<ProjectKind>[] = [
     label: 'Workbenches',
     sortable: false,
     width: 30,
+    info: {
+      popoverProps: { headerContent: 'Workbench counts', hasAutoWidth: true },
+      popover: WorkBenchDescription,
+    },
   },
   {
     field: 'kebab',

--- a/frontend/src/utilities/useRefreshInterval.ts
+++ b/frontend/src/utilities/useRefreshInterval.ts
@@ -6,7 +6,7 @@ const useRefreshInterval = (refreshInterval: number, callback: () => void): void
   cb.current = callback;
 
   React.useEffect(() => {
-    const timer = setInterval(cb.current, refreshInterval);
+    const timer = setInterval(() => cb.current(), refreshInterval);
     return () => clearInterval(timer);
   }, [refreshInterval]);
 };


### PR DESCRIPTION
Closes [RHOAIENG-14674](https://issues.redhat.com/browse/RHOAIENG-14674)

## Description
PM review revealed the inability to quickly find active workbenches and the need for too many click to shutdown active workbenches. Updated the Project list view to show active workbenches in the workbenches column. Added start/stop actions to each work bench row rather than have them in the kebab menu.

## How Has This Been Tested?
Navigate to the Data Science Project page.
Verify the workbench counts for stopped or active workbenches are accurate (workbenches in the `starting` phase are counted as active).
Expand the workbenches column for projects with active and stopped workbenches.
Verify the correct action is shown (start or stop) based on the workbench status.

## Test Impact
Updated the e2e tests to check for the correct counts and actions

## Screen shots

![image](https://github.com/user-attachments/assets/592ff797-14bc-472d-b337-d9ff3936e1f7)


![image](https://github.com/user-attachments/assets/ba49985c-8adf-4cb8-9420-027838a61461)


![image](https://github.com/user-attachments/assets/111a069c-aa81-4e7b-883e-d9452713a678)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

