### PR TITLE
Delete connection ref from notebooks when connection is deleted

### DIFF
--- a/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectedResources.tsx
@@ -25,7 +25,7 @@ const ConnectedResources: React.FC<Props> = ({ connection }) => {
     return <Spinner size="sm" />;
   }
 
-  if (!connectedNotebooks.length) {
+  if (!connectedNotebooks.length && !connectedModels.length) {
     return '-';
   }
 

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
-import { deleteSecret } from '~/api';
 import { Table } from '~/components/table';
 import ConnectionsTableRow from './ConnectionsTableRow';
 import { getColumns } from './connectionsTableColumns';
@@ -65,9 +64,6 @@ const ConnectionsTable: React.FC<ConnectionsTableProps> = ({
               refreshConnections();
             }
           }}
-          onDelete={() =>
-            deleteSecret(deleteConnection.metadata.namespace, deleteConnection.metadata.name)
-          }
         />
       )}
     </>

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsDeleteModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ConnectionsDeleteModal.spec.tsx
@@ -34,7 +34,6 @@ const mockNotebooks = [
   mockNotebookK8sResource({ name: 'another-notebook', displayName: 'Another notebook' }),
 ];
 describe('Delete connection modal', () => {
-  const onDelete = jest.fn();
   const onClose = jest.fn();
 
   beforeEach(() => {
@@ -68,7 +67,6 @@ describe('Delete connection modal', () => {
         namespace={deleteConnection.metadata.namespace}
         deleteConnection={deleteConnection}
         onClose={onClose}
-        onDelete={onDelete}
       />,
     );
 
@@ -104,7 +102,6 @@ describe('Delete connection modal', () => {
         namespace={deleteConnection.metadata.namespace}
         deleteConnection={deleteConnection}
         onClose={onClose}
-        onDelete={onDelete}
       />,
     );
 


### PR DESCRIPTION
Closes [RHOAIENG-14208](https://issues.redhat.com/browse/RHOAIENG-14208)

## Description
When removing a connection, delete the env var from the env var list of any connected notebooks

## How Has This Been Tested?
Delete a connection that has connected notebooks
Go to the workbenches tab and edit the notebooks that were connected.
Verify the connection is no longer listed in the Connections section

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

