### PR TITLE
feat(15588): mr style updates

### DIFF
--- a/frontend/src/components/DashboardDescriptionListGroup.tsx
+++ b/frontend/src/components/DashboardDescriptionListGroup.tsx
@@ -105,7 +105,7 @@ const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps
                     isInline
                     variant="link"
                     icon={<PencilAltIcon />}
-                    iconPosition="end"
+                    iconPosition="start"
                     onClick={onEditClick}
                   >
                     Edit

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Dropdown, DropdownList, MenuToggle, DropdownItem, Divider } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownList,
+  MenuToggle,
+  DropdownItem,
+  Button,
+  ButtonVariant,
+  ActionList,
+} from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
@@ -32,7 +40,16 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   const tooltipRef = React.useRef<HTMLButtonElement>(null);
 
   return (
-    <>
+    <ActionList>
+      <Button
+        id="deploy-button"
+        aria-label="Deploy version"
+        ref={tooltipRef}
+        variant={ButtonVariant.primary}
+        onClick={() => setIsDeployModalOpen(true)}
+      >
+        Deploy
+      </Button>
       <Dropdown
         isOpen={isOpenActionDropdown}
         onSelect={() => setOpenActionDropdown(false)}
@@ -40,7 +57,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
         popperProps={{ position: 'right' }}
         toggle={(toggleRef) => (
           <MenuToggle
-            variant="primary"
+            variant={ButtonVariant.secondary}
             ref={toggleRef}
             onClick={() => setOpenActionDropdown(!isOpenActionDropdown)}
             isExpanded={isOpenActionDropdown}
@@ -52,16 +69,6 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
         )}
       >
         <DropdownList>
-          <DropdownItem
-            id="deploy-button"
-            aria-label="Deploy version"
-            key="deploy-button"
-            onClick={() => setIsDeployModalOpen(true)}
-            ref={tooltipRef}
-          >
-            Deploy
-          </DropdownItem>
-          <Divider key="separator" />
           <DropdownItem
             isAriaDisabled={hasDeployment}
             id="archive-version-button"
@@ -114,7 +121,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
           modelVersionName={mv.name}
         />
       ) : null}
-    </>
+    </ActionList>
   );
 };
 

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
@@ -172,7 +172,7 @@ const ModelVersionListView: React.FC<ModelVersionListViewProps> = ({
               <>
                 <ToolbarItem>
                   <Button
-                    variant="secondary"
+                    variant="primary"
                     onClick={() => {
                       navigate(
                         registerVersionForModelUrl(rm?.id, preferredModelRegistry?.metadata.name),

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsHeaderActions.tsx
@@ -42,7 +42,7 @@ const ModelVersionsHeaderActions: React.FC<ModelVersionsHeaderActionsProps> = ({
             popperProps={{ position: 'end' }}
             toggle={(toggleRef) => (
               <MenuToggle
-                variant="primary"
+                variant="secondary"
                 ref={toggleRef}
                 onClick={() => setOpen(!isOpen)}
                 isExpanded={isOpen}


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-15588

## Description
mr style updates

## How Has This Been Tested?

- the edit icon should be at the start of button for editableTextDescriptionListGroup (which is used in MR details and MR version details). this component is not used anywhere else.
![image](https://github.com/user-attachments/assets/384ee0cb-c4f4-41d4-82b0-469bb17f1e37)
![image](https://github.com/user-attachments/assets/4a9d1440-4c18-4c74-a667-79923da90b52)

- register new version on the model versions list page should be primary:
![image](https://github.com/user-attachments/assets/cb4293b1-9f80-4a87-9fb6-af43cabb73a9)


- actions button should be secondary on the model detail and versions list page:
![image](https://github.com/user-attachments/assets/21fb6f05-9a25-45d6-b2c1-4aab55ef2013)

- version detail page should have a separate button with primary styling for deploy (removed from actions menu), and the actions button should be secondary styling
![image](https://github.com/user-attachments/assets/70b92bb0-4056-4aae-9e3b-61eb8af7a507)
![image](https://github.com/user-attachments/assets/0feaad9a-9b83-4d1d-85a8-af11caec7233)


## Test Impact
none - styling changes

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change. @yih-wang 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
