### PR TITLE
remove admin requirement to fetch connection types

### DIFF
--- a/backend/src/routes/api/connection-types/index.ts
+++ b/backend/src/routes/api/connection-types/index.ts
@@ -1,7 +1,7 @@
 import { V1ConfigMap } from '@kubernetes/client-node';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { KubeFastifyInstance, RecursivePartial } from '../../../types';
-import { secureAdminRoute } from '../../../utils/route-security';
+import { secureAdminRoute, secureRoute } from '../../../utils/route-security';
 import {
   getConnectionType,
   listConnectionTypes,
@@ -14,7 +14,7 @@ import {
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get(
     '/',
-    secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) =>
+    secureRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) =>
       listConnectionTypes(fastify)
         .then((res) => res)
         .catch((res) => {
@@ -25,7 +25,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
 
   fastify.get(
     '/:name',
-    secureAdminRoute(fastify)(
+    secureRoute(fastify)(
       async (request: FastifyRequest<{ Params: { name: string } }>, reply: FastifyReply) =>
         getConnectionType(fastify, request.params.name)
           .then((res) => res)


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-15217

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Connection type `GET` endpoint was secured behind admin protection. This PR makes it so that a regular user can use this endpoint.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- enable the connection types feature flag `disableConnectionTypes`
- As an admin:
- navigate to `Settings -> Connection types`
- observe OOBT connection types listed
- As a regular user:
- navigate to project details -> connections tab
- page loads without error and can create a connection 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A backend change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
