### PR TITLE
Add connection type to model serving create modal

### DIFF
--- a/frontend/src/concepts/connectionTypes/ConnectionDetailsHelperText.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionDetailsHelperText.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  HelperText,
+  HelperTextItem,
+  LabelGroup,
+  Popover,
+} from '@patternfly/react-core';
+import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import TruncatedText from '~/components/TruncatedText';
+import { Connection, ConnectionTypeConfigMapObj } from './types';
+import CategoryLabel from './CategoryLabel';
+
+type Props = {
+  connection: Connection;
+  connectionType?: ConnectionTypeConfigMapObj;
+};
+
+export const ConnectionDetailsHelperText: React.FC<Props> = ({ connection, connectionType }) => {
+  const displayName = getDisplayNameFromK8sResource(connection);
+  const description = getDescriptionFromK8sResource(connection);
+
+  return (
+    <HelperText>
+      {description && (
+        <HelperTextItem>
+          <TruncatedText maxLines={2} content={description} />
+        </HelperTextItem>
+      )}
+      <HelperTextItem>
+        <Popover
+          headerContent="Connection details"
+          bodyContent={
+            <DescriptionList>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Connection name</DescriptionListTerm>
+                <DescriptionListDescription>{displayName}</DescriptionListDescription>
+              </DescriptionListGroup>
+              {description ? (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Connection description</DescriptionListTerm>
+                  <DescriptionListDescription>{description}</DescriptionListDescription>
+                </DescriptionListGroup>
+              ) : undefined}
+              <DescriptionListGroup>
+                <DescriptionListTerm>Type</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {connectionType?.data?.category?.length ? (
+                    <LabelGroup>
+                      {connectionType.data.category.map((category) => (
+                        <CategoryLabel key={category} category={category} />
+                      ))}
+                    </LabelGroup>
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          }
+        >
+          <Button variant="link" isInline>
+            View connection details
+          </Button>
+        </Popover>
+      </HelperTextItem>
+    </HelperText>
+  );
+};

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -145,6 +145,18 @@ export const getDefaultValues = (
   return defaults;
 };
 
+export const withRequiredFields = (
+  connectionType?: ConnectionTypeConfigMapObj,
+  envVars?: string[],
+): ConnectionTypeConfigMapObj | undefined => {
+  for (const field of connectionType?.data?.fields ?? []) {
+    if (isConnectionTypeDataField(field) && envVars?.includes(field.envVar)) {
+      field.required = true;
+    }
+  }
+  return connectionType;
+};
+
 export const assembleConnectionSecret = (
   project: ProjectKind | string,
   connectionTypeName: string,

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -146,7 +146,7 @@ export const getDefaultValues = (
 };
 
 export const assembleConnectionSecret = (
-  project: ProjectKind,
+  project: ProjectKind | string,
   connectionTypeName: string,
   nameDesc: K8sNameDescriptionFieldData,
   values: {
@@ -166,7 +166,7 @@ export const assembleConnectionSecret = (
     kind: 'Secret',
     metadata: {
       name: nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name),
-      namespace: project.metadata.name,
+      namespace: typeof project === 'string' ? project : project.metadata.name,
       labels: {
         'opendatahub.io/dashboard': 'true',
         'opendatahub.io/managed': 'true',

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -133,7 +133,7 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
 
   const [connectionValues, setConnectionValues] = React.useState<{
     [key: string]: ConnectionTypeValueType;
-  }>(enabledConnectionTypes.length <= 1 ? getDefaultValues(enabledConnectionTypes[0]) : {});
+  }>(enabledConnectionTypes.length === 1 ? getDefaultValues(enabledConnectionTypes[0]) : {});
 
   const [validations, setValidations] = React.useState<{
     [key: string]: boolean;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -1,0 +1,294 @@
+import React from 'react';
+import { Button, FormGroup, FormSection, Popover, Radio } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import {
+  getDisplayNameFromK8sResource,
+  getResourceNameFromK8sResource,
+} from '~/concepts/k8s/utils';
+import {
+  Connection,
+  ConnectionTypeConfigMapObj,
+  ConnectionTypeFieldType,
+  ConnectionTypeValueType,
+  isConnectionTypeDataField,
+} from '~/concepts/connectionTypes/types';
+import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
+import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { assembleConnectionSecret, getDefaultValues } from '~/concepts/connectionTypes/utils';
+import { ConnectionDetailsHelperText } from '~/concepts/connectionTypes/ConnectionDetailsHelperText';
+import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
+import TypeaheadSelect, { TypeaheadSelectOption } from '~/components/TypeaheadSelect';
+import {
+  CreatingInferenceServiceObject,
+  InferenceServiceStorageType,
+} from '~/pages/modelServing/screens/types';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import useConnections from '~/pages/projects/screens/detail/connections/useConnections';
+import DataConnectionFolderPathField from './DataConnectionFolderPathField';
+
+type ExistingConnectionFieldProps = {
+  connectionTypes: ConnectionTypeConfigMapObj[];
+  projectConnections: Connection[];
+  selectedConnection?: Connection;
+  onSelect: (connection: Connection) => void;
+  folderPath: string;
+  setFolderPath: (path: string) => void;
+};
+
+const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
+  connectionTypes,
+  projectConnections,
+  selectedConnection,
+  onSelect,
+  folderPath,
+  setFolderPath,
+}) => {
+  const options: TypeaheadSelectOption[] = React.useMemo(
+    () =>
+      projectConnections.map((connection) => ({
+        content: getDisplayNameFromK8sResource(connection),
+        value: getResourceNameFromK8sResource(connection),
+        description: connection.metadata.annotations['openshift.io/description'],
+        isSelected:
+          !!selectedConnection &&
+          getResourceNameFromK8sResource(connection) ===
+            getResourceNameFromK8sResource(selectedConnection),
+      })),
+    [projectConnections, selectedConnection],
+  );
+  const selectedConnectionType = React.useMemo(
+    () =>
+      connectionTypes.find(
+        (t) =>
+          getResourceNameFromK8sResource(t) ===
+          selectedConnection?.metadata.annotations['opendatahub.io/connection-type'],
+      ),
+    [connectionTypes, selectedConnection?.metadata.annotations],
+  );
+
+  return (
+    <>
+      <Popover
+        aria-label="Hoverable popover"
+        bodyContent="This list includes only connections that are compatible with model serving."
+      >
+        <Button
+          style={{ paddingLeft: 0 }}
+          icon={<OutlinedQuestionCircleIcon />}
+          variant="link"
+          disabled
+        >
+          Not seeing what you&apos;re looking for?
+        </Button>
+      </Popover>
+      <FormGroup label="Connection" fieldId="connection" isRequired className="pf-v5-u-mb-lg">
+        <TypeaheadSelect
+          selectOptions={options}
+          onSelect={(_, value) => {
+            const newConnection = projectConnections.find(
+              (c) => getResourceNameFromK8sResource(c) === value,
+            );
+            if (newConnection) {
+              onSelect(newConnection);
+            }
+          }}
+          isDisabled={projectConnections.length === 0}
+        />
+        {selectedConnection && (
+          <ConnectionDetailsHelperText
+            connection={selectedConnection}
+            connectionType={selectedConnectionType}
+          />
+        )}
+      </FormGroup>
+      <DataConnectionFolderPathField folderPath={folderPath} setFolderPath={setFolderPath} />
+    </>
+  );
+};
+
+type NewConnectionFieldProps = {
+  connectionTypes: ConnectionTypeConfigMapObj[];
+  data: CreatingInferenceServiceObject;
+  setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+  setNewConnection: (connection: Connection) => void;
+  setIsConnectionvalid: (isValid: boolean) => void;
+};
+
+const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
+  connectionTypes,
+  data,
+  setData,
+  setNewConnection,
+  setIsConnectionvalid,
+}) => {
+  const enabledConnectionTypes = React.useMemo(
+    () =>
+      connectionTypes.filter((t) => t.metadata.annotations?.['opendatahub.io/enabled'] === 'true'),
+    [connectionTypes],
+  );
+  const [selectedConnectionType, setSelectedConnectionType] = React.useState<
+    ConnectionTypeConfigMapObj | undefined
+  >(enabledConnectionTypes.length === 1 ? connectionTypes[0] : undefined);
+  const { data: nameDescData, onDataChange: setNameDescData } = useK8sNameDescriptionFieldData();
+
+  const [connectionValues, setConnectionValues] = React.useState<{
+    [key: string]: ConnectionTypeValueType;
+  }>(enabledConnectionTypes.length <= 1 ? getDefaultValues(enabledConnectionTypes[0]) : {});
+
+  const [validations, setValidations] = React.useState<{
+    [key: string]: boolean;
+  }>({});
+  const isFormValid = React.useMemo(
+    () =>
+      !!selectedConnectionType &&
+      !!nameDescData.name &&
+      !selectedConnectionType.data?.fields?.find(
+        (field) =>
+          isConnectionTypeDataField(field) &&
+          field.required &&
+          !connectionValues[field.envVar] &&
+          field.type !== ConnectionTypeFieldType.Boolean,
+      ) &&
+      !Object.values(validations).includes(false),
+    [selectedConnectionType, nameDescData, connectionValues, validations],
+  );
+
+  React.useEffect(() => {
+    if (selectedConnectionType) {
+      setNewConnection(
+        assembleConnectionSecret(
+          data.project,
+          getResourceNameFromK8sResource(selectedConnectionType),
+          nameDescData,
+          connectionValues,
+        ),
+      );
+      setIsConnectionvalid(isFormValid);
+    }
+  }, [
+    connectionValues,
+    data.project,
+    isFormValid,
+    nameDescData,
+    selectedConnectionType,
+    setIsConnectionvalid,
+    setNewConnection,
+  ]);
+
+  return (
+    <FormSection>
+      <ConnectionTypeForm
+        options={enabledConnectionTypes}
+        connectionType={selectedConnectionType}
+        setConnectionType={(type) => {
+          setSelectedConnectionType(
+            connectionTypes.find((t) => getResourceNameFromK8sResource(t) === type),
+          );
+        }}
+        connectionNameDesc={nameDescData}
+        setConnectionNameDesc={setNameDescData}
+        connectionValues={connectionValues}
+        onChange={(field, value) =>
+          setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }))
+        }
+        onValidate={(field, isValid) =>
+          setValidations((prev) => ({ ...prev, [field.envVar]: isValid }))
+        }
+      />
+      <DataConnectionFolderPathField
+        folderPath={data.storage.path}
+        setFolderPath={(path) => setData('storage', { ...data.storage, path })}
+      />
+    </FormSection>
+  );
+};
+
+type Props = {
+  data: CreatingInferenceServiceObject;
+  setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+  setConnection: (connection?: Connection) => void;
+  setIsConnectionvalid: (isValid: boolean) => void;
+};
+
+export const ConnectionSection: React.FC<Props> = ({
+  data,
+  setData,
+  setConnection,
+  setIsConnectionvalid,
+}) => {
+  const [connectionTypes] = useWatchConnectionTypes(true);
+  const [projectConnections] = useConnections(data.project, true);
+
+  const selectedConnection = React.useMemo(
+    () =>
+      projectConnections.find(
+        (c) => getResourceNameFromK8sResource(c) === data.storage.dataConnection,
+      ),
+    [projectConnections, data.storage.dataConnection],
+  );
+
+  return (
+    <>
+      <Radio
+        name="existing-connection-radio"
+        id="existing-connection-radio"
+        data-testid="existing-connection-radio"
+        label="Existing connection"
+        isChecked={data.storage.type === InferenceServiceStorageType.EXISTING_STORAGE}
+        onChange={() => {
+          setConnection(undefined);
+          setData('storage', {
+            ...data.storage,
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+            alert: undefined,
+          });
+        }}
+        body={
+          data.storage.type === InferenceServiceStorageType.EXISTING_STORAGE && (
+            <ExistingConnectionField
+              connectionTypes={connectionTypes}
+              projectConnections={projectConnections}
+              selectedConnection={selectedConnection}
+              onSelect={(selection) => {
+                setConnection(selection);
+                setData('storage', {
+                  ...data.storage,
+                  dataConnection: getResourceNameFromK8sResource(selection),
+                });
+              }}
+              folderPath={data.storage.path}
+              setFolderPath={(path) => setData('storage', { ...data.storage, path })}
+            />
+          )
+        }
+      />
+      <Radio
+        name="new-connection-radio"
+        id="new-connection-radio"
+        data-testid="new-connection-radio"
+        className="pf-v5-u-mb-lg"
+        label="New connection"
+        isChecked={data.storage.type === InferenceServiceStorageType.NEW_STORAGE}
+        onChange={() => {
+          setConnection(undefined);
+          setData('storage', {
+            ...data.storage,
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            alert: undefined,
+          });
+        }}
+        body={
+          data.storage.type === InferenceServiceStorageType.NEW_STORAGE && (
+            <NewConnectionField
+              connectionTypes={connectionTypes}
+              data={data}
+              setData={setData}
+              setNewConnection={setConnection}
+              setIsConnectionvalid={setIsConnectionvalid}
+            />
+          )
+        }
+      />
+    </>
+  );
+};

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -10,11 +10,14 @@ import {
   ConnectionTypeConfigMapObj,
   ConnectionTypeFieldType,
   ConnectionTypeValueType,
-  isConnectionTypeDataField,
 } from '~/concepts/connectionTypes/types';
 import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
 import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
