### PR TITLE
Fix type error in DSC to prevent crashing when operator first deployed

### DIFF
--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -61,7 +61,7 @@ export const isAreaAvailable = (
   const requiredComponentsState =
     requiredComponents && dscStatus
       ? requiredComponents.reduce<IsAreaAvailableStatus['requiredComponents']>(
-          (acc, component) => ({ ...acc, [component]: dscStatus.installedComponents[component] }),
+          (acc, component) => ({ ...acc, [component]: dscStatus.installedComponents?.[component] }),
           {},
         )
       : null;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1387,7 +1387,7 @@ export type DataScienceClusterKindStatus = {
     };
   };
   conditions: K8sCondition[];
-  installedComponents: { [key in StackComponent]?: boolean };
+  installedComponents?: { [key in StackComponent]?: boolean };
   phase?: string;
   release?: {
     name: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-14095

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is because the `installedComponents` is possibly `undefined` in the first few minutes after the operator is deployed. It will be called `Array.reduce` later, which causes the error because you cannot call `Array.reduce` on `undefined`. Change the type to optional could help with this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can change the backend to mockup the DSC return value to see the result on the frontend. At https://github.com/opendatahub-io/odh-dashboard/blob/main/backend/src/utils/dsc.ts#L14, change it to
```
.then((res) => {
      const body = (res.body as DataScienceClusterList).items[0];
      delete body.status.installedComponents;
      return body;
    })
```
And see the change of the frontend. Before the change in this PR, you should get a crashed dashboard with the error message as described in the JIRA ticket. After applying the changes in this PR, the dashboard could show correctly the minimum availability of the components.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
