### PR TITLE
Fix search param issues on pipeline runs table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunTable.ts
@@ -49,13 +49,8 @@ class PipelineRunsTable {
     return cy.findByTestId(this.testId);
   }
 
-  shouldRowNotBeVisible(name: string) {
-    this.find()
-      .parents()
-      .find('tr')
-      .find(`[data-label=Name]`)
-      .contains(name)
-      .should('not.be.visible');
+  shouldRowNotExist(name: string) {
+    this.find().parents().find('tr').find(`[data-label=Name]`).contains(name).should('not.exist');
     return this;
   }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineDeleteRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineDeleteRuns.cy.ts
@@ -262,7 +262,7 @@ describe('Pipeline runs', () => {
           sort_by: 'created_at desc',
           page_size: '10',
           filter: encodeURIComponent(
-            '{"predicates":[{"key":"storage_state","operation":"EQUALS","string_value":"AVAILABLE"},{"key":"pipeline_version_id","operation":"EQUALS","string_value":"version_id"}]}',
+            '{"predicates":[{"key":"storage_state","operation":"EQUALS","string_value":"ARCHIVED"},{"key":"pipeline_version_id","operation":"EQUALS","string_value":"version_id"}]}',
           ),
         });
       });
@@ -319,7 +319,7 @@ describe('Pipeline runs', () => {
           sort_by: 'created_at desc',
           page_size: '10',
           filter: encodeURIComponent(
-            '{"predicates":[{"key":"storage_state","operation":"EQUALS","string_value":"AVAILABLE"},{"key":"pipeline_version_id","operation":"EQUALS","string_value":"version_id"}]}',
+            '{"predicates":[{"key":"storage_state","operation":"EQUALS","string_value":"ARCHIVED"},{"key":"pipeline_version_id","operation":"EQUALS","string_value":"version_id"}]}',
           ),
         });
       });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
