### PR TITLE
add option to remove all fields within a connection type section

### DIFF
--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -239,3 +239,14 @@ export const filterEnabledConnectionTypes = <
   connectionTypes: T[],
 ): T[] =>
   connectionTypes.filter((t) => t.metadata.annotations?.['opendatahub.io/disabled'] !== 'true');
+
+export const findSectionFields = (
+  sectionIndex: number,
+  fields: ConnectionTypeField[],
+): ConnectionTypeField[] => {
+  const nextSectionIndex = fields.findIndex(
+    (f, i) => i > sectionIndex && f.type === ConnectionTypeFieldType.Section,
+  );
+
+  return fields.slice(sectionIndex + 1, nextSectionIndex === -1 ? undefined : nextSectionIndex);
+};

--- a/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
+++ b/frontend/src/concepts/dashboard/DashboardModalFooter.tsx
@@ -14,10 +14,10 @@ type DashboardModalFooterProps = {
   submitButtonVariant?: ButtonProps['variant'];
   onSubmit: () => void;
   onCancel: () => void;
-  isSubmitDisabled: boolean;
+  isSubmitDisabled?: boolean;
   isSubmitLoading?: boolean;
   isCancelDisabled?: boolean;
-  alertTitle: string;
+  alertTitle?: string;
   error?: Error;
 };
 

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldRemoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldRemoveModal.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { Modal } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import { ConnectionTypeDataField } from '~/concepts/connectionTypes/types';
 
 type Props = {
-  field: string;
-  isSection: boolean;
+  field: ConnectionTypeDataField;
   onClose: (submit: boolean) => void;
 };
 
-export const ConnectionTypeFieldRemoveModal: React.FC<Props> = ({ field, isSection, onClose }) => (
+const ConnectionTypeDataFieldRemoveModal: React.FC<Props> = ({ field, onClose }) => (
   <Modal
     isOpen
-    title={isSection ? 'Remove section heading?' : 'Remove field?'}
+    title="Remove field?"
     onClose={() => onClose(false)}
     variant="small"
     footer={
@@ -19,14 +19,11 @@ export const ConnectionTypeFieldRemoveModal: React.FC<Props> = ({ field, isSecti
         submitLabel="Remove"
         onCancel={() => onClose(false)}
         onSubmit={() => onClose(true)}
-        alertTitle=""
-        isSubmitDisabled={false}
       />
     }
   >
-    The <b>{field}</b>{' '}
-    {isSection
-      ? `section heading will be removed. Associated fields will not be removed.`
-      : `field will be removed.`}
+    The <b>{field.name}</b> field will be removed.
   </Modal>
 );
+
+export default ConnectionTypeDataFieldRemoveModal;

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
@@ -53,7 +53,6 @@ export const ConnectionTypeMoveFieldToSectionModal: React.FC<Props> = ({
             }
           }}
           isSubmitDisabled={!selectedSection}
-          alertTitle=""
         />
       }
     >

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
@@ -39,7 +39,6 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit,
             }
           }}
           isSubmitDisabled={!canSubmit || !isValid}
-          alertTitle=""
         />
       }
       elementToFocus="#section-name"

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionRemoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionRemoveModal.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { Badge, Checkbox, ExpandableSection, List, ListItem, Modal } from '@patternfly/react-core';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import { ConnectionTypeField, SectionField } from '~/concepts/connectionTypes/types';
+
+type Props = {
+  field: SectionField;
+  onClose: (submit: boolean, removeFields: boolean) => void;
+  fields: ConnectionTypeField[];
+};
+
+const ConnectionTypeSectionRemoveModal: React.FC<Props> = ({ field, fields, onClose }) => {
+  const [removedFields, setRemovedFields] = React.useState(false);
+  return (
+    <Modal
+      isOpen
+      title="Remove section?"
+      onClose={() => onClose(false, false)}
+      variant="small"
+      footer={
+        <DashboardModalFooter
+          submitLabel="Remove"
+          onCancel={() => onClose(false, false)}
+          onSubmit={() => onClose(true, removedFields)}
+        />
+      }
+    >
+      <div>
+        The <b>{field.name}</b> section heading will be removed.
+      </div>
+      {fields.length > 0 ? (
+        <div className="pf-v5-u-mt-md">
+          <Checkbox
+            id="remove-fields-checkbox"
+            data-testid="remove-fields-checkbox"
+            label="Remove associated fields"
+            isChecked={removedFields}
+            onChange={(_, checked) => setRemovedFields(checked)}
+          />
+          <ExpandableSection
+            className="pf-v5-u-mt-md"
+            isIndented
+            toggleContent={
+              <>
+                Associated fields <Badge isRead>{fields.length}</Badge>
+              </>
+            }
+          >
+            <List>
+              {fields.map((f, i) => (
+                <ListItem key={i}>{f.name}</ListItem>
+              ))}
+            </List>
+          </ExpandableSection>
+        </div>
+      ) : null}
+    </Modal>
+  );
+};
+
+export default ConnectionTypeSectionRemoveModal;

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -7,10 +7,15 @@ import {
   ConnectionTypeFieldType,
   SectionField,
 } from '~/concepts/connectionTypes/types';
