### PR TITLE
use zod for form validation of connection types validation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,8 @@
         "redux-thunk": "^2.4.1",
         "sass": "^1.56.2",
         "showdown": "^2.1.0",
-        "yaml": "^2.2.2"
+        "yaml": "^2.2.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@babel/core": "^7.21.0",
@@ -26491,6 +26492,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,7 +93,8 @@
     "redux-thunk": "^2.4.1",
     "sass": "^1.56.2",
     "showdown": "^2.1.0",
-    "yaml": "^2.2.2"
+    "yaml": "^2.2.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/frontend/src/__tests__/unit/testUtils/hooks.ts
+++ b/frontend/src/__tests__/unit/testUtils/hooks.ts
@@ -104,9 +104,9 @@ export const renderHook = <
  *
  * ```
  * const renderResult = testHook(useSayHello)('world');
- * expectHook(renderResult).toBe('Hello world!');
+ * expect(renderResult).hookToBe('Hello world!');
  * renderResult.rerender('there');
- * expectHook(renderResult).toBe('Hello there!');
+ * expect(renderResult).hookToBe('Hello there!');
  * ```
  */
 export const testHook =
@@ -137,11 +137,11 @@ export const testHook =
  *
  * eg.
  * ```
- * expectHook(renderResult).isStrictEqual(standardUseFetchState('test value', true))
+ * expect(renderResult).hookToStrictEqual(standardUseFetchState('test value', true))
  * ```
  * is equivalent to:
  * ```
- * expectHook(renderResult).isStrictEqual(['test value', true, undefined, expect.any(Function)])
+ * expect(renderResult).hookToStrictEqual(['test value', true, undefined, expect.any(Function)])
  * ```
  */
 export const standardUseFetchState = <D>(

--- a/frontend/src/concepts/connectionTypes/__tests__/validationUtils.spec.ts
+++ b/frontend/src/concepts/connectionTypes/__tests__/validationUtils.spec.ts
@@ -1,0 +1,666 @@
+import {
+  BooleanField,
+  ConnectionTypeField,
+  ConnectionTypeFormData,
+  DropdownField,
+  FileField,
+  HiddenField,
+  NumericField,
+  SectionField,
+  ShortTextField,
+  TextField,
+  UriField,
+} from '~/concepts/connectionTypes/types';
+import {
+  booleanFieldSchema,
+  connectionTypeFormSchema,
+  dropdownFieldSchema,
+  fieldArraySchema,
+  fileFieldSchema,
+  hiddenFieldSchema,
+  numericFieldSchema,
+  sectionFieldSchema,
+  shortTextFieldSchema,
+  textFieldSchema,
+  uriFieldSchema,
+} from '~/concepts/connectionTypes/validationUtils';
+
+describe('sectionFieldSchema', () => {
+  it('should validate the section field', () => {
+    const section: SectionField = {
+      name: 'Section 1',
+      type: 'section',
+    };
+    const result = sectionFieldSchema.safeParse(section);
+    expect(result.success).toBe(true);
+  });
+  it('should error', () => {
+    const section: SectionField = {
+      name: '',
+      type: 'section',
+    };
+    const result = sectionFieldSchema.safeParse(section);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+  });
+});
+
+describe('shortTextFieldSchema', () => {
+  it('should validate the short text field', () => {
+    const field: ShortTextField = {
+      name: 'Field 1',
+      type: 'short-text',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'Hello, world!',
+      },
+    };
+    const result = shortTextFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error', () => {
+    const field: ShortTextField = {
+      name: '',
+      type: 'short-text',
+      envVar: 'FIELD_1',
+      properties: {},
+    };
+    const result = shortTextFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+  });
+});
+
+describe('textFieldSchema', () => {
+  it('should validate the text field', () => {
+    const field: TextField = {
+      name: 'Field 1',
+      type: 'text',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'Hello, world!',
+      },
+    };
+    const result = textFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error', () => {
+    const field: TextField = {
+      name: '',
+      type: 'text',
+      envVar: 'FIELD_1',
+      properties: {},
+    };
+    const result = textFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+  });
+});
+
+describe('hiddenFieldSchema', () => {
+  it('should validate the hidden text field', () => {
+    const field: HiddenField = {
+      name: 'Field 1',
+      type: 'hidden',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'Hello, world!',
+      },
+    };
+    const result = hiddenFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error', () => {
+    const field: HiddenField = {
+      name: '',
+      type: 'hidden',
+      envVar: 'FIELD_1',
+      properties: {},
+    };
+    const result = hiddenFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+  });
+});
+
+describe('uriFieldSchema', () => {
+  it('should validate the uri field', () => {
+    const field: UriField = {
+      name: 'Field 1',
+      type: 'uri',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'https://example.com',
+      },
+    };
+    const result = uriFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error', () => {
+    const field: UriField = {
+      name: '',
+      type: 'uri',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'not a uri',
+      },
+    };
+    const result = uriFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(2);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+    expect(result.error?.issues[1]).toEqual(
+      expect.objectContaining({
+        message: 'Invalid URI',
+        path: ['properties', 'defaultValue'],
+      }),
+    );
+  });
+});
+
+describe('booleanFieldSchema', () => {
+  it('should validate the boolean field', () => {
+    const field: BooleanField = {
+      name: 'Field 1',
+      type: 'boolean',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: true,
+        label: 'Checkbox label',
+      },
+    };
+    const result = booleanFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error', () => {
+    const field: BooleanField = {
+      name: '',
+      type: 'boolean',
+      envVar: 'FIELD_1',
+      properties: {},
+    };
+    const result = booleanFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(2);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+    expect(result.error?.issues[1]).toEqual(
+      expect.objectContaining({
+        message: 'Checkbox label is required',
+        path: ['properties', 'label'],
+      }),
+    );
+  });
+});
+
+describe('numericFieldSchema', () => {
+  it('should validate the numeric field', () => {
+    const field: NumericField = {
+      name: 'Field 1',
+      type: 'numeric',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 10,
+        unit: 'cm',
+        min: 1,
+        max: 100,
+      },
+    };
+    const result = numericFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error when name is empty', () => {
+    const field: NumericField = {
+      name: '',
+      type: 'numeric',
+      envVar: 'FIELD_1',
+      properties: {},
+    };
+    const result = numericFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+  });
+  it('should error when min is greater than max', () => {
+    const field: NumericField = {
+      name: 'Field 1',
+      type: 'numeric',
+      envVar: 'FIELD_1',
+      properties: {
+        min: 100,
+        max: 10,
+      },
+    };
+    const result = numericFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(2);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'The lower threshold must be less than the upper threshold',
+        path: ['properties', 'min'],
+      }),
+    );
+    expect(result.error?.issues[1]).toEqual(
+      expect.objectContaining({
+        message: 'The upper threshold must be greater than the lower threshold',
+        path: ['properties', 'max'],
+      }),
+    );
+  });
+  it('should error when defaultValue is less than min', () => {
+    const field: NumericField = {
+      name: 'Field 1',
+      type: 'numeric',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 5,
+        min: 10,
+      },
+    };
+    const result = numericFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'The default value must be greater than the lower threshold',
+        path: ['properties', 'defaultValue'],
+      }),
+    );
+  });
+  it('should error when defaultValue is greater than max', () => {
+    const field: NumericField = {
+      name: 'Field 1',
+      type: 'numeric',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 15,
+        max: 10,
+      },
+    };
+    const result = numericFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'The default value must be less than the upper threshold',
+        path: ['properties', 'defaultValue'],
+      }),
+    );
+  });
+});
+
+describe('fileFieldSchema', () => {
+  it('should validate the file field', () => {
+    const field: FileField = {
+      name: 'Field 1',
+      type: 'file',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'File content.',
+        extensions: ['.txt', '.md'],
+      },
+    };
+    const result = fileFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error when name is empty', () => {
+    const field: FileField = {
+      name: '',
+      type: 'file',
+      envVar: 'FIELD_1',
+      properties: {},
+    };
+    const result = fileFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+  });
+  it('should error when extensions are not valid', () => {
+    const field: FileField = {
+      name: 'Field 1',
+      type: 'file',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'File content.',
+        extensions: ['txt', 'md'],
+      },
+    };
+    const result = fileFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(2);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: "A valid extension must start with '.'",
+        path: ['properties', 'extensions', 0],
+      }),
+    );
+    expect(result.error?.issues[1]).toEqual(
+      expect.objectContaining({
+        message: "A valid extension must start with '.'",
+        path: ['properties', 'extensions', 1],
+      }),
+    );
+  });
+  it('should error when extensions are duplicated', () => {
+    const field: FileField = {
+      name: 'Field 1',
+      type: 'file',
+      envVar: 'FIELD_1',
+      properties: {
+        defaultValue: 'File content.',
+        extensions: ['.txt', '.txt'],
+      },
+    };
+    const result = fileFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Extension has already been specified.',
+        path: ['properties', 'extensions', 1],
+      }),
+    );
+  });
+});
+
+describe('dropdownFieldSchema', () => {
+  it('should validate the single variant dropdown field', () => {
+    const field: DropdownField = {
+      name: 'Field 1',
+      type: 'dropdown',
+      envVar: 'FIELD_1',
+      properties: {
+        variant: 'single',
+        defaultValue: ['Option 2 Value'],
+        items: [
+          { label: 'Option 1 Label', value: 'Option 1 Value' },
+          { label: 'Option 2 Label', value: 'Option 2 Value' },
+          { label: 'Option 3 Label', value: 'Option 3 Value' },
+        ],
+      },
+    };
+    const result = dropdownFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should validate the multi variant dropdown field', () => {
+    const field: DropdownField = {
+      name: 'Field 1',
+      type: 'dropdown',
+      envVar: 'FIELD_1',
+      properties: {
+        variant: 'multi',
+        defaultValue: ['Option 2 Value', 'Option 3 Value'],
+        items: [
+          { label: 'Option 1 Label', value: 'Option 1 Value' },
+          { label: 'Option 2 Label', value: 'Option 2 Value' },
+          { label: 'Option 3 Label', value: 'Option 3 Value' },
+        ],
+      },
+    };
+    const result = dropdownFieldSchema.safeParse(field);
+    expect(result.success).toBe(true);
+  });
+  it('should error when name and items are empty', () => {
+    const field: DropdownField = {
+      name: '',
+      type: 'dropdown',
+      envVar: 'FIELD_1',
+      properties: {
+        items: [],
+      },
+    };
+    const result = dropdownFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(2);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Name is required',
+        path: ['name'],
+      }),
+    );
+    expect(result.error?.issues[1]).toEqual(
+      expect.objectContaining({
+        message: 'At least one item is required',
+        path: ['properties', 'items'],
+      }),
+    );
+  });
+  it('should error when item values are missing', () => {
+    const field: DropdownField = {
+      name: 'Field 1',
+      type: 'dropdown',
+      envVar: 'FIELD_1',
+      properties: {
+        variant: 'single',
+        defaultValue: ['Option 1 Value'],
+        items: [{ label: 'Option 1 Label', value: '' }],
+      },
+    };
+    const result = dropdownFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Value is required',
+        path: ['properties', 'items', 0, 'value'],
+      }),
+    );
+  });
+  it('should error when item labels are duplicated', () => {
+    const field: DropdownField = {
+      name: 'Field 1',
+      type: 'dropdown',
+      envVar: 'FIELD_1',
+      properties: {
+        variant: 'single',
+        defaultValue: ['Option 2 Value'],
+        items: [
+          { label: 'Option Label', value: 'Option 1 Value' },
+          { label: 'Option Label', value: 'Option 2 Value' },
+        ],
+      },
+    };
+    const result = dropdownFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Option Label already exists.',
+        path: ['properties', 'items', 1, 'label'],
+      }),
+    );
+  });
+  it('should error when item values are duplicated', () => {
+    const field: DropdownField = {
+      name: 'Field 1',
+      type: 'dropdown',
+      envVar: 'FIELD_1',
+      properties: {
+        variant: 'single',
+        defaultValue: ['Option 2 Value'],
+        items: [
+          { label: 'Option 1 Label', value: 'Option Value' },
+          { label: 'Option 2 Label', value: 'Option Value' },
+        ],
+      },
+    };
+    const result = dropdownFieldSchema.safeParse(field);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Option Value already exists.',
+        path: ['properties', 'items', 1, 'value'],
+      }),
+    );
+  });
+});
+
+describe('fieldArraySchema', () => {
+  it('should validate the fields', () => {
+    const fields: ConnectionTypeField[] = [
+      {
+        name: 'Section 1',
+        type: 'section',
+      },
+      {
+        name: 'Field 1',
+        type: 'short-text',
+        envVar: 'FIELD_1',
+        properties: {},
+      },
+    ];
+    const result = fieldArraySchema.safeParse(fields);
+    expect(result.success).toBe(true);
+  });
+
+  it('should error when there are duplicate env vars', () => {
+    const fields: ConnectionTypeField[] = [
+      {
+        name: 'Section 1',
+        type: 'section',
+      },
+      {
+        name: 'Field 1',
+        type: 'short-text',
+        envVar: 'FIELD_1',
+        properties: {},
+      },
+      {
+        name: 'Field 2',
+        type: 'text',
+        envVar: 'FIELD_1',
+        properties: {},
+      },
+    ];
+    const result = fieldArraySchema.safeParse(fields);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(3);
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message:
+            'Two or more fields are using the same environment variable. Ensure that each field uses a unique environment variable to proceed.',
+          path: [],
+        }),
+        expect.objectContaining({
+          message: 'FIELD_1 already exists within this connection type.',
+          path: [1, 'envVar'],
+        }),
+        expect.objectContaining({
+          message: 'FIELD_1 already exists within this connection type.',
+          path: [2, 'envVar'],
+        }),
+      ]),
+    );
+  });
+});
+
+describe('connectionTypeFormSchema', () => {
+  it('should validate the connection type form', () => {
+    const form: ConnectionTypeFormData = {
+      enabled: true,
+      fields: [],
+      username: 'test',
+      category: ['test'],
+    };
+    const result = connectionTypeFormSchema.safeParse(form);
+    expect(result.success).toBe(true);
+  });
+  it('should error when username is empty', () => {
+    const form: ConnectionTypeFormData = {
+      enabled: true,
+      fields: [],
+      username: '',
+      category: ['test'],
+    };
+    const result = connectionTypeFormSchema.safeParse(form);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Username is required',
+        path: ['username'],
+      }),
+    );
+  });
+  it('should error when category array is empty', () => {
+    const form: ConnectionTypeFormData = {
+      enabled: true,
+      fields: [],
+      username: 'test',
+      category: [],
+    };
+    const result = connectionTypeFormSchema.safeParse(form);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'At least one category is required',
+        path: ['category'],
+      }),
+    );
+  });
+  it('should error when category is empty', () => {
+    const form: ConnectionTypeFormData = {
+      enabled: true,
+      fields: [],
+      username: 'test',
+      category: [''],
+    };
+    const result = connectionTypeFormSchema.safeParse(form);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toEqual(
+      expect.objectContaining({
+        message: 'Category is required',
+        path: ['category', 0],
+      }),
+    );
+  });
+});

