### PR TITLE
add action to duplicate connection type when editing

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -102,6 +102,10 @@ class CreateConnectionTypePage {
   getCategorySection() {
     return new CategorySection(() => cy.findByTestId('connection-type-category-toggle'));
   }
+
+  findDuplicateConnectionTypeButton() {
+    return cy.findByTestId('duplicate-connection-type');
+  }
 }
 
 class CategorySection extends Contextual<HTMLElement> {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -183,6 +183,24 @@ describe('edit', () => {
     );
   });
 
+  it('should duplicate connection into create page', () => {
+    cy.interceptOdh(
+      'GET /api/connection-types/:name',
+      { path: { name: 'existing' } },
+      toConnectionTypeConfigMap(existing),
+    );
+    createConnectionTypePage.visitEditPage('existing');
+
+    createConnectionTypePage.findConnectionTypeName().should('have.value', 'existing');
+    createConnectionTypePage.findConnectionTypeDesc().fill('new description');
+    createConnectionTypePage.findDuplicateConnectionTypeButton().click();
+
+    cy.url().should('include', '/connectionTypes/duplicate/existing');
+
+    createConnectionTypePage.findConnectionTypeName().should('have.value', 'Copy of existing');
+    createConnectionTypePage.findConnectionTypeDesc().should('have.value', 'new description');
+  });
+
   it('Drag and drop field rows in table', () => {
     cy.interceptOdh(
       'GET /api/connection-types/:name',

--- a/frontend/src/pages/connectionTypes/manage/DuplicateConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/DuplicateConnectionTypePage.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { useConnectionType } from '~/concepts/connectionTypes/useConnectionType';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import CreateConnectionTypePage from './CreateConnectionTypePage';
 
 const DuplicateConnectionTypePage: React.FC = () => {
+  const stateConnectionType = useLocation().state?.connectionType;
+
   const { name } = useParams();
   const [existingConnectionType, isLoaded, error] = useConnectionType(name);
 
@@ -13,17 +15,23 @@ const DuplicateConnectionTypePage: React.FC = () => {
     return <ApplicationsPage loaded={isLoaded} loadError={error} empty />;
   }
 
-  const duplicate = existingConnectionType
+  const connectionType = stateConnectionType || existingConnectionType;
+
+  const duplicate = connectionType
     ? {
-        ...existingConnectionType,
+        ...connectionType,
         metadata: {
-          ...existingConnectionType.metadata,
+          ...connectionType.metadata,
           name: '',
           annotations: {
-            ...existingConnectionType.metadata.annotations,
-            'openshift.io/display-name': `Copy of ${getDisplayNameFromK8sResource(
-              existingConnectionType,
-            )}`,
+            ...connectionType.metadata.annotations,
+            'openshift.io/display-name':
+              stateConnectionType &&
+              existingConnectionType &&
+              getDisplayNameFromK8sResource(stateConnectionType) !==
+                getDisplayNameFromK8sResource(existingConnectionType)
+                ? getDisplayNameFromK8sResource(stateConnectionType)
+                : `Copy of ${getDisplayNameFromK8sResource(connectionType)}`,
             'opendatahub.io/username': '',
           },
         },

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Alert,
+  AlertActionLink,
   Button,
   Checkbox,
   Form,
@@ -134,13 +135,30 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
             )
           }
         >
-          {isEdit ? (
+          {isEdit && prefill ? (
             <PageSection variant="light" className="pf-v5-u-pt-0">
               <Alert
                 isInline
                 variant="warning"
-                title="Editing this connection type does not affect existing connections of this type."
-              />
+                title="Consider duplicating"
+                actionLinks={
+                  <AlertActionLink
+                    data-testid="duplicate-connection-type"
+                    onClick={() => {
+                      navigate(`/connectionTypes/duplicate/${prefill.metadata.name}`, {
+                        state: {
+                          connectionType: connectionTypeObj,
+                        },
+                      });
+                    }}
+                  >
+                    Duplicate
+                  </AlertActionLink>
+                }
+              >
+                Editing this connection type does not affect existing connections of this type. To
+                keep track of previous versions of this connection type, consider duplicating it.
+              </Alert>
             </PageSection>
           ) : undefined}
           <PageSection isFilled variant="light" className="pf-v5-u-pt-0">


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14751

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates the edit connection type page banner to include a `Duplicate` action which changes the form from edit to create and copies over all changes in the form to the new form.

![image](https://github.com/user-attachments/assets/2c19bc19-a189-4873-9f25-d4c9a7d7f35e)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable connection types feature flag `disableConnectionTypes`
- Navigate to `Settings -> Connection types` as an admin
- Create a new connection type
- Edit that connection type
- make some changes in the form
- Click the `Duplicate` action link in the alert at the top of the page
- Observe the page changes to a create form, the url includes `/duplicate` and the form contains all the changes previously made.
- Note that if the display name was changed, the new name in the create form is unchanged. If however the name was unchanged, we prefix the name with `Copy of` to align with the normal duplicate action.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 