### PR TITLE
Update typeahead select to make it auto select the only option as needed

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -64,8 +64,21 @@ class ClusterStorageModal extends Modal {
   }
 
   selectWorkbenchName(row: number, name: string) {
-    this.findWorkbenchTable().find(`[data-label=Name]`).eq(row).find('button').click();
+    this.findWorkbenchSelect(row).click();
     cy.findByRole('option', { name, hidden: true }).click();
+  }
+
+  findWorkbenchSelect(row: number) {
+    return this.findWorkbenchTable()
+      .find(`[data-label=Name]`)
+      .eq(row)
+      .findByTestId('cluster-storage-workbench-select');
+  }
+
+  findWorkbenchSelectValueField(row: number) {
+    return this.findWorkbenchSelect(row).findByRole('combobox', {
+      name: 'Type to filter',
+    });
   }
 
   selectCustomPathFormat(row: number) {

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -353,11 +353,14 @@ class CreateSpawnerPage {
     return cy.findByTestId('existing-data-connection-type-radio');
   }
 
-  selectExistingDataConnection(name: string) {
-    cy.findByTestId('data-connection-group')
-      .findByRole('button', { name: 'Typeahead menu toggle' })
-      .findSelectOption(name)
-      .click();
+  findExistingDataConnectionSelect() {
+    return cy.findByTestId('existing-data-connection-select');
+  }
+
+  findExistingDataConnectionSelectValueField() {
+    return this.findExistingDataConnectionSelect().findByRole('combobox', {
+      name: 'Type to filter',
+    });
   }
 
   findAwsNameInput() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -183,7 +183,8 @@ describe('ClusterStorage', () => {
     //connect workbench
     addClusterStorageModal.findAddWorkbenchButton().click();
     addClusterStorageModal.findWorkbenchTable().should('exist');
-    addClusterStorageModal.selectWorkbenchName(0, 'test-notebook');
+    addClusterStorageModal.findWorkbenchSelect(0).should('have.attr', 'disabled');
+    addClusterStorageModal.findWorkbenchSelectValueField(0).should('have.value', 'Test Notebook');
 
     //don't allow duplicate path
     addClusterStorageModal.findMountPathField(0).fill('test-dupe');
@@ -268,7 +269,10 @@ describe('ClusterStorage', () => {
     const clusterStorageRow = clusterStorage.getClusterStorageRow('Existing PVC');
     clusterStorageRow.findKebabAction('Edit storage').click();
     updateClusterStorageModal.findAddWorkbenchButton().click();
-    updateClusterStorageModal.selectWorkbenchName(1, 'another-notebook');
+    addClusterStorageModal.findWorkbenchSelect(1).should('have.attr', 'disabled');
+    addClusterStorageModal
+      .findWorkbenchSelectValueField(1)
+      .should('have.value', 'Another Notebook');
     updateClusterStorageModal.findMountPathField(1).fill('new-data');
 
     cy.interceptK8s('PATCH', NotebookModel, anotherNotebook).as('updateClusterStorage');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -319,7 +319,10 @@ describe('Workbench page', () => {
 
     //add existing data connection
     createSpawnerPage.findExistingDataConnectionRadio().click();
-    createSpawnerPage.selectExistingDataConnection('Test Secret');
+    createSpawnerPage.findExistingDataConnectionSelect().should('have.attr', 'disabled');
+    createSpawnerPage
+      .findExistingDataConnectionSelectValueField()
+      .should('have.value', 'Test Secret');
 
     createSpawnerPage.findSubmitButton().click();
     cy.wait('@createConfigMap').then((interception) => {

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -16,8 +16,12 @@ import {
   Button,
   MenuToggleProps,
   SelectProps,
+  FormHelperText,
+  HelperTextItem,
+  HelperText,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
+import TruncatedText from '~/components/TruncatedText';
 
 export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content' | 'isSelected'> {
   /** Content of the select option. */
@@ -74,6 +78,8 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
   isRequired?: boolean;
   /** Test id of the toggle */
   dataTestId?: string;
+  /** Flag to indicate if showing the description under the toggle */
+  previewDescription?: boolean;
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
@@ -101,6 +107,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   toggleProps,
   isRequired = true,
   dataTestId,
+  previewDescription = true,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -419,32 +426,43 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   );
 
   return (
-    <Select
-      isOpen={isOpen}
-      selected={selected}
-      onSelect={handleSelect}
-      onOpenChange={(open) => !open && closeMenu()}
-      toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
-      ref={innerRef}
-      {...props}
-    >
-      <SelectList>
-        {filteredSelections.map((option, index) => {
-          const { content, value, ...optionProps } = option;
-          return (
-            <SelectOption
-              key={value}
-              value={value}
-              isFocused={focusedItemIndex === index}
-              {...optionProps}
-            >
-              {content}
-            </SelectOption>
-          );
-        })}
-      </SelectList>
-    </Select>
+    <>
+      <Select
+        isOpen={isOpen}
+        selected={selected}
+        onSelect={handleSelect}
+        onOpenChange={(open) => !open && closeMenu()}
+        toggle={toggle}
+        shouldFocusFirstItemOnOpen={false}
+        ref={innerRef}
+        {...props}
+      >
+        <SelectList>
+          {filteredSelections.map((option, index) => {
+            const { content, value, ...optionProps } = option;
+            return (
+              <SelectOption
+                key={value}
+                value={value}
+                isFocused={focusedItemIndex === index}
+                {...optionProps}
+              >
+                {content}
+              </SelectOption>
+            );
+          })}
+        </SelectList>
+      </Select>
+      {previewDescription && isSingleOption && selected?.description ? (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              <TruncatedText maxLines={2} content={selected.description} />
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      ) : null}
+    </>
   );
 };
 

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -70,6 +70,10 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
   toggleWidth?: string;
   /** Additional props passed to the toggle. */
   toggleProps?: MenuToggleProps;
+  /** Flag to indicate if the selection is required or not */
+  isRequired?: boolean;
+  /** Test id of the toggle */
+  dataTestId?: string;
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
@@ -95,6 +99,8 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   isDisabled,
   toggleWidth,
   toggleProps,
+  isRequired = true,
+  dataTestId,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -234,6 +240,19 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     closeMenu();
   };
 
+  const notAllowEmpty = !isCreatable && isRequired;
+  // Only when the field is required, not creatable and there is one option, we auto select the first option
+  const isSingleOption = selectOptions.length === 1 && notAllowEmpty;
+  const singleOptionValue = isSingleOption ? selectOptions[0].value : null;
+  // If there is only one option, call the onChange function
+  React.useEffect(() => {
+    if (singleOptionValue && onSelect) {
+      onSelect(undefined, singleOptionValue);
+    }
+    // We don't want the callback function to be a dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [singleOptionValue]);
+
   const handleSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
@@ -363,9 +382,10 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       ref={toggleRef}
       variant="typeahead"
       aria-label="Typeahead menu toggle"
+      data-testid={dataTestId}
       onClick={onToggleClick}
       isExpanded={isOpen}
-      isDisabled={isDisabled}
+      isDisabled={isDisabled || (selectOptions.length <= 1 && notAllowEmpty)}
       isFullWidth
       style={{ width: toggleWidth }}
       {...toggleProps}

--- a/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
@@ -146,7 +146,7 @@ const ConnectionTypeForm: React.FC<Props> = ({
               setConnectionType?.(selection);
             }
           }}
-          isDisabled={isPreview || !options || options.length <= 1}
+          isDisabled={isPreview || !options}
           placeholder={
             isPreview && !connectionType?.metadata.annotations?.['openshift.io/display-name']
               ? 'Unspecified'

--- a/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
@@ -166,6 +166,7 @@ const ConnectionTypeForm: React.FC<Props> = ({
                 String(o.data).toLowerCase().includes(filterValue.toLowerCase()),
             )
           }
+          previewDescription={false}
         />
         {connectionType && (
           <ConnectionTypeDetailsHelperText connectionType={connectionType} isPreview={isPreview} />

--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisteredModelSelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/RegisteredModelSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TextInput } from '@patternfly/react-core';
-import { TypeaheadSelect, TypeaheadSelectOption } from '@patternfly/react-templates';
 import { RegisteredModel } from '~/concepts/modelRegistry/types';
+import TypeaheadSelect, { TypeaheadSelectOption } from '~/components/TypeaheadSelect';
 
 type RegisteredModelSelectorProps = {
   registeredModels: RegisteredModel[];
@@ -49,7 +49,7 @@ const RegisteredModelSelector: React.FC<RegisteredModelSelectorProps> = ({
     <TypeaheadSelect
       id="model-name"
       onClearSelection={() => setRegisteredModelId('')}
-      initialOptions={options}
+      selectOptions={options}
       placeholder="Select a registered model"
       noOptionsFoundMessage={(filter) => `No results found for "${filter}"`}
       onSelect={(_event, selection) => {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -135,7 +135,6 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
               onSelect(newConnection);
             }
           }}
-          isDisabled={projectConnections.length === 0}
           popperProps={{ appendTo: 'inline' }}
         />
         {selectedConnection && (

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -136,6 +136,7 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
             }
           }}
           popperProps={{ appendTo: 'inline' }}
+          previewDescription={false}
         />
         {selectedConnection && (
           <ConnectionDetailsHelperText

--- a/frontend/src/pages/projects/notebook/ConnectedNotebookField.tsx
+++ b/frontend/src/pages/projects/notebook/ConnectedNotebookField.tsx
@@ -89,6 +89,7 @@ const ConnectedNotebookField: React.FC<SelectNotebookFieldProps> = ({
             id: 'notebook-search-input',
           }}
           data-testid="notebook-search-select"
+          isRequired={false}
         />
       )}
       <FormHelperText>

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
@@ -82,7 +82,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
           <TypeaheadSelect
             shouldFocusToggleOnSelect
             placeholder={placeholderText}
-            isDisabled={!availableNotebooks.loaded || selectOptions.length === 0}
+            isDisabled={!availableNotebooks.loaded}
             selectOptions={selectOptions}
             selected={obj.name}
             onClearSelection={() => onNotebookSelect('')}
@@ -91,6 +91,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
                 onNotebookSelect(selectedValue);
               }
             }}
+            previewDescription={false}
           />
         ) : (
           <>

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
@@ -26,6 +26,7 @@ import { ClusterStorageNotebookSelection } from '~/pages/projects/types';
 import { MOUNT_PATH_PREFIX } from '~/pages/projects/screens/spawner/storage/const';
 import SimpleSelect from '~/components/SimpleSelect';
 import { MountPathFormat } from '~/pages/projects/screens/spawner/storage/types';
+import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { isMountPathFormat, mountPathFormat, mountPathSuffix } from './utils';
 
 type ClusterStorageTableRowProps = {
@@ -61,7 +62,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
 
   const selectOptions = availableNotebooks.notebooks.map((notebook) => ({
     value: notebook.metadata.name,
-    content: notebook.metadata.name,
+    content: getDisplayNameFromK8sResource(notebook),
   }));
 
   let placeholderText: string;
@@ -92,6 +93,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
               }
             }}
             previewDescription={false}
+            dataTestId="cluster-storage-workbench-select"
           />
         ) : (
           <>

--- a/frontend/src/pages/projects/screens/detail/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/utils.ts
@@ -106,3 +106,11 @@ export const getInUseMountPaths = (
     .filter((key) => key !== existingPvcName)
     .map((key) => allInUseMountPaths[key]);
 };
+
+export const getDefaultMountPathFromStorageName = (
+  storageName?: string,
+  newRowId?: number,
+): string =>
+  storageName
+    ? `${MOUNT_PATH_PREFIX}${storageName.toLowerCase().replace(/\s+/g, '-')}-${newRowId ?? 1}`
+    : MOUNT_PATH_PREFIX;

--- a/frontend/src/pages/projects/screens/spawner/dataConnection/ExistingDataConnectionField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/dataConnection/ExistingDataConnectionField.tsx
@@ -57,13 +57,14 @@ const ExistingDataConnectionField: React.FC<ExistingDataConnectionFieldProps> = 
     >
       <TypeaheadSelect
         id="select-connection"
+        dataTestId="existing-data-connection-select"
         selectOptions={selectOptions}
         selected={selectedDataConnection}
         onSelect={(_ev, selection) => setDataConnection(String(selection))}
         onClearSelection={() => setDataConnection()}
         placeholder={placeholderText}
         noOptionsFoundMessage={(filter) => `No data connection was found for "${filter}"`}
-        isDisabled={!loaded || connections.length === 0}
+        isDisabled={!loaded}
       />
     </FormGroup>
   );

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -92,7 +92,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
         placeholder={placeholderText}
         noOptionsFoundMessage={(filter) => `No persistent storage was found for "${filter}"`}
         popperProps={{ direction: selectDirection, appendTo: menuAppendTo }}
-        isDisabled={!loaded || storages.length === 0}
+        isDisabled={!loaded}
         data-testid="persistent-storage-typeahead"
       />
     </FormGroup>

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -34,7 +34,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
   const [defaultSc] = useDefaultStorageClass();
 
   const enabledStorageClasses = storageClasses
-    // .filter((sc) => getStorageClassConfig(sc)?.isEnabled === true)
+    .filter((sc) => getStorageClassConfig(sc)?.isEnabled === true)
     .toSorted((a, b) => {
       const aConfig = getStorageClassConfig(a);
       const bConfig = getStorageClassConfig(b);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-16038](https://issues.redhat.com/browse/RHOAIENG-16038)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add a hook in TypeaheadSelect to auto-select the only option and disable the field. This only happens when:
1. The field is required (e.g. When adding a cluster storage, the connected notebook field is not required, we cannot force to select the only workbench)
2. The field is not creatable

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verify all the components that use `TypeaheadSelect` is working as expected.
- If it's creatable, it should not be changed by this PR
- If it's not required, it should not be changed by this PR
- Otherwise, if there is only one option in the select menu list, it should be disabled and auto-select the only option

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Update the cypress test in workbench

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
