### PR TITLE
Disable size field and show helper text when editing an unbound storage

### DIFF
--- a/frontend/src/__mocks__/mockPVCK8sResource.ts
+++ b/frontend/src/__mocks__/mockPVCK8sResource.ts
@@ -8,6 +8,7 @@ type MockResourceConfigType = {
   storageClassName?: string;
   displayName?: string;
   uid?: string;
+  status?: PersistentVolumeClaimKind['status'];
 };
 
 export const mockPVCK8sResource = ({
@@ -17,6 +18,13 @@ export const mockPVCK8sResource = ({
   storageClassName = 'gp3',
   displayName = 'Test Storage',
   uid = genUID('pvc'),
+  status = {
+    phase: 'Bound',
+    accessModes: ['ReadWriteOnce'],
+    capacity: {
+      storage,
+    },
+  },
 }: MockResourceConfigType): PersistentVolumeClaimKind => ({
   kind: 'PersistentVolumeClaim',
   apiVersion: 'v1',
@@ -43,11 +51,5 @@ export const mockPVCK8sResource = ({
     storageClassName,
     volumeMode: 'Filesystem',
   },
-  status: {
-    phase: 'Bound',
-    accessModes: ['ReadWriteOnce'],
-    capacity: {
-      storage,
-    },
-  },
+  status,
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -84,7 +84,7 @@ class ClusterStorageModal extends Modal {
 
   shouldHavePVSizeSelectValue(name: string) {
     this.findPVSizeSelectButton().contains(name).should('exist');
-    return this;
+    return this.findPVSizeSelectButton();
   }
 
   private findPVSizeField() {
@@ -95,8 +95,12 @@ class ClusterStorageModal extends Modal {
     return this.findPVSizeField().findByRole('button', { name: 'Minus' });
   }
 
-  findPersistentStorageWarning() {
-    return this.find().findByTestId('persistent-storage-warning');
+  findPersistentStorageWarningCanNotEdit() {
+    return this.find().findByTestId('persistent-storage-warning-can-not-edit');
+  }
+
+  findPersistentStorageWarningCanOnlyIncrease() {
+    return this.find().findByTestId('persistent-storage-warning-can-only-increase');
   }
 
   findPVSizeInput() {

--- a/frontend/src/components/ValueUnitField.tsx
+++ b/frontend/src/components/ValueUnitField.tsx
@@ -30,6 +30,7 @@ type ValueUnitFieldProps = {
   value: ValueUnitString;
   validated?: 'default' | 'error' | 'warning' | 'success' | ValidatedOptions | undefined;
   menuAppendTo?: HTMLElement;
+  isDisabled?: boolean;
 };
 
 const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
@@ -41,6 +42,7 @@ const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
   menuAppendTo,
   value: fullValue,
   validated,
+  isDisabled,
 }) => {
   const [open, setOpen] = React.useState(false);
   const [currentValue, currentUnitOption] = splitValueUnit(fullValue, options);
@@ -64,6 +66,7 @@ const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
           onChange={(value) => {
             onChange(`${value || minAsNumber}${currentUnitOption.unit}`);
           }}
+          isDisabled={isDisabled}
         />
       </SplitItem>
       <SplitItem>
@@ -80,6 +83,7 @@ const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
                 setOpen(!open);
               }}
               isExpanded={open}
+              isDisabled={isDisabled}
             >
               {currentUnitOption.name}
             </MenuToggle>

--- a/frontend/src/pages/projects/components/PVSizeField.tsx
+++ b/frontend/src/pages/projects/components/PVSizeField.tsx
@@ -3,13 +3,14 @@ import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternf
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import ValueUnitField from '~/components/ValueUnitField';
 import { MEMORY_UNITS_FOR_SELECTION, UnitOption } from '~/utilities/valueUnits';
+import { PersistentVolumeClaimKind } from '~/k8sTypes';
 
 type PVSizeFieldProps = {
   fieldID: string;
   size: string;
   menuAppendTo?: HTMLElement;
   setSize: (size: string) => void;
-  currentSize?: string;
+  currentStatus?: PersistentVolumeClaimKind['status'];
   label?: string;
   options?: UnitOption[];
 };
@@ -19,35 +20,55 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({
   size,
   menuAppendTo,
   setSize,
-  currentSize,
+  currentStatus,
   label = 'Persistent storage size',
   options = MEMORY_UNITS_FOR_SELECTION,
-}) => (
-  <FormGroup label={label} fieldId={fieldID} data-testid={fieldID}>
-    <ValueUnitField
-      min={currentSize ?? 1}
-      onBlur={(value) => setSize(value)}
-      menuAppendTo={menuAppendTo}
-      onChange={(value) => setSize(value)}
-      validated={currentSize ? 'warning' : 'default'}
-      options={options}
-      value={size}
-    />
-    {currentSize && (
-      <FormHelperText>
-        <HelperText>
-          <HelperTextItem
-            data-testid="persistent-storage-warning"
-            variant="warning"
-            icon={<ExclamationTriangleIcon />}
-          >
-            Storage size can only be increased. If you do so, the workbench will restart and be
-            unavailable for a period of time that is usually proportional to the size change.
-          </HelperTextItem>
-        </HelperText>
-      </FormHelperText>
-    )}
-  </FormGroup>
-);
+}) => {
+  const currentSize = currentStatus?.capacity?.storage;
+  const isUnbound = currentStatus && currentStatus.phase !== 'Bound';
+
+  return (
+    <FormGroup label={label} fieldId={fieldID} data-testid={fieldID}>
+      <ValueUnitField
+        min={currentSize ?? 1}
+        onBlur={(value) => setSize(value)}
+        menuAppendTo={menuAppendTo}
+        onChange={(value) => setSize(value)}
+        validated={currentSize ? 'warning' : 'default'}
+        options={options}
+        value={size}
+        isDisabled={isUnbound}
+      />
+
+      {(currentSize || isUnbound) && (
+        <FormHelperText>
+          <HelperText>
+            {isUnbound && (
+              <HelperTextItem
+                data-testid="persistent-storage-warning-can-not-edit"
+                variant="warning"
+                icon={<ExclamationTriangleIcon />}
+              >
+                To edit the size, you must first attach this cluster storage to a workbench, then
+                start the workbench. If the workbench is already running, it will restart
+                automatically.
+              </HelperTextItem>
+            )}
+            {currentSize && (
+              <HelperTextItem
+                data-testid="persistent-storage-warning-can-only-increase"
+                variant="warning"
+                icon={<ExclamationTriangleIcon />}
+              >
+                Storage size can only be increased. If you do so, the workbench will restart and be
+                unavailable for a period of time that is usually proportional to the size change.
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </FormHelperText>
+      )}
+    </FormGroup>
+  );
+};
 
 export default PVSizeField;

--- a/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
@@ -103,7 +103,7 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
             <CreateNewStorageSection
               data={createData}
               setData={setCreateData}
-              currentSize={existingData?.status?.capacity?.storage}
+              currentStatus={existingData?.status}
               autoFocusName
               disableStorageClassSelect={!!existingData}
             />

--- a/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ManageStorageModal.tsx
@@ -173,7 +173,7 @@ const ManageStorageModal: React.FC<AddStorageModalProps> = ({ existingData, onCl
             <CreateNewStorageSection
               data={createData}
               setData={setCreateData}
-              currentSize={existingData?.status?.capacity?.storage}
+              currentStatus={existingData?.status}
               autoFocusName
               disableStorageClassSelect={!!existingData}
             />

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -4,12 +4,13 @@ import { CreatingStorageObject, UpdateObjectAtPropAndValue } from '~/pages/proje
 import PVSizeField from '~/pages/projects/components/PVSizeField';
 import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import StorageClassSelect from './StorageClassSelect';
 
 type CreateNewStorageSectionProps<D extends CreatingStorageObject> = {
   data: D;
   setData: UpdateObjectAtPropAndValue<D>;
-  currentSize?: string;
+  currentStatus?: PersistentVolumeClaimKind['status'];
   autoFocusName?: boolean;
   menuAppendTo?: HTMLElement;
   disableStorageClassSelect?: boolean;
@@ -18,7 +19,7 @@ type CreateNewStorageSectionProps<D extends CreatingStorageObject> = {
 const CreateNewStorageSection = <D extends CreatingStorageObject>({
   data,
   setData,
-  currentSize,
+  currentStatus,
   menuAppendTo,
   autoFocusName,
   disableStorageClassSelect,
@@ -50,7 +51,7 @@ const CreateNewStorageSection = <D extends CreatingStorageObject>({
         <PVSizeField
           menuAppendTo={menuAppendTo}
           fieldID="create-new-storage-size"
-          currentSize={currentSize}
+          currentStatus={currentStatus}
           size={data.size}
           setSize={(size) => setData('size', size)}
         />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-526](https://issues.redhat.com/browse/RHOAIENG-526)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When editing storage, if it's not "Bound", we disable the size field and show a helper text to explain why.

<img width="1508" alt="Screenshot 2024-11-07 at 1 26 03 PM" src="https://github.com/user-attachments/assets/201f6122-6e1a-476d-9b7e-2bd6cd1819d9">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a new cluster storage, and don't connect it to any workbench
2. Try to edit the storage, check whether the size field is disabled and the helper text is shown
3. Try to connect it to a workbench, and start/restart that workbench
4. Wait for a few second (it may take a few second to make the PVC on the cluster bound with a PV), and try to edit the cluster storage again
5. Now you can see it's enabled and you can increase the size now

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a cypress test to verify you cannot edit the storage size field when it's not bound.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
