### PR TITLE
[RHOAIENG-14757]: Implement wrapped column header styling in ConnectionTypes field table

### DIFF
--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTable.tsx
@@ -77,7 +77,12 @@ const ManageConnectionTypeFieldsTable: React.FC<Props> = ({ fields, onFieldsChan
               <Tr>
                 <Th screenReaderText="Drag and drop" />
                 {columns.map((column, columnIndex) => (
-                  <Th key={columnIndex} width={column.width} visibility={column.visibility}>
+                  <Th
+                    modifier="wrap"
+                    key={columnIndex}
+                    width={column.width}
+                    visibility={column.visibility}
+                  >
                     {column.label}
                   </Th>
                 ))}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-14757

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Before:
<img width="500" alt="Screenshot 2024-11-20 at 12 08 57 PM" src="https://github.com/user-attachments/assets/617766e3-a803-4253-b9d1-848112569501">

After:
<img width="500" alt="Screenshot 2024-11-20 at 12 09 23 PM" src="https://github.com/user-attachments/assets/fb1c0a74-9611-4571-971e-6993aa718c5d">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to Connection Types -> "Create connection type"
2. Add rows to fields table by adding section heading(s) or field(s).
3. Resize window to smaller viewport and verify that table headers wrap instead of truncate. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, no changes to functionality. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
