### PR TITLE
MR API patch error fix

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -415,6 +415,7 @@ describe('Model version details', () => {
       cy.wait('@updateModelFormat').then((interception) => {
         expect(interception.request.body).to.deep.equal({
           modelFormatName: 'UpdatedFormat',
+          artifactType: 'model-artifact',
         });
       });
     });
@@ -439,6 +440,7 @@ describe('Model version details', () => {
       cy.wait('@updateModelVersion').then((interception) => {
         expect(interception.request.body).to.deep.equal({
           modelFormatVersion: '2.0.0',
+          artifactType: 'model-artifact',
         });
       });
     });

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -168,7 +168,11 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
             value={modelArtifact?.modelFormatName || ''}
             saveEditedValue={(value) =>
               apiState.api
-                .patchModelArtifact({}, { modelFormatName: value }, modelArtifact?.id || '')
+                .patchModelArtifact(
+                  {},
+                  { modelFormatName: value, artifactType: modelArtifact?.artifactType },
+                  modelArtifact?.id || '',
+                )
                 .then(() => {
                   refreshModelArtifacts();
                 })
@@ -183,7 +187,11 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
             isArchive={isArchiveVersion}
             saveEditedValue={(newVersion) =>
               apiState.api
-                .patchModelArtifact({}, { modelFormatVersion: newVersion }, modelArtifact?.id || '')
+                .patchModelArtifact(
+                  {},
+                  { modelFormatVersion: newVersion, artifactType: modelArtifact?.artifactType },
+                  modelArtifact?.id || '',
+                )
                 .then(() => {
                   refreshModelArtifacts();
                 })


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
[HOAIENG-14812](https://issues.redhat.com/browse/RHOAIENG-14812)
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
A follow up fix for the saving wasn't working because of an API changed made. Added the needed value the API was needing. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on MR UI- PLEASE use only modelregistry-sample-2 or a new model registry you create, as there is a bug on the API side that doesn't patch the old registries.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Test were written in the original feature PR

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
