### PR TITLE
feat(14692): predefined vars popover

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -10,6 +10,7 @@ type MockResourceConfigType = {
   apiProtocol?: ServingRuntimeAPIProtocol;
   isModelmesh?: boolean;
   containerName?: string;
+  containerEnvVars?: { name: string; value: string }[];
 };
 
 export const mockServingRuntimeTemplateK8sResource = ({
@@ -21,6 +22,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
   apiProtocol = ServingRuntimeAPIProtocol.REST,
   platforms,
   containerName = 'ovms',
+  containerEnvVars = undefined,
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -66,6 +68,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
               '--rest_bind_address=127.0.0.1',
               '--target_device=NVIDIA',
             ],
+            ...(containerEnvVars && { env: containerEnvVars }),
             image:
               'quay.io/modh/openvino-model-server@sha256:c89f76386bc8b59f0748cf173868e5beef21ac7d2f78dada69089c4d37c44116',
             name: containerName,

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -193,6 +193,22 @@ class ServingRuntimeModal extends Modal {
     return cy.findByTestId('predefined-args-list');
   }
 
+  findPredefinedArgsTooltip() {
+    return cy.findByTestId('predefined-args-tooltip');
+  }
+
+  findPredefinedVarsButton() {
+    return this.find().findByTestId('view-predefined-vars-button');
+  }
+
+  findPredefinedVarsList() {
+    return cy.findByTestId('predefined-vars-list');
+  }
+
+  findPredefinedVarsTooltip() {
+    return cy.findByTestId('predefined-vars-tooltip');
+  }
+
   findAuthenticationSection() {
     return this.find().findByTestId('auth-section');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -124,6 +124,7 @@ const initIntercepts = ({
           displayName: 'Caikit',
           platforms: [ServingRuntimePlatform.SINGLE],
           containerName: 'kserve-container',
+          containerEnvVars: [{ name: 'HF_HOME', value: '/tmp/hf_home' }],
         }),
         mockServingRuntimeTemplateK8sResource({
           name: 'template-3',
@@ -526,10 +527,32 @@ describe('Model Serving Global', () => {
     kserveModal.shouldBeOpen();
     kserveModal.findPredefinedArgsButton().click();
     kserveModal.findPredefinedArgsList().should('not.exist');
+    kserveModal.findPredefinedArgsTooltip().should('exist');
     kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
     kserveModal.findPredefinedArgsButton().click();
     kserveModal.findPredefinedArgsList().should('exist');
+    kserveModal.findPredefinedArgsTooltip().should('not.exist');
     kserveModal.findPredefinedArgsList().should('include.text', '--port=8001');
+  });
+
+  it('View predefined vars popover populates', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableServingRuntimeParamsConfig: false,
+    });
+    modelServingGlobal.visit('test-project');
+
+    modelServingGlobal.findDeployModelButton().click();
+
+    kserveModal.shouldBeOpen();
+    kserveModal.findPredefinedVarsButton().click();
+    kserveModal.findPredefinedVarsList().should('not.exist');
+    kserveModal.findPredefinedVarsTooltip().should('exist');
+    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+    kserveModal.findPredefinedVarsButton().click();
+    kserveModal.findPredefinedVarsList().should('exist');
+    kserveModal.findPredefinedVarsTooltip().should('not.exist');
+    kserveModal.findPredefinedVarsList().should('include.text', 'HF_HOME=/tmp/hf_home');
   });
 
   it('Navigate to kserve model metrics page only if enabled', () => {

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
@@ -3,11 +3,14 @@ import {
   Button,
   FormGroup,
   Icon,
+  List,
+  ListItem,
   Popover,
   Split,
   SplitItem,
   Stack,
   TextInput,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   MinusCircleIcon,
@@ -18,11 +21,13 @@ import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
 
 type EnvironmentVariablesSectionType = {
+  predefinedVars?: string[];
   data: CreatingInferenceServiceObject;
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
 };
 
 const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = ({
+  predefinedVars,
   data,
   setData,
 }) => {
@@ -53,9 +58,58 @@ const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = (
     }
   };
 
+  const labelInfo = () => {
+    const button = (
+      <Button
+        data-testid="view-predefined-vars-button"
+        variant="link"
+        isAriaDisabled={!predefinedVars}
+      >
+        View predefined variables
+      </Button>
+    );
+    if (!predefinedVars) {
+      return (
+        <Tooltip
+          data-testid="predefined-vars-tooltip"
+          content={
+            <div>Select a serving runtime to view its predefined environment variables.</div>
+          }
+        >
+          {button}
+        </Tooltip>
+      );
+    }
+    return (
+      <Popover
+        headerContent="Predefined variables of the selected serving runtime"
+        bodyContent={
+          <List isPlain data-testid="predefined-vars-list">
+            {!predefinedVars.length ? (
+              <ListItem key="0">No predefined variables</ListItem>
+            ) : (
+              predefinedVars.map((arg: string, index: number) => (
+                <ListItem key={index}>{arg}</ListItem>
+              ))
+            )}
+          </List>
+        }
+        footerContent={
+          <div>
+            To <strong>overwrite</strong> a predefined variable, specify a new value in the{' '}
+            <strong>Additional environment variables</strong> field.
+          </div>
+        }
+      >
+        {button}
+      </Popover>
+    );
+  };
+
   return (
     <FormGroup
       label="Additional environment variables"
+      labelInfo={labelInfo()}
       labelIcon={
         <Popover
           bodyContent={

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -26,6 +26,7 @@ import {
 } from '~/k8sTypes';
 import {
   getKServeContainerArgs,
+  getKServeContainerEnvVarStrs,
   requestsUnderLimits,
   resourcesArePositive,
 } from '~/pages/modelServing/utils';
@@ -448,6 +449,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   inputRef={servingRuntimeArgsInputRef}
                 />
                 <EnvironmentVariablesSection
+                  predefinedVars={getKServeContainerEnvVarStrs(servingRuntimeSelected)}
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
                 />

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -41,7 +41,10 @@ const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({
     );
     if (!predefinedArgs) {
       return (
-        <Tooltip content={<div>Select a serving runtime to view its predefined arguments</div>}>
+        <Tooltip
+          data-testid="predefined-args-tooltip"
+          content={<div>Select a serving runtime to view its predefined arguments</div>}
+        >
           {button}
         </Tooltip>
       );

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -274,6 +274,17 @@ export const getKServeContainerArgs = (
   return kserveContainer ? kserveContainer.args ?? [] : undefined;
 };
 
+// will return `undefined` if no kserve container, force empty array if there is kserve with no vars
+export const getKServeContainerEnvVarStrs = (
+  servingRuntime?: ServingRuntimeKind,
+): string[] | undefined => {
+  const kserveContainer = getKServeContainer(servingRuntime);
+  if (!kserveContainer) {
+    return undefined;
+  }
+  return kserveContainer.env?.map((ev) => `${ev.name}=${ev.value}`) || [];
+};
+
 export const getServingRuntimeSize = (
   sizes: ModelServingSize[],
   servingRuntime?: ServingRuntimeKind,


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHOAIENG-14692

## Description
No serving runtime selected:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/48dae9a7-9ed1-486a-8c8f-fe2d6cbebdf7">

Serving runtime with predefined env vars:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/834b47ed-021b-456f-884a-384e149e72f6">

Serving runtime with no predefined env vars:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/cbc724e3-77e2-4a96-be75-7338364d886b">
@yih-wang 


## How Has This Been Tested?
Tested locally with various selections for serving runtime

## Test Impact
added tests for the tooltip and popover displaying serving runtime env var

## Request review criteria:
tooltip exists before selecting serving runtime, popover exists after selecting serving runtime and contains env vars (if they exist on serving runtime)

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