-import { defaultValueToString, fieldTypeToString } from '~/concepts/connectionTypes/utils';
+import {
+  defaultValueToString,
+  fieldTypeToString,
+  findSectionFields,
+} from '~/concepts/connectionTypes/utils';
 import type { RowProps } from '~/utilities/useDraggableTableControlled';
 import { columns } from '~/pages/connectionTypes/manage/fieldTableColumns';
-import { ConnectionTypeFieldRemoveModal } from '~/pages/connectionTypes/manage/ConnectionTypeFieldRemoveModal';
+import ConnectionTypeDataFieldRemoveModal from '~/pages/connectionTypes/manage/ConnectionTypeDataFieldRemoveModal';
+import ConnectionTypeSectionRemoveModal from '~/pages/connectionTypes/manage/ConnectionTypeSectionRemoveModal';
 import { TableRowTitleDescription } from '~/components/table';
 import { ValidationContext } from '~/utilities/useValidation';
 import { ValidationErrorCodes } from '~/concepts/connectionTypes/validationUtils';
@@ -19,8 +24,8 @@ type Props = {
   row: ConnectionTypeField;
   fields: ConnectionTypeField[];
   onEdit: () => void;
-  onRemove: () => void;
-  onDuplicate: (field: ConnectionTypeField) => void;
+  onRemove: (removeSectionFields?: boolean) => void;
+  onDuplicate: () => void;
   onAddField: (parentSection: SectionField) => void;
   onMoveToSection: () => void;
   onChange: (updatedField: ConnectionTypeField) => void;
@@ -92,7 +97,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
               },
               {
                 title: 'Duplicate',
-                onClick: () => onDuplicate({ ...row, name: `Copy of ${row.name}` }),
+                onClick: () => onDuplicate(),
               },
               { isSeparator: true },
               {
@@ -103,13 +108,13 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
           />
         </Td>
         {showRemoveField ? (
-          <ConnectionTypeFieldRemoveModal
-            field={row.name}
-            isSection
-            onClose={(submit) => {
+          <ConnectionTypeSectionRemoveModal
+            field={row}
+            fields={findSectionFields(rowIndex, fields)}
+            onClose={(submit, removeFields) => {
               setShowRemoveField(false);
               if (submit) {
-                onRemove();
+                onRemove(removeFields);
               }
             }}
           />
@@ -181,7 +186,7 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
             },
             {
               title: 'Duplicate',
-              onClick: () => onDuplicate({ ...row, name: `Copy of ${row.name}` }),
+              onClick: () => onDuplicate(),
             },
             ...(showMoveToSection
               ? [
@@ -200,9 +205,8 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
         />
       </Td>
       {showRemoveField ? (
-        <ConnectionTypeFieldRemoveModal
-          field={row.name}
-          isSection={false}
+        <ConnectionTypeDataFieldRemoveModal
+          field={row}
           onClose={(submit) => {
             setShowRemoveField(false);
             if (submit) {

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeSectionRemoveModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeSectionRemoveModal.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ConnectionTypeField, SectionField } from '~/concepts/connectionTypes/types';
+import ConnectionTypeSectionRemoveModal from '~/pages/connectionTypes/manage/ConnectionTypeSectionRemoveModal';
+
+describe('ConnectionTypeSectionRemoveModal', () => {
+  it('should callback on submit ', () => {
+    const onClose = jest.fn();
+    const section: SectionField = {
+      type: 'section',
+      name: 'test name',
+      description: 'test desc',
+    };
+    render(<ConnectionTypeSectionRemoveModal field={section} fields={[]} onClose={onClose} />);
+
+    screen.getByTestId('modal-submit-button').click();
+    expect(onClose).toHaveBeenCalledWith(true, false);
+  });
+
+  it('should callback on submit to also remove fields', () => {
+    const onClose = jest.fn();
+    const section: SectionField = {
+      type: 'section',
+      name: 'test name',
+      description: 'test desc',
+    };
+    const fields: ConnectionTypeField[] = [
+      { type: 'short-text', name: 'test field', envVar: 'TEST_FIELD', properties: {} },
+    ];
+    render(<ConnectionTypeSectionRemoveModal field={section} fields={fields} onClose={onClose} />);
+
+    React.act(() => {
+      screen.getByTestId('remove-fields-checkbox').click();
+    });
+    screen.getByTestId('modal-submit-button').click();
+    expect(onClose).toHaveBeenCalledWith(true, true);
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14752

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When removing a section, the modal now includes an option to also remove all fields associated to the section; if there are any. Selecting the checkbox will remove the listed fields, otherwise only the section itself is removed.

Also fixed an issue where duplicating a field would add it to the end of the list instead of immediately adjacent to the field you duplicated. This also makes it easier to quickly create fields for testing this issue.

![image](https://github.com/user-attachments/assets/2b570077-f313-482a-86e3-a9fdc3eb063e)

![image](https://github.com/user-attachments/assets/08c87a1b-086c-4ab8-a7da-4e87a8ee0648)
_Note that the spacing between the list and the expandable title is the PF default behavior._

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable the connection types feature flag `disableConnectionTypes`
- Navigate to `Settings -> Connection types` as an admin
- create a connection type
- Add various sections and fields
- Delete sections choosing at times to delete the associated fields or not

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 