### PR TITLE
Model mesh deployment doesn't appear under server after creation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -403,7 +403,7 @@ describe('Model Serving Global', () => {
         apiVersion: 'serving.kserve.io/v1beta1',
         kind: 'InferenceService',
         metadata: {
-          name: 'test-name',
+          name: 'test-model',
           namespace: 'test-project',
           labels: { 'opendatahub.io/dashboard': 'true' },
           annotations: {
@@ -415,7 +415,7 @@ describe('Model Serving Global', () => {
           predictor: {
             model: {
               modelFormat: { name: 'onnx', version: '1' },
-              runtime: 'test-name',
+              runtime: 'test-model',
               storage: { key: 'test-secret', path: 'test-model/' },
               args: [],
               env: [],
@@ -468,7 +468,7 @@ describe('Model Serving Global', () => {
         apiVersion: 'serving.kserve.io/v1beta1',
         kind: 'InferenceService',
         metadata: {
-          name: 'trigger-error',
+          name: 'test-model',
           namespace: 'test-project',
           labels: { 'opendatahub.io/dashboard': 'true' },
           annotations: {
@@ -480,7 +480,7 @@ describe('Model Serving Global', () => {
           predictor: {
             model: {
               modelFormat: { name: 'onnx', version: '1' },
-              runtime: 'trigger-error',
+              runtime: 'test-model',
               storage: { key: 'test-secret', path: 'test-model/test-model/' },
               args: [],
               env: [],

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -478,7 +478,7 @@ describe('Serving Runtime List', () => {
         expect(interception.request.url).to.include('?dryRun=All');
         expect(interception.request.body).to.containSubset({
           metadata: {
-            name: 'test-name',
+            name: 'test-model-legacy',
             namespace: 'test-project',
             labels: { 'opendatahub.io/dashboard': 'true' },
             annotations: {
@@ -490,7 +490,7 @@ describe('Serving Runtime List', () => {
             predictor: {
               model: {
                 modelFormat: { name: 'onnx', version: '1' },
-                runtime: 'test-name',
+                runtime: 'test-model-legacy',
                 storage: { key: 'test-secret', path: 'test-model/' },
               },
             },

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -135,7 +135,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
         ...getCreateInferenceServiceLabels(registeredModelDeployInfo),
       },
       editInfo,
-      createData.k8sName,
+      createData.servingRuntimeName,
       createData.k8sName,
       true,
       undefined,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16540
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Go to Data Science projects and find a project that is configure with model mesh
Create a new model server (for example openvino) e.i. named "newserver"
in a modelmesh server Create a new model deployment under it e.i. name "newmodel" and save
Notice that "newmodel" is now appearing under "newserver" See screenshots below on the before and after


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on MR cluster 
BEFORE 
<img width="1372" alt="Screenshot 2024-12-04 at 10 25 48 AM" src="https://github.com/user-attachments/assets/fc7d916e-2e60-483c-b83a-f62fe7d3094b">
AFTER with same name
<img width="1378" alt="Screenshot 2024-12-04 at 10 23 58 AM" src="https://github.com/user-attachments/assets/3dd4ae9b-9cc4-4e42-ac08-89f9b8f9ac06">
AFTER with different names 
<img width="1365" alt="Screenshot 2024-12-04 at 10 29 37 AM" src="https://github.com/user-attachments/assets/f581804f-3495-4d3f-a31a-cbe1a9992b77">

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fixed the tests 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
