### PR TITLE
feat(14690): default serving runtime args popover

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -9,6 +9,7 @@ type MockResourceConfigType = {
   platforms?: ServingRuntimePlatform[];
   apiProtocol?: ServingRuntimeAPIProtocol;
   isModelmesh?: boolean;
+  containerName?: string;
 };
 
 export const mockServingRuntimeTemplateK8sResource = ({
@@ -19,6 +20,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
   isModelmesh = false,
   apiProtocol = ServingRuntimeAPIProtocol.REST,
   platforms,
+  containerName = 'ovms',
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -66,7 +68,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
             ],
             image:
               'quay.io/modh/openvino-model-server@sha256:c89f76386bc8b59f0748cf173868e5beef21ac7d2f78dada69089c4d37c44116',
-            name: 'ovms',
+            name: containerName,
             resources: {
               limits: {
                 cpu: '0',

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -185,6 +185,14 @@ class ServingRuntimeModal extends Modal {
     return this.find().findByTestId('serving-runtime-template-selection');
   }
 
+  findPredefinedArgsButton() {
+    return this.find().findByTestId('view-predefined-args-button');
+  }
+
+  findPredefinedArgsList() {
+    return cy.findByTestId('predefined-args-list');
+  }
+
   findAuthenticationSection() {
     return this.find().findByTestId('auth-section');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -524,8 +524,7 @@ describe('Model Serving Global', () => {
 
     kserveModal.shouldBeOpen();
     kserveModal.findPredefinedArgsButton().click();
-    kserveModal.findPredefinedArgsList().should('exist');
-    kserveModal.findPredefinedArgsList().should('not.include.text', '--port=8001');
+    kserveModal.findPredefinedArgsList().should('not.exist');
     kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
     kserveModal.findPredefinedArgsButton().click();
     kserveModal.findPredefinedArgsList().should('exist');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -123,6 +123,7 @@ const initIntercepts = ({
           name: 'template-2',
           displayName: 'Caikit',
           platforms: [ServingRuntimePlatform.SINGLE],
+          containerName: 'kserve-container',
         }),
         mockServingRuntimeTemplateK8sResource({
           name: 'template-3',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -507,11 +507,29 @@ describe('Model Serving Global', () => {
 
     modelServingGlobal.findDeployModelButton().click();
 
-    // test that you can not submit on empty
     kserveModal.shouldBeOpen();
     kserveModal.findServingRuntimeTemplateHelptext().should('not.exist');
     kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
     kserveModal.findServingRuntimeTemplateHelptext().should('exist');
+  });
+
+  it('View predefined args popover populates', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableServingRuntimeParamsConfig: false,
+    });
+    modelServingGlobal.visit('test-project');
+
+    modelServingGlobal.findDeployModelButton().click();
+
+    kserveModal.shouldBeOpen();
+    kserveModal.findPredefinedArgsButton().click();
+    kserveModal.findPredefinedArgsList().should('exist');
+    kserveModal.findPredefinedArgsList().should('not.include.text', '--port=8001');
+    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+    kserveModal.findPredefinedArgsButton().click();
+    kserveModal.findPredefinedArgsList().should('exist');
+    kserveModal.findPredefinedArgsList().should('include.text', '--port=8001');
   });
 
   it('Navigate to kserve model metrics page only if enabled', () => {

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -24,7 +24,11 @@ import {
   AccessReviewResourceAttributes,
   SecretKind,
 } from '~/k8sTypes';
-import { requestsUnderLimits, resourcesArePositive } from '~/pages/modelServing/utils';
+import {
+  getKServeContainerArgs,
+  requestsUnderLimits,
+  resourcesArePositive,
+} from '~/pages/modelServing/utils';
 import useCustomServingRuntimesEnabled from '~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
 import { getServingRuntimeFromName } from '~/pages/modelServing/customServingRuntimes/utils';
 import useServingAcceleratorProfileFormState from '~/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState';
@@ -299,6 +303,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
       });
   };
+
   return (
     <Modal
       title={editInfo ? 'Edit model' : 'Deploy model'}
@@ -437,9 +442,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
             {servingRuntimeParamsEnabled && (
               <FormSection title="Configuration parameters" id="configuration-params">
                 <ServingRuntimeArgsSection
-                  predefinedArgs={servingRuntimeSelected?.spec.containers
-                    .flatMap((c) => c.args)
-                    .filter((arg) => typeof arg === 'string')}
+                  predefinedArgs={getKServeContainerArgs(servingRuntimeSelected)}
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
                   inputRef={servingRuntimeArgsInputRef}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -437,6 +437,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
             {servingRuntimeParamsEnabled && (
               <FormSection title="Configuration parameters" id="configuration-params">
                 <ServingRuntimeArgsSection
+                  predefinedArgs={servingRuntimeSelected?.spec.containers
+                    .flatMap((c) => c.args)
+                    .filter((arg) => typeof arg === 'string')}
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
                   inputRef={servingRuntimeArgsInputRef}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -10,6 +10,7 @@ import {
   ListItem,
   Popover,
   TextArea,
+  Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
@@ -27,67 +28,87 @@ const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({
   data,
   setData,
   inputRef,
-}) => (
-  <FormGroup
-    label="Additional serving runtime arguments"
-    labelInfo={
+}) => {
+  const servingRuntimeArgsLabelInfo = () => {
+    const button = (
+      <Button
+        data-testid="view-predefined-args-button"
+        variant="link"
+        isAriaDisabled={!predefinedArgs}
+      >
+        View predefined arguments
+      </Button>
+    );
+    if (!predefinedArgs) {
+      return (
+        <Tooltip content={<div>Select a serving runtime to view its predefined arguments</div>}>
+          {button}
+        </Tooltip>
+      );
+    }
+    return (
       <Popover
         headerContent="Predefined arguments of the selected serving runtime"
         bodyContent={
           <List isPlain data-testid="predefined-args-list">
-            {predefinedArgs ? (
+            {!predefinedArgs.length ? (
+              <ListItem key="0">No predefined arguments</ListItem>
+            ) : (
               predefinedArgs.map((arg: string, index: number) => (
                 <ListItem key={index}>{arg}</ListItem>
               ))
-            ) : (
-              <ListItem key="no">{`You haven't yet selected a serving runtime.`}</ListItem>
             )}
           </List>
         }
         footerContent={
           <div>
-            To <strong>overrwrite</strong> a predefined argument, specify a new value in the{' '}
+            To <strong>overwrite</strong> a predefined argument, specify a new value in the{' '}
             <strong>Additional serving runtime arguments</strong> field.
           </div>
         }
       >
-        <Button data-testid="view-predefined-args-button" variant="link">
-          View predefined arguments
-        </Button>
+        {button}
       </Popover>
-    }
-    labelIcon={
-      <Popover
-        bodyContent={
-          <div>
-            Serving runtime arguments define how the deployed model behaves. Overwriting predefined
-            arguments only affects this model deployment.
-          </div>
-        }
-      >
-        <Icon aria-label="Additional serving runtime arguments info" role="button">
-          <OutlinedQuestionCircleIcon />
-        </Icon>
-      </Popover>
-    }
-    fieldId="serving-runtime-arguments"
-  >
-    <TextArea
-      id="serving-runtime-arguments"
-      ref={inputRef}
-      placeholder={`--arg\n--arg2=value2\n--arg3 value3`}
-      value={data.servingRuntimeArgs?.join('\n')}
-      onChange={(_e, srArgs) => setData('servingRuntimeArgs', srArgs.split('\n'))}
-      autoResize
-    />
-    <FormHelperText>
-      <HelperText>
-        <HelperTextItem>
-          {`Enter one argument and its values per line. Overwriting the runtime's predefined
+    );
+  };
+
+  return (
+    <FormGroup
+      label="Additional serving runtime arguments"
+      labelInfo={servingRuntimeArgsLabelInfo()}
+      labelIcon={
+        <Popover
+          bodyContent={
+            <div>
+              Serving runtime arguments define how the deployed model behaves. Overwriting
+              predefined arguments only affects this model deployment.
+            </div>
+          }
+        >
+          <Icon aria-label="Additional serving runtime arguments info" role="button">
+            <OutlinedQuestionCircleIcon />
+          </Icon>
+        </Popover>
+      }
+      fieldId="serving-runtime-arguments"
+    >
+      <TextArea
+        id="serving-runtime-arguments"
+        ref={inputRef}
+        placeholder={`--arg\n--arg2=value2\n--arg3 value3`}
+        value={data.servingRuntimeArgs?.join('\n')}
+        onChange={(_e, srArgs) => setData('servingRuntimeArgs', srArgs.split('\n'))}
+        autoResize
+      />
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>
+            {`Enter one argument and its values per line. Overwriting the runtime's predefined
             listening port or model location will likely result in a failed deployment.`}
-        </HelperTextItem>
-      </HelperText>
-    </FormHelperText>
-  </FormGroup>
-);
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    </FormGroup>
+  );
+};
 export default ServingRuntimeArgsSection;

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import {
+  Button,
   FormGroup,
   FormHelperText,
   HelperText,
   HelperTextItem,
   Icon,
+  List,
+  ListItem,
   Popover,
   TextArea,
 } from '@patternfly/react-core';
@@ -13,18 +16,46 @@ import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
 
 type ServingRuntimeArgsSectionType = {
+  predefinedArgs?: string[];
   data: CreatingInferenceServiceObject;
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
   inputRef: React.RefObject<HTMLTextAreaElement>;
 };
 
 const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({
+  predefinedArgs,
   data,
   setData,
   inputRef,
 }) => (
   <FormGroup
     label="Additional serving runtime arguments"
+    labelInfo={
+      <Popover
+        headerContent="Predefined arguments of the selected serving runtime"
+        bodyContent={
+          <List isPlain data-testid="predefined-args-list">
+            {predefinedArgs ? (
+              predefinedArgs.map((arg: string, index: number) => (
+                <ListItem key={index}>{arg}</ListItem>
+              ))
+            ) : (
+              <ListItem key="no">{`You haven't yet selected a serving runtime.`}</ListItem>
+            )}
+          </List>
+        }
+        footerContent={
+          <div>
+            To <strong>overrwrite</strong> a predefined argument, specify a new value in the{' '}
+            <strong>Additional serving runtime arguments</strong> field.
+          </div>
+        }
+      >
+        <Button data-testid="view-predefined-args-button" variant="link">
+          View predefined arguments
+        </Button>
+      </Popover>
+    }
     labelIcon={
       <Popover
         bodyContent={

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -30,6 +30,7 @@ import {
   InferenceServiceKind,
   ServiceAccountKind,
   RoleKind,
+  ServingContainer,
 } from '~/k8sTypes';
 import { ContainerResources } from '~/types';
 import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '~/concepts/k8s/utils';
@@ -258,6 +259,19 @@ export const getServingRuntimeOrReturnEmpty = (
   }
 
   return servingRuntime?.spec.containers[0]?.resources;
+};
+
+export const getKServeContainer = (
+  servingRuntime?: ServingRuntimeKind,
+): ServingContainer | undefined =>
+  servingRuntime?.spec.containers.find((container) => container.name === 'kserve-container');
+
+// will return `undefined` if no kserve container, force empty array if there is kserve with no args
+export const getKServeContainerArgs = (
+  servingRuntime?: ServingRuntimeKind,
+): string[] | undefined => {
+  const kserveContainer = getKServeContainer(servingRuntime);
+  return kserveContainer ? kserveContainer.args ?? [] : undefined;
 };
 
 export const getServingRuntimeSize = (


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-14690

## Description
the label help button and popover to view default serving runtime args for the selected serving runtime

with no selected serving runtime:
![image](https://github.com/user-attachments/assets/0287257a-45f5-4057-9955-afcc85569c99)

after selecting a serving runtime with no predefined args:
![image](https://github.com/user-attachments/assets/9ac17136-5313-4cb4-9aec-82b369663758)

after selecting a serving runtime with predefined args:
![image](https://github.com/user-attachments/assets/a3993f69-a9e3-43aa-ae7b-5309d81f858e)


## How Has This Been Tested?
tested locally with no runtime selected and with various runtimes

## Test Impact
added a test that the popover shows up with default serving runtime arg of the selected runtime

## Request review criteria:
check the popover looks correct with various runtimes selected

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
