### PR TITLE
guard against corrupt connection types and support previous categories

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connectionTypes.ts
@@ -139,7 +139,7 @@ class CategorySection extends Contextual<HTMLElement> {
   }
 
   findMultiGroupSelectButton(name: string) {
-    return cy.findByTestId(`select-multi-typeahead-${name}`).click();
+    return cy.findByTestId(`select-multi-typeahead-${name}`);
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
@@ -34,7 +34,9 @@ it('Connection types should be hidden by feature flag', () => {
     }),
   );
 
+  cy.interceptOdh('GET /api/connection-types', []);
   connectionTypesPage.visit();
+  connectionTypesPage.shouldBeEmpty();
 });
 
 describe('Connection types', () => {
@@ -48,6 +50,12 @@ describe('Connection types', () => {
       }),
     );
     cy.interceptOdh('GET /api/connection-types', [
+      {
+        ...mockConnectionTypeConfigMap({
+          name: 'corrupt',
+        }),
+        data: { category: '[[', fields: '{{' },
+      },
       mockConnectionTypeConfigMap({}),
       mockConnectionTypeConfigMap({
         name: 'no-display-name',
@@ -73,6 +81,8 @@ describe('Connection types', () => {
 
   it('should show the correct column values', () => {
     connectionTypesPage.visit();
+
+    connectionTypesPage.findTable().find('tbody tr').should('have.length', 3);
 
     const row = connectionTypesPage.getConnectionTypeRow('Test display name');
     row.shouldHaveDescription('Test description');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -22,6 +22,7 @@ describe('create', () => {
       mockConnectionTypeConfigMap({
         displayName: 'URI - v1',
         name: 'uri-v1',
+        category: ['existing-category'],
         fields: [
           {
             type: 'uri',
@@ -49,15 +50,16 @@ describe('create', () => {
 
     createConnectionTypePage.findConnectionTypeName().type('hello');
     categorySection.findCategoryTable();
-    categorySection.findMultiGroupSelectButton('Object-storage');
+    categorySection.findMultiGroupSelectButton('existing-category').should('exist');
+    categorySection.findMultiGroupSelectButton('Object-storage').click();
     createConnectionTypePage.findSubmitButton().should('be.enabled');
 
     categorySection.findMultiGroupInput().type('Database');
-    categorySection.findMultiGroupSelectButton('Database');
+    categorySection.findMultiGroupSelectButton('Database').click();
 
     categorySection.findMultiGroupInput().type('New category');
 
-    categorySection.findMultiGroupSelectButton('Option');
+    categorySection.findMultiGroupSelectButton('Option').click();
     categorySection.findChipItem('New category').should('exist');
     categorySection.findMultiGroupInput().type('{esc}');
 
@@ -88,7 +90,7 @@ describe('create', () => {
 
     createConnectionTypePage.findConnectionTypeName().type('hello');
     categorySection.findCategoryTable();
-    categorySection.findMultiGroupSelectButton('Object-storage');
+    categorySection.findMultiGroupSelectButton('Object-storage').click();
     createConnectionTypePage.findSubmitButton().should('be.enabled').click();
 
     createConnectionTypePage.findFooterError().should('contain.text', 'returned error message');

--- a/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
@@ -40,7 +40,7 @@ const createSelectOption = (
             <Truncate content={description} />
           </FlexItem>
         )}
-        {connectionType.data?.category?.length && (
+        {!!connectionType.data?.category?.length && (
           <FlexItem>
             <Truncate content={`Category: ${connectionType.data.category.join(', ')}`} />
           </FlexItem>

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -37,15 +37,21 @@ export const getConnectionTypeRef = (connection: Connection | undefined): string
 
 export const toConnectionTypeConfigMapObj = (
   configMap: ConnectionTypeConfigMap,
-): ConnectionTypeConfigMapObj => ({
-  ...configMap,
-  data: configMap.data
-    ? {
-        category: configMap.data.category ? JSON.parse(configMap.data.category) : undefined,
-        fields: configMap.data.fields ? JSON.parse(configMap.data.fields) : undefined,
-      }
-    : undefined,
-});
+): ConnectionTypeConfigMapObj => {
+  try {
+    return {
+      ...configMap,
+      data: configMap.data
+        ? {
+            category: configMap.data.category ? JSON.parse(configMap.data.category) : undefined,
+            fields: configMap.data.fields ? JSON.parse(configMap.data.fields) : undefined,
+          }
+        : undefined,
+    };
+  } catch (e) {
+    throw new Error('Failed to parse connection type data.');
+  }
+};
 
 export const toConnectionTypeConfigMap = (
   obj: ConnectionTypeConfigMapObj,

--- a/frontend/src/pages/connectionTypes/ConnectionTypesPage.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesPage.tsx
@@ -16,6 +16,7 @@ const ConnectionTypesPage: React.FC = () => {
       emptyStatePage={<EmptyConnectionTypes />}
       title="Connection types"
       description="Create and manage connection types for users in your organization. Connection types include customizable fields and optional default values to decrease the time required to add connections to data sources and sinks."
+      errorMessage="Unable to load connection types"
     >
       <PageSection isFilled variant="light">
         <ConnectionTypesTable connectionTypes={connectionTypes} onUpdate={refresh} />

--- a/frontend/src/pages/connectionTypes/manage/DuplicateConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/DuplicateConnectionTypePage.tsx
@@ -12,7 +12,14 @@ const DuplicateConnectionTypePage: React.FC = () => {
   const [existingConnectionType, isLoaded, error] = useConnectionType(name);
 
   if (!isLoaded || error) {
-    return <ApplicationsPage loaded={isLoaded} loadError={error} empty />;
+    return (
+      <ApplicationsPage
+        loaded={isLoaded}
+        loadError={error}
+        empty
+        errorMessage="Unable to load connection type"
+      />
+    );
   }
 
   const connectionType = stateConnectionType || existingConnectionType;

--- a/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
@@ -18,7 +18,14 @@ const EditConnectionTypePage: React.FC = () => {
   }
 
   if (!isLoaded || error) {
-    return <ApplicationsPage loaded={isLoaded} loadError={error} empty />;
+    return (
+      <ApplicationsPage
+        loaded={isLoaded}
+        loadError={error}
+        empty
+        errorMessage="Unable to load connection type"
+      />
+    );
   }
 
   return (

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -69,6 +69,12 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
     [connectionTypes],
   );
 
+  const allCategories = React.useMemo(
+    () =>
+      new Set([...categoryOptions, ...connectionTypes.map((ct) => ct.data?.category ?? []).flat()]),
+    [connectionTypes],
+  );
+
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
 
   const initialValues = React.useMemo<ConnectionTypeFormData>(() => {
@@ -100,11 +106,12 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
 
   const categoryItems = React.useMemo<SelectionOptions[]>(
     () =>
-      category
-        .filter((c) => !categoryOptions.includes(c))
-        .concat(categoryOptions)
-        .map((c) => ({ id: c, name: c, selected: category.includes(c) })),
-    [category],
+      [...new Set([...allCategories, ...category])].toSorted().map((c) => ({
+        id: c,
+        name: c,
+        selected: category.includes(c),
+      })),
+    [category, allCategories],
   );
 
   const connectionTypeObj = React.useMemo(

--- a/frontend/src/services/connectionTypesService.ts
+++ b/frontend/src/services/connectionTypesService.ts
@@ -12,22 +12,29 @@ import {
 export const fetchConnectionTypes = (): Promise<ConnectionTypeConfigMapObj[]> => {
   const url = `/api/connection-types`;
   return axios
-    .get(url)
+    .get<ConnectionTypeConfigMap[]>(url)
     .then((response) =>
-      response.data.map((cm: ConnectionTypeConfigMap) => toConnectionTypeConfigMapObj(cm)),
+      response.data.reduce<ConnectionTypeConfigMapObj[]>((acc, cm) => {
+        try {
+          acc.push(toConnectionTypeConfigMapObj(cm));
+        } catch (e) {
+          // ignore those which fail to parse
+        }
+        return acc;
+      }, []),
     )
     .catch((e) => {
-      throw new Error(e.response.data.message);
+      throw new Error(e?.response?.data?.message ?? e.message);
     });
 };
 
 export const fetchConnectionType = (name: string): Promise<ConnectionTypeConfigMapObj> => {
   const url = `/api/connection-types/${name}`;
   return axios
-    .get(url)
+    .get<ConnectionTypeConfigMap>(url)
     .then((response) => toConnectionTypeConfigMapObj(response.data))
     .catch((e) => {
-      throw new Error(e.response.data.message);
+      throw new Error(e?.response?.data?.message ?? e.message);
     });
 };
 
@@ -36,10 +43,10 @@ export const createConnectionType = (
 ): Promise<ResponseStatus> => {
   const url = `/api/connection-types`;
   return axios
-    .post(url, toConnectionTypeConfigMap(connectionType))
+    .post<ResponseStatus>(url, toConnectionTypeConfigMap(connectionType))
     .then((response) => response.data)
     .catch((e) => {
-      throw new Error(e.response.data.message);
+      throw new Error(e?.response?.data?.message ?? e.message);
     });
 };
 
@@ -48,10 +55,10 @@ export const updateConnectionType = (
 ): Promise<ResponseStatus> => {
   const url = `/api/connection-types/${connectionType.metadata.name}`;
   return axios
-    .put(url, toConnectionTypeConfigMap(connectionType))
+    .put<ResponseStatus>(url, toConnectionTypeConfigMap(connectionType))
     .then((response) => response.data)
     .catch((e) => {
-      throw new Error(e.response.data.message);
+      throw new Error(e?.response?.data?.message ?? e.message);
     });
 };
 
@@ -76,19 +83,19 @@ export const updateConnectionTypeEnabled = (
   });
 
   return axios
-    .patch(url, patch)
+    .patch<ResponseStatus>(url, patch)
     .then((response) => response.data)
     .catch((e) => {
-      throw new Error(e.response.data.message);
+      throw new Error(e?.response?.data?.message ?? e.message);
     });
 };
 
 export const deleteConnectionType = (name: string): Promise<ResponseStatus> => {
   const url = `/api/connection-types/${name}`;
   return axios
-    .delete(url)
+    .delete<ResponseStatus>(url)
     .then((response) => response.data)
     .catch((e) => {
-      throw new Error(e.response.data.message);
+      throw new Error(e?.response?.data?.message ?? e.message);
     });
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Address review comments from https://issues.redhat.com/browse/RHOAIENG-14740

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a new connection type, previously used categories will be shown as options in the categories dropdown along with pre-defined set:

When data in a connection type fails to parse, it was causing the app to error out. Now whenever fetch a list of connection types, the corrupt ones are omitted from the list and no error is thrown which will error out the app.
When using a direct link to edit or duplicate a corrupt connection type, the following error is shown:
![image](https://github.com/user-attachments/assets/d533b1d6-f0e9-4448-ba6d-6f82af435ae1)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable the connection type feature flag `disableConnectionTypes`

Categories:
- Navigate to Settings -> Connection types
- Create a new connection type
- add custom categories and save
- create a 2nd connection type
- Observe all previously added categories are available in the select menu

Corrupt data:
- create a connection type (name it `corrupt`
- using OpenShift console edit the connection type configmap to have invalid json 
- OR using the cmd line: `oc patch configmaps -n opendatahub corrupt -p '{"data":{"category":"[]","fields": "[[]"}}'`
- navigate directly to project list / details pages and the connections tab in the project details
- Observe no errors
- Navigate to Settings -> Connection types
- Observe no errors
- go directly to edit the corrupt connection type via URL: `/connectionTypes/edit/corrupt`
- Observe the error screen is shown

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit and cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw @andrewballantyne 