### PR TITLE
Fix workbench new connection env warning / editing new connection / and save failure handling

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
@@ -20,6 +20,7 @@ import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTyp
 import {
   filterEnabledConnectionTypes,
   getConnectionTypeDisplayName,
+  isConnection,
 } from '~/concepts/connectionTypes/utils';
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
 import { useNotebooksStates } from '~/pages/projects/notebook/useNotebooksStates';
@@ -264,12 +265,23 @@ export const ConnectionsFormSection: React.FC<Props> = ({
               refreshProjectConnections();
             }
           }}
-          onSubmit={(connection: Connection) => {
+          onSubmit={async (connection: Connection) => {
             if (manageConnectionModal.isEdit) {
-              return replaceSecret(connection);
+              const response = await replaceSecret(connection);
+              if (isConnection(response)) {
+                setSelectedConnections(
+                  selectedConnections.map((c) =>
+                    c.metadata.name === response.metadata.name ? response : c,
+                  ),
+                );
+              }
+              return response;
             }
-            setSelectedConnections([...selectedConnections, connection]);
-            return createSecret(connection);
+            const response = await createSecret(connection);
+            if (isConnection(response)) {
+              setSelectedConnections([...selectedConnections, response]);
+            }
+            return response;
           }}
           isEdit={manageConnectionModal.isEdit}
         />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-15584

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a new connection is created, it uses the connection made from `assembleConnection` which has its data inside `stringData` not `data` so check those. 

So this fixes 3 different issues oddly:
1. When creating a new connection to attach, it would not warn of duplicate env variables in the table anymore. This was because the `assembleConnection()` put the data into `stringData` not `data`
2. When saving a (new) connection, it would always add the new connection to the table, even if there was a failure. There was no success gate for adding it.
3. If you tried editing a connection you just created, it would not load the existing data you just entered, because it was in `stringData`

All of these are fixed by using the response of the save / replace and verifying it was successful 

Before:
![image](https://github.com/user-attachments/assets/0104194d-9a34-4271-ad89-f6b51a9f3873)
After:
![image](https://github.com/user-attachments/assets/974cb412-3423-4291-9732-8028d3dfb8ab)

Note the fields
before:
![image](https://github.com/user-attachments/assets/828eaeee-8827-4d9d-b23d-aa87f8599182)
after:
![image](https://github.com/user-attachments/assets/dc9b1ced-5962-404a-993f-64f6d4fccd44)

![image](https://github.com/user-attachments/assets/4850b24f-b2cc-427e-ad56-eccd4c0f2766)
![image](https://github.com/user-attachments/assets/32a4aac0-efa1-4ca2-bf47-920e3c707b42)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Duplicate env:
1. Create / edit a workbench
2. Attach an existing connection 
3. Create a new connection of the same type as the existing one and click save
4. See there is now a warning

Connection saving success gate:
1. Create / edit a workbench
2. Create a new connection and save it
3. Create another connection with the same name and save it
4. You'll see an error, close the modal.
5. With the fix, now that connection was not added to the table

Editing a new connection:
1. Create / edit a workbench
2. Create a new connection and save it
3. Edit the connection 
4. Make sure env var data has been populated with what you entered in step 2


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No updates, it's a bit tedious to test these edge cases since it requires a few steps across different components.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