--- a/frontend/src/concepts/connectionTypes/fields/ConnectionTypeFormFields.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/ConnectionTypeFormFields.tsx
@@ -7,9 +7,9 @@ import {
   ConnectionTypeField,
   ConnectionTypeFieldType,
   ConnectionTypeValueType,
-  isConnectionTypeDataField,
   SectionField,
 } from '~/concepts/connectionTypes/types';
+import { isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
 
 type Props = {
   fields?: ConnectionTypeField[];

--- a/frontend/src/concepts/connectionTypes/fields/fieldUtils.ts
+++ b/frontend/src/concepts/connectionTypes/fields/fieldUtils.ts
@@ -2,4 +2,4 @@ export const EXTENSION_REGEX = /^\.[a-zA-Z0-9]+(^.[a-zA-Z0-9]+)?$/;
 
 export const isDuplicateExtension = (index: number, values: string[]): boolean =>
   index !== 0 &&
-  !!values.slice(0, index).find((val) => values[index].toLowerCase() === val.toLowerCase());
+  values.slice(0, index).some((val) => values[index].toLowerCase() === val.toLowerCase());

--- a/frontend/src/concepts/connectionTypes/types.ts
+++ b/frontend/src/concepts/connectionTypes/types.ts
@@ -25,6 +25,16 @@ export const connectionTypeDataFields = [
   ConnectionTypeFieldType.URI,
 ];
 
+export type ConnectionTypeDataFieldTypeUnion =
+  | 'boolean'
+  | 'dropdown'
+  | 'file'
+  | 'hidden'
+  | 'numeric'
+  | 'short-text'
+  | 'text'
+  | 'uri';
+
 export type ConnectionTypeFieldTypeUnion =
   | ConnectionTypeFieldType
   | 'boolean'
@@ -107,10 +117,6 @@ export type ConnectionTypeField =
 
 export type ConnectionTypeDataField = Exclude<ConnectionTypeField, SectionField>;
 
-export const isConnectionTypeDataField = (
-  field: ConnectionTypeField,
-): field is ConnectionTypeDataField => field.type !== ConnectionTypeFieldType.Section;
-
 export type ConnectionTypeConfigMap = K8sResourceCommon & {
   metadata: {
     name: string;
@@ -152,8 +158,9 @@ export type Connection = SecretKind & {
   };
 };
 
-export const isConnection = (secret: SecretKind): secret is Connection =>
-  !!secret.metadata.annotations &&
-  'opendatahub.io/connection-type' in secret.metadata.annotations &&
-  !!secret.metadata.labels &&
-  secret.metadata.labels['opendatahub.io/managed'] === 'true';
+export type ConnectionTypeFormData = {
+  enabled: boolean;
+  fields: ConnectionTypeField[];
+  username: string;
+  category: string[];
+};

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -1,4 +1,4 @@
-import { ProjectKind } from '~/k8sTypes';
+import { ProjectKind, SecretKind } from '~/k8sTypes';
 import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
 import {
@@ -6,12 +6,29 @@ import {
   ConnectionTypeConfigMap,
   ConnectionTypeConfigMapObj,
   ConnectionTypeDataField,
+  connectionTypeDataFields,
+  ConnectionTypeDataFieldTypeUnion,
+  ConnectionTypeField,
   ConnectionTypeFieldType,
   ConnectionTypeFieldTypeUnion,
   ConnectionTypeValueType,
-  isConnectionTypeDataField,
 } from '~/concepts/connectionTypes/types';
 import { enumIterator } from '~/utilities/utils';
+
+export const isConnectionTypeDataFieldType = (
+  type: ConnectionTypeFieldTypeUnion | string,
+): type is ConnectionTypeDataFieldTypeUnion =>
+  connectionTypeDataFields.some((t) => t === type) && type !== ConnectionTypeFieldType.Section;
+
+export const isConnectionTypeDataField = (
+  field: ConnectionTypeField,
+): field is ConnectionTypeDataField => field.type !== ConnectionTypeFieldType.Section;
+
+export const isConnection = (secret: SecretKind): secret is Connection =>
+  !!secret.metadata.annotations &&
+  'opendatahub.io/connection-type' in secret.metadata.annotations &&
+  !!secret.metadata.labels &&
+  secret.metadata.labels['opendatahub.io/managed'] === 'true';
 
 export const toConnectionTypeConfigMapObj = (
   configMap: ConnectionTypeConfigMap,
@@ -90,7 +107,7 @@ export const fieldNameToEnvVar = (name: string): string => {
   return allUppercase;
 };
 
-const ENV_VAR_NAME_REGEX = new RegExp('^[_a-zA-Z][_a-zA-Z0-9]*$');
+export const ENV_VAR_NAME_REGEX = new RegExp('^[_a-zA-Z][_a-zA-Z0-9]*$');
 export const isValidEnvVar = (name: string): boolean => ENV_VAR_NAME_REGEX.test(name);
 
 export const isModelServingCompatible = (envVars: string[]): boolean =>

--- a/frontend/src/concepts/connectionTypes/validationUtils.ts
+++ b/frontend/src/concepts/connectionTypes/validationUtils.ts
@@ -1,0 +1,287 @@
+import { uniq } from 'lodash-es';
+import { z } from 'zod';
+import {
+  EXTENSION_REGEX,
+  isDuplicateExtension,
+} from '~/concepts/connectionTypes/fields/fieldUtils';
+import { ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
+import { ENV_VAR_NAME_REGEX, isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
+
+const baseFieldSchema = z.object({
+  name: z.string().min(1, { message: 'Name is required' }),
+  description: z.string().optional(),
+});
+
+const baseFieldPropertiesSchema = z.object({
+  defaultReadOnly: z.boolean().optional(),
+});
+
+const baseDataFieldPropertiesSchema = baseFieldSchema.extend({
+  envVar: z.string().regex(ENV_VAR_NAME_REGEX, {
+    message:
+      'Valid characters include letters, numbers, and underscores ( _ ), and must not start with a number.',
+  }),
+  required: z.boolean().optional(),
+});
+
+export const sectionFieldSchema = baseFieldSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.Section),
+});
+
+export const shortTextFieldSchema = baseDataFieldPropertiesSchema.merge(
+  z.object({
+    type: z.literal(ConnectionTypeFieldType.ShortText),
+    properties: baseFieldPropertiesSchema.extend({ defaultValue: z.string().optional() }),
+  }),
+);
+
+export const textFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.Text),
+  properties: baseFieldPropertiesSchema.extend({ defaultValue: z.string().optional() }),
+});
+
+export const hiddenFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.Hidden),
+  properties: baseFieldPropertiesSchema.extend({ defaultValue: z.string().optional() }),
+});
+
+export const uriFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.URI),
+  properties: baseFieldPropertiesSchema.extend({
+    defaultValue: z
+      .string()
+      .optional()
+      .refine(
+        (defaultValue) => {
+          if (!defaultValue) {
+            return true;
+          }
+
+          try {
+            return !!new URL(defaultValue);
+          } catch (e) {
+            return false;
+          }
+        },
+        { message: 'Invalid URI' },
+      ),
+  }),
+});
+
+export const booleanFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.Boolean),
+  properties: baseFieldPropertiesSchema.extend({
+    label: z
+      .string({ message: 'Checkbox label is required' })
+      .min(1, { message: 'Checkbox label is required' }),
+    defaultValue: z.boolean().optional(),
+  }),
+});
+
+export const numericFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.Numeric),
+  properties: baseFieldPropertiesSchema
+    .extend({
+      defaultValue: z.number().optional(),
+      unit: z.string().optional(),
+      min: z.number().optional(),
+      max: z.number().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.min != null && data.max != null && data.min >= data.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          message: 'The lower threshold must be less than the upper threshold',
+          path: ['min'],
+          maximum: data.max,
+          inclusive: false,
+          type: 'number',
+        });
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          message: 'The upper threshold must be greater than the lower threshold',
+          path: ['max'],
+          minimum: data.min,
+          inclusive: false,
+          type: 'number',
+        });
+      }
+      if (
+        data.defaultValue != null &&
+        data.min != null &&
+        !Number.isNaN(data.defaultValue) &&
+        !Number.isNaN(data.min) &&
+        data.defaultValue < data.min
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          message: 'The default value must be greater than the lower threshold',
+          path: ['defaultValue'],
+          minimum: data.min,
+          inclusive: false,
+          type: 'number',
+        });
+      }
+      if (
+        data.defaultValue != null &&
+        data.max != null &&
+        !Number.isNaN(data.defaultValue) &&
+        !Number.isNaN(data.max) &&
+        data.defaultValue > data.max
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          message: 'The default value must be less than the upper threshold',
+          path: ['defaultValue'],
+          maximum: data.max,
+          inclusive: false,
+          type: 'number',
+        });
+      }
+    }),
+});
+
+export const fileFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.File),
+  properties: baseFieldPropertiesSchema.extend({
+    extensions: z
+      .array(
+        z.string().regex(EXTENSION_REGEX, {
+          message: `A valid extension must start with '.'`,
+        }),
+      )
+      .superRefine((exts, ctx) => {
+        exts.forEach((_, i) => {
+          if (i > 0 && isDuplicateExtension(i, exts)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              params: { code: ValidationErrorCodes.DUPLICATE },
+              path: [i],
+              message: 'Extension has already been specified.',
+            });
+          }
+        });
+      })
+      .optional(),
+    defaultValue: z.string().optional(),
+  }),
+});
+
+export const dropdownFieldSchema = baseDataFieldPropertiesSchema.extend({
+  type: z.literal(ConnectionTypeFieldType.Dropdown),
+  properties: baseFieldPropertiesSchema.extend({
+    variant: z.union([z.literal('single'), z.literal('multi')]).optional(),
+    items: z
+      .array(
+        z.object({
+          label: z.string(),
+          value: z.string().min(1, { message: 'Value is required' }),
+        }),
+      )
+      .nonempty({ message: 'At least one item is required' })
+      .superRefine((items, ctx) => {
+        items.forEach((item, i) => {
+          if (
+            i > 0 &&
+            items
+              .slice(0, i)
+              .some(
+                (val) =>
+                  item.label && val.label && item.label.toLowerCase() === val.label.toLowerCase(),
+              )
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              params: { code: ValidationErrorCodes.DUPLICATE },
+              path: [i, 'label'],
+              message: `${item.label} already exists.`,
+            });
+          }
+          if (
+            i > 0 &&
+            items.slice(0, i).some((val) => item.value.toLowerCase() === val.value.toLowerCase())
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              params: { code: ValidationErrorCodes.DUPLICATE },
+              path: [i, 'value'],
+              message: `${item.value} already exists.`,
+            });
+          }
+        });
+      }),
+    defaultValue: z.array(z.string()).optional(),
+  }),
+});
+
+export const dataFieldSchema = z.discriminatedUnion('type', [
+  shortTextFieldSchema,
+  textFieldSchema,
+  hiddenFieldSchema,
+  uriFieldSchema,
+  booleanFieldSchema,
+  numericFieldSchema,
+  fileFieldSchema,
+  dropdownFieldSchema,
+]);
+
+export const fieldSchema = z.discriminatedUnion('type', [
+  sectionFieldSchema,
+  shortTextFieldSchema,
+  textFieldSchema,
+  hiddenFieldSchema,
+  uriFieldSchema,
+  booleanFieldSchema,
+  numericFieldSchema,
+  fileFieldSchema,
+  dropdownFieldSchema,
+]);
+
+export const fieldArraySchema = z.array(fieldSchema).superRefine((fields, ctx) => {
+  const envVars = fields.map((f) => (isConnectionTypeDataField(f) ? f.envVar : null));
+
+  if (uniq(envVars.filter((e) => e != null)).length !== envVars.filter((e) => e != null).length) {
+    ctx.addIssue({
+      params: {
+        code: ValidationErrorCodes.FIELDS_ENV_VAR_CONFLICT,
+      },
+      code: z.ZodIssueCode.custom,
+      message:
+        'Two or more fields are using the same environment variable. Ensure that each field uses a unique environment variable to proceed.',
+      path: [],
+    });
+
+    envVars.forEach((envVar, i) => {
+      if (
+        envVar != null &&
+        envVars.some(
+          (cmp, j) => i !== j && cmp != null && envVar.toLowerCase() === cmp.toLowerCase(),
+        )
+      ) {
+        ctx.addIssue({
+          params: {
+            code: ValidationErrorCodes.ENV_VAR_CONFLICT,
+          },
+          code: z.ZodIssueCode.custom,
+          message: `${envVar} already exists within this connection type.`,
+          path: [i, 'envVar'],
+        });
+      }
+    });
+  }
+});
+
+export enum ValidationErrorCodes {
+  FIELDS_ENV_VAR_CONFLICT = 'fields_envVar_conflict',
+  ENV_VAR_CONFLICT = 'envVar_conflict',
+  DUPLICATE = 'duplicate',
+}
+
+export const connectionTypeFormSchema = z.object({
+  enabled: z.boolean(),
+  fields: fieldArraySchema,
+  username: z.string().min(1, { message: 'Username is required' }),
+  category: z
+    .array(z.string().min(1, { message: 'Category is required' }))
+    .min(1, { message: 'At least one category is required' }),
+});

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -9,10 +9,7 @@ import {
   TimestampTooltipVariant,
   Truncate,
 } from '@patternfly/react-core';
