### PR TITLE
Hardware profile empty state

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -37,6 +37,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableKServeRaw: boolean;
       disableModelMesh: boolean;
       disableAcceleratorProfiles: boolean;
+      disableHardwareProfiles: boolean;
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
       disableServingRuntimeParams: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -62,6 +62,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableKServeRaw: true,
       disableModelMesh: false,
       disableAcceleratorProfiles: false,
+      disableHardwareProfiles: true,
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
       disableServingRuntimeParams: false,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -31,6 +31,7 @@ The following are a list of features that are supported, along with there defaul
 | disableKServeRaw             | true    | Disables the option to deploy in raw instead of serverless.                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
+| disableHardwareProfiles      | true    | Disables Hardware profiles from the Admin Panel.                                                     |
 | disableTrustyBiasMetrics     | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
@@ -62,6 +63,7 @@ spec:
     disableProjectSharing: false
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: false
+    disableHardwareProfiles: true
     disableKServeMetrics: false
     disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
@@ -158,6 +160,7 @@ spec:
     disableProjectSharing: true
     disableCustomServingRuntimes: false
     disableAcceleratorProfiles: true
+    disableHardwareProfiles: true
     disableKServeMetrics: true
     disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -21,6 +21,7 @@ export type MockDashboardConfigType = {
   disableKServeRaw?: boolean;
   disableModelMesh?: boolean;
   disableAcceleratorProfiles?: boolean;
+  disableHardwareProfiles?: boolean;
   disablePerformanceMetrics?: boolean;
   disableTrustyBiasMetrics?: boolean;
   disableDistributedWorkloads?: boolean;
@@ -53,6 +54,7 @@ export const mockDashboardConfig = ({
   disableKServeRaw = true,
   disableModelMesh = false,
   disableAcceleratorProfiles = false,
+  disableHardwareProfiles = false,
   disablePerformanceMetrics = false,
   disableTrustyBiasMetrics = false,
   disableDistributedWorkloads = false,
@@ -164,6 +166,7 @@ export const mockDashboardConfig = ({
       disableKServeRaw,
       disableModelMesh,
       disableAcceleratorProfiles,
+      disableHardwareProfiles,
       disableDistributedWorkloads,
       disableModelRegistry,
       disableServingRuntimeParams,

--- a/frontend/src/__mocks__/mockHardwareProfile.ts
+++ b/frontend/src/__mocks__/mockHardwareProfile.ts
@@ -1,0 +1,71 @@
+import { HardwareProfileKind } from '~/k8sTypes';
+import {
+  Identifier,
+  NodeSelector,
+  Toleration,
+  TolerationEffect,
+  TolerationOperator,
+} from '~/types';
+import { genUID } from './mockUtils';
+
+type MockResourceConfigType = {
+  name?: string;
+  namespace?: string;
+  uid?: string;
+  displayName?: string;
+  identifiers?: Identifier[];
+  description?: string;
+  enabled?: boolean;
+  nodeSelectors?: NodeSelector[];
+  tolerations?: Toleration[];
+};
+
+export const mockHardwareProfile = ({
+  name = 'migrated-gpu',
+  namespace = 'test-project',
+  uid = genUID('service'),
+  displayName = 'Nvidia GPU',
+  identifiers = [
+    {
+      displayName: 'Memory',
+      identifier: 'memory',
+      minCount: 5,
+      maxCount: 2,
+      defaultCount: 2,
+    },
+  ],
+  description = '',
+  enabled = true,
+  tolerations = [
+    {
+      key: 'nvidia.com/gpu',
+      operator: TolerationOperator.EXISTS,
+      effect: TolerationEffect.NO_SCHEDULE,
+    },
+  ],
+  nodeSelectors = [
+    {
+      key: 'test',
+      value: 'va;ue',
+    },
+  ],
+}: MockResourceConfigType): HardwareProfileKind => ({
+  apiVersion: 'dashboard.opendatahub.io/v1alpha1',
+  kind: 'HardwareProfile',
+  metadata: {
+    creationTimestamp: '2023-03-17T16:12:41Z',
+    generation: 1,
+    name,
+    namespace,
+    resourceVersion: '1309350',
+    uid,
+  },
+  spec: {
+    identifiers,
+    displayName,
+    enabled,
+    tolerations,
+    nodeSelectors,
+    description,
+  },
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -19,6 +19,7 @@ export * from './k8s/groups';
 export * from './k8s/templates';
 export * from './k8s/dashboardConfig';
 export * from './k8s/acceleratorProfiles';
+export * from './k8s/hardwareProfiles';
 export * from './k8s/clusterQueues';
 export * from './k8s/localQueues';
 export * from './k8s/workloads';

--- a/frontend/src/api/k8s/__tests__/hardwareProfiles.spec.ts
+++ b/frontend/src/api/k8s/__tests__/hardwareProfiles.spec.ts
@@ -1,0 +1,255 @@
+import {
+  k8sCreateResource,
+  k8sDeleteResource,
+  k8sGetResource,
+  k8sListResource,
+  K8sStatus,
+  k8sUpdateResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { HardwareProfileKind } from '~/k8sTypes';
+import { HardwareProfileModel } from '~/api/models';
+import {
+  createHardwareProfile,
+  deleteHardwareProfile,
+  getHardwareProfile,
+  listHardwareProfiles,
+  updateHardwareProfile,
+} from '~/api/k8s/hardwareProfiles';
+import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
+import { TolerationEffect, TolerationOperator } from '~/types';
+import { mock200Status, mock404Error } from '~/__mocks__';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+  k8sCreateResource: jest.fn(),
+  k8sUpdateResource: jest.fn(),
+  k8sDeleteResource: jest.fn(),
+  k8sGetResource: jest.fn(),
+}));
+
+const mockListResource = jest.mocked(k8sListResource<HardwareProfileKind>);
+const mockGetResource = jest.mocked(k8sGetResource<HardwareProfileKind>);
+const k8sCreateResourceMock = jest.mocked(k8sCreateResource<HardwareProfileKind>);
+const k8sUpdateResourceMock = jest.mocked(k8sUpdateResource<HardwareProfileKind>);
+const k8sDeleteResourceMock = jest.mocked(k8sDeleteResource<HardwareProfileKind, K8sStatus>);
+
+const data: HardwareProfileKind['spec'] = {
+  displayName: 'test',
+  identifiers: [
+    {
+      displayName: 'Memory',
+      identifier: 'memory',
+      minCount: 5,
+      maxCount: 2,
+      defaultCount: 2,
+    },
+  ],
+  description: 'test description',
+  enabled: true,
+  tolerations: [
+    {
+      key: 'nvidia.com/gpu',
+      operator: TolerationOperator.EXISTS,
+      effect: TolerationEffect.NO_SCHEDULE,
+    },
+  ],
+};
+
+const assembleHardwareProfileResult: HardwareProfileKind = {
+  apiVersion: 'dashboard.opendatahub.io/v1alpha1',
+  kind: 'HardwareProfile',
+  metadata: {
+    name: 'test-1',
+    namespace: 'namespace',
+  },
+  spec: data,
+};
+
+describe('listHardwareProfile', () => {
+  it('should fetch and return list of hardware profile', async () => {
+    const namespace = 'test-project';
+    mockListResource.mockResolvedValue(
+      mockK8sResourceList([mockHardwareProfile({ uid: 'test-project-12' })]),
+    );
+
+    const result = await listHardwareProfiles(namespace);
+    expect(mockListResource).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: {
+        ns: namespace,
+      },
+    });
+    expect(mockListResource).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([mockHardwareProfile({ uid: 'test-project-12' })]);
+  });
+
+  it('should handle errors when fetching list of hardware profile', async () => {
+    const namespace = 'test-project';
+    mockListResource.mockRejectedValue(new Error('error1'));
+
+    await expect(listHardwareProfiles(namespace)).rejects.toThrow('error1');
+    expect(mockListResource).toHaveBeenCalledTimes(1);
+    expect(mockListResource).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: {
+        ns: namespace,
+      },
+    });
+  });
+});
+
+describe('getHardwareProfile', () => {
+  it('should fetch and return  specific hardware profile', async () => {
+    const namespace = 'test-project';
+    const projectName = 'test';
+    mockGetResource.mockResolvedValue(mockHardwareProfile({ uid: 'test-project-12' }));
+
+    const result = await getHardwareProfile(projectName, namespace);
+    expect(mockGetResource).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: {
+        name: projectName,
+        ns: namespace,
+      },
+    });
+    expect(mockGetResource).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockHardwareProfile({ uid: 'test-project-12' }));
+  });
+
+  it('should handle errors when fetching a specific hardware profile', async () => {
+    const namespace = 'test-project';
+    const projectName = 'test';
+    mockGetResource.mockRejectedValue(new Error('error1'));
+
+    await expect(getHardwareProfile(projectName, namespace)).rejects.toThrow('error1');
+    expect(mockGetResource).toHaveBeenCalledTimes(1);
+    expect(mockGetResource).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: {
+        name: projectName,
+        ns: namespace,
+      },
+    });
+  });
+});
+
+describe('createHardwareProfiles', () => {
+  it('should create hadware profile', async () => {
+    k8sCreateResourceMock.mockResolvedValue(mockHardwareProfile({ uid: 'test' }));
+    const result = await createHardwareProfile('test-1', data, 'namespace');
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: HardwareProfileModel,
+      queryOptions: { queryParams: {} },
+      resource: assembleHardwareProfileResult,
+    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockHardwareProfile({ uid: 'test' }));
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sCreateResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(createHardwareProfile('test-1', data, 'namespace')).rejects.toThrow('error1');
+    expect(k8sCreateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: HardwareProfileModel,
+      queryOptions: { queryParams: {} },
+      resource: assembleHardwareProfileResult,
+    });
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('updateHardwareProfile', () => {
+  it('should update hardware profile', async () => {
+    k8sUpdateResourceMock.mockResolvedValue(
+      mockHardwareProfile({
+        uid: 'test',
+        displayName: 'test',
+        description: 'test description',
+      }),
+    );
+    const result = await updateHardwareProfile(
+      data,
+      mockHardwareProfile({ uid: 'test-1' }),
+      'namespace',
+    );
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: HardwareProfileModel,
+      queryOptions: { queryParams: {} },
+      resource: mockHardwareProfile({
+        uid: 'test-1',
+        namespace: 'namespace',
+        description: 'test description',
+        displayName: 'test',
+      }),
+    });
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(
+      mockHardwareProfile({
+        uid: 'test',
+        displayName: 'test',
+        description: 'test description',
+      }),
+    );
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sUpdateResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(
+      updateHardwareProfile(data, mockHardwareProfile({ uid: 'test-1' }), 'namespace'),
+    ).rejects.toThrow('error1');
+    expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sUpdateResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: HardwareProfileModel,
+      queryOptions: { queryParams: {} },
+      resource: mockHardwareProfile({
+        uid: 'test-1',
+        namespace: 'namespace',
+        description: 'test description',
+        displayName: 'test',
+      }),
+    });
+  });
+});
+
+describe('deleteHardwareProfile', () => {
+  it('should return status as Success', async () => {
+    const mockK8sStatus = mock200Status({});
+    k8sDeleteResourceMock.mockResolvedValue(mockK8sStatus);
+    const result = await deleteHardwareProfile('hardwareProfileName', 'namespace');
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: { name: 'hardwareProfileName', ns: 'namespace' },
+    });
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockK8sStatus);
+  });
+
+  it('should return status as Failure', async () => {
+    const mockK8sStatus = mock404Error({});
+    k8sDeleteResourceMock.mockResolvedValue(mockK8sStatus);
+    const result = await deleteHardwareProfile('hardwareProfileName', 'namespace');
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: { name: 'hardwareProfileName', ns: 'namespace' },
+    });
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockK8sStatus);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sDeleteResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(deleteHardwareProfile('hardwareProfileName', 'namespace')).rejects.toThrow(
+      'error1',
+    );
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      model: HardwareProfileModel,
+      queryOptions: { name: 'hardwareProfileName', ns: 'namespace' },
+    });
+  });
+});

