### PR TITLE
Fix types in accelerator spawner submit

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -834,7 +834,7 @@ export type NotebookData = {
   notebookSizeName: string;
   imageName: string;
   imageTagName: string;
-  acceleratorProfile: AcceleratorProfileState;
+  acceleratorProfile?: AcceleratorProfileState;
   envVars: EnvVarReducedTypeKeyValues;
   state: NotebookState;
   username?: string;
@@ -842,7 +842,7 @@ export type NotebookData = {
 };
 
 export type AcceleratorProfileState = {
-  acceleratorProfile?: AcceleratorProfileKind;
+  acceleratorProfile: AcceleratorProfileKind;
   count: number;
 };
 

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -196,7 +196,7 @@ export const assembleNotebook = async (
   const tolerations: Toleration[] = [];
 
   const affinity: NotebookAffinity = {};
-  if (data.acceleratorProfile?.count > 0 && data.acceleratorProfile.acceleratorProfile) {
+  if (data.acceleratorProfile?.count > 0) {
     if (!resources.limits) {
       resources.limits = {};
     }
@@ -274,7 +274,7 @@ export const assembleNotebook = async (
         'opendatahub.io/username': username,
         'kubeflow-resource-stopped': null,
         'opendatahub.io/accelerator-name':
-          data.acceleratorProfile?.acceleratorProfile?.metadata.name || '',
+          data.acceleratorProfile?.acceleratorProfile.metadata.name || '',
       },
       name: name,
       namespace: namespace,

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -160,7 +160,7 @@ export const assembleNotebook = async (
   envName: string,
   tolerationSettings: NotebookTolerationSettings,
 ): Promise<Notebook> => {
-  const { notebookSizeName, imageName, imageTagName, acceleratorProfile, envVars } = data;
+  const { notebookSizeName, imageName, imageTagName, envVars } = data;
 
   const notebookSize = getNotebookSize(notebookSizeName);
 
@@ -196,17 +196,17 @@ export const assembleNotebook = async (
   const tolerations: Toleration[] = [];
 
   const affinity: NotebookAffinity = {};
-  if (acceleratorProfile.count > 0 && acceleratorProfile.acceleratorProfile) {
+  if (data.acceleratorProfile?.count > 0 && data.acceleratorProfile.acceleratorProfile) {
     if (!resources.limits) {
       resources.limits = {};
     }
     if (!resources.requests) {
       resources.requests = {};
     }
-    resources.limits[acceleratorProfile.acceleratorProfile.spec.identifier] =
-      acceleratorProfile.count;
-    resources.requests[acceleratorProfile.acceleratorProfile.spec.identifier] =
-      acceleratorProfile.count;
+    resources.limits[data.acceleratorProfile.acceleratorProfile.spec.identifier] =
+      data.acceleratorProfile.count;
+    resources.requests[data.acceleratorProfile.acceleratorProfile.spec.identifier] =
+      data.acceleratorProfile.count;
   } else {
     // step type down to string to avoid type errors
     const containerResourceKeys: string[] = Object.values(ContainerResourceAttributes);
@@ -224,8 +224,8 @@ export const assembleNotebook = async (
     });
   }
 
-  if (acceleratorProfile.acceleratorProfile?.spec.tolerations) {
-    tolerations.push(...acceleratorProfile.acceleratorProfile.spec.tolerations);
+  if (data.acceleratorProfile?.acceleratorProfile?.spec.tolerations) {
+    tolerations.push(...data.acceleratorProfile.acceleratorProfile.spec.tolerations);
   }
 
   if (tolerationSettings?.enabled) {

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -274,7 +274,7 @@ export const assembleNotebook = async (
         'opendatahub.io/username': username,
         'kubeflow-resource-stopped': null,
         'opendatahub.io/accelerator-name':
-          acceleratorProfile.acceleratorProfile?.metadata.name || '',
+          data.acceleratorProfile?.acceleratorProfile?.metadata.name || '',
       },
       name: name,
       namespace: namespace,

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
@@ -40,6 +40,10 @@ class NotebookServer {
   findStopNotebookServerButton() {
     return cy.findByTestId('stop-nb-server-button');
   }
+
+  findAcceleratorProfileSelect() {
+    return cy.findByTestId('accelerator-profile-select');
+  }
 }
 
 export const notebookServer = new NotebookServer();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -89,7 +89,6 @@ describe('NotebookServer', () => {
         notebookSizeName: 'XSmall',
         imageName: 'code-server-notebook',
         imageTagName: '2023.2',
-        acceleratorProfile: undefined,
         envVars: { configMap: {}, secrets: {} },
         state: 'started',
         storageClassName: 'openshift-default-sc',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -89,7 +89,7 @@ describe('NotebookServer', () => {
         notebookSizeName: 'XSmall',
         imageName: 'code-server-notebook',
         imageTagName: '2023.2',
-        acceleratorProfile: { count: 0, acceleratorProfile: undefined },
+        acceleratorProfile: undefined,
         envVars: { configMap: {}, secrets: {} },
         state: 'started',
         storageClassName: 'openshift-default-sc',

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -273,7 +273,10 @@ const SpawnerPage: React.FC = () => {
       notebookSizeName: selectedSize.name,
       imageName: selectedImageTag.image?.name || '',
       imageTagName: selectedImageTag.tag?.name || '',
-      acceleratorProfile: acceleratorProfileFormData,
+      acceleratorProfile: {
+        acceleratorProfile: acceleratorProfileFormData.profile,
+        count: acceleratorProfileFormData.count,
+      },
       envVars,
       state: NotebookState.Started,
       username: impersonatedUsername || undefined,

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -273,10 +273,12 @@ const SpawnerPage: React.FC = () => {
       notebookSizeName: selectedSize.name,
       imageName: selectedImageTag.image?.name || '',
       imageTagName: selectedImageTag.tag?.name || '',
-      acceleratorProfile: {
-        acceleratorProfile: acceleratorProfileFormData.profile,
-        count: acceleratorProfileFormData.count,
-      },
+      acceleratorProfile: acceleratorProfileFormData.profile
+        ? {
+            acceleratorProfile: acceleratorProfileFormData.profile,
+            count: acceleratorProfileFormData.count,
+          }
+        : undefined,
       envVars,
       state: NotebookState.Started,
       username: impersonatedUsername || undefined,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -577,8 +577,8 @@ export type NotebookData = {
   notebookSizeName: string;
   imageName: string;
   imageTagName: string;
-  acceleratorProfile: {
-    acceleratorProfile?: AcceleratorProfileKind;
+  acceleratorProfile?: {
+    acceleratorProfile: AcceleratorProfileKind;
     count: number;
   };
   envVars: EnvVarReducedTypeKeyValues;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-15330

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
update logic for submitting of a juypyter notebook

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
try to submit a jupyter notebook with accelerator profile and make sure resulting notebook resource gets the accelerator details added 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
