### PR TITLE
Quick update to help text (followup to #3384)

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -48,7 +48,7 @@ const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = () =>
       <FormHelperText>
         <HelperText>
           <HelperTextItem>
-            {`Enter one parameter and its arguments per line. Overwriting the runtime's predefined
+            {`Enter one argument and its values per line. Overwriting the runtime's predefined
             listening port or model location will likely result in a failed deployment.`}
           </HelperTextItem>
         </HelperText>


### PR DESCRIPTION
Followup to https://issues.redhat.com/browse/RHOAIENG-14688 (#3384)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

A line of microcopy in the mockups changed since #3384 was opened, this just updates it to the correct text.

<img width="834" alt="Screenshot 2024-10-30 at 10 32 45 AM" src="https://github.com/user-attachments/assets/d479f89c-d1c4-47ff-a7f7-2f292ea44f61">

cc @yih-wang 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally, saw that the text renders correctly

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, microcopy change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
