### PR TITLE
Add feature flag for configuration parameters in Kserve modal

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -38,6 +38,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableAcceleratorProfiles: boolean;
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
+      disableServingRuntimeParams: boolean;
       disableConnectionTypes: boolean;
       disableStorageClasses: boolean;
       disableNIMModelServing: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -63,6 +63,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableAcceleratorProfiles: false,
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
+      disableServingRuntimeParams: true,
       disableConnectionTypes: true,
       disableStorageClasses: false,
       disableNIMModelServing: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -34,6 +34,7 @@ The following are a list of features that are supported, along with there defaul
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
+| disableServingRuntimeParams  | true    | Disables Serving Runtime params from the dashboard.                                                  |
 | disableConnectionTypes       | true    | Disables creating custom data connection types from the dashboard.                                   |
 | disableStorageClasses        | false    | Disables storage classes settings nav item from the dashboard.                                       |
 | disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.   

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -24,6 +24,7 @@ type MockDashboardConfigType = {
   disableTrustyBiasMetrics?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
+  disableServingRuntimeParams?: boolean;
   disableConnectionTypes?: boolean;
   disableStorageClasses?: boolean;
   disableNotebookController?: boolean;
@@ -54,6 +55,7 @@ export const mockDashboardConfig = ({
   disableTrustyBiasMetrics = false,
   disableDistributedWorkloads = false,
   disableModelRegistry = false,
+  disableServingRuntimeParams = true,
   disableConnectionTypes = true,
   disableStorageClasses = false,
   disableNotebookController = false,
@@ -161,6 +163,7 @@ export const mockDashboardConfig = ({
       disableAcceleratorProfiles,
       disableDistributedWorkloads,
       disableModelRegistry,
+      disableServingRuntimeParams,
       disableConnectionTypes,
       disableStorageClasses,
       disableNIMModelServing,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -26,6 +26,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableAcceleratorProfiles: false,
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
+  disableServingRuntimeParams: false,
   disableConnectionTypes: false,
   disableStorageClasses: false,
   disableNIMModelServing: true,
@@ -114,6 +115,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     featureFlags: ['disableModelRegistry'],
     requiredComponents: [StackComponent.MODEL_REGISTRY],
     requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
+  },
+  [SupportedArea.SERVING_RUNTIME_PARAMS]: {
+    featureFlags: ['disableServingRuntimeParams'],
+    reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.NIM_MODEL]: {
     featureFlags: ['disableNIMModelServing'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -61,6 +61,9 @@ export enum SupportedArea {
 
   /* Model Registry areas */
   MODEL_REGISTRY = 'model-registry',
+
+  /* Alter parameters areas */
+  SERVING_RUNTIME_PARAMS = 'serving-runtime-params',
 }
 
 /** Components deployed by the Operator. Part of the DSC Status. */

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1325,6 +1325,7 @@ export type DashboardCommonConfig = {
   disableAcceleratorProfiles: boolean;
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
+  disableServingRuntimeParams: boolean;
   disableConnectionTypes: boolean;
   disableStorageClasses: boolean;
   disableNIMModelServing: boolean;

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -138,6 +138,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
   const [alertVisible, setAlertVisible] = React.useState(true);
+  const servingRuntimeParamsEnabled = useIsAreaAvailable(
+    SupportedArea.SERVING_RUNTIME_PARAMS,
+  ).status;
 
   React.useEffect(() => {
     if (currentProjectName) {
@@ -403,6 +406,11 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   loadError={dataConnectionsLoadError}
                   dataConnections={dataConnections}
                 />
+              </FormSection>
+            )}
+            {servingRuntimeParamsEnabled && (
+              <FormSection title="Configuration parameters" id="configuration-params">
+                {/* TODO: enter the fields here */}
               </FormSection>
             )}
           </StackItem>

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -71,6 +71,8 @@ spec:
                       type: boolean
                     disableModelRegistry:
                       type: boolean
+                    disableServingRuntimeParams:
+                      type: boolean
                     disableConnectionTypes:
                       type: boolean
                     disableStorageClasses:

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -28,6 +28,7 @@ spec:
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: false
+    disableServingRuntimeParams: true
     disableConnectionTypes: true
     disableStorageClasses: false
     disableNIMModelServing: true


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Part of [RHOAIENG-14688](https://issues.redhat.com/browse/RHOAIENG-14688)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adding feature flag `disableServingRuntimeParams` to add "Configuration parameters" below "Source model location" `FormSection` to `ManageKserveModal` to unblock a part of the above ticket as well as [RHOAIENG-14689](https://issues.redhat.com/browse/RHOAIENG-14689) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Scale down `odh-dashboard` deployment pod.
2. Add the feature flag to `OdhDashboardConfig` CRD and to `odh-dashboard-config` in `opendatahub` namespace. You can switch the feature flag to false for testing this PR.
3. Switch `disableServingRuntimeParams` `true` and `false` and check whether you see "Configuration parameters" in the Kserve modal. You should see it when the feature flag is `false` and vice-versa

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Will add tests in a follow-up PR that adds fields within this FormSection

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
