### PR TITLE
Cluster storage that was disconnected from the workbench doesn't update it's size info

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -48,6 +48,19 @@ class ClusterStorageRow extends TableRow {
   findStorageClassResourceKindText() {
     return cy.findByTestId('resource-kind-text');
   }
+
+  findStorageSizeWarning() {
+    return cy.findByTestId('size-warning-popover').click();
+  }
+
+  findStorageSizeWarningText() {
+    return cy
+      .findByTestId('size-warning-popover-text')
+      .should(
+        'have.text',
+        'To complete the storage size update, you must connect and run a workbench.',
+      );
+  }
 }
 
 class ClusterStorageModal extends Modal {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -56,6 +56,28 @@ const initInterceptors = ({ isEmpty = false, storageClassName }: HandlersProps) 
               storageClassName,
               status: { phase: 'Pending' },
             }),
+            mockPVCK8sResource({
+              displayName: 'Updated storage with no workbench',
+              storageClassName,
+              storage: '13Gi',
+              status: {
+                phase: 'Bound',
+                accessModes: ['ReadWriteOnce'],
+                capacity: {
+                  storage: '12Gi',
+                },
+                conditions: [
+                  {
+                    type: 'FileSystemResizePending',
+                    status: 'True',
+                    lastProbeTime: null,
+                    lastTransitionTime: '2024-11-15T14:04:04Z',
+                    message:
+                      'Waiting for user to (re-)start a pod to finish file system resize of volume on node.',
+                  },
+                ],
+              },
+            }),
           ],
     ),
   );
@@ -320,6 +342,18 @@ describe('ClusterStorage', () => {
     clusterStorage.findClusterStorageTableHeaderButton('Name').should(be.sortAscending);
     clusterStorage.findClusterStorageTableHeaderButton('Name').click();
     clusterStorage.findClusterStorageTableHeaderButton('Name').should(be.sortDescending);
+  });
+
+  it('should show warning when cluster storage size is updated but no workbench is connected', () => {
+    initInterceptors({});
+    clusterStorage.visit('test-project');
+    const clusterStorageRow = clusterStorage.getClusterStorageRow(
+      'Updated storage with no workbench',
+    );
+    clusterStorageRow.toggleExpandableContent();
+    clusterStorageRow.shouldHaveStorageSize('Max 13Gi');
+    clusterStorageRow.findStorageSizeWarning();
+    clusterStorageRow.findStorageSizeWarning().should('exist');
   });
 
   it('Edit cluster storage', () => {

--- a/frontend/src/concepts/dashboard/DashboardPopupIconButton.tsx
+++ b/frontend/src/concepts/dashboard/DashboardPopupIconButton.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Button, ButtonProps, Icon } from '@patternfly/react-core';
+import { Button, ButtonProps, Icon, IconComponentProps } from '@patternfly/react-core';
 
 type DashboardPopupIconButtonProps = Omit<ButtonProps, 'variant' | 'isInline'> & {
   icon: React.ReactNode;
+  iconProps?: Omit<IconComponentProps, 'isInline'>;
 };
 
 /**
@@ -10,9 +11,19 @@ type DashboardPopupIconButtonProps = Omit<ButtonProps, 'variant' | 'isInline'> &
  */
 const DashboardPopupIconButton = ({
   icon,
+  iconProps,
   ...props
 }: DashboardPopupIconButtonProps): React.JSX.Element => (
-  <Button icon={<Icon isInline>{icon}</Icon>} variant="plain" isInline {...props} />
+  <Button
+    icon={
+      <Icon isInline {...iconProps}>
+        {icon}
+      </Icon>
+    }
+    variant="plain"
+    isInline
+    {...props}
+  />
 );
 
 export default DashboardPopupIconButton;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -313,6 +313,7 @@ export type PersistentVolumeClaimKind = K8sResourceCommon & {
     capacity?: {
       storage: string;
     };
+    conditions?: K8sCondition[];
   } & Record<string, unknown>;
 };
 

--- a/frontend/src/pages/projects/components/PVSizeField.tsx
+++ b/frontend/src/pages/projects/components/PVSizeField.tsx
@@ -4,6 +4,10 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import ValueUnitField from '~/components/ValueUnitField';
 import { MEMORY_UNITS_FOR_SELECTION, UnitOption } from '~/utilities/valueUnits';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
