### PR TITLE
Change token secret to have middle truncation

### DIFF
--- a/frontend/src/components/InlineTruncatedClipboardCopy.tsx
+++ b/frontend/src/components/InlineTruncatedClipboardCopy.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 type Props = {
   textToCopy: string;
+  truncatePosition?: 'start' | 'middle' | 'end';
   testId?: string;
   maxWidth?: number;
 };
@@ -12,7 +13,12 @@ type Props = {
  * https://github.com/patternfly/patternfly-react/issues/10890
  **/
 
-const InlineTruncatedClipboardCopy: React.FC<Props> = ({ textToCopy, testId, maxWidth }) => (
+const InlineTruncatedClipboardCopy: React.FC<Props> = ({
+  textToCopy,
+  testId,
+  maxWidth,
+  truncatePosition,
+}) => (
   <ClipboardCopy
     variant="inline-compact"
     style={{ display: 'inline-flex', maxWidth }}
@@ -23,7 +29,7 @@ const InlineTruncatedClipboardCopy: React.FC<Props> = ({ textToCopy, testId, max
     }}
     data-testid={testId}
   >
-    <Truncate content={textToCopy} />
+    <Truncate content={textToCopy} position={truncatePosition} />
   </ClipboardCopy>
 );
 

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokenDisplay.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokenDisplay.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { ClipboardCopy, HelperText, HelperTextItem, Skeleton } from '@patternfly/react-core';
+import { HelperText, HelperTextItem, Skeleton } from '@patternfly/react-core';
 import { SecretKind } from '~/k8sTypes';
+import InlineTruncatedClipboardCopy from '~/components/InlineTruncatedClipboardCopy';
 
 type ServingRuntimeTokenDisplayProps = {
   token: SecretKind;
@@ -27,7 +28,13 @@ const ServingRuntimeTokenDisplay: React.FC<ServingRuntimeTokenDisplayProps> = ({
     );
   }
 
-  return <ClipboardCopy isReadOnly>{atob(token.data.token)}</ClipboardCopy>;
+  return (
+    <InlineTruncatedClipboardCopy
+      testId="token-secret"
+      textToCopy={atob(token.data.token)}
+      truncatePosition="middle"
+    />
+  );
 };
 
 export default ServingRuntimeTokenDisplay;


### PR DESCRIPTION
Closes: [RHOAIENG-11861](https://issues.redhat.com/browse/RHOAIENG-11861)

## Description
Updated token secrets to have middle truncation.
Due to PatternFly not having a true fix for this yet, I’m using our InlineTruncatedClipoardCopy.tsx work around for this fix. A few modifications added to that file to allow for middle truncation. 


## How Has This Been Tested?
Tested locally. 

- Create a model mesh server with a model that requires a token
- View the Token secret in the Models and model servers table 

## Test Impact
No new tests added 

## Screenshots 
Before:
![Screenshot 2024-11-21 at 11 32 28 AM](https://github.com/user-attachments/assets/5d9a6c54-4bd5-4127-9f1e-3a66af612f88)

After:
![Screenshot 2024-11-21 at 11 32 45 AM](https://github.com/user-attachments/assets/5ee71386-e132-4dc8-a191-fb9f308794a5)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
