### PR TITLE
add env var to field details popover

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/DataFormFieldGroup.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/DataFormFieldGroup.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { FormGroup, GenerateId, Popover } from '@patternfly/react-core';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  FormGroup,
+  GenerateId,
+  Popover,
+} from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ConnectionTypeDataField } from '~/concepts/connectionTypes/types';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
@@ -19,14 +27,28 @@ const DataFormFieldGroup: React.FC<Props> = ({ field, children }): React.ReactNo
         // do not mark read only fields as required
         isRequired={field.required && !field.properties.defaultReadOnly}
         labelIcon={
-          field.description ? (
-            <Popover bodyContent={field.description}>
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info"
-              />
-            </Popover>
-          ) : undefined
+          <Popover
+            headerContent="Field details"
+            bodyContent={
+              <DescriptionList isCompact>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Environment variable</DescriptionListTerm>
+                  <DescriptionListDescription>{field.envVar}</DescriptionListDescription>
+                </DescriptionListGroup>
+                {field.description ? (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Description</DescriptionListTerm>
+                    <DescriptionListDescription>{field.description}</DescriptionListDescription>
+                  </DescriptionListGroup>
+                ) : null}
+              </DescriptionList>
+            }
+          >
+            <DashboardPopupIconButton
+              icon={<OutlinedQuestionCircleIcon />}
+              aria-label="More info"
+            />
+          </Popover>
         }
       >
         {children(id)}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

As part of the UX review we identified a missing update to the field details popover.
Added environment variable details to popover:

![image](https://github.com/user-attachments/assets/e7e8ef27-e817-4227-9426-665386d80dbc)
![image](https://github.com/user-attachments/assets/270739fb-232a-44f3-a080-f6f7d50bc73f)

cc @simrandhaliw 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- enable connection types feature flag
- go to Settings -> Connection types
- preview the s3 connection type
- click the `?` for a field
- observe the popover details includes env var

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
