### PR TITLE
run ForkTsCheckerWebpackPlugin only in dev env

### DIFF
--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -3,7 +3,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const { setupWebpackDotenvFilesForEnv } = require('./dotenv');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._ODH_IS_PROJECT_ROOT_DIR;
@@ -179,7 +178,6 @@ module.exports = (env) => {
       publicPath: PUBLIC_PATH,
     },
     plugins: [
-      new ForkTsCheckerWebpackPlugin(),
       ...setupWebpackDotenvFilesForEnv({
         directory: RELATIVE_DIRNAME,
         isRoot: IS_PROJECT_ROOT_DIR,

--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const path = require('path');
 const { merge } = require('webpack-merge');
 const { setupWebpackDotenvFilesForEnv, setupDotenvFilesForEnv } = require('./dotenv');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 
@@ -146,7 +147,10 @@ module.exports = smp.wrap(
           },
         ],
       },
-      plugins: [new ReactRefreshWebpackPlugin({ overlay: false })],
+      plugins: [
+        new ForkTsCheckerWebpackPlugin(),
+        new ReactRefreshWebpackPlugin({ overlay: false }),
+      ],
     },
   ),
 );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
`ForkTsCheckerWebpackPlugin` was type checking all files including cypress files. Since we omit optional dependencies, errors were found type checking cypress files. 

The fix here is to only run `ForkTsCheckerWebpackPlugin` in dev environment as previous done before the change that introduced it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- delete your `node_modules` folders
- `npm ci --omit=optional` from the root
- build the frontend dir: `npm run build`
- should succeed without error

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
