### PR TITLE
fix validation error markers when dnd field row

### DIFF
--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -86,9 +86,8 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
             <Tbody {...tableProps.tbodyProps}>
               {rowsToRender.map(({ data: row, rowProps }, index) => (
                 <ManageConnectionTypeFieldsTableRow
-                  key={index}
+                  key={rowProps.id}
                   row={row}
-                  rowIndex={index}
                   fields={fields}
                   onEdit={() => {
                     setModalField({

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -17,7 +17,6 @@ import { ValidationErrorCodes } from '~/concepts/connectionTypes/validationUtils
 
 type Props = {
   row: ConnectionTypeField;
-  rowIndex: number;
   fields: ConnectionTypeField[];
   onEdit: () => void;
   onRemove: () => void;
@@ -29,7 +28,6 @@ type Props = {
 
 const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   row,
-  rowIndex,
   fields,
   onEdit,
   onRemove,
@@ -39,6 +37,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
   onChange,
   ...props
 }) => {
+  const rowIndex = React.useMemo(() => fields.findIndex((f) => f === row), [fields, row]);
   const { hasValidationIssue } = React.useContext(ValidationContext);
   const showMoveToSection = React.useMemo(() => {
     const parentSection = fields.findLast(

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
@@ -25,7 +25,6 @@ const renderRow = (
           onEdit={fn}
           onMoveToSection={fn}
           id="test"
-          rowIndex={0}
           {...props}
         />
       </tbody>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-13664

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

If multiple connection type fields have the same env var name, then an error will appear in the field row adjacent to the env var name. During DnD of the fields, the error marker incorrectly jumps to another row because while dragging the index of the field is changing however the index of the validation error is not. Therefore the two get out of sync.

The fix is to compute the index of the row from the original field set so that the index aligns with the indicies of the validation error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- enable connection types feature using the `disableConnectionTypes` feature flag
- navigate to `Settings -> Connection types`
- create a connection type
- add multiple fields and sections
- add two fields with the same env var name
- observe the two fields have error markers in the field row
- drag various fields to reorder

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
