### PR TITLE
Change the deprecated storage alert message

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -140,7 +140,7 @@ class ClusterStorage {
       .findByTestId('storage-class-deprecated-alert')
       .should(
         'contain.text',
-        'Warning alert:Deprecated storage classA storage class has been deprecated by your administrator, but the cluster storage using it is still active. If you want to migrate your data to a cluster storage instance using a different storage class, contact your administrator.',
+        'Warning alert:Deprecated storage classOne or more storage classes have been deprecated by your administrator, but the cluster storage instances using them remain active. If you want to migrate your data to a cluster storage instance using a different storage class, contact your administrator.',
       );
   }
 

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -61,9 +61,9 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
             />
           }
         >
-          A storage class has been deprecated by your administrator, but the cluster storage using
-          it is still active. If you want to migrate your data to a cluster storage instance using a
-          different storage class, contact your administrator.
+          One or more storage classes have been deprecated by your administrator, but the cluster
+          storage instances using them remain active. If you want to migrate your data to a cluster
+          storage instance using a different storage class, contact your administrator.
         </Alert>
       )}
       <Table


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-13457

## Description
Minor text change in deprecated storage alert message

<img width="1188" alt="Screenshot 2024-10-22 at 5 56 51 PM" src="https://github.com/user-attachments/assets/2e047f66-6c8a-4869-8b17-a91d8bb01e90">

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Create a DSP and assign multiple storage classes.
2. Disable at least 2 of the storage classes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
updated the existing cypress test
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
