### PR TITLE
Update 'Resource name' fields to meet UX guidelines: Cluster storage

### DIFF
--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Button,
   FormGroup,
-  FormHelperText,
   HelperText,
   HelperTextItem,
   TextArea,
@@ -75,29 +74,31 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
           value={name}
           onChange={(event, value) => onDataChange?.('name', value)}
         />
-        {!showK8sField && !k8sName.state.immutable && (
-          <FormHelperText>
-            <HelperText>
-              {nameHelperText}
-              {k8sName.value && (
+        {nameHelperText || (!showK8sField && !k8sName.state.immutable) ? (
+          <HelperText>
+            {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
+            {!showK8sField && !k8sName.state.immutable && (
+              <>
+                {k8sName.value && (
+                  <HelperTextItem>
+                    The resource name will be <b>{k8sName.value}</b>.
+                  </HelperTextItem>
+                )}
                 <HelperTextItem>
-                  The resource name will be <b>{k8sName.value}</b>.
+                  <Button
+                    data-testid={`${dataTestId}-editResourceLink`}
+                    variant="link"
+                    isInline
+                    onClick={() => setShowK8sField(true)}
+                  >
+                    Edit resource name
+                  </Button>{' '}
+                  <ResourceNameDefinitionTooltip />
                 </HelperTextItem>
-              )}
-              <HelperTextItem>
-                <Button
-                  data-testid={`${dataTestId}-editResourceLink`}
-                  variant="link"
-                  isInline
-                  onClick={() => setShowK8sField(true)}
-                >
-                  Edit resource name
-                </Button>{' '}
-                <ResourceNameDefinitionTooltip />
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        )}
+              </>
+            )}
+          </HelperText>
+        ) : null}
       </FormGroup>
       <ResourceNameField
         allowEdit={showK8sField}

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/types.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/types.ts
@@ -60,6 +60,8 @@ export type UseK8sNameDescriptionDataConfiguration = {
   regexp?: RegExp;
   /** Optional invalid characters message */
   invalidCharsMessage?: string;
+  /** allow the k8sName value to be edited even though it is pre-set */
+  editableK8sName?: boolean;
 };
 
 type K8sNameDescriptionFieldUpdateFunctionTemplate<T> = (

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -46,6 +46,7 @@ export const setupDefaults = ({
   staticPrefix,
   regexp,
   invalidCharsMessage,
+  editableK8sName,
 }: UseK8sNameDescriptionDataConfiguration): K8sNameDescriptionFieldData => {
   let initialName = '';
   let initialDescription = '';
@@ -72,7 +73,7 @@ export const setupDefaults = ({
     k8sName: {
       value: initialK8sNameValue,
       state: {
-        immutable: initialK8sNameValue !== '',
+        immutable: !editableK8sName && initialK8sNameValue !== '',
         invalidCharacters: false,
         invalidLength: false,
         maxLength: configuredMaxLength,
@@ -80,7 +81,10 @@ export const setupDefaults = ({
         staticPrefix,
         regexp,
         invalidCharsMessage,
-        touched: false,
+        touched:
+          !!editableK8sName &&
+          initialK8sNameValue !== '' &&
+          initialK8sNameValue !== translateDisplayNameForK8s(initialName),
       },
     },
   })('name', initialName) satisfies K8sNameDescriptionFieldData;

--- a/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
@@ -41,7 +41,8 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
   onClose,
   onNameChange,
 }) => {
-  const [createData, setCreateData, resetData] = useCreateStorageObject(existingPvc, existingData);
+  const [createData, setCreateData] = useCreateStorageObject(existingPvc, existingData);
+  const [nameDescValid, setNameDescValid] = React.useState<boolean>();
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const preferredStorageClass = usePreferredStorageClass();
   const [defaultStorageClass] = useDefaultStorageClass();
@@ -64,21 +65,14 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
     setCreateData,
   ]);
 
-  const onBeforeClose = (submitted: boolean) => {
-    onClose(submitted);
-    setError(undefined);
-    setActionInProgress(false);
-    resetData();
-  };
-
-  const canCreate = !actionInProgress && createData.name.trim().length > 0 && isValid;
+  const canCreate = !actionInProgress && nameDescValid && isValid;
 
   const submit = () => {
     setError(undefined);
     setActionInProgress(true);
 
     onSubmit(createData)
-      .then(() => onBeforeClose(true))
+      .then(() => onClose(true))
       .catch((err) => {
         setError(err);
         setActionInProgress(false);
@@ -91,13 +85,13 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
       description={description}
       variant="medium"
       isOpen
-      onClose={() => onBeforeClose(false)}
+      onClose={() => onClose(false)}
       showClose
       footer={
         <DashboardModalFooter
           submitLabel={submitLabel}
           onSubmit={submit}
-          onCancel={() => onBeforeClose(false)}
+          onCancel={() => onClose(false)}
           isSubmitDisabled={!canCreate}
           error={error}
           alertTitle="Error creating storage"
@@ -118,8 +112,10 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
               currentStatus={existingPvc?.status}
               autoFocusName
               onNameChange={onNameChange}
+              setValid={setNameDescValid}
               hasDuplicateName={hasDuplicateName}
               disableStorageClassSelect={!!existingPvc}
+              editableK8sName={!existingPvc}
             />
           </StackItem>
           {children}

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StackItem } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
 import { ForNotebookSelection, StorageData } from '~/pages/projects/types';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
@@ -133,30 +133,26 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
       {workbenchEnabled && (
         <>
           {hasExistingNotebookConnections && (
-            <StackItem>
-              <ExistingConnectedNotebooks
-                connectedNotebooks={removableNotebooks}
-                onNotebookRemove={(notebook: NotebookKind) =>
-                  setRemovedNotebooks([...removedNotebooks, notebook.metadata.name])
-                }
-                loaded={removableNotebookLoaded}
-                error={removableNotebookError}
-              />
-            </StackItem>
-          )}
-          <StackItem>
-            <StorageNotebookConnections
-              setForNotebookData={(forNotebookData) => {
-                setNotebookData(forNotebookData);
-              }}
-              forNotebookData={notebookData}
-              connectedNotebooks={connectedNotebooks}
+            <ExistingConnectedNotebooks
+              connectedNotebooks={removableNotebooks}
+              onNotebookRemove={(notebook: NotebookKind) =>
+                setRemovedNotebooks([...removedNotebooks, notebook.metadata.name])
+              }
+              loaded={removableNotebookLoaded}
+              error={removableNotebookError}
             />
-          </StackItem>
+          )}
+          <StorageNotebookConnections
+            setForNotebookData={(forNotebookData) => {
+              setNotebookData(forNotebookData);
+            }}
+            forNotebookData={notebookData}
+            connectedNotebooks={connectedNotebooks}
+          />
           {restartNotebooks.length !== 0 && (
-            <StackItem>
+            <FormGroup>
               <NotebookRestartAlert notebooks={restartNotebooks} />
-            </StackItem>
+            </FormGroup>
           )}
         </>
       )}

--- a/frontend/src/pages/projects/screens/detail/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/utils.ts
@@ -1,4 +1,4 @@
-import { getDisplayNameFromK8sResource, getDescriptionFromK8sResource } from '~/concepts/k8s/utils';
+import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import { StorageData } from '~/pages/projects/types';
 

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { FormSection, HelperTextItem } from '@patternfly/react-core';
 import { StorageData, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import PVSizeField from '~/pages/projects/components/PVSizeField';
-import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
-import { DuplicateNameHelperText } from '~/concepts/pipelines/content/DuplicateNameHelperText';
+import K8sNameDescriptionField, {
+  useK8sNameDescriptionFieldData,
+} from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import StorageClassSelect from './StorageClassSelect';
 
 type CreateNewStorageSectionProps<D extends StorageData> = {
@@ -16,7 +18,9 @@ type CreateNewStorageSectionProps<D extends StorageData> = {
   menuAppendTo?: HTMLElement;
   disableStorageClassSelect?: boolean;
   onNameChange?: (value: string) => void;
+  setValid?: (isValid: boolean) => void;
   hasDuplicateName?: boolean;
+  editableK8sName?: boolean;
 };
 
 const CreateNewStorageSection = <D extends StorageData>({
@@ -27,49 +31,62 @@ const CreateNewStorageSection = <D extends StorageData>({
   autoFocusName,
   disableStorageClassSelect,
   onNameChange,
+  setValid,
   hasDuplicateName,
+  editableK8sName,
 }: CreateNewStorageSectionProps<D>): React.ReactNode => {
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
+  const { data: clusterStorageNameDesc, onDataChange: setClusterNameDesc } =
+    useK8sNameDescriptionFieldData({
+      initialData: {
+        name: data.name,
+        k8sName: data.k8sName,
+        description: data.description,
+      },
+      editableK8sName,
+    });
+
+  React.useEffect(() => {
+    setData('name', clusterStorageNameDesc.name);
+    setData('k8sName', clusterStorageNameDesc.k8sName.value);
+    setData('description', clusterStorageNameDesc.description);
+    onNameChange?.(clusterStorageNameDesc.name);
+    setValid?.(isK8sNameDescriptionDataValid(clusterStorageNameDesc));
+    // only update if the name description changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clusterStorageNameDesc]);
 
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <NameDescriptionField
-          nameFieldId="create-new-storage-name"
-          descriptionFieldId="create-new-storage-description"
-          data={{ name: data.name, description: data.description || '' }}
-          setData={(newData) => {
-            setData('name', newData.name);
-            setData('description', newData.description);
-          }}
-          onNameChange={onNameChange}
-          hasNameError={hasDuplicateName}
-          nameHelperText={
-            hasDuplicateName ? <DuplicateNameHelperText isError name={data.name} /> : undefined
-          }
-          autoFocusName={autoFocusName}
-        />
-      </StackItem>
-      <StackItem>
-        {isStorageClassesAvailable && (
-          <StorageClassSelect
-            storageClassName={data.storageClassName}
-            setStorageClassName={(name) => setData('storageClassName', name)}
-            disableStorageClassSelect={disableStorageClassSelect}
-            menuAppendTo={menuAppendTo}
-          />
-        )}
-      </StackItem>
-      <StackItem>
-        <PVSizeField
+    <FormSection>
+      <K8sNameDescriptionField
+        data={clusterStorageNameDesc}
+        onDataChange={setClusterNameDesc}
+        dataTestId="create-new-storage"
+        autoFocusName={autoFocusName}
+        nameHelperText={
+          hasDuplicateName ? (
+            <HelperTextItem variant="error" hasIcon>
+              <b>{data.name}</b> already exists. Try a different name.
+            </HelperTextItem>
+          ) : undefined
+        }
+      />
+      {isStorageClassesAvailable && (
+        <StorageClassSelect
+          storageClassName={data.storageClassName}
+          setStorageClassName={(name) => setData('storageClassName', name)}
+          disableStorageClassSelect={disableStorageClassSelect}
           menuAppendTo={menuAppendTo}
-          fieldID="create-new-storage-size"
-          currentStatus={currentStatus}
-          size={String(data.size)}
-          setSize={(size) => setData('size', size)}
         />
-      </StackItem>
-    </Stack>
+      )}
+      <PVSizeField
+        menuAppendTo={menuAppendTo}
+        fieldID="create-new-storage-size"
+        currentStatus={currentStatus}
+        size={String(data.size)}
+        setSize={(size) => setData('size', size)}
+      />
+    </FormSection>
   );
 };
 

--- a/frontend/src/pages/projects/screens/spawner/storage/WorkbenchStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/WorkbenchStorageModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StackItem } from '@patternfly/react-core';
 import { MountPath, StorageData } from '~/pages/projects/types';
 import BaseStorageModal from '~/pages/projects/screens/detail/storage/BaseStorageModal';
 import SpawnerMountPathField from './SpawnerMountPathField';
@@ -60,13 +59,11 @@ const WorkbenchStorageModal: React.FC<WorkbenchStorageModalProps> = ({
       isValid={!actionInProgress && !mountPath.error && !hasDuplicateName}
       onClose={onClose}
     >
-      <StackItem>
-        <SpawnerMountPathField
-          mountPath={mountPath}
-          inUseMountPaths={existingMountPaths}
-          onChange={setMountPath}
-        />
-      </StackItem>
+      <SpawnerMountPathField
+        mountPath={mountPath}
+        inUseMountPaths={existingMountPaths}
+        onChange={setMountPath}
+      />
     </BaseStorageModal>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import {
   useCreateStorageObject,
   useMountPathFormat,
@@ -49,8 +49,10 @@ describe('useCreateStorageObject', () => {
     const [data] = result.current;
     expect(data).toEqual({
       name: '',
+      k8sName: '',
       description: '',
       size: '1Gi',
+      storageClassName: undefined,
     });
   });
 
@@ -62,21 +64,6 @@ describe('useCreateStorageObject', () => {
     expect(data.description).toBe('Test PVC Description');
     expect(data.size).toBe('2Gi');
     expect(data.storageClassName).toBe('test-storage-class');
-  });
-
-  it('should reset to default values when resetDefaults is called', () => {
-    const { result } = renderHook(() => useCreateStorageObject(existingData));
-    const [, , resetDefaults] = result.current;
-
-    act(() => {
-      resetDefaults();
-    });
-
-    const [data] = result.current;
-    expect(data.name).toBe('');
-    expect(data.description).toBe('');
-    expect(data.size).toBe('1Gi'); // Default size from mock
-    expect(data.storageClassName).toBeUndefined();
   });
 });
 

--- a/frontend/src/pages/projects/screens/spawner/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/utils.ts
@@ -19,38 +19,21 @@ import { MOUNT_PATH_PREFIX } from './const';
 export const useCreateStorageObject = (
   existingData?: PersistentVolumeClaimKind,
   formData?: StorageData,
-): [
-  data: StorageData,
-  setData: UpdateObjectAtPropAndValue<StorageData>,
-  resetDefaults: () => void,
-] => {
+): [data: StorageData, setData: UpdateObjectAtPropAndValue<StorageData>] => {
   const size = useDefaultPvcSize();
-  const createDataState = useGenericObjectState<StorageData>({
-    name: '',
-    description: '',
-    size,
-  });
-  const [, setCreateData] = createDataState;
 
-  const existingName =
-    formData?.name || (existingData ? getDisplayNameFromK8sResource(existingData) : '');
-  const existingDescription =
-    formData?.description || (existingData ? getDescriptionFromK8sResource(existingData) : '');
-  const existingSize =
-    formData?.size || (existingData ? existingData.spec.resources.requests.storage : size);
-  const existingStorageClassName =
-    formData?.storageClassName || existingData?.spec.storageClassName;
+  const createStorageData = {
+    name: formData?.name || (existingData ? getDisplayNameFromK8sResource(existingData) : ''),
+    k8sName: formData?.k8sName || (existingData ? existingData.metadata.name : ''),
+    description:
+      formData?.description || (existingData ? getDescriptionFromK8sResource(existingData) : ''),
+    size: formData?.size || (existingData ? existingData.spec.resources.requests.storage : size),
+    storageClassName: formData?.storageClassName || existingData?.spec.storageClassName,
+  };
 
-  React.useEffect(() => {
-    if (existingName) {
-      setCreateData('name', existingName);
-      setCreateData('description', existingDescription);
-      setCreateData('size', existingSize);
-      setCreateData('storageClassName', existingStorageClassName);
-    }
-  }, [existingName, existingDescription, setCreateData, existingSize, existingStorageClassName]);
+  const [data, setData] = useGenericObjectState<StorageData>(createStorageData);
 
-  return createDataState;
+  return [data, setData];
 };
 
 export const useCreateStorageObjectForNotebook = (

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -60,6 +60,7 @@ export enum StorageType {
 
 export type StorageData = {
   name: string;
+  k8sName?: string;
   size?: string;
   storageType?: StorageType;
   description?: string;

--- a/frontend/src/utilities/useGenericObjectState.ts
+++ b/frontend/src/utilities/useGenericObjectState.ts
@@ -11,7 +11,12 @@ const useGenericObjectState = <T>(defaultData: T | (() => T)): GenericObjectStat
   const [value, setValue] = React.useState<T>(defaultData);
 
   const setPropValue = React.useCallback<UpdateObjectAtPropAndValue<T>>((propKey, propValue) => {
-    setValue((oldValue) => ({ ...oldValue, [propKey]: propValue }));
+    setValue((oldValue) => {
+      if (oldValue[propKey] !== propValue) {
+        return { ...oldValue, [propKey]: propValue };
+      }
+      return oldValue;
+    });
   }, []);
 
   const defaultDataRef = React.useRef(value);


### PR DESCRIPTION
Closes [RHOAIENG-14746](https://issues.redhat.com/browse/RHOAIENG-14746)

## Description
Updates create/edit cluster storage modals to use `K8sNameDescriptionField` component in order to meet current UX guidelines.

## Screen shots

### Create cluster storage
![image](https://github.com/user-attachments/assets/c083f359-a50f-4ab2-9faa-1cd81fa01d86)

### Create cluster storage - edit resource name
![image](https://github.com/user-attachments/assets/417587fe-6f6e-40aa-ab3c-b293cbc4b303)

### Edit cluster storage
![image](https://github.com/user-attachments/assets/d1633016-4a20-4cde-887b-1992812bbe5a)

## How Has This Been Tested?
- Navigate to a project and go to the Cluster storage tab
  - Select `Add cluster storage`
  - Enter a name
  - Verify the `Add storage` button is enabled
  - View the resource name via the `Edit resource name` link.
  - Change the resource name to something invalid (ie. contains a space)
  - Verify the `Add storage` button is disabled
  - Change the resource name to something valid
  - Enter a description
  - Verify the `Add storage` button is enabled
  - Save the storage.
  - Verify the cluster storage is created with the correct Display name and Resource Name and Description.

- Navigate to a project and go to the Cluster storage tab
  - Select a kebab for an existing cluster storage item
  - Select `Edit storage`
  - Verify the name, resource name, and description are shown correctly
  - Verify the resource name is not editable

- Navigate to a project and go to the Workbenches tab
  - Select `Create workbench`
  - Enter a name
  - Select an Image
  - Verify the `Create workbench` button is enabled
  - Click the `Create storage` button
    - Enter a name
    - Enter a valid mount path
    - Verify the `Create` button is enabled
    - View the resource name via the `Edit resource name` link.
    - Change the resource name to something invalid (ie. contains a space)
    - Verify the `Create` button is disabled
    - Change the resource name to something valid
    - Enter a description
    - Verify the `Create` button is enabled
    - Save the storage.
  - In the Cluster storage list, select the kebab next to the new storage to be created
    - Verify the cluster storage is created with the correct Display name and Resource Name and Description.


## Test Impact
Updated unit tests for new fields

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @simrandhaliw 