+import {
+  ConnectedNotebookContext,
+  useRelatedNotebooks,
+} from '~/pages/projects/notebook/useRelatedNotebooks';
 
 type PVSizeFieldProps = {
   fieldID: string;
@@ -13,6 +17,7 @@ type PVSizeFieldProps = {
   currentStatus?: PersistentVolumeClaimKind['status'];
   label?: string;
   options?: UnitOption[];
+  existingPvcName?: string;
 };
 
 const PVSizeField: React.FC<PVSizeFieldProps> = ({
@@ -23,9 +28,17 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({
   currentStatus,
   label = 'Persistent storage size',
   options = MEMORY_UNITS_FOR_SELECTION,
+  existingPvcName,
 }) => {
   const currentSize = currentStatus?.capacity?.storage;
   const isUnbound = currentStatus && currentStatus.phase !== 'Bound';
+
+  const { notebooks } = useRelatedNotebooks(
+    ConnectedNotebookContext.REMOVABLE_PVC,
+    existingPvcName,
+  );
+
+  const hasExistingNotebookConnections = notebooks.length > 0;
 
   return (
     <FormGroup label={label} fieldId={fieldID} data-testid={fieldID}>
@@ -60,8 +73,9 @@ const PVSizeField: React.FC<PVSizeFieldProps> = ({
                 variant="warning"
                 icon={<ExclamationTriangleIcon />}
               >
-                Storage size can only be increased. If you do so, the workbench will restart and be
-                unavailable for a period of time that is usually proportional to the size change.
+                {!hasExistingNotebookConnections
+                  ? 'Storage size can only be increased. To complete the storage size update, you must connect to and run a workbench.'
+                  : 'Storage size can only be increased. If you do so, the workbench will restart and be unavailable for a period of time that is usually proportional to the size change.'}
               </HelperTextItem>
             )}
           </HelperText>

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -85,6 +85,7 @@ const CreateNewStorageSection = <D extends StorageData>({
         currentStatus={currentStatus}
         size={String(data.size)}
         setSize={(size) => setData('size', size)}
+        existingPvcName={data.existingPvc?.metadata.name}
       />
     </FormSection>
   );

--- a/frontend/src/pages/projects/screens/spawner/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/utils.ts
@@ -29,6 +29,7 @@ export const useCreateStorageObject = (
       formData?.description || (existingData ? getDescriptionFromK8sResource(existingData) : ''),
     size: formData?.size || (existingData ? existingData.spec.resources.requests.storage : size),
     storageClassName: formData?.storageClassName || existingData?.spec.storageClassName,
+    existingPvc: existingData,
   };
 
   const [data, setData] = useGenericObjectState<StorageData>(createStorageData);

--- a/frontend/src/pages/projects/utils.ts
+++ b/frontend/src/pages/projects/utils.ts
@@ -9,6 +9,9 @@ export const getNotebookStatusPriority = (notebookState: NotebookState): number 
 export const getPvcTotalSize = (pvc: PersistentVolumeClaimKind): string =>
   formatMemory(pvc.status?.capacity?.storage || pvc.spec.resources.requests.storage);
 
+export const getPvcRequestSize = (pvc: PersistentVolumeClaimKind): string =>
+  formatMemory(pvc.spec.resources.requests.storage);
+
 export const getCustomNotebookSize = (
   existingNotebook: NotebookKind | undefined,
 ): NotebookSize => ({


### PR DESCRIPTION
[RHOAIENG-527](https://issues.redhat.com/browse/RHOAIENG-527)

## Description
When the storage size is updated but no pod connected, the size doesn't get updated on UI. So added a condition which will display the updated size with warning.

<img width="676" alt="Screenshot 2024-11-15 at 8 54 36 PM" src="https://github.com/user-attachments/assets/d33f50da-f67c-460d-934d-8bdd05cf381c">


If the storage is connected to workbenches

![Screenshot 2024-11-26 at 3 49 27 PM](https://github.com/user-attachments/assets/8cfa1ef6-696d-4d38-ad0d-af0f72805eb4)

If the storage is not connected to any workbench

![Screenshot 2024-11-26 at 3 49 18 PM](https://github.com/user-attachments/assets/2e6eb9ec-0626-42ba-af0d-fbd6529b7768)


## How Has This Been Tested?
1. Create a cluster storage with workbench connected. (size: 12Gi)
2. Disconnect the workbench from it.
3. Edit the size. (size: 13Gi)
4. You can see the updated size with warning popover.

## Test Impact
Added cypress test to check the warning when cluster storage size is updated but no workbench is connected.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@xianli123 @kaedward 