### PR TITLE
Allow user to choose a model serving platform without deploying a model

### DIFF
--- a/backend/src/routes/api/namespaces/const.ts
+++ b/backend/src/routes/api/namespaces/const.ts
@@ -18,5 +18,5 @@ export enum NamespaceApplicationCase {
   /**
    * Downgrade a project from Modelmesh, Kserve or NIM so the platform can be selected again.
    */
-  RESET_MODEL_SERVING,
+  RESET_MODEL_SERVING_PLATFORM,
 }

--- a/backend/src/routes/api/namespaces/const.ts
+++ b/backend/src/routes/api/namespaces/const.ts
@@ -15,4 +15,8 @@ export enum NamespaceApplicationCase {
    * Nvidia NIMs run on KServe but have different requirements than regular models.
    */
   KSERVE_NIM_PROMOTION,
+  /**
+   * Downgrade a project from Modelmesh, Kserve or NIM so the platform can be selected again.
+   */
+  RESET_MODEL_SERVING,
 }

--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -100,6 +100,13 @@ export const applyNamespaceChange = async (
         checkPermissionsFn = checkEditNamespacePermission;
       }
       break;
+    case NamespaceApplicationCase.RESET_MODEL_SERVING:
+      {
+        annotations = { 'opendatahub.io/nim-support': null };
+        labels = { 'modelmesh-enabled': null };
+        checkPermissionsFn = checkEditNamespacePermission;
+      }
+      break;
     default:
       throw createCustomError('Unknown configuration', 'Cannot apply namespace change', 400);
   }

--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -100,7 +100,7 @@ export const applyNamespaceChange = async (
         checkPermissionsFn = checkEditNamespacePermission;
       }
       break;
