### PR TITLE
feat(14691): serving runtime link to args

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -177,6 +177,10 @@ class ServingRuntimeModal extends Modal {
     return this.find().findByLabelText('Model server size');
   }
 
+  findServingRuntimeTemplateHelptext() {
+    return this.find().findByTestId('serving-runtime-template-helptext');
+  }
+
   findServingRuntimeTemplateDropdown() {
     return this.find().findByTestId('serving-runtime-template-selection');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -14,6 +14,7 @@ import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/Delete
 import {
   inferenceServiceModal,
   inferenceServiceModalEdit,
+  kserveModal,
   modelServingGlobal,
 } from '~/__tests__/cypress/cypress/pages/modelServing';
 import {
@@ -38,6 +39,7 @@ type HandlersProps = {
   delayInferenceServices?: boolean;
   delayServingRuntimes?: boolean;
   disableKServeMetrics?: boolean;
+  disableServingRuntimeParamsConfig?: boolean;
 };
 
 const initIntercepts = ({
@@ -49,11 +51,15 @@ const initIntercepts = ({
   delayInferenceServices,
   delayServingRuntimes,
   disableKServeMetrics,
+  disableServingRuntimeParamsConfig,
 }: HandlersProps) => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      installedComponents: { kserve: true, 'model-mesh': true },
+      installedComponents: {
+        kserve: true,
+        'model-mesh': true,
+      },
     }),
   );
   cy.interceptOdh(
@@ -62,6 +68,7 @@ const initIntercepts = ({
       disableKServe: disableKServeConfig,
       disableModelMesh: disableModelMeshConfig,
       disableKServeMetrics,
+      disableServingRuntimeParams: disableServingRuntimeParamsConfig,
     }),
   );
   cy.interceptK8sList(ServingRuntimeModel, mockK8sResourceList(servingRuntimes));
@@ -490,6 +497,23 @@ describe('Model Serving Global', () => {
     modelServingGlobal.findDeployModelButton().click();
     cy.findByText('Error creating model server').should('not.exist');
   });
+
+  it('Serving runtime helptext', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableServingRuntimeParamsConfig: false,
+    });
+    modelServingGlobal.visit('test-project');
+
+    modelServingGlobal.findDeployModelButton().click();
+
+    // test that you can not submit on empty
+    kserveModal.shouldBeOpen();
+    kserveModal.findServingRuntimeTemplateHelptext().should('not.exist');
+    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+    kserveModal.findServingRuntimeTemplateHelptext().should('exist');
+  });
+
   it('Navigate to kserve model metrics page only if enabled', () => {
     initIntercepts({});
     modelServingGlobal.visit('test-project');

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react';
-import { FormGroup, Label, Split, SplitItem, Truncate } from '@patternfly/react-core';
+import {
+  Button,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Label,
+  Split,
+  SplitItem,
+  Truncate,
+} from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingServingRuntimeObject } from '~/pages/modelServing/screens/types';
 import { TemplateKind } from '~/k8sTypes';
@@ -14,6 +24,7 @@ import { AcceleratorProfileFormData } from '~/utilities/useAcceleratorProfileFor
 
 type ServingRuntimeTemplateSectionProps = {
   data: CreatingServingRuntimeObject;
+  onConfigureParamsClick?: () => void;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
   templates: TemplateKind[];
   isEditing?: boolean;
@@ -22,6 +33,7 @@ type ServingRuntimeTemplateSectionProps = {
 
 const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps> = ({
   data,
+  onConfigureParamsClick,
   setData,
   templates,
   isEditing,
@@ -77,6 +89,19 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
           setData('servingRuntimeTemplateName', name);
         }}
       />
+      {data.servingRuntimeTemplateName && onConfigureParamsClick && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem data-testid="serving-runtime-template-helptext">
+              You can optimize model performance by{' '}
+              <Button isInline onClick={() => onConfigureParamsClick()} variant="link">
+                configuring the parameters
+              </Button>{' '}
+              of the selected serving runtime.
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
     </FormGroup>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -215,6 +215,8 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     [editInfo, servingRuntimeTemplates, createDataServingRuntime.servingRuntimeTemplateName],
   );
 
+  const servingRuntimeArgsInputRef = React.useRef<HTMLTextAreaElement>(null);
+
   const onBeforeClose = (submitted: boolean) => {
     fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', {
       outcome: TrackingOutcome.cancel,
@@ -377,6 +379,14 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   />
                   <ServingRuntimeTemplateSection
                     data={createDataServingRuntime}
+                    onConfigureParamsClick={
+                      servingRuntimeParamsEnabled
+                        ? () =>
+                            requestAnimationFrame(() => {
+                              servingRuntimeArgsInputRef.current?.focus();
+                            })
+                        : undefined
+                    }
                     setData={setCreateDataServingRuntime}
                     templates={servingRuntimeTemplates || []}
                     isEditing={!!editInfo}
@@ -440,6 +450,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 <ServingRuntimeArgsSection
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
+                  inputRef={servingRuntimeArgsInputRef}
                 />
                 <EnvironmentVariablesSection
                   data={createDataInferenceService}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -15,9 +15,14 @@ import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/typ
 type ServingRuntimeArgsSectionType = {
   data: CreatingInferenceServiceObject;
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
+  inputRef: React.RefObject<HTMLTextAreaElement>;
 };
 
-const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({ data, setData }) => (
+const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({
+  data,
+  setData,
+  inputRef,
+}) => (
   <FormGroup
     label="Additional serving runtime arguments"
     labelIcon={
@@ -37,9 +42,11 @@ const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({ da
     fieldId="serving-runtime-arguments"
   >
     <TextArea
+      id="servingRuntimeArgsInput"
+      ref={inputRef}
       placeholder={`--arg\n--arg2=value2\n--arg3 value3`}
       value={data.servingRuntimeArgs?.join('\n')}
-      onChange={(e, srArgs) => setData('servingRuntimeArgs', srArgs.split('\n'))}
+      onChange={(_e, srArgs) => setData('servingRuntimeArgs', srArgs.split('\n'))}
       autoResize
     />
     <FormHelperText>


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-14691

## Description
![image](https://github.com/user-attachments/assets/7df1f19f-6f13-4788-aac4-2f1deb1f7a2c)
no change until serving runtime is selected, at which point a helptext with link shows up:
![image](https://github.com/user-attachments/assets/5d8ab715-0b98-44a0-aeec-2035751a3f28)
clicking that link will scroll (if necessary) and focus on the additional args textarea
![image](https://github.com/user-attachments/assets/52847d0a-54f8-4a15-a7e6-45168c11f0df)


## How Has This Been Tested?
locally

## Test Impact
added tests that it doesn't show up initially, until selecting serving runtime

## Request review criteria:
should only show up in kserve, with servingRunTimeParamsEnabled, and after selecting a serving runtime

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
