### PR TITLE
enable edit form submit button only when form is dirty

### DIFF
--- a/frontend/src/__mocks__/mockConnectionType.ts
+++ b/frontend/src/__mocks__/mockConnectionType.ts
@@ -308,7 +308,9 @@ const mockFields: ConnectionTypeField[] = [
     description: 'Test boolean',
     envVar: 'boolean_1',
     required: false,
-    properties: {},
+    properties: {
+      label: 'Input label',
+    },
   },
   {
     type: 'boolean',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -106,6 +106,7 @@ describe('duplicate', () => {
   it('Prefill details from existing connection', () => {
     createConnectionTypePage.visitDuplicatePage('existing');
 
+    createConnectionTypePage.findSubmitButton().should('be.enabled');
     createConnectionTypePage
       .findConnectionTypeName()
       .should(
@@ -190,6 +191,8 @@ describe('edit', () => {
     );
     createConnectionTypePage.visitEditPage('existing');
 
+    createConnectionTypePage.findSubmitButton().should('be.disabled');
+
     createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'header1');
     createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'field1');
     createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'field2');
@@ -205,6 +208,8 @@ describe('edit', () => {
     createConnectionTypePage.getFieldsTableRow(0).findName().should('contain.text', 'field2');
     createConnectionTypePage.getFieldsTableRow(1).findName().should('contain.text', 'field1');
     createConnectionTypePage.getFieldsTableRow(2).findName().should('contain.text', 'header1');
+
+    createConnectionTypePage.findSubmitButton().should('be.enabled');
   });
 
   it('Move field to section modal', () => {

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
@@ -4,6 +4,7 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { SectionField } from '~/concepts/connectionTypes/types';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
 
 type Props = {
   field?: SectionField;
@@ -13,9 +14,12 @@ type Props = {
 };
 
 const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit, isEdit }) => {
-  const [name, setName] = React.useState(field?.name || '');
-  const [description, setDescription] = React.useState(field?.description || '');
-
+  const [data, setData] = useGenericObjectState({
+    name: field?.name || '',
+    description: field?.description || '',
+  });
+  const canSubmit = React.useRef(data).current !== data || !isEdit;
+  const { name, description } = data;
   const isValid = name.length > 0;
 
   return (
@@ -34,7 +38,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit,
               onClose();
             }
           }}
-          isSubmitDisabled={!isValid}
+          isSubmitDisabled={!canSubmit || !isValid}
           alertTitle=""
         />
       }
@@ -62,7 +66,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit,
             id="section-name"
             data-testid="section-name"
             value={name}
-            onChange={(_e, value) => setName(value)}
+            onChange={(_e, value) => setData('name', value)}
           />
         </FormGroup>
         <FormGroup
@@ -84,7 +88,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit,
             id="section-description"
             data-testid="section-description"
             value={description}
-            onChange={(_e, value) => setDescription(value)}
+            onChange={(_e, value) => setData('description', value)}
           />
         </FormGroup>
       </Form>

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -72,6 +72,10 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
   const { data: connectionNameDesc, onDataChange: setConnectionNameDesc } =
     useK8sNameDescriptionFieldData({ initialData: prefill });
 
+  const isDataDirty = React.useRef(data).current !== data;
+  const isNameDirty = React.useRef(connectionNameDesc).current !== connectionNameDesc;
+  const canSubmit = isDataDirty || isNameDirty || !isEdit;
+
   const categoryItems = React.useMemo<SelectionOptions[]>(
     () =>
       category
@@ -209,7 +213,7 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
                 })
               }
               onCancel={onCancel}
-              isSaveDisabled={!isValid}
+              isSaveDisabled={!canSubmit || !isValid}
               saveButtonLabel={isEdit ? 'Save' : 'Create'}
             />
           </PageSection>

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
@@ -263,4 +263,27 @@ describe('ConnectionTypeDataFieldModal', () => {
 
     expect(screen.queryByTestId('envvar-conflict-warning')).not.toBeInTheDocument();
   });
+
+  it('should not be able to submit until form is dirty', () => {
+    const field: ShortTextField = {
+      type: 'short-text',
+      name: 'test',
+      envVar: 'test_envvar',
+      properties: {},
+    };
+    render(
+      <ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} isEdit field={field} />,
+    );
+
+    const submitButton = screen.getByTestId('modal-submit-button');
+    const fieldNameInput = screen.getByTestId('field-name-input');
+
+    expect(submitButton).toBeDisabled();
+
+    act(() => {
+      fireEvent.change(fieldNameInput, { target: { value: 'new-field' } });
+    });
+
+    expect(submitButton).not.toBeDisabled();
+  });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14750

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates the connection type form, along with section and data field modals. When entering these forms through an edit scenario, the form submit button will remain disabled until the form becomes dirty. Dirty is a simple computation in that as soon as any value changes, the form is considered dirty. However returning back to the original value will still be considered dirty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- enable connection types feature flag 'disableConnectionTypes'
- navigate to `Settings -> Connection types'

Connection type:
- create a connection type
- observe the submit button is disabled until the form is valid
- complete the connection type and save
- edit the connection type
- observe the submit button is disabled
- modify any value or add a section or field
- observe the submit button is enabled
- save the changes
- duplicate the connection type
- observe the submit button is enabled

Section:
- while editing or creating a connection type
- add a new section
- observe the submit button is disabled until the form is valid
- save the section
- edit the section
- observe the submit button is disabled
- modify any value 
- observe the submit button is enabled
- save the changes
- duplicate the section
- observe the submit button is enabled

Data field:
- while editing or creating a connection type
- add a new field
- observe the submit button is disabled until the form is valid
- save the field
- edit the field
- observe the submit button is disabled
- modify any value 
- observe the submit button is enabled
- save the changes
- duplicate the field
- observe the submit button is enabled

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated existing tests and added new tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
