### PR TITLE
RHOAIENG-14811 The userdID was not correctly transferred to the frontend

### DIFF
--- a/frontend/src/__mocks__/mockStatus.ts
+++ b/frontend/src/__mocks__/mockStatus.ts
@@ -12,6 +12,7 @@ export const mockStatus = (options?: {
     },
     namespace: 'opendatahub',
     userName: 'test-user',
+    userID: '1234',
     clusterID: '16855612-2bb7-4a4c-9ff0-72rasdfd5',
     clusterBranding: 'ocp',
     isAdmin: options?.isAdmin ?? false,

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -79,6 +79,7 @@ describe('AboutDialog', () => {
     dsciFetchStatus = [dsciStatus, true, undefined, () => Promise.resolve(dsciStatus)];
     userInfo = {
       username: 'test-user',
+      userID: '1234',
       isAdmin: false,
       isAllowed: true,
       userLoading: false,

--- a/frontend/src/concepts/analyticsTracking/useSegmentTracking.ts
+++ b/frontend/src/concepts/analyticsTracking/useSegmentTracking.ts
@@ -10,9 +10,8 @@ export const useSegmentTracking = (): void => {
   const { segmentKey, loaded, loadError } = useWatchSegmentKey();
   const { dashboardConfig } = useAppContext();
   const username = useAppSelector((state) => state.user);
-  const userID = useAppSelector((state) => state.userID);
   const clusterID = useAppSelector((state) => state.clusterID);
-  const [userProps, uPropsLoaded] = useTrackUser(username, userID);
+  const [userProps, uPropsLoaded] = useTrackUser(username);
   const disableTrackingConfig = dashboardConfig.spec.dashboardConfig.disableTracking;
 
   React.useEffect(() => {

--- a/frontend/src/concepts/analyticsTracking/useTrackUser.ts
+++ b/frontend/src/concepts/analyticsTracking/useTrackUser.ts
@@ -4,12 +4,9 @@ import { useAccessReview } from '~/api';
 import { AccessReviewResourceAttributes } from '~/k8sTypes';
 import { IdentifyEventProperties } from '~/concepts/analyticsTracking/trackingProperties';
 
-export const useTrackUser = (
-  username?: string,
-  ssoUserID?: string,
-): [IdentifyEventProperties, boolean] => {
-  const { isAdmin } = useUser();
-  const [userID, setUserID] = React.useState<string | undefined>(ssoUserID);
+export const useTrackUser = (username?: string): [IdentifyEventProperties, boolean] => {
+  const { isAdmin, userID } = useUser();
+  const [finalUserID, setUserID] = React.useState<string | undefined>(userID);
 
   const createReviewResource: AccessReviewResourceAttributes = {
     group: 'project.openshift.io',
@@ -29,7 +26,7 @@ export const useTrackUser = (
       return aId;
     };
 
-    if (!ssoUserID) {
+    if (!userID) {
       computeAnonymousUserId().then((val) => {
         setUserID(val);
       });
@@ -42,10 +39,10 @@ export const useTrackUser = (
     () => ({
       isAdmin,
       canCreateProjects: allowCreate,
-      userID,
+      userID: finalUserID,
     }),
-    [isAdmin, allowCreate, userID],
+    [isAdmin, allowCreate, finalUserID],
   );
 
-  return [props, acLoaded && !!userID];
+  return [props, acLoaded && !!finalUserID];
 };

--- a/frontend/src/pages/projects/screens/projects/__tests__/EmptyProjects.spec.tsx
+++ b/frontend/src/pages/projects/screens/projects/__tests__/EmptyProjects.spec.tsx
@@ -22,6 +22,7 @@ jest.mock('react-router-dom', () => ({
 const useUserMock = jest.mocked(useUser);
 useUserMock.mockReturnValue({
   username: 'test-user',
+  userID: '1234',
   isAdmin: false,
   isAllowed: true,
   userLoading: false,

--- a/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
@@ -65,6 +65,7 @@ useAppContextMock.mockReturnValue({
 const useUserMock = jest.mocked(useUser);
 useUserMock.mockReturnValue({
   username: 'test-user',
+  userID: '1234',
   isAdmin: false,
   isAllowed: true,
   userLoading: false,

--- a/frontend/src/redux/actions/actions.ts
+++ b/frontend/src/redux/actions/actions.ts
@@ -12,6 +12,7 @@ export const getUserPending = (): GetUserAction => ({
 export const getUserFulfilled = (response: StatusResponse): GetUserAction => ({
   type: Actions.GET_USER_FULFILLED,
   payload: {
+    userId: response.kube.userID,
     user: response.kube.userName,
     clusterID: response.kube.clusterID,
     clusterBranding: response.kube.clusterBranding,

--- a/frontend/src/redux/reducers/appReducer.ts
+++ b/frontend/src/redux/reducers/appReducer.ts
@@ -24,6 +24,7 @@ const appReducer = (state: AppState = initialState, action: GetUserAction): AppS
       return {
         ...state,
         user: action.payload.user,
+        userID: action.payload.userId,
         userLoading: false,
         userError: null,
         clusterID: action.payload.clusterID,

--- a/frontend/src/redux/selectors/types.ts
+++ b/frontend/src/redux/selectors/types.ts
@@ -1,5 +1,6 @@
 export type UserState = {
   username: string;
+  userID: string;
   isAdmin: boolean;
   isAllowed: boolean;
   userLoading: boolean;

--- a/frontend/src/redux/selectors/user.ts
+++ b/frontend/src/redux/selectors/user.ts
@@ -5,6 +5,7 @@ import { UserState } from './types';
 
 const getUser = (state: AppState): UserState => ({
   username: state.user ?? '', // TODO: alternative?
+  userID: state.userID ?? '',
   isAdmin: !!state.isAdmin,
   isAllowed: !!state.isAllowed,
   userLoading: state.userLoading,

--- a/frontend/src/redux/types.ts
+++ b/frontend/src/redux/types.ts
@@ -26,6 +26,7 @@ export interface GetUserAction {
   type: string;
   payload: {
     user?: string;
+    userId?: string;
     clusterID?: string;
     serverURL?: string;
     clusterBranding?: string;
@@ -64,6 +65,7 @@ export type StatusResponse = {
       token: string;
     };
     namespace: string;
+    userID: string;
     userName: string;
     clusterID: string;
     clusterBranding: string;

--- a/frontend/src/utilities/__tests__/useDetectUser.spec.ts
+++ b/frontend/src/utilities/__tests__/useDetectUser.spec.ts
@@ -29,6 +29,7 @@ describe('useDetectUser', () => {
         },
         namespace: 'myNamespace',
         userName: 'John Doe',
+        userID: '1234',
         clusterID: 'myClusterID',
         clusterBranding: 'My Cluster',
         isAdmin: true,


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-14811
We now get the userID from the status api endpoint if set. 
This builds on RHOAIENG-9480/PR #3107.
This closes the first try in #3362

## Description

The previous code did not correctly pass the userID from the backend around in the frontend.
The backend already has it correctly on a 2.14 cluster and provides it via /api/status call.

## How Has This Been Tested?

Manual test in dev-mode running `npm run start:dev:ext` against an instance on Dev-Sandbox and a non-Sandbox one.

Then looking at the console output for the the Identify event

```
Identify event triggered: {... "userID":"b09067a69...99"}
```

If the userID looks like this (whith chars) it is an anonymous one. If it is numeric (may be negative) and short (probably < 8 digits), then it is a web-user-id. 

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)


After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


cc @andrewballantyne 