### PR TITLE
add model serving compatible select to connection type form

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -107,6 +107,14 @@ class CreateConnectionTypePage {
   findDuplicateConnectionTypeButton() {
     return cy.findByTestId('duplicate-connection-type');
   }
+
+  findCompatibleModelServingTypesAlert() {
+    return cy.findByTestId('compatible-model-serving-types-alert');
+  }
+
+  findModelServingCompatibleTypeDropdown() {
+    return cy.findByTestId('select-model-serving-compatible-type');
+  }
 }
 
 class CategorySection extends Contextual<HTMLElement> {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -18,20 +18,31 @@ describe('create', () => {
         disableConnectionTypes: false,
       }),
     );
+    cy.interceptOdh('GET /api/connection-types', [
+      mockConnectionTypeConfigMap({
+        displayName: 'URI - v1',
+        name: 'uri-v1',
+        fields: [
+          {
+            type: 'uri',
+            name: 'URI field test',
+            envVar: 'URI',
+            required: true,
+            properties: {},
+          },
+        ],
+      }),
+    ]);
   });
 
-  it('Display base page', () => {
+  it('Can create connection type', () => {
+    const categorySection = createConnectionTypePage.getCategorySection();
     createConnectionTypePage.visitCreatePage();
 
     createConnectionTypePage.findConnectionTypeName().should('exist');
     createConnectionTypePage.findConnectionTypeDesc().should('exist');
     createConnectionTypePage.findConnectionTypeEnableCheckbox().should('exist');
     createConnectionTypePage.findConnectionTypePreviewToggle().should('exist');
-  });
-
-  it('Allows create button with valid name and category', () => {
-    const categorySection = createConnectionTypePage.getCategorySection();
-    createConnectionTypePage.visitCreatePage();
 
     createConnectionTypePage.findConnectionTypeName().should('have.value', '');
     createConnectionTypePage.findSubmitButton().should('be.disabled');
@@ -39,6 +50,28 @@ describe('create', () => {
     createConnectionTypePage.findConnectionTypeName().type('hello');
     categorySection.findCategoryTable();
     categorySection.findMultiGroupSelectButton('Object-storage');
+    createConnectionTypePage.findSubmitButton().should('be.enabled');
+
+    categorySection.findMultiGroupInput().type('Database');
+    categorySection.findMultiGroupSelectButton('Database');
+
+    categorySection.findMultiGroupInput().type('New category');
+
+    categorySection.findMultiGroupSelectButton('Option');
+    categorySection.findChipItem('New category').should('exist');
+    categorySection.findMultiGroupInput().type('{esc}');
+
+    createConnectionTypePage
+      .findModelServingCompatibleTypeDropdown()
+      .findDropdownItem('URI')
+      .click();
+    createConnectionTypePage.findCompatibleModelServingTypesAlert().should('exist');
+    createConnectionTypePage.getFieldsTableRow(0).findSectionHeading().should('exist');
+    createConnectionTypePage
+      .getFieldsTableRow(1)
+      .findName()
+      .should('contain.text', 'URI field test');
+
     createConnectionTypePage.findSubmitButton().should('be.enabled');
   });
 
@@ -59,28 +92,6 @@ describe('create', () => {
     createConnectionTypePage.findSubmitButton().should('be.enabled').click();
 
     createConnectionTypePage.findFooterError().should('contain.text', 'returned error message');
-  });
-
-  it('Selects category or creates new category', () => {
-    createConnectionTypePage.visitCreatePage();
-
-    const categorySection = createConnectionTypePage.getCategorySection();
-
-    categorySection.findCategoryTable();
-    categorySection.findMultiGroupSelectButton('Object-storage');
-
-    categorySection.findChipItem('Object storage').should('exist');
-    categorySection.clearMultiChipItem();
-
-    categorySection.findMultiGroupSelectButton('Object-storage');
-
-    categorySection.findMultiGroupInput().type('Database');
-    categorySection.findMultiGroupSelectButton('Database');
-
-    categorySection.findMultiGroupInput().type('New category');
-
-    categorySection.findMultiGroupSelectButton('Option');
-    categorySection.findChipItem('New category').should('exist');
   });
 });
 

--- a/frontend/src/components/SimpleMenuActions.tsx
+++ b/frontend/src/components/SimpleMenuActions.tsx
@@ -22,12 +22,20 @@ const isSpacer = (v: Item | Spacer): v is Spacer => 'isSpacer' in v;
 type SimpleDropdownProps = {
   dropdownItems: (Item | Spacer)[];
   testId?: string;
+  toggleLabel?: string;
+  variant?: React.ComponentProps<typeof MenuToggle>['variant'];
 } & Omit<
   React.ComponentProps<typeof Dropdown>,
   'isOpen' | 'isPlain' | 'popperProps' | 'toggle' | 'onChange'
 >;
 
-const SimpleMenuActions: React.FC<SimpleDropdownProps> = ({ dropdownItems, testId, ...props }) => {
+const SimpleMenuActions: React.FC<SimpleDropdownProps> = ({
+  dropdownItems,
+  testId,
+  toggleLabel,
+  variant,
+  ...props
+}) => {
   const [open, setOpen] = React.useState(false);
 
   return (
@@ -37,17 +45,17 @@ const SimpleMenuActions: React.FC<SimpleDropdownProps> = ({ dropdownItems, testI
       onOpenChange={(isOpened) => setOpen(isOpened)}
       toggle={(toggleRef) => (
         <MenuToggle
-          aria-label="Actions"
+          aria-label={toggleLabel ?? 'Actions'}
           data-testid={testId}
-          variant="plain"
+          variant={variant ?? (toggleLabel ? 'default' : 'plain')}
           ref={toggleRef}
           onClick={() => setOpen(!open)}
           isExpanded={open}
         >
-          <EllipsisVIcon />
+          {toggleLabel ?? <EllipsisVIcon />}
         </MenuToggle>
       )}
-      popperProps={{ position: 'right' }}
+      popperProps={!toggleLabel ? { position: 'right' } : undefined}
     >
       <DropdownList>
         {dropdownItems.map((itemOrSpacer, i) =>

--- a/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
@@ -12,7 +12,9 @@ import {
   fieldTypeToString,
   getCompatibleTypes,
   isModelServingCompatible,
+  isModelServingTypeCompatible,
   isValidEnvVar,
+  ModelServingCompatibleConnectionTypes,
   toConnectionTypeConfigMap,
   toConnectionTypeConfigMapObj,
 } from '~/concepts/connectionTypes/utils';
@@ -310,5 +312,31 @@ describe('getCompatibleTypes', () => {
         'URI',
       ]),
     ).toEqual([CompatibleTypes.ModelServing]);
+  });
+});
+
+describe('isModelServingTypeCompatible', () => {
+  it('should identify model serving compatible env vars', () => {
+    expect(
+      isModelServingTypeCompatible(['invalid'], ModelServingCompatibleConnectionTypes.ModelServing),
+    ).toBe(false);
+    expect(
+      isModelServingTypeCompatible(
+        ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_S3_ENDPOINT', 'AWS_S3_BUCKET'],
+        ModelServingCompatibleConnectionTypes.ModelServing,
+      ),
+    ).toBe(true);
+    expect(
+      isModelServingTypeCompatible(['invalid'], ModelServingCompatibleConnectionTypes.OCI),
+    ).toBe(false);
+    expect(isModelServingTypeCompatible(['URI'], ModelServingCompatibleConnectionTypes.OCI)).toBe(
+      true,
+    );
+    expect(
+      isModelServingTypeCompatible(['invalid'], ModelServingCompatibleConnectionTypes.URI),
+    ).toBe(false);
+    expect(isModelServingTypeCompatible(['URI'], ModelServingCompatibleConnectionTypes.URI)).toBe(
+      true,
+    );
   });
 });

--- a/frontend/src/utilities/__tests__/string.spec.ts
+++ b/frontend/src/utilities/__tests__/string.spec.ts
@@ -7,6 +7,7 @@ import {
   replaceNumericPartWithString,
   containsMultipleSlashesPattern,
   triggerFileDownload,
+  joinWithCommaAnd,
 } from '~/utilities/string';
 
 global.URL.createObjectURL = jest.fn(() => 'test-url');
@@ -232,5 +233,37 @@ describe('triggerFileDownload', () => {
     createElementSpy.mockRestore();
     appendChildSpy.mockRestore();
     removeChildSpy.mockRestore();
+  });
+});
+
+describe('joinWithCommaAnd', () => {
+  it('should join items with comma and oxford comma', () => {
+    expect(joinWithCommaAnd(['item1', 'item2', 'item3'])).toBe('item1, item2, and item3');
+  });
+
+  it('should join items with no comma if only two items', () => {
+    expect(joinWithCommaAnd(['item1', 'item2'])).toBe('item1 and item2');
+  });
+
+  it('should join items with comma and with custom prefix and suffix', () => {
+    expect(
+      joinWithCommaAnd(['item1', 'item2', 'item3'], {
+        singlePrefix: 'invalid',
+        singleSuffix: 'invalid',
+        multiPrefix: 'Prefix ',
+        multiSuffix: ' suffix.',
+      }),
+    ).toBe('Prefix item1, item2, and item3 suffix.');
+  });
+
+  it('should join single item with custom prefix and suffix', () => {
+    expect(
+      joinWithCommaAnd(['item1'], {
+        singlePrefix: 'Prefix ',
+        singleSuffix: ' suffix.',
+        multiPrefix: 'invalid',
+        multiSuffix: 'invalid',
+      }),
+    ).toBe('Prefix item1 suffix.');
   });
 });

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -113,3 +113,21 @@ export const truncateString = (str: string, length: number): string => {
   }
   return `${str.substring(0, length)}…`;
 };
+
+export const joinWithCommaAnd = (
+  items: string[],
+  options?: {
+    singlePrefix?: string;
+    singleSuffix?: string;
+    multiPrefix?: string;
+    multiSuffix?: string;
+  },
+): string =>
+  items.length > 1
+    ? `${options?.multiPrefix ?? ''}${items
+        .slice(0, items.length - 1)
+        .map((i) => i)
+        .join(', ')}${items.length > 2 ? ',' : ''} and ${items[items.length - 1]}${
+        options?.multiSuffix ?? ''
+      }`
+    : `${options?.singlePrefix ?? ''}${items[0]}${options?.singleSuffix ?? ''}`;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14813

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds a dropdown to the connection type creation page to add model serving compatible fields.
All OOTB types are present in the dropdown.
Selecting one of the types inserts a new section field along with all other fields found in the connection type.

When the connection type is found to be compatible (ie it has the same env vars), then we show an alert. Currently this is based strictly on the env var name and not of the field type or other properties such as required, name or description.

cc @simrandhaliw 

![image](https://github.com/user-attachments/assets/76bf438e-a8d6-4e93-8fd5-2d903bde951c)
![image](https://github.com/user-attachments/assets/15d32e68-d9d8-4fc7-80c1-a7e6fd3967d5)
![image](https://github.com/user-attachments/assets/8f5e7947-9b93-4ec1-9cfe-9e3359daae1f)
![image](https://github.com/user-attachments/assets/fa9201b3-a510-4c78-9478-c8bab6ca35fa)
![image](https://github.com/user-attachments/assets/961da456-62fc-40d5-8d9d-6079eeb9d457)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ensure your cluster has the OOTB connection types applied. https://github.com/opendatahub-io/odh-dashboard/pull/3335
You can manually add them to your cluster with `oc apply -f ...`. They are found in the `manifests/common/connection-types` directory of the git repo. Note that if they are not present, then the dropdown menu will not show up.

- enable the connection type feature flag `disableConnectionTypes`
- Navigate to `Settings -> Connection types` as an admin
- Create a connection type
- Observe the menu shows up to select a compatible model serving type
- Select an option
- observe a new section and field(s) are added to the connection type along with an alert
- Delete one of the newly added fields and observe the alert disappears

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
