### PR TITLE
[RHOAIENG-15773] Fix MR permissions management error (give dashboard ServiceAccount permission to get endpoints)

### DIFF
--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -219,3 +219,9 @@ rules:
       - delete
     resources:
       - accounts
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - endpoints


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Resolves critical bug [RHOAIENG-15773](https://issues.redhat.com/browse/RHOAIENG-15773).

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Due to a change in the Model Registry operator ([PR here](https://github.com/opendatahub-io/model-registry-operator/pull/160/files#diff-ef231245a2fe05b23d3b1a452ddfacc56a03cd441b5bd2b7af46061466043eed), [issue here](https://issues.redhat.com/browse/RHOAIENG-15574)), the `registry-user-${registryname}` role that is generated for each model registry now has an additional permission: get endpoints.

The service account used by the dashboard to create rolebindings for managing model registry permissions does not have permission to get endpoints today. Because of this change, the Manage Permissions page's requests to create new rolebindings using this role are failing in the dashboard. This is due to a cluster API restriction that a user may not grant other users permissions that they don't have themselves.

We would like to discuss a longer-term solution to the constraint we've found here. It should not be possible to cause dashboard permission regressions by changing roles in another component (ideally, any user with rhoai admin permissions should have the same permissions any model registry user have). But for now, the short term fix is to add this new `get endpoints` permission to our ServiceAccount's ClusterRole.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Observe that with these manifests changed (via a devFlag on the cluster), the `odh-dashboard` ClusterRole has the changes from this PR's diff. Go to Model Registry Settings, click Manage Permissions on a registry, try to add a user, group or project, and make sure it succeeds.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, end to end tests would be nice for this case though once we are ready for that.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
