### PR TITLE
change connection types annotation from enabled to disabled

### DIFF
--- a/frontend/src/__mocks__/mockConnectionType.ts
+++ b/frontend/src/__mocks__/mockConnectionType.ts
@@ -42,7 +42,7 @@ export const mockConnectionTypeConfigMapObj = ({
     annotations: {
       'openshift.io/display-name': displayName,
       'openshift.io/description': description,
-      'opendatahub.io/enabled': enabled ? 'true' : 'false',
+      'opendatahub.io/disabled': enabled ? 'false' : 'true',
       'opendatahub.io/username': username || '',
     },
     ...(preInstalled

--- a/frontend/src/concepts/connectionTypes/createConnectionTypeUtils.ts
+++ b/frontend/src/concepts/connectionTypes/createConnectionTypeUtils.ts
@@ -14,7 +14,7 @@ export const extractConnectionTypeFromMap = (
   k8sName: configMap?.metadata.name ?? '',
   name: configMap?.metadata.annotations?.['openshift.io/display-name'] ?? '',
   description: configMap?.metadata.annotations?.['openshift.io/description'] ?? '',
-  enabled: configMap?.metadata.annotations?.['opendatahub.io/enabled'] === 'true',
+  enabled: configMap?.metadata.annotations?.['opendatahub.io/disabled'] !== 'true',
   username: configMap?.metadata.annotations?.['opendatahub.io/username'] ?? '',
   fields: configMap?.data?.fields ?? [],
   category: configMap?.data?.category ?? [],
@@ -36,7 +36,7 @@ export const createConnectionTypeObj = (
     annotations: {
       'openshift.io/display-name': displayName,
       'openshift.io/description': description,
-      'opendatahub.io/enabled': enabled ? 'true' : 'false',
+      'opendatahub.io/disabled': enabled ? 'false' : 'true',
       'opendatahub.io/username': username,
     },
     labels: { 'opendatahub.io/dashboard': 'true', 'opendatahub.io/connection-type': 'true' },

--- a/frontend/src/concepts/connectionTypes/types.ts
+++ b/frontend/src/concepts/connectionTypes/types.ts
@@ -115,7 +115,7 @@ export type ConnectionTypeConfigMap = K8sResourceCommon & {
   metadata: {
     name: string;
     annotations?: DisplayNameAnnotations & {
-      'opendatahub.io/enabled'?: 'true' | 'false';
+      'opendatahub.io/disabled'?: 'true' | 'false';
       'opendatahub.io/username'?: string;
     };
     labels: DashboardLabels & {

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -221,4 +221,4 @@ export const filterEnabledConnectionTypes = <
 >(
   connectionTypes: T[],
 ): T[] =>
-  connectionTypes.filter((t) => t.metadata.annotations?.['opendatahub.io/enabled'] === 'true');
+  connectionTypes.filter((t) => t.metadata.annotations?.['opendatahub.io/disabled'] !== 'true');

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -43,7 +43,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
   const notification = useNotification();
   const [isUpdating, setIsUpdating] = React.useState(false);
   const [isEnabled, setIsEnabled] = React.useState(
-    () => obj.metadata.annotations?.['opendatahub.io/enabled'] === 'true',
+    () => obj.metadata.annotations?.['opendatahub.io/disabled'] !== 'true',
   );
   const createdDate = obj.metadata.creationTimestamp
     ? new Date(obj.metadata.creationTimestamp)
@@ -78,10 +78,6 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
         setIsUpdating(false);
       });
   };
-
-  React.useEffect(() => {
-    setIsEnabled(obj.metadata.annotations?.['opendatahub.io/enabled'] === 'true');
-  }, [obj.metadata.annotations]);
 
   const compatibleTypes = getCompatibleTypes(
     obj.data?.fields

--- a/frontend/src/services/connectionTypesService.ts
+++ b/frontend/src/services/connectionTypesService.ts
@@ -70,9 +70,9 @@ export const updateConnectionTypeEnabled = (
     });
   }
   patch.push({
-    op: connectionType.metadata.annotations?.['opendatahub.io/enabled'] ? 'replace' : 'add',
-    path: '/metadata/annotations/opendatahub.io~1enabled',
-    value: String(enabled),
+    op: connectionType.metadata.annotations?.['opendatahub.io/disabled'] ? 'replace' : 'add',
+    path: '/metadata/annotations/opendatahub.io~1disabled',
+    value: String(!enabled),
   });
 
   return axios


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14749

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Replaces annotation `opendatahub.io/enabled` with the inverse `opendatahub.io/disabled`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Enable the connection type feature flag: `disableConnectionType`
- Navigate to `Settings -> Connection types`
- Create and edit various connection types. Set the enabled checkbox to checked and unchecked.
- Use the toggle button in the connection types list to toggle the enabled state.
- Navigate to a project via the project list page.
- Go to the `Connections` tab.
- Create a new connection. Observe that only the enabled connections are present.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Existing tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
