### PR TITLE
Update Model registry version selector on the details page title to show only active versions

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -24,7 +24,7 @@ import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 import { modelVersionDetails } from '~/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails';
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
 import { modelServingGlobal } from '~/__tests__/cypress/cypress/pages/modelServing';
-import { ModelRegistryMetadataType } from '~/concepts/modelRegistry/types';
+import { ModelRegistryMetadataType, ModelState } from '~/concepts/modelRegistry/types';
 
 const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
 const mockModelVersions = mockModelVersion({
@@ -170,6 +170,13 @@ const initIntercepts = () => {
           registeredModelId: '1',
           id: '2',
           name: 'Version 2',
+        }),
+        mockModelVersion({
+          author: 'Author 3',
+          registeredModelId: '1',
+          id: '3',
+          name: 'Version 3',
+          state: ModelState.ARCHIVED,
         }),
       ],
     }),
@@ -333,6 +340,7 @@ describe('Model version details', () => {
     it('Switching model versions', () => {
       modelVersionDetails.findVersionId().contains('1');
       modelVersionDetails.findModelVersionDropdownButton().click();
+      modelVersionDetails.findModelVersionDropdownItem('Version 3').should('not.exist');
       modelVersionDetails.findModelVersionDropdownSearch().fill('Version 2');
       modelVersionDetails.findModelVersionDropdownItem('Version 2').click();
       modelVersionDetails.findVersionId().contains('2');

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionSelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionSelector.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-core';
 import useModelVersionsByRegisteredModel from '~/concepts/modelRegistry/apiHooks/useModelVersionsByRegisteredModel';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
+import { filterLiveVersions } from '~/concepts/modelRegistry/utils';
 
 type ModelVersionSelectorProps = {
   rmId?: string;
@@ -33,8 +34,9 @@ const ModelVersionSelector: React.FC<ModelVersionSelectorProps> = ({
   const menuRef = React.useRef(null);
 
   const [modelVersions] = useModelVersionsByRegisteredModel(rmId);
+  const liveModelVersions = filterLiveVersions(modelVersions.items);
 
-  const menuListItems = modelVersions.items
+  const menuListItems = liveModelVersions
     .filter((item) => !input || item.name.toLowerCase().includes(input.toString().toLowerCase()))
     .map((mv, index) => (
       <MenuItem isSelected={mv.id === selection.id} itemId={mv.id} key={index}>
@@ -42,7 +44,7 @@ const ModelVersionSelector: React.FC<ModelVersionSelectorProps> = ({
       </MenuItem>
     ));
 
-  if (input && modelVersions.size === 0) {
+  if (input && liveModelVersions.length === 0) {
     menuListItems.push(
       <MenuItem isDisabled key="no result">
         No results found
@@ -75,7 +77,7 @@ const ModelVersionSelector: React.FC<ModelVersionSelectorProps> = ({
           </MenuSearchInput>
           <HelperText style={{ paddingTop: '0.5rem' }}>
             <HelperTextItem variant="indeterminate">
-              {`Type a name to search your ${modelVersions.size} versions.`}
+              {`Type a name to search your ${liveModelVersions.length} versions.`}
             </HelperTextItem>
           </HelperText>
         </MenuSearch>


### PR DESCRIPTION
Closes: [RHOAIENG-14705](https://issues.redhat.com/browse/RHOAIENG-14705)

## Description
This PR aims to update Model registry version selector on the details page title to show only active versions.

<img width="1501" alt="Screenshot 2024-10-21 at 9 13 30 PM" src="https://github.com/user-attachments/assets/7ab15075-b73c-427b-9fcf-a8eca405363f">


## How Has This Been Tested?
1. Go to the model registry
2. Create 2 versions - v1 and v2
3. Archive v2
4. Click on v1 to get into the details page
5. On the top right corner, you will only see v1 (active version)

## Test Impact
Added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
