### PR TITLE
Allow users to start/stop notebooks when related image is deleted

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -129,6 +129,10 @@ class NotebookRow extends TableRow {
     return this;
   }
 
+  findNotebookImageAvailability() {
+    return cy.findByTestId('notebook-image-availability');
+  }
+
   shouldHaveClusterStorageTitle() {
     this.findExpansion()
       .findByTestId('notebook-storage-bar-title')

--- a/frontend/src/pages/projects/notebook/NotebookStateAction.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateAction.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
-import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
-import useNotebookImage from '~/pages/projects/screens/detail/notebooks/useNotebookImage';
 import { NotebookState } from './types';
 
 type Props = {
@@ -12,13 +10,9 @@ type Props = {
 };
 
 const NotebookStateAction: React.FC<Props> = ({ notebookState, onStart, onStop, isDisabled }) => {
-  const { notebook, isStarting, isRunning, isStopping } = notebookState;
-  const [notebookImage] = useNotebookImage(notebook);
+  const { isStarting, isRunning, isStopping } = notebookState;
 
-  const actionDisabled =
-    isDisabled ||
-    isStopping ||
-    (notebookImage?.imageAvailability === NotebookImageAvailability.DELETED && !isRunning);
+  const actionDisabled = isDisabled || isStopping;
 
   return isStarting || isRunning ? (
     <Button


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-14134](https://issues.redhat.com/browse/RHOAIENG-14134)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Simply remove the detection of image availability to unblock users from starting with a deleted notebook image.
<img width="1512" alt="Screenshot 2024-10-23 at 1 14 11 PM" src="https://github.com/user-attachments/assets/fec88708-f3d0-4615-8027-7096a0da0816">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Import a custom image in the settings page
2. Create a workbench with that image
3. Stop the workbench
4. Delete the custom image you created at step 1
5. Go back to the workbench list, and make sure you can still click the start button. (You will definitely get an error when starting, though)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a cypress test case to verify the button is enabled even when the notebook image is deleted.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
