### PR TITLE
Show conn type name in options and details

### DIFF
--- a/frontend/src/concepts/connectionTypes/ConnectionDetailsHelperText.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionDetailsHelperText.tsx
@@ -7,13 +7,12 @@ import {
   DescriptionListTerm,
   HelperText,
   HelperTextItem,
-  LabelGroup,
   Popover,
 } from '@patternfly/react-core';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import TruncatedText from '~/components/TruncatedText';
 import { Connection, ConnectionTypeConfigMapObj } from './types';
-import CategoryLabel from './CategoryLabel';
+import { getConnectionTypeDisplayName } from './utils';
 
 type Props = {
   connection: Connection;
@@ -23,6 +22,7 @@ type Props = {
 export const ConnectionDetailsHelperText: React.FC<Props> = ({ connection, connectionType }) => {
   const displayName = getDisplayNameFromK8sResource(connection);
   const description = getDescriptionFromK8sResource(connection);
+  const connectionTypeName = getConnectionTypeDisplayName(connection, connectionType);
 
   return (
     <HelperText>
@@ -48,17 +48,7 @@ export const ConnectionDetailsHelperText: React.FC<Props> = ({ connection, conne
               ) : undefined}
               <DescriptionListGroup>
                 <DescriptionListTerm>Type</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {connectionType?.data?.category?.length ? (
-                    <LabelGroup>
-                      {connectionType.data.category.map((category) => (
-                        <CategoryLabel key={category} category={category} />
-                      ))}
-                    </LabelGroup>
-                  ) : (
-                    '-'
-                  )}
-                </DescriptionListDescription>
+                <DescriptionListDescription>{connectionTypeName}</DescriptionListDescription>
               </DescriptionListGroup>
             </DescriptionList>
           }

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -248,12 +248,14 @@ export const parseConnectionSecretValues = (
 
 export const getConnectionTypeDisplayName = (
   connection: Connection,
-  connectionTypes: ConnectionTypeConfigMapObj[],
+  connectionTypes?: ConnectionTypeConfigMapObj[] | ConnectionTypeConfigMapObj,
 ): string => {
-  const matchingType = connectionTypes.find(
-    (type) =>
-      type.metadata.name === connection.metadata.annotations['opendatahub.io/connection-type'],
-  );
+  const matchingType = Array.isArray(connectionTypes)
+    ? connectionTypes.find(
+        (type) =>
+          type.metadata.name === connection.metadata.annotations['opendatahub.io/connection-type'],
+      )
+    : connectionTypes;
   return (
     matchingType?.metadata.annotations?.['openshift.io/display-name'] ||
     connection.metadata.annotations['opendatahub.io/connection-type']

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
-import { Button, FormGroup, FormSection, Popover, Radio } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  FormGroup,
+  FormSection,
+  Popover,
+  Radio,
+  Truncate,
+} from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
+  getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
   getResourceNameFromK8sResource,
 } from '~/concepts/k8s/utils';
@@ -16,6 +26,7 @@ import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptio
 import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import {
   assembleConnectionSecret,
+  getConnectionTypeDisplayName,
   getDefaultValues,
   isConnectionTypeDataField,
   S3ConnectionTypeKeys,
@@ -54,13 +65,26 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
       projectConnections.map((connection) => ({
         content: getDisplayNameFromK8sResource(connection),
         value: getResourceNameFromK8sResource(connection),
-        description: connection.metadata.annotations['openshift.io/description'],
+        description: (
+          <Flex direction={{ default: 'column' }} rowGap={{ default: 'rowGapNone' }}>
+            {getDescriptionFromK8sResource(connection) && (
+              <FlexItem>
+                <Truncate content={getDescriptionFromK8sResource(connection)} />
+              </FlexItem>
+            )}
+            <FlexItem>
+              <Truncate
+                content={`Type: ${getConnectionTypeDisplayName(connection, connectionTypes)}`}
+              />
+            </FlexItem>
+          </Flex>
+        ),
         isSelected:
           !!selectedConnection &&
           getResourceNameFromK8sResource(connection) ===
             getResourceNameFromK8sResource(selectedConnection),
       })),
-    [projectConnections, selectedConnection],
+    [connectionTypes, projectConnections, selectedConnection],
   );
   const selectedConnectionType = React.useMemo(
     () =>

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
@@ -77,7 +77,7 @@ describe('ConnectionsFormSection', () => {
     expect(result.getByRole('textbox', { name: 'folder-path' })).toHaveValue('');
 
     await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
-    await act(async () => result.getByRole('option', { name: 's3-connection' }).click());
+    await act(async () => result.getByRole('option', { name: 's3-connection Type: s3' }).click());
     expect(mockSetData).toHaveBeenLastCalledWith('storage', {
       type: InferenceServiceStorageType.EXISTING_STORAGE,
       path: '',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Follow up to https://issues.redhat.com/browse/RHOAIENG-13139 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Clarification detailed that we will show the connection type name instead of the categories. 

![image](https://github.com/user-attachments/assets/3305c08b-41d7-4137-9e75-76dd03b07c92)
![image](https://github.com/user-attachments/assets/b2c0443f-d3af-4c65-9491-ee35281d547b)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to model serving
2. Create or edit an existing model serving deployment.
3. The "Existing connection" radio option will show the connection type in the option description and click the "View connection details" to see it in the popover.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I did actually update a test and the option selection will include the "type: s3"  in the description, so the test confirms it works.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@simrandhaliw 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
