### PR TITLE
add data-testid to connection form fields

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
@@ -162,7 +162,7 @@ describe('Connections', () => {
     projectDetails.visitSection('test-project', 'connections');
 
     connectionsPage.getConnectionRow('test2').findKebabAction('Edit').click();
-    cy.findByTestId(['field_env']).fill('new data');
+    cy.findByTestId(['field', 'field_env']).fill('new data');
     cy.findByTestId('modal-submit-button').click();
 
     cy.wait('@editConnection').then((interception) => {

--- a/frontend/src/concepts/connectionTypes/fields/ConnectionTypeFormFields.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/ConnectionTypeFormFields.tsx
@@ -65,9 +65,10 @@ const ConnectionTypeFormFields: React.FC<Props> = ({
   }, [connectionValues, fields]);
 
   const renderDataFields = (dataFields: ConnectionTypeDataField[]) =>
-    dataFields.map((field, i) => (
-      <DataFormFieldGroup key={i} field={field}>
-        {(id) => (
+    dataFields.map((field, i) => {
+      const id = `field-${field.envVar}`;
+      return (
+        <DataFormFieldGroup key={i} field={field} id={id}>
           <ConnectionTypeDataFormField
             id={id}
             field={field}
@@ -75,16 +76,17 @@ const ConnectionTypeFormFields: React.FC<Props> = ({
             onChange={onChange ? (v) => onChange(field, v) : undefined}
             value={connectionValues?.[field.envVar]}
             onValidate={onValidate ? (e) => onValidate(field, e) : undefined}
+            data-testid={`field ${field.envVar}`}
           />
-        )}
-      </DataFormFieldGroup>
-    ));
+        </DataFormFieldGroup>
+      );
+    });
 
   return (
     <>
       {fieldGroups?.map((fieldGroup, i) =>
         fieldGroup.section ? (
-          <SectionFormField field={fieldGroup.section} key={i}>
+          <SectionFormField field={fieldGroup.section} key={i} data-testid="fields-section">
             {renderDataFields(fieldGroup.fields)}
           </SectionFormField>
         ) : (

--- a/frontend/src/concepts/connectionTypes/fields/DataFormFieldGroup.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/DataFormFieldGroup.tsx
@@ -5,7 +5,6 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   FormGroup,
-  GenerateId,
   Popover,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -14,47 +13,41 @@ import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconBut
 
 type Props = {
   field: ConnectionTypeDataField;
-  children: (id: string) => React.ReactNode;
+  id: string;
+  children: React.ReactNode;
 };
 
-const DataFormFieldGroup: React.FC<Props> = ({ field, children }): React.ReactNode => (
-  <GenerateId>
-    {(id) => (
-      <FormGroup
-        label={field.name}
-        fieldId={id}
-        data-testid={`field ${field.type} ${field.envVar}`}
-        // do not mark read only fields as required
-        isRequired={field.required && !field.properties.defaultReadOnly}
-        labelIcon={
-          <Popover
-            headerContent="Field details"
-            bodyContent={
-              <DescriptionList isCompact>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Environment variable</DescriptionListTerm>
-                  <DescriptionListDescription>{field.envVar}</DescriptionListDescription>
-                </DescriptionListGroup>
-                {field.description ? (
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Description</DescriptionListTerm>
-                    <DescriptionListDescription>{field.description}</DescriptionListDescription>
-                  </DescriptionListGroup>
-                ) : null}
-              </DescriptionList>
-            }
-          >
-            <DashboardPopupIconButton
-              icon={<OutlinedQuestionCircleIcon />}
-              aria-label="More info"
-            />
-          </Popover>
+const DataFormFieldGroup: React.FC<Props> = ({ field, id, children }): React.ReactNode => (
+  <FormGroup
+    label={field.name}
+    fieldId={id}
+    data-testid={`field-group ${field.type} ${field.envVar}`}
+    // do not mark read only fields as required
+    isRequired={field.required && !field.properties.defaultReadOnly}
+    labelIcon={
+      <Popover
+        headerContent="Field details"
+        bodyContent={
+          <DescriptionList isCompact>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Environment variable</DescriptionListTerm>
+              <DescriptionListDescription>{field.envVar}</DescriptionListDescription>
+            </DescriptionListGroup>
+            {field.description ? (
+              <DescriptionListGroup>
+                <DescriptionListTerm>Description</DescriptionListTerm>
+                <DescriptionListDescription>{field.description}</DescriptionListDescription>
+              </DescriptionListGroup>
+            ) : null}
+          </DescriptionList>
         }
       >
-        {children(id)}
-      </FormGroup>
-    )}
-  </GenerateId>
+        <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+      </Popover>
+    }
+  >
+    {children}
+  </FormGroup>
 );
 
 export default DataFormFieldGroup;

--- a/frontend/src/concepts/connectionTypes/fields/SectionFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/SectionFormField.tsx
@@ -13,7 +13,7 @@ const SectionFormField: React.FC<Props> = ({
   children,
   'data-testid': dataTestId,
 }) => (
-  <FormSection title={name} description={description} data-testud={dataTestId}>
+  <FormSection title={name} description={description} data-testid={dataTestId}>
     {children}
   </FormSection>
 );

--- a/frontend/src/concepts/connectionTypes/fields/TextFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/TextFormField.tsx
@@ -4,7 +4,14 @@ import { TextField } from '~/concepts/connectionTypes/types';
 import { FieldProps } from '~/concepts/connectionTypes/fields/types';
 import DefaultValueTextRenderer from '~/concepts/connectionTypes/fields/DefaultValueTextRenderer';
 
-const TextFormField: React.FC<FieldProps<TextField>> = ({ id, field, mode, onChange, value }) => {
+const TextFormField: React.FC<FieldProps<TextField>> = ({
+  id,
+  field,
+  mode,
+  onChange,
+  value,
+  'data-testid': dataTestId,
+}) => {
   const isPreview = mode === 'preview';
   return (
     <DefaultValueTextRenderer id={id} field={field} mode={mode} component="pre">
@@ -14,6 +21,7 @@ const TextFormField: React.FC<FieldProps<TextField>> = ({ id, field, mode, onCha
         isRequired={field.required}
         id={id}
         name={id}
+        data-testid={dataTestId}
         resizeOrientation="vertical"
         value={(isPreview ? field.properties.defaultValue : value) ?? ''}
         onChange={isPreview || !onChange ? undefined : (_e, v) => onChange(v)}

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/ConnectionTypeFormFields.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/ConnectionTypeFormFields.spec.tsx
@@ -42,16 +42,21 @@ describe('ConnectionTypeFormFields', () => {
   it('should render sectioned fields', () => {
     const result = render(<ConnectionTypeFormFields fields={testFields} isPreview />);
 
-    const section1 = result.getByRole('group', { name: 'section-1' });
-    const section2 = result.getByRole('group', { name: 'section-2' });
+    const [section1, section2] = result.getAllByTestId('fields-section');
 
-    // test unground
-    within(result.container).getByTestId('field boolean boolean_1');
-    expect(within(section1).queryByTestId('field boolean boolean_1')).toBe(null);
-    expect(within(section2).queryByTestId('field boolean boolean_1')).toBe(null);
+    // test ungrouped fields
+    within(result.container).getByTestId('field-group boolean boolean_1');
+    expect(within(section1).queryByTestId('field-group boolean boolean_1')).toBe(null);
+    expect(within(section2).queryByTestId('field-group boolean boolean_1')).toBe(null);
 
-    within(section1).getByTestId('field text text_1');
-    within(section1).getByTestId('field text text_2');
-    within(section2).getByTestId('field numeric numeric_1');
+    within(section1).getByTestId('field-group text text_1');
+    expect(within(section1).getByTestId('field text_1')).toHaveAttribute('id', 'field-text_1');
+    within(section1).getByTestId('field-group text text_2');
+    expect(within(section1).getByTestId('field text_2')).toHaveAttribute('id', 'field-text_2');
+    expect(within(section2).getByTestId('field-group numeric numeric_1')).toBeInTheDocument();
+    expect(within(section2).getByTestId('field numeric_1')).toHaveAttribute(
+      'id',
+      'field-numeric_1',
+    );
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds `field <env var>` `data-testid` to field control elements.
Replaces generated field IDs with `field-<env var>` values to ensure predicable IDs can be used with bitwarden.
Add `data-testid` to sections.

![image](https://github.com/user-attachments/assets/d3b44d04-d24c-4b99-9a64-02de23de3e8a)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Web inspector

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
