### PR TITLE
Model registry settings table icon updates

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Label, Popover, Stack, StackItem } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
-  DegradedIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   InProgressIcon,
@@ -71,8 +70,8 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
       !popoverMessages.some((message) => message.includes('ContainerCreating'))
     ) {
       statusLabel = ModelRegistryStatusLabel.Unavailable;
-      icon = <ExclamationCircleIcon />;
-      color = 'red';
+      icon = <ExclamationTriangleIcon />;
+      color = 'gold';
     }
     // Available
     else if (availableCondition?.status === ConditionStatus.True) {
@@ -83,14 +82,14 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     // Progressing
     else if (progressCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Progressing;
-      icon = <InProgressIcon />;
+      icon = <InProgressIcon className="odh-u-spin" />;
       color = 'blue';
     }
     // Degrading
     else if (degradedCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Degrading;
-      icon = <DegradedIcon />;
-      color = 'gold';
+      icon = <InProgressIcon className="odh-u-spin" />;
+      color = 'grey';
       popoverTitle = 'Service is degrading';
     }
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-15587](https://issues.redhat.com/browse/RHOAIENG-15587)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

https://github.com/user-attachments/assets/8be8c8c3-89f0-48b1-8441-2589b4e3f304


https://github.com/user-attachments/assets/bf497fbe-54f2-4cd1-9f29-c775b323b272

<img width="1025" alt="Screenshot 2024-11-11 at 9 41 19 PM" src="https://github.com/user-attachments/assets/770cf60f-2525-466c-a1fb-d9eb7c6cfc75">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Model registry admin settings page now shows the following:
1. Progressing status should have animated `InProgressIcon`
2. Degrading status is grey in color and has animated `InProgressIcon` 
3. Unavailable status has`ExclamationTriangleIcon` and is yellow in color.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Only icon updates(no text/status updates) - so no tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
