### PR TITLE
Update menus to include a divider for separating delete actions

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/experiment/ArchivedExperimentTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ArchivedExperimentTable.tsx
@@ -29,6 +29,7 @@ const ArchivedExperimentTable: React.FC<ArchivedExperimentTableProps> = ({ ...ba
               setIsRestoreModalOpen(true);
             },
           },
+          { isSeparator: true },
           {
             title: 'Delete',
             isDisabled: experiment.display_name === 'Default',

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRow.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRow.tsx
@@ -197,6 +197,7 @@ const RoleBindingPermissionsTableRow: React.FC<RoleBindingPermissionsTableRowPro
                     onEdit();
                   },
                 },
+                { isSeparator: true },
                 {
                   title: 'Delete',
                   onClick: () => {

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow.tsx
@@ -68,6 +68,7 @@ const AcceleratorProfilesTableRow: React.FC<AcceleratorProfilesTableRowType> = (
               onClick: () =>
                 navigate(`/acceleratorProfiles/edit/${acceleratorProfile.metadata.name}`),
             },
+            { isSeparator: true },
             {
               title: 'Delete',
               onClick: () => handleDelete(acceleratorProfile),

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationRow.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationRow.tsx
@@ -27,6 +27,7 @@ const TolerationRow: React.FC<TolerationRowProps> = ({ toleration, onEdit, onDel
               title: 'Edit',
               onClick: () => onEdit(toleration),
             },
+            { isSeparator: true },
             {
               title: 'Delete',
               onClick: () => onDelete(toleration),

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -154,6 +154,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
               title: 'Duplicate',
               onClick: () => navigate(`/connectionTypes/duplicate/${obj.metadata.name}`),
             },
+            { isSeparator: true },
             {
               title: 'Delete',
               onClick: () => handleDelete(obj),

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -95,6 +95,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
                 title: 'Duplicate',
                 onClick: () => onDuplicate({ ...row, name: `Copy of ${row.name}` }),
               },
+              { isSeparator: true },
               {
                 title: 'Remove',
                 onClick: () => setShowRemoveField(true),
@@ -191,6 +192,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
                   },
                 ]
               : []),
+            { isSeparator: true },
             {
               title: 'Remove',
               onClick: () => setShowRemoveField(true),

--- a/frontend/src/pages/modelRegistry/screens/ModelPropertiesTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelPropertiesTableRow.tsx
@@ -181,6 +181,7 @@ const ModelPropertiesTableRow: React.FC<ModelPropertiesTableRowProps> = ({
               popperProps={{ direction: 'up' }}
               items={[
                 { title: 'Edit', onClick: onEditClick, isDisabled: isSavingEdits },
+                { isSeparator: true },
                 { title: 'Delete', onClick: onDeleteClick, isDisabled: isSavingEdits },
               ]}
             />

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, DropdownList, MenuToggle, DropdownItem } from '@patternfly/react-core';
+import { Dropdown, DropdownList, MenuToggle, DropdownItem, Divider } from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
@@ -61,6 +61,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
           >
             Deploy
           </DropdownItem>
+          <Divider key="separator" />
           <DropdownItem
             isAriaDisabled={hasDeployment}
             id="archive-version-button"

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -51,6 +51,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
           title: 'Deploy',
           onClick: () => setIsDeployModalOpen(true),
         },
+        { isSeparator: true },
         {
           title: 'Archive model version',
           onClick: () => setIsArchiveModalOpen(true),

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -51,19 +51,24 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
         }
       },
     },
-    isArchiveRow
-      ? {
-          title: 'Restore model',
-          onClick: () => setIsRestoreModalOpen(true),
-        }
-      : {
-          title: 'Archive model',
-          onClick: () => setIsArchiveModalOpen(true),
-          isAriaDisabled: hasDeploys,
-          tooltipProps: hasDeploys
-            ? { content: 'Models with deployed versions cannot be archived.' }
-            : undefined,
-        },
+    ...(isArchiveRow
+      ? [
+          {
+            title: 'Restore model',
+            onClick: () => setIsRestoreModalOpen(true),
+          },
+        ]
+      : [
+          { isSeparator: true },
+          {
+            title: 'Archive model',
+            onClick: () => setIsArchiveModalOpen(true),
+            isAriaDisabled: hasDeploys,
+            tooltipProps: hasDeploys
+              ? { content: 'Models with deployed versions cannot be archived.' }
+              : undefined,
+          },
+        ]),
   ];
 
   return (

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
@@ -68,6 +68,7 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
                 title: 'View database configuration',
                 onClick: () => setIsDatabaseConfigModalOpen(true),
               },
+              { isSeparator: true },
               {
                 title: 'Delete model registry',
                 onClick: () => setIsDeleteModalOpen(true),

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -126,6 +126,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
                         onEditInferenceService(inferenceService);
                       },
                     },
+                    { isSeparator: true },
                   ]),
               {
                 title: 'Delete',

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationTableRow.tsx
@@ -51,6 +51,7 @@ const BiasConfigurationTableRow: React.FC<BiasConfigurationTableRowProps> = ({
                   onCloneConfiguration(obj);
                 },
               },
+              { isSeparator: true },
               {
                 title: 'Delete',
                 onClick: () => {

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
@@ -176,6 +176,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
                 : []),
               ...(allowDelete
                 ? [
+                    { isSeparator: true },
                     {
                       title: 'Delete model server',
                       onClick: () => onDeleteServingRuntime(obj),

--- a/frontend/src/pages/projects/notebook/NotebookActionsColumn.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookActionsColumn.tsx
@@ -30,6 +30,7 @@ export const NotebookActionsColumn: React.FC<Props> = ({
             );
           },
         },
+        { isSeparator: true },
         {
           title: 'Delete workbench',
           onClick: () => {

--- a/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, DropdownItem, MenuToggle, DropdownList } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, MenuToggle, DropdownList, Divider } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { getDashboardMainContainer } from '~/utilities/utils';
 import { AccessReviewResourceAttributes, ProjectKind } from '~/k8sTypes';
@@ -68,9 +68,12 @@ const ProjectActions: React.FC<Props> = ({ project }) => {
           </DropdownItem>
         ) : null}
         {canDelete ? (
-          <DropdownItem data-testid="delete-project-action" onClick={() => setDeleteOpen(true)}>
-            Delete project
-          </DropdownItem>
+          <>
+            <Divider />
+            <DropdownItem data-testid="delete-project-action" onClick={() => setDeleteOpen(true)}>
+              Delete project
+            </DropdownItem>
+          </>
         ) : null}
       </DropdownList>
     </Dropdown>

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
@@ -41,6 +41,7 @@ const ConnectionsTable: React.FC<ConnectionsTableProps> = ({
                   setManageConnectionModal(connection);
                 },
               },
+              { isSeparator: true },
               {
                 title: 'Delete',
                 onClick: () => {

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
@@ -50,6 +50,7 @@ const DataConnectionsTableRow: React.FC<DataConnectionsTableRowProps> = ({
               onEditDataConnection(obj);
             },
           },
+          { isSeparator: true },
           {
             title: 'Delete data connection',
             onClick: () => {

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -63,6 +63,7 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
   ];
 
   if (!isRootVolume) {
+    actions.push({ isSeparator: true });
     actions.push({
       title: 'Delete storage',
       onClick: () => {

--- a/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
@@ -166,6 +166,7 @@ export const ConnectionsFormSection: React.FC<Props> = ({
                     setManageConnectionModal({ connection, isEdit: true });
                   },
                 },
+                { isSeparator: true },
                 {
                   title: 'Detach',
                   onClick: () => {


### PR DESCRIPTION
Closes [RHOAIENG-13971](https://issues.redhat.com/browse/RHOAIENG-13971)

## Description
Adds a menu separator before destructive actions in menus.

## How Has This Been Tested?
Menus with destructive actions:
- Experiments
- Role bindings
- Accelerator profiles
- Tolerations
- Connection types
- Connection type fields
- Connection type sections
- Models
- Model versions (header in details page)
- Model versions (in table)
- Registered models
- Model registries
- Inference services
- Bias configurations
- Serving runtimes
- Notebooks
- Projects
- Connections
- Data connections
- Cluster storage
- Notebook spawner - Detach a connection

## Test Impact
No test impact

## Sample screen shot

![image](https://github.com/user-attachments/assets/5b9c10bf-538a-44d5-a3a5-81d696b8ccf5)


![image](https://github.com/user-attachments/assets/f7ac0ff5-fc00-4d24-8798-1f2faf79f29b)


## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

/cc @simrandhaliw 