### PR TITLE
disable required toggle when field has default value and is read only

### DIFF
--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -233,7 +233,12 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
         </FormGroup>
         <DataFieldPropertiesForm
           field={newField}
-          onChange={(value) => setData('properties', value)}
+          onChange={(value) => {
+            setData('properties', value);
+            if (value.defaultReadOnly && newField.required) {
+              setData('required', false);
+            }
+          }}
           onValidate={setPropertiesValid}
         />
         <FormGroup fieldId="isRequired">
@@ -241,6 +246,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
             id="isRequired"
             data-testid="field-required-checkbox"
             label="Field is required"
+            isDisabled={properties.defaultReadOnly}
             isChecked={required || false}
             onChange={(_ev, checked) => {
               setData('required', checked);

--- a/frontend/src/pages/connectionTypes/manage/DataFieldPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/DataFieldPropertiesForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, FormGroup } from '@patternfly/react-core';
+import { Checkbox, FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 import { ConnectionTypeDataField } from '~/concepts/connectionTypes/types';
 import ConnectionTypeDataFormField from '~/concepts/connectionTypes/fields/ConnectionTypeDataFormField';
 import DataFieldAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm';
@@ -45,6 +45,12 @@ const DataFieldPropertiesForm = <T extends ConnectionTypeDataField>({
           value={field.properties.defaultValue}
           data-testid="field-default-value"
         />
+        <HelperText>
+          <HelperTextItem>
+            Do not enter sensitive information. Default values are visible to users with access to
+            the connection type.
+          </HelperTextItem>
+        </HelperText>
         <Checkbox
           id="defaultReadOnly"
           label="Default value is read-only"

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -174,7 +174,12 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
           aria-label="toggle field required"
           isChecked={row.required || false}
           data-testid="field-required"
-          onChange={() => onChange({ ...row, required: !row.required })}
+          isDisabled={row.properties.defaultReadOnly}
+          onChange={
+            !row.properties.defaultReadOnly
+              ? () => onChange({ ...row, required: !row.required })
+              : undefined
+          }
         />
       </Td>
       <Td isActionCell>

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ConnectionTypeDataFieldModal.spec.tsx
@@ -286,4 +286,28 @@ describe('ConnectionTypeDataFieldModal', () => {
 
     expect(submitButton).not.toBeDisabled();
   });
+
+  it('should unset required if default value is read-only', () => {
+    const field: ShortTextField = {
+      type: 'short-text',
+      name: 'test',
+      envVar: 'test_envvar',
+      required: true,
+      properties: {
+        defaultValue: 'default value',
+        defaultReadOnly: false,
+      },
+    };
+    render(
+      <ConnectionTypeDataFieldModal onClose={onClose} onSubmit={onSubmit} isEdit field={field} />,
+    );
+    const requiredCheckbox = screen.getByTestId('field-required-checkbox');
+    expect(requiredCheckbox).toBeChecked();
+    const readOnlyCheckbox = screen.getByTestId('field-default-value-readonly-checkbox');
+    expect(readOnlyCheckbox).not.toBeChecked();
+    act(() => {
+      fireEvent.click(requiredCheckbox);
+    });
+    expect(requiredCheckbox).not.toBeChecked();
+  });
 });

--- a/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/__tests__/ManageConnectionTypeFieldsTableRow.spec.tsx
@@ -66,4 +66,20 @@ describe('ManageConnectionTypeFieldsTableRow', () => {
     expect(hasValidationIssueMock).toHaveBeenCalledTimes(1);
     expect(hasValidationIssueMock).toHaveBeenCalledWith(['fields', 0, 'envVar'], 'envVar_conflict');
   });
+
+  it('should not be able to set required if default value is read-only', () => {
+    const field: ShortTextField = {
+      type: 'short-text',
+      name: 'test',
+      envVar: 'test_envvar',
+      properties: {
+        defaultValue: 'default value',
+        defaultReadOnly: true,
+      },
+    };
+    render(renderRow({ row: field, fields: [field] }));
+    const requiredSwitch = screen.getByTestId('field-required');
+    expect(requiredSwitch).not.toBeChecked();
+    expect(requiredSwitch).toBeDisabled();
+  });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Add helper text to default values to guide the user to not store sensitive information in default values.

When the field is marked as read only with a default value, the field is unmarked as required.

![image](https://github.com/user-attachments/assets/a8af763b-ead1-41cd-81d5-02ec5f6fa967)
![image](https://github.com/user-attachments/assets/816855ac-f373-4366-91e1-b7aec9658278)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable the connection types feature flag
- create a connection type
- add a field
- make the field required and then set a default value and mark it read only
- observe the required checkbox gets unchecked when making this field read only
- save the field
- observe in the table, the toggle switch to make the field required is off and disabled

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 