### PR TITLE
support devFeatureFlags=true/false to quickly toggle all feature flags

### DIFF
--- a/frontend/src/app/useDevFeatureFlags.ts
+++ b/frontend/src/app/useDevFeatureFlags.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useBrowserStorage } from '~/components/browserStorage';
+import { allFeatureFlags } from '~/concepts/areas/const';
 import { isFeatureFlag } from '~/concepts/areas/utils';
 import { DashboardCommonConfig, DashboardConfigKind } from '~/k8sTypes';
 import { DevFeatureFlags } from '~/types';
@@ -19,6 +20,8 @@ const capitalize = (v: string) => v.charAt(0).toUpperCase() + v.slice(1);
  *  - disableHome = false
  *  - disableAppLauncher = false
  *  - disableSupport = false
+ *
+ * Use `?devFeatureFlags=true` to enable all feature flags and `?devFeatureFlags=false` to disable all feature flags.
  */
 const useDevFeatureFlags = (
   dashboardConfig?: DashboardConfigKind | null,
@@ -64,6 +67,15 @@ const useDevFeatureFlags = (
       ? (() => {
           const devFlagsParam = searchParams.get(PARAM_NAME);
           if (devFlagsParam != null) {
+            if (devFlagsParam === 'true' || devFlagsParam === 'false') {
+              const value = devFlagsParam === 'false';
+              return allFeatureFlags.reduce<Partial<DashboardCommonConfig>>((acc, v) => {
+                if (isFeatureFlag(v)) {
+                  acc[v] = value;
+                }
+                return acc;
+              }, {});
+            }
             return devFlagsParam.split(',').reduce<Partial<DashboardCommonConfig>>((acc, v) => {
               const [name, bool] = v.split('=');
               if (isFeatureFlag(name)) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16107

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
cc @manosnoam @andrewballantyne 

Adds the ability to enable and disable all feature flags using `?devFeatureFlags=true|false`.

The enabled state of a feature flag is still managed as individual flags. This change only adds a new interpretation of the query param.

A value of `true` will enable all features => set all `disableFeatureName=false`
A value of `false` will disable all features => set all `disableFeatureName=true`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Modify the app url to include `?devFeatureFlags=true` and observe that all features are enabled.
- Modify the app url to include `?devFeatureFlags=false` and observe that all features are disabled.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
