### PR TITLE
fix(frontend): prevent unintended deletion of shared ConfigMaps and Secrets during notebook deletion

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -938,7 +938,7 @@ describe('Workbench page', () => {
       envFrom: [
         {
           secretRef: {
-            name: 'secret-1',
+            name: 'secret-123456',
           },
         },
         {
@@ -948,7 +948,7 @@ describe('Workbench page', () => {
         },
         {
           configMapRef: {
-            name: 'configmap-2',
+            name: 'configmap-123456',
           },
         },
         {
@@ -962,7 +962,7 @@ describe('Workbench page', () => {
       {
         model: SecretModel,
         ns: 'test-project',
-        name: 'secret-1',
+        name: 'secret-123456',
       },
       {
         statusCode: 404,
@@ -973,7 +973,7 @@ describe('Workbench page', () => {
       {
         model: ConfigMapModel,
         ns: 'test-project',
-        name: 'configmap-2',
+        name: 'configmap-123456',
       },
       {
         statusCode: 404,
@@ -992,16 +992,16 @@ describe('Workbench page', () => {
 
     cy.interceptK8s(
       'DELETE',
-      { model: SecretModel, ns: 'test-project', name: 'secret-1' },
+      { model: SecretModel, ns: 'test-project', name: 'secret-123456' },
       mock200Status({}),
     ).as('deleteSecret1');
     cy.interceptK8s(
       'DELETE',
-      { model: ConfigMapModel, ns: 'test-project', name: 'configmap-2' },
+      { model: ConfigMapModel, ns: 'test-project', name: 'configmap-123456' },
       mock200Status({}),
     ).as('deleteSecret2');
 
-    // Intercept any DELETE requests for custom-secret and custom-configmap to verify they don't happen
+    // Intercept any DELETE requests for resources that should not be deleted
     cy.interceptK8s(
       'DELETE',
       { model: ConfigMapModel, ns: 'test-project', name: 'custom-configmap' },

--- a/frontend/src/api/k8s/configMaps.ts
+++ b/frontend/src/api/k8s/configMaps.ts
@@ -14,7 +14,7 @@ export const CONFIGMAP_PREFIX = 'configmap-';
 
 export const getGeneratedConfigMapName = (): string => `${CONFIGMAP_PREFIX}${genRandomChars()}`;
 export const isGeneratedConfigMapName = (name: string): boolean =>
-  Boolean(name.match(new RegExp(`^${CONFIGMAP_PREFIX}[a-z0-9]{6}$`)));
+  new RegExp(`^${CONFIGMAP_PREFIX}[a-z0-9]{6}$`).test(name);
 
 export const assembleConfigMap = (
   projectName: string,

--- a/frontend/src/api/k8s/configMaps.ts
+++ b/frontend/src/api/k8s/configMaps.ts
@@ -12,6 +12,10 @@ import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 
 export const CONFIGMAP_PREFIX = 'configmap-';
 
+export const getGeneratedConfigMapName = (): string => `${CONFIGMAP_PREFIX}${genRandomChars()}`;
+export const isGeneratedConfigMapName = (name: string): boolean =>
+  Boolean(name.match(new RegExp(`^${CONFIGMAP_PREFIX}[a-z0-9]{6}$`)));
+
 export const assembleConfigMap = (
   projectName: string,
   configMapData: Record<string, string>,
@@ -20,7 +24,7 @@ export const assembleConfigMap = (
   apiVersion: 'v1',
   kind: 'ConfigMap',
   metadata: {
-    name: configMapName || `${CONFIGMAP_PREFIX}${genRandomChars()}`,
+    name: configMapName || getGeneratedConfigMapName(),
     namespace: projectName,
     labels: {
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',

--- a/frontend/src/api/k8s/configMaps.ts
+++ b/frontend/src/api/k8s/configMaps.ts
@@ -10,6 +10,8 @@ import { ConfigMapModel } from '~/api/models';
 import { genRandomChars } from '~/utilities/string';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 
+export const CONFIGMAP_PREFIX = 'configmap-';
+
 export const assembleConfigMap = (
   projectName: string,
   configMapData: Record<string, string>,
@@ -18,7 +20,7 @@ export const assembleConfigMap = (
   apiVersion: 'v1',
   kind: 'ConfigMap',
   metadata: {
-    name: configMapName || `configmap-${genRandomChars()}`,
+    name: configMapName || `${CONFIGMAP_PREFIX}${genRandomChars()}`,
     namespace: projectName,
     labels: {
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -13,6 +13,7 @@ import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 
 export const DATA_CONNECTION_PREFIX = 'aws-connection';
+export const SECRET_PREFIX = 'secret-';
 
 export const assembleSecret = (
   projectName: string,
@@ -26,7 +27,7 @@ export const assembleSecret = (
   const annotations: Record<string, string> = {};
 
   let stringData = data;
-  let name = `secret-${genRandomChars()}`;
+  let name = `${SECRET_PREFIX}${genRandomChars()}`;
 
   if (type === 'aws') {
     const { Name, ...secretBody } = data;

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -17,7 +17,7 @@ export const SECRET_PREFIX = 'secret-';
 
 export const getGeneratedSecretName = (): string => `${SECRET_PREFIX}${genRandomChars()}`;
 export const isGeneratedSecretName = (name: string): boolean =>
-  Boolean(name.match(new RegExp(`^${SECRET_PREFIX}[a-z0-9]{6}$`)));
+  new RegExp(`^${SECRET_PREFIX}[a-z0-9]{6}$`).test(name);
 
 export const assembleSecret = (
   projectName: string,

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -31,7 +31,7 @@ export const assembleSecret = (
   const annotations: Record<string, string> = {};
 
   let stringData = data;
-  let name = secretName || getGeneratedSecretName();
+  let name = getGeneratedSecretName();
 
   if (type === 'aws') {
     const { Name, ...secretBody } = data;
@@ -46,7 +46,7 @@ export const assembleSecret = (
     apiVersion: 'v1',
     kind: 'Secret',
     metadata: {
-      name,
+      name: secretName || name,
       namespace: projectName,
       annotations,
       labels,

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -46,7 +46,7 @@ export const assembleSecret = (
     apiVersion: 'v1',
     kind: 'Secret',
     metadata: {
-      name: secretName || name,
+      name,
       namespace: projectName,
       annotations,
       labels,

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -15,6 +15,10 @@ import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 export const DATA_CONNECTION_PREFIX = 'aws-connection';
 export const SECRET_PREFIX = 'secret-';
 
+export const getGeneratedSecretName = (): string => `${SECRET_PREFIX}${genRandomChars()}`;
+export const isGeneratedSecretName = (name: string): boolean =>
+  Boolean(name.match(new RegExp(`^${SECRET_PREFIX}[a-z0-9]{6}$`)));
+
 export const assembleSecret = (
   projectName: string,
   data: Record<string, string>,
@@ -27,7 +31,7 @@ export const assembleSecret = (
   const annotations: Record<string, string> = {};
 
   let stringData = data;
-  let name = `${SECRET_PREFIX}${genRandomChars()}`;
+  let name = secretName || getGeneratedSecretName();
 
   if (type === 'aws') {
     const { Name, ...secretBody } = data;

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -45,13 +45,15 @@ const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onC
         const configMapNames = nonDataConnectionVariables
           .filter(
             (envName): envName is ConfigMapRef =>
-              !!envName.configMapRef && envName.configMapRef.name.startsWith(CONFIGMAP_PREFIX),
+              !!envName.configMapRef &&
+              Boolean(envName.configMapRef.name.match(new RegExp(`^${CONFIGMAP_PREFIX}.{6}$`))),
           )
           .map((data) => data.configMapRef.name);
         const secretNames = nonDataConnectionVariables
           .filter(
             (envName): envName is SecretRef =>
-              !!envName.secretRef && envName.secretRef.name.startsWith(SECRET_PREFIX),
+              !!envName.secretRef &&
+              Boolean(envName.secretRef.name.match(new RegExp(`^${SECRET_PREFIX}.{6}$`))),
           )
           .map((data) => data.secretRef.name);
 

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import { NotebookKind } from '~/k8sTypes';
-import { DATA_CONNECTION_PREFIX, deleteConfigMap, deleteNotebook, deleteSecret } from '~/api';
+import {
+  CONFIGMAP_PREFIX,
+  DATA_CONNECTION_PREFIX,
+  deleteConfigMap,
+  deleteNotebook,
+  deleteSecret,
+  SECRET_PREFIX,
+} from '~/api';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
 import { getEnvFromList } from '~/pages/projects/pvc/utils';
 import { ConfigMapRef, SecretRef } from '~/pages/projects/types';
@@ -36,10 +43,16 @@ const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onC
           (envFrom) => !envFrom.secretRef?.name.includes(DATA_CONNECTION_PREFIX),
         );
         const configMapNames = nonDataConnectionVariables
-          .filter((envName): envName is ConfigMapRef => !!envName.configMapRef)
+          .filter(
+            (envName): envName is ConfigMapRef =>
+              !!envName.configMapRef && envName.configMapRef.name.startsWith(CONFIGMAP_PREFIX),
+          )
           .map((data) => data.configMapRef.name);
         const secretNames = nonDataConnectionVariables
-          .filter((envName): envName is SecretRef => !!envName.secretRef)
+          .filter(
+            (envName): envName is SecretRef =>
+              !!envName.secretRef && envName.secretRef.name.startsWith(SECRET_PREFIX),
+          )
           .map((data) => data.secretRef.name);
 
         const { namespace } = notebook.metadata;

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import { NotebookKind } from '~/k8sTypes';
 import {
-  CONFIGMAP_PREFIX,
   DATA_CONNECTION_PREFIX,
   deleteConfigMap,
   deleteNotebook,
   deleteSecret,
-  SECRET_PREFIX,
+  isGeneratedConfigMapName,
+  isGeneratedSecretName,
 } from '~/api';
 import DeleteModal from '~/pages/projects/components/DeleteModal';
 import { getEnvFromList } from '~/pages/projects/pvc/utils';
@@ -45,15 +45,13 @@ const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onC
         const configMapNames = nonDataConnectionVariables
           .filter(
             (envName): envName is ConfigMapRef =>
-              !!envName.configMapRef &&
-              Boolean(envName.configMapRef.name.match(new RegExp(`^${CONFIGMAP_PREFIX}.{6}$`))),
+              !!envName.configMapRef && isGeneratedConfigMapName(envName.configMapRef.name),
           )
           .map((data) => data.configMapRef.name);
         const secretNames = nonDataConnectionVariables
           .filter(
             (envName): envName is SecretRef =>
-              !!envName.secretRef &&
-              Boolean(envName.secretRef.name.match(new RegExp(`^${SECRET_PREFIX}.{6}$`))),
+              !!envName.secretRef && isGeneratedSecretName(envName.secretRef.name),
           )
           .map((data) => data.secretRef.name);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16192

fixes https://github.com/opendatahub-io/odh-dashboard/issues/3521 (we will follow up with more flexibility in the future)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR addresses an issue where deleting a notebook would unintentionally delete ConfigMaps and Secrets that might be shared between multiple workbenches. The fix introduces prefix-based filtering to ensure only dashboard-generated resources are deleted.

- Modified deletion logic to only delete resources that start with these prefixes
- Updated tests to verify that custom resources are preserved

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated delete test

1. create test resources
```yaml
# Create a shared ConfigMap
kind: ConfigMap
apiVersion: v1
metadata:
  name: shared-test-configmap
  labels:
    opendatahub.io/dashboard: 'true'
data:
  STAGE: test

# Create a shared Secret
kind: Secret
apiVersion: v1
metadata:
  name: shared-test-secret
  labels:
    opendatahub.io/dashboard: 'true'
data:
  USER_PW: bXlzYW1wbGVwYXNzd29yZDM0
type: Opaque
```

2. Create Notebook with secret and env var
3. Link manually created resources to notebook (shared-test-secret, shared-test-configmap)
```yaml
   envFrom:
            # Dashboard-generated (will be deleted with notebook)
            - secretRef:
                name: secret-abc123
            - configMapRef:
                name: configmap-xyz789
            
            # Shared/Custom resources (will NOT be deleted)
            - secretRef:
                name: shared-test-secret
            - configMapRef:
                name: shared-test-configmap
```
5. Test Deletion
   - Delete notebook-1 through the dashboard
   - Verify that:
      - notebook-1 is deleted
      - The shared ConfigMap and Secret remain
  
**Expected Results**
- Only resources prefixed with secret- or configmap- should be deleted
- Shared resources without these prefixes should remain intact
- Second notebook should continue to function with shared resources

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
