### PR TITLE
fix adding dropdown fields to section

### DIFF
--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -119,7 +119,7 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
                   onAddField={() => {
                     const nextSectionIndex = index + findSectionFields(index, fields).length;
                     if (nextSectionIndex >= 0) {
-                      setModalField({ index: nextSectionIndex });
+                      setModalField({ index: nextSectionIndex + 1 });
                     } else {
                       setModalField({});
                     }

--- a/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm.tsx
@@ -36,11 +36,17 @@ const DropdownAdvancedPropertiesForm: React.FC<AdvancedFieldProps<DropdownField>
     // filter out empty rows for validation (they will be removed on save)
     const itemsWithoutEmptyRows =
       properties.items?.filter((item) => item.label || item.value) ?? [];
-    const duplicateLabels = itemsWithoutEmptyRows.find((item1, index1) =>
-      properties.items?.find((item2, index2) => item1.label === item2.label && index1 !== index2),
+    const duplicateLabels = itemsWithoutEmptyRows.some(
+      (item1, index1) =>
+        item1.label &&
+        itemsWithoutEmptyRows.some(
+          (item2, index2) => item1.label === item2.label && index1 !== index2,
+        ),
     );
-    const duplicateValues = itemsWithoutEmptyRows.find((item1, index1) =>
-      properties.items?.find((item2, index2) => item1.value === item2.value && index1 !== index2),
+    const duplicateValues = itemsWithoutEmptyRows.some((item1, index1) =>
+      itemsWithoutEmptyRows.some(
+        (item2, index2) => item1.value === item2.value && index1 !== index2,
+      ),
     );
     const noMissingValues = itemsWithoutEmptyRows.every((item) => item.value);
 

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/DropdownAdvancedPropertiesForm.spec.tsx
@@ -201,4 +201,24 @@ describe('DropdownFieldAdvancedPropertiesForm', () => {
     expect(screen.getByText('a already exists.')).toBeVisible();
     expect(screen.getByText('b already exists.')).toBeVisible();
   });
+
+  it('should validate to true with empty rows', async () => {
+    render(
+      <DropdownAdvancedPropertiesForm
+        properties={{
+          variant: 'single',
+          items: [
+            { label: '', value: 'v1' },
+            { label: '', value: '' },
+            { label: '', value: 'v2' },
+          ],
+        }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(true);
+  });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fixes validation with connection type dropdown items. Labels are not required and therefore empty labels should not cause the form to become invalid.

Fixes adding fields to sections.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  enable the connection type feature flag
- create a new connection type
- add a section
- click the add field button for the section
- select the field type as drop down
- add a name and env var
- add an item and supply value `v1`
- add another item and supply value `v2`
- Ensure the modal can be saved
- save the modal
- observe the item is correctly added to the section
- try adding another field to the same or another section

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added test case

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 