### PR TITLE
14688-14689: add ui component of runtime args and env vars

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import {
+  Button,
+  FormGroup,
+  Icon,
+  Popover,
+  Split,
+  SplitItem,
+  Stack,
+  TextInput,
+} from '@patternfly/react-core';
+import {
+  MinusCircleIcon,
+  OutlinedQuestionCircleIcon,
+  PlusCircleIcon,
+} from '@patternfly/react-icons';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
+
+type EnvironmentVariablesSectionType = {
+  data?: CreatingInferenceServiceObject;
+  setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+};
+
+const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = () => {
+  const [additionalEnvVars, setAdditionalEnvVars] = React.useState<
+    Array<{ name: string; value: string }>
+  >([]);
+
+  const addEnvVar = () => {
+    setAdditionalEnvVars((prevVars) => [...prevVars, { name: '', value: '' }]);
+  };
+
+  const removeEnvVar = (indexToRemove: number) => {
+    setAdditionalEnvVars((prevVars) => prevVars.filter((_, i) => i !== indexToRemove));
+  };
+
+  const updateEnvVar = (indexToUpdate: number, updates: { name?: string; value?: string }) => {
+    setAdditionalEnvVars((prevVars) => {
+      const newVars = [...prevVars];
+      newVars[indexToUpdate] = { ...prevVars[indexToUpdate], ...updates };
+      return newVars;
+    });
+  };
+
+  return (
+    <FormGroup
+      label="Additional environment variables"
+      labelIcon={
+        <Popover
+          bodyContent={
+            <div>
+              Environment variables can be predefined by the selected serving runtime. Overwriting
+              predefined variables only affects this model deployment.
+            </div>
+          }
+        >
+          <Icon aria-label="Additional environment variables info" role="button">
+            <OutlinedQuestionCircleIcon />
+          </Icon>
+        </Popover>
+      }
+      fieldId="model-server-replicas"
+    >
+      <Stack hasGutter>
+        {additionalEnvVars.map((envVar, index) => (
+          <Split hasGutter key={index}>
+            <SplitItem isFilled>
+              <TextInput
+                aria-label="env var name"
+                value={envVar.name}
+                onChange={(_event: React.FormEvent<HTMLInputElement>, value: string) =>
+                  updateEnvVar(index, { name: value })
+                }
+              />
+            </SplitItem>
+            <SplitItem isFilled>
+              <TextInput
+                aria-label="env var value"
+                value={envVar.value}
+                onChange={(_event: React.FormEvent<HTMLInputElement>, value: string) =>
+                  updateEnvVar(index, { value })
+                }
+              />
+            </SplitItem>
+            <SplitItem>
+              <Button
+                onClick={() => removeEnvVar(index)}
+                variant="plain"
+                icon={<MinusCircleIcon />}
+              />
+            </SplitItem>
+          </Split>
+        ))}
+        <Button isInline variant="link" onClick={addEnvVar} icon={<PlusCircleIcon />}>
+          Add variable
+        </Button>
+      </Stack>
+    </FormGroup>
+  );
+};
+
+export default EnvironmentVariablesSection;

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -56,6 +56,8 @@ import {
   TrackingOutcome,
 } from '~/concepts/analyticsTracking/trackingProperties';
 import KServeAutoscalerReplicaSection from './KServeAutoscalerReplicaSection';
+import EnvironmentVariablesSection from './EnvironmentVariablesSection';
+import ServingRuntimeArgsSection from './ServingRuntimeArgsSection';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'rbac.authorization.k8s.io',
@@ -92,7 +94,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   editInfo,
   projectSection,
   registeredModelDeployInfo,
-  shouldFormHidden,
+  shouldFormHidden: hideForm,
 }) => {
   const [createDataServingRuntime, setCreateDataServingRuntime, resetDataServingRuntime, sizes] =
     useCreateServingRuntimeObject(editInfo?.servingRuntimeEditInfo);
@@ -290,7 +292,6 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
       });
   };
-
   return (
     <Modal
       title={editInfo ? 'Edit model' : 'Deploy model'}
@@ -350,7 +351,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   }
                 />
               )}
-              {!shouldFormHidden && (
+              {!hideForm && (
                 <>
                   <InferenceServiceNameSection
                     data={createDataInferenceService}
@@ -397,7 +398,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 </>
               )}
             </FormSection>
-            {!shouldFormHidden && (
+            {!hideForm && (
               <FormSection title="Source model location" id="model-location">
                 <DataConnectionSection
                   data={createDataInferenceService}
@@ -410,7 +411,14 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
             )}
             {servingRuntimeParamsEnabled && (
               <FormSection title="Configuration parameters" id="configuration-params">
-                {/* TODO: enter the fields here */}
+                <ServingRuntimeArgsSection
+                  data={createDataInferenceService}
+                  setData={setCreateDataInferenceService}
+                />
+                <EnvironmentVariablesSection
+                  data={createDataInferenceService}
+                  setData={setCreateDataInferenceService}
+                />
               </FormSection>
             )}
           </StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Icon,
+  Popover,
+  TextArea,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
+
+type ServingRuntimeArgsSectionType = {
+  data?: CreatingInferenceServiceObject;
+  setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+};
+
+const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = () => {
+  const [args, setArgs] = React.useState('');
+
+  return (
+    <FormGroup
+      label="Additional serving runtime arguments"
+      labelIcon={
+        <Popover
+          bodyContent={
+            <div>
+              Serving runtime arguments define how the deployed model behaves. Overwriting
+              predefined arguments only affects this model deployment.
+            </div>
+          }
+        >
+          <Icon aria-label="Additional serving runtime arguments info" role="button">
+            <OutlinedQuestionCircleIcon />
+          </Icon>
+        </Popover>
+      }
+      fieldId="model-server-replicas"
+    >
+      <TextArea
+        placeholder={`--arg\n--arg2=value2\n--arg3 value3`}
+        value={args}
+        onChange={(e) => setArgs(e.target.value)}
+        autoResize
+      />
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>
+            {`Enter one parameter and its arguments per line. Overwriting the runtime's predefined
+            listening port or model location will likely result in a failed deployment.`}
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default ServingRuntimeArgsSection;


### PR DESCRIPTION
closes: [14688](https://issues.redhat.com/browse/RHOAIENG-14688)
closes: [14689](https://issues.redhat.com/browse/RHOAIENG-14689)

## Description
the UI components only of Additional Serving Runtime Args and Env Vars for the Manage KServe Modal. Leaving the "View Predefined __" buttons for later story as they require working around the PF components a bit.

![image](https://github.com/user-attachments/assets/c27f6a7e-b7ee-46f9-85f0-ab94cc033784)
![image](https://github.com/user-attachments/assets/3e1f0e1a-732e-4dad-8dcd-ffa21d848bd2)


## How Has This Been Tested?
1. You should see both the "Additional serving runtime arguments" and "Additional environment variables" fields when the `disableServingRuntimeParams` feature flag is turned on

## Test Impact
tests will need to be added along with connecting the data to the UI components.

## Request review criteria:
check that these two sections work for KServe deploy modal. No data connections, but the help info, placeholder, adding/removing/editing env vars, etc shoudl work. Will need `servingRuntimeParamsEnabled`.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
