### PR TITLE
Model Registry Selector: don't navigate on selection unless necessary

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/ModelRegistrySelectorNavigator.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistrySelectorNavigator.tsx
@@ -11,15 +11,17 @@ const ModelRegistrySelectorNavigator: React.FC<ModelRegistrySelectorNavigatorPro
   ...modelRegistrySelectorProps
 }) => {
   const navigate = useNavigate();
-  const { modelRegistry } = useParams<{ modelRegistry: string }>();
+  const { modelRegistry: currentModelRegistry } = useParams<{ modelRegistry: string }>();
 
   return (
     <ModelRegistrySelector
       {...modelRegistrySelectorProps}
       onSelection={(modelRegistryName) => {
-        navigate(getRedirectPath(modelRegistryName));
+        if (modelRegistryName !== currentModelRegistry) {
+          navigate(getRedirectPath(modelRegistryName));
+        }
       }}
-      modelRegistry={modelRegistry ?? ''}
+      modelRegistry={currentModelRegistry ?? ''}
     />
   );
 };


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/RHOAIENG-15471

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Prevents infinite loop on mounting the ModelRegistrySelectorNavigator when there is only one registry, caused by  https://github.com/opendatahub-io/odh-dashboard/pull/3345. The `onSelection` callback will be called on first render, which was triggering a navigation that would call it again, triggering an infinite loop. Now it will only navigate if we are not already on the registry we want to navigate to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I attempted to write a cypress test for this, but the infinite loop was not happening in the Cypress environment so I couldn't get the test to fail without the fix. I gave up 🤷 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
