### PR TITLE
Update DefaultTaskGroup custom icon to use BanIcon

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@patternfly/react-table": "^5.4.0",
         "@patternfly/react-templates": "^1.1.0",
         "@patternfly/react-tokens": "^5.4.0",
-        "@patternfly/react-topology": "^5.4.0",
+        "@patternfly/react-topology": "^5.4.1",
         "@patternfly/react-virtualized-extension": "^5.1.0",
         "@segment/analytics-next": "^1.72.0",
         "@types/classnames": "^2.3.1",
@@ -4389,9 +4389,9 @@
       "integrity": "sha512-KONkwCVOMyklhuuaYeYgcAsGtCBQXnsBGZeolhOdSzr2Mj0RVSW0oMrQPgZuPVzhhC/kbqgClHJJl6xuG9xheA=="
     },
     "node_modules/@patternfly/react-topology": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-5.4.0.tgz",
-      "integrity": "sha512-WGPunNm8HAQSkkTn0N05vFdNer9UOHWduTBXdyvuVAr/fQZrgglvplJe4qdMPOmT3R/8aVyGJP7itxV2J2b8EA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-5.4.1.tgz",
+      "integrity": "sha512-3tgldDj7qKIGFKTQ1gyrwr3a/VDa/I5w0RBPqicppywvFygPrfi2NlK1Mt+3rtGW5R/fG64tzOcyZKx/y2Wpvw==",
       "dependencies": {
         "@dagrejs/dagre": "1.1.2",
         "@patternfly/react-core": "^5.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "@patternfly/react-table": "^5.4.0",
     "@patternfly/react-templates": "^1.1.0",
     "@patternfly/react-tokens": "^5.4.0",
-    "@patternfly/react-topology": "^5.4.0",
+    "@patternfly/react-topology": "^5.4.1",
     "@patternfly/react-virtualized-extension": "^5.1.0",
     "@segment/analytics-next": "^1.72.0",
     "@types/classnames": "^2.3.1",

--- a/frontend/src/concepts/topology/PipelineDefaultTaskGroup.tsx
+++ b/frontend/src/concepts/topology/PipelineDefaultTaskGroup.tsx
@@ -16,6 +16,7 @@ import {
   LabelPosition,
 } from '@patternfly/react-topology';
 import { Flex, FlexItem, Popover, Stack, StackItem } from '@patternfly/react-core';
+import { BanIcon } from '@patternfly/react-icons';
 import { PipelineNodeModelExpanded, StandardTaskNodeData } from '~/concepts/topology/types';
 import NodeStatusIcon from '~/concepts/topology/NodeStatusIcon';
 import { ExecutionStateKF } from '~/concepts/pipelines/kfTypes';
@@ -68,14 +69,17 @@ const DefaultTaskGroupInner: React.FunctionComponent<PipelinesDefaultGroupInnerP
       }
     }, [state, runStatus]);
 
-    // TODO, Update canceled status icon with BanIcon when PF topology is updated
-    // https://issues.redhat.com/browse/RHOAIENG-14822
     const groupNode = (
       <DefaultTaskGroup
         element={element}
         collapsible
         recreateLayoutOnCollapseChange
-        GroupLabelComponent={TaskGroupPillLabel}
+        GroupLabelComponent={(props) => (
+          <TaskGroupPillLabel
+            {...props}
+            customStatusIcon={status === RunStatus.Cancelled ? <BanIcon /> : undefined}
+          />
+        )}
         selected={selected}
         onSelect={onSelect}
         hideDetailsAtMedium
@@ -83,6 +87,7 @@ const DefaultTaskGroupInner: React.FunctionComponent<PipelinesDefaultGroupInnerP
         labelPosition={LabelPosition.top}
         showStatusState
         scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
+        customStatusIcon={status === RunStatus.Cancelled ? <BanIcon /> : undefined}
         showLabelOnHover
         status={status}
         hiddenDetailsShownStatuses={[


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-14822

## Description
Updated the DefaultTaskGroup to use BanIcon

<img width="645" alt="Screenshot 2024-11-19 at 11 53 44 AM" src="https://github.com/user-attachments/assets/d3814084-5c18-4917-aa5c-b801b82fec09">

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Run a pipeline with cancelled task
- Check whether the ExclamationTriangleIcon is changed to BanIcon for cancelled task

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