--- a/frontend/src/api/k8s/hardwareProfiles.ts
+++ b/frontend/src/api/k8s/hardwareProfiles.ts
@@ -1,0 +1,82 @@
+import * as _ from 'lodash-es';
+import {
+  k8sCreateResource,
+  k8sDeleteResource,
+  k8sGetResource,
+  k8sListResource,
+  K8sStatus,
+  k8sUpdateResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { HardwareProfileKind, K8sAPIOptions } from '~/k8sTypes';
+import { HardwareProfileModel } from '~/api/models';
+import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
+import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
+
+export const listHardwareProfiles = async (namespace: string): Promise<HardwareProfileKind[]> =>
+  k8sListResource<HardwareProfileKind>({
+    model: HardwareProfileModel,
+    queryOptions: {
+      ns: namespace,
+    },
+  }).then((listResource) => listResource.items);
+
+export const getHardwareProfile = (name: string, namespace: string): Promise<HardwareProfileKind> =>
+  k8sGetResource<HardwareProfileKind>({
+    model: HardwareProfileModel,
+    queryOptions: { name, ns: namespace },
+  });
+
+export const assembleHardwareProfile = (
+  hardwareProfileName: string,
+  data: HardwareProfileKind['spec'],
+  namespace: string,
+): HardwareProfileKind => ({
+  apiVersion: `${HardwareProfileModel.apiGroup}/${HardwareProfileModel.apiVersion}`,
+  kind: HardwareProfileModel.kind,
+  metadata: {
+    name: hardwareProfileName || translateDisplayNameForK8s(data.displayName),
+    namespace,
+  },
+  spec: data,
+});
+
+export const createHardwareProfile = (
+  hardwareProfileName: string,
+  data: HardwareProfileKind['spec'],
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<HardwareProfileKind> => {
+  const resource = assembleHardwareProfile(hardwareProfileName, data, namespace);
+  return k8sCreateResource<HardwareProfileKind>(
+    applyK8sAPIOptions(
+      {
+        model: HardwareProfileModel,
+        resource,
+      },
+      opts,
+    ),
+  );
+};
+
+export const updateHardwareProfile = (
+  data: HardwareProfileKind['spec'],
+  existingHardwareProfile: HardwareProfileKind,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<HardwareProfileKind> => {
+  const resource = assembleHardwareProfile(existingHardwareProfile.metadata.name, data, namespace);
+  const hardwareProfileResource = _.merge({}, existingHardwareProfile, resource);
+
+  return k8sUpdateResource<HardwareProfileKind>(
+    applyK8sAPIOptions({ model: HardwareProfileModel, resource: hardwareProfileResource }, opts),
+  );
+};
+
+export const deleteHardwareProfile = (
+  hardwareProfileName: string,
+  namespace: string,
+): Promise<K8sStatus> =>
+  k8sDeleteResource<HardwareProfileKind, K8sStatus>({
+    model: HardwareProfileModel,
+    queryOptions: { name: hardwareProfileName, ns: namespace },
+  });

--- a/frontend/src/api/models/odh.ts
+++ b/frontend/src/api/models/odh.ts
@@ -14,6 +14,13 @@ export const AcceleratorProfileModel: K8sModelCommon = {
   plural: 'acceleratorprofiles',
 };
 
+export const HardwareProfileModel = {
+  apiVersion: 'v1alpha1',
+  apiGroup: 'dashboard.opendatahub.io',
+  kind: 'HardwareProfile',
+  plural: 'hardwareprofiles',
+} satisfies K8sModelCommon;
+
 export const NotebookModel: K8sModelCommon = {
   apiVersion: 'v1',
   apiGroup: 'kubeflow.org',

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -68,6 +68,10 @@ const AcceleratorProfileRoutes = React.lazy(
   () => import('../pages/acceleratorProfiles/AcceleratorProfilesRoutes'),
 );
 
+const HardwareProfileRoutes = React.lazy(
+  () => import('../pages/hardwareProfiles/HardwareProfilesRoutes'),
+);
+
 const StorageClassesPage = React.lazy(() => import('../pages/storageClasses/StorageClassesPage'));
 
 const ModelRegistryRoutes = React.lazy(() => import('../pages/modelRegistry/ModelRegistryRoutes'));
@@ -131,6 +135,7 @@ const AppRoutes: React.FC = () => {
             <Route path="/notebookImages" element={<BYONImagesPage />} />
             <Route path="/clusterSettings" element={<ClusterSettingsPage />} />
             <Route path="/acceleratorProfiles/*" element={<AcceleratorProfileRoutes />} />
+            <Route path="/hardwareProfiles/*" element={<HardwareProfileRoutes />} />
             <Route path="/servingRuntimes/*" element={<CustomServingRuntimeRoutes />} />
             {isConnectionTypesAvailable ? (
               <Route path="/connectionTypes/*" element={<ConnectionTypeRoutes />} />

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -25,6 +25,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableKServeRaw: true,
   disableModelMesh: false,
   disableAcceleratorProfiles: false,
+  disableHardwareProfiles: false,
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
   disableServingRuntimeParams: false,
@@ -39,6 +40,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.ACCELERATOR_PROFILES]: {
     featureFlags: ['disableAcceleratorProfiles'],
+  },
+  [SupportedArea.HARDWARE_PROFILES]: {
+    featureFlags: ['disableHardwareProfiles'],
   },
   [SupportedArea.CLUSTER_SETTINGS]: {
     featureFlags: ['disableClusterManager'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -37,6 +37,7 @@ export enum SupportedArea {
   CLUSTER_SETTINGS = 'cluster-settings',
   USER_MANAGEMENT = 'user-management',
   ACCELERATOR_PROFILES = 'accelerator-profiles',
+  HARDWARE_PROFILES = 'hardware-profiles',
   CONNECTION_TYPES = 'connections-types',
   STORAGE_CLASSES = 'storage-classes',
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -5,8 +5,10 @@ import { StackComponent } from '~/concepts/areas/types';
 import {
   ContainerResourceAttributes,
   ContainerResources,
+  Identifier,
   ImageStreamStatusTagCondition,
   ImageStreamStatusTagItem,
+  NodeSelector,
   NotebookSize,
   PodAffinity,
   PodContainer,
@@ -1187,6 +1189,7 @@ export type DashboardCommonConfig = {
   disableKServeRaw: boolean;
   disableModelMesh: boolean;
   disableAcceleratorProfiles: boolean;
+  disableHardwareProfiles: boolean;
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
   disableServingRuntimeParams: boolean;
@@ -1229,6 +1232,20 @@ export type AcceleratorProfileKind = K8sResourceCommon & {
     identifier: string;
     description?: string;
     tolerations?: Toleration[];
+  };
+};
+
+export type HardwareProfileKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+  };
+  spec: {
+    displayName: string;
+    enabled: boolean;
+    description?: string;
+    tolerations?: Toleration[];
+    identifiers?: Identifier[];
+    nodeSelectors?: NodeSelector[];
   };
 };
 

--- a/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import {
+  Button,
+  ButtonVariant,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+  PageSection,
+  Title,
+  EmptyStateActions,
+  EmptyStateFooter,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import { useDashboardNamespace } from '~/redux/selectors';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
+import useHardwareProfiles from './useHardwareProfiles';
+
+const description = `Manage hardware profile settings for users in your organization.`;
+
+const HardwareProfiles: React.FC = () => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [hardwareProfiles, loaded, loadError] = useHardwareProfiles(dashboardNamespace);
+
+  const isEmpty = hardwareProfiles.length === 0;
+
+  const noHardwareProfilePageSection = (
+    <PageSection isFilled>
+      <EmptyState
+        variant={EmptyStateVariant.full}
+        data-id="empty-empty-state"
+        icon={PlusCircleIcon}
+      >
+        <Title data-testid="no-available-hardware-profiles" headingLevel="h5" size="lg">
+          No available hardware profiles yet
+        </Title>
+        <EmptyStateBody>
+          You don&apos;t have any hardware profiles yet. To get started, please ask your cluster
+          administrator about the hardware availability in your cluster and create corresponding
+          profiles in {ODH_PRODUCT_NAME}.
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button
+              data-testid="display-hardware-modal-button"
+              variant={ButtonVariant.primary}
+              onClick={() => {
+                /* Todo: Create hardware profile */
+              }}
+            >
+              Add new hardware profile
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </PageSection>
+  );
+
+  return (
+    <ApplicationsPage
+      title="Hardware profiles"
+      description={description}
+      loaded={loaded}
+      empty={isEmpty}
+      loadError={loadError}
+      errorMessage="Unable to load hardware profiles."
+      emptyStatePage={noHardwareProfilePageSection}
+      provideChildrenPadding
+    >
+      {/* Todo: Create hardware table */}
+    </ApplicationsPage>
+  );
+};
+
+export default HardwareProfiles;

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesRoutes.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesRoutes.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import HardwareProfiles from './HardwareProfiles';
+
+const HardwareProfilesRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<HardwareProfiles />} />
+    <Route path="*" element={<Navigate to="." />} />
+  </Routes>
+);
+
+export default HardwareProfilesRoutes;

--- a/frontend/src/pages/hardwareProfiles/__tests__/useHardwareProfile.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/__tests__/useHardwareProfile.spec.ts
@@ -1,0 +1,75 @@
+import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { act } from 'react';
+import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import { HardwareProfileModel } from '~/api';
+import { HardwareProfileKind } from '~/k8sTypes';
+import useHardwareProfile from '~/pages/hardwareProfiles/useHardwareProfile';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+}));
+
+const k8sGetResourceMock = jest.mocked(k8sGetResource<HardwareProfileKind>);
+
+describe('useHardwareProfile', () => {
+  it('should return hardware profile', async () => {
+    k8sGetResourceMock.mockResolvedValue(mockHardwareProfile({ uid: 'test-1' }));
+    const options = {
+      model: HardwareProfileModel,
+      queryOptions: { name: 'migrated-gpu', ns: 'test' },
+    };
+    const renderResult = testHook(useHardwareProfile)('test', 'migrated-gpu');
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sGetResourceMock).toHaveBeenCalledWith(options);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState(mockHardwareProfile({ uid: 'test-1' }), true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sGetResourceMock.mockResolvedValue(mockHardwareProfile({}));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle no name error', async () => {
+    const renderResult = testHook(useHardwareProfile)('test');
+    expect(k8sGetResourceMock).not.toHaveBeenCalled();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sGetResourceMock.mockRejectedValue(new Error('error1'));
+
+    const renderResult = testHook(useHardwareProfile)('namespace', 'test');
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    k8sGetResourceMock.mockRejectedValue(new Error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sGetResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(null, false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/pages/hardwareProfiles/__tests__/useHardwareProfiles.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/__tests__/useHardwareProfiles.spec.ts
@@ -1,0 +1,68 @@
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { act } from 'react';
+import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
+import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
+import { standardUseFetchState, testHook } from '~/__tests__/unit/testUtils/hooks';
+import { HardwareProfileModel } from '~/api';
+import { HardwareProfileKind } from '~/k8sTypes';
+import useHardwareProfiles from '~/pages/hardwareProfiles/useHardwareProfiles';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+const k8sListResourceMock = jest.mocked(k8sListResource<HardwareProfileKind>);
+
+describe('useHardwareProfile', () => {
+  const hardwareProfilesMock = mockK8sResourceList([mockHardwareProfile({ uid: 'test-1' })]);
+  it('should return hardware profile', async () => {
+    k8sListResourceMock.mockResolvedValue(hardwareProfilesMock);
+    const options = {
+      model: HardwareProfileModel,
+      queryOptions: { ns: 'test' },
+    };
+    const renderResult = testHook(useHardwareProfiles)('test');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith(options);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState(hardwareProfilesMock.items, true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([false, false, true, true]);
+
+    // refresh
+    k8sListResourceMock.mockResolvedValue(hardwareProfilesMock);
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([false, true, true, true]);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error1'));
+
+    const renderResult = testHook(useHardwareProfiles)('namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error1')));
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+
+    // refresh
+    k8sListResourceMock.mockRejectedValue(new Error('error2'));
+    await act(() => renderResult.result.current[3]());
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], false, new Error('error2')));
+    expect(renderResult).hookToHaveUpdateCount(3);
+    expect(renderResult).hookToBeStable([true, true, false, true]);
+  });
+});

--- a/frontend/src/pages/hardwareProfiles/useHardwareProfile.ts
+++ b/frontend/src/pages/hardwareProfiles/useHardwareProfile.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+import { getHardwareProfile } from '~/api';
+import { HardwareProfileKind } from '~/k8sTypes';
+import useFetchState, {
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '~/utilities/useFetchState';
+
+const useHardwareProfile = (
+  namespace: string,
+  name?: string,
+): FetchState<HardwareProfileKind | null> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<HardwareProfileKind | null>>(() => {
+    if (!name) {
+      return Promise.reject(new NotReadyError('Hardware profile name is missing'));
+    }
+    return getHardwareProfile(name, namespace);
+  }, [name, namespace]);
+
+  return useFetchState(callback, null);
+};
+
+export default useHardwareProfile;

--- a/frontend/src/pages/hardwareProfiles/useHardwareProfiles.ts
+++ b/frontend/src/pages/hardwareProfiles/useHardwareProfiles.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+import useFetchState, { FetchState } from '~/utilities/useFetchState';
+import { HardwareProfileKind } from '~/k8sTypes';
+import { listHardwareProfiles } from '~/api';
+
+const useHardwareProfiles = (namespace: string): FetchState<HardwareProfileKind[]> => {
+  const getHardwareProfiles = React.useCallback(() => listHardwareProfiles(namespace), [namespace]);
+  return useFetchState<HardwareProfileKind[]>(getHardwareProfiles, []);
+};
+
+export default useHardwareProfiles;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -304,6 +304,19 @@ export type Toleration = {
   tolerationSeconds?: number;
 };
 
+export type Identifier = {
+  displayName: string;
+  identifier: string;
+  minCount: number | string;
+  maxCount: number | string;
+  defaultCount: number | string;
+};
+
+export type NodeSelector = {
+  key: string;
+  value: string;
+};
+
 export type PodContainer = {
   name: string;
   image: string;

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -197,11 +197,21 @@ const useAcceleratorProfilesNav = (): NavDataHref[] =>
     },
   ]);
 
+const useHardwareProfilesNav = (): NavDataHref[] =>
+  useAreaCheck<NavDataHref>(SupportedArea.HARDWARE_PROFILES, [
+    {
+      id: 'settings-hardware-profiles',
+      label: 'Hardware profiles',
+      href: '/hardwareProfiles',
+    },
+  ]);
+
 const useSettingsNav = (): NavDataGroup[] => {
   const settingsNavs: NavDataHref[] = [
     ...useCustomNotebooksNav(),
     ...useClusterSettingsNav(),
     ...useAcceleratorProfilesNav(),
+    ...useHardwareProfilesNav(),
     ...useCustomRuntimesNav(),
     ...useConnectionTypesNav(),
     ...useStorageClassesNav(),

--- a/manifests/common/crd/hardwareprofiles.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/hardwareprofiles.opendatahub.io.crd.yaml
@@ -1,0 +1,98 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hardwareprofiles.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  scope: Namespaced
+  names:
+    plural: hardwareprofiles
+    singular: hardwareprofile
+    kind: HardwareProfile
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - displayName
+                - enabled
+              properties:
+                displayName:
+                  type: string
+                  description: 'The display name of the hardware profile.'
+                enabled:
+                  type: boolean
+                  description: 'Indicates whether the hardware profile is available for new resources.'
+                description:
+                  type: string
+                  description: 'A short description of the hardware profile.'
+                tolerations:
+                  type: array
+                  description: 'Any number of Kubernetes toleration values that are added to resources when created or updated to this hardware profile.'
+                  items:
+                    type: object
+                    required:
+                      - key
+                    properties:
+                      key:
+                        type: string
+                        description: 'Taint key. Empty matches all keys.'
+                      operator:
+                        type: string
+                        description: "Relationship with the value. Valid: 'Exists', 'Equal'. Defaults to 'Equal'."
+                      value:
+                        type: string
+                        description: "Tolerance value. If key is empty, use 'Exists' to match all values and keys."
+                      effect:
+                        type: string
+                        description: "Taint effect. Empty matches all effects. Allowed: 'NoSchedule', 'PreferNoSchedule', 'NoExecute'."
+                      tolerationSeconds:
+                        type: integer
+                        description: "Duration in seconds. If effect is 'NoExecute', specifies eviction time. Default is forever."
+                identifiers:
+                  type: array
+                  description: 'The array of identifiers'
+                  items:
+                    type: object
+                    required:
+                      - displayName
+                      - identifier
+                      - minCount
+                      - maxCount
+                      - defaultCount
+                    properties:
+                      displayName:
+                        type: string
+                        description: 'The display name of identifier.'
+                      identifier:
+                        type: string
+                        description: 'The resource identifier of the hardware device.'
+                      minCount:
+                        x-kubernetes-int-or-string: true
+                        description: 'The minimum count can be a integer or a number.'
+                      maxCount:
+                        x-kubernetes-int-or-string: true
+                        description: 'The maximum count can be a integer or a number.'
+                      defaultCount:
+                        x-kubernetes-int-or-string: true
+                        description: 'The default count can be a integer or a number.'
+                nodeSelectors:
+                  type: array
+                  description: 'Number of node selector available.'
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: 'The key for the node selector.'
+                      value:
+                        type: string
+                        description: 'The value for the node selector.'

--- a/manifests/common/crd/kustomization.yaml
+++ b/manifests/common/crd/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - odhdocuments.dashboard.opendatahub.io.crd.yaml
 - odhapplications.dashboard.opendatahub.io.crd.yaml
 - acceleratorprofiles.opendatahub.io.crd.yaml
+- hardwareprofiles.opendatahub.io.crd.yaml

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -67,6 +67,8 @@ spec:
                       type: boolean
                     disableAcceleratorProfiles:
                       type: boolean
+                    disableHardwareProfiles:
+                      type: boolean
                     disableDistributedWorkloads:
                       type: boolean
                     disableModelRegistry:

--- a/manifests/core-bases/base/fetch-hardwares.rbac.yaml
+++ b/manifests/core-bases/base/fetch-hardwares.rbac.yaml
@@ -1,0 +1,26 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fetch-hardware-profiles-role
+rules:
+  - apiGroups:
+      - dashboard.opendatahub.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - hardwareprofiles
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hardware-profile-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fetch-hardware-profiles-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/manifests/core-bases/base/kustomization.yaml
+++ b/manifests/core-bases/base/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - model-serving-role.yaml
   - model-serving-role-binding.yaml
   - fetch-accelerators.rbac.yaml
+  - fetch-hardwares.rbac.yaml
 images:
   - name: oauth-proxy
     newName: registry.redhat.io/openshift4/ose-oauth-proxy


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-16253

## Description

- created disableHardwareProfiles feature flag
- created side navigation settings called "Hardware profiles"
- Hide navigation behind new feature flag
- created new HardwareProfile CRD (spec)
- created useHardwareProfile hook
- will need to fetch new crd
- create empty state for side navigation
- Update RBAC for authenticated users

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- oc apply the manifest file
- check for the hardware profile when you are a clusteradmin
- check in the openshift console , whether hardware profile is created in custom resource definition
- console log the `createHardwareProfile` , `deleteHardwareProfile`, `updateHardwareProfile` to check whether hardware profile instance is created, updated or deleted
- check if the `useHardwareProfile`  and `useHardwareProfile` list all the hardware
Be a regularuser
- check hardware profile from setting doesnt appear
- check you can still fetch the hardware profile details in spawner page

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added unit test
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
