### PR TITLE
Add model redeploying status

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -11,7 +11,9 @@ type MockResourceConfigType = {
   secretName?: string;
   deleted?: boolean;
   isModelMesh?: boolean;
+  missingStatus?: boolean;
   activeModelState?: string;
+  targetModelState?: string;
   url?: string;
   path?: string;
   acceleratorIdentifier?: string;
@@ -72,7 +74,9 @@ export const mockInferenceServiceK8sResource = ({
   secretName = 'test-secret',
   deleted = false,
   isModelMesh = false,
+  missingStatus = false,
   activeModelState = 'Pending',
+  targetModelState = '',
   url = '',
   acceleratorIdentifier = '',
   path = 'path/to/model',
@@ -146,45 +150,47 @@ export const mockInferenceServiceK8sResource = ({
       },
     },
   },
-  status: {
-    components: {
-      ...(statusPredictor && { predictor: statusPredictor }),
-    },
-    url,
-    conditions: [
-      {
-        lastTransitionTime: '2023-03-17T16:12:41Z',
-        status: 'False',
-        type: 'PredictorReady',
+  status: missingStatus
+    ? undefined
+    : {
+        components: {
+          ...(statusPredictor && { predictor: statusPredictor }),
+        },
+        url,
+        conditions: [
+          {
+            lastTransitionTime: '2023-03-17T16:12:41Z',
+            status: 'False',
+            type: 'PredictorReady',
+          },
+          {
+            lastTransitionTime: '2023-03-17T16:12:41Z',
+            status: 'False',
+            type: 'Ready',
+          },
+        ],
+        modelStatus: {
+          copies: {
+            failedCopies: 0,
+            totalCopies: 0,
+          },
+          lastFailureInfo: {
+            message: lastFailureInfoMessage,
+            modelRevisionName: 'model-size__isvc-59ce37c85b',
+            reason: 'RuntimeUnhealthy',
+            location: '',
+            time: '',
+          },
+          states: {
+            activeModelState,
+            targetModelState,
+          },
+          transitionStatus: '',
+        },
+        ...(kserveInternalUrl && {
+          address: {
+            url: kserveInternalUrl,
+          },
+        }),
       },
-      {
-        lastTransitionTime: '2023-03-17T16:12:41Z',
-        status: 'False',
-        type: 'Ready',
-      },
-    ],
-    modelStatus: {
-      copies: {
-        failedCopies: 0,
-        totalCopies: 0,
-      },
-      lastFailureInfo: {
-        message: lastFailureInfoMessage,
-        modelRevisionName: 'model-size__isvc-59ce37c85b',
-        reason: 'RuntimeUnhealthy',
-        location: '',
-        time: '',
-      },
-      states: {
-        activeModelState,
-        targetModelState: '',
-      },
-      transitionStatus: '',
-    },
-    ...(kserveInternalUrl && {
-      address: {
-        url: kserveInternalUrl,
-      },
-    }),
-  },
 });

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -8,7 +8,7 @@ import {
 } from '@patternfly/react-icons';
 import { InferenceServiceKind } from '~/k8sTypes';
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
-import { getInferenceServiceActiveModelState, getInferenceServiceStatusMessage } from './utils';
+import { getInferenceServiceModelState, getInferenceServiceStatusMessage } from './utils';
 import { useModelStatus } from './useModelStatus';
 
 type InferenceServiceStatusProps = {
@@ -30,7 +30,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
 
   const state = modelStatus?.failedToSchedule
     ? 'FailedToLoad'
-    : getInferenceServiceActiveModelState(inferenceService);
+    : getInferenceServiceModelState(inferenceService);
 
   const statusIcon = () => {
     switch (state) {

--- a/frontend/src/pages/modelServing/screens/global/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/global/__tests__/utils.spec.ts
@@ -1,5 +1,9 @@
-import { checkModelStatus } from '~/pages/modelServing/screens/global/utils';
+import {
+  checkModelStatus,
+  getInferenceServiceStatusMessage,
+} from '~/pages/modelServing/screens/global/utils';
 import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
+import { mockInferenceServiceK8sResource } from '~/__mocks__';
 
 const mockModelStatus = (status: boolean) => ({
   failedToSchedule: status,
@@ -14,5 +18,66 @@ describe('checkModelStatus', () => {
 
   it('Should return false when pod is scheduled.', async () => {
     expect(checkModelStatus(mockPodK8sResource({}))).toEqual(mockModelStatus(false));
+  });
+});
+
+describe('getInferenceServiceStatusMessage', () => {
+  it('Should "Loaded" when model is fully loaded', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      activeModelState: 'Loaded',
+      targetModelState: 'Loaded',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService)).toEqual('Loaded');
+  });
+
+  it('Should return loading when first deploying', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      activeModelState: '',
+      targetModelState: 'Loading',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService)).toEqual('Loading');
+    const inferenceService2 = mockInferenceServiceK8sResource({
+      activeModelState: '',
+      targetModelState: 'Pending',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService2)).toEqual('Pending');
+  });
+
+  it('Should return "Redploying" when updating exist deployment', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      activeModelState: 'Loaded',
+      targetModelState: 'Loading',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService)).toEqual('Redeploying');
+    const inferenceService2 = mockInferenceServiceK8sResource({
+      activeModelState: 'Loaded',
+      targetModelState: 'Pending',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService2)).toEqual('Redeploying');
+  });
+
+  it('Should return "Unknown" when missing status updates', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      missingStatus: true,
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService)).toEqual('Unknown');
+  });
+
+  it('Should return error message when loading failure', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      activeModelState: 'FailedToLoad',
+      lastFailureInfoMessage: 'Waiting for runtime Pod to become available',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService)).toEqual(
+      'Waiting for runtime Pod to become available',
+    );
+  });
+
+  it('Should return empty message when status is empty ', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      activeModelState: '',
+      targetModelState: '',
+    });
+    expect(getInferenceServiceStatusMessage(inferenceService)).toEqual('');
   });
 });

