### PR TITLE
Update 'Resource name' fields to meet UX guidelines: Image streams

### DIFF
--- a/backend/src/routes/api/images/imageUtils.ts
+++ b/backend/src/routes/api/images/imageUtils.ts
@@ -264,9 +264,10 @@ export const postImage = async (
     'opendatahub.io/dashboard': 'true',
   };
   const imageStreams = (await getImageStreams(fastify, labels)) as ImageStream[];
-  const validName = imageStreams.filter((is) => is.metadata.name === body.name);
+  const name = body.name || `custom-${translateDisplayNameForK8s(body.display_name)}`;
+  const existingImage = imageStreams.find((is) => is.metadata.name === name);
 
-  if (validName.length > 0) {
+  if (existingImage) {
     fastify.log.error('Duplicate name unable to add notebook image');
     return {
       success: false,
@@ -287,7 +288,7 @@ export const postImage = async (
           body.recommendedAcceleratorIdentifiers ?? [],
         ),
       },
-      name: `custom-${translateDisplayNameForK8s(body.display_name)}`,
+      name,
       namespace: namespace,
       labels: labels,
     },

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookImageSettings.ts
@@ -1,6 +1,7 @@
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+import { K8sNameDescriptionField } from '~/__tests__/cypress/cypress/pages/components/subComponents/K8sNameDescriptionField';
 import { DeleteModal } from './components/DeleteModal';
 import { TableToolbar } from './components/TableToolbar';
 
@@ -86,6 +87,8 @@ class NotebookImageDeleteModal extends DeleteModal {
 }
 
 class ImportUpdateNotebookImageModal extends Modal {
+  k8sNameDescription = new K8sNameDescriptionField('byon-image');
+
   constructor(private edit = false) {
     super(`${edit ? 'Update' : 'Import'} notebook image`);
   }
@@ -99,11 +102,11 @@ class ImportUpdateNotebookImageModal extends Modal {
   }
 
   findNameInput() {
-    return this.find().findByTestId('byon-image-name-input');
+    return this.k8sNameDescription.findDisplayNameInput();
   }
 
   findDescriptionInput() {
-    return this.find().findByTestId('byon-image-description-input');
+    return this.k8sNameDescription.findDescriptionInput();
   }
 
   // Software tab

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/notebookImageSettings/notebookImageSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/notebookImageSettings/notebookImageSettings.cy.ts
@@ -131,6 +131,24 @@ describe('Notebook image settings', () => {
 
     importNotebookImageModal.findSaveResourceButton('Software').click();
     importNotebookImageModal.findSubmitButton().should('be.enabled');
+
+    // test resource name validation
+    importNotebookImageModal.k8sNameDescription.findResourceEditLink().click();
+    importNotebookImageModal.k8sNameDescription
+      .findResourceNameInput()
+      .should('have.attr', 'aria-invalid', 'false');
+    // Invalid character k8s names fail
+    importNotebookImageModal.k8sNameDescription
+      .findResourceNameInput()
+      .clear()
+      .type('InVaLiD vAlUe!');
+    importNotebookImageModal.k8sNameDescription
+      .findResourceNameInput()
+      .should('have.attr', 'aria-invalid', 'true');
+    importNotebookImageModal.findSubmitButton().should('be.disabled');
+    importNotebookImageModal.k8sNameDescription.findResourceNameInput().clear().type('image');
+    importNotebookImageModal.findSubmitButton().should('be.enabled');
+
     let notebookImageTabRow = importNotebookImageModal.getSoftwareRow('software');
     notebookImageTabRow.shouldHaveVersionColumn('version');
 
@@ -198,6 +216,7 @@ describe('Notebook image settings', () => {
       expect(interception.request.body).to.eql({
         /* eslint-disable-next-line camelcase */
         display_name: 'image',
+        name: 'image',
         url: 'image:latest',
         description: '',
         recommendedAcceleratorIdentifiers: [],

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/HelperTextItemVariants.tsx
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/HelperTextItemVariants.tsx
@@ -33,8 +33,8 @@ export const HelperTextItemValidCharacters: HelperTextItemType = ({ k8sName }) =
 
   return (
     <HelperTextItem variant={variant} hasIcon>
-      Must start and end with a letter or number. Valid characters include lowercase letters,
-      numbers, and hyphens (-).
+      {k8sName.state.invalidCharsMessage ||
+        'Must start and end with a letter or number. Valid characters include lowercase letters, numbers, and hyphens (-).'}
     </HelperTextItem>
   );
 };

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/types.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/types.ts
@@ -13,6 +13,10 @@ export type K8sNameDescriptionFieldData = {
       invalidCharacters: boolean;
       /** If the maxLength is exceeded */
       invalidLength: boolean;
+      /** Optional regexp for the resource name */
+      regexp?: RegExp;
+      /** Optional invalid characters message */
+      invalidCharsMessage?: string;
       /**
        * Optional safe prefix for translation.
        * @see AdditionalCriteriaForTranslation
@@ -52,6 +56,10 @@ export type UseK8sNameDescriptionDataConfiguration = {
    * @see AdditionalCriteriaForTranslation
    */
   staticPrefix?: boolean;
+  /** Optional regexp for the resource name */
+  regexp?: RegExp;
+  /** Optional invalid characters message */
+  invalidCharsMessage?: string;
 };
 
 type K8sNameDescriptionFieldUpdateFunctionTemplate<T> = (

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -44,6 +44,8 @@ export const setupDefaults = ({
   limitNameResourceType,
   safePrefix,
   staticPrefix,
+  regexp,
+  invalidCharsMessage,
 }: UseK8sNameDescriptionDataConfiguration): K8sNameDescriptionFieldData => {
   let initialName = '';
   let initialDescription = '';
@@ -76,6 +78,8 @@ export const setupDefaults = ({
         maxLength: configuredMaxLength,
         safePrefix,
         staticPrefix,
+        regexp,
+        invalidCharsMessage,
         touched: false,
       },
     },
@@ -111,7 +115,8 @@ export const handleUpdateLogic =
       case 'k8sName':
         changedData.k8sName = {
           state: {
-            invalidCharacters: value.length > 0 ? !isValidK8sName(value) : false,
+            invalidCharacters:
+              value.length > 0 ? !isValidK8sName(value, existingData.k8sName.state.regexp) : false,
             invalidLength: value.length > existingData.k8sName.state.maxLength,
             touched: true,
           },
@@ -130,7 +135,7 @@ export const isK8sNameDescriptionDataValid = ({
   name,
   k8sName: {
     value,
-    state: { invalidCharacters, invalidLength },
+    state: { invalidCharacters, invalidLength, regexp },
   },
 }: K8sNameDescriptionFieldData): boolean =>
-  name.trim().length > 0 && isValidK8sName(value) && !invalidLength && !invalidCharacters;
+  name.trim().length > 0 && isValidK8sName(value, regexp) && !invalidLength && !invalidCharacters;

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -117,8 +117,10 @@ export const translateDisplayNameForK8s = (
   additionalCriteria: AdditionalCriteriaForTranslation = {},
 ): string => translateDisplayNameForK8sAndReport(name, additionalCriteria)[0];
 
-export const isValidK8sName = (name?: string): boolean =>
-  name === undefined || (name.length > 0 && /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(name));
+export const isValidK8sName = (
+  name?: string,
+  regExp = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/,
+): boolean => name === undefined || (name.length > 0 && regExp.test(name));
 
 type ResourceWithConditions = K8sResourceCommon & { status?: { conditions?: K8sCondition[] } };
 


### PR DESCRIPTION
Towards [RHOAIENG-14746](https://issues.redhat.com/browse/RHOAIENG-14746)

## Description
Updates the create/edit dialog for Notebook Images to use the common `K8sNameDescriptionField` component in order to meet current UX guidelines.

## Screen shots

### Create
![image](https://github.com/user-attachments/assets/3ce86753-a246-48ad-b647-5d8d8667003a)

### Create editing Resource name
![image](https://github.com/user-attachments/assets/da3044a2-0d8a-441c-ae18-c9ed45e6b414)

### Edit
![image](https://github.com/user-attachments/assets/76694712-ace1-485f-b0e9-56009a75bf62)

## How Has This Been Tested?
- Navigate to a `Settings` -> `Notebook images`
  - Select `Import new image
  - Enter an image location
  - Enter the name for the new notebook image
  - Enter a description for the new notebook image
  - View the resource name via the `Edit resource name` link.
  - Change the resource name to something invalid (ie. contains a space)
  - Verify the `Import` button is disabled
  - Change the resource name to something valid
  - Verify the `Import` button is enabled
  - Save the notebook image.
  - Verify the notebook is created with the correct Display name, Description, and Resource Name.
- Navigate to a `Settings` -> `Notebook images`
  - Select the kebab for an existing notebook image and choose `Edit`
  - Update the Name field
  - Notice the resource name is not editable
  - Update the description field
  - Save the notebook image
  - Verify the notebook image is updated with the correct Display name and Description.

## Test Impact
Updated unit tests for new fields

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw 