### PR TITLE
Make MR Degrading status more prominent

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -73,6 +73,13 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
       icon = <ExclamationTriangleIcon />;
       color = 'gold';
     }
+    // Degrading
+    else if (degradedCondition?.status === ConditionStatus.True) {
+      statusLabel = ModelRegistryStatusLabel.Degrading;
+      icon = <InProgressIcon className="odh-u-spin" />;
+      color = 'grey';
+      popoverTitle = 'Service is degrading';
+    }
     // Available
     else if (availableCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Available;
@@ -84,13 +91,6 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
       statusLabel = ModelRegistryStatusLabel.Progressing;
       icon = <InProgressIcon className="odh-u-spin" />;
       color = 'blue';
-    }
-    // Degrading
-    else if (degradedCondition?.status === ConditionStatus.True) {
-      statusLabel = ModelRegistryStatusLabel.Degrading;
-      icon = <InProgressIcon className="odh-u-spin" />;
-      color = 'grey';
-      popoverTitle = 'Service is degrading';
     }
   }
   // Handle popover logic for Unavailable status


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Part of [RHOAIENG-15587](https://issues.redhat.com/browse/RHOAIENG-15587)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The Degrading status wasn't visible at first, found during QA verification of [RHOAIENG-15587](https://issues.redhat.com/browse/RHOAIENG-15587)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The `Degrading` state usually appears for a very short period while deleting resources related to a specific MR. There is high possibility of not seeing this state unless you have issues during deletion. To simulate this state, add finalizers to any MR resource using OpenShift Console and try deleting the same MR via Dashboard, you should see the Degrading status. 

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests already covered.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
