### PR TITLE
bump v1alpha1 to v1

### DIFF
--- a/backend/src/routes/api/service/mlmd/index.ts
+++ b/backend/src/routes/api/service/mlmd/index.ts
@@ -4,7 +4,7 @@ import { proxyService } from '../../../../utils/proxy';
 export default proxyService<DSPipelineKind>(
   {
     apiGroup: 'datasciencepipelinesapplications.opendatahub.io',
-    apiVersion: 'v1alpha1',
+    apiVersion: 'v1',
     kind: 'DataSciencepipelinesApplication',
     plural: 'datasciencepipelinesapplications',
   },

--- a/backend/src/routes/api/service/pipelines/index.ts
+++ b/backend/src/routes/api/service/pipelines/index.ts
@@ -4,7 +4,7 @@ import { proxyService } from '../../../../utils/proxy';
 export default proxyService<DSPipelineKind>(
   {
     apiGroup: 'datasciencepipelinesapplications.opendatahub.io',
-    apiVersion: 'v1alpha1',
+    apiVersion: 'v1',
     kind: 'DataSciencepipelinesApplication',
     plural: 'datasciencepipelinesapplications',
   },

--- a/frontend/src/__mocks__/mockDataSciencePipelinesApplicationK8sResource.ts
+++ b/frontend/src/__mocks__/mockDataSciencePipelinesApplicationK8sResource.ts
@@ -18,7 +18,7 @@ export const mockDataSciencePipelineApplicationK8sResource = ({
   message = '',
   dspaSecretName = 'aws-connection-testdb',
 }: MockResourceConfigType): DSPipelineKind => ({
-  apiVersion: 'datasciencepipelinesapplications.opendatahub.io/v1alpha1',
+  apiVersion: 'datasciencepipelinesapplications.opendatahub.io/v1',
   kind: 'DataSciencePipelinesApplication',
   metadata: {
     name,

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/dspa.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/dspa.yaml
@@ -1,8 +1,8 @@
-apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
 kind: DataSciencePipelinesApplication
 metadata:
   name: dspa
-  namespace: {{NAMESPACE}}
+  namespace: { { NAMESPACE } }
 spec:
   apiServer:
     caBundleFileMountPath: ''
@@ -32,14 +32,14 @@ spec:
     enableExternalRoute: false
     externalStorage:
       basePath: ''
-      bucket: {{AWS_S3_BUCKET}}
+      bucket: { { AWS_S3_BUCKET } }
       host: s3.amazonaws.com
       port: ''
       region: us-east-1
       s3CredentialsSecret:
         accessKey: AWS_ACCESS_KEY_ID
         secretKey: AWS_SECRET_ACCESS_KEY
-        secretName: {{DSPA_SECRET_NAME}}
+        secretName: { { DSPA_SECRET_NAME } }
       scheme: https
   persistenceAgent:
     deploy: true

--- a/frontend/src/api/models/pipelines.ts
+++ b/frontend/src/api/models/pipelines.ts
@@ -1,7 +1,7 @@
 import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
 
 export const DataSciencePipelineApplicationModel: K8sModelCommon = {
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1',
   apiGroup: 'datasciencepipelinesapplications.opendatahub.io',
   kind: 'DataSciencePipelinesApplication',
   plural: 'datasciencepipelinesapplications',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-15234

## Description
Reopening this PR
DataSciencePipelineApplicationModels to be bumped to v1
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Adjust the pipeline devFlags to point to main
- check whether pipeline server created successfully

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated the mocks to use v1
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
