### PR TITLE
RHOAIENG-14811 web-user-id for Sandbox is not correctly set.

### DIFF
--- a/backend/src/routes/api/groups-config/groupsConfigUtil.ts
+++ b/backend/src/routes/api/groups-config/groupsConfigUtil.ts
@@ -8,7 +8,7 @@ import {
   KubeFastifyInstance,
 } from '../../../types';
 import { getAllGroups, getGroupsCR, updateGroupsCR } from '../../../utils/groupsUtils';
-import { getUserInfo } from '../../../utils/userUtils';
+import { getUserName } from '../../../utils/userUtils';
 import { isUserAdmin } from '../../../utils/adminUtils';
 
 const SYSTEM_AUTHENTICATED = 'system:authenticated';
@@ -34,8 +34,8 @@ export const updateGroupsConfig = async (
   const { customObjectsApi } = fastify.kube;
   const { namespace } = fastify.kube;
 
-  const userInfo = await getUserInfo(fastify, request);
-  const isAdmin = await isUserAdmin(fastify, userInfo.userName, namespace);
+  const userName = await getUserName(fastify, request);
+  const isAdmin = await isUserAdmin(fastify, userName, namespace);
 
   if (!isAdmin) {
     const error = createError(403, 'Error updating groups, user needs to be admin');

--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -2,7 +2,7 @@ import { V1ContainerStatus, V1Pod, V1PodList } from '@kubernetes/client-node';
 import { FastifyRequest } from 'fastify';
 import { isHttpError } from '../../../utils';
 import { KubeFastifyInstance, Notebook, NotebookData } from '../../../types';
-import { getUserInfo } from '../../../utils/userUtils';
+import { getUserName } from '../../../utils/userUtils';
 import {
   createNotebook,
   generateNotebookNameFromUsername,
@@ -69,7 +69,7 @@ export const enableNotebook = async (
 ): Promise<Notebook> => {
   const notebookData = request.body;
   const { notebookNamespace } = getNamespaces(fastify);
-  const username = request.body.username || (await getUserInfo(fastify, request)).userName;
+  const username = request.body.username || (await getUserName(fastify, request));
   const name = generateNotebookNameFromUsername(username);
   const url = request.headers.origin;
 

--- a/backend/src/routes/api/status/adminAllowedUsers.ts
+++ b/backend/src/routes/api/status/adminAllowedUsers.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 import { KubeFastifyInstance } from '../../../types';
-import { getUserInfo } from '../../../utils/userUtils';
+import { getUserName } from '../../../utils/userUtils';
 import {
   getAdminUserList,
   getAllowedUserList,
@@ -66,8 +66,7 @@ export const getAllowedUsers = async (
   request: FastifyRequest<{ Params: { namespace: string } }>,
 ): Promise<AllowedUser[]> => {
   const { namespace } = request.params;
-  const userInfo = await getUserInfo(fastify, request);
-  const currentUser = userInfo.userName;
+  const currentUser = await getUserName(fastify, request);
   const isAdmin = await isUserAdmin(fastify, currentUser, namespace);
   if (!isAdmin) {
     // Privileged call -- return nothing

--- a/backend/src/routes/api/status/statusUtils.ts
+++ b/backend/src/routes/api/status/statusUtils.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 import { KubeFastifyInstance, KubeStatus } from '../../../types';
-import { getUserInfo } from '../../../utils/userUtils';
+import { getUserName } from '../../../utils/userUtils';
 import { createCustomError } from '../../../utils/requestUtils';
 import { isUserAdmin, isUserAllowed } from '../../../utils/adminUtils';
 import { isImpersonating } from '../../../devFlags';
@@ -19,7 +19,7 @@ export const status = async (
 
   const { server } = currentCluster;
 
-  const { userName, userID } = await getUserInfo(fastify, request);
+  const userName = await getUserName(fastify, request);
   const isAdmin = await isUserAdmin(fastify, userName, namespace);
   const isAllowed = isAdmin ? true : await isUserAllowed(fastify, userName);
 
@@ -37,7 +37,6 @@ export const status = async (
       currentUser,
       namespace,
       userName,
-      userID,
       clusterID,
       clusterBranding,
       isAdmin,

--- a/backend/src/utils/fileUtils.ts
+++ b/backend/src/utils/fileUtils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
 import { LOG_DIR } from './constants';
-import { getUserInfo } from './userUtils';
+import { getUserName } from './userUtils';
 import { getNamespaces } from './notebookUtils';
 import { isUserAdmin } from './adminUtils';
 
@@ -27,13 +27,13 @@ export const logRequestDetails = (
   };
 
   const writeLogAsync = async () => {
-    const userInfo = await getUserInfo(fastify, request);
+    const userName = await getUserName(fastify, request);
     const { dashboardNamespace } = getNamespaces(fastify);
-    const isAdmin = await isUserAdmin(fastify, userInfo.userName, dashboardNamespace);
+    const isAdmin = await isUserAdmin(fastify, userName, dashboardNamespace);
 
     writeAdminLog(fastify, {
       ...data,
-      user: userInfo.userName,
+      user: userName,
       isAdmin: isAdmin,
     });
   };

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -20,7 +20,7 @@ import {
   TolerationOperator,
   VolumeMount,
 } from '../types';
-import { getUserInfo, usernameTranslate } from './userUtils';
+import { getUserName, usernameTranslate } from './userUtils';
 import { createCustomError } from './requestUtils';
 import {
   PatchUtils,
@@ -389,7 +389,7 @@ export const stopNotebook = async (
     Body: NotebookData;
   }>,
 ): Promise<Notebook> => {
-  const username = request.body.username || (await getUserInfo(fastify, request)).userName;
+  const username = request.body.username || (await getUserName(fastify, request));
   const name = generateNotebookNameFromUsername(username);
   const { notebookNamespace } = getNamespaces(fastify);
 

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { getOpenshiftUser, getUserInfo, usernameTranslate } from './userUtils';
+import { getOpenshiftUser, getUserName, usernameTranslate } from './userUtils';
 import { createCustomError } from './requestUtils';
 import { isUserAdmin } from './adminUtils';
 import { getNamespaces } from './notebookUtils';
@@ -18,9 +18,9 @@ const testAdmin = async (
   request: OauthFastifyRequest,
   needsAdmin: boolean,
 ): Promise<boolean> => {
-  const userInfo = await getUserInfo(fastify, request);
+  const userName = await getUserName(fastify, request);
   const { dashboardNamespace } = getNamespaces(fastify);
-  const isAdmin = await isUserAdmin(fastify, userInfo.userName, dashboardNamespace);
+  const isAdmin = await isUserAdmin(fastify, userName, dashboardNamespace);
   if (isAdmin) {
     // User is an admin, pass to caller that we can bypass some logic
     return true;
@@ -29,7 +29,7 @@ const testAdmin = async (
   if (needsAdmin) {
     // Not an admin, route needs one -- reject
     fastify.log.error(
-      `A Non-Admin User (${userInfo.userName}) made a request against an endpoint that requires an admin.`,
+      `A Non-Admin User (${userName}) made a request against an endpoint that requires an admin.`,
     );
     throw createCustomError(
       'Not Admin',
@@ -68,8 +68,8 @@ const requestSecurityGuard = async (
   name?: string,
 ): Promise<void> => {
   const { notebookNamespace, dashboardNamespace } = getNamespaces(fastify);
-  const userInfo = await getUserInfo(fastify, request);
-  const translatedUsername = usernameTranslate(userInfo.userName);
+  const userName = await getUserName(fastify, request);
+  const translatedUsername = usernameTranslate(userName);
   const isReadRequest = request.method.toLowerCase() === 'get';
 
   // Check to see if a request was made against one of our namespaces
@@ -208,12 +208,12 @@ const handleSecurityOnRouteData = async (
     }
 
     // Not getting a resource, mutating something that is not verify-able theirs -- log the user encase of malicious behaviour
-    const userInfo = await getUserInfo(fastify, request);
+    const userName = await getUserName(fastify, request);
     const { dashboardNamespace } = getNamespaces(fastify);
-    const isAdmin = await isUserAdmin(fastify, userInfo.userName, dashboardNamespace);
+    const isAdmin = await isUserAdmin(fastify, userName, dashboardNamespace);
     fastify.log.warn(
       `${isAdmin ? 'Admin ' : ''}User
-      ${userInfo.userName} interacted with a resource that was not secure.`,
+      ${userName} interacted with a resource that was not secure.`,
     );
   }
 };

--- a/backend/src/utils/userUtils.ts
+++ b/backend/src/utils/userUtils.ts
@@ -89,27 +89,21 @@ export const getUser = async (
   }
 };
 
-export const getUserInfo = async (
+export const getUserName = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest,
-): Promise<{ userName: string; userID: string }> => {
+): Promise<string> => {
   const { currentUser } = fastify.kube;
 
   try {
     const userOauth = await getUser(fastify, request);
-    return {
-      userName: userOauth.metadata.name,
-      userID: userOauth.metadata.annotations?.['toolchain.dev.openshift.com/sso-user-id'],
-    };
+    return userOauth.metadata.name;
   } catch (e) {
     if (DEV_MODE) {
       if (isImpersonating()) {
-        return { userName: DEV_IMPERSONATE_USER ?? '', userID: undefined };
+        return DEV_IMPERSONATE_USER ?? '';
       }
-      return {
-        userName: (currentUser.username || currentUser.name).split('/')[0],
-        userID: undefined,
-      };
+      return (currentUser.username || currentUser.name).split('/')[0];
     }
     fastify.log.error(`Failed to retrieve username: ${errorHandler(e)}`);
     const error = createCustomError(

--- a/frontend/src/__mocks__/mockStatus.ts
+++ b/frontend/src/__mocks__/mockStatus.ts
@@ -12,6 +12,7 @@ export const mockStatus = (options?: {
     },
     namespace: 'opendatahub',
     userName: 'test-user',
+    userID: '1234',
     clusterID: '16855612-2bb7-4a4c-9ff0-72rasdfd5',
     clusterBranding: 'ocp',
     isAdmin: options?.isAdmin ?? false,

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -79,6 +79,7 @@ describe('AboutDialog', () => {
     dsciFetchStatus = [dsciStatus, true, undefined, () => Promise.resolve(dsciStatus)];
     userInfo = {
       username: 'test-user',
+      userID: '',
       isAdmin: false,
       isAllowed: true,
       userLoading: false,

--- a/frontend/src/concepts/analyticsTracking/useSegmentTracking.ts
+++ b/frontend/src/concepts/analyticsTracking/useSegmentTracking.ts
@@ -10,9 +10,8 @@ export const useSegmentTracking = (): void => {
   const { segmentKey, loaded, loadError } = useWatchSegmentKey();
   const { dashboardConfig } = useAppContext();
   const username = useAppSelector((state) => state.user);
-  const userID = useAppSelector((state) => state.userID);
   const clusterID = useAppSelector((state) => state.clusterID);
-  const [userProps, uPropsLoaded] = useTrackUser(username, userID);
+  const [userProps, uPropsLoaded] = useTrackUser(username);
   const disableTrackingConfig = dashboardConfig.spec.dashboardConfig.disableTracking;
 
   React.useEffect(() => {

--- a/frontend/src/concepts/analyticsTracking/useTrackUser.ts
+++ b/frontend/src/concepts/analyticsTracking/useTrackUser.ts
@@ -4,12 +4,9 @@ import { useAccessReview } from '~/api';
 import { AccessReviewResourceAttributes } from '~/k8sTypes';
 import { IdentifyEventProperties } from '~/concepts/analyticsTracking/trackingProperties';
 
-export const useTrackUser = (
-  username?: string,
-  ssoUserID?: string,
-): [IdentifyEventProperties, boolean] => {
-  const { isAdmin } = useUser();
-  const [userID, setUserID] = React.useState<string | undefined>(ssoUserID);
+export const useTrackUser = (username?: string): [IdentifyEventProperties, boolean] => {
+  const { isAdmin, userID } = useUser();
+  const [finalUserID, setUserID] = React.useState<string | undefined>(userID);
 
   const createReviewResource: AccessReviewResourceAttributes = {
     group: 'project.openshift.io',
@@ -29,7 +26,7 @@ export const useTrackUser = (
       return aId;
     };
 
-    if (!ssoUserID) {
+    if (!userID) {
       computeAnonymousUserId().then((val) => {
         setUserID(val);
       });
@@ -42,10 +39,10 @@ export const useTrackUser = (
     () => ({
       isAdmin,
       canCreateProjects: allowCreate,
-      userID,
+      userID: finalUserID,
     }),
-    [isAdmin, allowCreate, userID],
+    [isAdmin, allowCreate, finalUserID],
   );
 
-  return [props, acLoaded && !!userID];
+  return [props, acLoaded && !!finalUserID];
 };

--- a/frontend/src/pages/projects/screens/projects/__tests__/EmptyProjects.spec.tsx
+++ b/frontend/src/pages/projects/screens/projects/__tests__/EmptyProjects.spec.tsx
@@ -22,6 +22,7 @@ jest.mock('react-router-dom', () => ({
 const useUserMock = jest.mocked(useUser);
 useUserMock.mockReturnValue({
   username: 'test-user',
+  userID: '1234',
   isAdmin: false,
   isAllowed: true,
   userLoading: false,

--- a/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
@@ -65,6 +65,7 @@ useAppContextMock.mockReturnValue({
 const useUserMock = jest.mocked(useUser);
 useUserMock.mockReturnValue({
   username: 'test-user',
+  userID: '1234',
   isAdmin: false,
   isAllowed: true,
   userLoading: false,

--- a/frontend/src/redux/actions/actions.ts
+++ b/frontend/src/redux/actions/actions.ts
@@ -12,6 +12,7 @@ export const getUserPending = (): GetUserAction => ({
 export const getUserFulfilled = (response: StatusResponse): GetUserAction => ({
   type: Actions.GET_USER_FULFILLED,
   payload: {
+    userId: response.kube.userID,
     user: response.kube.userName,
     clusterID: response.kube.clusterID,
     clusterBranding: response.kube.clusterBranding,

--- a/frontend/src/redux/reducers/appReducer.ts
+++ b/frontend/src/redux/reducers/appReducer.ts
@@ -24,6 +24,7 @@ const appReducer = (state: AppState = initialState, action: GetUserAction): AppS
       return {
         ...state,
         user: action.payload.user,
+        userID: action.payload.userId,
         userLoading: false,
         userError: null,
         clusterID: action.payload.clusterID,

--- a/frontend/src/redux/selectors/types.ts
+++ b/frontend/src/redux/selectors/types.ts
@@ -1,5 +1,6 @@
 export type UserState = {
   username: string;
+  userID: string;
   isAdmin: boolean;
   isAllowed: boolean;
   userLoading: boolean;

--- a/frontend/src/redux/selectors/user.ts
+++ b/frontend/src/redux/selectors/user.ts
@@ -5,6 +5,7 @@ import { UserState } from './types';
 
 const getUser = (state: AppState): UserState => ({
   username: state.user ?? '', // TODO: alternative?
+  userID: state.userID ?? '',
   isAdmin: !!state.isAdmin,
   isAllowed: !!state.isAllowed,
   userLoading: state.userLoading,

--- a/frontend/src/redux/types.ts
+++ b/frontend/src/redux/types.ts
@@ -26,6 +26,7 @@ export interface GetUserAction {
   type: string;
   payload: {
     user?: string;
+    userId?: string;
     clusterID?: string;
     serverURL?: string;
     clusterBranding?: string;
@@ -65,6 +66,7 @@ export type StatusResponse = {
     };
     namespace: string;
     userName: string;
+    userID: string;
     clusterID: string;
     clusterBranding: string;
     isAdmin: boolean;

--- a/frontend/src/utilities/__tests__/useDetectUser.spec.ts
+++ b/frontend/src/utilities/__tests__/useDetectUser.spec.ts
@@ -29,6 +29,7 @@ describe('useDetectUser', () => {
         },
         namespace: 'myNamespace',
         userName: 'John Doe',
+        userID: '1234',
         clusterID: 'myClusterID',
         clusterBranding: 'My Cluster',
         isAdmin: true,


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-14811
We now get the userID from the status api endpoint if set. 
This reverts parts of RHOAIENG-9480/PR #3107

## Description

The previous code assumes that the (sso/web-)userId is passed in an annotation in the 
get user object. This seems not be true in the real world. The underlying Kube is exposing
that id in the response to the /status call

The code reverts the try to fetch from the annotation and instead takes it from the Kube
object if present .

## How Has This Been Tested?

Manual test in dev-mode running `npm run start:dev:ext` against an instance on Dev-Sandbox and a non-Sandbox one.

Then looking at the console output for the the Identify event

```
Identify event triggered: {... "userID":"b09067a69...99"}
```

If the userID looks like this (whith chars) it is an anonymous one. If it is numeric (may be negative) and short (probably < 8 digits), then it is a web-user-id. 

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)


After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


cc @andrewballantyne 