### PR TITLE
feat(15128): load and error state for modelArtifact on mr version detail

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -326,6 +326,17 @@ describe('Model version details', () => {
     });
 
     it('Switching model versions', () => {
+      cy.interceptOdh(
+        `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts`,
+        {
+          path: {
+            serviceName: 'modelregistry-sample',
+            apiVersion: MODEL_REGISTRY_API_VERSION,
+            modelVersionId: 2,
+          },
+        },
+        mockModelArtifactList({}),
+      );
       modelVersionDetails.findVersionId().contains('1');
       modelVersionDetails.findModelVersionDropdownButton().click();
       modelVersionDetails.findModelVersionDropdownItem('Version 3').should('not.exist');

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -6,6 +6,9 @@ import {
   FlexItem,
   ContentVariants,
   Title,
+  Bullseye,
+  Spinner,
+  Alert,
 } from '@patternfly/react-core';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
@@ -30,11 +33,20 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
   isArchiveVersion,
   refresh,
 }) => {
-  // TODO handle loading state / error for artifacts here?
-  const [modelArtifacts, , , refreshModelArtifacts] = useModelArtifactsByVersionId(mv.id);
+  const [modelArtifacts, modelArtifactsLoaded, modelArtifactsLoadError, refreshModelArtifacts] =
+    useModelArtifactsByVersionId(mv.id);
+
   const modelArtifact = modelArtifacts.items.length ? modelArtifacts.items[0] : null;
   const { apiState } = React.useContext(ModelRegistryContext);
   const storageFields = uriToObjectStorageFields(modelArtifact?.uri || '');
+
+  if (!modelArtifactsLoaded) {
+    return (
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    );
+  }
 
   return (
     <Flex
@@ -106,102 +118,114 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
         <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
           Model location
         </Title>
-        <DescriptionList>
-          {storageFields && (
-            <>
-              <DashboardDescriptionListGroup
-                title="Endpoint"
-                isEmpty={modelArtifacts.size === 0 || !storageFields.endpoint}
-                contentWhenEmpty="No endpoint"
-              >
-                <InlineTruncatedClipboardCopy
-                  testId="storage-endpoint"
-                  textToCopy={storageFields.endpoint}
-                />
-              </DashboardDescriptionListGroup>
-              <DashboardDescriptionListGroup
-                title="Region"
-                isEmpty={modelArtifacts.size === 0 || !storageFields.region}
-                contentWhenEmpty="No region"
-              >
-                <InlineTruncatedClipboardCopy
-                  testId="storage-region"
-                  textToCopy={storageFields.region || ''}
-                />
-              </DashboardDescriptionListGroup>
-              <DashboardDescriptionListGroup
-                title="Bucket"
-                isEmpty={modelArtifacts.size === 0 || !storageFields.bucket}
-                contentWhenEmpty="No bucket"
-              >
-                <InlineTruncatedClipboardCopy
-                  testId="storage-bucket"
-                  textToCopy={storageFields.bucket}
-                />
-              </DashboardDescriptionListGroup>
-              <DashboardDescriptionListGroup
-                title="Path"
-                isEmpty={modelArtifacts.size === 0 || !storageFields.path}
-                contentWhenEmpty="No path"
-              >
-                <InlineTruncatedClipboardCopy
-                  testId="storage-path"
-                  textToCopy={storageFields.path}
-                />
-              </DashboardDescriptionListGroup>
-            </>
-          )}
-          {!storageFields && (
-            <>
-              <DashboardDescriptionListGroup
-                title="URI"
-                isEmpty={modelArtifacts.size === 0 || !modelArtifact?.uri}
-                contentWhenEmpty="No URI"
-              >
-                <InlineTruncatedClipboardCopy
-                  testId="storage-uri"
-                  textToCopy={modelArtifact?.uri || ''}
-                />
-              </DashboardDescriptionListGroup>
-            </>
-          )}
-        </DescriptionList>
-        <Divider style={{ marginTop: '1em' }} />
-        <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
-          Source model format
-        </Title>
-        <DescriptionList>
-          <EditableTextDescriptionListGroup
-            editableVariant="TextInput"
-            baseTestId="source-model-format"
-            isArchive={isArchiveVersion}
-            value={modelArtifact?.modelFormatName || ''}
-            saveEditedValue={(value) =>
-              apiState.api
-                .patchModelArtifact({}, { modelFormatName: value }, modelArtifact?.id || '')
-                .then(() => {
-                  refreshModelArtifacts();
-                })
-            }
-            title="Model Format"
-            contentWhenEmpty="No model format specified"
-          />
-          <EditableTextDescriptionListGroup
-            editableVariant="TextInput"
-            baseTestId="source-model-version"
-            value={modelArtifact?.modelFormatVersion || ''}
-            isArchive={isArchiveVersion}
-            saveEditedValue={(newVersion) =>
-              apiState.api
-                .patchModelArtifact({}, { modelFormatVersion: newVersion }, modelArtifact?.id || '')
-                .then(() => {
-                  refreshModelArtifacts();
-                })
-            }
-            title="Version"
-            contentWhenEmpty="No source model format version"
-          />
-        </DescriptionList>
+        {modelArtifactsLoadError ? (
+          <Alert variant="danger" isInline title={modelArtifactsLoadError.name}>
+            {modelArtifactsLoadError.message}
+          </Alert>
+        ) : (
+          <>
+            <DescriptionList>
+              {storageFields && (
+                <>
+                  <DashboardDescriptionListGroup
+                    title="Endpoint"
+                    isEmpty={modelArtifacts.size === 0 || !storageFields.endpoint}
+                    contentWhenEmpty="No endpoint"
+                  >
+                    <InlineTruncatedClipboardCopy
+                      testId="storage-endpoint"
+                      textToCopy={storageFields.endpoint}
+                    />
+                  </DashboardDescriptionListGroup>
+                  <DashboardDescriptionListGroup
+                    title="Region"
+                    isEmpty={modelArtifacts.size === 0 || !storageFields.region}
+                    contentWhenEmpty="No region"
+                  >
+                    <InlineTruncatedClipboardCopy
+                      testId="storage-region"
+                      textToCopy={storageFields.region || ''}
+                    />
+                  </DashboardDescriptionListGroup>
+                  <DashboardDescriptionListGroup
+                    title="Bucket"
+                    isEmpty={modelArtifacts.size === 0 || !storageFields.bucket}
+                    contentWhenEmpty="No bucket"
+                  >
+                    <InlineTruncatedClipboardCopy
+                      testId="storage-bucket"
+                      textToCopy={storageFields.bucket}
+                    />
+                  </DashboardDescriptionListGroup>
+                  <DashboardDescriptionListGroup
+                    title="Path"
+                    isEmpty={modelArtifacts.size === 0 || !storageFields.path}
+                    contentWhenEmpty="No path"
+                  >
+                    <InlineTruncatedClipboardCopy
+                      testId="storage-path"
+                      textToCopy={storageFields.path}
+                    />
+                  </DashboardDescriptionListGroup>
+                </>
+              )}
+              {!storageFields && (
+                <>
+                  <DashboardDescriptionListGroup
+                    title="URI"
+                    isEmpty={modelArtifacts.size === 0 || !modelArtifact?.uri}
+                    contentWhenEmpty="No URI"
+                  >
+                    <InlineTruncatedClipboardCopy
+                      testId="storage-uri"
+                      textToCopy={modelArtifact?.uri || ''}
+                    />
+                  </DashboardDescriptionListGroup>
+                </>
+              )}
+            </DescriptionList>
+            <Divider style={{ marginTop: '1em' }} />
+            <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
+              Source model format
+            </Title>
+            <DescriptionList>
+              <EditableTextDescriptionListGroup
+                editableVariant="TextInput"
+                baseTestId="source-model-format"
+                isArchive={isArchiveVersion}
+                value={modelArtifact?.modelFormatName || ''}
+                saveEditedValue={(value) =>
+                  apiState.api
+                    .patchModelArtifact({}, { modelFormatName: value }, modelArtifact?.id || '')
+                    .then(() => {
+                      refreshModelArtifacts();
+                    })
+                }
+                title="Model Format"
+                contentWhenEmpty="No model format specified"
+              />
+              <EditableTextDescriptionListGroup
+                editableVariant="TextInput"
+                baseTestId="source-model-version"
+                value={modelArtifact?.modelFormatVersion || ''}
+                isArchive={isArchiveVersion}
+                saveEditedValue={(newVersion) =>
+                  apiState.api
+                    .patchModelArtifact(
+                      {},
+                      { modelFormatVersion: newVersion },
+                      modelArtifact?.id || '',
+                    )
+                    .then(() => {
+                      refreshModelArtifacts();
+                    })
+                }
+                title="Version"
+                contentWhenEmpty="No source model format version"
+              />
+            </DescriptionList>
+          </>
+        )}
         <Divider style={{ marginTop: '1em' }} />
         <DescriptionList isFillColumns style={{ marginTop: '1em' }}>
           <DashboardDescriptionListGroup


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/RHOAIENG-15128

## Description
add loading spinner and error for the loading of modelArtifacts on mr version details page.

show spinner on full page as the loading doesn't take long and determines some of the page format
![image](https://github.com/user-attachments/assets/b07cf55f-d221-405b-862f-2029212448ec)


show error in the model location area
![image](https://github.com/user-attachments/assets/96610069-aafe-4187-b791-6cbcabb97355)


## How Has This Been Tested?
you can see the spinner briefly if you refresh the page. otherwise i was hard coding an error value to see that.

## Test Impact
had to add an intercept to make sure the right side of mr version detail loads after selecting a different version #

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
