### PR TITLE
Make SimpleSelect one-option hook triggered on key instead of the options

### DIFF
--- a/frontend/src/components/SimpleSelect.tsx
+++ b/frontend/src/components/SimpleSelect.tsx
@@ -27,6 +27,7 @@ export type SimpleSelectOption = {
   isDisabled?: boolean;
   isFavorited?: boolean;
   dataTestId?: string;
+  optionKey?: string; // Used to differentiate the only option with the same key to trigger the one-option hook in the component
 };
 
 export type SimpleGroupSelectOption = {
@@ -37,7 +38,6 @@ export type SimpleGroupSelectOption = {
 
 type SimpleSelectProps = {
   options?: SimpleSelectOption[];
-  isLoadingOptions?: boolean;
   groupedOptions?: SimpleGroupSelectOption[];
   value?: string;
   toggleLabel?: React.ReactNode;
@@ -59,7 +59,6 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
   isDisabled,
   onChange,
   options,
-  isLoadingOptions = false,
   groupedOptions,
   placeholder = 'Select...',
   value,
@@ -92,15 +91,16 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
     [options, groupedOptionsFlat],
   );
 
+  const singleOptionKey =
+    totalOptions.length === 1 ? totalOptions[0].optionKey || totalOptions[0].key : null;
   // If there is only one option, call the onChange function
   React.useEffect(() => {
-    const singleOptionKey = totalOptions.length === 1 ? totalOptions[0].key : null;
-    if (singleOptionKey && !isLoadingOptions) {
-      onChange(singleOptionKey, false);
+    if (singleOptionKey && !isSkeleton) {
+      onChange(totalOptions[0].key, false);
     }
     // We don't want the callback function to be a dependency
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [totalOptions, isLoadingOptions]);
+  }, [singleOptionKey, isSkeleton]);
 
   if (isSkeleton) {
     return (

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/InferenceServiceFrameworkSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/InferenceServiceFrameworkSection.tsx
@@ -17,6 +17,7 @@ type InferenceServiceFrameworkSectionProps = {
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
   modelContext?: SupportedModelFormats[];
   registeredModelFormat?: string;
+  servingRuntimeName?: string;
 };
 
 const InferenceServiceFrameworkSection: React.FC<InferenceServiceFrameworkSectionProps> = ({
@@ -24,6 +25,7 @@ const InferenceServiceFrameworkSection: React.FC<InferenceServiceFrameworkSectio
   setData,
   modelContext,
   registeredModelFormat,
+  servingRuntimeName,
 }) => {
   const [modelsContextLoaded, loaded, loadError] = useModelFramework(
     modelContext ? undefined : data.servingRuntimeName,
@@ -56,12 +58,12 @@ const InferenceServiceFrameworkSection: React.FC<InferenceServiceFrameworkSectio
             ? `${framework.name} - ${framework.version}`
             : `${framework.name}`;
           return {
+            optionKey: `${servingRuntimeName}-${name}`,
             key: name,
             label: name,
           };
         })}
         isSkeleton={!modelContext && !loaded && data.servingRuntimeName !== ''}
-        isLoadingOptions={!modelContext && !loaded}
         isFullWidth
         toggleLabel={
           dataFormatVersion

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -203,6 +203,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
                 <InferenceServiceFrameworkSection
                   data={createData}
                   setData={setCreateData}
+                  servingRuntimeName={projectContext?.currentServingRuntime?.metadata.name}
                   modelContext={projectContext?.currentServingRuntime?.spec.supportedModelFormats}
                   registeredModelFormat={registeredModelDeployInfo?.modelFormat}
                 />

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -390,6 +390,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   <InferenceServiceFrameworkSection
                     data={createDataInferenceService}
                     setData={setCreateDataInferenceService}
+                    servingRuntimeName={servingRuntimeSelected?.metadata.name}
                     modelContext={servingRuntimeSelected?.spec.supportedModelFormats}
                     registeredModelFormat={registeredModelDeployInfo?.modelFormat}
                   />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-15526

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Update the `SimpleSelect` component, make it not depend on the whole options array (which is not stable). Instead, make it only depend on the first option key. Added a prop to the option named `optionKey` to adapt to some special cases. Here is the reason why we need the `optionKey`:

Normally, `key` in the `SelectOption` is used to differentiate the options and will be triggered an auto-update if there is only one option in the Select component, but there is a special use case in the Model Serving area. When deploying a KServe model, user needs to choose a template, and the options for the `Model format` will be changed by the choice of the template. However, 2 different templates could have the same one option (For example, template A and template B could provide same one and only option `model-format-xyz` in the Model format field). In this case, the one-option `onChange` hook cannot be triggered because it thinks the 2 options are the same, while they are different.
In this PR, I added a new key named `optionKey`, the hook will check that key first, and if it's not provided, then it will check the `key` prop. The `onChange` update will still be on the `key` prop like before. The `optionKey` is only used to trigger the one option hook if the options are actually different.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Make sure you can edit the environment variable fields for the notebook controller (This is the related JIRA ticket)
2. Make sure you can deploy a KServe and Model mesh normally. (Recommend test this on KServe shared cluster, try to go to the deploy modal and switch between different templates, make sure nothing is broken)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
