### PR TITLE
Cypress: Retry mechanism for e2e tests

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -138,7 +138,7 @@ export default defineConfig({
       // Apply retries only for tests in the "e2e" folder
       return {
         ...config,
-        retries: config.specPattern.includes('/e2e/') ? 2 : config.retries,
+        retries: !env.CY_MOCK && !env.CY_RECORD ? 2 : config.retries,
       };
     },
   },

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -135,12 +135,11 @@ export default defineConfig({
         await mergeFiles(outputFile, inputFiles);
       });
 
-      const updatedConfig = { ...config };
-      if (config.specPattern.includes('/e2e/')) {
-        // Apply retries only for tests in the "e2e" folder
-        updatedConfig.retries = 2;
-      }
-      return updatedConfig;
+      // Apply retries only for tests in the "e2e" folder
+      return {
+        ...config,
+        retries: config.specPattern.includes('/e2e/') ? 2 : config.retries,
+      };
     },
   },
 });

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -135,11 +135,12 @@ export default defineConfig({
         await mergeFiles(outputFile, inputFiles);
       });
 
+      const updatedConfig = { ...config };
       if (config.specPattern.includes('/e2e/')) {
         // Apply retries only for tests in the "e2e" folder
-        config.retries = 2;
+        updatedConfig.retries = 2;
       }
-      return config;
+      return updatedConfig;
     },
   },
 });

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -137,7 +137,7 @@ export default defineConfig({
 
       if (config.specPattern.includes('/e2e/')) {
         // Apply retries only for tests in the "e2e" folder
-        config.retries = 3;
+        config.retries = 2;
       }
       return config;
     },

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -135,6 +135,10 @@ export default defineConfig({
         await mergeFiles(outputFile, inputFiles);
       });
 
+      if (config.specPattern.includes('/e2e/')) {
+        // Apply retries only for tests in the "e2e" folder
+        config.retries = 3;
+      }
       return config;
     },
   },

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/application.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/application.cy.ts
@@ -3,6 +3,8 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e
 describe('application', { testIsolation: false }, () => {
   it('should login and load page', () => {
     cy.visitWithLogin('/');
-    cy.findByRole('banner', { name: 'page masthead' }).contains('Force failure');
+    cy.findByRole('banner', { name: 'page masthead' }).contains(
+      HTPASSWD_CLUSTER_ADMIN_USER.USERNAME,
+    );
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/application.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/application.cy.ts
@@ -3,8 +3,6 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e
 describe('application', { testIsolation: false }, () => {
   it('should login and load page', () => {
     cy.visitWithLogin('/');
-    cy.findByRole('banner', { name: 'page masthead' }).contains(
-      HTPASSWD_CLUSTER_ADMIN_USER.USERNAME,
-    );
+    cy.findByRole('banner', { name: 'page masthead' }).contains('Force failure');
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16485 

## Description
Add a retry  mechanism to the e2e Cypress tests.


## How Has This Been Tested?
I've forced the failure of the application.cy.ts test here 9a1c6762723ce4564cdf81746b2589a35dfe43af 
Then I've ran the cypress job (cypress/job/cypress-tests/59)
In the report, 3 attempts are shown:
![image](https://github.com/user-attachments/assets/6471621e-b89c-4d3c-9fc6-47b66902226c)

Then I've fixed the test here  8e55ff23222efa539c2d43f8df9b2eed57b091d6 
And ran the cypress job (cypress/job/cypress-tests/60)
And the test was up and running fine again
![image](https://github.com/user-attachments/assets/fe43b7a8-8fb2-45e1-a7a6-49361cd4d792)

## Test Impact
It's an "enhancement" 
 
## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
