### PR TITLE
Fix NIM selection issue

### DIFF
--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -122,5 +122,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.NIM_MODEL]: {
     featureFlags: ['disableNIMModelServing'],
+    reliantAreas: [SupportedArea.K_SERVE],
   },
 };

--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -2,15 +2,12 @@ import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
-import { getProjectModelServingPlatform } from '~/pages/modelServing/screens/projects/utils';
-import { ServingRuntimePlatform } from '~/types';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
 import EmptyDetailsView from '~/components/EmptyDetailsView';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import ServeModelButton from '~/pages/modelServing/screens/global/ServeModelButton';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
-import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nimUtils';
 
 const EmptyModelServing: React.FC = () => {
   const navigate = useNavigate();
@@ -19,14 +16,9 @@ const EmptyModelServing: React.FC = () => {
     project,
   } = React.useContext(ModelServingContext);
   const servingPlatformStatuses = useServingPlatformStatuses();
-  const isKServeNIMEnabled = project ? isProjectNIMSupported(project) : false;
 
-  if (
-    (getProjectModelServingPlatform(project, servingPlatformStatuses).platform !==
-      ServingRuntimePlatform.SINGLE ||
-      isKServeNIMEnabled) &&
-    servingRuntimes.length === 0
-  ) {
+  if (servingPlatformStatuses.modelMesh.enabled && servingRuntimes.length === 0) {
+    // Server needed -- must deploy from the project
     return (
       <EmptyDetailsView
         title="No deployed models"

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -93,15 +93,11 @@ const ModelServingPlatform: React.FC = () => {
   const emptyTemplates = templatesEnabled.length === 0;
   const emptyModelServer = servingRuntimes.length === 0;
 
-  const {
-    platform: currentProjectServingPlatform,
-    hasMultiplePlatformOptions,
-    noPlatformsActive,
-    error: platformError,
-  } = getProjectModelServingPlatform(currentProject, servingPlatformStatuses);
+  const { platform: currentProjectServingPlatform, error: platformError } =
+    getProjectModelServingPlatform(currentProject, servingPlatformStatuses);
 
   const shouldShowPlatformSelection =
-    (!!hasMultiplePlatformOptions || !!noPlatformsActive) && !currentProjectServingPlatform;
+    servingPlatformStatuses.platformEnabledCount !== 1 && !currentProjectServingPlatform;
 
   const isProjectModelMesh = currentProjectServingPlatform === ServingRuntimePlatform.MULTI;
 
@@ -259,7 +255,7 @@ const ModelServingPlatform: React.FC = () => {
         isEmpty={shouldShowPlatformSelection}
         loadError={platformError || servingRuntimeError || templateError}
         emptyState={
-          hasMultiplePlatformOptions ? (
+          servingPlatformStatuses.platformEnabledCount > 1 ? (
             <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapLg' }}>
               <FlexItem
                 flex={{ default: 'flex_1' }}
@@ -334,7 +330,7 @@ const ModelServingPlatform: React.FC = () => {
                       ? 'Multi-model serving enabled'
                       : 'Single-model serving enabled'}
                   </Label>
-                  {emptyModelServer && hasMultiplePlatformOptions && (
+                  {emptyModelServer && servingPlatformStatuses.platformEnabledCount > 1 && (
                     <ModelServingPlatformSelectButton
                       namespace={currentProject.metadata.name}
                       servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -67,21 +67,21 @@ const getMockServingPlatformStatuses = ({
   kServeInstalled = true,
   modelMeshEnabled = true,
   modelMeshInstalled = true,
-  nimAvailable = true,
+  nimEnabled = false,
+  nimInstalled = false,
 }): ServingPlatformStatuses => ({
   kServe: {
     enabled: kServeEnabled,
     installed: kServeInstalled,
   },
+  kServeNIM: {
+    enabled: nimEnabled,
+    installed: nimInstalled,
+  },
   modelMesh: {
     enabled: modelMeshEnabled,
     installed: modelMeshInstalled,
   },
-  nim: {
-    available: nimAvailable,
-  },
-  numServingPlatformsAvailable: [kServeEnabled, modelMeshEnabled, nimAvailable].filter(Boolean)
-    .length,
 });
 
 describe('getProjectModelServingPlatform', () => {
@@ -91,7 +91,10 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({ kServeEnabled: false, modelMeshEnabled: false }),
       ),
-    ).toStrictEqual({});
+    ).toStrictEqual({
+      hasMultiplePlatformOptions: false,
+      noPlatformsActive: true,
+    });
   });
   it('should return undefined if both KServe and ModelMesh are enabled, and project has no platform label', () => {
     expect(
@@ -99,7 +102,10 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({}),
       ),
-    ).toStrictEqual({});
+    ).toStrictEqual({
+      hasMultiplePlatformOptions: true,
+      noPlatformsActive: false,
+    });
   });
   it('should return Single Platform if has platform label set to false and KServe is installed', () => {
     expect(
@@ -107,13 +113,23 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({ enableModelMesh: false }),
         getMockServingPlatformStatuses({}),
       ),
-    ).toStrictEqual({ platform: ServingRuntimePlatform.SINGLE, error: undefined });
+    ).toStrictEqual({
+      platform: ServingRuntimePlatform.SINGLE,
+      hasMultiplePlatformOptions: true,
+      noPlatformsActive: false,
+      error: undefined,
+    });
     expect(
       getProjectModelServingPlatform(
         mockProjectK8sResource({ enableModelMesh: false }),
         getMockServingPlatformStatuses({ kServeEnabled: false }),
       ),
-    ).toStrictEqual({ platform: ServingRuntimePlatform.SINGLE, error: undefined });
+    ).toStrictEqual({
+      platform: ServingRuntimePlatform.SINGLE,
+      hasMultiplePlatformOptions: false,
+      noPlatformsActive: false,
+      error: undefined,
+    });
   });
   it('should give error if has platform label set to false and KServe is not installed', () => {
     expect(
@@ -129,13 +145,23 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({ enableModelMesh: true }),
         getMockServingPlatformStatuses({}),
       ),
-    ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI, error: undefined });
+    ).toStrictEqual({
+      platform: ServingRuntimePlatform.MULTI,
+      hasMultiplePlatformOptions: true,
+      noPlatformsActive: false,
+      error: undefined,
+    });
     expect(
       getProjectModelServingPlatform(
         mockProjectK8sResource({ enableModelMesh: true }),
         getMockServingPlatformStatuses({ modelMeshEnabled: false }),
       ),
-    ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI, error: undefined });
+    ).toStrictEqual({
+      platform: ServingRuntimePlatform.MULTI,
+      hasMultiplePlatformOptions: false,
+      noPlatformsActive: false,
+      error: undefined,
+    });
   });
   it('should give error if has platform label set to true and ModelMesh is not installed', () => {
     expect(
@@ -151,7 +177,11 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({ modelMeshEnabled: false }),
       ),
-    ).toStrictEqual({ platform: ServingRuntimePlatform.SINGLE });
+    ).toStrictEqual({
+      platform: ServingRuntimePlatform.SINGLE,
+      hasMultiplePlatformOptions: false,
+      noPlatformsActive: false,
+    });
   });
   it('should return Multi Platform if only ModelMesh is enabled, and project has no platform label', () => {
     expect(
@@ -159,7 +189,11 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({ kServeEnabled: false }),
       ),
-    ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI });
+    ).toStrictEqual({
+      platform: ServingRuntimePlatform.MULTI,
+      hasMultiplePlatformOptions: false,
+      noPlatformsActive: false,
+    });
   });
 });
 

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -82,6 +82,7 @@ const getMockServingPlatformStatuses = ({
     enabled: modelMeshEnabled,
     installed: modelMeshInstalled,
   },
+  platformEnabledCount: [kServeEnabled, nimEnabled, modelMeshEnabled].filter(Boolean).length,
 });
 
 describe('getProjectModelServingPlatform', () => {
@@ -91,10 +92,7 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({ kServeEnabled: false, modelMeshEnabled: false }),
       ),
-    ).toStrictEqual({
-      hasMultiplePlatformOptions: false,
-      noPlatformsActive: true,
-    });
+    ).toStrictEqual({});
   });
   it('should return undefined if both KServe and ModelMesh are enabled, and project has no platform label', () => {
     expect(
@@ -102,10 +100,7 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({}),
       ),
-    ).toStrictEqual({
-      hasMultiplePlatformOptions: true,
-      noPlatformsActive: false,
-    });
+    ).toStrictEqual({});
   });
   it('should return Single Platform if has platform label set to false and KServe is installed', () => {
     expect(
@@ -113,23 +108,13 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({ enableModelMesh: false }),
         getMockServingPlatformStatuses({}),
       ),
-    ).toStrictEqual({
-      platform: ServingRuntimePlatform.SINGLE,
-      hasMultiplePlatformOptions: true,
-      noPlatformsActive: false,
-      error: undefined,
-    });
+    ).toStrictEqual({ platform: ServingRuntimePlatform.SINGLE, error: undefined });
     expect(
       getProjectModelServingPlatform(
         mockProjectK8sResource({ enableModelMesh: false }),
         getMockServingPlatformStatuses({ kServeEnabled: false }),
       ),
-    ).toStrictEqual({
-      platform: ServingRuntimePlatform.SINGLE,
-      hasMultiplePlatformOptions: false,
-      noPlatformsActive: false,
-      error: undefined,
-    });
+    ).toStrictEqual({ platform: ServingRuntimePlatform.SINGLE, error: undefined });
   });
   it('should give error if has platform label set to false and KServe is not installed', () => {
     expect(
@@ -145,23 +130,13 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({ enableModelMesh: true }),
         getMockServingPlatformStatuses({}),
       ),
-    ).toStrictEqual({
-      platform: ServingRuntimePlatform.MULTI,
-      hasMultiplePlatformOptions: true,
-      noPlatformsActive: false,
-      error: undefined,
-    });
+    ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI, error: undefined });
     expect(
       getProjectModelServingPlatform(
         mockProjectK8sResource({ enableModelMesh: true }),
         getMockServingPlatformStatuses({ modelMeshEnabled: false }),
       ),
-    ).toStrictEqual({
-      platform: ServingRuntimePlatform.MULTI,
-      hasMultiplePlatformOptions: false,
-      noPlatformsActive: false,
-      error: undefined,
-    });
+    ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI, error: undefined });
   });
   it('should give error if has platform label set to true and ModelMesh is not installed', () => {
     expect(
@@ -177,11 +152,7 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({ modelMeshEnabled: false }),
       ),
-    ).toStrictEqual({
-      platform: ServingRuntimePlatform.SINGLE,
-      hasMultiplePlatformOptions: false,
-      noPlatformsActive: false,
-    });
+    ).toStrictEqual({ platform: ServingRuntimePlatform.SINGLE });
   });
   it('should return Multi Platform if only ModelMesh is enabled, and project has no platform label', () => {
     expect(
@@ -189,11 +160,7 @@ describe('getProjectModelServingPlatform', () => {
         mockProjectK8sResource({}),
         getMockServingPlatformStatuses({ kServeEnabled: false }),
       ),
-    ).toStrictEqual({
-      platform: ServingRuntimePlatform.MULTI,
-      hasMultiplePlatformOptions: false,
-      noPlatformsActive: false,
-    });
+    ).toStrictEqual({ platform: ServingRuntimePlatform.MULTI });
   });
 });
 

