### PR TITLE
Update UI to use new resource color palette

### DIFF
--- a/frontend/src/concepts/design/TypeBorderCard.scss
+++ b/frontend/src/concepts/design/TypeBorderCard.scss
@@ -3,81 +3,17 @@
   border-radius: 16px;
   border: 1px solid var(--pf-v5-global--BorderColor--100);
   padding: 1px;
+  --border-color: transparent;
 
   &:after {
     position: absolute;
     width: 48px;
     height: 4px;
-    background: transparent;
+    background: var(--border-color);
     top: 0;
     left: calc(50% - 24px);
     border-radius: 0 0 4px 4px;
     content: ' ';
-  }
-  &.project {
-    &:after {
-      background: var(--ai-project--BorderColor);
-    }
-  }
-  &.notebook {
-    &:after {
-      background: var(--ai-notebook--BorderColor);
-    }
-  }
-  &.pipeline {
-    &:after {
-      background: var(--ai-pipeline--BorderColor);
-    }
-  }
-  &.pipeline-run {
-    &:after {
-      background: var(--ai-pipeline--BorderColor);
-    }
-  }
-  &.cluster-storage {
-    &:after {
-      background: var(--ai-cluster-storage--BorderColor);
-    }
-  }
-  &.model-server {
-    &:after {
-      background: var(--ai-model-server--BorderColor);
-    }
-  }
-  &.data-connection {
-    &:after {
-      background: var(--ai-data-connection--BorderColor);
-    }
-  }
-  &.user {
-    &:after {
-      background: var(--ai-user--BorderColor);
-    }
-  }
-  &.group {
-    &:after {
-      background: var(--ai-group--BorderColor);
-    }
-  }
-  &.set-up {
-    &:after {
-      background: var(--ai-set-up--BorderColor);
-    }
-  }
-  &.organize {
-    &:after {
-      background: var(--ai-organize--BorderColor);
-    }
-  }
-  &.training {
-    &:after {
-      background: var(--ai-training--BorderColor);
-    }
-  }
-  &.serving {
-    &:after {
-      background: var(--ai-serving--BorderColor);
-    }
   }
   &.m-is-selectable {
     &:after {
@@ -90,52 +26,61 @@
       cursor: pointer;
     }
     &:hover, &.m-is-selected {
+      border-color: var(--selected-color);
       &:after {
-        display: block
-      }
-      &.project {
-        border-color: var(--ai-project--BorderColor);
-      }
-      &.notebook {
-        border-color: var(--ai-notebook--BorderColor);
-      }
-      &.pipeline {
-        border-color: var(--ai-pipeline--BorderColor);
-      }
-      &.pipeline-run {
-        border-color: var(--ai-pipeline--BorderColor);
-      }
-      &.cluster-storage {
-        border-color: var(--ai-cluster-storage--BorderColor);
-      }
-      &.model-server {
-        border-color: var(--ai-model-server--BorderColor);
-      }
-      &.data-connection {
-        border-color: var(--ai-data-connection--BorderColor);
-      }
-      &.user {
-        border-color: var(--ai-user--BorderColor);
-      }
-      &.group {
-        border-color: var(--ai-group--BorderColor);
-      }
-      &.set-up {
-        border-color: var(--ai-set-up--BorderColor);
-      }
-      &.organize {
-        border-color: var(--ai-organize--BorderColor);
-      }
-      &.training {
-        border-color: var(--ai-training--BorderColor);
-      }
-      &.serving {
-        border-color: var(--ai-serving--BorderColor);
+        display: block;
+        background: var(--selected-color);
       }
     }
     &.m-is-selected {
       border-width: 2px;
       padding: 0;
     }
+  }
+  &.project,
+  &.organize {
+    --border-color: var(--ai-project--BorderColor);
+    --selected-color: var(--ai-project--SelectedColor);
+  }
+  &.notebook {
+    --border-color: var(--ai-notebook--BorderColor);
+    --selected-color: var(--ai-notebook--SelectedColor);
+  }
+  &.pipeline,
+  &.pipeline-run {
+    --border-color: var(--ai-pipeline--BorderColor);
+    --selected-color: var(--ai-pipeline--SelectedColor);
+  }
+  &.cluster-storage {
+    --border-color: var(--ai-cluster-storage--BorderColor);
+    --selected-color: var(--ai-cluster-storage--SelectedColor);
+  }
+  &.model-server {
+    --border-color: var(--ai-model-server--BorderColor);
+    --selected-color: var(--ai-model-server--SelectedColor);
+  }
+  &.data-connection {
+    --border-color: var(--ai-data-connection--BorderColor);
+    --selected-color: var(--data-connection--SelectedColor);
+  }
+  &.user {
+    --border-color: var(--ai-user--BorderColor);
+    --selected-color: var(--ai-user--SelectedColor);
+  }
+  &.group {
+    --border-color: var(--ai-group--BorderColor);
+    --selected-color: var(--ai-group--SelectedColor);
+  }
+  &.set-up {
+    --border-color: var(--ai-set-up--BorderColor);
+    --selected-color: var(--ai-set-up--SelectedColor);
+  }
+  &.training {
+    --border-color: var(--ai-training--BorderColor);
+    --selected-color: var(--ai-training--SelectedColor);
+  }
+  &.serving {
+    --border-color: var(--ai-serving--BorderColor);
+    --selected-color: var(--ai-serving--SelectedColor);
   }
 }