-import { assembleConnectionSecret, getDefaultValues } from '~/concepts/connectionTypes/utils';
+import {
+  assembleConnectionSecret,
+  getDefaultValues,
+  isConnectionTypeDataField,
+} from '~/concepts/connectionTypes/utils';
 import { ConnectionDetailsHelperText } from '~/concepts/connectionTypes/ConnectionDetailsHelperText';
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
 import TypeaheadSelect, { TypeaheadSelectOption } from '~/components/TypeaheadSelect';

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -17,6 +17,7 @@ import {
   assembleConnectionSecret,
   getDefaultValues,
   isConnectionTypeDataField,
+  withRequiredFields,
 } from '~/concepts/connectionTypes/utils';
 import { ConnectionDetailsHelperText } from '~/concepts/connectionTypes/ConnectionDetailsHelperText';
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
@@ -131,7 +132,16 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
   );
   const [selectedConnectionType, setSelectedConnectionType] = React.useState<
     ConnectionTypeConfigMapObj | undefined
-  >(enabledConnectionTypes.length === 1 ? connectionTypes[0] : undefined);
+  >(
+    enabledConnectionTypes.length === 1
+      ? withRequiredFields(connectionTypes[0], [
+          'AWS_ACCESS_KEY_ID',
+          'AWS_SECRET_ACCESS_KEY',
+          'AWS_S3_ENDPOINT',
+          'AWS_S3_BUCKET',
+        ])
+      : undefined,
+  );
   const { data: nameDescData, onDataChange: setNameDescData } = useK8sNameDescriptionFieldData();
 
   const [connectionValues, setConnectionValues] = React.useState<{
@@ -185,7 +195,10 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
         connectionType={selectedConnectionType}
         setConnectionType={(type) => {
           setSelectedConnectionType(
-            connectionTypes.find((t) => getResourceNameFromK8sResource(t) === type),
+            withRequiredFields(
+              connectionTypes.find((t) => getResourceNameFromK8sResource(t) === type),
+              ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_S3_ENDPOINT', 'AWS_S3_BUCKET'],
+            ),
           );
         }}
         connectionNameDesc={nameDescData}

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -68,7 +68,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
 
   const isConnectionTypesEnabled = useConnectionTypesEnabled();
   const [connection, setConnection] = React.useState<Connection>();
-  const [isConnectionValid, setIsConnectionvalid] = React.useState(false);
+  const [isConnectionValid, setIsConnectionValid] = React.useState(false);
 
   const hasEditInfo = !!editInfo;
   React.useEffect(() => {
@@ -205,7 +205,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
                       data={createData}
                       setData={setCreateData}
                       setConnection={setConnection}
-                      setIsConnectionvalid={setIsConnectionvalid}
+                      setIsConnectionValid={setIsConnectionValid}
                     />
                   ) : (
                     <DataConnectionSection

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -16,11 +16,14 @@ import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '~/con
 import { containsOnlySlashes, isS3PathValid } from '~/utilities/string';
 import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
 import usePrefillDeployModalFromModelRegistry from '~/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry';
+import useConnectionTypesEnabled from '~/concepts/connectionTypes/useConnectionTypesEnabled';
+import { Connection } from '~/concepts/connectionTypes/types';
 import DataConnectionSection from './DataConnectionSection';
 import ProjectSection from './ProjectSection';
 import InferenceServiceFrameworkSection from './InferenceServiceFrameworkSection';
 import InferenceServiceServingRuntimeSection from './InferenceServiceServingRuntimeSection';
 import InferenceServiceNameSection from './InferenceServiceNameSection';
+import { ConnectionSection } from './ConnectionSection';
 
 type ManageInferenceServiceModalProps = {
   onClose: (submit: boolean) => void;
@@ -63,6 +66,10 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
       registeredModelDeployInfo,
     );
 
+  const isConnectionTypesEnabled = useConnectionTypesEnabled();
+  const [connection, setConnection] = React.useState<Connection>();
+  const [isConnectionValid, setIsConnectionvalid] = React.useState(false);
+
   const hasEditInfo = !!editInfo;
   React.useEffect(() => {
     if (!hasEditInfo) {
@@ -74,6 +81,9 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
   const storageCanCreate = (): boolean => {
     if (createData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
       return createData.storage.dataConnection !== '';
+    }
+    if (isConnectionTypesEnabled) {
+      return isConnectionValid;
     }
     return isAWSValid(createData.storage.awsData, [AwsKeys.AWS_S3_BUCKET]);
   };
@@ -118,6 +128,12 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
       editInfo,
       undefined,
       true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      connection,
     )
       .then(() => onSuccess())
       .catch((e) => {
@@ -184,13 +200,22 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
               </StackItem>
               <StackItem>
                 <FormSection title="Source model location" id="model-location">
-                  <DataConnectionSection
-                    data={createData}
-                    setData={setCreateData}
-                    loaded={!!projectContext?.dataConnections || dataConnectionsLoaded}
-                    loadError={dataConnectionsLoadError}
-                    dataConnections={dataConnections}
-                  />
+                  {isConnectionTypesEnabled ? (
+                    <ConnectionSection
+                      data={createData}
+                      setData={setCreateData}
+                      setConnection={setConnection}
+                      setIsConnectionvalid={setIsConnectionvalid}
+                    />
+                  ) : (
+                    <DataConnectionSection
+                      data={createData}
+                      setData={setCreateData}
+                      loaded={!!projectContext?.dataConnections || dataConnectionsLoaded}
+                      loadError={dataConnectionsLoadError}
+                      dataConnections={dataConnections}
+                    />
+                  )}
                 </FormSection>
               </StackItem>
             </>

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
@@ -16,7 +16,25 @@ jest.mock('~/utilities/useWatchConnectionTypes', () => ({
           {
             type: 'short-text',
             name: 'Access key',
-            envVar: 'text',
+            envVar: 'AWS_ACCESS_KEY_ID',
+            properties: {},
+          },
+          {
+            type: 'short-text',
+            name: 'Secret key',
+            envVar: 'AWS_SECRET_ACCESS_KEY',
+            properties: {},
+          },
+          {
+            type: 'short-text',
+            name: 'Endpoint',
+            envVar: 'AWS_S3_ENDPOINT',
+            properties: {},
+          },
+          {
+            type: 'short-text',
+            name: 'Bucket',
+            envVar: 'AWS_S3_BUCKET',
             properties: {},
           },
         ],
@@ -49,7 +67,7 @@ describe('ConnectionsFormSection', () => {
         })}
         setData={mockSetData}
         setConnection={mockSetConnection}
-        setIsConnectionvalid={() => undefined}
+        setIsConnectionValid={() => undefined}
       />,
     );
 
@@ -93,7 +111,7 @@ describe('ConnectionsFormSection', () => {
         })}
         setData={() => undefined}
         setConnection={() => undefined}
-        setIsConnectionvalid={() => undefined}
+        setIsConnectionValid={() => undefined}
       />,
     );
 
@@ -118,7 +136,7 @@ describe('ConnectionsFormSection', () => {
         })}
         setData={mockSetData}
         setConnection={mockSetConnection}
-        setIsConnectionvalid={() => undefined}
+        setIsConnectionValid={() => undefined}
       />,
     );
 

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
@@ -1,0 +1,137 @@
+import React, { act } from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { mockConnection } from '~/__mocks__/mockConnection';
+import { mockConnectionTypeConfigMapObj } from '~/__mocks__/mockConnectionType';
+import { mockInferenceServiceModalData } from '~/__mocks__/mockInferenceServiceModalData';
+import { ConnectionSection } from '~/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection';
+import { InferenceServiceStorageType } from '~/pages/modelServing/screens/types';
+
+jest.mock('~/utilities/useWatchConnectionTypes', () => ({
+  useWatchConnectionTypes: jest.fn().mockReturnValue([
+    [
+      mockConnectionTypeConfigMapObj({
+        name: 's3',
+        fields: [
+          {
+            type: 'short-text',
+            name: 'Access key',
+            envVar: 'text',
+            properties: {},
+          },
+        ],
+      }),
+      mockConnectionTypeConfigMapObj({ name: 'uri' }),
+    ],
+  ]),
+}));
+jest.mock('~/pages/projects/screens/detail/connections/useConnections', () =>
+  jest
+    .fn()
+    .mockReturnValue([
+      [mockConnection({ name: 's3-connection' }), mockConnection({ name: 'uri-connection' })],
+    ]),
+);
+
+describe('ConnectionsFormSection', () => {
+  it('should select existing connection', async () => {
+    const mockSetData = jest.fn();
+    const mockSetConnection = jest.fn();
+    const result = render(
+      <ConnectionSection
+        data={mockInferenceServiceModalData({
+          storage: {
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+            path: '',
+            dataConnection: '',
+            awsData: [],
+          },
+        })}
+        setData={mockSetData}
+        setConnection={mockSetConnection}
+        setIsConnectionvalid={() => undefined}
+      />,
+    );
+
+    expect(result.getByRole('radio', { name: 'Existing connection' })).toBeChecked();
+
+    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('');
+    expect(result.getByRole('textbox', { name: 'folder-path' })).toHaveValue('');
+
+    await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
+    await act(async () => result.getByRole('option', { name: 's3-connection' }).click());
+    expect(mockSetData).toHaveBeenLastCalledWith('storage', {
+      type: InferenceServiceStorageType.EXISTING_STORAGE,
+      path: '',
+      dataConnection: 's3-connection',
+      awsData: [],
+    });
+
+    await act(async () =>
+      fireEvent.change(result.getByRole('textbox', { name: 'folder-path' }), {
+        target: { value: 'models/fraud' },
+      }),
+    );
+    expect(mockSetData).toHaveBeenLastCalledWith('storage', {
+      type: InferenceServiceStorageType.EXISTING_STORAGE,
+      path: 'models/fraud',
+      dataConnection: '',
+      awsData: [],
+    });
+  });
+
+  it('should show existing connection', async () => {
+    const result = render(
+      <ConnectionSection
+        data={mockInferenceServiceModalData({
+          storage: {
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+            path: 'models/fraud',
+            dataConnection: 's3-connection',
+            awsData: [],
+          },
+        })}
+        setData={() => undefined}
+        setConnection={() => undefined}
+        setIsConnectionvalid={() => undefined}
+      />,
+    );
+
+    expect(result.getByRole('radio', { name: 'Existing connection' })).toBeChecked();
+
+    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('s3-connection');
+    expect(result.getByRole('textbox', { name: 'folder-path' })).toHaveValue('models/fraud');
+  });
+
+  it('should render new connection radio selection', async () => {
+    const mockSetData = jest.fn();
+    const mockSetConnection = jest.fn();
+    const result = render(
+      <ConnectionSection
+        data={mockInferenceServiceModalData({
+          storage: {
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            path: '',
+            dataConnection: '',
+            awsData: [],
+          },
+        })}
+        setData={mockSetData}
+        setConnection={mockSetConnection}
+        setIsConnectionvalid={() => undefined}
+      />,
+    );
+
+    expect(result.getByRole('radio', { name: 'New connection' })).toBeChecked();
+
+    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('');
+    expect(result.getByRole('textbox', { name: 'folder-path' })).toHaveValue('');
+
+    await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
+    await act(async () => result.getByRole('option', { name: /s3/ }).click());
+
+    expect(result.getByRole('textbox', { name: 'Connection name' })).toHaveValue('');
+    expect(result.getByRole('textbox', { name: 'Connection description' })).toHaveValue('');
+    expect(result.getByRole('textbox', { name: 'Access key' })).toHaveValue('');
+  });
+});

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -55,6 +55,9 @@ import {
   FormTrackingEventProperties,
   TrackingOutcome,
 } from '~/concepts/analyticsTracking/trackingProperties';
+import useConnectionTypesEnabled from '~/concepts/connectionTypes/useConnectionTypesEnabled';
+import { Connection } from '~/concepts/connectionTypes/types';
+import { ConnectionSection } from '~/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection';
 import KServeAutoscalerReplicaSection from './KServeAutoscalerReplicaSection';
 import EnvironmentVariablesSection from './EnvironmentVariablesSection';
 import ServingRuntimeArgsSection from './ServingRuntimeArgsSection';
@@ -111,6 +114,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       setCreateDataInferenceService,
       registeredModelDeployInfo,
     );
+
+  const isConnectionTypesEnabled = useConnectionTypesEnabled();
+  const [connection, setConnection] = React.useState<Connection>();
+  const [isConnectionValid, setIsConnectionvalid] = React.useState(false);
 
   const isAuthorinoEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status;
   const currentProjectName = projectContext?.currentProject.metadata.name;
@@ -169,6 +176,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const storageCanCreate = (): boolean => {
     if (createDataInferenceService.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
       return createDataInferenceService.storage.dataConnection !== '';
+    }
+    if (isConnectionTypesEnabled) {
+      return isConnectionValid;
     }
     return isAWSValid(createDataInferenceService.storage.awsData, [AwsKeys.AWS_S3_BUCKET]);
   };
@@ -259,6 +269,8 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
       selectedAcceleratorProfile,
       allowCreate,
       editInfo?.secrets,
+      undefined,
+      connection,
     );
 
     const props: FormTrackingEventProperties = {
@@ -400,13 +412,22 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
             </FormSection>
             {!hideForm && (
               <FormSection title="Source model location" id="model-location">
-                <DataConnectionSection
-                  data={createDataInferenceService}
-                  setData={setCreateDataInferenceService}
-                  loaded={!!projectContext?.dataConnections || dataConnectionsLoaded}
-                  loadError={dataConnectionsLoadError}
-                  dataConnections={dataConnections}
-                />
+                {isConnectionTypesEnabled ? (
+                  <ConnectionSection
+                    data={createDataInferenceService}
+                    setData={setCreateDataInferenceService}
+                    setConnection={setConnection}
+                    setIsConnectionvalid={setIsConnectionvalid}
+                  />
+                ) : (
+                  <DataConnectionSection
+                    data={createDataInferenceService}
+                    setData={setCreateDataInferenceService}
+                    loaded={!!projectContext?.dataConnections || dataConnectionsLoaded}
+                    loadError={dataConnectionsLoadError}
+                    dataConnections={dataConnections}
+                  />
+                )}
               </FormSection>
             )}
             {servingRuntimeParamsEnabled && (

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -117,7 +117,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
 
   const isConnectionTypesEnabled = useConnectionTypesEnabled();
   const [connection, setConnection] = React.useState<Connection>();
-  const [isConnectionValid, setIsConnectionvalid] = React.useState(false);
+  const [isConnectionValid, setIsConnectionValid] = React.useState(false);
 
   const isAuthorinoEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status;
   const currentProjectName = projectContext?.currentProject.metadata.name;
@@ -417,7 +417,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                     data={createDataInferenceService}
                     setData={setCreateDataInferenceService}
                     setConnection={setConnection}
-                    setIsConnectionvalid={setIsConnectionvalid}
+                    setIsConnectionValid={setIsConnectionValid}
                   />
                 ) : (
                   <DataConnectionSection

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -53,6 +53,7 @@ import {
   getNIMData,
   getNIMResource,
 } from '~/pages/modelServing/screens/projects/nimUtils';
+import { Connection } from '~/concepts/connectionTypes/types';
 
 const NIM_CONFIGMAP_NAME = 'nvidia-nim-images-data';
 
@@ -320,7 +321,7 @@ export const createAWSSecret = (
     { dryRun },
   );
 
-const createInferenceServiceAndDataConnection = (
+const createInferenceServiceAndDataConnection = async (
   inferenceServiceData: CreatingInferenceServiceObject,
   existingStorage: boolean,
   editInfo?: InferenceServiceKind,
@@ -329,51 +330,41 @@ const createInferenceServiceAndDataConnection = (
   selectedAcceleratorProfile?: AcceleratorProfileSelectFieldState,
   dryRun = false,
   isStorageNeeded?: boolean,
+  connection?: Connection,
 ) => {
+  let secret;
   if (!existingStorage) {
-    return createAWSSecret(inferenceServiceData, dryRun).then((secret) =>
-      editInfo
-        ? updateInferenceService(
-            inferenceServiceData,
-            editInfo,
-            secret.metadata.name,
-            isModelMesh,
-            initialAcceleratorProfile,
-            selectedAcceleratorProfile,
-            dryRun,
-            isStorageNeeded,
-          )
-        : createInferenceService(
-            inferenceServiceData,
-            secret.metadata.name,
-            isModelMesh,
-            initialAcceleratorProfile,
-            selectedAcceleratorProfile,
-            dryRun,
-            isStorageNeeded,
-          ),
+    if (connection) {
+      secret = await createSecret(connection, { dryRun });
+    } else {
+      secret = await createAWSSecret(inferenceServiceData, dryRun);
+    }
+  }
+
+  let inferenceService;
+  if (editInfo) {
+    inferenceService = await updateInferenceService(
+      inferenceServiceData,
+      editInfo,
+      secret?.metadata.name,
+      isModelMesh,
+      initialAcceleratorProfile,
+      selectedAcceleratorProfile,
+      dryRun,
+      isStorageNeeded,
+    );
+  } else {
+    inferenceService = await createInferenceService(
+      inferenceServiceData,
+      secret?.metadata.name,
+      isModelMesh,
+      initialAcceleratorProfile,
+      selectedAcceleratorProfile,
+      dryRun,
+      isStorageNeeded,
     );
   }
-  return editInfo !== undefined
-    ? updateInferenceService(
-        inferenceServiceData,
-        editInfo,
-        undefined,
-        isModelMesh,
-        initialAcceleratorProfile,
-        selectedAcceleratorProfile,
-        dryRun,
-        isStorageNeeded,
-      )
-    : createInferenceService(
-        inferenceServiceData,
-        undefined,
-        isModelMesh,
-        initialAcceleratorProfile,
-        selectedAcceleratorProfile,
-        dryRun,
-        isStorageNeeded,
-      );
+  return inferenceService;
 };
 
 export const getSubmitInferenceServiceResourceFn = (
@@ -386,6 +377,7 @@ export const getSubmitInferenceServiceResourceFn = (
   allowCreate?: boolean,
   secrets?: SecretKind[],
   isStorageNeeded?: boolean,
+  connection?: Connection,
 ): ((opts: { dryRun?: boolean }) => Promise<void>) => {
   const inferenceServiceData = {
     ...createData,
@@ -416,6 +408,7 @@ export const getSubmitInferenceServiceResourceFn = (
       selectedAcceleratorProfile,
       dryRun,
       isStorageNeeded,
+      connection,
     ).then((inferenceService) =>
       setUpTokenAuth(
         createData,

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -9,6 +9,8 @@ import {
   ConnectionTypeValueType,
 } from '~/concepts/connectionTypes/types';
 import { ProjectKind, SecretKind } from '~/k8sTypes';
+import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
+import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import {
   assembleConnectionSecret,
@@ -17,7 +19,6 @@ import {
   isConnectionTypeDataField,
   parseConnectionSecretValues,
 } from '~/concepts/connectionTypes/utils';
-import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
 
 type Props = {
   connection?: Connection;
@@ -83,7 +84,7 @@ export const ManageConnectionModal: React.FC<Props> = ({
   const isFormValid = React.useMemo(
     () =>
       !!connectionTypeName &&
-      !!nameDescData.name &&
+      isK8sNameDescriptionDataValid(nameDescData) &&
       !selectedConnectionType?.data?.fields?.find(
         (field) =>
           isConnectionTypeDataField(field) &&
@@ -147,7 +148,12 @@ export const ManageConnectionModal: React.FC<Props> = ({
             }
 
             onSubmit(
-              assembleConnectionSecret(project, connectionTypeName, nameDescData, connectionValues),
+              assembleConnectionSecret(
+                project.metadata.name,
+                connectionTypeName,
+                nameDescData,
+                connectionValues,
+              ),
             )
               .then(() => {
                 onClose(true);

--- a/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
@@ -8,21 +8,34 @@ import useFetchState, {
 import { Connection } from '~/concepts/connectionTypes/types';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE, LABEL_SELECTOR_DATA_CONNECTION_AWS } from '~/const';
 import { isConnection } from '~/concepts/connectionTypes/utils';
+import { isModelServingCompatible } from '~/concepts/connectionTypes/utils';
 
-const useConnections = (namespace?: string): FetchState<Connection[]> => {
+const useConnections = (
+  namespace?: string,
+  modelServingCompatible?: boolean,
+): FetchState<Connection[]> => {
   const callback = React.useCallback<FetchStateCallbackPromise<Connection[]>>(
-    (opts) => {
+    async (opts) => {
       if (!namespace) {
         return Promise.reject(new NotReadyError('No namespace'));
       }
 
-      return getSecretsByLabel(
+      const secrets = await getSecretsByLabel(
         `${LABEL_SELECTOR_DASHBOARD_RESOURCE},${LABEL_SELECTOR_DATA_CONNECTION_AWS}`,
         namespace,
         opts,
-      ).then((secrets) => secrets.filter((secret) => isConnection(secret)));
+      );
+      let connections = secrets.filter((secret) => isConnection(secret));
+
+      if (modelServingCompatible) {
+        connections = connections.filter(
+          (secret) => !!secret.data && isModelServingCompatible(Object.keys(secret.data)),
+        );
+      }
+
+      return connections;
     },
-    [namespace],
+    [namespace, modelServingCompatible],
   );
 
   return useFetchState(callback, []);

--- a/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
@@ -7,8 +7,7 @@ import useFetchState, {
 } from '~/utilities/useFetchState';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE, LABEL_SELECTOR_DATA_CONNECTION_AWS } from '~/const';
-import { isConnection } from '~/concepts/connectionTypes/utils';
-import { isModelServingCompatible } from '~/concepts/connectionTypes/utils';
+import { isConnection, isModelServingCompatible } from '~/concepts/connectionTypes/utils';
 
 const useConnections = (
   namespace?: string,

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -20,10 +20,7 @@ export const useWatchConnectionTypes = (
     if (modelServingCompatible) {
       connectionTypes = connectionTypes.filter((type) => {
         const compatibleTypes = getCompatibleTypes(
-          type.data?.fields
-            ?.filter(isConnectionTypeDataField)
-            .filter((field) => field.required)
-            .map((field) => field.envVar) ?? [],
+          type.data?.fields?.filter(isConnectionTypeDataField).map((field) => field.envVar) ?? [],
         );
 
         return compatibleTypes.includes(CompatibleTypes.ModelServing);

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -14,9 +14,7 @@ export const useWatchConnectionTypes = (
   const callback = React.useCallback<
     FetchStateCallbackPromise<ConnectionTypeConfigMapObj[]>
   >(async () => {
-    const secrets = await fetchConnectionTypes();
-
-    let connectionTypes = secrets;
+    let connectionTypes = await fetchConnectionTypes();
     if (modelServingCompatible) {
       connectionTypes = connectionTypes.filter((type) => {
         const compatibleTypes = getCompatibleTypes(

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -1,6 +1,36 @@
-import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+import React from 'react';
+import {
+  ConnectionTypeConfigMapObj,
+  isConnectionTypeDataField,
+} from '~/concepts/connectionTypes/types';
+import { CompatibleTypes, getCompatibleTypes } from '~/concepts/connectionTypes/utils';
 import { fetchConnectionTypes } from '~/services/connectionTypesService';
-import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
 
-export const useWatchConnectionTypes = (): FetchState<ConnectionTypeConfigMapObj[]> =>
-  useFetchState<ConnectionTypeConfigMapObj[]>(fetchConnectionTypes, []);
+export const useWatchConnectionTypes = (
+  modelServingCompatible?: boolean,
+): FetchState<ConnectionTypeConfigMapObj[]> => {
+  const callback = React.useCallback<
+    FetchStateCallbackPromise<ConnectionTypeConfigMapObj[]>
+  >(async () => {
+    const secrets = await fetchConnectionTypes();
+
+    let connectionTypes = secrets;
+    if (modelServingCompatible) {
+      connectionTypes = connectionTypes.filter((type) => {
+        const compatibleTypes = getCompatibleTypes(
+          type.data?.fields
+            ?.filter(isConnectionTypeDataField)
+            .filter((field) => field.required)
+            .map((field) => field.envVar) ?? [],
+        );
+
+        return compatibleTypes.includes(CompatibleTypes.ModelServing);
+      });
+    }
+
+    return connectionTypes;
+  }, [modelServingCompatible]);
+
+  return useFetchState<ConnectionTypeConfigMapObj[]>(callback, []);
+};

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import {
-  ConnectionTypeConfigMapObj,
+  CompatibleTypes,
+  getCompatibleTypes,
   isConnectionTypeDataField,
-} from '~/concepts/connectionTypes/types';
-import { CompatibleTypes, getCompatibleTypes } from '~/concepts/connectionTypes/utils';
+} from '~/concepts/connectionTypes/utils';
 import { fetchConnectionTypes } from '~/services/connectionTypesService';
 import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13139

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Replaces the data connections section in the model serving modals with connection types. The existing connection has fairly similar behavior. The new connection options has the ability to create a new connection inline, 

Updated the single kserving modal and the modelmesh multi model modals.

![image](https://github.com/user-attachments/assets/4967db21-f801-4eb9-92d7-221c3fa19977)
![image](https://github.com/user-attachments/assets/da40857c-d524-4cb6-8577-928dbeb6f421)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Set disableConnectionTypes dev flag to false
2. either navigate to a project and open the "Models" details section OR go to `/modelServing` which is the "Model Serving" on the left nav bar
3. Make sure you have a runtime setup 
    -  (either single serving or multi. you can have 2 projects with each having one of them)
4. Edit or deploy a new model
    - Try various combinations of connections types and connection instances on the project

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Jest tests added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
