### PR TITLE
Fetch correct cluster admin list for the notebook controller admin panel

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1254,3 +1254,8 @@ export type NIMAccountKind = K8sResourceCommon & {
     conditions?: K8sCondition[];
   };
 };
+
+export type ResourceAccessReviewResponse = {
+  groups?: string[];
+  users?: string[];
+};

--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -29,6 +29,10 @@ export const getAdminUserList = async (fastify: KubeFastifyInstance): Promise<st
     .split(',')
     .filter((groupName) => groupName && !groupName.startsWith('system:')); // Handle edge-cases and ignore k8s defaults
 
+  return getGroupUserList(fastify, adminGroupsList);
+};
+
+export const getClusterAdminUserList = async (fastify: KubeFastifyInstance): Promise<string[]> => {
   // fetch all the users and groups who have cluster-admin role and put them into the admin user list
   const { notebookNamespace } = getNamespaces(fastify);
   const clusterAdminUsersAndGroups = await fastify.kube.customObjectsApi
@@ -50,11 +54,10 @@ export const getAdminUserList = async (fastify: KubeFastifyInstance): Promise<st
   const clusterAdminUsers = clusterAdminUsersAndGroups.users || [];
   const clusterAdminGroups = clusterAdminUsersAndGroups.groups || [];
   const filteredClusterAdminGroups = clusterAdminGroups.filter(
-    (group) => !group.startsWith('system:') && !adminGroupsList.includes(group),
+    (group) => !group.startsWith('system:'),
   );
   const filteredClusterAdminUsers = clusterAdminUsers.filter((user) => !user.startsWith('system:'));
-  adminGroupsList.push(...filteredClusterAdminGroups);
-  return getGroupUserList(fastify, adminGroupsList, filteredClusterAdminUsers);
+  return getGroupUserList(fastify, filteredClusterAdminGroups, filteredClusterAdminUsers);
 };
 
 export const getAllowedUserList = async (fastify: KubeFastifyInstance): Promise<string[]> => {

--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -3,9 +3,10 @@ import {
   V1ClusterRoleBinding,
   V1ClusterRoleBindingList,
 } from '@kubernetes/client-node';
-import { KubeFastifyInstance } from '../types';
+import { KubeFastifyInstance, ResourceAccessReviewResponse } from '../types';
 import { getAdminGroups, getAllGroupsByUser, getAllowedGroups, getGroup } from './groupsUtils';
 import { flatten, uniq } from 'lodash';
+import { getNamespaces } from '../utils/notebookUtils';
 
 const SYSTEM_AUTHENTICATED = 'system:authenticated';
 /** Usernames with invalid characters can start with `b64:` to keep their unwanted characters */
@@ -14,10 +15,11 @@ export const KUBE_SAFE_PREFIX = 'b64:';
 const getGroupUserList = async (
   fastify: KubeFastifyInstance,
   groupListNames: string[],
+  additionalUsers: string[] = [],
 ): Promise<string[]> => {
   const customObjectApi = fastify.kube.customObjectsApi;
   return Promise.all(groupListNames.map((group) => getGroup(customObjectApi, group))).then(
-    (usersPerGroup: string[][]) => uniq(flatten(usersPerGroup)),
+    (usersPerGroup: string[][]) => uniq([...flatten(usersPerGroup), ...additionalUsers]),
   );
 };
 
@@ -26,8 +28,33 @@ export const getAdminUserList = async (fastify: KubeFastifyInstance): Promise<st
   const adminGroupsList = adminGroups
     .split(',')
     .filter((groupName) => groupName && !groupName.startsWith('system:')); // Handle edge-cases and ignore k8s defaults
-  adminGroupsList.push('cluster-admins');
-  return getGroupUserList(fastify, adminGroupsList);
+
+  // fetch all the users and groups who have cluster-admin role and put them into the admin user list
+  const { notebookNamespace } = getNamespaces(fastify);
+  const clusterAdminUsersAndGroups = await fastify.kube.customObjectsApi
+    // This is not actually fetching all the groups who have admin access to the notebook resources
+    // But only the cluster admins
+    // The "*" in the verb field is more like a placeholder
+    .createClusterCustomObject('authorization.openshift.io', 'v1', 'resourceaccessreviews', {
+      resource: 'notebooks',
+      resourceAPIGroup: 'kubeflow.org',
+      resourceAPIVersion: 'v1',
+      verb: '*',
+      namespace: notebookNamespace,
+    })
+    .then((rar) => rar.body as ResourceAccessReviewResponse)
+    .catch((e) => {
+      fastify.log.error(`Failure to fetch cluster admin users and groups: ${e.response.body}`);
+      return { users: [], groups: [] };
+    });
+  const clusterAdminUsers = clusterAdminUsersAndGroups.users || [];
+  const clusterAdminGroups = clusterAdminUsersAndGroups.groups || [];
+  const filteredClusterAdminGroups = clusterAdminGroups.filter(
+    (group) => !group.startsWith('system:') && !adminGroupsList.includes(group),
+  );
+  const filteredClusterAdminUsers = clusterAdminUsers.filter((user) => !user.startsWith('system:'));
+  adminGroupsList.push(...filteredClusterAdminGroups);
+  return getGroupUserList(fastify, adminGroupsList, filteredClusterAdminUsers);
 };
 
 export const getAllowedUserList = async (fastify: KubeFastifyInstance): Promise<string[]> => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-16434

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Use `ResourceAccessReview` API as described [here](https://docs.openshift.com/container-platform/4.17/rest_api/authorization_apis/resourceaccessreview-authorization-openshift-io-v1.html) to fetch the cluster admin users and groups instead of arbitrarily push `cluster-admins` group to the list and fetch it. This could also avoid the error mentioned in the JIRA where we are fetching a non-exist user group.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create some user groups
2. Bind them to the `cluster-admin` role
3. Add some users to those groups separately
4. Go to the Jupyter notebook controller admin panel, make sure those users are there and shown as `Admin`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