@@ -301,7 +301,7 @@ describe('Pipeline runs', () => {
         activeRunsTable.mockGetRuns([mockActiveRuns[1]], [runToArchive], projectName);
         archiveRunModal.findConfirmInput().type(runToArchive.display_name);
         archiveRunModal.findSubmitButton().click();
-        activeRunsTable.shouldRowNotBeVisible(runToArchive.display_name);
+        activeRunsTable.shouldRowNotExist(runToArchive.display_name);
 
         pipelineRunsGlobal.findArchivedRunsTab().click();
         archivedRunsTable.getRowByName(runToArchive.display_name).find().should('exist');
@@ -603,7 +603,7 @@ describe('Pipeline runs', () => {
 
         archivedRunsTable.mockGetRuns([runToRestore], [mockArchivedRuns[1]], projectName);
         restoreRunModal.findSubmitButton().click();
-        archivedRunsTable.shouldRowNotBeVisible(runToRestore.display_name);
+        archivedRunsTable.shouldRowNotExist(runToRestore.display_name);
 
         pipelineRunsGlobal.findActiveRunsTab().click();
         activeRunsTable.getRowByName(runToRestore.display_name).find().should('exist');

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTable.tsx
@@ -8,7 +8,7 @@ import DeletePipelineRunsModal from '~/concepts/pipelines/content/DeletePipeline
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineRunType } from '~/pages/pipelines/global/runs/types';
 import { PipelinesFilter } from '~/concepts/pipelines/types';
-import usePipelineFilter from '~/concepts/pipelines/content/tables/usePipelineFilter';
+import { usePipelineFilterSearchParams } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 import SimpleMenuActions from '~/components/SimpleMenuActions';
 import { pipelineRecurringRunColumns } from '~/concepts/pipelines/content/tables/columns';
 import PipelineRecurringRunTableRow from './PipelineRecurringRunTableRow';
@@ -44,7 +44,7 @@ const PipelineRecurringRunTable: React.FC<PipelineRecurringRunTableProps> = ({
 }) => {
   const { refreshAllAPI } = usePipelinesAPI();
   const { experimentId, pipelineVersionId } = useParams();
-  const { onClearFilters, ...filterToolbarProps } = usePipelineFilter(setFilter, undefined, true);
+  const { onClearFilters, ...filterToolbarProps } = usePipelineFilterSearchParams(setFilter);
   const {
     selections,
     tableProps: checkboxTableProps,

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableToolbar.tsx
@@ -28,18 +28,19 @@ const PipelineRecurringRunTableToolbar: React.FC<PipelineRecurringRunTableToolba
   const { experiments } = React.useContext(PipelineRunExperimentsContext);
   const { versions } = React.useContext(PipelineRunVersionsContext);
   const { isExperimentArchived } = useIsExperimentArchived();
-  const { pipelineVersionId, experimentId } = useParams();
-
-  const options = {
-    [FilterOptions.NAME]: 'Schedule',
-    ...(!experimentId && {
-      [FilterOptions.EXPERIMENT]: 'Experiment',
+  const { experimentId, pipelineVersionId } = useParams();
+  const options = React.useMemo(
+    () => ({
+      [FilterOptions.NAME]: 'Schedule',
+      ...(!experimentId && {
+        [FilterOptions.EXPERIMENT]: 'Experiment',
+      }),
+      ...(!pipelineVersionId && {
+        [FilterOptions.PIPELINE_VERSION]: 'Pipeline version',
+      }),
     }),
-    ...(!pipelineVersionId && {
-      [FilterOptions.PIPELINE_VERSION]: 'Pipeline version',
-    }),
-  };
-
+    [experimentId, pipelineVersionId],
+  );
   return (
     <PipelineFilterBar<keyof typeof options>
       {...toolbarProps}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -18,7 +18,7 @@ import DeletePipelineRunsModal from '~/concepts/pipelines/content/DeletePipeline
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineRunType } from '~/pages/pipelines/global/runs/types';
 import { PipelinesFilter } from '~/concepts/pipelines/types';
-import usePipelineFilter from '~/concepts/pipelines/content/tables/usePipelineFilter';
+import { usePipelineFilterSearchParams } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 import SimpleMenuActions from '~/components/SimpleMenuActions';
 import { ArchiveRunModal } from '~/pages/pipelines/global/runs/ArchiveRunModal';
 import { RestoreRunModal } from '~/pages/pipelines/global/runs/RestoreRunModal';
@@ -59,7 +59,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
   const navigate = useNavigate();
   const { experimentId, pipelineVersionId, pipelineId } = useParams();
   const { namespace, refreshAllAPI } = usePipelinesAPI();
-  const { onClearFilters, ...filterToolbarProps } = usePipelineFilter(setFilter, undefined, true);
+  const { onClearFilters, ...filterToolbarProps } = usePipelineFilterSearchParams(setFilter);
   const { metricsColumnNames, runs, runArtifactsError, runArtifactsLoaded, metricsNames } =
     useMetricColumns(runWithoutMetrics, experimentId ?? '');
   const {

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsPage.tsx
@@ -19,7 +19,6 @@ import { CompareRunsSearchParam, PathProps } from '~/concepts/pipelines/content/
 import { compareRunsRoute, createRunRoute, experimentRunsRoute } from '~/routes';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import usePipelineFilter from '~/concepts/pipelines/content/tables/usePipelineFilter';
 import { ExperimentContext } from '~/pages/pipelines/global/experiments/ExperimentContext';
 import { EmptyRunsState } from '~/concepts/pipelines/content/tables/pipelineRun/EmptyRunsState';
 import { ManageRunsTable } from './ManageRunsTable';
@@ -30,11 +29,6 @@ const ManageRunsPage: React.FC<PathProps> = ({ breadcrumbPath }) => {
   const { namespace } = usePipelinesAPI();
   const [[{ items: runs, totalSize }, loaded, error], { initialLoaded, ...tableProps }] =
     usePipelineActiveRunsTable({ experimentId: experiment?.experiment_id });
-  const { onClearFilters, ...filterProps } = usePipelineFilter(
-    tableProps.setFilter,
-    undefined,
-    true,
-  );
   const selectedRunIds = searchParams.get(CompareRunsSearchParam.RUNS)?.split(',') ?? [];
 
   if (error) {
@@ -102,8 +96,6 @@ const ManageRunsPage: React.FC<PathProps> = ({ breadcrumbPath }) => {
     >
       <ManageRunsTable
         runs={runs}
-        filterProps={filterProps}
-        onClearFilters={onClearFilters}
         selectedRunIds={selectedRunIds}
         loading={!loaded}
         totalSize={totalSize}

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
@@ -13,13 +13,11 @@ import PipelineRunTableToolbar from '~/concepts/pipelines/content/tables/pipelin
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import { compareRunsRoute } from '~/routes';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { FilterProps } from '~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbarBase';
 import { ExperimentContext } from '~/pages/pipelines/global/experiments/ExperimentContext';
+import { usePipelineFilterSearchParams } from '~/concepts/pipelines/content/tables/usePipelineFilter';
 
 type ManageRunsTableProps = Omit<React.ComponentProps<typeof PipelineRunTable>, 'runType'> & {
-  filterProps: FilterProps;
   selectedRunIds: string[];
-  onClearFilters: () => void;
 };
 
 export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
@@ -31,14 +29,13 @@ export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
   pageSize,
   setPage,
   setPageSize,
-  filterProps,
-  onClearFilters,
   ...tableProps
 }) => {
   const navigate = useNavigate();
   const { namespace } = usePipelinesAPI();
   const pageRunIds = runs.map(({ run_id: runId }) => runId);
   const { experiment } = React.useContext(ExperimentContext);
+  const { onClearFilters, ...filterProps } = usePipelineFilterSearchParams(tableProps.setFilter);
 
   const {
     selections,

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineRunsTabs.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineRunsTabs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { asEnumMember } from '~/utilities/utils';
 import {
@@ -20,21 +20,35 @@ type GlobalPipelineRunsTabsProps = {
 const GlobalPipelineRunsTabs: React.FC<GlobalPipelineRunsTabsProps> = ({ tab, basePath }) => {
   const navigate = useNavigate();
 
+  // This is used to record the most recent search params for each tab
+  // so when you switch between tabs, it can record the filters
+  const [searchParams] = useSearchParams();
+  const searchParamsRef = React.useRef<Partial<Record<PipelineRunType, URLSearchParams>>>({});
+  searchParamsRef.current[tab] = searchParams;
+
   return (
     <Tabs
       activeKey={tab}
       onSelect={(_event, tabId) => {
         const enumValue = asEnumMember(tabId, PipelineRunType);
-        navigate(
-          `${basePath}/${
-            enumValue === PipelineRunType.SCHEDULED ? 'schedules' : `runs/${enumValue}`
-          }`,
-        );
+        if (enumValue) {
+          navigate(
+            `${basePath}/${
+              enumValue === PipelineRunType.SCHEDULED ? 'schedules' : `runs/${enumValue}`
+            }${
+              searchParamsRef.current[enumValue]
+                ? `?${searchParamsRef.current[enumValue].toString()}`
+                : ''
+            }`,
+          );
+        }
       }}
       aria-label="Pipeline run page tabs"
       role="region"
       className="odh-pipeline-runs-page-tabs"
       data-testid="pipeline-runs-global-tabs"
+      mountOnEnter
+      unmountOnExit
     >
       <Tab
         eventKey={PipelineRunType.ACTIVE}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-16026](https://issues.redhat.com/browse/RHOAIENG-16026)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix issues as described in the JIRA.
Added a hook named `usePipelineFilterSearchParams` to use the search params as the only source of truth for the pipeline filters on the pipeline runs table.
1. When loading with search params in the URL, it will automatically find the valid filters and apply it
2. When switching between the tabs, it will unmount and mount the tabs in case the search params change on one tab affects another
3. The tab will remember it's last search params when switching between tabs, so users won't lose track of the filters when they change tabs in the pipeline runs table. If you navigate to another page and click back to the page, all the filters will be reset. (However, if you use the `Back` button on the browser, the filters will be kept because the search params are in the history)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the global pipeline runs page
2. Set some filters, see how the URL changes with the search params
3. Go to other tabs on the same page, set some different filters
4. Switch between tabs and see if all the filters are kept for different tabs
5. Refresh the page with the search params, see if the search filters are auto set according to the search params

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added some tests to verify the new hook.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
