### PR TITLE
enable connection types by default

### DIFF
--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -64,7 +64,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
       disableServingRuntimeParams: false,
-      disableConnectionTypes: true,
+      disableConnectionTypes: false,
       disableStorageClasses: false,
       disableNIMModelServing: true,
     },

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -30,14 +30,13 @@ The following are a list of features that are supported, along with there defaul
 | disableKServeMetrics         | false   | Disables the ability to see KServe Metrics.                                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
-| disableTrustyBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
+| disableTrustyBiasMetrics     | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
-| disableServingRuntimeParams  | false    | Disables Serving Runtime params from the dashboard.                                                  |
-| disableConnectionTypes       | true    | Disables creating custom data connection types from the dashboard.                                   |
-| disableStorageClasses        | false    | Disables storage classes settings nav item from the dashboard.                                       |
-| disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.   
+| disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
+| disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
+| disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |
 
 ## Defaults
 
@@ -66,7 +65,6 @@ spec:
     disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
     disableDistributedWorkloads: false
-    disableConnectionTypes: false
     disableStorageClasses: false
     disableNIMModelServing: true
 ```

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -73,8 +73,6 @@ spec:
                       type: boolean
                     disableServingRuntimeParams:
                       type: boolean
-                    disableConnectionTypes:
-                      type: boolean
                     disableStorageClasses:
                       type: boolean
                     disableNIMModelServing:

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -29,7 +29,6 @@ spec:
     disableDistributedWorkloads: false
     disableModelRegistry: false
     disableServingRuntimeParams: false
-    disableConnectionTypes: true
     disableStorageClasses: false
     disableNIMModelServing: true
   groupsConfig:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14748

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- apply the CRD changes to your test cluster, thus removing the `disableConnectionTypes` feature flag
- if testing locally, run a local backend server with the changes
- observe the UI shows connection types enabled by default

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @andrewballantyne @dgutride @emilys314 