-import {
-  ConnectionTypeConfigMapObj,
-  isConnectionTypeDataField,
-} from '~/concepts/connectionTypes/types';
+import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { relativeTime } from '~/utilities/time';
 import { updateConnectionTypeEnabled } from '~/services/connectionTypesService';
 import useNotification from '~/utilities/useNotification';
@@ -25,7 +22,7 @@ import {
 } from '~/concepts/k8s/utils';
 import { connectionTypeColumns } from '~/pages/connectionTypes/columns';
 import CategoryLabel from '~/concepts/connectionTypes/CategoryLabel';
-import { getCompatibleTypes } from '~/concepts/connectionTypes/utils';
+import { getCompatibleTypes, isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
 import CompatibilityLabel from '~/concepts/connectionTypes/CompatibilityLabel';
 
 type ConnectionTypesTableRowProps = {

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -26,11 +26,11 @@ import {
   connectionTypeDataFields,
   ConnectionTypeField,
   ConnectionTypeFieldType,
-  isConnectionTypeDataField,
 } from '~/concepts/connectionTypes/types';
 import {
   fieldNameToEnvVar,
   fieldTypeToString,
+  isConnectionTypeDataField,
   isValidEnvVar,
 } from '~/concepts/connectionTypes/utils';
 import { isEnumMember } from '~/utilities/utils';

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -10,12 +10,10 @@ import {
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
 import { OpenDrawerRightIcon } from '@patternfly/react-icons';
-import { uniq } from 'lodash-es';
 import { useUser } from '~/redux/selectors';
 import {
   ConnectionTypeConfigMapObj,
-  ConnectionTypeField,
-  isConnectionTypeDataField,
+  ConnectionTypeFormData,
 } from '~/concepts/connectionTypes/types';
 import ConnectionTypePreviewDrawer from '~/concepts/connectionTypes/ConnectionTypePreviewDrawer';
 import {
@@ -29,6 +27,12 @@ import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescription
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { MultiSelection, SelectionOptions } from '~/components/MultiSelection';
 import { categoryOptions } from '~/pages/connectionTypes/const';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
+import { useValidation, ValidationContext } from '~/utilities/useValidation';
+import {
+  connectionTypeFormSchema,
+  ValidationErrorCodes,
+} from '~/concepts/connectionTypes/validationUtils';
 import CreateConnectionTypeFooter from './ManageConnectionTypeFooter';
 import ManageConnectionTypeFieldsTable from './ManageConnectionTypeFieldsTable';
 import ManageConnectionTypeBreadcrumbs from './ManageConnectionTypeBreadcrumbs';
@@ -45,21 +49,28 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
 
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
 
-  const {
-    enabled: prefillEnabled,
-    fields: prefillFields,
-    username: prefillUsername,
-    category: prefillCategory,
-  } = extractConnectionTypeFromMap(prefill);
+  const initialValues = React.useMemo<ConnectionTypeFormData>(() => {
+    if (prefill) {
+      const { category, enabled, fields, username } = extractConnectionTypeFromMap(prefill);
+      return { category, enabled, fields, username: username || currentUsername };
+    }
+    return {
+      category: [],
+      enabled: true,
+      fields: [],
+      username: currentUsername,
+    };
+    // compute default values only once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const username = prefillUsername || currentUsername;
+  const [data, setData] = useGenericObjectState(initialValues);
+  const validation = useValidation(data, connectionTypeFormSchema);
+
+  const { category, enabled, fields, username } = data;
 
   const { data: connectionNameDesc, onDataChange: setConnectionNameDesc } =
     useK8sNameDescriptionFieldData({ initialData: prefill });
-  const [connectionEnabled, setConnectionEnabled] = React.useState<boolean>(prefillEnabled);
-  const [connectionFields, setConnectionFields] =
-    React.useState<ConnectionTypeField[]>(prefillFields);
-  const [category, setCategory] = React.useState<string[]>(prefillCategory);
 
   const categoryItems = React.useMemo<SelectionOptions[]>(
     () =>
@@ -76,24 +87,17 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
         connectionNameDesc.k8sName.value,
         connectionNameDesc.name,
         connectionNameDesc.description,
-        connectionEnabled,
+        enabled,
         username,
-        connectionFields,
+        fields,
         category,
       ),
-    [connectionNameDesc, connectionEnabled, connectionFields, username, category],
+    [connectionNameDesc, enabled, fields, username, category],
   );
 
-  const isEnvVarConflict = React.useMemo(() => {
-    const envVars = connectionFields.filter(isConnectionTypeDataField).map((f) => f.envVar);
-    return uniq(envVars).length !== envVars.length;
-  }, [connectionFields]);
-
-  const isValid = React.useMemo(
-    () =>
-      isK8sNameDescriptionDataValid(connectionNameDesc) && !isEnvVarConflict && category.length > 0,
-    [connectionNameDesc, isEnvVarConflict, category],
-  );
+  const isValid =
+    React.useMemo(() => isK8sNameDescriptionDataValid(connectionNameDesc), [connectionNameDesc]) &&
+    validation.validationResult.success;
 
   const onCancel = () => {
     navigate('/connectionTypes');
@@ -101,110 +105,117 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
 
   const pageName = isEdit ? 'Edit connection type' : 'Create connection type';
   return (
-    <ConnectionTypePreviewDrawer
-      isExpanded={isDrawerExpanded}
-      onClose={() => setIsDrawerExpanded(false)}
-      obj={connectionTypeObj}
-    >
-      <ApplicationsPage
-        title={pageName}
-        loaded
-        empty={false}
-        errorMessage="Unable to load connection types"
-        breadcrumb={<ManageConnectionTypeBreadcrumbs name={pageName} />}
-        headerAction={
-          isDrawerExpanded ? undefined : (
-            <Button
-              variant="secondary"
-              icon={<OpenDrawerRightIcon />}
-              aria-expanded={isDrawerExpanded}
-              onClick={() => setIsDrawerExpanded(!isDrawerExpanded)}
-              data-testid="preview-drawer-toggle-button"
-            >
-              Preview
-            </Button>
-          )
-        }
+    <ValidationContext.Provider value={validation}>
+      <ConnectionTypePreviewDrawer
+        isExpanded={isDrawerExpanded}
+        onClose={() => setIsDrawerExpanded(false)}
+        obj={connectionTypeObj}
       >
-        {isEdit ? (
-          <PageSection variant="light" className="pf-v5-u-pt-0">
-            <Alert
-              isInline
-              variant="warning"
-              title="Editing this connection type does not affect existing connections of this type."
+        <ApplicationsPage
+          title={pageName}
+          loaded
+          empty={false}
+          breadcrumb={<ManageConnectionTypeBreadcrumbs name={pageName} />}
+          headerAction={
+            isDrawerExpanded ? undefined : (
+              <Button
+                variant="secondary"
+                icon={<OpenDrawerRightIcon />}
+                aria-expanded={isDrawerExpanded}
+                onClick={() => setIsDrawerExpanded(!isDrawerExpanded)}
+                data-testid="preview-drawer-toggle-button"
+              >
+                Preview
+              </Button>
+            )
+          }
+        >
+          {isEdit ? (
+            <PageSection variant="light" className="pf-v5-u-pt-0">
+              <Alert
+                isInline
+                variant="warning"
+                title="Editing this connection type does not affect existing connections of this type."
+              />
+            </PageSection>
+          ) : undefined}
+          <PageSection isFilled variant="light" className="pf-v5-u-pt-0">
+            <Form>
+              <FormSection title="Type details" style={{ maxWidth: 625 }}>
+                <K8sNameDescriptionField
+                  dataTestId="connection-type"
+                  nameLabel="Connection type name"
+                  descriptionLabel="Connection type description"
+                  data={connectionNameDesc}
+                  onDataChange={setConnectionNameDesc}
+                  autoFocusName
+                />
+                <FormGroup label="Category" fieldId="connection-type-category" isRequired>
+                  <MultiSelection
+                    inputId="connection-type-category"
+                    data-testid="connection-type-category"
+                    toggleTestId="connection-type-category-toggle"
+                    ariaLabel="Category"
+                    placeholder="Select a category"
+                    isCreatable
+                    value={categoryItems}
+                    setValue={(value) => {
+                      setData(
+                        'category',
+                        value.filter((v) => v.selected).map((v) => String(v.id)),
+                      );
+                    }}
+                  />
+                </FormGroup>
+              </FormSection>
+              <FormGroup label="Enable" fieldId="connection-type-enable">
+                <Checkbox
+                  label="Enable users in your organization to use this connection type when adding connections."
+                  id="connection-type-enable"
+                  name="connection-type-enable"
+                  data-testid="connection-type-enable"
+                  isChecked={enabled}
+                  onChange={(_e, value) => setData('enabled', value)}
+                />
+              </FormGroup>
+              <FormSection title="Fields" className="pf-v5-u-mt-0">
+                <FormGroup>
+                  {validation.hasValidationIssue(
+                    ['fields'],
+                    ValidationErrorCodes.FIELDS_ENV_VAR_CONFLICT,
+                  ) ? (
+                    <Alert isInline variant="danger" title="Environment variables conflict">
+                      Two or more fields are using the same environment variable. Ensure that each
+                      field uses a unique environment variable to proceed.
+                    </Alert>
+                  ) : null}
+                  <ManageConnectionTypeFieldsTable
+                    fields={fields}
+                    onFieldsChange={(value) => setData('fields', value)}
+                  />
+                </FormGroup>
+              </FormSection>
+            </Form>
+          </PageSection>
+          <PageSection
+            stickyOnBreakpoint={{ default: 'bottom' }}
+            variant="light"
+            style={{ flexGrow: 0 }}
+          >
+            <CreateConnectionTypeFooter
+              onSave={() =>
+                onSave(connectionTypeObj).then(() => {
+                  navigate('/connectionTypes');
+                })
+              }
+              onCancel={onCancel}
+              isSaveDisabled={!isValid}
+              saveButtonLabel={isEdit ? 'Save' : 'Create'}
             />
           </PageSection>
-        ) : undefined}
-        <PageSection isFilled variant="light" className="pf-v5-u-pt-0">
-          <Form>
-            <FormSection title="Type details" style={{ maxWidth: 625 }}>
-              <K8sNameDescriptionField
-                dataTestId="connection-type"
-                nameLabel="Connection type name"
-                descriptionLabel="Connection type description"
-                data={connectionNameDesc}
-                onDataChange={setConnectionNameDesc}
-                autoFocusName
-              />
-              <FormGroup label="Category" fieldId="connection-type-category" isRequired>
-                <MultiSelection
-                  inputId="connection-type-category"
-                  data-testid="connection-type-category"
-                  toggleTestId="connection-type-category-toggle"
-                  ariaLabel="Category"
-                  placeholder="Select a category"
-                  isCreatable
-                  value={categoryItems}
-                  setValue={(value) => {
-                    setCategory(value.filter((v) => v.selected).map((v) => String(v.id)));
-                  }}
-                />
-              </FormGroup>
-            </FormSection>
-            <FormGroup label="Enable" fieldId="connection-type-enable">
-              <Checkbox
-                label="Enable users in your organization to use this connection type when adding connections."
-                id="connection-type-enable"
-                name="connection-type-enable"
-                data-testid="connection-type-enable"
-                isChecked={connectionEnabled}
-                onChange={(_e, value) => setConnectionEnabled(value)}
-              />
-            </FormGroup>
-            <FormSection title="Fields" className="pf-v5-u-mt-0">
-              <FormGroup>
-                {isEnvVarConflict ? (
-                  <Alert isInline variant="danger" title="Environment variables conflict">
-                    Two or more fields are using the same environment variable. Ensure that each
-                    field uses a unique environment variable to proceed.
-                  </Alert>
-                ) : null}
-                <ManageConnectionTypeFieldsTable
-                  fields={connectionFields}
-                  onFieldsChange={setConnectionFields}
-                />
-              </FormGroup>
-            </FormSection>
-          </Form>
-        </PageSection>
-        <PageSection
-          stickyOnBreakpoint={{ default: 'bottom' }}
-          variant="light"
-          style={{ flexGrow: 0 }}
-        >
-          <CreateConnectionTypeFooter
-            onSave={() =>
-              onSave(connectionTypeObj).then(() => {
-                navigate('/connectionTypes');
-              })
-            }
-            onCancel={onCancel}
-            isSaveDisabled={!isValid}
-            saveButtonLabel={isEdit ? 'Save' : 'Create'}
-          />
-        </PageSection>
-      </ApplicationsPage>
-    </ConnectionTypePreviewDrawer>
+        </ApplicationsPage>
+      </ConnectionTypePreviewDrawer>
+    </ValidationContext.Provider>
   );
 };
 

--- a/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
@@ -6,7 +6,7 @@ import NumericAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanc
 import FileUploadAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm';
 import DropdownAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm';
 
-const CustomFieldPropertiesForm = <T extends ConnectionTypeDataField>(
+const DataFieldAdvancedPropertiesForm = <T extends ConnectionTypeDataField>(
   props: AdvancedFieldProps<T>,
 ): React.ReactNode => {
   const Component = (() => {
@@ -36,4 +36,4 @@ const CustomFieldPropertiesForm = <T extends ConnectionTypeDataField>(
   ) : undefined;
 };
 
-export default CustomFieldPropertiesForm;
+export default DataFieldAdvancedPropertiesForm;

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -23,11 +23,14 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
   onChange,
   onValidate,
 }) => {
+  const { variant } = properties;
   React.useEffect(() => {
-    if (!properties.variant) {
+    if (!variant) {
       onChange({ ...properties, variant: 'single' });
     }
-  });
+    // only run when variant is not set
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [variant]);
 
   React.useEffect(() => {
     // filter out empty rows for validation (they will be removed on save)

--- a/frontend/src/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm.tsx
@@ -50,24 +50,29 @@ const FileUploadAdvancedPropertiesForm: React.FC<AdvancedFieldProps<FileField>> 
             isDuplicate={isDuplicateExtension(index, displayedExtensions)}
             textRef={index === displayedExtensions.length - 1 ? lastTextRef : undefined}
             onChange={(val) => {
+              if (!val && displayedExtensions.length === 1) {
+                onChange({ ...properties, extensions: [] });
+              } else {
+                onChange({
+                  ...properties,
+                  extensions: [
+                    ...displayedExtensions.slice(0, index),
+                    val,
+                    ...displayedExtensions.slice(index + 1),
+                  ],
+                });
+              }
+            }}
+            onRemove={() => {
+              const exts = [
+                ...displayedExtensions.slice(0, index),
+                ...displayedExtensions.slice(index + 1),
+              ];
               onChange({
                 ...properties,
-                extensions: [
-                  ...displayedExtensions.slice(0, index),
-                  val,
-                  ...displayedExtensions.slice(index + 1),
-                ],
+                extensions: exts.length === 1 && exts[0].length === 0 ? [] : exts,
               });
             }}
-            onRemove={() =>
-              onChange({
-                ...properties,
-                extensions: [
-                  ...displayedExtensions.slice(0, index),
-                  ...displayedExtensions.slice(index + 1),
-                ],
-              })
-            }
             allowRemove={displayedExtensions.length > 1 || !!displayedExtensions[0]}
           />
         ))}

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -7,7 +7,6 @@ import {
   ConnectionTypeConfigMapObj,
   ConnectionTypeFieldType,
   ConnectionTypeValueType,
-  isConnectionTypeDataField,
 } from '~/concepts/connectionTypes/types';
 import { ProjectKind, SecretKind } from '~/k8sTypes';
 import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
@@ -15,6 +14,7 @@ import {
   assembleConnectionSecret,
   filterEnabledConnectionTypes,
   getDefaultValues,
+  isConnectionTypeDataField,
   parseConnectionSecretValues,
 } from '~/concepts/connectionTypes/utils';
 import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';

--- a/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
@@ -5,8 +5,9 @@ import useFetchState, {
   FetchStateCallbackPromise,
   NotReadyError,
 } from '~/utilities/useFetchState';
-import { Connection, isConnection } from '~/concepts/connectionTypes/types';
+import { Connection } from '~/concepts/connectionTypes/types';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE, LABEL_SELECTOR_DATA_CONNECTION_AWS } from '~/const';
+import { isConnection } from '~/concepts/connectionTypes/utils';
 
 const useConnections = (namespace?: string): FetchState<Connection[]> => {
   const callback = React.useCallback<FetchStateCallbackPromise<Connection[]>>(

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { getConfigMap, getSecret } from '~/api';
 import { ConfigMapKind, NotebookKind, SecretKind } from '~/k8sTypes';
 import { EnvVarResourceType } from '~/types';
-import { isConnection } from '~/concepts/connectionTypes/types';
 import {
   ConfigMapCategory,
   EnvironmentVariableType,
   EnvVariable,
   SecretCategory,
 } from '~/pages/projects/types';
+import { isConnection } from '~/concepts/connectionTypes/utils';
 import { isSecretKind } from './utils';
 
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {

--- a/frontend/src/utilities/__tests__/useValidation.spec.ts
+++ b/frontend/src/utilities/__tests__/useValidation.spec.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { useValidation } from '~/utilities/useValidation';
+
+const objectSchema = z.object({
+  foo: z.string().regex(/^foo-/, 'invalid foo'),
+  bar: z.number().min(4, 'invalid bar').optional(),
+});
+
+const nonObjectSchema = z
+  .object(objectSchema.shape)
+  .refine((data) => data.foo.length !== data.bar, 'test error');
+
+describe('useValidation', () => {
+  it('should validate the data with object schema', () => {
+    const renderResult = testHook(useValidation)({ foo: 'foo-test', bar: 100 }, objectSchema);
+    expect(renderResult.result.current.validationResult.success).toBe(true);
+
+    renderResult.rerender({ foo: 'foo', bar: 1 }, objectSchema);
+    expect(renderResult.result.current.validationResult.success).toBe(false);
+    expect(renderResult.result.current.validationResult.error?.errors).toHaveLength(2);
+    expect(renderResult.result.current.validationResult.error?.errors[0]).toEqual(
+      expect.objectContaining({
+        code: 'invalid_string',
+        path: ['foo'],
+        message: 'invalid foo',
+      }),
+    );
+    expect(renderResult.result.current.validationResult.error?.errors[1]).toEqual(
+      expect.objectContaining({
+        code: 'too_small',
+        path: ['bar'],
+        message: 'invalid bar',
+      }),
+    );
+
+    expect(renderResult.result.current.hasValidationIssue(['foo'], 'invalid_string')).toBe(true);
+    expect(renderResult.result.current.hasValidationIssue(['foo'], 'too_small')).toBe(false);
+    expect(renderResult.result.current.hasValidationIssue(['bar'], 'invalid_string')).toBe(false);
+    expect(renderResult.result.current.hasValidationIssue(['bar'], 'too_small')).toBe(true);
+  });
+
+  it('should validate the data with non-object schema', () => {
+    const renderResult = testHook(useValidation)({ foo: 'foo-test', bar: 8 }, nonObjectSchema);
+    expect(renderResult.result.current.validationResult.success).toBe(false);
+    expect(renderResult.result.current.validationResult.error?.errors).toHaveLength(1);
+    expect(renderResult.result.current.validationResult.error?.errors[0]).toEqual(
+      expect.objectContaining({
+        code: 'custom',
+        path: [],
+        message: 'test error',
+      }),
+    );
+  });
+
+  it('should be stable', () => {
+    const renderResult = testHook(useValidation)({ foo: 'foo-test', bar: 100 }, objectSchema);
+    renderResult.rerender({ foo: 'foo-test', bar: 100 }, objectSchema);
+    expect(renderResult).hookToBeStable({ validationResult: true, getValidationIssue: true });
+    renderResult.rerender({ foo: 'foo-test', bar: 101 }, objectSchema);
+    expect(renderResult).hookToBeStable({ validationResult: false, getValidationIssue: true });
+    expect(renderResult).hookToHaveUpdateCount(3);
+  });
+});

--- a/frontend/src/utilities/useValidation.ts
+++ b/frontend/src/utilities/useValidation.ts
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { z } from 'zod';
+
+const isObjectSchema = <T>(
+  schema: z.ZodType<T>,
+): schema is z.ZodObject<z.ZodRawShape, 'strip', z.ZodTypeAny, T, T> => 'shape' in schema;
+
+/*
+  A hook to be used in conjunction with simple object states such as useGenericObjectState
+  to provide validation results for the data.
+
+  If the schema is an object schema, only the changed properties will be validated to be more efficient.
+  Otherwise, the entire schema will be validated for any change to data.
+*/
+export const useValidation = <T>(data: T, schema: z.ZodType<T>): ValidationContextType<T> => {
+  const schemaRef = React.useRef(schema);
+  const prevDataRef = React.useRef<T>(data);
+  const resultRef = React.useRef<Omit<z.SafeParseReturnType<T, T>, 'data'>>();
+
+  resultRef.current = React.useMemo(() => {
+    // Validate the entire schema on first pass, or if it's not an object schema or if the schema has changed.
+    if (!isObjectSchema(schema) || resultRef.current == null || schemaRef.current !== schema) {
+      schemaRef.current = schema;
+      return schema.safeParse(data);
+    }
+
+    // Only validate the changed properties related to the object shape schema and merge the result.
+    let newResult = resultRef.current;
+    for (const key in data) {
+      if (prevDataRef.current[key] !== data[key]) {
+        const partialResult = schema.shape[key].safeParse(data[key], { path: [key] });
+        if (partialResult.error) {
+          if (newResult.error) {
+            newResult = {
+              error: new z.ZodError<T>([
+                ...newResult.error.issues.filter((issue) => issue.path[0] !== key),
+                ...partialResult.error.issues,
+              ]),
+              success: false,
+            };
+          } else {
+            newResult = {
+              error: partialResult.error,
+              success: false,
+            };
+          }
+        } else if (newResult.error) {
+          const issues = newResult.error.issues.filter((issue) => issue.path[0] !== key);
+          if (issues.length === 0) {
+            newResult = {
+              error: undefined,
+              success: true,
+            };
+          } else {
+            newResult = {
+              error: new z.ZodError<T>(issues),
+              success: false,
+            };
+          }
+        }
+      }
+    }
+    return newResult;
+  }, [data, schema]);
+
+  prevDataRef.current = data;
+
+  const getValidationIssue = React.useCallback((path: (string | number)[], code: string) => {
+    const error = resultRef.current?.error;
+    if (!error) {
+      return undefined;
+    }
+    return error.issues.find(
+      (issue) =>
+        issue.path.join('.') === path.join('.') &&
+        // compare custom codes stored in `params.code`
+        (issue.code === code || (issue.code === 'custom' && issue.params?.code === code)),
+    );
+  }, []);
+
+  const hasValidationIssue = React.useCallback(
+    (path: (string | number)[], code: string) => getValidationIssue(path, code) !== undefined,
+    [getValidationIssue],
+  );
+
+  return {
+    validationResult: resultRef.current,
+    getValidationIssue,
+    hasValidationIssue,
+  };
+};
+
+export type ValidationContextType<T = unknown> = {
+  validationResult: Omit<z.SafeParseReturnType<T, T>, 'data'>;
+  getValidationIssue: (path: (string | number)[], code: string) => z.ZodIssue | undefined;
+  hasValidationIssue: (path: (string | number)[], code: string) => boolean;
+};
+
+export const ValidationContext = React.createContext<ValidationContextType>({
+  validationResult: { error: undefined, success: true },
+  getValidationIssue: () => undefined,
+  hasValidationIssue: () => false,
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13664

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Introduces `zod` for form validation. Added basic support to work with zod schemas and validation errors until future integration with a form library.

Added hook `useValidation(<data>, <object schema>)` as a means to integrate `zod` with form which utilize `useGenericObjectState`.

Added schema for connection types and updated the connection types admin form to make use of the schema for validation. This update is only for the main form and not any sub form in modals.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Enable the `disableConnectionTypes` feature flag
- As a dashboard admin, go to `Settings -> Connection types`
- Test creating, editing, and duplicating a connection type.
- Ensure that the submit button is only enabled when the form is valid.
- Ensure that the fields table shows error banner and inline error when fields have the same env var.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
