### PR TITLE
unable to create a connection from the empty state

### DIFF
--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsList.tsx
@@ -35,62 +35,67 @@ const ConnectionsList: React.FC = () => {
   }>();
 
   return (
-    <DetailsSection
-      objectType={ProjectObjectType.connections}
-      id={ProjectSectionID.CONNECTIONS}
-      title={ProjectSectionTitles[ProjectSectionID.CONNECTIONS]}
-      popover={
-        <Popover headerContent="About connections" bodyContent={ConnectionsDescription}>
-          <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
-        </Popover>
-      }
-      actions={[
-        <Button
-          key={`action-${ProjectSectionID.CONNECTIONS}`}
-          data-testid="add-connection-button"
-          variant="primary"
-          onClick={() => {
-            setManageConnectionModal({});
-          }}
-          isDisabled={enabledConnectionTypes.length === 0}
-        >
-          Add connection
-        </Button>,
-      ]}
-      isLoading={!loaded || !connectionTypesLoaded}
-      isEmpty={connections.length === 0}
-      loadError={error || connectionTypesError}
-      emptyState={
-        <EmptyDetailsView
-          title="No connections"
-          description={ConnectionsDescription}
-          iconImage={typedEmptyImage(ProjectObjectType.connections)}
-          imageAlt="create a connection"
-          createButton={
-            <Button
-              key={`action-${ProjectSectionID.CONNECTIONS}`}
-              variant="primary"
-              data-testid="create-connection-button"
-              onClick={() => {
-                setManageConnectionModal({});
-              }}
-              isDisabled={enabledConnectionTypes.length === 0}
-            >
-              Create connection
-            </Button>
+    <>
+      <DetailsSection
+        objectType={ProjectObjectType.connections}
+        id={ProjectSectionID.CONNECTIONS}
+        title={ProjectSectionTitles[ProjectSectionID.CONNECTIONS]}
+        popover={
+          <Popover headerContent="About connections" bodyContent={ConnectionsDescription}>
+            <DashboardPopupIconButton
+              icon={<OutlinedQuestionCircleIcon />}
+              aria-label="More info"
+            />
+          </Popover>
+        }
+        actions={[
+          <Button
+            key={`action-${ProjectSectionID.CONNECTIONS}`}
+            data-testid="add-connection-button"
+            variant="primary"
+            onClick={() => {
+              setManageConnectionModal({});
+            }}
+            isDisabled={enabledConnectionTypes.length === 0}
+          >
+            Add connection
+          </Button>,
+        ]}
+        isLoading={!loaded || !connectionTypesLoaded}
+        isEmpty={connections.length === 0}
+        loadError={error || connectionTypesError}
+        emptyState={
+          <EmptyDetailsView
+            title="No connections"
+            description={ConnectionsDescription}
+            iconImage={typedEmptyImage(ProjectObjectType.connections)}
+            imageAlt="create a connection"
+            createButton={
+              <Button
+                key={`action-${ProjectSectionID.CONNECTIONS}`}
+                variant="primary"
+                data-testid="create-connection-button"
+                onClick={() => {
+                  setManageConnectionModal({});
+                }}
+                isDisabled={enabledConnectionTypes.length === 0}
+              >
+                Create connection
+              </Button>
+            }
+          />
+        }
+      >
+        <ConnectionsTable
+          namespace={currentProject.metadata.name}
+          connections={connections}
+          connectionTypes={connectionTypes}
+          refreshConnections={refreshConnections}
+          setManageConnectionModal={(modalConnection?: Connection) =>
+            setManageConnectionModal({ connection: modalConnection, isEdit: true })
           }
         />
-      }
-    >
-      <ConnectionsTable
-        namespace={currentProject.metadata.name}
-        connections={connections}
-        connectionTypes={connectionTypes}
-        refreshConnections={refreshConnections}
-        setManageConnectionModal={(modalConnection?: Connection) =>
-          setManageConnectionModal({ connection: modalConnection, isEdit: true })
-        }
-      />
+      </DetailsSection>
       {manageConnectionModal && (
         <ManageConnectionModal
           connection={manageConnectionModal.connection}
@@ -108,7 +113,7 @@ const ConnectionsList: React.FC = () => {
           isEdit={manageConnectionModal.isEdit}
         />
       )}
-    </DetailsSection>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When the empty state is shown on the connection tab, the `Create connection` button would not open the modal. This is because the modal was rendered within the children of the details page. 

The fix is simply to move the modal rendering to a fragment sibling of the details component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Enable the connection types feature flag `disableConnectionTypes`
- Create a project
- Go to the project details -> Connections tab
- Click the `Create connection` button in th empty state
- Observe the modal to create a connect opens
- Complete the modal
- Observe the new connection in the table

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
