### PR TITLE
Cluster storage modal

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -234,7 +234,7 @@ class CreateSpawnerPage {
     cy.findByTestId('persistent-storage-group')
       .findByRole('button', { name: 'Typeahead menu toggle' })
       .click();
-    cy.get('[id="dashboard-page-main"]').findByRole('option', { name }).click();
+    cy.get('[id="dashboard-page-main"]').contains('button.pf-v5-c-menu__item', name).click();
   }
 
   selectPVSize(name: string) {

--- a/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { Form, Modal, Stack, StackItem } from '@patternfly/react-core';
+import { PersistentVolumeClaimKind } from '~/k8sTypes';
+import CreateNewStorageSection from '~/pages/projects/screens/spawner/storage/CreateNewStorageSection';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import usePreferredStorageClass from '~/pages/projects/screens/spawner/storage/usePreferredStorageClass';
+import useDefaultStorageClass from '~/pages/projects/screens/spawner/storage/useDefaultStorageClass';
+import { useCreateStorageObject } from '~/pages/projects/screens/spawner/storage/utils';
+import { CreatingStorageObject } from '~/pages/projects/types';
+
+export type BaseStorageModalProps = {
+  submitLabel?: string;
+  title?: string;
+  description?: string;
+  children: React.ReactNode;
+  isValid: boolean;
+  onSubmit: (data: CreatingStorageObject) => Promise<void>;
+  existingData?: PersistentVolumeClaimKind;
+  onClose: (submitted: boolean) => void;
+};
+
+const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
+  existingData,
+  onSubmit,
+  submitLabel = 'Add storage',
+  title = 'Add cluster storage',
+  description = 'Add storage and optionally connect it with an existing workbench.',
+  children,
+  isValid,
+  onClose,
+}) => {
+  const [createData, setCreateData, resetData] = useCreateStorageObject(existingData);
+  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
+  const preferredStorageClass = usePreferredStorageClass();
+  const [defaultStorageClass] = useDefaultStorageClass();
+  const [error, setError] = React.useState<Error | undefined>();
+  const [actionInProgress, setActionInProgress] = React.useState(false);
+  React.useEffect(() => {
+    if (!existingData) {
+      if (isStorageClassesAvailable) {
+        setCreateData('storageClassName', defaultStorageClass?.metadata.name);
+      } else {
+        setCreateData('storageClassName', preferredStorageClass?.metadata.name);
+      }
+    }
+  }, [
+    isStorageClassesAvailable,
+    defaultStorageClass,
+    preferredStorageClass,
+    existingData,
+    setCreateData,
+  ]);
+
+  const onBeforeClose = (submitted: boolean) => {
+    onClose(submitted);
+    setError(undefined);
+    setActionInProgress(false);
+    resetData();
+  };
+
+  const canCreate = !actionInProgress && createData.nameDesc.name.trim().length > 0 && isValid;
+
+  const submit = () => {
+    setError(undefined);
+    setActionInProgress(true);
+
+    onSubmit(createData)
+      .then(() => onBeforeClose(true))
+      .catch((err) => {
+        setError(err);
+        setActionInProgress(false);
+      });
+  };
+
+  return (
+    <Modal
+      title={title}
+      description={description}
+      variant="medium"
+      isOpen
+      onClose={() => onBeforeClose(false)}
+      showClose
+      footer={
+        <DashboardModalFooter
+          submitLabel={submitLabel}
+          onSubmit={submit}
+          onCancel={() => onBeforeClose(false)}
+          isSubmitDisabled={!canCreate}
+          error={error}
+          alertTitle="Error creating storage"
+        />
+      }
+    >
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        <Stack hasGutter>
+          <StackItem>
+            <CreateNewStorageSection
+              data={createData}
+              setData={setCreateData}
+              currentSize={existingData?.status?.capacity?.storage}
+              autoFocusName
+              disableStorageClassSelect={!!existingData}
+            />
+          </StackItem>
+          {children}
+        </Stack>
+      </Form>
+    </Modal>
+  );
+};
+
+export default BaseStorageModal;

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import { StackItem } from '@patternfly/react-core';
+import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
+import { CreatingStorageObject, ForNotebookSelection, StorageData } from '~/pages/projects/types';
+import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
+import { attachNotebookPVC, createPvc, removeNotebookPVC, restartNotebook, updatePvc } from '~/api';
+import {
+  ConnectedNotebookContext,
+  useRelatedNotebooks,
+} from '~/pages/projects/notebook/useRelatedNotebooks';
+import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import NotebookRestartAlert from '~/pages/projects/components/NotebookRestartAlert';
+import StorageNotebookConnections from '~/pages/projects/notebook/StorageNotebookConnections';
+import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksRestart';
+import BaseStorageModal from './BaseStorageModal';
+import ExistingConnectedNotebooks from './ExistingConnectedNotebooks';
+
+type ClusterStorageModalProps = {
+  existingData?: PersistentVolumeClaimKind;
+  onClose: (submit: boolean) => void;
+};
+
+const ClusterStorageModal: React.FC<ClusterStorageModalProps> = (props) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const namespace = currentProject.metadata.name;
+  const [removedNotebooks, setRemovedNotebooks] = React.useState<string[]>([]);
+  const [notebookData, setNotebookData] = React.useState<ForNotebookSelection>({
+    name: '',
+    mountPath: { value: '', error: '' },
+  });
+  const { notebooks: connectedNotebooks } = useRelatedNotebooks(
+    ConnectedNotebookContext.EXISTING_PVC,
+    props.existingData?.metadata.name,
+  );
+  const { notebooks: relatedNotebooks } = useRelatedNotebooks(
+    ConnectedNotebookContext.REMOVABLE_PVC,
+    props.existingData?.metadata.name,
+  );
+
+  const hasExistingNotebookConnections = relatedNotebooks.length > 0;
+
+  const {
+    notebooks: removableNotebooks,
+    loaded: removableNotebookLoaded,
+    error: removableNotebookError,
+  } = useRelatedNotebooks(
+    ConnectedNotebookContext.REMOVABLE_PVC,
+    props.existingData?.metadata.name,
+  );
+
+  const restartNotebooks = useWillNotebooksRestart([...removedNotebooks, notebookData.name]);
+
+  const handleSubmit = async (
+    storageData: StorageData['creating'],
+    attachNotebookData?: ForNotebookSelection,
+    dryRun?: boolean,
+  ) => {
+    const promises: Promise<PersistentVolumeClaimKind | NotebookKind>[] = [];
+    const { existingData } = props;
+
+    if (existingData) {
+      const pvcName = existingData.metadata.name;
+
+      // Check if PVC needs to be updated (name, description, size, storageClass)
+      if (
+        getDisplayNameFromK8sResource(existingData) !== storageData.nameDesc.name ||
+        getDescriptionFromK8sResource(existingData) !== storageData.nameDesc.description ||
+        existingData.spec.resources.requests.storage !== storageData.size ||
+        existingData.spec.storageClassName !== storageData.storageClassName
+      ) {
+        promises.push(updatePvc(storageData, existingData, namespace, { dryRun }));
+      }
+
+      // Restart notebooks if the PVC size has changed
+      if (existingData.spec.resources.requests.storage !== storageData.size) {
+        connectedNotebooks.map((connectedNotebook) =>
+          promises.push(restartNotebook(connectedNotebook.metadata.name, namespace, { dryRun })),
+        );
+      }
+
+      // Remove connections to notebooks that were removed
+      if (removedNotebooks.length > 0) {
+        promises.push(
+          ...removedNotebooks.map((nM) => removeNotebookPVC(nM, namespace, pvcName, { dryRun })),
+        );
+      }
+
+      await Promise.all(promises);
+
+      if (attachNotebookData?.name) {
+        await attachNotebookPVC(
+          attachNotebookData.name,
+          namespace,
+          pvcName,
+          attachNotebookData.mountPath.value,
+          {
+            dryRun,
+          },
+        );
+      }
+      return;
+    }
+    // Create new PVC if it doesn't exist
+    const createdPvc = await createPvc(storageData, namespace, { dryRun });
+
+    // Attach the new PVC to a notebook if specified
+    if (attachNotebookData?.name) {
+      await attachNotebookPVC(
+        attachNotebookData.name,
+        namespace,
+        createdPvc.metadata.name,
+        attachNotebookData.mountPath.value,
+        { dryRun },
+      );
+    }
+  };
+
+  const submit = async (data: CreatingStorageObject) => {
+    const storageData: CreatingStorageObject = {
+      nameDesc: data.nameDesc,
+      size: data.size,
+      storageClassName: data.storageClassName,
+    };
+
+    return handleSubmit(storageData, notebookData, true).then(() =>
+      handleSubmit(storageData, notebookData, false),
+    );
+  };
+
+  const hasValidNotebookRelationship = notebookData.name
+    ? !!notebookData.mountPath.value && !notebookData.mountPath.error
+    : true;
+
+  const isValid = hasValidNotebookRelationship;
+
+  return (
+    <BaseStorageModal
+      {...props}
+      onSubmit={(data) => submit(data)}
+      title={props.existingData ? 'Update cluster storage' : 'Add cluster storage'}
+      description={
+        props.existingData
+          ? 'Make changes to cluster storage, or connect it to additional workspaces.'
+          : 'Add storage and optionally connect it with an existing workbench.'
+      }
+      submitLabel={props.existingData ? 'Update' : 'Add storage'}
+      isValid={isValid}
+      onClose={(submitted) => props.onClose(submitted)}
+    >
+      <>
+        {hasExistingNotebookConnections && (
+          <StackItem>
+            <ExistingConnectedNotebooks
+              connectedNotebooks={removableNotebooks}
+              onNotebookRemove={(notebook: NotebookKind) =>
+                setRemovedNotebooks([...removedNotebooks, notebook.metadata.name])
+              }
+              loaded={removableNotebookLoaded}
+              error={removableNotebookError}
+            />
+          </StackItem>
+        )}
+        <StackItem>
+          <StorageNotebookConnections
+            setForNotebookData={(forNotebookData) => {
+              setNotebookData(forNotebookData);
+            }}
+            forNotebookData={notebookData}
+            connectedNotebooks={connectedNotebooks}
+          />
+        </StackItem>
+        {restartNotebooks.length !== 0 && (
+          <StackItem>
+            <NotebookRestartAlert notebooks={restartNotebooks} />
+          </StackItem>
+        )}
+      </>
+    </BaseStorageModal>
+  );
+};
+
+export default ClusterStorageModal;

