### PR TITLE
Distributed workloads popover fix

### DIFF
--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -5,12 +5,18 @@ import { TopResourceConsumingWorkloads } from './sections/TopResourceConsumingWo
 import { WorkloadResourceMetricsTable } from './sections/WorkloadResourceMetricsTable';
 import { DWSectionCard } from './sections/DWSectionCard';
 
+const PopoverContent = () => (
+  <>
+    In this section, <strong>all projects</strong> refers to all of the projects that share the
+    specified resource. You might not have access to all of these projects.
+  </>
+);
 const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => (
   <Stack hasGutter>
     <StackItem data-testid="dw-requested-resources">
       <DWSectionCard
         title="Requested resources"
-        helpTooltip="In this section, all projects refers to all of the projects that share the specified resource. You might not have access to all of these projects."
+        helpTooltip={<PopoverContent />}
         content={<RequestedResources />}
       />
     </StackItem>

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/DWSectionCard.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/DWSectionCard.tsx
@@ -1,17 +1,26 @@
 import * as React from 'react';
-import { Card, CardTitle, CardHeader, Divider } from '@patternfly/react-core';
-import DashboardHelpTooltip from '~/concepts/dashboard/DashboardHelpTooltip';
+import { Card, CardTitle, CardHeader, Divider, Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 
 export const DWSectionCard: React.FC<{
   title: string;
-  helpTooltip?: string;
+  helpTooltip?: React.ReactNode;
   hasDivider?: boolean;
   content: React.ReactNode;
 }> = ({ title, hasDivider = true, helpTooltip, content }) => (
   <Card isFullHeight>
     <CardHeader>
       <CardTitle>
-        {title} {helpTooltip ? <DashboardHelpTooltip content={helpTooltip} /> : null}
+        {title}
+        {helpTooltip ? (
+          <Popover bodyContent={helpTooltip}>
+            <DashboardPopupIconButton
+              icon={<OutlinedQuestionCircleIcon />}
+              aria-label="More info"
+            />
+          </Popover>
+        ) : null}
       </CardTitle>
     </CardHeader>
     {hasDivider && <Divider />}


### PR DESCRIPTION
Closes: [RHOAIENG-12280](https://issues.redhat.com/browse/RHOAIENG-12280)

## Description
Changes the tooltip for requested resources to a popover

## How Has This Been Tested?
Tested locally using Cypress
Navigate to Distributed workload metrics, and click the icon next to Requested resources

## Test Impact
No new tests added 

## Screenshots
Before:
![Screenshot 2024-11-12 at 2 06 34 PM](https://github.com/user-attachments/assets/cfbaf2fe-9544-4291-9550-56bd637766a9)

After:
![Screenshot 2024-11-14 at 9 01 30 AM](https://github.com/user-attachments/assets/375dd956-4352-4232-8c72-4db82a952a7a)



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
