### PR TITLE
Fix tooltip clipping on distributed workloads

### DIFF
--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
@@ -61,7 +61,13 @@ const TopResourceConsumingWorkloadsChart: React.FC<TopResourceConsumingWorkloads
       <ChartDonut
         constrainToVisibleArea
         labelRadius={50}
-        labelComponent={<ChartTooltip center={{ x: 150, y: 0 }} />}
+        labelComponent={
+          <ChartTooltip
+            center={{ x: 225, y: 0 }}
+            constrainToVisibleArea
+            pointerOrientation="left"
+          />
+        }
         height={chartHeight}
         ariaTitle={`${metricLabel} chart`}
         data={


### PR DESCRIPTION
Closes: [RHOAIENG-14197](https://issues.redhat.com/browse/RHOAIENG-14197)

## Description
This fixes the clipping that's happening on the donut graphs on distributed workload metrics. The tooltips are now constrained to the graph area, and moved over a bit to make space for text. 

## How Has This Been Tested?
Tested locally using the cypress file `globalDistributedWorkloads.cy.ts` 
Instructions for creating a workload on your cluster can be found [here](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.13/html/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads#configuring-the-distributed-workloads-components_distributed-workloads).

Testing: Navigate to Distribute Workload Metrics. Hover over the donut graph under top resource-consuming distributed workloads. Tooltip should be readable now

## Screenshots
Before: (Text clipping at the top and on the side)
![Screenshot 2024-11-19 at 3 31 11 PM](https://github.com/user-attachments/assets/4c5a85c7-ec2a-4468-99c3-ae94e97fa8bf)
![Screenshot 2024-11-19 at 3 31 20 PM](https://github.com/user-attachments/assets/f3d27343-e408-4af8-ae9d-3e17f5019569)

After:
![Screenshot 2024-11-19 at 3 28 12 PM](https://github.com/user-attachments/assets/adfb8dde-aaee-467e-ae21-566b5494d2d1)
![Screenshot 2024-11-19 at 3 29 18 PM](https://github.com/user-attachments/assets/75d1cfb4-c277-4dc9-a70c-855902e7a4c5)


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
