### PR TITLE
Update 'Resource name' fields to meet UX guidelines: Accelerator Profiles

### DIFF
--- a/backend/src/routes/api/accelerator-profiles/acceleratorProfilesUtils.ts
+++ b/backend/src/routes/api/accelerator-profiles/acceleratorProfilesUtils.ts
@@ -10,13 +10,14 @@ export const postAcceleratorProfile = async (
 ): Promise<{ success: boolean; error: string }> => {
   const { customObjectsApi } = fastify.kube;
   const { namespace } = fastify.kube;
-  const body = request.body as AcceleratorProfileKind['spec'];
+  const requestBody = request.body as { name?: string } & AcceleratorProfileKind['spec'];
+  const { name, ...body } = requestBody;
 
   const payload: AcceleratorProfileKind = {
     apiVersion: 'dashboard.opendatahub.io/v1',
     kind: 'AcceleratorProfile',
     metadata: {
-      name: translateDisplayNameForK8s(body.displayName),
+      name: name || translateDisplayNameForK8s(body.displayName),
       namespace,
       annotations: {
         'opendatahub.io/modified-date': new Date().toISOString(),

--- a/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
@@ -1,3 +1,4 @@
+import { K8sNameDescriptionField } from '~/__tests__/cypress/cypress/pages/components/subComponents/K8sNameDescriptionField';
 import { Modal } from './components/Modal';
 import { TableToolbar } from './components/TableToolbar';
 import { TableRow } from './components/table';
@@ -86,9 +87,7 @@ class AcceleratorProfile {
 }
 
 class ManageAcceleratorProfile {
-  findAcceleratorNameInput() {
-    return cy.findByTestId('accelerator-name-input');
-  }
+  k8sNameDescription = new K8sNameDescriptionField('accelerator-profile');
 
   findIdentifierInput() {
     return cy.findByTestId('accelerator-identifier-input');
@@ -101,10 +100,6 @@ class ManageAcceleratorProfile {
 
   findTolerationsButton() {
     return cy.findByTestId('add-toleration-button');
-  }
-
-  findDescriptionInput() {
-    return cy.findByTestId('accelerator-description-input');
   }
 
   findSubmitButton() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts
@@ -50,9 +50,32 @@ describe('Manage Accelerator Profile', () => {
     createAcceleratorProfile.findSubmitButton().should('be.disabled');
 
     // test required fields
-    createAcceleratorProfile.findAcceleratorNameInput().fill('test-accelerator');
+    createAcceleratorProfile.k8sNameDescription.findDisplayNameInput().fill('test-accelerator');
     createAcceleratorProfile.findSubmitButton().should('be.disabled');
     createAcceleratorProfile.findIdentifierInput().fill('nvidia.com/gpu');
+    createAcceleratorProfile.findSubmitButton().should('be.enabled');
+
+    // test resource name validation
+    createAcceleratorProfile.k8sNameDescription.findResourceEditLink().click();
+    createAcceleratorProfile.k8sNameDescription
+      .findResourceNameInput()
+      .should('have.attr', 'aria-invalid', 'false');
+    createAcceleratorProfile.k8sNameDescription
+      .findResourceNameInput()
+      .should('have.value', 'test-accelerator');
+    // Invalid character k8s names fail
+    createAcceleratorProfile.k8sNameDescription
+      .findResourceNameInput()
+      .clear()
+      .type('InVaLiD vAlUe!');
+    createAcceleratorProfile.k8sNameDescription
+      .findResourceNameInput()
+      .should('have.attr', 'aria-invalid', 'true');
+    createAcceleratorProfile.findSubmitButton().should('be.disabled');
+    createAcceleratorProfile.k8sNameDescription
+      .findResourceNameInput()
+      .clear()
+      .type('test-accelerator-name');
     createAcceleratorProfile.findSubmitButton().should('be.enabled');
 
     // test tolerations
@@ -127,7 +150,9 @@ describe('Manage Accelerator Profile', () => {
 
     cy.wait('@createAccelerator').then((interception) => {
       expect(interception.request.body).to.be.eql({
+        name: 'test-accelerator-name',
         displayName: 'test-accelerator',
+        description: '',
         identifier: 'nvidia.com/gpu',
         enabled: true,
         tolerations: [],
@@ -138,9 +163,13 @@ describe('Manage Accelerator Profile', () => {
   it('edit page has expected values', () => {
     initIntercepts({});
     editAcceleratorProfile.visit('test-accelerator');
-    editAcceleratorProfile.findAcceleratorNameInput().should('have.value', 'Test Accelerator');
+    editAcceleratorProfile.k8sNameDescription
+      .findDisplayNameInput()
+      .should('have.value', 'Test Accelerator');
     editAcceleratorProfile.findIdentifierInput().should('have.value', 'nvidia.com/gpu');
-    editAcceleratorProfile.findDescriptionInput().should('have.value', 'Test description');
+    editAcceleratorProfile.k8sNameDescription
+      .findDescriptionInput()
+      .should('have.value', 'Test description');
     editAcceleratorProfile
       .getRow('nvidia.com/gpu')
       .shouldHaveEffect('NoSchedule')
@@ -153,10 +182,11 @@ describe('Manage Accelerator Profile', () => {
       { path: { name: 'test-accelerator' } },
       { success: true },
     ).as('updatedAccelerator');
-    editAcceleratorProfile.findDescriptionInput().fill('Updated description');
+    editAcceleratorProfile.k8sNameDescription.findDescriptionInput().fill('Updated description');
     editAcceleratorProfile.findSubmitButton().click();
     cy.wait('@updatedAccelerator').then((interception) => {
       expect(interception.request.body).to.eql({
+        name: 'test-accelerator',
         displayName: 'Test Accelerator',
         identifier: 'nvidia.com/gpu',
         enabled: true,

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -48,6 +48,7 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
   return (
     <FormGroup {...formGroupProps} isRequired>
       <TextInput
+        id={`${dataTestId}-resourceName`}
         data-testid={`${dataTestId}-resourceName`}
         name={`${dataTestId}-resourceName`}
         isRequired

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/types.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/types.ts
@@ -26,9 +26,15 @@ export type K8sNameDescriptionFieldData = {
   };
 };
 
+export type K8sNameDescriptionType = {
+  name?: string;
+  k8sName?: string;
+  description?: string;
+};
+
 export type UseK8sNameDescriptionDataConfiguration = {
   /** Seed the state with initial data */
-  initialData?: K8sResourceCommon;
+  initialData?: K8sResourceCommon | K8sNameDescriptionType;
   /** Allow for custom internal logic for limiting k8s names based on their type */
   limitNameResourceType?: LimitNameResourceType;
   /**

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash-es';
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
@@ -10,6 +11,7 @@ import { RecursivePartial } from '~/typeHelpers';
 import {
   K8sNameDescriptionFieldData,
   K8sNameDescriptionFieldUpdateFunctionInternal,
+  K8sNameDescriptionType,
   UseK8sNameDescriptionDataConfiguration,
 } from './types';
 
@@ -33,6 +35,10 @@ export enum LimitNameResourceType {
 /** K8s max DNS subdomain name length */
 const MAX_RESOURCE_NAME_LENGTH = 253;
 
+export const isK8sNameDescriptionType = (
+  x?: K8sNameDescriptionType | K8sResourceCommon,
+): x is K8sNameDescriptionType => !!x && 'k8sName' in x;
+
 export const setupDefaults = ({
   initialData,
   limitNameResourceType,
@@ -43,11 +49,16 @@ export const setupDefaults = ({
   let initialK8sNameValue = '';
   let configuredMaxLength = MAX_RESOURCE_NAME_LENGTH;
 
-  if (isK8sDSGResource(initialData)) {
+  if (isK8sNameDescriptionType(initialData)) {
+    initialName = initialData.name || '';
+    initialDescription = initialData.description || '';
+    initialK8sNameValue = initialData.k8sName || '';
+  } else if (isK8sDSGResource(initialData)) {
     initialName = getDisplayNameFromK8sResource(initialData);
     initialDescription = getDescriptionFromK8sResource(initialData);
     initialK8sNameValue = initialData.metadata.name;
   }
+
   if (limitNameResourceType != null) {
     configuredMaxLength = ROUTE_BASED_NAME_LENGTH;
   }

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
@@ -1,25 +1,15 @@
-import {
-  FormSection,
-  Stack,
-  StackItem,
-  FormGroup,
-  TextInput,
-  TextArea,
-  Switch,
-  Popover,
-} from '@patternfly/react-core';
+import { StackItem, FormGroup, Switch, Popover } from '@patternfly/react-core';
 import React from 'react';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useSearchParams } from 'react-router-dom';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
-import { ManageAcceleratorProfileSectionTitles } from './const';
-import { ManageAcceleratorProfileSectionID } from './types';
+import { AcceleratorProfileFormData } from './types';
 import { IdentifierSelectField } from './IdentifierSelectField';
 
 type ManageAcceleratorProfileDetailsSectionProps = {
-  state: AcceleratorProfileKind['spec'];
+  state: AcceleratorProfileFormData;
   setState: UpdateObjectAtPropAndValue<AcceleratorProfileKind['spec']>;
 };
 
@@ -34,69 +24,37 @@ export const ManageAcceleratorProfileDetailsSection: React.FC<
   );
 
   return (
-    <FormSection
-      id={ManageAcceleratorProfileSectionID.DETAILS}
-      aria-label={ManageAcceleratorProfileSectionTitles[ManageAcceleratorProfileSectionID.DETAILS]}
-      title={ManageAcceleratorProfileSectionTitles[ManageAcceleratorProfileSectionID.DETAILS]}
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <FormGroup label="Name" isRequired>
-            <TextInput
-              isRequired
-              value={state.displayName}
-              id="accelerator-name"
-              name="accelerator-name"
-              onChange={(_, name) => setState('displayName', name)}
-              aria-label="Name"
-              data-testid="accelerator-name-input"
-            />
-          </FormGroup>
-        </StackItem>
-        <StackItem>
-          <FormGroup
-            label="Identifier"
-            isRequired
-            labelIcon={
-              <Popover bodyContent="An identifier is a unique string that names a specific hardware accelerator resource.">
-                <DashboardPopupIconButton
-                  icon={<OutlinedQuestionCircleIcon />}
-                  aria-label="More info for identifier field"
-                />
-              </Popover>
-            }
-          >
-            <IdentifierSelectField
-              value={state.identifier}
-              onChange={(identifier) => setState('identifier', identifier)}
-              identifierOptions={acceleratorIdentifiers}
-            />
-          </FormGroup>
-        </StackItem>
-        <StackItem>
-          <FormGroup label="Description">
-            <TextArea
-              resizeOrientation="vertical"
-              id="accelerator-description"
-              name="accelerator-description"
-              value={state.description}
-              onChange={(_, description) => setState('description', description)}
-              aria-label="Description"
-              data-testid="accelerator-description-input"
-            />
-          </FormGroup>
-        </StackItem>
-        <StackItem>
-          <FormGroup label="Enabled">
-            <Switch
-              id="accelerator-enabled"
-              isChecked={state.enabled}
-              onChange={(_, enabled) => setState('enabled', enabled)}
-              aria-label="Enabled"
-            />
-          </FormGroup>
-        </StackItem>
-      </Stack>
-    </FormSection>
+    <>
+      <StackItem>
+        <FormGroup
+          label="Identifier"
+          isRequired
+          labelIcon={
+            <Popover bodyContent="An identifier is a unique string that names a specific hardware accelerator resource.">
+              <DashboardPopupIconButton
+                icon={<OutlinedQuestionCircleIcon />}
+                aria-label="More info for identifier field"
+              />
+            </Popover>
+          }
+        >
+          <IdentifierSelectField
+            value={state.identifier}
+            onChange={(identifier) => setState('identifier', identifier)}
+            identifierOptions={acceleratorIdentifiers}
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Enabled">
+          <Switch
+            id="accelerator-enabled"
+            isChecked={state.enabled}
+            onChange={(_, enabled) => setState('enabled', enabled)}
+            aria-label="Enabled"
+          />
+        </FormGroup>
+      </StackItem>
+    </>
   );
 };

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
@@ -13,21 +13,22 @@ import {
   createAcceleratorProfile,
   updateAcceleratorProfile,
 } from '~/services/acceleratorProfileService';
+import { AcceleratorProfileFormData } from '~/pages/acceleratorProfiles/screens/manage/types';
 
 type ManageAcceleratorProfileFooterProps = {
-  state: AcceleratorProfileKind['spec'];
+  state: AcceleratorProfileFormData;
   existingAcceleratorProfile?: AcceleratorProfileKind;
+  validFormData: boolean;
 };
 
 export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFooterProps> = ({
   state,
   existingAcceleratorProfile,
+  validFormData,
 }) => {
   const [errorMessage, setErrorMessage] = React.useState<string>('');
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const navigate = useNavigate();
-
-  const isButtonDisabled = !state.displayName || !state.identifier;
 
   const onCreateAcceleratorProfile = async () => {
     setIsLoading(true);
@@ -86,7 +87,7 @@ export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFo
         <ActionList>
           <ActionListItem>
             <Button
-              isDisabled={isButtonDisabled || isLoading}
+              isDisabled={!validFormData || isLoading}
               isLoading={isLoading}
               variant="primary"
               id="create-button"

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/types.ts
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/types.ts
@@ -1,3 +1,5 @@
+import { AcceleratorProfileKind } from '~/k8sTypes';
+
 export enum ManageAcceleratorProfileSectionID {
   DETAILS = 'details',
   TOLERATIONS = 'tolerations',
@@ -6,3 +8,5 @@ export enum ManageAcceleratorProfileSectionID {
 export type ManageAcceleratorProfileSectionTitlesType = {
   [key in ManageAcceleratorProfileSectionID]: string;
 };
+
+export type AcceleratorProfileFormData = { name?: string } & AcceleratorProfileKind['spec'];

--- a/frontend/src/services/acceleratorProfileService.ts
+++ b/frontend/src/services/acceleratorProfileService.ts
@@ -3,7 +3,7 @@ import { AcceleratorProfileKind } from '~/k8sTypes';
 import { ResponseStatus } from '~/types';
 
 export const createAcceleratorProfile = (
-  acceleratorProfile: AcceleratorProfileKind['spec'],
+  acceleratorProfile: { name?: string } & AcceleratorProfileKind['spec'],
 ): Promise<ResponseStatus> => {
   const url = '/api/accelerator-profiles';
   return axios


### PR DESCRIPTION
Towards [RHOAIENG-14746](https://issues.redhat.com/browse/RHOAIENG-14746)

## Description
Updates the create/edit dialog for Accelerator Profiles to use the common `K8sNameDescriptionField` component in order to meet current UX guidelines.

## How Has This Been Tested?
- Navigate to Settings -> Accelerator profiles
  - Select `Create accelerator profile`
  - Enter the name for the new profile.
  - View the resource name via the `Edit resource name` link.
  - Change the resource name
  - Save the profile.
  - Verify the profile is created with the correct Display name, Resource Name, and Description.
- Navigate to Settings -> Accelerator profiles
  - Select the kebab for an existing profile and choose `Edit`
  - Update the Name field
  - Update the Description field
  - Notice the resource name is not editable
  - Save the profile.
  - Verify the profile is updated with the correct Display name and Description.

## Test Impact
Updated tests to verify fields in the `K8sNameDescriptionField` component of the dialog

## Screen shots

### Create
![image](https://github.com/user-attachments/assets/4b050761-bf8a-44c6-9fa5-4008c835ccbe)


### Create editing Resource name
![image](https://github.com/user-attachments/assets/e08ec8d9-eb01-46db-a42e-a2faf6761db7)


### Edit
![image](https://github.com/user-attachments/assets/bfd4df9b-b890-4e1e-bcad-71c602accd32)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw 