### PR TITLE
update to use connection-type-ref annotation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
@@ -100,6 +100,9 @@ describe('Connection types', () => {
       },
       { success: true },
     ).as('delete');
+
+    connectionTypesPage.shouldHaveConnectionTypes();
+
     cy.interceptOdh('GET /api/connection-types', [
       mockConnectionTypeConfigMap({}),
       mockConnectionTypeConfigMap({
@@ -111,7 +114,6 @@ describe('Connection types', () => {
       }),
     ]);
 
-    connectionTypesPage.shouldHaveConnectionTypes();
     connectionTypesPage.getConnectionTypeRow('Test display name').findKebabAction('Delete').click();
     deleteModal.findSubmitButton().should('be.disabled');
     deleteModal.findInput().fill('Test display name');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
@@ -123,11 +123,11 @@ describe('Connections', () => {
         kind: 'Secret',
         metadata: {
           annotations: {
-            'opendatahub.io/connection-type': 'test',
+            'opendatahub.io/connection-type-ref': 'test',
             'openshift.io/description': '',
             'openshift.io/display-name': 'new connection',
           },
-          labels: { 'opendatahub.io/dashboard': 'true', 'opendatahub.io/managed': 'true' },
+          labels: { 'opendatahub.io/dashboard': 'true' },
           name: 'new-connection',
           namespace: 'test-project',
         },
@@ -171,7 +171,8 @@ describe('Connections', () => {
         kind: 'Secret',
         metadata: {
           annotations: {
-            'opendatahub.io/connection-type': 'postgres',
+            'opendatahub.io/connection-type': 's3',
+            'opendatahub.io/connection-type-ref': 'postgres',
             'openshift.io/description': '',
             'openshift.io/display-name': 'test2',
           },

--- a/frontend/src/concepts/connectionTypes/types.ts
+++ b/frontend/src/concepts/connectionTypes/types.ts
@@ -150,7 +150,8 @@ export type Connection = SecretKind & {
       'opendatahub.io/managed'?: 'true';
     };
     annotations: DisplayNameAnnotations & {
-      'opendatahub.io/connection-type': string;
+      'opendatahub.io/connection-type'?: 's3' | string;
+      'opendatahub.io/connection-type-ref'?: string;
     };
   };
   data?: {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -27,6 +27,7 @@ import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescription
 import {
   assembleConnectionSecret,
   getConnectionTypeDisplayName,
+  getConnectionTypeRef,
   getDefaultValues,
   isConnectionTypeDataField,
   isUriConnection,
@@ -79,7 +80,9 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
             )}
             <FlexItem>
               <Truncate
-                content={`Type: ${getConnectionTypeDisplayName(connection, connectionTypes)}`}
+                content={`Type: ${
+                  getConnectionTypeDisplayName(connection, connectionTypes) || 'Unknown'
+                }`}
               />
             </FlexItem>
           </Flex>
@@ -94,11 +97,9 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
   const selectedConnectionType = React.useMemo(
     () =>
       connectionTypes.find(
-        (t) =>
-          getResourceNameFromK8sResource(t) ===
-          selectedConnection?.metadata.annotations['opendatahub.io/connection-type'],
+        (t) => getResourceNameFromK8sResource(t) === getConnectionTypeRef(selectedConnection),
       ),
-    [connectionTypes, selectedConnection?.metadata.annotations],
+    [connectionTypes, selectedConnection],
   );
 
   React.useEffect(() => {

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
@@ -3,7 +3,7 @@ import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTyp
 import { deleteSecret } from '~/api';
 import { Table } from '~/components/table';
 import ConnectionsTableRow from './ConnectionsTableRow';
-import { columns } from './connectionsTableColumns';
+import { getColumns } from './connectionsTableColumns';
 import { ConnectionsDeleteModal } from './ConnectionsDeleteModal';
 
 type ConnectionsTableProps = {
@@ -22,6 +22,8 @@ const ConnectionsTable: React.FC<ConnectionsTableProps> = ({
   setManageConnectionModal,
 }) => {
   const [deleteConnection, setDeleteConnection] = React.useState<Connection>();
+
+  const columns = React.useMemo(() => getColumns(connectionTypes), [connectionTypes]);
 
   return (
     <>

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTableRow.tsx
@@ -30,7 +30,7 @@ const ConnectionsTableRow: React.FC<ConnectionsTableRowProps> = ({
   showWarningIcon = false,
 }) => {
   const connectionTypeDisplayName = React.useMemo(
-    () => getConnectionTypeDisplayName(obj, connectionTypes ?? []),
+    () => getConnectionTypeDisplayName(obj, connectionTypes ?? []) || 'Unknown',
     [obj, connectionTypes],
   );
 

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -15,6 +15,7 @@ import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptio
 import {
   assembleConnectionSecret,
   filterEnabledConnectionTypes,
+  getConnectionTypeRef,
   getDefaultValues,
   isConnectionTypeDataField,
   parseConnectionSecretValues,
@@ -46,7 +47,7 @@ export const ManageConnectionModal: React.FC<Props> = ({
     [connectionTypes],
   );
 
-  const connectionTypeSource = connection?.metadata.annotations['opendatahub.io/connection-type'];
+  const connectionTypeSource = getConnectionTypeRef(connection);
 
   const [selectedConnectionType, setSelectedConnectionType] = React.useState<
     ConnectionTypeConfigMapObj | undefined

--- a/frontend/src/pages/projects/screens/detail/connections/connectionsTableColumns.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/connectionsTableColumns.ts
@@ -1,7 +1,10 @@
-import { Connection } from '~/concepts/connectionTypes/types';
+import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { SortableData } from '~/components/table';
+import { getConnectionTypeDisplayName } from '~/concepts/connectionTypes/utils';
 
-export const columns: SortableData<Connection>[] = [
+export const getColumns = (
+  connectionTypes?: ConnectionTypeConfigMapObj[],
+): SortableData<Connection>[] => [
   {
     field: 'name',
     label: 'Name',
@@ -16,8 +19,8 @@ export const columns: SortableData<Connection>[] = [
     label: 'Type',
     width: 20,
     sortable: (a, b) =>
-      a.metadata.annotations['opendatahub.io/connection-type'].localeCompare(
-        b.metadata.annotations['opendatahub.io/connection-type'],
+      (getConnectionTypeDisplayName(a, connectionTypes) || '').localeCompare(
+        getConnectionTypeDisplayName(b, connectionTypes) || '',
       ),
   },
   {

--- a/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
@@ -39,8 +39,8 @@ const getColumns = (connectionTypes: ConnectionTypeConfigMapObj[]): SortableData
     field: 'type',
     label: 'Type',
     sortable: (a, b) =>
-      getConnectionTypeDisplayName(a, connectionTypes).localeCompare(
-        getConnectionTypeDisplayName(b, connectionTypes),
+      (getConnectionTypeDisplayName(a, connectionTypes) || '').localeCompare(
+        getConnectionTypeDisplayName(b, connectionTypes) || '',
       ),
   },
   {

--- a/frontend/src/pages/projects/screens/spawner/connections/SelectConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/SelectConnectionsModal.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, FlexItem, Form, FormGroup, Modal, Truncate } from '@patte
 import { MultiSelection, SelectionOptions } from '~/components/MultiSelection';
 import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { getConnectionTypeRef } from '~/concepts/connectionTypes/utils';
 import { connectionEnvVarConflicts, DuplicateEnvVarWarning } from './DuplicateEnvVarsWarning';
 
 type Props = {
@@ -21,9 +22,7 @@ export const SelectConnectionsModal: React.FC<Props> = ({
   const [selectionOptions, setSelectionOptions] = React.useState<SelectionOptions[]>(() =>
     connectionsToList.map((c) => {
       const category = connectionTypes
-        .find(
-          (type) => c.metadata.annotations['opendatahub.io/connection-type'] === type.metadata.name,
-        )
+        .find((type) => getConnectionTypeRef(c) === type.metadata.name)
         ?.data?.category?.join(', ');
 
       return {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Depends on https://github.com/opendatahub-io/odh-dashboard/pull/3417

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Problem
- Can’t use `opendatahub.io/connection-type` label arbitrarily because a controller reads this value to populate `storage-config` `Secret` with `s3` properties used by `InferenceService`
- Doesn’t seem to be a way to change the type of the referenced secret in the `InferenceService` outside of our connection `Secret`.
- The `opendatahub.io/managed=true` annotation is used by a controller to identify secrets which will be used to populate the `storage-config` `InferenceService` will fail unless the type related to the reference `Secret` is of type `s3`	

Solution
- At connection creation / edit time, set `opendatahub.io/managed=true` and `opendatahub.io/connection-type=s3` if the connection is an s3 model serving compatible secret (ie it also has a bucket)
- `opendatahub.io/connection-type-ref` instead to reference back the connection type with a fallback to `opendatahub.io/connection-type`
- Ensure model serving only includes URI compatible and s3 compatible (including annotations and labels) in the list of available connection types

No visual impact to the UI.
However if a connection is created from an s3 connection type but the bucket field is omitted, it will not be marked as model serving compatible in the connections table.
cc @simrandhaliw 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable the connection types feature flag `disableConnectionTypes`
- create duplicate s3 compatible connection types so that the configmap resource isn't named `s3`
- create some older data connection to test compatibility
- create some new connections:
    - s3 with and without bucket
    - s3 from the non pre-installed type
    - uri
    - some other arbitrary connections
- Observe only s3 connection with a bucket are marked as model serving compatible
- Observe connections with a URI env var are marked as model serving compatible
- Ensure all connections are assignable to a workbench
- Ensure only model serving compatible connections are usable in model deployments

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- updated some tests to align with the new use of the labels

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