-    case NamespaceApplicationCase.RESET_MODEL_SERVING:
+    case NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM:
       {
         annotations = { 'opendatahub.io/nim-support': null };
         labels = { 'modelmesh-enabled': null };

--- a/frontend/src/__mocks__/mockProjectK8sResource.ts
+++ b/frontend/src/__mocks__/mockProjectK8sResource.ts
@@ -10,6 +10,7 @@ type MockResourceConfigType = {
   k8sName?: string;
   creationTimestamp?: string;
   enableModelMesh?: boolean;
+  enableNIM?: boolean;
   isDSProject?: boolean;
   phase?: 'Active' | 'Terminating';
 };
@@ -21,6 +22,7 @@ export const mockProjectK8sResource = ({
   k8sName = 'test-project',
   creationTimestamp = '2023-02-14T21:43:59Z',
   enableModelMesh,
+  enableNIM = false,
   description = '',
   isDSProject = true,
   phase = 'Active',
@@ -35,6 +37,9 @@ export const mockProjectK8sResource = ({
       'kubernetes.io/metadata.name': k8sName,
       ...(enableModelMesh !== undefined && {
         [KnownLabels.MODEL_SERVING_PROJECT]: enableModelMesh ? 'true' : 'false',
+      }),
+      ...(enableNIM && {
+        'opendatahub.io/nim-support': 'true',
       }),
       ...(isDSProject && { [KnownLabels.DASHBOARD_RESOURCE]: 'true' }),
     },

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -357,6 +357,10 @@ class InferenceServiceRow extends TableRow {
   }
 }
 class ServingPlatformCard extends Contextual<HTMLElement> {
+  findSelectPlatformButton(platform: string) {
+    return this.find().findByTestId(`${platform}-serving-select-button`);
+  }
+
   findDeployModelButton() {
     return this.find().findByTestId('single-serving-deploy-button');
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -2,7 +2,6 @@ import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 import { mixin } from '~/__tests__/cypress/cypress/utils/mixin';
-import { Contextual } from './components/Contextual';
 import { TableToolbar } from './components/TableToolbar';
 
 class ModelServingToolbar extends TableToolbar {}
@@ -356,26 +355,10 @@ class InferenceServiceRow extends TableRow {
     return this.find().find(`[data-label=Project]`);
   }
 }
-class ServingPlatformCard extends Contextual<HTMLElement> {
-  findSelectPlatformButton(platform: string) {
-    return this.find().findByTestId(`${platform}-serving-select-button`);
-  }
 
-  findDeployModelButton() {
-    return this.find().findByTestId('single-serving-deploy-button');
-  }
-
-  findAddModelServerButton() {
-    return this.find().findByTestId('multi-serving-add-server-button');
-  }
-}
 class ModelServingSection {
   find() {
     return cy.findByTestId('section-model-server');
-  }
-
-  getServingPlatformCard(name: string) {
-    return new ServingPlatformCard(() => cy.findAllByTestId(`${name}-platform-card`));
   }
 
   private findKServeTable() {

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -248,12 +248,18 @@ class ProjectDetails {
     return cy.findByTestId('import-pipeline-button', { timeout });
   }
 
-  findSingleModelDeployButton() {
-    return this.findModelServingPlatform('single').findByTestId('single-serving-deploy-button');
+  findSelectPlatformButton(platform: string) {
+    return this.findModelServingPlatform(platform).findByTestId(
+      `${platform}-serving-select-button`,
+    );
   }
 
-  findMultiModelButton() {
-    return this.findModelServingPlatform('multi').findByTestId('multi-serving-add-server-button');
+  findTopLevelDeployModelButton() {
+    return cy.findByTestId('deploy-button');
+  }
+
+  findTopLevelAddModelServerButton() {
+    return cy.findByTestId('add-server-button');
   }
 
   findDeployModelTooltip() {

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -184,8 +184,8 @@ class ProjectDetails {
     this.wait();
   }
 
-  visitSection(project: string, section: string) {
-    cy.visitWithLogin(`/projects/${project}?section=${section}`);
+  visitSection(project: string, section: string, extraUrlParams = '') {
+    cy.visitWithLogin(`/projects/${project}?section=${section}${extraUrlParams}`);
     this.wait(section);
   }
 
@@ -249,9 +249,23 @@ class ProjectDetails {
   }
 
   findSelectPlatformButton(platform: string) {
-    return this.findModelServingPlatform(platform).findByTestId(
-      `${platform}-serving-select-button`,
-    );
+    return cy.findByTestId(`${platform}-serving-select-button`);
+  }
+
+  findResetPlatformButton() {
+    return cy.findByTestId('change-serving-platform-button');
+  }
+
+  findErrorSelectingPlatform() {
+    return cy.findByTestId('error-selecting-serving-platform');
+  }
+
+  findDeployModelDropdown() {
+    return cy.findByTestId('deploy-model-dropdown');
+  }
+
+  findBackToRegistryButton() {
+    return cy.findByTestId('deploy-from-registry');
   }
 
   findTopLevelDeployModelButton() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -696,11 +696,12 @@ describe('Serving Runtime List', () => {
         disableKServeConfig: false,
         servingRuntimes: [],
         requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+        projectEnableModelMesh: false,
       });
 
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -806,11 +807,12 @@ describe('Serving Runtime List', () => {
         disableKServeConfig: false,
         disableKServeAuthConfig: true,
         servingRuntimes: [],
+        projectEnableModelMesh: false,
       });
 
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -833,11 +835,12 @@ describe('Serving Runtime List', () => {
         disableKServeAuthConfig: false,
         servingRuntimes: [],
         requiredCapabilities: [],
+        projectEnableModelMesh: false,
       });
 
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -852,11 +855,12 @@ describe('Serving Runtime List', () => {
         disableKServeAuthConfig: false,
         servingRuntimes: [],
         requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+        projectEnableModelMesh: false,
       });
 
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -864,9 +868,10 @@ describe('Serving Runtime List', () => {
       kserveModal.findAuthenticationCheckbox().should('exist');
     });
 
-    it('Do not deploy KServe model when user cannot edit namespace', () => {
+    it('Do not deploy KServe model when user cannot edit namespace (only one serving platform enabled)', () => {
+      // If only one platform is enabled, project platform selection has not happened yet and patching the namespace with the platform happens at deploy time.
       initIntercepts({
-        disableModelMeshConfig: false,
+        disableModelMeshConfig: true,
         disableKServeConfig: false,
         servingRuntimes: [],
         rejectAddSupportServingPlatformProject: true,
@@ -874,7 +879,7 @@ describe('Serving Runtime List', () => {
 
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -1094,10 +1099,11 @@ describe('Serving Runtime List', () => {
         disableModelMeshConfig: false,
         disableKServeConfig: false,
         servingRuntimes: [],
+        projectEnableModelMesh: false,
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -1146,10 +1152,11 @@ describe('Serving Runtime List', () => {
         disableKServeConfig: false,
         servingRuntimes: [],
         requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+        projectEnableModelMesh: false,
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection.getServingPlatformCard('single-serving').findDeployModelButton().click();
+      modelServingSection.findDeployModelButton().click();
 
       kserveModal.shouldBeOpen();
 
@@ -1345,18 +1352,15 @@ describe('Serving Runtime List', () => {
       });
     });
 
-    it('Successfully add model server when user can edit namespace', () => {
+    it('Successfully add model server when user can edit namespace (only one serving platform enabled)', () => {
+      // If only one platform is enabled, project platform selection has not happened yet and patching the namespace with the platform happens at deploy time.
       initIntercepts({
-        projectEnableModelMesh: undefined,
-        disableKServeConfig: false,
+        disableKServeConfig: true,
         disableModelMeshConfig: false,
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection
-        .getServingPlatformCard('multi-serving')
-        .findAddModelServerButton()
-        .click();
+      modelServingSection.findAddModelServerButton().click();
 
       createServingRuntimeModal.shouldBeOpen();
 
@@ -1401,19 +1405,16 @@ describe('Serving Runtime List', () => {
       });
     });
 
-    it('Do not add model server when user cannot edit namespace', () => {
+    it('Do not add model server when user cannot edit namespace (only one serving platform enabled)', () => {
+      // If only one platform is enabled, project platform selection has not happened yet and patching the namespace with the platform happens at deploy time.
       initIntercepts({
-        projectEnableModelMesh: undefined,
-        disableKServeConfig: false,
+        disableKServeConfig: true,
         disableModelMeshConfig: false,
         rejectAddSupportServingPlatformProject: true,
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection
-        .getServingPlatformCard('multi-serving')
-        .findAddModelServerButton()
-        .click();
+      modelServingSection.findAddModelServerButton().click();
 
       createServingRuntimeModal.shouldBeOpen();
 
@@ -1457,16 +1458,13 @@ describe('Serving Runtime List', () => {
   describe('Model server with SericeAccount and RoleBinding', () => {
     it('Add model server - do not create ServiceAccount or RoleBinding if token auth is not selected', () => {
       initIntercepts({
-        projectEnableModelMesh: undefined,
+        projectEnableModelMesh: true,
         disableKServeConfig: false,
         disableModelMeshConfig: false,
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection
-        .getServingPlatformCard('multi-serving')
-        .findAddModelServerButton()
-        .click();
+      modelServingSection.findAddModelServerButton().click();
 
       createServingRuntimeModal.shouldBeOpen();
 
@@ -1523,16 +1521,13 @@ describe('Serving Runtime List', () => {
 
     it('Add model server - create ServiceAccount and RoleBinding if token auth is selected', () => {
       initIntercepts({
-        projectEnableModelMesh: undefined,
+        projectEnableModelMesh: true,
         disableKServeConfig: false,
         disableModelMeshConfig: false,
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection
-        .getServingPlatformCard('multi-serving')
-        .findAddModelServerButton()
-        .click();
+      modelServingSection.findAddModelServerButton().click();
 
       createServingRuntimeModal.shouldBeOpen();
 
@@ -1597,7 +1592,7 @@ describe('Serving Runtime List', () => {
 
     it('Add model server - do not create ServiceAccount or RoleBinding if they already exist', () => {
       initIntercepts({
-        projectEnableModelMesh: undefined,
+        projectEnableModelMesh: true,
         disableKServeConfig: false,
         disableModelMeshConfig: false,
         serviceAccountAlreadyExists: true,
@@ -1606,10 +1601,7 @@ describe('Serving Runtime List', () => {
       });
       projectDetails.visitSection('test-project', 'model-server');
 
-      modelServingSection
-        .getServingPlatformCard('multi-serving')
-        .findAddModelServerButton()
-        .click();
+      modelServingSection.findAddModelServerButton().click();
 
       createServingRuntimeModal.shouldBeOpen();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
@@ -19,15 +19,11 @@ import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/Delete
 
 describe('NIM Model Serving', () => {
   describe('Deploying a model from an existing Project', () => {
-    it('should be disabled if the modal is empty', () => {
-      initInterceptsToEnableNim({ hasAllModels: true });
+    it('should be disabled if the modal is empty (NIM already selected for project)', () => {
+      initInterceptsToEnableNim({ hasAllModels: false });
 
       projectDetails.visitSection('test-project', 'model-server');
-      // For multiple cards use case
-      projectDetails
-        .findModelServingPlatform('nvidia-nim-model')
-        .findByTestId('nim-serving-deploy-button')
-        .click();
+      cy.findByTestId('deploy-button').click();
 
       // test that you can not submit on empty
       nimDeployModal.shouldBeOpen();
@@ -168,7 +164,7 @@ describe('NIM Model Serving', () => {
         nimDeployModal.shouldBeOpen();
       });
 
-      it("should allow deploying NIM from a Project's Overview tab when multiple platforms exist", () => {
+      it("should allow selecting NIM from a Project's Overview tab when multiple platforms exist", () => {
         initInterceptorsValidatingNimEnablement({
           disableKServe: false,
           disableModelMesh: false,
@@ -177,8 +173,14 @@ describe('NIM Model Serving', () => {
         projectDetailsOverviewTab.visit('test-project');
         projectDetailsOverviewTab
           .findModelServingPlatform('nvidia-nim')
-          .findByTestId('model-serving-platform-button')
-          .click();
+          .findByTestId('nim-serving-select-button')
+          .should('be.enabled');
+      });
+
+      it("should allow deploying NIM from a Project's Overview tab when NIM is selected", () => {
+        initInterceptsToEnableNim({ hasAllModels: false });
+        projectDetailsOverviewTab.visit('test-project');
+        cy.findByTestId('model-serving-platform-button').click();
         nimDeployModal.shouldBeOpen();
       });
 
@@ -189,7 +191,7 @@ describe('NIM Model Serving', () => {
         nimDeployModal.shouldBeOpen();
       });
 
-      it("should allow deploying NIM from a Project's Models tab when multiple platforms exist", () => {
+      it("should allow selecting NIM from a Project's Models tab when multiple platforms exist", () => {
         initInterceptorsValidatingNimEnablement({
           disableKServe: false,
           disableModelMesh: false,
@@ -198,8 +200,14 @@ describe('NIM Model Serving', () => {
         projectDetails.visitSection('test-project', 'model-server');
         projectDetails
           .findModelServingPlatform('nvidia-nim-model')
-          .findByTestId('nim-serving-deploy-button')
-          .click();
+          .findByTestId('nim-serving-select-button')
+          .should('be.enabled');
+      });
+
+      it("should allow deploying NIM from a Project's Models tab when NIM is selected", () => {
+        initInterceptsToEnableNim({ hasAllModels: false });
+        projectDetails.visitSection('test-project', 'model-server');
+        cy.get('button[data-testid=deploy-button]').click();
         nimDeployModal.shouldBeOpen();
       });
     });
@@ -244,7 +252,7 @@ describe('NIM Model Serving', () => {
         });
         projectDetails.visitSection('test-project', 'model-server');
         projectDetails.findModelServingPlatform('nvidia-nim-model').should('not.exist');
-        cy.findByTestId('nim-serving-deploy-button').should('not.exist');
+        cy.findByTestId('nim-serving-select-button').should('not.exist');
       });
     });
 
@@ -300,7 +308,7 @@ describe('NIM Model Serving', () => {
         );
         projectDetails.visitSection('test-project', 'model-server');
         projectDetails.findModelServingPlatform('nvidia-nim-model').should('not.exist');
-        cy.findByTestId('nim-serving-deploy-button').should('not.exist');
+        cy.findByTestId('nim-serving-select-button').should('not.exist');
       });
     });
   });

--- a/frontend/src/api/k8s/__tests__/projects.spec.ts
+++ b/frontend/src/api/k8s/__tests__/projects.spec.ts
@@ -274,7 +274,7 @@ describe('addSupportServingPlatformProject', () => {
     await expect(
       addSupportServingPlatformProject(name, NamespaceApplicationCase.MODEL_MESH_PROMOTION),
     ).rejects.toThrow(
-      `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
+      `Unable to select a model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
     );
     expect(mockedAxios).toHaveBeenCalledTimes(1);
     expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1', { params: {} });
@@ -285,7 +285,7 @@ describe('addSupportServingPlatformProject', () => {
     await expect(
       addSupportServingPlatformProject(name, NamespaceApplicationCase.MODEL_MESH_PROMOTION),
     ).rejects.toThrow(
-      `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
+      `Unable to select a model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
     );
     expect(mockedAxios).toHaveBeenCalledTimes(1);
     expect(mockedAxios).toHaveBeenCalledWith('/api/namespaces/test/1', { params: {} });

--- a/frontend/src/api/k8s/projects.ts
+++ b/frontend/src/api/k8s/projects.ts
@@ -106,7 +106,7 @@ export const addSupportServingPlatformProject = (
       const applied = response.data?.applied ?? false;
       if (!applied) {
         throw new Error(
-          `Unable to enable model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
+          `Unable to select a model serving platform in your project. Ask a ${ODH_PRODUCT_NAME} admin for assistance.`,
         );
       }
       return name;

--- a/frontend/src/components/EmptyDetailsView.tsx
+++ b/frontend/src/components/EmptyDetailsView.tsx
@@ -10,7 +10,7 @@ import {
 
 type EmptyDetailsViewProps = {
   title?: string;
-  description?: string;
+  description?: React.ReactNode;
   iconImage?: string;
   imageAlt?: string;
   allowCreate?: boolean;

--- a/frontend/src/components/EmptyDetailsView.tsx
+++ b/frontend/src/components/EmptyDetailsView.tsx
@@ -15,6 +15,7 @@ type EmptyDetailsViewProps = {
   imageAlt?: string;
   allowCreate?: boolean;
   createButton?: React.ReactNode;
+  footerExtraChildren?: React.ReactNode;
   imageSize?: string;
 };
 
@@ -25,6 +26,7 @@ const EmptyDetailsView: React.FC<EmptyDetailsViewProps> = ({
   imageAlt,
   allowCreate = true,
   createButton,
+  footerExtraChildren = null,
   imageSize = '320px',
 }) => (
   <EmptyState variant="lg">
@@ -44,6 +46,7 @@ const EmptyDetailsView: React.FC<EmptyDetailsViewProps> = ({
     {allowCreate && createButton ? (
       <EmptyStateFooter>
         <EmptyStateActions>{createButton}</EmptyStateActions>
+        {footerExtraChildren}
       </EmptyStateFooter>
     ) : null}
   </EmptyState>

--- a/frontend/src/components/SimpleMenuActions.tsx
+++ b/frontend/src/components/SimpleMenuActions.tsx
@@ -6,6 +6,7 @@ import {
   Divider,
   DropdownList,
   TooltipProps,
+  MenuToggleProps,
 } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
@@ -23,6 +24,7 @@ type SimpleDropdownProps = {
   dropdownItems: (Item | Spacer)[];
   testId?: string;
   toggleLabel?: string;
+  toggleProps?: Partial<MenuToggleProps>;
   variant?: React.ComponentProps<typeof MenuToggle>['variant'];
 } & Omit<
   React.ComponentProps<typeof Dropdown>,
@@ -33,6 +35,7 @@ const SimpleMenuActions: React.FC<SimpleDropdownProps> = ({
   dropdownItems,
   testId,
   toggleLabel,
+  toggleProps,
   variant,
   ...props
 }) => {
@@ -51,6 +54,7 @@ const SimpleMenuActions: React.FC<SimpleDropdownProps> = ({
           ref={toggleRef}
           onClick={() => setOpen(!open)}
           isExpanded={open}
+          {...toggleProps}
         >
           {toggleLabel ?? <EllipsisVIcon />}
         </MenuToggle>

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -11,6 +11,7 @@ import { ServingRuntimePlatform } from '~/types';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import useRegisteredModelDeployInfo from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
+import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { getKServeTemplates } from '~/pages/modelServing/customServingRuntimes/utils';
 import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
 
@@ -30,6 +31,7 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
     servingRuntimeTemplateOrder: { data: templateOrder },
     servingRuntimeTemplateDisablement: { data: templateDisablement },
   } = React.useContext(ModelRegistryContext);
+  const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
 
   const [selectedProject, setSelectedProject] = React.useState<ProjectKind | null>(null);
   const servingPlatformStatuses = useServingPlatformStatuses();
@@ -65,6 +67,9 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
       selectedProject={selectedProject}
       setSelectedProject={setSelectedProject}
       error={error}
+      modelRegistryName={preferredModelRegistry?.metadata.name}
+      registeredModelId={modelVersion.registeredModelId}
+      modelVersionId={modelVersion.id}
     />
   );
 

--- a/frontend/src/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert.tsx
+++ b/frontend/src/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert.tsx
@@ -1,0 +1,26 @@
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
+import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
+import * as React from 'react';
+
+type ModelServingPlatformSelectErrorAlertProps = {
+  error: Error;
+  clearError: () => void;
+};
+
+const ModelServingPlatformSelectErrorAlert: React.FC<ModelServingPlatformSelectErrorAlertProps> = ({
+  error,
+  clearError,
+}) => (
+  <Alert
+    variant="danger"
+    isInline
+    title="Model serving platform selection failed"
+    actionClose={<AlertActionCloseButton onClose={clearError} />}
+    isExpandable
+    className={alignment.textAlignLeft}
+  >
+    <p>{error.message}</p>
+  </Alert>
+);
+
+export default ModelServingPlatformSelectErrorAlert;

--- a/frontend/src/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert.tsx
+++ b/frontend/src/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert.tsx
@@ -18,6 +18,7 @@ const ModelServingPlatformSelectErrorAlert: React.FC<ModelServingPlatformSelectE
     actionClose={<AlertActionCloseButton onClose={clearError} />}
     isExpandable
     className={alignment.textAlignLeft}
+    data-testid="error-selecting-serving-platform"
   >
     <p>{error.message}</p>
   </Alert>

--- a/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
@@ -10,87 +10,47 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { ServingRuntimePlatform } from '~/types';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-  getTemplateEnabledForPlatform,
-} from '~/pages/modelServing/customServingRuntimes/utils';
-import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
-import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 
-const EmptyMultiModelServingCard: React.FC = () => {
-  const [open, setOpen] = React.useState(false);
+type EmptyMultiModelServingCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+};
 
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-  const emptyTemplates = templatesEnabled.length === 0;
-
-  const onSubmit = (submit: boolean) => {
-    if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-    }
-  };
-
+const EmptyMultiModelServingCard: React.FC<EmptyMultiModelServingCardProps> = ({
+  setErrorSelectingPlatform,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
-    <>
-      <Card
-        style={{
-          height: '100%',
-          border: '1px solid var(--pf-v5-global--BorderColor--100)',
-          borderRadius: 16,
-        }}
-        data-testid="multi-serving-platform-card"
-      >
-        <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h2}>Multi-model serving platform</Text>
-          </TextContent>
-        </CardTitle>
-        <CardBody>
-          Multiple models can be deployed on one shared model server. Choose this option when you
-          want to deploy a number of small or medium-sized models that can share the server
-          resources.
-        </CardBody>
-        <CardFooter>
-          <Bullseye>
-            <ModelServingPlatformButtonAction
-              isProjectModelMesh
-              emptyTemplates={emptyTemplates}
-              onClick={() => setOpen(true)}
-              variant="secondary"
-              testId="multi-serving-add-server-button"
-            />
-          </Bullseye>
-        </CardFooter>
-      </Card>
-      {open ? (
-        <ManageServingRuntimeModal
-          currentProject={currentProject}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
-          )}
-          onClose={(submit: boolean) => {
-            setOpen(false);
-            onSubmit(submit);
-          }}
-        />
-      ) : null}
-    </>
+    <Card
+      style={{
+        height: '100%',
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 16,
+      }}
+      data-testid="multi-serving-platform-card"
+    >
+      <CardTitle>
+        <TextContent>
+          <Text component={TextVariants.h2}>Multi-model serving platform</Text>
+        </TextContent>
+      </CardTitle>
+      <CardBody>
+        Multiple models can be deployed on one shared model server. Choose this option when you want
+        to deploy a number of small or medium-sized models that can share the server resources.
+      </CardBody>
+      <CardFooter>
+        <Bullseye>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="secondary"
+            data-testid="multi-serving-select-button" // TODO this changed from multi-serving-add-server-button, inform QE and look for other cases
+          />
+        </Bullseye>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
@@ -10,107 +10,47 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { ServingRuntimePlatform } from '~/types';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-  getTemplateEnabledForPlatform,
-} from '~/pages/modelServing/customServingRuntimes/utils';
-import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 
 type EmptyMultiModelServingCardProps = {
   setErrorSelectingPlatform: (e?: Error) => void;
-  numServingPlatformsAvailable: number;
 };
 
 const EmptyMultiModelServingCard: React.FC<EmptyMultiModelServingCardProps> = ({
   setErrorSelectingPlatform,
-  numServingPlatformsAvailable,
 }) => {
-  const [open, setOpen] = React.useState(false);
-
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-  const emptyTemplates = templatesEnabled.length === 0;
-
-  const onSubmit = (submit: boolean) => {
-    if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-    }
-  };
-
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
-    <>
-      <Card
-        style={{
-          height: '100%',
-          border: '1px solid var(--pf-v5-global--BorderColor--100)',
-          borderRadius: 16,
-        }}
-        data-testid="multi-serving-platform-card"
-      >
-        <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h2}>Multi-model serving platform</Text>
-          </TextContent>
-        </CardTitle>
-        <CardBody>
-          Multiple models can be deployed on one shared model server. Choose this option when you
-          want to deploy a number of small or medium-sized models that can share the server
-          resources.
-        </CardBody>
-        <CardFooter>
-          <Bullseye>
-            {numServingPlatformsAvailable > 1 ? (
-              <ModelServingPlatformSelectButton
-                namespace={currentProject.metadata.name}
-                servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
-                setError={setErrorSelectingPlatform}
-                variant="secondary"
-                data-testid="multi-serving-select-button"
-              />
-            ) : (
-              <ModelServingPlatformButtonAction
-                isProjectModelMesh
-                emptyTemplates={emptyTemplates}
-                onClick={() => setOpen(true)}
-                variant="secondary"
-                testId="multi-serving-add-server-button"
-              />
-            )}
-          </Bullseye>
-        </CardFooter>
-      </Card>
-      {open ? (
-        <ManageServingRuntimeModal
-          currentProject={currentProject}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
-          )}
-          onClose={(submit: boolean) => {
-            setOpen(false);
-            onSubmit(submit);
-          }}
-        />
-      ) : null}
-    </>
+    <Card
+      style={{
+        height: '100%',
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 16,
+      }}
+      data-testid="multi-serving-platform-card"
+    >
+      <CardTitle>
+        <TextContent>
+          <Text component={TextVariants.h2}>Multi-model serving platform</Text>
+        </TextContent>
+      </CardTitle>
+      <CardBody>
+        Multiple models can be deployed on one shared model server. Choose this option when you want
+        to deploy a number of small or medium-sized models that can share the server resources.
+      </CardBody>
+      <CardFooter>
+        <Bullseye>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="secondary"
+            data-testid="multi-serving-select-button"
+          />
+        </Bullseye>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
@@ -84,7 +84,7 @@ const EmptyMultiModelServingCard: React.FC<EmptyMultiModelServingCardProps> = ({
                 servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
                 setError={setErrorSelectingPlatform}
                 variant="secondary"
-                data-testid="multi-serving-select-button" // TODO this changed from multi-serving-add-server-button, inform QE and look for other cases
+                data-testid="multi-serving-select-button"
               />
             ) : (
               <ModelServingPlatformButtonAction

--- a/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
@@ -10,47 +10,87 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ServingRuntimePlatform } from '~/types';
+import {
+  getSortedTemplates,
+  getTemplateEnabled,
+  getTemplateEnabledForPlatform,
+} from '~/pages/modelServing/customServingRuntimes/utils';
+import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 
-type EmptyMultiModelServingCardProps = {
-  setErrorSelectingPlatform: (e?: Error) => void;
-};
+const EmptyMultiModelServingCard: React.FC = () => {
+  const [open, setOpen] = React.useState(false);
 
-const EmptyMultiModelServingCard: React.FC<EmptyMultiModelServingCardProps> = ({
-  setErrorSelectingPlatform,
-}) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const {
+    servingRuntimes: { refresh: refreshServingRuntime },
+    servingRuntimeTemplates: [templates],
+    servingRuntimeTemplateOrder: { data: templateOrder },
+    servingRuntimeTemplateDisablement: { data: templateDisablement },
+    serverSecrets: { refresh: refreshTokens },
+    inferenceServices: { refresh: refreshInferenceServices },
+    currentProject,
+  } = React.useContext(ProjectDetailsContext);
+
+  const templatesSorted = getSortedTemplates(templates, templateOrder);
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, templateDisablement),
+  );
+  const emptyTemplates = templatesEnabled.length === 0;
+
+  const onSubmit = (submit: boolean) => {
+    if (submit) {
+      refreshServingRuntime();
+      refreshInferenceServices();
+      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
+    }
+  };
+
   return (
-    <Card
-      style={{
-        height: '100%',
-        border: '1px solid var(--pf-v5-global--BorderColor--100)',
-        borderRadius: 16,
-      }}
-      data-testid="multi-serving-platform-card"
-    >
-      <CardTitle>
-        <TextContent>
-          <Text component={TextVariants.h2}>Multi-model serving platform</Text>
-        </TextContent>
-      </CardTitle>
-      <CardBody>
-        Multiple models can be deployed on one shared model server. Choose this option when you want
-        to deploy a number of small or medium-sized models that can share the server resources.
-      </CardBody>
-      <CardFooter>
-        <Bullseye>
-          <ModelServingPlatformSelectButton
-            namespace={currentProject.metadata.name}
-            servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
-            setError={setErrorSelectingPlatform}
-            variant="secondary"
-            data-testid="multi-serving-select-button" // TODO this changed from multi-serving-add-server-button, inform QE and look for other cases
-          />
-        </Bullseye>
-      </CardFooter>
-    </Card>
+    <>
+      <Card
+        style={{
+          height: '100%',
+          border: '1px solid var(--pf-v5-global--BorderColor--100)',
+          borderRadius: 16,
+        }}
+        data-testid="multi-serving-platform-card"
+      >
+        <CardTitle>
+          <TextContent>
+            <Text component={TextVariants.h2}>Multi-model serving platform</Text>
+          </TextContent>
+        </CardTitle>
+        <CardBody>
+          Multiple models can be deployed on one shared model server. Choose this option when you
+          want to deploy a number of small or medium-sized models that can share the server
+          resources.
+        </CardBody>
+        <CardFooter>
+          <Bullseye>
+            <ModelServingPlatformButtonAction
+              isProjectModelMesh
+              emptyTemplates={emptyTemplates}
+              onClick={() => setOpen(true)}
+              variant="secondary"
+              testId="multi-serving-add-server-button"
+            />
+          </Bullseye>
+        </CardFooter>
+      </Card>
+      {open ? (
+        <ManageServingRuntimeModal
+          currentProject={currentProject}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
+          )}
+          onClose={(submit: boolean) => {
+            setOpen(false);
+            onSubmit(submit);
+          }}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyMultiModelServingCard.tsx
@@ -17,9 +17,19 @@ import {
   getTemplateEnabledForPlatform,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
 import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 
-const EmptyMultiModelServingCard: React.FC = () => {
+type EmptyMultiModelServingCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+  numServingPlatformsAvailable: number;
+};
+
+const EmptyMultiModelServingCard: React.FC<EmptyMultiModelServingCardProps> = ({
+  setErrorSelectingPlatform,
+  numServingPlatformsAvailable,
+}) => {
   const [open, setOpen] = React.useState(false);
 
   const {
@@ -68,13 +78,23 @@ const EmptyMultiModelServingCard: React.FC = () => {
         </CardBody>
         <CardFooter>
           <Bullseye>
-            <ModelServingPlatformButtonAction
-              isProjectModelMesh
-              emptyTemplates={emptyTemplates}
-              onClick={() => setOpen(true)}
-              variant="secondary"
-              testId="multi-serving-add-server-button"
-            />
+            {numServingPlatformsAvailable > 1 ? (
+              <ModelServingPlatformSelectButton
+                namespace={currentProject.metadata.name}
+                servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
+                setError={setErrorSelectingPlatform}
+                variant="secondary"
+                data-testid="multi-serving-select-button" // TODO this changed from multi-serving-add-server-button, inform QE and look for other cases
+              />
+            ) : (
+              <ModelServingPlatformButtonAction
+                isProjectModelMesh
+                emptyTemplates={emptyTemplates}
+                onClick={() => setOpen(true)}
+                variant="secondary"
+                testId="multi-serving-add-server-button"
+              />
+            )}
           </Bullseye>
         </CardFooter>
       </Card>

--- a/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
@@ -10,88 +10,48 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-} from '~/pages/modelServing/customServingRuntimes/utils';
-import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
-import DeployNIMServiceModal from './NIMServiceModal/DeployNIMServiceModal';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 
-const EmptyNIMModelServingCard: React.FC = () => {
-  const {
-    dataConnections: { data: dataConnections },
-  } = React.useContext(ProjectDetailsContext);
-  const [open, setOpen] = React.useState(false);
+type EmptyNIMModelServingCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+};
 
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const onSubmit = (submit: boolean) => {
-    if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-    }
-  };
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-  const emptyTemplates = templatesEnabled.length === 0;
-
+const EmptyNIMModelServingCard: React.FC<EmptyNIMModelServingCardProps> = ({
+  setErrorSelectingPlatform,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
-    <>
-      <Card
-        style={{
-          height: '100%',
-          border: '1px solid var(--pf-v5-global--BorderColor--100)',
-          borderRadius: 16,
-        }}
-        data-testid="nvidia-nim-model-serving-platform-card"
-      >
-        <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h2}>NVIDIA NIM model serving platform</Text>
-          </TextContent>
-        </CardTitle>
-        <CardBody>
-          Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
-          deploy your model within a NIM container. Please provide the API key to authenticate with
-          the NIM service.
-        </CardBody>
-        <CardFooter>
-          <Bullseye>
-            <ModelServingPlatformButtonAction
-              isProjectModelMesh={false}
-              emptyTemplates={emptyTemplates}
-              onClick={() => setOpen(true)}
-              variant="secondary"
-              testId="nim-serving-deploy-button"
-            />
-          </Bullseye>
-        </CardFooter>
-      </Card>
-      {open && (
-        <DeployNIMServiceModal
-          projectContext={{
-            currentProject,
-            dataConnections,
-          }}
-          onClose={(submit) => {
-            onSubmit(submit);
-            setOpen(false);
-          }}
-        />
-      )}
-    </>
+    <Card
+      style={{
+        height: '100%',
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 16,
+      }}
+      data-testid="nvidia-nim-model-serving-platform-card"
+    >
+      <CardTitle>
+        <TextContent>
+          <Text component={TextVariants.h2}>NVIDIA NIM model serving platform</Text>
+        </TextContent>
+      </CardTitle>
+      <CardBody>
+        Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
+        deploy your model within a NIM container. Please provide the API key to authenticate with
+        the NIM service.
+      </CardBody>
+      <CardFooter>
+        <Bullseye>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="secondary"
+            data-testid="nim-serving-select-button" // TODO this changed from nim-serving-deploy-button, inform QE and look for other cases
+          />
+        </Bullseye>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
@@ -15,9 +15,19 @@ import {
   getTemplateEnabled,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
 import DeployNIMServiceModal from './NIMServiceModal/DeployNIMServiceModal';
 
-const EmptyNIMModelServingCard: React.FC = () => {
+type EmptyNIMModelServingCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+  numServingPlatformsAvailable: number;
+};
+
+const EmptyNIMModelServingCard: React.FC<EmptyNIMModelServingCardProps> = ({
+  setErrorSelectingPlatform,
+  numServingPlatformsAvailable,
+}) => {
   const {
     dataConnections: { data: dataConnections },
   } = React.useContext(ProjectDetailsContext);
@@ -69,13 +79,23 @@ const EmptyNIMModelServingCard: React.FC = () => {
         </CardBody>
         <CardFooter>
           <Bullseye>
-            <ModelServingPlatformButtonAction
-              isProjectModelMesh={false}
-              emptyTemplates={emptyTemplates}
-              onClick={() => setOpen(true)}
-              variant="secondary"
-              testId="nim-serving-deploy-button"
-            />
+            {numServingPlatformsAvailable > 1 ? (
+              <ModelServingPlatformSelectButton
+                namespace={currentProject.metadata.name}
+                servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
+                setError={setErrorSelectingPlatform}
+                variant="secondary"
+                data-testid="nim-serving-select-button" // TODO this changed from nim-serving-deploy-button, inform QE and look for other cases
+              />
+            ) : (
+              <ModelServingPlatformButtonAction
+                isProjectModelMesh={false}
+                emptyTemplates={emptyTemplates}
+                onClick={() => setOpen(true)}
+                variant="secondary"
+                testId="nim-serving-deploy-button"
+              />
+            )}
           </Bullseye>
         </CardFooter>
       </Card>

--- a/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
@@ -10,48 +10,88 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import {
+  getSortedTemplates,
+  getTemplateEnabled,
+} from '~/pages/modelServing/customServingRuntimes/utils';
+import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import DeployNIMServiceModal from './NIMServiceModal/DeployNIMServiceModal';
 
-type EmptyNIMModelServingCardProps = {
-  setErrorSelectingPlatform: (e?: Error) => void;
-};
+const EmptyNIMModelServingCard: React.FC = () => {
+  const {
+    dataConnections: { data: dataConnections },
+  } = React.useContext(ProjectDetailsContext);
+  const [open, setOpen] = React.useState(false);
 
-const EmptyNIMModelServingCard: React.FC<EmptyNIMModelServingCardProps> = ({
-  setErrorSelectingPlatform,
-}) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const {
+    servingRuntimes: { refresh: refreshServingRuntime },
+    servingRuntimeTemplates: [templates],
+    servingRuntimeTemplateOrder: { data: templateOrder },
+    servingRuntimeTemplateDisablement: { data: templateDisablement },
+    serverSecrets: { refresh: refreshTokens },
+    inferenceServices: { refresh: refreshInferenceServices },
+    currentProject,
+  } = React.useContext(ProjectDetailsContext);
+
+  const onSubmit = (submit: boolean) => {
+    if (submit) {
+      refreshServingRuntime();
+      refreshInferenceServices();
+      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
+    }
+  };
+
+  const templatesSorted = getSortedTemplates(templates, templateOrder);
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, templateDisablement),
+  );
+  const emptyTemplates = templatesEnabled.length === 0;
+
   return (
-    <Card
-      style={{
-        height: '100%',
-        border: '1px solid var(--pf-v5-global--BorderColor--100)',
-        borderRadius: 16,
-      }}
-      data-testid="nvidia-nim-model-serving-platform-card"
-    >
-      <CardTitle>
-        <TextContent>
-          <Text component={TextVariants.h2}>NVIDIA NIM model serving platform</Text>
-        </TextContent>
-      </CardTitle>
-      <CardBody>
-        Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
-        deploy your model within a NIM container. Please provide the API key to authenticate with
-        the NIM service.
-      </CardBody>
-      <CardFooter>
-        <Bullseye>
-          <ModelServingPlatformSelectButton
-            namespace={currentProject.metadata.name}
-            servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
-            setError={setErrorSelectingPlatform}
-            variant="secondary"
-            data-testid="nim-serving-select-button" // TODO this changed from nim-serving-deploy-button, inform QE and look for other cases
-          />
-        </Bullseye>
-      </CardFooter>
-    </Card>
+    <>
+      <Card
+        style={{
+          height: '100%',
+          border: '1px solid var(--pf-v5-global--BorderColor--100)',
+          borderRadius: 16,
+        }}
+        data-testid="nvidia-nim-model-serving-platform-card"
+      >
+        <CardTitle>
+          <TextContent>
+            <Text component={TextVariants.h2}>NVIDIA NIM model serving platform</Text>
+          </TextContent>
+        </CardTitle>
+        <CardBody>
+          Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
+          deploy your model within a NIM container. Please provide the API key to authenticate with
+          the NIM service.
+        </CardBody>
+        <CardFooter>
+          <Bullseye>
+            <ModelServingPlatformButtonAction
+              isProjectModelMesh={false}
+              emptyTemplates={emptyTemplates}
+              onClick={() => setOpen(true)}
+              variant="secondary"
+              testId="nim-serving-deploy-button"
+            />
+          </Bullseye>
+        </CardFooter>
+      </Card>
+      {open && (
+        <DeployNIMServiceModal
+          projectContext={{
+            currentProject,
+            dataConnections,
+          }}
+          onClose={(submit) => {
+            onSubmit(submit);
+            setOpen(false);
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
@@ -85,7 +85,7 @@ const EmptyNIMModelServingCard: React.FC<EmptyNIMModelServingCardProps> = ({
                 servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
                 setError={setErrorSelectingPlatform}
                 variant="secondary"
-                data-testid="nim-serving-select-button" // TODO this changed from nim-serving-deploy-button, inform QE and look for other cases
+                data-testid="nim-serving-select-button"
               />
             ) : (
               <ModelServingPlatformButtonAction

--- a/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptyNIMModelServingCard.tsx
@@ -10,108 +10,48 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-} from '~/pages/modelServing/customServingRuntimes/utils';
-import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
-import DeployNIMServiceModal from './NIMServiceModal/DeployNIMServiceModal';
 
 type EmptyNIMModelServingCardProps = {
   setErrorSelectingPlatform: (e?: Error) => void;
-  numServingPlatformsAvailable: number;
 };
 
 const EmptyNIMModelServingCard: React.FC<EmptyNIMModelServingCardProps> = ({
   setErrorSelectingPlatform,
-  numServingPlatformsAvailable,
 }) => {
-  const {
-    dataConnections: { data: dataConnections },
-  } = React.useContext(ProjectDetailsContext);
-  const [open, setOpen] = React.useState(false);
-
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const onSubmit = (submit: boolean) => {
-    if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-    }
-  };
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-  const emptyTemplates = templatesEnabled.length === 0;
-
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
-    <>
-      <Card
-        style={{
-          height: '100%',
-          border: '1px solid var(--pf-v5-global--BorderColor--100)',
-          borderRadius: 16,
-        }}
-        data-testid="nvidia-nim-model-serving-platform-card"
-      >
-        <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h2}>NVIDIA NIM model serving platform</Text>
-          </TextContent>
-        </CardTitle>
-        <CardBody>
-          Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
-          deploy your model within a NIM container. Please provide the API key to authenticate with
-          the NIM service.
-        </CardBody>
-        <CardFooter>
-          <Bullseye>
-            {numServingPlatformsAvailable > 1 ? (
-              <ModelServingPlatformSelectButton
-                namespace={currentProject.metadata.name}
-                servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
-                setError={setErrorSelectingPlatform}
-                variant="secondary"
-                data-testid="nim-serving-select-button"
-              />
-            ) : (
-              <ModelServingPlatformButtonAction
-                isProjectModelMesh={false}
-                emptyTemplates={emptyTemplates}
-                onClick={() => setOpen(true)}
-                variant="secondary"
-                testId="nim-serving-deploy-button"
-              />
-            )}
-          </Bullseye>
-        </CardFooter>
-      </Card>
-      {open && (
-        <DeployNIMServiceModal
-          projectContext={{
-            currentProject,
-            dataConnections,
-          }}
-          onClose={(submit) => {
-            onSubmit(submit);
-            setOpen(false);
-          }}
-        />
-      )}
-    </>
+    <Card
+      style={{
+        height: '100%',
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 16,
+      }}
+      data-testid="nvidia-nim-model-serving-platform-card"
+    >
+      <CardTitle>
+        <TextContent>
+          <Text component={TextVariants.h2}>NVIDIA NIM model serving platform</Text>
+        </TextContent>
+      </CardTitle>
+      <CardBody>
+        Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
+        deploy your model within a NIM container. Please provide the API key to authenticate with
+        the NIM service.
+      </CardBody>
+      <CardFooter>
+        <Bullseye>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="secondary"
+            data-testid="nim-serving-select-button"
+          />
+        </Bullseye>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
@@ -10,92 +10,47 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { ServingRuntimePlatform } from '~/types';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-  getTemplateEnabledForPlatform,
-} from '~/pages/modelServing/customServingRuntimes/utils';
-import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
-import ManageKServeModal from './kServeModal/ManageKServeModal';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 
-const EmptySingleModelServingCard: React.FC = () => {
-  const {
-    dataConnections: { data: dataConnections },
-  } = React.useContext(ProjectDetailsContext);
-  const [open, setOpen] = React.useState(false);
+type EmptySingleModelServingCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+};
 
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const onSubmit = (submit: boolean) => {
-    if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-    }
-  };
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-  const emptyTemplates = templatesEnabled.length === 0;
-
+const EmptySingleModelServingCard: React.FC<EmptySingleModelServingCardProps> = ({
+  setErrorSelectingPlatform,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
-    <>
-      <Card
-        style={{
-          height: '100%',
-          border: '1px solid var(--pf-v5-global--BorderColor--100)',
-          borderRadius: 16,
-        }}
-        data-testid="single-serving-platform-card"
-      >
-        <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h2}>Single-model serving platform</Text>
-          </TextContent>
-        </CardTitle>
-        <CardBody>
-          Each model is deployed on its own model server. Choose this option when you want to deploy
-          a large model such as a large language model (LLM).
-        </CardBody>
-        <CardFooter>
-          <Bullseye>
-            <ModelServingPlatformButtonAction
-              isProjectModelMesh={false}
-              emptyTemplates={emptyTemplates}
-              onClick={() => setOpen(true)}
-              variant="secondary"
-              testId="single-serving-deploy-button"
-            />
-          </Bullseye>
-        </CardFooter>
-      </Card>
-      {open ? (
-        <ManageKServeModal
-          projectContext={{
-            currentProject,
-            dataConnections,
-          }}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-          )}
-          onClose={(submit) => {
-            onSubmit(submit);
-            setOpen(false);
-          }}
-        />
-      ) : null}
-    </>
+    <Card
+      style={{
+        height: '100%',
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 16,
+      }}
+      data-testid="single-serving-platform-card"
+    >
+      <CardTitle>
+        <TextContent>
+          <Text component={TextVariants.h2}>Single-model serving platform</Text>
+        </TextContent>
+      </CardTitle>
+      <CardBody>
+        Each model is deployed on its own model server. Choose this option when you want to deploy a
+        large model such as a large language model (LLM).
+      </CardBody>
+      <CardFooter>
+        <Bullseye>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="secondary"
+            data-testid="single-serving-select-button" // TODO this changed from single-serving-deploy-button, inform QE and look for other cases
+          />
+        </Bullseye>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
@@ -86,7 +86,7 @@ const EmptySingleModelServingCard: React.FC<EmptySingleModelServingCardProps> = 
                 servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
                 setError={setErrorSelectingPlatform}
                 variant="secondary"
-                data-testid="single-serving-select-button" // TODO this changed from single-serving-deploy-button, inform QE and look for other cases
+                data-testid="single-serving-select-button"
               />
             ) : (
               <ModelServingPlatformButtonAction

--- a/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
@@ -17,9 +17,19 @@ import {
   getTemplateEnabledForPlatform,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
 import ManageKServeModal from './kServeModal/ManageKServeModal';
 
-const EmptySingleModelServingCard: React.FC = () => {
+type EmptySingleModelServingCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+  numServingPlatformsAvailable: number;
+};
+
+const EmptySingleModelServingCard: React.FC<EmptySingleModelServingCardProps> = ({
+  setErrorSelectingPlatform,
+  numServingPlatformsAvailable,
+}) => {
   const {
     dataConnections: { data: dataConnections },
   } = React.useContext(ProjectDetailsContext);
@@ -70,13 +80,23 @@ const EmptySingleModelServingCard: React.FC = () => {
         </CardBody>
         <CardFooter>
           <Bullseye>
-            <ModelServingPlatformButtonAction
-              isProjectModelMesh={false}
-              emptyTemplates={emptyTemplates}
-              onClick={() => setOpen(true)}
-              variant="secondary"
-              testId="single-serving-deploy-button"
-            />
+            {numServingPlatformsAvailable > 1 ? (
+              <ModelServingPlatformSelectButton
+                namespace={currentProject.metadata.name}
+                servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+                setError={setErrorSelectingPlatform}
+                variant="secondary"
+                data-testid="single-serving-select-button" // TODO this changed from single-serving-deploy-button, inform QE and look for other cases
+              />
+            ) : (
+              <ModelServingPlatformButtonAction
+                isProjectModelMesh={false}
+                emptyTemplates={emptyTemplates}
+                onClick={() => setOpen(true)}
+                variant="secondary"
+                testId="single-serving-deploy-button"
+              />
+            )}
           </Bullseye>
         </CardFooter>
       </Card>

--- a/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
@@ -10,47 +10,92 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ServingRuntimePlatform } from '~/types';
+import {
+  getSortedTemplates,
+  getTemplateEnabled,
+  getTemplateEnabledForPlatform,
+} from '~/pages/modelServing/customServingRuntimes/utils';
+import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
+import ManageKServeModal from './kServeModal/ManageKServeModal';
 
-type EmptySingleModelServingCardProps = {
-  setErrorSelectingPlatform: (e?: Error) => void;
-};
+const EmptySingleModelServingCard: React.FC = () => {
+  const {
+    dataConnections: { data: dataConnections },
+  } = React.useContext(ProjectDetailsContext);
+  const [open, setOpen] = React.useState(false);
 
-const EmptySingleModelServingCard: React.FC<EmptySingleModelServingCardProps> = ({
-  setErrorSelectingPlatform,
-}) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const {
+    servingRuntimes: { refresh: refreshServingRuntime },
+    servingRuntimeTemplates: [templates],
+    servingRuntimeTemplateOrder: { data: templateOrder },
+    servingRuntimeTemplateDisablement: { data: templateDisablement },
+    serverSecrets: { refresh: refreshTokens },
+    inferenceServices: { refresh: refreshInferenceServices },
+    currentProject,
+  } = React.useContext(ProjectDetailsContext);
+
+  const onSubmit = (submit: boolean) => {
+    if (submit) {
+      refreshServingRuntime();
+      refreshInferenceServices();
+      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
+    }
+  };
+
+  const templatesSorted = getSortedTemplates(templates, templateOrder);
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, templateDisablement),
+  );
+  const emptyTemplates = templatesEnabled.length === 0;
+
   return (
-    <Card
-      style={{
-        height: '100%',
-        border: '1px solid var(--pf-v5-global--BorderColor--100)',
-        borderRadius: 16,
-      }}
-      data-testid="single-serving-platform-card"
-    >
-      <CardTitle>
-        <TextContent>
-          <Text component={TextVariants.h2}>Single-model serving platform</Text>
-        </TextContent>
-      </CardTitle>
-      <CardBody>
-        Each model is deployed on its own model server. Choose this option when you want to deploy a
-        large model such as a large language model (LLM).
-      </CardBody>
-      <CardFooter>
-        <Bullseye>
-          <ModelServingPlatformSelectButton
-            namespace={currentProject.metadata.name}
-            servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
-            setError={setErrorSelectingPlatform}
-            variant="secondary"
-            data-testid="single-serving-select-button" // TODO this changed from single-serving-deploy-button, inform QE and look for other cases
-          />
-        </Bullseye>
-      </CardFooter>
-    </Card>
+    <>
+      <Card
+        style={{
+          height: '100%',
+          border: '1px solid var(--pf-v5-global--BorderColor--100)',
+          borderRadius: 16,
+        }}
+        data-testid="single-serving-platform-card"
+      >
+        <CardTitle>
+          <TextContent>
+            <Text component={TextVariants.h2}>Single-model serving platform</Text>
+          </TextContent>
+        </CardTitle>
+        <CardBody>
+          Each model is deployed on its own model server. Choose this option when you want to deploy
+          a large model such as a large language model (LLM).
+        </CardBody>
+        <CardFooter>
+          <Bullseye>
+            <ModelServingPlatformButtonAction
+              isProjectModelMesh={false}
+              emptyTemplates={emptyTemplates}
+              onClick={() => setOpen(true)}
+              variant="secondary"
+              testId="single-serving-deploy-button"
+            />
+          </Bullseye>
+        </CardFooter>
+      </Card>
+      {open ? (
+        <ManageKServeModal
+          projectContext={{
+            currentProject,
+            dataConnections,
+          }}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+          )}
+          onClose={(submit) => {
+            onSubmit(submit);
+            setOpen(false);
+          }}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/EmptySingleModelServingCard.tsx
@@ -10,112 +10,47 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { ServingRuntimePlatform } from '~/types';
-import {
-  getSortedTemplates,
-  getTemplateEnabled,
-  getTemplateEnabledForPlatform,
-} from '~/pages/modelServing/customServingRuntimes/utils';
-import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ManageKServeModal from './kServeModal/ManageKServeModal';
 
 type EmptySingleModelServingCardProps = {
   setErrorSelectingPlatform: (e?: Error) => void;
-  numServingPlatformsAvailable: number;
 };
 
 const EmptySingleModelServingCard: React.FC<EmptySingleModelServingCardProps> = ({
   setErrorSelectingPlatform,
-  numServingPlatformsAvailable,
 }) => {
-  const {
-    dataConnections: { data: dataConnections },
-  } = React.useContext(ProjectDetailsContext);
-  const [open, setOpen] = React.useState(false);
-
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const onSubmit = (submit: boolean) => {
-    if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500); // need a timeout to wait for tokens creation
-    }
-  };
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-  const emptyTemplates = templatesEnabled.length === 0;
-
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
-    <>
-      <Card
-        style={{
-          height: '100%',
-          border: '1px solid var(--pf-v5-global--BorderColor--100)',
-          borderRadius: 16,
-        }}
-        data-testid="single-serving-platform-card"
-      >
-        <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h2}>Single-model serving platform</Text>
-          </TextContent>
-        </CardTitle>
-        <CardBody>
-          Each model is deployed on its own model server. Choose this option when you want to deploy
-          a large model such as a large language model (LLM).
-        </CardBody>
-        <CardFooter>
-          <Bullseye>
-            {numServingPlatformsAvailable > 1 ? (
-              <ModelServingPlatformSelectButton
-                namespace={currentProject.metadata.name}
-                servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
-                setError={setErrorSelectingPlatform}
-                variant="secondary"
-                data-testid="single-serving-select-button"
-              />
-            ) : (
-              <ModelServingPlatformButtonAction
-                isProjectModelMesh={false}
-                emptyTemplates={emptyTemplates}
-                onClick={() => setOpen(true)}
-                variant="secondary"
-                testId="single-serving-deploy-button"
-              />
-            )}
-          </Bullseye>
-        </CardFooter>
-      </Card>
-      {open ? (
-        <ManageKServeModal
-          projectContext={{
-            currentProject,
-            dataConnections,
-          }}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-          )}
-          onClose={(submit) => {
-            onSubmit(submit);
-            setOpen(false);
-          }}
-        />
-      ) : null}
-    </>
+    <Card
+      style={{
+        height: '100%',
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 16,
+      }}
+      data-testid="single-serving-platform-card"
+    >
+      <CardTitle>
+        <TextContent>
+          <Text component={TextVariants.h2}>Single-model serving platform</Text>
+        </TextContent>
+      </CardTitle>
+      <CardBody>
+        Each model is deployed on its own model server. Choose this option when you want to deploy a
+        large model such as a large language model (LLM).
+      </CardBody>
+      <CardFooter>
+        <Bullseye>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="secondary"
+            data-testid="single-serving-select-button"
+          />
+        </Bullseye>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -11,14 +11,28 @@ type ProjectSelectorProps = {
   selectedProject: ProjectKind | null;
   setSelectedProject: (project: ProjectKind | null) => void;
   error?: Error;
+  modelRegistryName?: string;
+  registeredModelId?: string;
+  modelVersionId?: string;
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   selectedProject,
   setSelectedProject,
   error,
+  modelRegistryName,
+  registeredModelId,
+  modelVersionId,
 }) => {
   const { projects } = React.useContext(ProjectsContext);
+
+  const projectLinkUrlParams = new URLSearchParams();
+  projectLinkUrlParams.set('section', ProjectSectionID.MODEL_SERVER);
+  if (modelRegistryName && registeredModelId && modelVersionId) {
+    projectLinkUrlParams.set('modelRegistryName', modelRegistryName);
+    projectLinkUrlParams.set('registeredModelId', registeredModelId);
+    projectLinkUrlParams.set('modelVersionId', modelVersionId);
+  }
 
   return (
     <FormGroup label="Project" fieldId="deploy-model-project-selector" isRequired>
@@ -54,7 +68,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           <StackItem>
             <Alert isInline variant="danger" title={error.message}>
               <Link
-                to={`/projects/${selectedProject.metadata.name}?section=${ProjectSectionID.MODEL_SERVER}`}
+                to={`/projects/${selectedProject.metadata.name}?${projectLinkUrlParams.toString()}`}
               >
                 Go to <b>{getDisplayNameFromK8sResource(selectedProject)}</b> project page
               </Link>

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
@@ -3,13 +3,15 @@ import * as React from 'react';
 import { Button, Icon, Skeleton, Tooltip, Truncate } from '@patternfly/react-core';
 import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { KnownLabels, ServingRuntimeKind } from '~/k8sTypes';
+import SimpleMenuActions from '~/components/SimpleMenuActions';
 import EmptyTableCellForAlignment from '~/pages/projects/components/EmptyTableCellForAlignment';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { ServingRuntimeTableTabs } from '~/pages/modelServing/screens/types';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { getDisplayNameFromServingRuntimeTemplate } from '~/pages/modelServing/customServingRuntimes/utils';
+import { modelVersionUrl } from '~/pages/modelRegistry/screens/routeUtils';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 import {
@@ -36,6 +38,13 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
   allowDelete,
 }) => {
   const navigate = useNavigate();
+
+  const [queryParams] = useSearchParams();
+  const modelRegistryName = queryParams.get('modelRegistryName');
+  const registeredModelId = queryParams.get('registeredModelId');
+  const modelVersionId = queryParams.get('modelVersionId');
+  // deployingFromRegistry = User came from the Model Registry page because this project didn't have a serving platform selected
+  const deployingFromRegistry = !!(modelRegistryName && registeredModelId && modelVersionId);
 
   const {
     currentProject,
@@ -147,14 +156,37 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
           )}
         </Td>
         <Td style={{ textAlign: 'end' }}>
-          <Button
-            data-testid="deploy-model-button"
-            onClick={() => onDeployModel(obj)}
-            key={`action-${ProjectSectionID.CLUSTER_STORAGES}`}
-            variant="secondary"
-          >
-            Deploy model
-          </Button>
+          {deployingFromRegistry ? (
+            <SimpleMenuActions
+              key={`action-${ProjectSectionID.MODEL_SERVER}`}
+              testId="deploy-model-dropdown"
+              toggleProps={{ variant: 'secondary' }}
+              toggleLabel="Deploy model"
+              dropdownItems={[
+                {
+                  key: 'deploy',
+                  label: 'Deploy model',
+                  onClick: () => onDeployModel(obj),
+                },
+                {
+                  key: 'deployFromRegistry',
+                  label: 'Deploy model from model registry',
+                  onClick: () => {
+                    navigate(modelVersionUrl(modelVersionId, registeredModelId, modelRegistryName));
+                  },
+                },
+              ]}
+            />
+          ) : (
+            <Button
+              data-testid="deploy-model-button"
+              onClick={() => onDeployModel(obj)}
+              key={`action-${ProjectSectionID.MODEL_SERVER}`}
+              variant="secondary"
+            >
+              Deploy model
+            </Button>
+          )}
         </Td>
         <Td isActionCell>
           <ActionsColumn

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
   Alert,
-  AlertActionCloseButton,
   Flex,
   FlexItem,
   Gallery,
@@ -38,6 +37,9 @@ import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nim
 import DeployNIMServiceModal from '~/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal';
 import { useDashboardNamespace } from '~/redux/selectors';
 import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import ModelServingPlatformSelectErrorAlert from '~/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert';
 import ManageServingRuntimeModal from './ServingRuntimeModal/ManageServingRuntimeModal';
 import ModelMeshServingRuntimeTable from './ModelMeshSection/ServingRuntimeTable';
 import ModelServingPlatformButtonAction from './ModelServingPlatformButtonAction';
@@ -111,9 +113,19 @@ const ModelServingPlatform: React.FC = () => {
           imageAlt={modelMeshEnabled ? 'No model servers' : 'No deployed models'}
           title={modelMeshEnabled ? 'Start by adding a model server' : 'Start by deploying a model'}
           description={
-            modelMeshEnabled
-              ? 'Model servers are used to deploy models and to allow apps to send requests to your models. Configuring a model server includes specifying the number of replicas being deployed, the server size, the token authentication, the serving runtime, and how the project that the model server belongs to is accessed.\n'
-              : 'Each model is deployed on its own model server.'
+            <Stack hasGutter>
+              {errorSelectingPlatform && (
+                <ModelServingPlatformSelectErrorAlert
+                  error={errorSelectingPlatform}
+                  clearError={() => setErrorSelectingPlatform(undefined)}
+                />
+              )}
+              <StackItem>
+                {modelMeshEnabled
+                  ? 'Model servers are used to deploy models and to allow apps to send requests to your models. Configuring a model server includes specifying the number of replicas being deployed, the server size, the token authentication, the serving runtime, and how the project that the model server belongs to is accessed.\n'
+                  : 'Each model is deployed on its own model server.'}
+              </StackItem>
+            </Stack>
           }
           createButton={
             <ModelServingPlatformButtonAction
@@ -265,19 +277,10 @@ const ModelServingPlatform: React.FC = () => {
                     </Gallery>
                   </StackItem>
                   {errorSelectingPlatform && (
-                    <StackItem>
-                      <Alert
-                        variant="danger"
-                        isInline
-                        isPlain
-                        title={errorSelectingPlatform.message} // TODO follow up on this message
-                        actionClose={
-                          <AlertActionCloseButton
-                            onClose={() => setErrorSelectingPlatform(undefined)}
-                          />
-                        }
-                      />
-                    </StackItem>
+                    <ModelServingPlatformSelectErrorAlert
+                      error={errorSelectingPlatform}
+                      clearError={() => setErrorSelectingPlatform(undefined)}
+                    />
                   )}
                   <StackItem>
                     <Alert
@@ -297,11 +300,23 @@ const ModelServingPlatform: React.FC = () => {
         labels={
           currentProjectServingPlatform
             ? [
-                <Label key="serving-platform-label" data-testid="serving-platform-label">
-                  {isProjectModelMesh
-                    ? 'Multi-model serving enabled'
-                    : 'Single-model serving enabled'}
-                </Label>,
+                <Flex gap={{ default: 'gapSm' }} key="serving-platform-label">
+                  <Label data-testid="serving-platform-label">
+                    {isProjectModelMesh
+                      ? 'Multi-model serving enabled'
+                      : 'Single-model serving enabled'}
+                  </Label>
+                  {emptyModelServer && (
+                    <ModelServingPlatformSelectButton
+                      namespace={currentProject.metadata.name}
+                      servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
+                      setError={setErrorSelectingPlatform}
+                      variant="link"
+                      isInline
+                      data-testid="change-serving-platform-button"
+                    />
+                  )}
+                </Flex>,
               ]
             : undefined
         }

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
   Alert,
+  AlertActionCloseButton,
   Flex,
   FlexItem,
   Gallery,
@@ -46,6 +47,8 @@ const ModelServingPlatform: React.FC = () => {
   const [platformSelected, setPlatformSelected] = React.useState<
     ServingRuntimePlatform | undefined
   >(undefined);
+
+  const [errorSelectingPlatform, setErrorSelectingPlatform] = React.useState<Error>();
 
   const servingPlatformStatuses = useServingPlatformStatuses();
 
@@ -243,18 +246,39 @@ const ModelServingPlatform: React.FC = () => {
                   <StackItem>
                     <Gallery hasGutter>
                       <GalleryItem>
-                        <EmptySingleModelServingCard />
+                        <EmptySingleModelServingCard
+                          setErrorSelectingPlatform={setErrorSelectingPlatform}
+                        />
                       </GalleryItem>
                       <GalleryItem>
-                        <EmptyMultiModelServingCard />
+                        <EmptyMultiModelServingCard
+                          setErrorSelectingPlatform={setErrorSelectingPlatform}
+                        />
                       </GalleryItem>
                       {isNIMAvailable && (
                         <GalleryItem>
-                          <EmptyNIMModelServingCard />
+                          <EmptyNIMModelServingCard
+                            setErrorSelectingPlatform={setErrorSelectingPlatform}
+                          />
                         </GalleryItem>
                       )}
                     </Gallery>
                   </StackItem>
+                  {errorSelectingPlatform && (
+                    <StackItem>
+                      <Alert
+                        variant="danger"
+                        isInline
+                        isPlain
+                        title={errorSelectingPlatform.message} // TODO follow up on this message
+                        actionClose={
+                          <AlertActionCloseButton
+                            onClose={() => setErrorSelectingPlatform(undefined)}
+                          />
+                        }
+                      />
+                    </StackItem>
+                  )}
                   <StackItem>
                     <Alert
                       variant="info"

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -213,7 +213,6 @@ const ModelServingPlatform: React.FC = () => {
     );
   };
 
-  // TODO Do we need a "Deploy model from model registry" link in the table view here?
   return (
     <>
       <DetailsSection

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -288,20 +288,17 @@ const ModelServingPlatform: React.FC = () => {
                       <GalleryItem>
                         <EmptySingleModelServingCard
                           setErrorSelectingPlatform={setErrorSelectingPlatform}
-                          numServingPlatformsAvailable={numServingPlatformsAvailable}
                         />
                       </GalleryItem>
                       <GalleryItem>
                         <EmptyMultiModelServingCard
                           setErrorSelectingPlatform={setErrorSelectingPlatform}
-                          numServingPlatformsAvailable={numServingPlatformsAvailable}
                         />
                       </GalleryItem>
                       {isNIMAvailable && (
                         <GalleryItem>
                           <EmptyNIMModelServingCard
                             setErrorSelectingPlatform={setErrorSelectingPlatform}
-                            numServingPlatformsAvailable={numServingPlatformsAvailable}
                           />
                         </GalleryItem>
                       )}

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -336,7 +336,7 @@ const ModelServingPlatform: React.FC = () => {
                       ? 'Multi-model serving enabled'
                       : 'Single-model serving enabled'}
                   </Label>
-                  {emptyModelServer && (
+                  {emptyModelServer && numServingPlatformsAvailable > 1 && (
                     <ModelServingPlatformSelectButton
                       namespace={currentProject.metadata.name}
                       servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -161,6 +161,7 @@ const ModelServingPlatform: React.FC = () => {
                   onClick={() =>
                     navigate(modelVersionUrl(modelVersionId, registeredModelId, modelRegistryName))
                   }
+                  data-testid="deploy-from-registry"
                 >
                   Deploy model from model registry
                 </Button>

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -38,8 +38,6 @@ import EmptyModelServingPlatform from '~/pages/modelServing/screens/projects/Emp
 import EmptyNIMModelServingCard from '~/pages/modelServing/screens/projects/EmptyNIMModelServingCard';
 import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nimUtils';
 import DeployNIMServiceModal from '~/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal';
-import { useDashboardNamespace } from '~/redux/selectors';
-import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import ModelServingPlatformSelectErrorAlert from '~/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert';
@@ -65,12 +63,12 @@ const ModelServingPlatform: React.FC = () => {
   const deployingFromRegistry = !!(modelRegistryName && registeredModelId && modelVersionId);
 
   const servingPlatformStatuses = useServingPlatformStatuses();
-
-  const { dashboardNamespace } = useDashboardNamespace();
-  const isNIMAvailable = useIsNIMAvailable(dashboardNamespace);
-
-  const kServeEnabled = servingPlatformStatuses.kServe.enabled;
-  const modelMeshEnabled = servingPlatformStatuses.modelMesh.enabled;
+  const {
+    kServe: { enabled: kServeEnabled },
+    modelMesh: { enabled: modelMeshEnabled },
+    nim: { available: isNIMAvailable },
+    numServingPlatformsAvailable,
+  } = servingPlatformStatuses;
 
   const {
     servingRuntimes: {
@@ -289,17 +287,20 @@ const ModelServingPlatform: React.FC = () => {
                       <GalleryItem>
                         <EmptySingleModelServingCard
                           setErrorSelectingPlatform={setErrorSelectingPlatform}
+                          numServingPlatformsAvailable={numServingPlatformsAvailable}
                         />
                       </GalleryItem>
                       <GalleryItem>
                         <EmptyMultiModelServingCard
                           setErrorSelectingPlatform={setErrorSelectingPlatform}
+                          numServingPlatformsAvailable={numServingPlatformsAvailable}
                         />
                       </GalleryItem>
                       {isNIMAvailable && (
                         <GalleryItem>
                           <EmptyNIMModelServingCard
                             setErrorSelectingPlatform={setErrorSelectingPlatform}
+                            numServingPlatformsAvailable={numServingPlatformsAvailable}
                           />
                         </GalleryItem>
                       )}

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelectButton.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatformSelectButton.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { Button, ButtonProps } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import { addSupportServingPlatformProject } from '~/api';
+
+type ModelServingPlatformSelectButtonProps = ButtonProps & {
+  namespace: string;
+  servingPlatform:
+    | NamespaceApplicationCase.MODEL_MESH_PROMOTION
+    | NamespaceApplicationCase.KSERVE_PROMOTION
+    | NamespaceApplicationCase.KSERVE_NIM_PROMOTION
+    | NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM;
+  setError: (e?: Error) => void;
+};
+
+const buttonLabels = {
+  [NamespaceApplicationCase.MODEL_MESH_PROMOTION]: 'Select multi-model',
+  [NamespaceApplicationCase.KSERVE_PROMOTION]: 'Select single-model',
+  [NamespaceApplicationCase.KSERVE_NIM_PROMOTION]: 'Select NVIDIA NIM',
+  [NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM]: 'Change',
+};
+
+const ModelServingPlatformSelectButton: React.FC<ModelServingPlatformSelectButtonProps> = ({
+  namespace,
+  servingPlatform,
+  setError,
+  ...buttonProps
+}) => {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const isResetAction = servingPlatform === NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM;
+
+  return (
+    <Button
+      {...buttonProps}
+      aria-label={isResetAction ? 'Change model serving platform' : undefined}
+      icon={isResetAction ? <PencilAltIcon /> : undefined}
+      isLoading={isLoading}
+      isDisabled={isLoading}
+      onClick={async () => {
+        try {
+          setError(undefined);
+          setIsLoading(true);
+          await addSupportServingPlatformProject(namespace, servingPlatform);
+        } catch (e) {
+          if (e instanceof Error) {
+            setError(e);
+          }
+        } finally {
+          setIsLoading(false);
+        }
+      }}
+    >
+      {buttonLabels[servingPlatform]}
+    </Button>
+  );
+};
+
+export default ModelServingPlatformSelectButton;

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -66,6 +66,7 @@ const getMockServingPlatformStatuses = ({
   kServeInstalled = true,
   modelMeshEnabled = true,
   modelMeshInstalled = true,
+  nimAvailable = true,
 }): ServingPlatformStatuses => ({
   kServe: {
     enabled: kServeEnabled,
@@ -75,6 +76,11 @@ const getMockServingPlatformStatuses = ({
     enabled: modelMeshEnabled,
     installed: modelMeshInstalled,
   },
+  nim: {
+    available: nimAvailable,
+  },
+  numServingPlatformsAvailable: [kServeEnabled, modelMeshEnabled, nimAvailable].filter(Boolean)
+    .length,
 });
 
 describe('getProjectModelServingPlatform', () => {

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -117,6 +117,10 @@ export type ServingPlatformStatuses = {
     enabled: boolean;
     installed: boolean;
   };
+  nim: {
+    available: boolean;
+  };
+  numServingPlatformsAvailable: number;
 };
 
 export type LabeledDataConnection = {

--- a/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
+++ b/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
@@ -12,7 +12,7 @@ const useServingPlatformStatuses = (): ServingPlatformStatuses => {
   const modelMeshEnabled = modelMeshStatus.status;
   const kServeInstalled = !!kServeStatus.requiredComponents?.[StackComponent.K_SERVE];
   const modelMeshInstalled = !!modelMeshStatus.requiredComponents?.[StackComponent.MODEL_MESH];
-  const isNIMAvailable = useIsNIMAvailable(dashboardNamespace); // TODO lift this to context?
+  const isNIMAvailable = useIsNIMAvailable(dashboardNamespace);
 
   return {
     kServe: {

--- a/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
+++ b/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
@@ -1,13 +1,18 @@
 import { StackComponent, SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
+import { useDashboardNamespace } from '~/redux/selectors';
+import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 
 const useServingPlatformStatuses = (): ServingPlatformStatuses => {
+  const { dashboardNamespace } = useDashboardNamespace();
+
   const kServeStatus = useIsAreaAvailable(SupportedArea.K_SERVE);
   const modelMeshStatus = useIsAreaAvailable(SupportedArea.MODEL_MESH);
   const kServeEnabled = kServeStatus.status;
   const modelMeshEnabled = modelMeshStatus.status;
   const kServeInstalled = !!kServeStatus.requiredComponents?.[StackComponent.K_SERVE];
   const modelMeshInstalled = !!modelMeshStatus.requiredComponents?.[StackComponent.MODEL_MESH];
+  const isNIMAvailable = useIsNIMAvailable(dashboardNamespace); // TODO lift this to context?
 
   return {
     kServe: {
@@ -18,6 +23,11 @@ const useServingPlatformStatuses = (): ServingPlatformStatuses => {
       enabled: modelMeshEnabled,
       installed: modelMeshInstalled,
     },
+    nim: {
+      available: isNIMAvailable,
+    },
+    numServingPlatformsAvailable: [kServeEnabled, modelMeshEnabled, isNIMAvailable].filter(Boolean)
+      .length,
   };
 };
 

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { CardFooter } from '@patternfly/react-core';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Button, CardFooter, Flex } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import ModelServingPlatformButtonAction from '~/pages/modelServing/screens/projects/ModelServingPlatformButtonAction';
 import { ServingRuntimePlatform } from '~/types';
@@ -13,6 +14,7 @@ import { getProjectModelServingPlatform } from '~/pages/modelServing/screens/pro
 import ManageServingRuntimeModal from '~/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal';
 import ManageKServeModal from '~/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
 import DeployNIMServiceModal from '~/pages/modelServing/screens/projects/NIMServiceModal/DeployNIMServiceModal';
+import { modelVersionUrl } from '~/pages/modelRegistry/screens/routeUtils';
 
 type AddModelFooterProps = {
   selectedPlatform?: ServingRuntimePlatform;
@@ -20,6 +22,8 @@ type AddModelFooterProps = {
 };
 
 const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM }) => {
+  const navigate = useNavigate();
+
   const [modalShown, setModalShown] = React.useState<boolean>(false);
 
   const servingPlatformStatuses = useServingPlatformStatuses();
@@ -59,17 +63,37 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
     }
   };
 
+  const [queryParams] = useSearchParams();
+  const modelRegistryName = queryParams.get('modelRegistryName');
+  const registeredModelId = queryParams.get('registeredModelId');
+  const modelVersionId = queryParams.get('modelVersionId');
+  // deployingFromRegistry = User came from the Model Registry page because this project didn't have a serving platform selected
+  const deployingFromRegistry = modelRegistryName && registeredModelId && modelVersionId;
+
   return (
     <CardFooter>
-      <ModelServingPlatformButtonAction
-        isProjectModelMesh={isProjectModelMesh}
-        emptyTemplates={emptyTemplates}
-        onClick={() => setModalShown(true)}
-        variant="link"
-        isInline
-        testId="model-serving-platform-button"
-      />
-      {/* TODO this may be where we put a button to return to model registry? */}
+      <Flex gap={{ default: 'gapMd' }}>
+        <ModelServingPlatformButtonAction
+          isProjectModelMesh={isProjectModelMesh}
+          emptyTemplates={emptyTemplates}
+          onClick={() => setModalShown(true)}
+          variant="link"
+          isInline
+          testId="model-serving-platform-button"
+        />
+        {deployingFromRegistry &&
+          !isProjectModelMesh && ( // For modelmesh we don't want to offer this until there is a model server
+            <Button
+              variant="link"
+              isInline
+              onClick={() =>
+                navigate(modelVersionUrl(modelVersionId, registeredModelId, modelRegistryName))
+              }
+            >
+              Deploy model from model registry
+            </Button>
+          )}
+      </Flex>
       {modalShown && isProjectModelMesh && !isNIM ? (
         <ManageServingRuntimeModal
           currentProject={currentProject}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
@@ -69,6 +69,7 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
         isInline
         testId="model-serving-platform-button"
       />
+      {/* TODO this may be where we put a button to return to model registry? */}
       {modalShown && isProjectModelMesh && !isNIM ? (
         <ManageServingRuntimeModal
           currentProject={currentProject}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
@@ -86,9 +86,9 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
             <Button
               variant="link"
               isInline
-              onClick={() =>
-                navigate(modelVersionUrl(modelVersionId, registeredModelId, modelRegistryName))
-              }
+              onClick={() => {
+                navigate(modelVersionUrl(modelVersionId, registeredModelId, modelRegistryName));
+              }}
             >
               Deploy model from model registry
             </Button>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/AddModelFooter.tsx
@@ -89,6 +89,7 @@ const AddModelFooter: React.FC<AddModelFooterProps> = ({ selectedPlatform, isNIM
               onClick={() => {
                 navigate(modelVersionUrl(modelVersionId, registeredModelId, modelRegistryName));
               }}
+              data-testid="deploy-from-registry"
             >
               Deploy model from model registry
             </Button>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Alert, Gallery, Stack, Text, TextContent } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertActionCloseButton,
+  Gallery,
+  Stack,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
 import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 import { useDashboardNamespace } from '~/redux/selectors';
@@ -9,6 +16,8 @@ import SelectMultiModelCard from './SelectMultiModelCard';
 
 const PlatformSelectSection: React.FC = () => {
   const { dashboardNamespace } = useDashboardNamespace();
+  const [errorSelectingPlatform, setErrorSelectingPlatform] = React.useState<Error>();
+
   const isNIMAvailable = useIsNIMAvailable(dashboardNamespace);
 
   const galleryWidths = isNIMAvailable
@@ -34,10 +43,22 @@ const PlatformSelectSection: React.FC = () => {
           </Text>
         </TextContent>
         <Gallery hasGutter {...galleryWidths}>
-          <SelectSingleModelCard />
-          <SelectMultiModelCard />
-          {isNIMAvailable && <SelectNIMCard />}
+          <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          {isNIMAvailable && (
+            <SelectNIMCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          )}
         </Gallery>
+        {errorSelectingPlatform && (
+          <Alert
+            isInline
+            variant="danger"
+            title={errorSelectingPlatform.message} // TODO follow up on this message
+            actionClose={
+              <AlertActionCloseButton onClose={() => setErrorSelectingPlatform(undefined)} />
+            }
+          />
+        )}
         <Alert
           isInline
           variant="info"

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -1,14 +1,8 @@
 import * as React from 'react';
-import {
-  Alert,
-  AlertActionCloseButton,
-  Gallery,
-  Stack,
-  Text,
-  TextContent,
-} from '@patternfly/react-core';
+import { Alert, Gallery, Stack, Text, TextContent } from '@patternfly/react-core';
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
 import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
+import ModelServingPlatformSelectErrorAlert from '~/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert';
 import { useDashboardNamespace } from '~/redux/selectors';
 import SelectNIMCard from './SelectNIMCard';
 import SelectSingleModelCard from './SelectSingleModelCard';
@@ -50,13 +44,9 @@ const PlatformSelectSection: React.FC = () => {
           )}
         </Gallery>
         {errorSelectingPlatform && (
-          <Alert
-            isInline
-            variant="danger"
-            title={errorSelectingPlatform.message} // TODO follow up on this message
-            actionClose={
-              <AlertActionCloseButton onClose={() => setErrorSelectingPlatform(undefined)} />
-            }
+          <ModelServingPlatformSelectErrorAlert
+            error={errorSelectingPlatform}
+            clearError={() => setErrorSelectingPlatform(undefined)}
           />
         )}
         <Alert

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -13,7 +13,6 @@ const PlatformSelectSection: React.FC = () => {
   const servingPlatformStatuses = useServingPlatformStatuses();
   const {
     nim: { available: isNIMAvailable },
-    numServingPlatformsAvailable,
   } = servingPlatformStatuses;
 
   const galleryWidths = isNIMAvailable
@@ -39,19 +38,10 @@ const PlatformSelectSection: React.FC = () => {
           </Text>
         </TextContent>
         <Gallery hasGutter {...galleryWidths}>
-          <SelectSingleModelCard
-            setErrorSelectingPlatform={setErrorSelectingPlatform}
-            numServingPlatformsAvailable={numServingPlatformsAvailable}
-          />
-          <SelectMultiModelCard
-            setErrorSelectingPlatform={setErrorSelectingPlatform}
-            numServingPlatformsAvailable={numServingPlatformsAvailable}
-          />
+          <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
           {isNIMAvailable && (
-            <SelectNIMCard
-              setErrorSelectingPlatform={setErrorSelectingPlatform}
-              numServingPlatformsAvailable={numServingPlatformsAvailable}
-            />
+            <SelectNIMCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
           )}
         </Gallery>
         {errorSelectingPlatform && (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 import { Alert, Gallery, Stack, Text, TextContent } from '@patternfly/react-core';
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
-import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 import ModelServingPlatformSelectErrorAlert from '~/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert';
-import { useDashboardNamespace } from '~/redux/selectors';
+import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
 import SelectNIMCard from './SelectNIMCard';
 import SelectSingleModelCard from './SelectSingleModelCard';
 import SelectMultiModelCard from './SelectMultiModelCard';
 
 const PlatformSelectSection: React.FC = () => {
-  const { dashboardNamespace } = useDashboardNamespace();
   const [errorSelectingPlatform, setErrorSelectingPlatform] = React.useState<Error>();
 
-  const isNIMAvailable = useIsNIMAvailable(dashboardNamespace);
+  const servingPlatformStatuses = useServingPlatformStatuses();
+  const {
+    nim: { available: isNIMAvailable },
+    numServingPlatformsAvailable,
+  } = servingPlatformStatuses;
 
   const galleryWidths = isNIMAvailable
     ? {
@@ -37,10 +39,19 @@ const PlatformSelectSection: React.FC = () => {
           </Text>
         </TextContent>
         <Gallery hasGutter {...galleryWidths}>
-          <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
-          <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          <SelectSingleModelCard
+            setErrorSelectingPlatform={setErrorSelectingPlatform}
+            numServingPlatformsAvailable={numServingPlatformsAvailable}
+          />
+          <SelectMultiModelCard
+            setErrorSelectingPlatform={setErrorSelectingPlatform}
+            numServingPlatformsAvailable={numServingPlatformsAvailable}
+          />
           {isNIMAvailable && (
-            <SelectNIMCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+            <SelectNIMCard
+              setErrorSelectingPlatform={setErrorSelectingPlatform}
+              numServingPlatformsAvailable={numServingPlatformsAvailable}
+            />
           )}
         </Gallery>
         {errorSelectingPlatform && (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
@@ -36,6 +36,7 @@ const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
           servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
           setError={setErrorSelectingPlatform}
           variant="link"
+          isInline
           data-testid="multi-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
         />
       </CardFooter>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
@@ -1,28 +1,46 @@
 import * as React from 'react';
-import { CardBody, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ServingRuntimePlatform } from '~/types';
-import AddModelFooter from './AddModelFooter';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 
-const SelectMultiModelCard: React.FC = () => (
-  <OverviewCard
-    objectType={ProjectObjectType.modelServer}
-    sectionType={SectionType.serving}
-    title="Multi-model serving platform"
-    data-testid="multi-serving-platform-card"
-  >
-    <CardBody>
-      <TextContent>
-        <Text component="small">
-          Multiple models can be deployed on one shared model server. Choose this option when you
-          want to deploy a number of small or medium-sized models that can share the server
-          resources.
-        </Text>
-      </TextContent>
-    </CardBody>
-    <AddModelFooter selectedPlatform={ServingRuntimePlatform.MULTI} />
-  </OverviewCard>
-);
+type SelectMultiModelCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+};
+
+const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
+  setErrorSelectingPlatform,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  return (
+    <OverviewCard
+      objectType={ProjectObjectType.modelServer}
+      sectionType={SectionType.serving}
+      title="Multi-model serving platform"
+      data-testid="multi-serving-platform-card"
+    >
+      <CardBody>
+        <TextContent>
+          <Text component="small">
+            Multiple models can be deployed on one shared model server. Choose this option when you
+            want to deploy a number of small or medium-sized models that can share the server
+            resources.
+          </Text>
+        </TextContent>
+      </CardBody>
+      <CardFooter>
+        <ModelServingPlatformSelectButton
+          namespace={currentProject.metadata.name}
+          servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
+          setError={setErrorSelectingPlatform}
+          variant="link"
+          data-testid="multi-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+        />
+      </CardFooter>
+    </OverviewCard>
+  );
+};
 
 export default SelectMultiModelCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
@@ -2,20 +2,16 @@ import * as React from 'react';
 import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ServingRuntimePlatform } from '~/types';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
-import AddModelFooter from './AddModelFooter';
 
 type SelectMultiModelCardProps = {
   setErrorSelectingPlatform: (e?: Error) => void;
-  numServingPlatformsAvailable: number;
 };
 
 const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
   setErrorSelectingPlatform,
-  numServingPlatformsAvailable,
 }) => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
@@ -34,20 +30,16 @@ const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
           </Text>
         </TextContent>
       </CardBody>
-      {numServingPlatformsAvailable > 1 ? (
-        <CardFooter>
-          <ModelServingPlatformSelectButton
-            namespace={currentProject.metadata.name}
-            servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
-            setError={setErrorSelectingPlatform}
-            variant="link"
-            isInline
-            data-testid="multi-serving-select-button"
-          />
-        </CardFooter>
-      ) : (
-        <AddModelFooter selectedPlatform={ServingRuntimePlatform.MULTI} />
-      )}
+      <CardFooter>
+        <ModelServingPlatformSelectButton
+          namespace={currentProject.metadata.name}
+          servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
+          setError={setErrorSelectingPlatform}
+          variant="link"
+          isInline
+          data-testid="multi-serving-select-button"
+        />
+      </CardFooter>
     </OverviewCard>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
@@ -1,47 +1,28 @@
 import * as React from 'react';
-import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ServingRuntimePlatform } from '~/types';
+import AddModelFooter from './AddModelFooter';
 
-type SelectMultiModelCardProps = {
-  setErrorSelectingPlatform: (e?: Error) => void;
-};
-
-const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
-  setErrorSelectingPlatform,
-}) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
-  return (
-    <OverviewCard
-      objectType={ProjectObjectType.modelServer}
-      sectionType={SectionType.serving}
-      title="Multi-model serving platform"
-      data-testid="multi-serving-platform-card"
-    >
-      <CardBody>
-        <TextContent>
-          <Text component="small">
-            Multiple models can be deployed on one shared model server. Choose this option when you
-            want to deploy a number of small or medium-sized models that can share the server
-            resources.
-          </Text>
-        </TextContent>
-      </CardBody>
-      <CardFooter>
-        <ModelServingPlatformSelectButton
-          namespace={currentProject.metadata.name}
-          servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
-          setError={setErrorSelectingPlatform}
-          variant="link"
-          isInline
-          data-testid="multi-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
-        />
-      </CardFooter>
-    </OverviewCard>
-  );
-};
+const SelectMultiModelCard: React.FC = () => (
+  <OverviewCard
+    objectType={ProjectObjectType.modelServer}
+    sectionType={SectionType.serving}
+    title="Multi-model serving platform"
+    data-testid="multi-serving-platform-card"
+  >
+    <CardBody>
+      <TextContent>
+        <Text component="small">
+          Multiple models can be deployed on one shared model server. Choose this option when you
+          want to deploy a number of small or medium-sized models that can share the server
+          resources.
+        </Text>
+      </TextContent>
+    </CardBody>
+    <AddModelFooter selectedPlatform={ServingRuntimePlatform.MULTI} />
+  </OverviewCard>
+);
 
 export default SelectMultiModelCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
@@ -42,7 +42,7 @@ const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
             setError={setErrorSelectingPlatform}
             variant="link"
             isInline
-            data-testid="multi-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+            data-testid="multi-serving-select-button"
           />
         </CardFooter>
       ) : (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectMultiModelCard.tsx
@@ -1,28 +1,55 @@
 import * as React from 'react';
-import { CardBody, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
 import { ServingRuntimePlatform } from '~/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
 import AddModelFooter from './AddModelFooter';
 
-const SelectMultiModelCard: React.FC = () => (
-  <OverviewCard
-    objectType={ProjectObjectType.modelServer}
-    sectionType={SectionType.serving}
-    title="Multi-model serving platform"
-    data-testid="multi-serving-platform-card"
-  >
-    <CardBody>
-      <TextContent>
-        <Text component="small">
-          Multiple models can be deployed on one shared model server. Choose this option when you
-          want to deploy a number of small or medium-sized models that can share the server
-          resources.
-        </Text>
-      </TextContent>
-    </CardBody>
-    <AddModelFooter selectedPlatform={ServingRuntimePlatform.MULTI} />
-  </OverviewCard>
-);
+type SelectMultiModelCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+  numServingPlatformsAvailable: number;
+};
+
+const SelectMultiModelCard: React.FC<SelectMultiModelCardProps> = ({
+  setErrorSelectingPlatform,
+  numServingPlatformsAvailable,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  return (
+    <OverviewCard
+      objectType={ProjectObjectType.modelServer}
+      sectionType={SectionType.serving}
+      title="Multi-model serving platform"
+      data-testid="multi-serving-platform-card"
+    >
+      <CardBody>
+        <TextContent>
+          <Text component="small">
+            Multiple models can be deployed on one shared model server. Choose this option when you
+            want to deploy a number of small or medium-sized models that can share the server
+            resources.
+          </Text>
+        </TextContent>
+      </CardBody>
+      {numServingPlatformsAvailable > 1 ? (
+        <CardFooter>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.MODEL_MESH_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="link"
+            isInline
+            data-testid="multi-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+          />
+        </CardFooter>
+      ) : (
+        <AddModelFooter selectedPlatform={ServingRuntimePlatform.MULTI} />
+      )}
+    </OverviewCard>
+  );
+};
 
 export default SelectMultiModelCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
@@ -34,6 +34,7 @@ const SelectNIMCard: React.FC<SelectNIMCardProps> = ({ setErrorSelectingPlatform
           servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
           setError={setErrorSelectingPlatform}
           variant="link"
+          isInline
           data-testid="nim-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
         />
       </CardFooter>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
@@ -1,28 +1,44 @@
 import * as React from 'react';
-import { CardBody, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ServingRuntimePlatform } from '~/types';
-import AddModelFooter from './AddModelFooter';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 
-const SelectNIMCard: React.FC = () => (
-  <OverviewCard
-    objectType={ProjectObjectType.modelServer}
-    sectionType={SectionType.serving}
-    title="NVIDIA NIM model serving platform"
-    data-testid="nvidia-nim-platform-card"
-  >
-    <CardBody>
-      <TextContent>
-        <Text component="small">
-          Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
-          deploy your model within a NIM container. Please provide the API key to authenticate with
-          the NIM service.
-        </Text>
-      </TextContent>
-    </CardBody>
-    <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} isNIM />
-  </OverviewCard>
-);
+type SelectNIMCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+};
+
+const SelectNIMCard: React.FC<SelectNIMCardProps> = ({ setErrorSelectingPlatform }) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  return (
+    <OverviewCard
+      objectType={ProjectObjectType.modelServer}
+      sectionType={SectionType.serving}
+      title="NVIDIA NIM model serving platform"
+      data-testid="nvidia-nim-platform-card"
+    >
+      <CardBody>
+        <TextContent>
+          <Text component="small">
+            Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
+            deploy your model within a NIM container. Please provide the API key to authenticate
+            with the NIM service.
+          </Text>
+        </TextContent>
+      </CardBody>
+      <CardFooter>
+        <ModelServingPlatformSelectButton
+          namespace={currentProject.metadata.name}
+          servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+          setError={setErrorSelectingPlatform}
+          variant="link"
+          data-testid="nim-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+        />
+      </CardFooter>
+    </OverviewCard>
+  );
+};
 
 export default SelectNIMCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
@@ -2,21 +2,15 @@ import * as React from 'react';
 import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ServingRuntimePlatform } from '~/types';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
-import AddModelFooter from './AddModelFooter';
 
 type SelectNIMCardProps = {
   setErrorSelectingPlatform: (e?: Error) => void;
-  numServingPlatformsAvailable: number;
 };
 
-const SelectNIMCard: React.FC<SelectNIMCardProps> = ({
-  setErrorSelectingPlatform,
-  numServingPlatformsAvailable,
-}) => {
+const SelectNIMCard: React.FC<SelectNIMCardProps> = ({ setErrorSelectingPlatform }) => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
     <OverviewCard
@@ -34,20 +28,16 @@ const SelectNIMCard: React.FC<SelectNIMCardProps> = ({
           </Text>
         </TextContent>
       </CardBody>
-      {numServingPlatformsAvailable > 1 ? (
-        <CardFooter>
-          <ModelServingPlatformSelectButton
-            namespace={currentProject.metadata.name}
-            servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
-            setError={setErrorSelectingPlatform}
-            variant="link"
-            isInline
-            data-testid="nim-serving-select-button"
-          />
-        </CardFooter>
-      ) : (
-        <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} isNIM />
-      )}
+      <CardFooter>
+        <ModelServingPlatformSelectButton
+          namespace={currentProject.metadata.name}
+          servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
+          setError={setErrorSelectingPlatform}
+          variant="link"
+          isInline
+          data-testid="nim-serving-select-button"
+        />
+      </CardFooter>
     </OverviewCard>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
@@ -1,28 +1,55 @@
 import * as React from 'react';
-import { CardBody, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
 import { ServingRuntimePlatform } from '~/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
 import AddModelFooter from './AddModelFooter';
 
-const SelectNIMCard: React.FC = () => (
-  <OverviewCard
-    objectType={ProjectObjectType.modelServer}
-    sectionType={SectionType.serving}
-    title="NVIDIA NIM model serving platform"
-    data-testid="nvidia-nim-platform-card"
-  >
-    <CardBody>
-      <TextContent>
-        <Text component="small">
-          Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
-          deploy your model within a NIM container. Please provide the API key to authenticate with
-          the NIM service.
-        </Text>
-      </TextContent>
-    </CardBody>
-    <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} isNIM />
-  </OverviewCard>
-);
+type SelectNIMCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+  numServingPlatformsAvailable: number;
+};
+
+const SelectNIMCard: React.FC<SelectNIMCardProps> = ({
+  setErrorSelectingPlatform,
+  numServingPlatformsAvailable,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  return (
+    <OverviewCard
+      objectType={ProjectObjectType.modelServer}
+      sectionType={SectionType.serving}
+      title="NVIDIA NIM model serving platform"
+      data-testid="nvidia-nim-platform-card"
+    >
+      <CardBody>
+        <TextContent>
+          <Text component="small">
+            Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
+            deploy your model within a NIM container. Please provide the API key to authenticate
+            with the NIM service.
+          </Text>
+        </TextContent>
+      </CardBody>
+      {numServingPlatformsAvailable > 1 ? (
+        <CardFooter>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.KSERVE_NIM_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="link"
+            isInline
+            data-testid="nim-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+          />
+        </CardFooter>
+      ) : (
+        <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} isNIM />
+      )}
+    </OverviewCard>
+  );
+};
 
 export default SelectNIMCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
@@ -1,45 +1,28 @@
 import * as React from 'react';
-import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ServingRuntimePlatform } from '~/types';
+import AddModelFooter from './AddModelFooter';
 
-type SelectNIMCardProps = {
-  setErrorSelectingPlatform: (e?: Error) => void;
-};
-
-const SelectNIMCard: React.FC<SelectNIMCardProps> = ({ setErrorSelectingPlatform }) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
-  return (
-    <OverviewCard
-      objectType={ProjectObjectType.modelServer}
-      sectionType={SectionType.serving}
-      title="NVIDIA NIM model serving platform"
-      data-testid="nvidia-nim-platform-card"
-    >
-      <CardBody>
-        <TextContent>
-          <Text component="small">
-            Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
-            deploy your model within a NIM container. Please provide the API key to authenticate
-            with the NIM service.
-          </Text>
-        </TextContent>
-      </CardBody>
-      <CardFooter>
-        <ModelServingPlatformSelectButton
-          namespace={currentProject.metadata.name}
-          servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
-          setError={setErrorSelectingPlatform}
-          variant="link"
-          isInline
-          data-testid="nim-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
-        />
-      </CardFooter>
-    </OverviewCard>
-  );
-};
+const SelectNIMCard: React.FC = () => (
+  <OverviewCard
+    objectType={ProjectObjectType.modelServer}
+    sectionType={SectionType.serving}
+    title="NVIDIA NIM model serving platform"
+    data-testid="nvidia-nim-platform-card"
+  >
+    <CardBody>
+      <TextContent>
+        <Text component="small">
+          Models are deployed using NVIDIA NIM microservices. Choose this option when you want to
+          deploy your model within a NIM container. Please provide the API key to authenticate with
+          the NIM service.
+        </Text>
+      </TextContent>
+    </CardBody>
+    <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} isNIM />
+  </OverviewCard>
+);
 
 export default SelectNIMCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectNIMCard.tsx
@@ -42,7 +42,7 @@ const SelectNIMCard: React.FC<SelectNIMCardProps> = ({
             setError={setErrorSelectingPlatform}
             variant="link"
             isInline
-            data-testid="nim-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+            data-testid="nim-serving-select-button"
           />
         </CardFooter>
       ) : (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
@@ -35,6 +35,7 @@ const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
           servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
           setError={setErrorSelectingPlatform}
           variant="link"
+          isInline
           data-testid="single-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
         />
       </CardFooter>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
@@ -1,27 +1,45 @@
 import * as React from 'react';
-import { CardBody, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ServingRuntimePlatform } from '~/types';
-import AddModelFooter from './AddModelFooter';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 
-const SelectSingleModelCard: React.FC = () => (
-  <OverviewCard
-    objectType={ProjectObjectType.modelServer}
-    sectionType={SectionType.serving}
-    title="Single-model serving platform"
-    data-testid="single-serving-platform-card"
-  >
-    <CardBody>
-      <TextContent>
-        <Text component="small">
-          Each model is deployed on its own model server. Choose this option when you want to deploy
-          a large model such as a large language model (LLM).
-        </Text>
-      </TextContent>
-    </CardBody>
-    <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} />
-  </OverviewCard>
-);
+type SelectSingleModelCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+};
+
+const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
+  setErrorSelectingPlatform,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  return (
+    <OverviewCard
+      objectType={ProjectObjectType.modelServer}
+      sectionType={SectionType.serving}
+      title="Single-model serving platform"
+      data-testid="single-serving-platform-card"
+    >
+      <CardBody>
+        <TextContent>
+          <Text component="small">
+            Each model is deployed on its own model server. Choose this option when you want to
+            deploy a large model such as a large language model (LLM).
+          </Text>
+        </TextContent>
+      </CardBody>
+      <CardFooter>
+        <ModelServingPlatformSelectButton
+          namespace={currentProject.metadata.name}
+          servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+          setError={setErrorSelectingPlatform}
+          variant="link"
+          data-testid="single-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+        />
+      </CardFooter>
+    </OverviewCard>
+  );
+};
 
 export default SelectSingleModelCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
@@ -41,7 +41,7 @@ const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
             setError={setErrorSelectingPlatform}
             variant="link"
             isInline
-            data-testid="single-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+            data-testid="single-serving-select-button"
           />
         </CardFooter>
       ) : (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
@@ -2,20 +2,16 @@ import * as React from 'react';
 import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ServingRuntimePlatform } from '~/types';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
-import AddModelFooter from './AddModelFooter';
 
 type SelectSingleModelCardProps = {
   setErrorSelectingPlatform: (e?: Error) => void;
-  numServingPlatformsAvailable: number;
 };
 
 const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
   setErrorSelectingPlatform,
-  numServingPlatformsAvailable,
 }) => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
   return (
@@ -33,20 +29,16 @@ const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
           </Text>
         </TextContent>
       </CardBody>
-      {numServingPlatformsAvailable > 1 ? (
-        <CardFooter>
-          <ModelServingPlatformSelectButton
-            namespace={currentProject.metadata.name}
-            servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
-            setError={setErrorSelectingPlatform}
-            variant="link"
-            isInline
-            data-testid="single-serving-select-button"
-          />
-        </CardFooter>
-      ) : (
-        <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} />
-      )}
+      <CardFooter>
+        <ModelServingPlatformSelectButton
+          namespace={currentProject.metadata.name}
+          servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+          setError={setErrorSelectingPlatform}
+          variant="link"
+          isInline
+          data-testid="single-serving-select-button"
+        />
+      </CardFooter>
     </OverviewCard>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
@@ -1,46 +1,27 @@
 import * as React from 'react';
-import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
-import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { NamespaceApplicationCase } from '~/pages/projects/types';
-import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ServingRuntimePlatform } from '~/types';
+import AddModelFooter from './AddModelFooter';
 
-type SelectSingleModelCardProps = {
-  setErrorSelectingPlatform: (e?: Error) => void;
-};
-
-const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
-  setErrorSelectingPlatform,
-}) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
-  return (
-    <OverviewCard
-      objectType={ProjectObjectType.modelServer}
-      sectionType={SectionType.serving}
-      title="Single-model serving platform"
-      data-testid="single-serving-platform-card"
-    >
-      <CardBody>
-        <TextContent>
-          <Text component="small">
-            Each model is deployed on its own model server. Choose this option when you want to
-            deploy a large model such as a large language model (LLM).
-          </Text>
-        </TextContent>
-      </CardBody>
-      <CardFooter>
-        <ModelServingPlatformSelectButton
-          namespace={currentProject.metadata.name}
-          servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
-          setError={setErrorSelectingPlatform}
-          variant="link"
-          isInline
-          data-testid="single-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
-        />
-      </CardFooter>
-    </OverviewCard>
-  );
-};
+const SelectSingleModelCard: React.FC = () => (
+  <OverviewCard
+    objectType={ProjectObjectType.modelServer}
+    sectionType={SectionType.serving}
+    title="Single-model serving platform"
+    data-testid="single-serving-platform-card"
+  >
+    <CardBody>
+      <TextContent>
+        <Text component="small">
+          Each model is deployed on its own model server. Choose this option when you want to deploy
+          a large model such as a large language model (LLM).
+        </Text>
+      </TextContent>
+    </CardBody>
+    <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} />
+  </OverviewCard>
+);
 
 export default SelectSingleModelCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/SelectSingleModelCard.tsx
@@ -1,27 +1,54 @@
 import * as React from 'react';
-import { CardBody, Text, TextContent } from '@patternfly/react-core';
+import { CardBody, CardFooter, Text, TextContent } from '@patternfly/react-core';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import OverviewCard from '~/pages/projects/screens/detail/overview/components/OverviewCard';
 import { ServingRuntimePlatform } from '~/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
 import AddModelFooter from './AddModelFooter';
 
-const SelectSingleModelCard: React.FC = () => (
-  <OverviewCard
-    objectType={ProjectObjectType.modelServer}
-    sectionType={SectionType.serving}
-    title="Single-model serving platform"
-    data-testid="single-serving-platform-card"
-  >
-    <CardBody>
-      <TextContent>
-        <Text component="small">
-          Each model is deployed on its own model server. Choose this option when you want to deploy
-          a large model such as a large language model (LLM).
-        </Text>
-      </TextContent>
-    </CardBody>
-    <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} />
-  </OverviewCard>
-);
+type SelectSingleModelCardProps = {
+  setErrorSelectingPlatform: (e?: Error) => void;
+  numServingPlatformsAvailable: number;
+};
+
+const SelectSingleModelCard: React.FC<SelectSingleModelCardProps> = ({
+  setErrorSelectingPlatform,
+  numServingPlatformsAvailable,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  return (
+    <OverviewCard
+      objectType={ProjectObjectType.modelServer}
+      sectionType={SectionType.serving}
+      title="Single-model serving platform"
+      data-testid="single-serving-platform-card"
+    >
+      <CardBody>
+        <TextContent>
+          <Text component="small">
+            Each model is deployed on its own model server. Choose this option when you want to
+            deploy a large model such as a large language model (LLM).
+          </Text>
+        </TextContent>
+      </CardBody>
+      {numServingPlatformsAvailable > 1 ? (
+        <CardFooter>
+          <ModelServingPlatformSelectButton
+            namespace={currentProject.metadata.name}
+            servingPlatform={NamespaceApplicationCase.KSERVE_PROMOTION}
+            setError={setErrorSelectingPlatform}
+            variant="link"
+            isInline
+            data-testid="single-serving-select-button" // TODO this changed from model-serving-platform-button (which was duplicated), inform QE and look for other cases
+          />
+        </CardFooter>
+      ) : (
+        <AddModelFooter selectedPlatform={ServingRuntimePlatform.SINGLE} />
+      )}
+    </OverviewCard>
+  );
+};
 
 export default SelectSingleModelCard;

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/ServeModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/ServeModelsSection.tsx
@@ -9,9 +9,10 @@ import DeployedModelsSection from './deployedModels/DeployedModelsSection';
 
 const ServeModelsSection: React.FC = () => {
   const servingPlatformStatuses = useServingPlatformStatuses();
-
-  const kServeEnabled = servingPlatformStatuses.kServe.enabled;
-  const modelMeshEnabled = servingPlatformStatuses.modelMesh.enabled;
+  const {
+    numServingPlatformsAvailable,
+    modelMesh: { enabled: modelMeshEnabled },
+  } = servingPlatformStatuses;
 
   const { currentProject } = React.useContext(ProjectDetailsContext);
 
@@ -20,11 +21,11 @@ const ServeModelsSection: React.FC = () => {
     servingPlatformStatuses,
   );
 
-  if (kServeEnabled && modelMeshEnabled && !currentProjectServingPlatform) {
+  if (numServingPlatformsAvailable > 1 && !currentProjectServingPlatform) {
     return <PlatformSelectSection />;
   }
 
-  if (!kServeEnabled && !modelMeshEnabled) {
+  if (numServingPlatformsAvailable === 0) {
     return <NoProjectServingEnabledSection />;
   }
 

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -14,6 +14,7 @@ import {
   FlexItem,
   Label,
   Spinner,
+  Stack,
   Text,
   TextContent,
 } from '@patternfly/react-core';
@@ -33,6 +34,9 @@ import { InferenceServiceKind } from '~/k8sTypes';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import ModelServingContextProvider from '~/pages/modelServing/ModelServingContext';
 import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nimUtils';
+import { NamespaceApplicationCase } from '~/pages/projects/types';
+import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';
+import ModelServingPlatformSelectErrorAlert from '~/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert';
 import DeployedModelsCard from './DeployedModelsCard';
 
 interface DeployedModelsSectionProps {
@@ -55,6 +59,8 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
   const [deployedModels, setDeployedModels] = React.useState<InferenceServiceKind[]>([]);
 
   const isKServeNIMEnabled = isProjectNIMSupported(currentProject);
+
+  const [errorSelectingPlatform, setErrorSelectingPlatform] = React.useState<Error>();
 
   React.useEffect(() => {
     if (!inferenceServicesLoaded || !modelServersLoaded) {
@@ -118,19 +124,39 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
           objectType={ProjectObjectType.deployedModels}
           sectionType={SectionType.serving}
           title="Deployed models"
-          headerInfo={<Label>Multi-model serving enabled</Label>}
+          headerInfo={
+            <Flex gap={{ default: 'gapSm' }}>
+              <Label>Multi-model serving enabled</Label>
+              <ModelServingPlatformSelectButton
+                namespace={currentProject.metadata.name}
+                servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
+                setError={setErrorSelectingPlatform}
+                variant="link"
+                isInline
+                data-testid="change-serving-platform-button"
+              />
+            </Flex>
+          }
         >
           <CardBody>
-            <TextContent>
-              <Text component="small">
-                Multiple models can be deployed from a single model server. Manage model servers and
-                and deploy models from the{' '}
-                <Button component="a" isInline variant="link" onClick={navToModels}>
-                  Models
-                </Button>{' '}
-                tab.
-              </Text>
-            </TextContent>
+            <Stack hasGutter>
+              {errorSelectingPlatform && (
+                <ModelServingPlatformSelectErrorAlert
+                  error={errorSelectingPlatform}
+                  clearError={() => setErrorSelectingPlatform(undefined)}
+                />
+              )}
+              <TextContent>
+                <Text component="small">
+                  Multiple models can be deployed from a single model server. Manage model servers
+                  and and deploy models from the{' '}
+                  <Button component="a" isInline variant="link" onClick={navToModels}>
+                    Models
+                  </Button>{' '}
+                  tab.
+                </Text>
+              </TextContent>
+            </Stack>
           </CardBody>
           <CardFooter>
             <Flex gap={{ default: 'gapLg' }}>
@@ -159,25 +185,43 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
           sectionType={isMultiPlatform ? SectionType.setup : SectionType.serving}
           title={isMultiPlatform ? 'No model servers' : 'Deployed models'}
           headerInfo={
-            <Label>
-              {isMultiPlatform ? 'Multi-model serving enabled' : 'Single-model serving enabled'}
-            </Label>
+            <Flex gap={{ default: 'gapSm' }}>
+              <Label>
+                {isMultiPlatform ? 'Multi-model serving enabled' : 'Single-model serving enabled'}
+              </Label>
+              <ModelServingPlatformSelectButton
+                namespace={currentProject.metadata.name}
+                servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
+                setError={setErrorSelectingPlatform}
+                variant="link"
+                isInline
+                data-testid="change-serving-platform-button"
+              />
+            </Flex>
           }
         >
           <CardBody>
-            {platformError ? (
-              <Alert isInline title="Loading error" variant="danger">
-                {platformError.message}
-              </Alert>
-            ) : (
-              <TextContent>
-                <Text component="small">
-                  {isMultiPlatform
-                    ? 'Before deploying a model, you must first add a model server.'
-                    : 'Each model is deployed on its own model server.'}
-                </Text>
-              </TextContent>
-            )}
+            <Stack hasGutter>
+              {errorSelectingPlatform && (
+                <ModelServingPlatformSelectErrorAlert
+                  error={errorSelectingPlatform}
+                  clearError={() => setErrorSelectingPlatform(undefined)}
+                />
+              )}
+              {platformError ? (
+                <Alert isInline title="Loading error" variant="danger">
+                  {platformError.message}
+                </Alert>
+              ) : (
+                <TextContent>
+                  <Text component="small">
+                    {isMultiPlatform
+                      ? 'Before deploying a model, you must first add a model server.'
+                      : 'Each model is deployed on its own model server.'}
+                  </Text>
+                </TextContent>
+              )}
+            </Stack>
           </CardBody>
           {!platformError ? <AddModelFooter isNIM={isKServeNIMEnabled} /> : null}
         </OverviewCard>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -52,6 +52,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
   } = React.useContext(ProjectDetailsContext);
 
   const servingPlatformStatuses = useServingPlatformStatuses();
+  const { numServingPlatformsAvailable } = servingPlatformStatuses;
   const { error: platformError } = getProjectModelServingPlatform(
     currentProject,
     servingPlatformStatuses,
@@ -127,14 +128,16 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
           headerInfo={
             <Flex gap={{ default: 'gapSm' }}>
               <Label>Multi-model serving enabled</Label>
-              <ModelServingPlatformSelectButton
-                namespace={currentProject.metadata.name}
-                servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
-                setError={setErrorSelectingPlatform}
-                variant="link"
-                isInline
-                data-testid="change-serving-platform-button"
-              />
+              {numServingPlatformsAvailable > 1 && (
+                <ModelServingPlatformSelectButton
+                  namespace={currentProject.metadata.name}
+                  servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
+                  setError={setErrorSelectingPlatform}
+                  variant="link"
+                  isInline
+                  data-testid="change-serving-platform-button"
+                />
+              )}
             </Flex>
           }
         >
@@ -189,14 +192,16 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
               <Label>
                 {isMultiPlatform ? 'Multi-model serving enabled' : 'Single-model serving enabled'}
               </Label>
-              <ModelServingPlatformSelectButton
-                namespace={currentProject.metadata.name}
-                servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
-                setError={setErrorSelectingPlatform}
-                variant="link"
-                isInline
-                data-testid="change-serving-platform-button"
-              />
+              {numServingPlatformsAvailable > 1 && (
+                <ModelServingPlatformSelectButton
+                  namespace={currentProject.metadata.name}
+                  servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
+                  setError={setErrorSelectingPlatform}
+                  variant="link"
+                  isInline
+                  data-testid="change-serving-platform-button"
+                />
+              )}
             </Flex>
           }
         >

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -18,7 +18,7 @@ import {
   Text,
   TextContent,
 } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
@@ -44,7 +44,7 @@ interface DeployedModelsSectionProps {
 }
 
 const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPlatform }) => {
-  const navigate = useNavigate();
+  const [queryParams, setQueryParams] = useSearchParams();
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const {
     inferenceServices: { data: inferenceServices, loaded: inferenceServicesLoaded },
@@ -115,10 +115,12 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
     }
 
     if (isMultiPlatform && modelServers.length && deployedModels.length === 0) {
-      const navToModels = () =>
-        navigate(
-          `/projects/${currentProject.metadata.name}?section=${ProjectSectionID.MODEL_SERVER}`,
-        );
+      const navToModels = () => {
+        // Instead of calling navigate(), change tabs by changing the section query param to retain other query params.
+        // This is how the GenericHorizontalBar component changes tabs internally.
+        queryParams.set('section', ProjectSectionID.MODEL_SERVER);
+        setQueryParams(queryParams);
+      };
 
       return (
         <OverviewCard

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -172,5 +172,5 @@ export enum NamespaceApplicationCase {
   /**
    * Downgrade a project from Modelmesh, Kserve or NIM so the platform can be selected again.
    */
-  RESET_MODEL_SERVING,
+  RESET_MODEL_SERVING_PLATFORM,
 }

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -169,4 +169,8 @@ export enum NamespaceApplicationCase {
    * Nvidia NIMs run on KServe but have different requirements than regular models.
    */
   KSERVE_NIM_PROMOTION,
+  /**
+   * Downgrade a project from Modelmesh, Kserve or NIM so the platform can be selected again.
+   */
+  RESET_MODEL_SERVING,
 }


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/RHOAIENG-13633

Based on design option 3 here: https://www.figma.com/design/QvGExX8ZYFHnyeiVsRgBbq/Projects-page-changes-for-RHOAIENG-13633?node-id=5004-12576&node-type=canvas&t=IEE8aKxFJojmaDm2-0

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

cc @yih-wang @vconzola 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

In order to improve the experience of deploying to a new project from the model registry, this PR adds the ability to select a model serving platform for a project without deploying a model or adding a model server.

If you want to skip to the good part, here are some demo videos. For further explanation, keep scrolling.

Deploying from the model registry to a new project and selecting single-model serving:

https://github.com/user-attachments/assets/f1d16399-e50f-46c5-b841-ac3ffce6239b

Deploying from the model registry to a new project and selecting multi-model serving:

https://github.com/user-attachments/assets/5f7d08fb-cacc-42d9-b727-4bb49a4ad2d6

Changing serving platforms freely in a project before anything is deployed:

https://github.com/user-attachments/assets/d1f69089-5ed5-44b1-83ef-ae28fb45d61c

---

There's a lot going on here...

### The problem with the current implementation

When deploying a model version from the model registry and selecting a brand new project that does not have a serving platform selected, the user is told "Cannot deploy the model until you select a model serving platform" and sent to the project page:

![Screenshot 2024-11-05 at 4 03 02 PM](https://github.com/user-attachments/assets/c04ee847-7814-4882-82fe-4e4afeeef784)

From here, the only way to select a platform is to deploy a model from outside the registry:

![Screenshot 2024-11-05 at 4 03 23 PM](https://github.com/user-attachments/assets/f62dd0a7-454f-4338-82cb-90ddcd5187f5)

We need to allow the user to select their platform (single-model, multi-model or NIM) without deploying anything and then easily navigate back to the page in model registry they were trying to deploy from.

### New changes

In the Project Details page, this PR changes the empty state cards on the Models tab and in the Deployed Models section of the Overview tab so that the "deploy model" / "add model server" buttons are replaced with "Select single-model" / "select multi-model" / "select NVIDIA NIM" buttons.

On the Models tab:
![Screenshot 2024-11-05 at 4 42 10 PM](https://github.com/user-attachments/assets/9ecec67c-fa6f-43fc-806a-733ede6dae06)

On the Overview tab:
![Screenshot 2024-11-05 at 4 42 20 PM](https://github.com/user-attachments/assets/21a828a0-699b-4ec5-8075-931ce353d0c3)

Once the user clicks one of these buttons, the project is updated with the labels to set its serving platform (which previously only happened while deploying a model or adding a model server), and the project moves to a "platform selected empty state" with the "deploy model" / "add model server" button present for only the selected platform (you could previously reach this state by deploying a model/server and then deleting it, leaving the project with no models/servers but the platform still set):

On the Models tab, after selecting Single-model serving (the same view is used for NIM):
![Screenshot 2024-11-05 at 4 43 10 PM](https://github.com/user-attachments/assets/fe0a4009-a2d9-4f09-9841-86a5b6f57203)

On the Overview tab, after selecting Single-model serving (the same view is used for NIM):
![Screenshot 2024-11-05 at 4 43 18 PM](https://github.com/user-attachments/assets/e17e9218-ad84-46c9-9220-b80b7b0ae743)

On the Models tab, after selecting Multi-model serving:
![Screenshot 2024-11-05 at 4 44 30 PM](https://github.com/user-attachments/assets/2343f5ef-0a28-436e-9dfc-803f0225e8c3)

On the Overview tab, after selecting Multi-model serving:
![Screenshot 2024-11-05 at 4 44 40 PM](https://github.com/user-attachments/assets/a48abfd5-fb05-4159-921a-f9175b296869)

While in this "platform selected empty state", there is a new "Change" button in the corner (next to the "Single-model serving enabled"/"Multi-model serving enabled" badge). Clicking this Change button will remove the platform labels from the project and return it to the original empty state where you can select a different platform. This "Change" button disappears once you deploy a model / add a model server, and reappears if you delete all models/servers from the project.

![Screenshot 2024-11-05 at 4 48 40 PM](https://github.com/user-attachments/assets/8e98ef4a-dd3e-4f8c-bda6-81cf1a101a15)

**Note: the above changes only take effect if more than one model serving platform is enabled/available in the cluster**. If only one platform is available, the current behavior is retained: there is no button to select it, the empty state cards for the platforms are never shown, the project starts out in the "platform selected empty state" ready to deploy a model / add a server, and the "Change" button never appears.

### Error handling

If there is a problem updating the labels on the project to select or un-select a platform, an expandable alert is shown. Note that the error message here is preexisting - the same error previously appeared when encountering this same problem while deploying the first model in a project. The "Open Data Hub" branding here is dynamic and will show the product name for a downstream build.

Failing to select a platform on the Models tab (the alert appears the same way for all platforms):
![Screenshot 2024-11-05 at 5 04 49 PM](https://github.com/user-attachments/assets/ce47be8f-dd66-4f7f-b142-093159e523fa)

Failing to select a platform on the Overview tab (the alert appears the same way for all platforms):
![Screenshot 2024-11-05 at 5 05 00 PM](https://github.com/user-attachments/assets/60d8c8e9-a296-473a-8f29-e5b34f6e0d96)

Failing to un-select a platform ("Change" button) on the Models tab (the alert appears the same way for all platforms):
![Screenshot 2024-11-05 at 5 09 04 PM](https://github.com/user-attachments/assets/f5b2a24b-44fc-4db8-85d2-6c0e67376d5d)

Failing to un-select a platform ("Change" button) on the Overview tab (the alert appears the same way for all platforms):
![Screenshot 2024-11-05 at 5 09 16 PM](https://github.com/user-attachments/assets/b2faaa89-a19d-42fb-856d-bf17b738439d)

### Navigating back to the model registry

In addition to these changes, there is some additional behavior if the user reached the project details page by clicking that "go to project page" button from the model registry deploy form (the first screenshot at the top of this PR). When clicking that button, the user will reach the project details page's Model tab with some additional URL parameters to indicate where they came from in the model registry (e.g. `&modelRegistryName=modelregistry-sample&registeredModelId=1&modelVersionId=2`). These URL parameters will be retained when switching tabs on the project details page, but will disappear if the user navigates to a different page. After the user selects the project's serving platform, if these params are present, they will get an extra "Deploy model from model registry" button that will return them to the registered version they were originally trying to deploy. For single-model serving or NIM, this button appears in the empty states on both the Models tab and the Overview tab. For multi-model serving, the "Deploy model" buttons on the model servers table of the Models tab becomes a dropdown to include this option.

After choosing Single-model serving, on the Models tab (the same view is used for NIM):
![Screenshot 2024-11-05 at 4 55 48 PM](https://github.com/user-attachments/assets/8135bec4-ba0e-45a0-9437-0542d6e727db)

After choosing Single-model serving, on the Overview tab (the same view is used for NIM):
![Screenshot 2024-11-05 at 4 57 34 PM](https://github.com/user-attachments/assets/2e6953ca-6247-4452-af56-f801fd5a4c3a)

After choosing Multi-model serving and creating a model server, on the Models tab (note: this is still a button unless the user came here from the model registry, it only becomes a dropdown if the URL params are present):
![Screenshot 2024-11-05 at 5 00 04 PM](https://github.com/user-attachments/assets/dd476f38-7884-4c92-aa70-3eec5a21374e)

After choosing Multi-model serving and creating a model server, on the Overview tab (the user has to click Go to Models and use the dropdown in the last screenshot):
![Screenshot 2024-11-05 at 5 00 16 PM](https://github.com/user-attachments/assets/1984a717-4541-470e-9091-b7913b2b7764)

All of these "Deploy model from model registry" buttons will return the user to the model version details page in the model registry page, where they can click Deploy again in the Actions dropdown.

![Screenshot 2024-11-05 at 5 15 41 PM](https://github.com/user-attachments/assets/10fd3729-b7fc-45e5-bc49-f8ae84f9c37a)

### Additional changes

There are a few places in `ModelServingPlatform` where `modelMeshEnabled` was used when it should have been `isProjectModelMesh`. This resulted in multi-model-specific microcopy appearing on single-model projects if both serving platforms are enabled in the cluster. This PR fixes that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and in a cluster (ods-qe-psi-08).

Note that there are backend changes required to support the "Change" buttons un-setting a serving platform. The rest of the functionality can be tested via `npm run start:dev:ext`, however.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Existing tests that broke due to these changes have been fixed, and many new Cypress tests are added to cover the platform selecting/unselecting behavior for all 3 serving platforms, and the returning-to-model-registry behavior.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
