### PR TITLE
Follow-up fix for RHOAIENG-14133 about pipeline server condition check

### DIFF
--- a/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
+++ b/frontend/src/concepts/pipelines/EnsureCompatiblePipelineServer.tsx
@@ -20,10 +20,12 @@ const DOCS_LINK =
 
 type EnsureCompatiblePipelineServerProps = {
   children: React.ReactNode;
+  emptyStateVariant?: EmptyStateVariant;
 };
 
 const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerProps> = ({
   children,
+  emptyStateVariant = EmptyStateVariant.lg,
 }) => {
   const { pipelinesServer } = usePipelinesAPI();
   const [isDeleting, setIsDeleting] = React.useState(false);
@@ -44,7 +46,7 @@ const EnsureCompatiblePipelineServer: React.FC<EnsureCompatiblePipelineServerPro
     return (
       <>
         <Bullseye data-testid="incompatible-pipelines-server">
-          <EmptyState variant={EmptyStateVariant.lg}>
+          <EmptyState variant={emptyStateVariant}>
             <EmptyStateHeader
               data-testid="incompatible-pipelines-server-title"
               titleText="Unsupported pipeline and pipeline server version"

--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesCard.tsx
@@ -8,6 +8,7 @@ import {
   EmptyStateBody,
   EmptyStateHeader,
   EmptyStateIcon,
+  EmptyStateVariant,
   Spinner,
   Stack,
   Text,
@@ -84,7 +85,7 @@ const PipelinesCard: React.FC = () => {
       );
     }
 
-    if (pipelinesServer.timedOut) {
+    if (pipelinesServer.timedOut && pipelinesServer.compatible) {
       return (
         <CardBody>
           <PipelineServerTimedOut />
@@ -94,7 +95,7 @@ const PipelinesCard: React.FC = () => {
 
     return (
       <EnsureAPIAvailability>
-        <EnsureCompatiblePipelineServer>
+        <EnsureCompatiblePipelineServer emptyStateVariant={EmptyStateVariant.xs}>
           <PipelinesCardMetrics />
         </EnsureCompatiblePipelineServer>
       </EnsureAPIAvailability>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Follow up for [RHOAIENG-14133](https://issues.redhat.com/browse/RHOAIENG-14133)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Per requested here: https://github.com/opendatahub-io/odh-dashboard/pull/3404#discussion_r1827284829, I added an extra check for the pipelines server condition for the pipelines card on the project overview page to make sure it can correctly render the incompatible v1 servers.

<img width="1508" alt="Screenshot 2024-11-05 at 11 27 42 AM" src="https://github.com/user-attachments/assets/4eb1809c-6632-4814-a9fe-fed66db7bf50">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Change dspVersion from v2 to v1
2. Check the error state on the project overview page pipelines card

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
