### PR TITLE
fix(15448): no match version search crashes ui

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry.ts
@@ -87,6 +87,10 @@ class ModelRegistry {
     return cy.findByTestId('empty-model-registries-state');
   }
 
+  findModelRegistryEmptyTableState() {
+    return cy.findByTestId('dashboard-empty-table-state');
+  }
+
   shouldregisteredModelsEmpty() {
     cy.findByTestId('empty-registered-models').should('exist');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersions.cy.ts
@@ -245,6 +245,11 @@ describe('Model Versions', () => {
     modelRegistry.findModelVersionsTableSearch().type('Test author');
     modelRegistry.findModelVersionsTableRows().should('have.length', 1);
     modelRegistry.findModelVersionsTableRows().contains('Test author');
+
+    // searching with no matches shows no results screen
+    modelRegistry.findModelVersionsTableSearch().focused().clear();
+    modelRegistry.findModelVersionsTableSearch().type('no matches for this');
+    modelRegistry.findModelRegistryEmptyTableState();
   });
 
   it('Model version details back button should lead to versions table', () => {

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useParams } from 'react-router-dom';
 import { Table } from '~/components/table';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
@@ -22,9 +23,8 @@ const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
   isArchiveModel,
   refresh,
 }) => {
-  const inferenceServices = useMakeFetchObject(
-    useInferenceServices(undefined, modelVersions[0].registeredModelId),
-  );
+  const { registeredModelId } = useParams();
+  const inferenceServices = useMakeFetchObject(useInferenceServices(undefined, registeredModelId));
   const hasDeploys = (mvId: string) =>
     !!inferenceServices.data.some(
       (s) => s.metadata.labels?.[KnownLabels.MODEL_VERSION_ID] === mvId,


### PR DESCRIPTION
closes https://issues.redhat.com/browse/RHOAIENG-15448

## Description
fixed issue where searching on the model details page caused the ui to crash. now correctly shows the no results view:
![image](https://github.com/user-attachments/assets/c40743ee-65e1-45dd-9d9d-233373071114)


## How Has This Been Tested?
locally tested with search that has results and search that doesn't

## Test Impact
added a test for searching with no matches

## Request review criteria:
searching on the model registry versions page will correctly show results if they exist, and show a "no results found" screen if not.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