--- a/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageList.tsx
@@ -9,7 +9,7 @@ import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import StorageTable from './StorageTable';
-import ManageStorageModal from './ManageStorageModal';
+import ClusterStorageModal from './ClusterStorageModal';
 
 const StorageList: React.FC = () => {
   const [isOpen, setOpen] = React.useState(false);
@@ -73,10 +73,10 @@ const StorageList: React.FC = () => {
         ) : null}
       </DetailsSection>
       {isOpen ? (
-        <ManageStorageModal
-          onClose={(submit: boolean) => {
+        <ClusterStorageModal
+          onClose={(submitted) => {
             setOpen(false);
-            if (submit) {
+            if (submitted) {
               refresh();
             }
           }}

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -8,8 +8,8 @@ import { getStorageClassConfig } from '~/pages/storageClasses/utils';
 import useStorageClasses from '~/concepts/k8s/useStorageClasses';
 import StorageTableRow from './StorageTableRow';
 import { columns } from './data';
-import ManageStorageModal from './ManageStorageModal';
 import { StorageTableData } from './types';
+import ClusterStorageModal from './ClusterStorageModal';
 
 type StorageTableProps = {
   pvcs: PersistentVolumeClaimKind[];
@@ -86,7 +86,7 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
         )}
       />
       {editPVC ? (
-        <ManageStorageModal
+        <ClusterStorageModal
           existingData={editPVC}
           onClose={(updated) => {
             if (updated) {

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -22,12 +22,23 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const [storages, loaded, loadError] = useProjectPvcs(currentProject.metadata.name);
 
+  const selectDescription = (size: string, description?: string) => (
+    <div>
+      <div>Size: {size}</div>
+      {description && <div>Description: {description}</div>}
+    </div>
+  );
+
   const selectOptions = React.useMemo(
     () =>
       loaded
         ? storages.map((pvc) => ({
             value: pvc.metadata.name,
             content: getDisplayNameFromK8sResource(pvc),
+            description: selectDescription(
+              pvc.spec.resources.requests.storage,
+              pvc.metadata.annotations?.['openshift.io/description'],
+            ),
           }))
         : [],
     [loaded, storages],
@@ -44,7 +55,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
   let placeholderText: string;
 
   if (!loaded) {
-    placeholderText = 'Loading storages...';
+    placeholderText = 'Loading storages';
   } else if (storages.length === 0) {
     placeholderText = 'No existing storages available';
   } else {
@@ -66,6 +77,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
         noOptionsFoundMessage={(filter) => `No persistent storage was found for "${filter}"`}
         popperProps={{ direction: selectDirection, appendTo: menuAppendTo }}
         isDisabled={!loaded || storages.length === 0}
+        data-testid="persistent-storage-typeahead"
       />
     </FormGroup>
   );

--- a/frontend/src/pages/projects/screens/spawner/storage/AttachExistingStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AttachExistingStorageModal.tsx
@@ -1,0 +1,78 @@
+import { Form, Modal, Stack, StackItem } from '@patternfly/react-core';
+import React from 'react';
+import { ExistingStorageObject, MountPath } from '~/pages/projects/types';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import SpawnerMountPathField from './SpawnerMountPathField';
+import AddExistingStorageField from './AddExistingStorageField';
+
+type AttachExistingStorageModalData = ExistingStorageObject & {
+  mountPath: MountPath;
+};
+
+type AttachExistingStorageModalProps = {
+  onClose: (submit: boolean, storageData?: AttachExistingStorageModalData) => void;
+};
+
+const initialState: AttachExistingStorageModalData = {
+  storage: '',
+  mountPath: { value: '', error: '' },
+};
+
+const AttachExistingStorageModal: React.FC<AttachExistingStorageModalProps> = ({ onClose }) => {
+  const [data, setData] = React.useState<AttachExistingStorageModalData>(initialState);
+
+  const onBeforeClose = (submitted: boolean, storageData?: AttachExistingStorageModalData) => {
+    onClose(submitted, storageData);
+    setData(initialState);
+  };
+
+  const isValid =
+    data.mountPath.value.length > 0 &&
+    data.mountPath.value !== '/' &&
+    !data.mountPath.error &&
+    data.storage.trim() !== '';
+
+  return (
+    <Modal
+      title="Attach Existing Storage"
+      variant="medium"
+      onClose={() => onBeforeClose(false)}
+      showClose
+      isOpen
+      footer={
+        <DashboardModalFooter
+          submitLabel="Attach storage"
+          onSubmit={() => onBeforeClose(true, data)}
+          onCancel={() => onBeforeClose(false)}
+          isSubmitDisabled={!isValid}
+          alertTitle="Error creating storage"
+        />
+      }
+    >
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onBeforeClose(true, data);
+        }}
+      >
+        <Stack hasGutter>
+          <StackItem>
+            <AddExistingStorageField
+              data={data}
+              setData={(storageName) => setData({ ...data, storage: storageName.storage })}
+            />
+          </StackItem>
+          <StackItem>
+            <SpawnerMountPathField
+              isCreate
+              mountPath={data.mountPath}
+              onChange={(path) => setData({ ...data, mountPath: path })}
+            />
+          </StackItem>
+        </Stack>
+      </Form>
+    </Modal>
+  );
+};
+
+export default AttachExistingStorageModal;

--- a/frontend/src/pages/projects/screens/spawner/storage/SpawnerMountPathField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/SpawnerMountPathField.tsx
@@ -1,0 +1,184 @@
+import {
+  Flex,
+  FlexItem,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  InputGroupText,
+  Radio,
+  Stack,
+  StackItem,
+  TextInput,
+} from '@patternfly/react-core';
+import React from 'react';
+import FieldGroupHelpLabelIcon from '~/components/FieldGroupHelpLabelIcon';
+import { useMountPathFormat, validateMountPath } from './utils';
+import { MountPathFormat } from './types';
+import { MOUNT_PATH_PREFIX } from './const';
+
+interface MountPath {
+  value: string;
+  error: string;
+}
+
+interface SpawnerMountPathFieldProps {
+  isCreate: boolean;
+  mountPath: MountPath;
+  inUseMountPaths?: string[];
+  onChange: (path: MountPath) => void;
+}
+
+const SpawnerMountPathField: React.FC<SpawnerMountPathFieldProps> = ({
+  isCreate,
+  mountPath,
+  inUseMountPaths,
+  onChange,
+}) => {
+  const [format, setFormat] = useMountPathFormat(isCreate, mountPath.value);
+  const [shouldShowValidation, setShouldShowValidation] = React.useState(false);
+
+  const pathSuffix = React.useMemo(() => {
+    const prefix = format === MountPathFormat.STANDARD ? MOUNT_PATH_PREFIX : '/';
+    return mountPath.value.startsWith(prefix)
+      ? mountPath.value.slice(prefix.length)
+      : mountPath.value;
+  }, [mountPath.value, format]);
+
+  React.useEffect(() => {
+    const initialValue = format === MountPathFormat.STANDARD ? MOUNT_PATH_PREFIX : '/';
+    onChange({ value: initialValue, error: '' });
+    // Only run on initial mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const validateAndUpdate = React.useCallback(
+    (suffix: string, newFormat: MountPathFormat = format) => {
+      const prefix = newFormat === MountPathFormat.STANDARD ? MOUNT_PATH_PREFIX : '/';
+      const newValue = `${prefix}${suffix}`;
+
+      // Only validate after the field has been touched
+      if (!shouldShowValidation && !suffix.trim()) {
+        onChange({ value: newValue, error: '' });
+        return;
+      }
+
+      const error = validateMountPath(suffix, inUseMountPaths || [], newFormat);
+      onChange({ value: newValue, error });
+    },
+    [format, inUseMountPaths, onChange, shouldShowValidation],
+  );
+
+  const handleFormatChange = (newFormat: MountPathFormat) => {
+    setFormat(newFormat);
+    validateAndUpdate(pathSuffix, newFormat);
+  };
+
+  const handleSuffixChange = (suffix: string) => {
+    if (!shouldShowValidation) {
+      setShouldShowValidation(true);
+    }
+    validateAndUpdate(suffix);
+  };
+
+  return (
+    <FormGroup
+      label="Mount path"
+      fieldId="mount-path"
+      isRequired
+      labelIcon={
+        <FieldGroupHelpLabelIcon
+          content={
+            <>
+              The directory within a container where a volume is mounted and accessible. Only
+              standard paths that begin with <b>{MOUNT_PATH_PREFIX}</b> are visible in the
+              JupyterLab file browser.
+            </>
+          }
+        />
+      }
+    >
+      <Stack hasGutter>
+        {isCreate ? (
+          <>
+            <StackItem>
+              <Flex>
+                <FlexItem>
+                  <Radio
+                    id="mount-path-radio-standard"
+                    label="Standard path"
+                    name="mount-path-format-radio"
+                    value={MountPathFormat.STANDARD}
+                    isChecked={format === MountPathFormat.STANDARD}
+                    onChange={() => handleFormatChange(MountPathFormat.STANDARD)}
+                  />
+                </FlexItem>
+                <FlexItem>
+                  <Radio
+                    id="mount-path-radio-custom"
+                    label="Custom path"
+                    name="mount-path-format-radio"
+                    value={MountPathFormat.CUSTOM}
+                    isChecked={format === MountPathFormat.CUSTOM}
+                    onChange={() => handleFormatChange(MountPathFormat.CUSTOM)}
+                  />
+                </FlexItem>
+              </Flex>
+            </StackItem>
+            <StackItem>
+              <InputGroup>
+                <InputGroupText id="path-prefix" aria-label="Mount path prefix">
+                  {format === MountPathFormat.STANDARD ? MOUNT_PATH_PREFIX : '/'}
+                </InputGroupText>
+                <InputGroupItem isFill>
+                  <TextInput
+                    id="mount-path-input"
+                    data-testid="mount-path-folder-value"
+                    aria-label="Mount path suffix"
+                    type="text"
+                    value={pathSuffix}
+                    onChange={(_, value) => handleSuffixChange(value)}
+                    isRequired
+                    validated={
+                      mountPath.error ? 'error' : pathSuffix.length > 0 ? 'success' : 'default'
+                    }
+                  />
+                </InputGroupItem>
+              </InputGroup>
+              <HelperText>
+                <HelperTextItem
+                  variant={mountPath.error ? 'error' : 'indeterminate'}
+                  data-testid="mount-path-folder-helper-text"
+                >
+                  {mountPath.error ||
+                    'Must only consist of lowercase letters, dashes, and slashes.'}
+                </HelperTextItem>
+                {format === MountPathFormat.CUSTOM && (
+                  <HelperTextItem variant="warning" hasIcon>
+                    Depending on the workbench type, this location may not be visible or accessible.
+                    For example, the JupyterLab file browser only displays folders and files under
+                    /opt/app-root/src
+                  </HelperTextItem>
+                )}
+              </HelperText>
+            </StackItem>
+          </>
+        ) : (
+          <StackItem>
+            <TextInput
+              isRequired
+              isDisabled
+              value={mountPath.value}
+              onChange={(_, value) => onChange({ value, error: mountPath.error })}
+              id="mount-path"
+              data-testid="mount-path-input"
+            />
+          </StackItem>
+        )}
+      </Stack>
+    </FormGroup>
+  );
+};
+
+export default SpawnerMountPathField;

--- a/frontend/src/pages/projects/screens/spawner/storage/WorkbenchStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/WorkbenchStorageModal.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { StackItem } from '@patternfly/react-core';
+import { PersistentVolumeClaimKind } from '~/k8sTypes';
+import { CreatingStorageObject, MountPath } from '~/pages/projects/types';
+import BaseStorageModal from '~/pages/projects/screens/detail/storage/BaseStorageModal';
+import SpawnerMountPathField from './SpawnerMountPathField';
+
+type WorkbenchStorageModalProps = {
+  existingData?: PersistentVolumeClaimKind;
+  onClose: (submit: boolean) => void;
+};
+
+const WorkbenchStorageModal: React.FC<WorkbenchStorageModalProps> = (props) => {
+  const [mountPath, setMountPath] = React.useState<MountPath>({
+    value: '',
+    error: '',
+  });
+  const [actionInProgress, setActionInProgress] = React.useState(false);
+
+  //TODO: handleSubmit function to be completed in RHOAIENG-1101
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleSubmit = async (createData: CreatingStorageObject) => {
+    setActionInProgress(true);
+  };
+
+  const isValid =
+    !actionInProgress &&
+    mountPath.error === '' &&
+    mountPath.value.length > 0 &&
+    mountPath.value !== '/';
+
+  return (
+    <BaseStorageModal
+      {...props}
+      onSubmit={(createData) => handleSubmit(createData)}
+      title={props.existingData ? 'Edit storage' : 'Create storage'}
+      submitLabel={props.existingData ? 'Save' : 'Create'}
+      isValid={isValid}
+    >
+      <StackItem>
+        <SpawnerMountPathField
+          isCreate
+          mountPath={mountPath}
+          onChange={(path) => setMountPath(path)}
+        />
+      </StackItem>
+    </BaseStorageModal>
+  );
+};
+
+export default WorkbenchStorageModal;

--- a/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
@@ -1,0 +1,192 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  useCreateStorageObject,
+  useMountPathFormat,
+  validateMountPath,
+} from '~/pages/projects/screens/spawner/storage/utils';
+import { MountPathFormat } from '~/pages/projects/screens/spawner/storage/types';
+import { MOUNT_PATH_PREFIX } from '~/pages/projects/screens/spawner/storage/const';
+import { PersistentVolumeClaimKind } from '~/k8sTypes';
+
+jest.mock('~/pages/projects/screens/spawner/storage/useDefaultPvcSize.ts', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue('1Gi'), // Set the default PVC size to 1Gi
+}));
+
+jest.mock('~/concepts/k8s/utils', () => ({
+  getDisplayNameFromK8sResource: jest.fn(
+    (data) => data?.metadata.annotations?.['openshift.io/display-name'] || '',
+  ),
+  getDescriptionFromK8sResource: jest.fn(
+    (data) => data?.metadata.annotations?.['openshift.io/description'] || '',
+  ),
+}));
+
+describe('useCreateStorageObject', () => {
+  const existingData: PersistentVolumeClaimKind = {
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaim',
+    metadata: {
+      annotations: {
+        'openshift.io/description': 'Test PVC Description',
+        'openshift.io/display-name': 'test-pvc',
+      },
+      labels: { 'opendatahub.io/dashboard': 'true' },
+      name: 'test-pvc',
+      namespace: 'namespace',
+    },
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      resources: { requests: { storage: '2Gi' } },
+      volumeMode: 'Filesystem',
+      storageClassName: 'test-storage-class',
+    },
+    status: { phase: 'Pending' },
+  };
+  it('should initialize with default values when no existingData is provided', () => {
+    const { result } = renderHook(() => useCreateStorageObject());
+
+    const [data] = result.current;
+    expect(data).toEqual({
+      nameDesc: { name: '', k8sName: undefined, description: '' },
+      size: '1Gi',
+    });
+  });
+
+  it('should initialize with existingData when provided', () => {
+    const { result } = renderHook(() => useCreateStorageObject(existingData));
+
+    const [data] = result.current;
+    expect(data.nameDesc.name).toBe('test-pvc');
+    expect(data.nameDesc.description).toBe('Test PVC Description');
+    expect(data.size).toBe('2Gi');
+    expect(data.storageClassName).toBe('test-storage-class');
+  });
+
+  it('should reset to default values when resetDefaults is called', () => {
+    const { result } = renderHook(() => useCreateStorageObject(existingData));
+    const [, , resetDefaults] = result.current;
+
+    act(() => {
+      resetDefaults();
+    });
+
+    const [data] = result.current;
+    expect(data.nameDesc.name).toBe('');
+    expect(data.nameDesc.description).toBe('');
+    expect(data.size).toBe('1Gi'); // Default size from mock
+    expect(data.storageClassName).toBeUndefined();
+  });
+});
+
+describe('validateMountPath', () => {
+  const inUseMountPaths = ['/existing-folder', '/another-folder'];
+
+  it('should return error message for empty value in CUSTOM format', () => {
+    const result = validateMountPath('', inUseMountPaths, MountPathFormat.CUSTOM);
+    expect(result).toBe(
+      'Enter a path to a model or folder. This path cannot point to a root folder.',
+    );
+  });
+
+  it('should not return an error for empty value in STANDARD format', () => {
+    const result = validateMountPath('', inUseMountPaths, MountPathFormat.STANDARD);
+    expect(result).toBe('');
+  });
+
+  it('should return error message for invalid characters in the path', () => {
+    const result = validateMountPath('Invalid/Path', inUseMountPaths, MountPathFormat.STANDARD);
+    expect(result).toBe('Must only consist of lowercase letters, dashes, and slashes.');
+  });
+
+  it('should return error message for already in-use mount path', () => {
+    const result = validateMountPath('existing-folder', inUseMountPaths, MountPathFormat.STANDARD);
+    expect(result).toBe('Mount folder is already in use for this workbench.');
+  });
+
+  it('should return an empty string for valid and unused mount path', () => {
+    const result = validateMountPath('new-folder', inUseMountPaths, MountPathFormat.STANDARD);
+    expect(result).toBe('');
+  });
+
+  it('should allow valid folder name with a trailing slash', () => {
+    const result = validateMountPath('valid-folder/', inUseMountPaths, MountPathFormat.STANDARD);
+    expect(result).toBe('');
+  });
+
+  it('should return error for an invalid folder name with numbers or uppercase letters', () => {
+    const result = validateMountPath('Invalid123', inUseMountPaths, MountPathFormat.STANDARD);
+    expect(result).toBe('Must only consist of lowercase letters, dashes, and slashes.');
+  });
+
+  it('should return an empty string for valid mount path in CUSTOM format', () => {
+    const result = validateMountPath('custom-folder', inUseMountPaths, MountPathFormat.CUSTOM);
+    expect(result).toBe('');
+  });
+
+  it('should return error for an invalid folder name with uppercase letters in CUSTOM format', () => {
+    const result = validateMountPath('InvalidFolder', inUseMountPaths, MountPathFormat.CUSTOM);
+    expect(result).toBe('Must only consist of lowercase letters, dashes, and slashes.');
+  });
+});
+
+describe('useMountPathFormat', () => {
+  it('return MountPathFormat.STANDARD if isCreate is true', () => {
+    const { result } = renderHook(() => useMountPathFormat(true, 'some-path'));
+
+    const [format] = result.current;
+    expect(format).toBe(MountPathFormat.STANDARD);
+  });
+
+  it('return MountPathFormat.STANDARD if mountPath starts with /opt/app-root/src/', () => {
+    const { result } = renderHook(() =>
+      useMountPathFormat(false, `${MOUNT_PATH_PREFIX}/some-path`),
+    );
+
+    const [format] = result.current;
+    expect(format).toBe(MountPathFormat.STANDARD);
+  });
+
+  it('return MountPathFormat.CUSTOM if mountPath does not start with /opt/app-root/src/', () => {
+    const { result } = renderHook(() => useMountPathFormat(false, '/custom-path'));
+
+    const [format] = result.current;
+    expect(format).toBe(MountPathFormat.CUSTOM);
+  });
+
+  it('should update format based on the mountPath change', () => {
+    const { result, rerender } = renderHook(
+      ({ isCreate, mountPath }) => useMountPathFormat(isCreate, mountPath),
+      {
+        initialProps: { isCreate: false, mountPath: '/custom-path' },
+      },
+    );
+
+    // Initial format
+    expect(result.current[0]).toBe(MountPathFormat.CUSTOM);
+
+    // Change the mountPath to a path with MOUNT_PATH_PREFIX
+    rerender({ isCreate: false, mountPath: `${MOUNT_PATH_PREFIX}/new-path` });
+
+    // Format should update to STANDARD
+    expect(result.current[0]).toBe(MountPathFormat.STANDARD);
+  });
+
+  it('should not update format if isCreate is true, regardless of mountPath', () => {
+    const { result, rerender } = renderHook(
+      ({ isCreate, mountPath }) => useMountPathFormat(isCreate, mountPath),
+      {
+        initialProps: { isCreate: true, mountPath: '/custom-path' },
+      },
+    );
+
+    // Initial format
+    expect(result.current[0]).toBe(MountPathFormat.STANDARD);
+
+    // Change the mountPath but keep isCreate true
+    rerender({ isCreate: true, mountPath: `${MOUNT_PATH_PREFIX}/new-path` });
+
+    // Format should remain STANDARD
+    expect(result.current[0]).toBe(MountPathFormat.STANDARD);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/storage/const.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/const.ts
@@ -1,0 +1,1 @@
+export const MOUNT_PATH_PREFIX = '/opt/app-root/src/';

--- a/frontend/src/pages/projects/screens/spawner/storage/types.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/types.ts
@@ -1,0 +1,4 @@
+export enum MountPathFormat {
+  STANDARD = 'standard',
+  CUSTOM = 'custom',
+}

--- a/frontend/src/pages/projects/screens/spawner/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/utils.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  CreatingStorageObject,
   CreatingStorageObjectForNotebook,
   ExistingStorageObjectForNotebook,
   StorageData,
@@ -15,6 +16,46 @@ import useGenericObjectState from '~/utilities/useGenericObjectState';
 import { getRootVolumeName } from '~/pages/projects/screens/spawner/spawnerUtils';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import useDefaultPvcSize from './useDefaultPvcSize';
+import { MountPathFormat } from './types';
+import { MOUNT_PATH_PREFIX } from './const';
+
+export const useCreateStorageObject = (
+  existingData?: PersistentVolumeClaimKind,
+): [
+  data: CreatingStorageObject,
+  setData: UpdateObjectAtPropAndValue<CreatingStorageObject>,
+  resetDefaults: () => void,
+] => {
+  const size = useDefaultPvcSize();
+  const createDataState = useGenericObjectState<CreatingStorageObject>({
+    nameDesc: {
+      name: '',
+      k8sName: undefined,
+      description: '',
+    },
+    size,
+  });
+
+  const [, setCreateData] = createDataState;
+
+  const existingName = existingData ? getDisplayNameFromK8sResource(existingData) : '';
+  const existingDescription = existingData ? getDescriptionFromK8sResource(existingData) : '';
+  const existingSize = existingData ? existingData.spec.resources.requests.storage : size;
+  const existingStorageClassName = existingData?.spec.storageClassName;
+
+  React.useEffect(() => {
+    if (existingName) {
+      setCreateData('nameDesc', {
+        name: existingName,
+        description: existingDescription,
+      });
+      setCreateData('size', existingSize);
+      setCreateData('storageClassName', existingStorageClassName);
+    }
+  }, [existingName, existingDescription, setCreateData, existingSize, existingStorageClassName]);
+
+  return createDataState;
+};
 
 export const useCreateStorageObjectForNotebook = (
   existingData?: PersistentVolumeClaimKind,
@@ -112,4 +153,58 @@ export const useStorageDataObject = (
       storage: getRootVolumeName(notebook),
     },
   });
+};
+
+// Returns the initial mount path format based on the isCreate and mountPath props.
+export const useMountPathFormat = (
+  isCreate: boolean,
+  mountPath: string,
+): [MountPathFormat, React.Dispatch<React.SetStateAction<MountPathFormat>>] => {
+  const getInitialFormat = React.useCallback(() => {
+    if (isCreate) {
+      return MountPathFormat.STANDARD;
+    }
+    return mountPath.startsWith(MOUNT_PATH_PREFIX)
+      ? MountPathFormat.STANDARD
+      : MountPathFormat.CUSTOM;
+  }, [isCreate, mountPath]);
+
+  const [format, setFormat] = React.useState(getInitialFormat);
+
+  React.useEffect(() => {
+    if (!isCreate) {
+      const newFormat = mountPath.startsWith(MOUNT_PATH_PREFIX)
+        ? MountPathFormat.STANDARD
+        : MountPathFormat.CUSTOM;
+      setFormat(newFormat);
+    }
+  }, [isCreate, mountPath]);
+
+  return [format, setFormat] as const;
+};
+
+// Validates the mount path for a storage object.
+export const validateMountPath = (
+  value: string,
+  inUseMountPaths: string[],
+  format: MountPathFormat,
+): string => {
+  if (value.length === 0 && format === MountPathFormat.CUSTOM) {
+    return 'Enter a path to a model or folder. This path cannot point to a root folder.';
+  }
+
+  // Regex to allow empty string for Standard format
+  const regex =
+    format === MountPathFormat.STANDARD
+      ? /^(\/?[a-z-]+(\/[a-z-]+)*\/?|)$/
+      : /^(\/?[a-z-]+(\/[a-z-]+)*\/?)$/;
+
+  if (!regex.test(value)) {
+    return 'Must only consist of lowercase letters, dashes, and slashes.';
+  }
+
+  if (inUseMountPaths.includes(`/${value}`)) {
+    return 'Mount folder is already in use for this workbench.';
+  }
+  return '';
 };


### PR DESCRIPTION
[RHOAIENG-7681](https://issues.redhat.com/browse/RHOAIENG-7681)

## Description
Added `BaseStorageModal` which defines the structure and functionality of the Create/Edit storage modal.

Two sub-models are created taking `BaseStorageModal` as base.
* `WorkbenchStorageModal` to create/edit cluster storage in Spawner.
* `ClusterStorageModal` to create/edit cluster storage in Storage section under projects page.

Create storage modal: Updated the ManageStorageModal:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/49c1e65f-6f9f-44b7-bf48-0a5f51fec604">

Attach storage modal: 
<img width="894" alt="image" src="https://github.com/user-attachments/assets/6b0896a0-bd17-4fbd-9053-cf9e2d54a5d2">


Working of cluster storage modal (will be same as the old one):

https://github.com/user-attachments/assets/8fe94c26-f872-4724-b37d-1970e661b280



## How Has This Been Tested?
Workbench modal:
1. Uncomment the code in SpawnerPage.tsx from lines 244 to 275.
2. Open the spawner page in the dashboard. You will find two new buttons added in the Cluster Storage section.
3. Try creating and attaching cluster storage. You can check the console log for the output.

Cluster Storage modal:
1. Open the Storage section in the project page. 
2. Try creating or editing the cluster storage.

## Test Impact
Added unit tests for utility and hook functions.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@xianli123