--- a/frontend/src/pages/modelServing/screens/global/useRouteForInferenceService.ts
+++ b/frontend/src/pages/modelServing/screens/global/useRouteForInferenceService.ts
@@ -3,7 +3,7 @@ import { InferenceServiceKind } from '~/k8sTypes';
 import { getRoute } from '~/api';
 import { getUrlFromKserveInferenceService } from '~/pages/modelServing/screens/projects/utils';
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
-import { getInferenceServiceActiveModelState } from './utils';
+import { getInferenceServiceModelState } from './utils';
 
 const useRouteForInferenceService = (
   inferenceService: InferenceServiceKind,
@@ -17,7 +17,7 @@ const useRouteForInferenceService = (
   const routeName = inferenceService.metadata.name;
   const routeNamespace = inferenceService.metadata.namespace;
   const kserveRoute = isKServe ? getUrlFromKserveInferenceService(inferenceService) : null;
-  const state = getInferenceServiceActiveModelState(inferenceService);
+  const state = getInferenceServiceModelState(inferenceService);
   const kserveLoaded = state === InferenceServiceModelState.LOADED;
 
   React.useEffect(() => {

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -14,7 +14,7 @@ export const getInferenceServiceStatusMessage = (is: InferenceServiceKind): stri
   const activeModelState = is.status?.modelStatus?.states?.activeModelState;
   const targetModelState = is.status?.modelStatus?.states?.targetModelState;
 
-  const stateMessage = targetModelState || activeModelState || 'Unknown';
+  const stateMessage = (targetModelState || activeModelState) ?? 'Unknown';
 
   if (
     activeModelState === InferenceServiceModelState.FAILED_TO_LOAD ||

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -3,24 +3,36 @@ import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { InferenceServiceModelState, ModelStatus } from '~/pages/modelServing/screens/types';
 import { asEnumMember } from '~/utilities/utils';
 
-export const getInferenceServiceActiveModelState = (
+export const getInferenceServiceModelState = (
   is: InferenceServiceKind,
 ): InferenceServiceModelState =>
-  asEnumMember(is.status?.modelStatus?.states?.activeModelState, InferenceServiceModelState) ||
   asEnumMember(is.status?.modelStatus?.states?.targetModelState, InferenceServiceModelState) ||
+  asEnumMember(is.status?.modelStatus?.states?.activeModelState, InferenceServiceModelState) ||
   InferenceServiceModelState.UNKNOWN;
 
 export const getInferenceServiceStatusMessage = (is: InferenceServiceKind): string => {
   const activeModelState = is.status?.modelStatus?.states?.activeModelState;
   const targetModelState = is.status?.modelStatus?.states?.targetModelState;
 
-  const failedToLoad = InferenceServiceModelState.FAILED_TO_LOAD;
-  const isFailedToLoad = activeModelState === failedToLoad || targetModelState === failedToLoad;
+  const stateMessage = targetModelState || activeModelState || 'Unknown';
 
-  const lastFailureMessage = is.status?.modelStatus?.lastFailureInfo?.message;
-  const stateMessage = activeModelState ?? targetModelState ?? 'Unknown';
+  if (
+    activeModelState === InferenceServiceModelState.FAILED_TO_LOAD ||
+    targetModelState === InferenceServiceModelState.FAILED_TO_LOAD
+  ) {
+    const lastFailureMessage = is.status?.modelStatus?.lastFailureInfo?.message;
+    return lastFailureMessage || stateMessage;
+  }
 
-  return isFailedToLoad ? lastFailureMessage ?? stateMessage : stateMessage;
+  if (
+    activeModelState === InferenceServiceModelState.LOADED &&
+    (targetModelState === InferenceServiceModelState.LOADING ||
+      targetModelState === InferenceServiceModelState.PENDING)
+  ) {
+    return 'Redeploying';
+  }
+
+  return stateMessage;
 };
 
 export const getInferenceServiceProjectDisplayName = (

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
@@ -20,7 +20,7 @@ import { isModelMesh } from '~/pages/modelServing/utils';
 import { getPodsForKserve, getPodsForModelMesh } from '~/api';
 import {
   checkModelStatus,
-  getInferenceServiceActiveModelState,
+  getInferenceServiceModelState,
 } from '~/pages/modelServing/screens/global/utils';
 import { InferenceServiceModelState, ModelStatus } from '~/pages/modelServing/screens/types';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
@@ -58,7 +58,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
     const updateServiceState = (inferenceService: InferenceServiceKind, status?: ModelStatus) => {
       const state = status?.failedToSchedule
         ? InferenceServiceModelState.FAILED_TO_LOAD
-        : getInferenceServiceActiveModelState(inferenceService);
+        : getInferenceServiceModelState(inferenceService);
 
       setInferenceServiceStates((prev) => {
         const states = { ...prev };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-3409

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Makes the status a spinner after editing a model, popover message says "Redeploying".

Basically the status functions will prioritize looking at the target state, since that is more indicative of what is going on. 
I'm not 100% on what the correct message is to display. But the special return case could be removed and then it would default to the state of the target i.e. "Loading". 

![image](https://github.com/user-attachments/assets/74da02d7-982c-4983-bf40-822726269fb6)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Deploy a model
2. Edit the model and change something (most things will reload it)
3. The status should change to loading (the polling may be slow to update it)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Jest unit tests could be added to the utils functions, but there aren't any so i didn't add any.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@vconzola 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
