### PR TITLE
[RHOAI-14745]: Apply Final Microcopy Changes

### DIFF
--- a/frontend/src/concepts/connectionTypes/validationUtils.ts
+++ b/frontend/src/concepts/connectionTypes/validationUtils.ts
@@ -19,7 +19,7 @@ const baseFieldPropertiesSchema = z.object({
 const baseDataFieldPropertiesSchema = baseFieldSchema.extend({
   envVar: z.string().regex(ENV_VAR_NAME_REGEX, {
     message:
-      'Valid characters include letters, numbers, and underscores ( _ ), and must not start with a number.',
+      'Must start with a letter or underscore. Valid characters include letters, numbers, and underscores ( _ ).',
   }),
   required: z.boolean().optional(),
 });

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -191,14 +191,14 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
                 variant={isEnvVarValid ? 'default' : 'error'}
                 icon={isEnvVarValid ? undefined : <ExclamationCircleIcon />}
               >
-                Valid characters include letters, numbers, and underscores ( _ ), and must not start
-                with a number.
+                Must start with a letter or underscore. Valid characters include letters, numbers,
+                and underscores ( _ ).
               </HelperTextItem>
             </HelperText>
             {isEnvVarConflict ? (
               <HelperText data-testid="envvar-conflict-warning">
                 <HelperTextItem icon={<WarningTriangleIcon />} variant="warning">
-                  {envVar} already exists within this connection type.
+                  {envVar} already exists within this connection type. Try a different name.
                 </HelperTextItem>
               </HelperText>
             ) : undefined}

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Popover } from '@patternfly/react-core';
+import { Button, Popover, Tooltip } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '~/pages/projects/screens/detail/const';
@@ -34,6 +34,8 @@ const ConnectionsList: React.FC = () => {
     isEdit?: boolean;
   }>();
 
+  const tooltipRef = React.useRef<HTMLButtonElement>();
+
   return (
     <>
       <DetailsSection
@@ -49,17 +51,29 @@ const ConnectionsList: React.FC = () => {
           </Popover>
         }
         actions={[
-          <Button
-            key={`action-${ProjectSectionID.CONNECTIONS}`}
-            data-testid="add-connection-button"
-            variant="primary"
-            onClick={() => {
-              setManageConnectionModal({});
-            }}
-            isDisabled={enabledConnectionTypes.length === 0}
-          >
-            Add connection
-          </Button>,
+          <>
+            <Button
+              data-testid="add-connection-button"
+              variant="primary"
+              onClick={() => {
+                setManageConnectionModal({});
+              }}
+              aria-describedby={
+                enabledConnectionTypes.length === 0 ? 'no-connection-types-tooltip' : undefined
+              }
+              isAriaDisabled={enabledConnectionTypes.length === 0}
+              ref={tooltipRef}
+            >
+              Add connection
+            </Button>
+            {enabledConnectionTypes.length === 0 && (
+              <Tooltip
+                id="no-connection-types-tooltip"
+                content="No connection types available"
+                triggerRef={tooltipRef}
+              />
+            )}
+          </>,
         ]}
         isLoading={!loaded || !connectionTypesLoaded}
         isEmpty={connections.length === 0}
@@ -71,17 +85,29 @@ const ConnectionsList: React.FC = () => {
             iconImage={typedEmptyImage(ProjectObjectType.connections)}
             imageAlt="create a connection"
             createButton={
-              <Button
-                key={`action-${ProjectSectionID.CONNECTIONS}`}
-                variant="primary"
-                data-testid="create-connection-button"
-                onClick={() => {
-                  setManageConnectionModal({});
-                }}
-                isDisabled={enabledConnectionTypes.length === 0}
-              >
-                Create connection
-              </Button>
+              <>
+                <Button
+                  variant="primary"
+                  data-testid="create-connection-button"
+                  aria-describedby={
+                    enabledConnectionTypes.length === 0 ? 'no-connection-types-tooltip' : undefined
+                  }
+                  isAriaDisabled={enabledConnectionTypes.length === 0}
+                  onClick={() => {
+                    setManageConnectionModal({});
+                  }}
+                  ref={tooltipRef}
+                >
+                  Create connection
+                </Button>
+                {enabledConnectionTypes.length === 0 && (
+                  <Tooltip
+                    id="no-connection-types-tooltip"
+                    content="No connection types available"
+                    triggerRef={tooltipRef}
+                  />
+                )}
+              </>
             }
           />
         }

--- a/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
@@ -17,7 +17,10 @@ import { createSecret, replaceSecret } from '~/api';
 import { NotebookKind, ProjectKind } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
-import { getConnectionTypeDisplayName } from '~/concepts/connectionTypes/utils';
+import {
+  filterEnabledConnectionTypes,
+  getConnectionTypeDisplayName,
+} from '~/concepts/connectionTypes/utils';
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
 import { useNotebooksStates } from '~/pages/projects/notebook/useNotebooksStates';
 import { SpawnerPageSectionTitles } from '~/pages/projects/screens/spawner/const';
@@ -71,6 +74,11 @@ export const ConnectionsFormSection: React.FC<Props> = ({
 }) => {
   const [connectionTypes] = useWatchConnectionTypes();
 
+  const enabledConnectionTypes = React.useMemo(
+    () => filterEnabledConnectionTypes(connectionTypes),
+    [connectionTypes],
+  );
+
   const columns = React.useMemo(() => getColumns(connectionTypes), [connectionTypes]);
 
   const initialNumberConnections = React.useRef(selectedConnections.length);
@@ -106,7 +114,8 @@ export const ConnectionsFormSection: React.FC<Props> = ({
     [selectedConnections],
   );
 
-  const tooltipRef = React.useRef<HTMLButtonElement>();
+  const connectionsTooltipRef = React.useRef<HTMLButtonElement>();
+  const connectionTypesTooltipRef = React.useRef<HTMLButtonElement>();
 
   return (
     <FormSection
@@ -122,26 +131,39 @@ export const ConnectionsFormSection: React.FC<Props> = ({
               variant="secondary"
               isAriaDisabled={unselectedConnections.length === 0}
               onClick={() => setShowAttachConnectionsModal(true)}
-              ref={tooltipRef}
+              ref={connectionsTooltipRef}
             >
               Attach existing connections
             </Button>
             {unselectedConnections.length === 0 && (
               <Tooltip
                 id="no-connections-tooltip"
-                content="No existing connections available"
-                triggerRef={tooltipRef}
+                content="No connections available"
+                triggerRef={connectionsTooltipRef}
               />
             )}
           </FlexItem>
           <FlexItem>
             <Button
               data-testid="create-connection-button"
+              aria-describedby={
+                enabledConnectionTypes.length === 0 ? 'no-connection-types-tooltip' : undefined
+              }
               variant="secondary"
+              content="No connection types available"
+              isAriaDisabled={enabledConnectionTypes.length === 0}
               onClick={() => setManageConnectionModal({ connection: undefined, isEdit: false })}
+              ref={connectionTypesTooltipRef}
             >
               Create connection
             </Button>
+            {enabledConnectionTypes.length === 0 && (
+              <Tooltip
+                id="no-connection-types-tooltip"
+                content="No connection types available"
+                triggerRef={connectionTypesTooltipRef}
+              />
+            )}
           </FlexItem>
         </Flex>
       }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14745

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
<details><summary>Before</summary>

Environment Variable: Default Help Text
<img width="500" alt="Screenshot 2024-10-30 at 12 32 53 PM" src="https://github.com/user-attachments/assets/80093692-e6aa-4cdb-8a53-934f84107135">


Environment Variable: Error Text
<img width="500" alt="Screenshot 2024-10-30 at 12 32 58 PM" src="https://github.com/user-attachments/assets/82962f56-61bc-481a-881d-0edc41e826d2">


Environment Variable: Warning Text
<img width="500" alt="Screenshot 2024-10-30 at 12 33 09 PM" src="https://github.com/user-attachments/assets/e3104e2b-4321-4be3-9faa-97f64dd0fa0e">


"Attach existing connection" button tooltip in workbench creation form:
<img width="500" alt="Screenshot 2024-10-29 at 2 56 17 PM" src="https://github.com/user-attachments/assets/3f52c0b4-6c04-4594-a28e-da30d68a1ab1">

"Create connection" button in Connections tab of project view (tooltip does not exist here):

<img width="500" alt="Screenshot 2024-10-30 at 12 32 31 PM" src="https://github.com/user-attachments/assets/b7778ea7-c9ee-44a8-bb90-d76e4921ce32">


</details>

<details><summary>After</summary>

Environment Variable: Default Help Text
<img width="500" alt="Screenshot 2024-10-30 at 11 57 11 AM" src="https://github.com/user-attachments/assets/07d1dc3c-16cf-42e8-afd7-77e71ac914c3">

Environment Variable: Error Text
<img width="500" alt="Screenshot 2024-10-30 at 11 57 20 AM" src="https://github.com/user-attachments/assets/6e719077-4015-4f61-b33d-87078c8b6614">

Environment Variable: Warning Text
<img width="500" alt="Screenshot 2024-10-30 at 11 58 24 AM" src="https://github.com/user-attachments/assets/53be2fdd-5080-4558-bf3e-a61571e49231">'

"Attach existing connections" button tooltip in "Create workbench" form: 
<img width="718" alt="Screenshot 2024-10-30 at 11 59 47 AM" src="https://github.com/user-attachments/assets/cbf06328-ba58-485d-bdae-2b8f1b4be4ce">

"Create connection" button tooltip in Connections tab of project view:
<img width="1606" alt="Screenshot 2024-10-30 at 11 56 39 AM" src="https://github.com/user-attachments/assets/a7046d72-410e-48bb-8e10-117b160de424">




</details>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add field modal:
Connection Types -> "Edit" in kebab dropdown for connection type -> "Add field"

In workbench creation form:
Disable all connection types -> Navigate into a DSP -> Create workbench -> Verify "Attach existing connections" button is disabled and has correct microcopy on tooltip when hovered: "No connection types available".

In "Connections" tab of a DSP:
Disable all connection types -> Navigate into a DSP -> Go to "Connections" tab -> Verify "Create connection" button is disabled and has correct microcopy on tooltip when hovered: "No connection types available".


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A - updates to microcopy

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
