### PR TITLE
support better handling of name and description in import pipeline modal

### DIFF
--- a/frontend/src/concepts/k8s/NameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/NameDescriptionField.tsx
@@ -85,9 +85,8 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
             maxLength={maxLengthName}
             validated={hasNameError ? 'error' : 'default'}
           />
-
-          {maxLengthName && <CharLimitHelperText limit={maxLengthName} />}
           {nameHelperText}
+          {maxLengthName && <CharLimitHelperText limit={maxLengthName} />}
         </FormGroup>
       </StackItem>
       {showK8sName && (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-14617

## Description
The name and description for the `import pipeline/ pipeline version modal` now has a max limit of 255
the submit button is disbaled if the name is duplicated

![Screenshot 2024-11-22 at 1 07 58 PM](https://github.com/user-attachments/assets/cc10e566-c835-4405-90b8-ac937bf32bb7)

![Screenshot 2024-11-22 at 1 08 21 PM](https://github.com/user-attachments/assets/6fd4dd30-4acf-430e-a028-5f4ca697cec9)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Create a pipeline using `import pipeline modal` with name larger character set
2. Verify for the helperText 
3. Verify that the name gets trim after 255 character is achieved
4. Verify that when duplicated name is typed the `submit button` is disabled with error helperText

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

