### PR TITLE
Show no-default alert correctly when first loading storage classes settings page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -30,6 +30,10 @@ class StorageClassesPage {
     return cy.findByTestId('storage-classes-empty-state');
   }
 
+  findNoDefaultAlert() {
+    return cy.findByTestId('no-default-storage-class-alert');
+  }
+
   mockGetStorageClasses(storageClasses?: StorageClassKind[], times?: number) {
     return cy.interceptK8sList(
       {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -434,5 +434,21 @@ describe('Storage classes', () => {
       toolbar.fillSearchInput('test');
       storageClassesTable.findRows().should('have.length', 1);
     });
+
+    it('should not show no default alert when there is an OpenShift default storage class', () => {
+      storageClassesPage.mockGetStorageClasses([openshiftDefaultStorageClass]);
+      storageClassesTable.mockUpdateStorageClass(openshiftDefaultStorageClass.metadata.name, 1);
+      storageClassesPage.visit();
+
+      storageClassesPage.findNoDefaultAlert().should('not.exist');
+    });
+
+    it('should show no default alert when there is no OpenShift default storage classes', () => {
+      storageClassesPage.mockGetStorageClasses([otherStorageClass]);
+      storageClassesTable.mockUpdateStorageClass(otherStorageClass.metadata.name, 1);
+      storageClassesPage.visit();
+
+      storageClassesPage.findNoDefaultAlert().should('exist');
+    });
   });
 });

--- a/frontend/src/pages/storageClasses/StorageClassesContext.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesContext.tsx
@@ -138,7 +138,7 @@ export const StorageClassContextProvider: React.FC<StorageClassContextProviderPr
         if (successResponses.length) {
           await refresh();
 
-          if (!defaultStorageClassName) {
+          if (!openshiftDefaultScName) {
             setIsAutoDefaultAlertOpen(true);
           }
         }

--- a/frontend/src/pages/storageClasses/StorageClassesPage.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesPage.tsx
@@ -89,6 +89,7 @@ const StorageClassesPage: React.FC = () => {
                 isInline
                 title="Review default storage class"
                 actionClose={<AlertActionCloseButton onClose={() => setIsAlertOpen(false)} />}
+                data-testid="no-default-storage-class-alert"
               >
                 Some OpenShift AI features won&apos;t work without a default storage class. No
                 OpenShift default exists, so an OpenShift AI default was set automatically. Review


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-15219

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
A one-liner change to update the condition to show the alert correctly.

<img width="1508" alt="Screenshot 2024-11-04 at 12 37 41 PM" src="https://github.com/user-attachments/assets/b6f7929b-2ea4-4dc5-ac78-12c02696f739">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to OpenShift console and find all the storage classes
2. Find the default storage class, change the annotation `storageclass.kubernetes.io/is-default-class: 'true'` to `storageclass.kubernetes.io/is-default-class: 'false'`
3. Remove the annotation `opendatahub.io/sc-config` from all the storage classes
4. Go back to the Dashboard storage classes settings page and refresh
5. You should be able to see the alert
6. Change the storage class in step 2 back to default
7. Remove the annotation `opendatahub.io/sc-config` from all the storage classes again
8. Go back to the Dashboard storage classes settings page and refresh
9. You shouldn't see the alert even if the annotations are patch

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a cypress test to verify the change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
