### PR TITLE
Fix 0 model replicas display text

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -39,7 +39,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ obj, isvc
       <DescriptionListGroup>
         <DescriptionListTerm>Model server replicas</DescriptionListTerm>
         <DescriptionListDescription>
-          {isvc?.spec.predictor.minReplicas || obj.spec.replicas || 'Unknown'}
+          {isvc?.spec.predictor.minReplicas ?? obj.spec.replicas ?? 'Unknown'}
         </DescriptionListDescription>
       </DescriptionListGroup>
       {resources && (

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -226,9 +226,9 @@ export const useCreateInferenceServiceObject = (
   const existingFormat =
     useDeepCompareMemoize(existingData?.spec.predictor.model?.modelFormat) || undefined;
   const existingMinReplicas =
-    existingData?.spec.predictor.minReplicas || existingServingRuntimeData?.spec.replicas || 1;
+    existingData?.spec.predictor.minReplicas ?? existingServingRuntimeData?.spec.replicas ?? 1;
   const existingMaxReplicas =
-    existingData?.spec.predictor.maxReplicas || existingServingRuntimeData?.spec.replicas || 1;
+    existingData?.spec.predictor.maxReplicas ?? existingServingRuntimeData?.spec.replicas ?? 1;
 
   const existingExternalRoute =
     existingData?.metadata.labels?.['networking.knative.dev/visibility'] !== 'cluster-local';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-384

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The initial data retrieve on the modal would skip 0 and default to 1 because it was a falsey check and not a nullish check.

I also saw on the model row details it would show "Unknown" for 0, so i did the same fix there.

![changes](https://github.com/user-attachments/assets/8ddb4016-9407-4792-87a3-25beca35dcce)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Edit an already deployed model (kserve and/or modelmesh)
2. Set the replicas to 0 ("Number of model server replicas to deploy" field)
3. Save
4. The model row details should show "Model server replicas 0" instead of "Model server replicas Unknown"
5. Edit the model again
6. The "Number of model server replicas to deploy" field should display 0 instead of 1

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Very minor change so no tests updated

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
