### PR TITLE
Fix name overflow on deployed model card

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Button,
   CardBody,
   CardFooter,
   CardHeader,
@@ -13,7 +14,7 @@ import {
   TextListVariants,
   Truncate,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ProjectObjectType } from '~/concepts/design/utils';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import InferenceServiceStatus from '~/pages/modelServing/screens/global/InferenceServiceStatus';
@@ -37,6 +38,7 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
   servingRuntime,
 }) => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
+  const navigate = useNavigate();
   const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
   const modelMesh = isModelMesh(inferenceService);
   const { currentProject } = React.useContext(ProjectDetailsContext);
@@ -62,11 +64,18 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
             <FlexItem>
               <ResourceNameTooltip resource={inferenceService}>
                 {modelMetricsSupported ? (
-                  <Link
-                    to={`/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`}
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => {
+                      navigate(
+                        `/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`,
+                      );
+                    }}
+                    style={{ fontSize: 'var(--pf-v5-global--FontSize--md)' }}
                   >
                     <Truncate content={inferenceServiceDisplayName} />
-                  </Link>
+                  </Button>
                 ) : (
                   inferenceServiceDisplayName
                 )}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
@@ -11,6 +11,7 @@ import {
   TextListItem,
   TextListItemVariants,
   TextListVariants,
+  Truncate,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { ProjectObjectType } from '~/concepts/design/utils';
@@ -64,7 +65,7 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
                   <Link
                     to={`/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`}
                   >
-                    {inferenceServiceDisplayName}
+                    <Truncate content={inferenceServiceDisplayName} />
                   </Link>
                 ) : (
                   inferenceServiceDisplayName


### PR DESCRIPTION
Closes: [RHOAIENG-13078](https://issues.redhat.com/browse/RHOAIENG-13078)

## Description
Fixes a bug where model names over 55+ characters overflow off of the deployed model card. It will now truncate at the end. It will also show a tooltip for names that are truncated.

## How Has This Been Tested?
Tested locally
1. Create a project
2. Deploy a model via model serving with a name of 55+ characters
3. Navigate to Data Science Projects > Project
4. Scroll down to 'Serve Models' element
5. Name should be truncated now

## Test Impact
No new tests added

## Screenshots
Before:
![Screenshot 2024-11-12 at 12 57 44 PM](https://github.com/user-attachments/assets/b61910b4-4796-499c-a21e-98c8546f3302)
After:
![Screenshot 2024-11-12 at 12 58 10 PM](https://github.com/user-attachments/assets/4cf5b814-d604-427d-8e5b-565fac5d51c5)
![Screenshot 2024-11-12 at 3 25 55 PM](https://github.com/user-attachments/assets/03f0e058-b5c7-44d8-8bd5-f227ad047131)



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
