### PR TITLE
Display the storage class metadata name in the end user UI

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -36,6 +36,18 @@ class ClusterStorageRow extends TableRow {
     this.find().siblings().find('[data-label=Size]').contains(name).should('exist');
     return this;
   }
+
+  showStorageClassDetails() {
+    return this.findStorageClassColumn().findByTestId('resource-name-icon-button').click();
+  }
+
+  findStorageClassResourceNameText() {
+    return cy.findByTestId('resource-name-text');
+  }
+
+  findStorageClassResourceKindText() {
+    return cy.findByTestId('resource-kind-text');
+  }
 }
 
 class ClusterStorageModal extends Modal {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -110,6 +110,11 @@ describe('ClusterStorage', () => {
       clusterStorage.visit('test-project');
       const clusterStorageRow = clusterStorage.getClusterStorageRow('Test Storage');
       clusterStorageRow.findStorageClassColumn().should('exist');
+      clusterStorageRow.showStorageClassDetails();
+      clusterStorageRow
+        .findStorageClassResourceNameText()
+        .should('have.text', 'openshift-default-sc');
+      clusterStorageRow.findStorageClassResourceKindText().should('have.text', 'StorageClass');
     });
 
     it('Check whether the Storage class is deprecated', () => {

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -15,7 +15,6 @@ import {
   Text,
   TextVariants,
   Tooltip,
-  Truncate,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, HddIcon } from '@patternfly/react-icons';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
@@ -108,13 +107,14 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
               alignItems={{ default: 'alignItemsCenter' }}
             >
               <FlexItem>
-                <Truncate
-                  content={
+                <TableRowTitleDescription
+                  title={
                     storageClassConfig?.displayName ??
                     obj.storageClass?.metadata.name ??
                     obj.pvc.spec.storageClassName ??
                     ''
                   }
+                  resource={obj.storageClass}
                 />
               </FlexItem>
               {storageClassesLoaded && (

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -62,7 +62,13 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
     return {
       key: sc.metadata.name,
       label: config?.displayName || sc.metadata.name,
-      description: config?.description,
+      description: (
+        <>
+          Resource name: {sc.metadata.name}
+          <br />
+          {config?.description && `Description: ${config.description}`}
+        </>
+      ),
       isDisabled: !config?.isEnabled,
       dropdownLabel: (
         <Split>
@@ -96,6 +102,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
         isDisabled={disableStorageClassSelect || !storageClassesLoaded}
         placeholder="Select storage class"
         popperProps={{ appendTo: menuAppendTo }}
+        previewDescription={false}
       />
       <FormHelperText>
         {selectedStorageClassConfig && !selectedStorageClassConfig.isEnabled ? (


### PR DESCRIPTION
[RHOAIENG-13984](https://issues.redhat.com/browse/RHOAIENG-13984)

## Description
Added resource tooltip to storage class name in the table.

<img width="491" alt="Screenshot 2024-11-13 at 9 15 43 PM" src="https://github.com/user-attachments/assets/a52fc93f-bb71-42e4-bb61-8ca9b5482e80">

Description and resource name added in select dropdown

<img width="902" alt="Screenshot 2024-11-13 at 9 15 55 PM" src="https://github.com/user-attachments/assets/205557cc-f929-4a0d-a469-a0d3af0b9d4c">


## How Has This Been Tested?
Create a storage class, and check the name, resourcename and description in storage table and create storage modal.

## Test Impact
Added cypress test to check resource name in storage table.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@xianli123 