### PR TITLE
create preview modal for connection types

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -1,4 +1,5 @@
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 import { TableRow } from './components/table';
 import { TableToolbar } from './components/TableToolbar';
 import { Contextual } from './components/Contextual';
@@ -258,5 +259,12 @@ class ConnectionTypesPage {
   }
 }
 
+class ConnectionTypePreviewModal extends Modal {
+  constructor() {
+    super('Preview connection');
+  }
+}
+
 export const connectionTypesPage = new ConnectionTypesPage();
 export const createConnectionTypePage = new CreateConnectionTypePage();
+export const connectionTypePreviewModal = new ConnectionTypePreviewModal();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
@@ -3,7 +3,10 @@ import {
   asProductAdminUser,
   asProjectAdminUser,
 } from '~/__tests__/cypress/cypress/utils/mockUsers';
-import { connectionTypesPage } from '~/__tests__/cypress/cypress/pages/connectionTypes';
+import {
+  connectionTypePreviewModal,
+  connectionTypesPage,
+} from '~/__tests__/cypress/cypress/pages/connectionTypes';
 import { mockDashboardConfig } from '~/__mocks__';
 import {
   mockConnectionTypeConfigMap,
@@ -81,6 +84,11 @@ describe('Connection types', () => {
     row2.shouldShowPreInstalledLabel();
     row2.shouldBeDisabled();
     row2.shouldHaveModelServingCompatibility();
+
+    row2.findKebabAction('Preview').click();
+    connectionTypePreviewModal.shouldBeOpen();
+    connectionTypePreviewModal.findCloseButton().click();
+    connectionTypePreviewModal.shouldBeOpen(false);
   });
 
   it('should delete connection type', () => {

--- a/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import {
   Flex,
   FlexItem,
-  Form,
   FormGroup,
   FormSection,
   MenuToggleStatus,
-  Title,
   Truncate,
 } from '@patternfly/react-core';
 import ConnectionTypeFormFields from '~/concepts/connectionTypes/fields/ConnectionTypeFormFields';
@@ -138,8 +136,7 @@ const ConnectionTypeForm: React.FC<Props> = ({
   );
 
   return (
-    <Form>
-      {isPreview && <Title headingLevel="h1">Add connection</Title>}
+    <>
       <FormGroup label="Connection type" fieldId="connection-type" isRequired>
         <TypeaheadSelect
           id="connection-type"
@@ -207,7 +204,7 @@ const ConnectionTypeForm: React.FC<Props> = ({
           />
         </FormSection>
       )}
-    </Form>
+    </>
   );
 };
 

--- a/frontend/src/concepts/connectionTypes/ConnectionTypePreviewDrawer.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypePreviewDrawer.tsx
@@ -11,6 +11,7 @@ import {
   CardBody,
   Divider,
   DrawerContentBody,
+  Form,
 } from '@patternfly/react-core';
 import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
 import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
@@ -53,7 +54,10 @@ const ConnectionTypePreviewDrawer: React.FC<Props> = ({ children, isExpanded, on
       >
         <Card isFlat isRounded>
           <CardBody>
-            <ConnectionTypeForm isPreview connectionType={obj} />
+            <Form>
+              <Title headingLevel="h1">Add connection</Title>
+              <ConnectionTypeForm isPreview connectionType={obj} />
+            </Form>
           </CardBody>
         </Card>
       </DrawerContentBody>

--- a/frontend/src/concepts/connectionTypes/ConnectionTypePreviewModal.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypePreviewModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Form, Modal } from '@patternfly/react-core';
+import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
+import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+
+type Props = {
+  onClose: () => void;
+  obj: ConnectionTypeConfigMapObj;
+};
+
+const ConnectionTypePreviewModal: React.FC<Props> = ({ onClose, obj }) => (
+  <Modal
+    data-testid="connection-type-preview-modal"
+    isOpen
+    variant="medium"
+    onClose={() => onClose()}
+    title="Preview connection"
+    description="This preview shows the user view of the connection form, and is for reference only."
+  >
+    <Form>
+      <ConnectionTypeForm isPreview connectionType={obj} />
+    </Form>
+  </Modal>
+);
+
+export default ConnectionTypePreviewModal;

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -24,6 +24,7 @@ import { connectionTypeColumns } from '~/pages/connectionTypes/columns';
 import CategoryLabel from '~/concepts/connectionTypes/CategoryLabel';
 import { getCompatibleTypes, isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
 import CompatibilityLabel from '~/concepts/connectionTypes/CompatibilityLabel';
+import ConnectionTypePreviewModal from '~/concepts/connectionTypes/ConnectionTypePreviewModal';
 
 type ConnectionTypesTableRowProps = {
   obj: ConnectionTypeConfigMapObj;
@@ -38,6 +39,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
 }) => {
   const navigate = useNavigate();
   const notification = useNotification();
+  const [showPreview, setShowPreview] = React.useState(false);
   const [isUpdating, setIsUpdating] = React.useState(false);
   const [isEnabled, setIsEnabled] = React.useState(
     () => obj.metadata.annotations?.['opendatahub.io/disabled'] !== 'true',
@@ -143,6 +145,10 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
         <ActionsColumn
           items={[
             {
+              title: 'Preview',
+              onClick: () => setShowPreview(true),
+            },
+            {
               title: 'Edit',
               onClick: () => navigate(`/connectionTypes/edit/${obj.metadata.name}`),
             },
@@ -158,6 +164,9 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
           ]}
         />
       </Td>
+      {showPreview ? (
+        <ConnectionTypePreviewModal obj={obj} onClose={() => setShowPreview(false)} />
+      ) : null}
     </Tr>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Modal } from '@patternfly/react-core';
+import { Alert, Modal, Form } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
 import {
@@ -175,34 +175,36 @@ export const ManageConnectionModal: React.FC<Props> = ({
           restarted, redeployed, or otherwise regenerated.
         </Alert>
       )}
-      <ConnectionTypeForm
-        options={!isEdit ? enabledConnectionTypes : undefined}
-        connectionType={selectedConnectionType || (isEdit ? connectionTypeSource : undefined)}
-        setConnectionType={(name: string) => {
-          const obj = connectionTypes.find((c) => c.metadata.name === name);
-          if (!isModified) {
-            setIsModified(true);
+      <Form>
+        <ConnectionTypeForm
+          options={!isEdit ? enabledConnectionTypes : undefined}
+          connectionType={selectedConnectionType || (isEdit ? connectionTypeSource : undefined)}
+          setConnectionType={(name: string) => {
+            const obj = connectionTypes.find((c) => c.metadata.name === name);
+            if (!isModified) {
+              setIsModified(true);
+            }
+            changeSelectionType(obj);
+          }}
+          connectionNameDesc={nameDescData}
+          setConnectionNameDesc={(key: keyof K8sNameDescriptionFieldData, value: string) => {
+            if (!isModified) {
+              setIsModified(true);
+            }
+            setNameDescData(key, value);
+          }}
+          connectionValues={connectionValues}
+          onChange={(field, value) => {
+            if (!isModified) {
+              setIsModified(true);
+            }
+            setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
+          }}
+          onValidate={(field, isValid) =>
+            setValidations((prev) => ({ ...prev, [field.envVar]: isValid }))
           }
-          changeSelectionType(obj);
-        }}
-        connectionNameDesc={nameDescData}
-        setConnectionNameDesc={(key: keyof K8sNameDescriptionFieldData, value: string) => {
-          if (!isModified) {
-            setIsModified(true);
-          }
-          setNameDescData(key, value);
-        }}
-        connectionValues={connectionValues}
-        onChange={(field, value) => {
-          if (!isModified) {
-            setIsModified(true);
-          }
-          setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
-        }}
-        onValidate={(field, isValid) =>
-          setValidations((prev) => ({ ...prev, [field.envVar]: isValid }))
-        }
-      />
+        />
+      </Form>
     </Modal>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14754

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a preview action to connection types which opens a preview modal with the connection form in read only mode.

![image](https://github.com/user-attachments/assets/3351d40e-4be0-4d2d-be2c-8609f396f6f0)
![image](https://github.com/user-attachments/assets/c50fa66e-45aa-4c76-a5c9-9b15005699db)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable the connection types feature flag `disableConnectionTypes`
- navigate to `Settings -> Connection types` as an admin
- Create a connection type
- From the connection type list, open the kebab menu for the connection type and select `Preview`
- Observe the preview modal is read only and can be closed

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 