### PR TITLE
fix(12782): display actual error msg for failed mr creation

### DIFF
--- a/backend/src/routes/api/modelRegistries/index.ts
+++ b/backend/src/routes/api/modelRegistries/index.ts
@@ -1,6 +1,7 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { secureAdminRoute } from '../../../utils/route-security';
 import { KubeFastifyInstance, ModelRegistryKind, RecursivePartial } from '../../../types';
+import createError from 'http-errors';
 import {
   createModelRegistryAndSecret,
   deleteModelRegistryAndSecret,
@@ -61,7 +62,9 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             modelRegistryNamespace,
             databasePassword,
             !!dryRun,
-          );
+          ).catch((e) => {
+            throw createError(e.statusCode, e?.body?.message);
+          });
         } catch (e) {
           fastify.log.error(
             `ModelRegistry ${modelRegistry.metadata.name} could not be created, ${


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-12782

## Description
give the real error message from k8s, this includes "[name] already exists"
![image](https://github.com/user-attachments/assets/bb7b52e3-7bfa-4e57-96a3-2dc36261bd9b)


## How Has This Been Tested?
locally, kserve cluster, creating an MR (in MR settings) that has the same name as an existing MR. Run backend and frontend separately to see the changes in this PR.

## Test Impact
none

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