--- a/frontend/src/pages/modelServing/screens/projects/useIsNIMAvailable.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useIsNIMAvailable.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { isNIMServingRuntimeTemplateAvailable } from '~/pages/modelServing/screens/projects/nimUtils';
+import { useDashboardNamespace } from '~/redux/selectors';
 
-export const useIsNIMAvailable = (dashboardNamespace: string): boolean => {
+export const useIsNIMAvailable = (): boolean => {
+  const { dashboardNamespace } = useDashboardNamespace();
   const [isNIMAvailable, setIsNIMAvailable] = useState<boolean>(false);
   const isNIMModelServingAvailable = useIsAreaAvailable(SupportedArea.NIM_MODEL).status;
 

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -116,6 +116,7 @@ export type ServingPlatformStatuses = {
   kServe: PlatformStatus;
   kServeNIM: PlatformStatus;
   modelMesh: PlatformStatus;
+  platformEnabledCount: number;
 };
 
 export type LabeledDataConnection = {

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -108,19 +108,14 @@ export type ServingRuntimeEditInfo = {
   secrets: SecretKind[];
 };
 
+type PlatformStatus = {
+  enabled: boolean;
+  installed: boolean;
+};
 export type ServingPlatformStatuses = {
-  kServe: {
-    enabled: boolean;
-    installed: boolean;
-  };
-  modelMesh: {
-    enabled: boolean;
-    installed: boolean;
-  };
-  nim: {
-    available: boolean;
-  };
-  numServingPlatformsAvailable: number;
+  kServe: PlatformStatus;
+  kServeNIM: PlatformStatus;
+  modelMesh: PlatformStatus;
 };
 
 export type LabeledDataConnection = {

--- a/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
+++ b/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
@@ -1,33 +1,30 @@
 import { StackComponent, SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
-import { useDashboardNamespace } from '~/redux/selectors';
 import { useIsNIMAvailable } from '~/pages/modelServing/screens/projects/useIsNIMAvailable';
 
 const useServingPlatformStatuses = (): ServingPlatformStatuses => {
-  const { dashboardNamespace } = useDashboardNamespace();
-
   const kServeStatus = useIsAreaAvailable(SupportedArea.K_SERVE);
   const modelMeshStatus = useIsAreaAvailable(SupportedArea.MODEL_MESH);
   const kServeEnabled = kServeStatus.status;
   const modelMeshEnabled = modelMeshStatus.status;
   const kServeInstalled = !!kServeStatus.requiredComponents?.[StackComponent.K_SERVE];
   const modelMeshInstalled = !!modelMeshStatus.requiredComponents?.[StackComponent.MODEL_MESH];
-  const isNIMAvailable = useIsNIMAvailable(dashboardNamespace);
+
+  const isNIMAvailable = useIsNIMAvailable();
 
   return {
     kServe: {
       enabled: kServeEnabled,
       installed: kServeInstalled,
     },
+    kServeNIM: {
+      enabled: isNIMAvailable,
+      installed: kServeInstalled,
+    },
     modelMesh: {
       enabled: modelMeshEnabled,
       installed: modelMeshInstalled,
     },
-    nim: {
-      available: isNIMAvailable,
-    },
-    numServingPlatformsAvailable: [kServeEnabled, modelMeshEnabled, isNIMAvailable].filter(Boolean)
-      .length,
   };
 };
 

--- a/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
+++ b/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
@@ -25,6 +25,7 @@ const useServingPlatformStatuses = (): ServingPlatformStatuses => {
       enabled: modelMeshEnabled,
       installed: modelMeshInstalled,
     },
+    platformEnabledCount: [kServeEnabled, isNIMAvailable, modelMeshEnabled].filter(Boolean).length,
   };
 };
 

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -11,11 +11,12 @@ const PlatformSelectSection: React.FC = () => {
   const [errorSelectingPlatform, setErrorSelectingPlatform] = React.useState<Error>();
 
   const servingPlatformStatuses = useServingPlatformStatuses();
-  const {
-    nim: { available: isNIMAvailable },
-  } = servingPlatformStatuses;
+  const kServeEnabled = servingPlatformStatuses.kServe.enabled;
+  const isNIMAvailable = servingPlatformStatuses.kServeNIM.enabled;
+  const modelMeshEnabled = servingPlatformStatuses.modelMesh.enabled;
 
-  const galleryWidths = isNIMAvailable
+  const threeEnabled = [kServeEnabled, modelMeshEnabled, isNIMAvailable].every((v) => v);
+  const galleryWidths = threeEnabled
     ? {
         minWidths: { default: '100%', lg: 'calc(33.33% - 1rem / 3 * 2)' },
         maxWidths: { default: '100%', lg: 'calc(33.33% - 1rem / 3 * 2)' },
@@ -38,8 +39,12 @@ const PlatformSelectSection: React.FC = () => {
           </Text>
         </TextContent>
         <Gallery hasGutter {...galleryWidths}>
-          <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
-          <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          {kServeEnabled && (
+            <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          )}
+          {modelMeshEnabled && (
+            <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+          )}
           {isNIMAvailable && (
             <SelectNIMCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
           )}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/ServeModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/ServeModelsSection.tsx
@@ -10,22 +10,22 @@ import DeployedModelsSection from './deployedModels/DeployedModelsSection';
 const ServeModelsSection: React.FC = () => {
   const servingPlatformStatuses = useServingPlatformStatuses();
   const {
-    numServingPlatformsAvailable,
     modelMesh: { enabled: modelMeshEnabled },
   } = servingPlatformStatuses;
 
   const { currentProject } = React.useContext(ProjectDetailsContext);
 
-  const { platform: currentProjectServingPlatform } = getProjectModelServingPlatform(
-    currentProject,
-    servingPlatformStatuses,
-  );
+  const {
+    platform: currentProjectServingPlatform,
+    noPlatformsActive,
+    hasMultiplePlatformOptions,
+  } = getProjectModelServingPlatform(currentProject, servingPlatformStatuses);
 
-  if (numServingPlatformsAvailable > 1 && !currentProjectServingPlatform) {
+  if (hasMultiplePlatformOptions && !currentProjectServingPlatform) {
     return <PlatformSelectSection />;
   }
 
-  if (numServingPlatformsAvailable === 0) {
+  if (noPlatformsActive) {
     return <NoProjectServingEnabledSection />;
   }
 

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/ServeModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/ServeModelsSection.tsx
@@ -11,21 +11,21 @@ const ServeModelsSection: React.FC = () => {
   const servingPlatformStatuses = useServingPlatformStatuses();
   const {
     modelMesh: { enabled: modelMeshEnabled },
+    platformEnabledCount,
   } = servingPlatformStatuses;
 
   const { currentProject } = React.useContext(ProjectDetailsContext);
 
-  const {
-    platform: currentProjectServingPlatform,
-    noPlatformsActive,
-    hasMultiplePlatformOptions,
-  } = getProjectModelServingPlatform(currentProject, servingPlatformStatuses);
+  const { platform: currentProjectServingPlatform } = getProjectModelServingPlatform(
+    currentProject,
+    servingPlatformStatuses,
+  );
 
-  if (hasMultiplePlatformOptions && !currentProjectServingPlatform) {
+  if (platformEnabledCount > 1 && !currentProjectServingPlatform) {
     return <PlatformSelectSection />;
   }
 
-  if (noPlatformsActive) {
+  if (platformEnabledCount === 0) {
     return <NoProjectServingEnabledSection />;
   }
 

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -52,7 +52,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
   } = React.useContext(ProjectDetailsContext);
 
   const servingPlatformStatuses = useServingPlatformStatuses();
-  const { hasMultiplePlatformOptions, error: platformError } = getProjectModelServingPlatform(
+  const { error: platformError } = getProjectModelServingPlatform(
     currentProject,
     servingPlatformStatuses,
   );
@@ -129,7 +129,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
           headerInfo={
             <Flex gap={{ default: 'gapSm' }}>
               <Label>Multi-model serving enabled</Label>
-              {hasMultiplePlatformOptions && (
+              {servingPlatformStatuses.platformEnabledCount > 1 && (
                 <ModelServingPlatformSelectButton
                   namespace={currentProject.metadata.name}
                   servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
@@ -193,7 +193,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
               <Label>
                 {isMultiPlatform ? 'Multi-model serving enabled' : 'Single-model serving enabled'}
               </Label>
-              {hasMultiplePlatformOptions && (
+              {servingPlatformStatuses.platformEnabledCount > 1 && (
                 <ModelServingPlatformSelectButton
                   namespace={currentProject.metadata.name}
                   servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -52,8 +52,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
   } = React.useContext(ProjectDetailsContext);
 
   const servingPlatformStatuses = useServingPlatformStatuses();
-  const { numServingPlatformsAvailable } = servingPlatformStatuses;
-  const { error: platformError } = getProjectModelServingPlatform(
+  const { hasMultiplePlatformOptions, error: platformError } = getProjectModelServingPlatform(
     currentProject,
     servingPlatformStatuses,
   );
@@ -130,7 +129,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
           headerInfo={
             <Flex gap={{ default: 'gapSm' }}>
               <Label>Multi-model serving enabled</Label>
-              {numServingPlatformsAvailable > 1 && (
+              {hasMultiplePlatformOptions && (
                 <ModelServingPlatformSelectButton
                   namespace={currentProject.metadata.name}
                   servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
@@ -194,7 +193,7 @@ const DeployedModelsSection: React.FC<DeployedModelsSectionProps> = ({ isMultiPl
               <Label>
                 {isMultiPlatform ? 'Multi-model serving enabled' : 'Single-model serving enabled'}
               </Label>
-              {numServingPlatformsAvailable > 1 && (
+              {hasMultiplePlatformOptions && (
                 <ModelServingPlatformSelectButton
                   namespace={currentProject.metadata.name}
                   servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
(I'll have to create an issue -- don't think we have it yet)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes the issue where if KServe is the only thing installed, NIM doesn't appear as an option and it auto-selects KServe.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not having MM installed then installing the NIM tile & then creating a new project

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Test fixes -- no new tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
