### PR TITLE
fix: prevent deletion of active connection secrets when updating note…

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -154,6 +154,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       envVariables,
       dataConnection,
       existingNotebookDataConnection,
+      connections,
       dryRun,
     );
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -88,9 +88,6 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     defaultStorageClassName,
   );
 
-  const [envVariables, setEnvVariables, envVariablesLoaded, deletedConfigMaps, deletedSecrets] =
-    useNotebookEnvVariables(existingNotebook);
-
   const [dataConnectionData, setDataConnectionData] = useNotebookDataConnection(
     dataConnections.data,
     existingNotebook,
@@ -102,6 +99,12 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
       ? getConnectionsFromNotebook(existingNotebook, projectConnections)
       : [],
   );
+
+  const [envVariables, setEnvVariables, envVariablesLoaded, deletedConfigMaps, deletedSecrets] =
+    useNotebookEnvVariables(existingNotebook, [
+      ...notebookConnections.map((connection) => connection.metadata.name),
+      dataConnectionData.existing?.secretRef.name || '',
+    ]);
 
   const restartNotebooks = useWillNotebooksRestart([existingNotebook?.metadata.name || '']);
 

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -75,6 +75,7 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
 
 export const useNotebookEnvVariables = (
   notebook?: NotebookKind,
+  excludedResources: string[] = [],
 ): [
   envVariables: EnvVariable[],
   setEnvVariables: (envVars: EnvVariable[]) => void,
@@ -96,6 +97,7 @@ export const useNotebookEnvVariables = (
   const { deletedConfigMaps, deletedSecrets } = getDeletedConfigMapOrSecretVariables(
     notebook,
     existingEnvVariables,
+    excludedResources,
   );
   React.useEffect(() => {
     setEnvVariables(existingEnvVariables);

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
@@ -23,6 +23,7 @@ export const isStringKeyValuePairObject = (object: unknown): object is Record<st
 export const getDeletedConfigMapOrSecretVariables = (
   notebook: NotebookKind | undefined,
   envVariables: EnvVariable[],
+  excludedResources: string[] = [],
 ): {
   deletedSecrets: string[];
   deletedConfigMaps: string[];
@@ -32,10 +33,18 @@ export const getDeletedConfigMapOrSecretVariables = (
   const deletedSecrets: string[] = [];
 
   (notebook?.spec.template.spec.containers[0].envFrom || []).forEach((env) => {
-    if (env.configMapRef && !existingEnvVariables.has(env.configMapRef.name)) {
+    if (
+      env.configMapRef &&
+      !existingEnvVariables.has(env.configMapRef.name) &&
+      !excludedResources.includes(env.configMapRef.name)
+    ) {
       deletedConfigMaps.push(env.configMapRef.name);
     }
-    if (env.secretRef && !existingEnvVariables.has(env.secretRef.name)) {
+    if (
+      env.secretRef &&
+      !existingEnvVariables.has(env.secretRef.name) &&
+      !excludedResources.includes(env.secretRef.name)
+    ) {
       deletedSecrets.push(env.secretRef.name);
     }
   });

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -24,6 +24,7 @@ import {
 } from '~/pages/projects/types';
 import { ROOT_MOUNT_PATH } from '~/pages/projects/pvc/const';
 import { ConfigMapKind, NotebookKind, SecretKind } from '~/k8sTypes';
+import { Connection } from '~/concepts/connectionTypes/types';
 import { getVolumesByStorageData } from './spawnerUtils';
 import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnvVariables';
 import { getDeletedConfigMapOrSecretVariables } from './environmentVariables/utils';
@@ -194,12 +195,17 @@ export const updateConfigMapsAndSecretsForNotebook = async (
   envVariables: EnvVariable[],
   dataConnection?: DataConnectionData,
   existingDataConnection?: DataConnection,
+  connections?: Connection[],
   dryRun = false,
 ): Promise<EnvironmentFromVariable[]> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
   const { deletedConfigMaps, deletedSecrets } = getDeletedConfigMapOrSecretVariables(
     notebook,
     existingEnvVars,
+    [
+      existingDataConnection?.data.metadata.name || '',
+      ...(connections || []).map((connection) => connection.metadata.name),
+    ],
   );
   const newDataConnection =
     dataConnection?.enabled && dataConnection.type === 'creating' && dataConnection.creating


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-15228

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The system incorrectly deletes active connection secrets when updating notebook environment variables, potentially causing disruption to running connections.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Create a notebook with environment variables
2. Set up an connection to a data connection
3. Set up other connection types as well (turn dat feature flag on)
4. save
5. edit
6. Observe that the active connection secrets are not incorrectly deleted and the warning message is not there

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