--- a/frontend/src/concepts/design/utils.ts
+++ b/frontend/src/concepts/design/utils.ts
@@ -32,6 +32,7 @@ export enum SectionType {
 
 export enum ProjectObjectType {
   project = 'project',
+  projectContext = 'projectContext',
   notebook = 'notebook',
   pipelineSetup = 'pipeline-setup',
   pipeline = 'pipeline',
@@ -52,6 +53,8 @@ export const typedBackgroundColor = (objectType: ProjectObjectType): string => {
   switch (objectType) {
     case ProjectObjectType.project:
       return 'var(--ai-project--BackgroundColor)';
+    case ProjectObjectType.projectContext:
+      return 'var(--ai-project-context--BackgroundColor)';
     case ProjectObjectType.notebook:
       return 'var(--ai-notebook--BackgroundColor)';
     case ProjectObjectType.pipeline:
@@ -82,6 +85,8 @@ export const typedColor = (objectType: ProjectObjectType): string => {
   switch (objectType) {
     case ProjectObjectType.project:
       return 'var(--ai-project--Color)';
+    case ProjectObjectType.projectContext:
+      return 'var(--ai-project-context--Color)';
     case ProjectObjectType.notebook:
       return 'var(--ai-notebook--Color)';
     case ProjectObjectType.pipeline:
@@ -111,6 +116,7 @@ export const typedColor = (objectType: ProjectObjectType): string => {
 export const typedObjectImage = (objectType: ProjectObjectType): string => {
   switch (objectType) {
     case ProjectObjectType.project:
+    case ProjectObjectType.projectContext:
       return projectImg;
     case ProjectObjectType.notebook:
       return notebookImg;
@@ -144,6 +150,7 @@ export const typedObjectImage = (objectType: ProjectObjectType): string => {
 export const typedEmptyImage = (objectType: ProjectObjectType, option?: string): string => {
   switch (objectType) {
     case ProjectObjectType.project:
+    case ProjectObjectType.projectContext:
       return projectEmptyStateImg;
     case ProjectObjectType.notebook:
       return notebookEmptyStateImg;

--- a/frontend/src/concepts/design/vars.scss
+++ b/frontend/src/concepts/design/vars.scss
@@ -1,48 +1,97 @@
 :root {
   --ai-set-up--BackgroundColor: #ffe8cc;
-  --ai-organize--BackgroundColor: #ffe8cc;
-  --ai-training--BackgroundColor: #daf2f2;
-  --ai-serving--BackgroundColor: #e0f0ff;
-
+  --ai-set-up--LabelBackgroundColor: #fccb8f;
   --ai-set-up--BorderColor: #f8ae54;
-  --ai-organize--BorderColor: #f8ae54;
-  --ai-training--BorderColor: #9ad8d8;
-  --ai-serving--BorderColor: #92c5f9;
+  --ai-set-up--SelectedColor: #f5921b;
+  --ai-set-up--Color: #f5921b;
 
+  --ai-config--BackgroundColor: var(--ai-set-up--BackgroundColor);
+  --ai-config--LabelBackgroundColor: var(--ai-set-up--LabelBackgroundColor);
+  --ai-config--BorderColor: var(--ai-set-up--BorderColor);
+  --ai-config--SelectedColor: var(--ai-set-up--SelectedColor);
+  --ai-config--Color: var(--ai-set-up--Color);
+
+  --ai-organize--BackgroundColor: var(--ai-set-up--BackgroundColor);
+  --ai-organize--LabelBackgroundColor: var(--ai-set-up--LabelBackgroundColor);
+  --ai-organize--BorderColor: var(--ai-set-up--BorderColor);
+  --ai-organize--SelectedColor: var(--ai-set-up--SelectedColor);
+  --ai-organize--Color: var(--ai-set-up--Color);
+
+  --ai-training--BackgroundColor: #daf2f2;
+  --ai-training--LabelBackgroundColor: #b9e5e5;
+  --ai-training--BorderColor: #9ad8d8;
+  --ai-training--SelectedColor: #63bdbd;
+  --ai-training--Color: #37a3a3;
+
+  --ai-serving--BackgroundColor: #ece6ff;
+  --ai-serving--LabelBackgroundColor: #d0c5f4;
+  --ai-serving--BorderColor: #b6a6e9;
+  --ai-serving--SelectedColor: #876fd4;
+  --ai-serving--Color: #5e40be;
+
+  --ai-general--BackgroundColor: #f2f2f2;
+  --ai-general--LabelBackgroundColor: #e0e0e0;
+  --ai-general--BorderColor: #c7c7c7;
+  --ai-general--SelectedColor: #a3a3a3;
+  --ai-general--Color: #707070;
 
   --ai-project--BackgroundColor: var(--ai-organize--BackgroundColor);
+  --ai-project--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
   --ai-project--BorderColor: var(--ai-organize--BorderColor);
+  --ai-project--SelectedColor: var(--ai-organize--SelectedColor);
   --ai-project--Color: var(--ai-organize--BorderColor);
 
+  --ai-project-context--BackgroundColor: var(--ai-general--BackgroundColor);
+  --ai-project-context--LabelBackgroundColor: var(--ai-general-LabelBackgroundColor);
+  --ai-project-context--BorderColor: var(--ai-general--BorderColor);
+  --ai-project-context--SelectedColor: var(--ai-general--SelectedColor);
+  --ai-project-context--Color: var(--ai-general--BorderColor);
+
   --ai-data-connection--BackgroundColor: var(--ai-organize--BackgroundColor);
+  --ai-data-connection--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
   --ai-data-connection--BorderColor: var(--ai-organize--BorderColor);
+  --ai-data-connection--SelectedColor: var(--ai-organize--SelectedColor);
   --ai-data-connection--Color: var(--ai-organize--BorderColor);
 
   --ai-cluster-storage--BackgroundColor: var(--ai-organize--BackgroundColor);
+  --ai-cluster-storage--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
   --ai-cluster-storage--BorderColor: var(--ai-organize--BorderColor);
+  --ai-cluster-storage--SelectedColor: var(--ai-organize--SelectedColor);
   --ai-cluster-storage--Color: var(--ai-organize--BorderColor);
 
   --ai-notebook--BackgroundColor: var(--ai-training--BackgroundColor);
+  --ai-notebook--LabelBackgroundColor: var(--ai-training-LabelBackgroundColor);
   --ai-notebook--BorderColor: var(--ai-training--BorderColor);
-  --ai-notebook--Color: #37a3a3;
+  --ai-notebook--SelectedColor: var(--ai-training--SelectedColor);
+  --ai-notebook--Color: var(--ai-training--Color);
 
   --ai-model--BackgroundColor: var(--ai-serving--BackgroundColor);
-  --ai-model--BorderColor: var(--ai-serviing--BorderColor);
-  --ai-model--Color: var(--ai-serviing--BorderColor);
+  --ai-model--LabelBackgroundColor: var(--ai-serving-LabelBackgroundColor);
+  --ai-model--BorderColor: var(--ai-serving--BorderColor);
+  --ai-model--SelectedColor: var(--ai-serving--SelectedColor);
+  --ai-model--Color: var(--ai-serving--BorderColor);
 
   --ai-pipeline--BackgroundColor: var(--ai-training--BackgroundColor);
+  --ai-pipeline--LabelBackgroundColor: var(--ai-training-LabelBackgroundColor);
   --ai-pipeline--BorderColor: var(--ai-training--BorderColor);
+  --ai-pipeline--SelectedColor: var(--ai-training--SelectedColor);
   --ai-pipeline--Color: var(--ai-training--BorderColor);
 
   --ai-model-server--BackgroundColor: var(--ai-serving--BackgroundColor);
+  --ai-model-server--LabelBackgroundColor: var(--ai-serving-LabelBackgroundColor);
   --ai-model-server--BorderColor: var(--ai-serving--BorderColor);
-  --ai-model-server--Color: #5E40BE;
+  --ai-model-server--SelectedColor: var(--ai-serving--SelectedColor);
+  --ai-model-server--Color: var(--ai-serving--Color);
 
   --ai-user--BackgroundColor: var(--ai-set-up--BackgroundColor);
+  --ai-user--LabelBackgroundColor: var(--ai-set-up-LabelBackgroundColor);
   --ai-user--BorderColor: var(--ai-set-up--BorderColor);
+  --ai-user--SelectedColor: var(--ai-set-up--SelectedColor);
   --ai-user--Color: var(--ai-set-up--BorderColor);
 
   --ai-group--BackgroundColor: var(--ai-set-up--BackgroundColor);
+  --ai-group--LabelBackgroundColor: var(--ai-set-up-LabelBackgroundColor);
   --ai-group--BorderColor: var(--ai-set-up--BorderColor);
+  --ai-group--SelectedColor: var(--ai-set-up--SelectedColor);
   --ai-group--Color: var(--ai-set-up--BorderColor);
 }

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -10,13 +10,14 @@ import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import useModelServingEnabled from '~/pages/modelServing/useModelServingEnabled';
 import { useQueryParams } from '~/utilities/useQueryParams';
 import ModelServingPlatform from '~/pages/modelServing/screens/projects/ModelServingPlatform';
-import { typedObjectImage, ProjectObjectType } from '~/concepts/design/utils';
+import { ProjectObjectType } from '~/concepts/design/utils';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { AccessReviewResourceAttributes } from '~/k8sTypes';
 import { useAccessReview } from '~/api';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import useConnectionTypesEnabled from '~/concepts/connectionTypes/useConnectionTypesEnabled';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
+import HeaderIcon from '~/concepts/design/HeaderIcon';
 import useCheckLogoutParams from './useCheckLogoutParams';
 import ProjectOverview from './overview/ProjectOverview';
 import NotebookList from './notebooks/NotebookList';
@@ -120,11 +121,8 @@ const ProjectDetails: React.FC = () => {
   return (
     <ApplicationsPage
       title={
-        <Flex
-          spaceItems={{ default: 'spaceItemsSm' }}
-          alignItems={{ default: 'alignItemsFlexStart' }}
-        >
-          <img style={{ height: 32 }} src={typedObjectImage(ProjectObjectType.project)} alt="" />
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <HeaderIcon type={ProjectObjectType.projectContext} />
           <FlexItem>
             <ResourceNameTooltip resource={currentProject} wrap={false}>
               {displayName}


### PR DESCRIPTION
Closes [RHOAIENG-14753](https://issues.redhat.com/browse/RHOAIENG-14753)

## Description
The color palette used for resources has been updated in the new [guidelines](https://docs.google.com/document/d/1OdaE6LjTikTMTIOHvgGQzRDJpm9Bn-kPxsfoqRh5tsU/edit#heading=h.v94u92bpa671)

## How Has This Been Tested?
Navigate thru the UI and check the colors for each resource type.

## Test Impact
No automated test impact as this is only a change in colors.

## Screen shots

![image](https://github.com/user-attachments/assets/39269f81-1dcf-4804-9fb5-dc86040c81ac)


![image](https://github.com/user-attachments/assets/963f86e1-ea1f-4e0a-ad3b-0fa51ef57a85)


![image](https://github.com/user-attachments/assets/4ec05a22-490a-400a-9a2c-67f99ed23953)


![image](https://github.com/user-attachments/assets/f410ee4a-0ff7-4fc7-a58c-294654db2143)


![image](https://github.com/user-attachments/assets/68daa551-cd2e-4c7c-b32a-148d06d00f3a)


![image](https://github.com/user-attachments/assets/8b2b1b3b-b74b-494e-b5d3-26913f3e152d)


## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw @tobiastal 