### PR TITLE
add helper text for default value sensitive information

### DIFF
--- a/frontend/src/pages/connectionTypes/manage/DataFieldPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/DataFieldPropertiesForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, FormGroup } from '@patternfly/react-core';
+import { Checkbox, FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 import { ConnectionTypeDataField } from '~/concepts/connectionTypes/types';
 import ConnectionTypeDataFormField from '~/concepts/connectionTypes/fields/ConnectionTypeDataFormField';
 import DataFieldAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm';
@@ -45,6 +45,12 @@ const DataFieldPropertiesForm = <T extends ConnectionTypeDataField>({
           value={field.properties.defaultValue}
           data-testid="field-default-value"
         />
+        <HelperText>
+          <HelperTextItem>
+            Do not enter sensitive information. Default values are visible to users in your
+            organization.
+          </HelperTextItem>
+        </HelperText>
         <Checkbox
           id="defaultReadOnly"
           label="Default value is read-only"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Add helper text to default values to guide the user to not store sensitive information in default values.

![image](https://github.com/user-attachments/assets/e7e0569b-af0f-48c3-9957-539477320a22)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- enable the connection types feature flag
- create a connection type
- add a field
- observe the helper text below the default value

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @simrandhaliw 