### PR TITLE
fix: add capability to update existing secret

### DIFF
--- a/backend/src/routes/api/integrations/nim/index.ts
+++ b/backend/src/routes/api/integrations/nim/index.ts
@@ -5,13 +5,12 @@ import { isString } from 'lodash';
 import { createNIMAccount, createNIMSecret, getNIMAccount, isAppEnabled } from './nimUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  const { namespace } = fastify.kube;
   const PAGE_NOT_FOUND_MESSAGE = '404 page not found';
 
   fastify.get(
     '/',
     secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
-      await getNIMAccount(fastify, namespace)
+      await getNIMAccount(fastify)
         .then((response) => {
           if (response) {
             // Installed
@@ -62,9 +61,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       ) => {
         const enableValues = request.body;
         try {
-          const { createdNew } = await createNIMSecret(fastify, namespace, enableValues);
+          const { createdNew } = await createNIMSecret(fastify, enableValues);
           if (createdNew) {
-            const response = await createNIMAccount(fastify, namespace);
+            const response = await createNIMAccount(fastify);
             const isEnabled = isAppEnabled(response);
             reply.send({
               isInstalled: true,
@@ -74,7 +73,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
             });
           } else {
             // Secret was updated, so we skip creating the NIM account but still need to get the status.
-            const account = await getNIMAccount(fastify, namespace);
+            const account = await getNIMAccount(fastify);
             if (account) {
               const isEnabled = isAppEnabled(account);
               reply.send({

--- a/backend/src/routes/api/integrations/nim/index.ts
+++ b/backend/src/routes/api/integrations/nim/index.ts
@@ -85,27 +85,14 @@ module.exports = async (fastify: KubeFastifyInstance) => {
               });
             }
           } catch (accountError: any) {
-            const message =
-              accountError.response?.statusCode === 409
-                ? 'NIM account already exists.'
-                : `Failed to create or retrieve NIM account: ${accountError.response?.body?.message}`;
+            const message = `Failed to create or retrieve NIM account: ${accountError.response?.body?.message}`;
             fastify.log.error(message);
             reply.status(accountError.response?.statusCode || 500).send(new Error(message));
           }
         } catch (secretError: any) {
-          if (secretError.response?.statusCode === 409) {
-            fastify.log.error(`NIM secret already exists, skipping creation.`);
-            reply.status(409).send(new Error(`NIM secret already exists, skipping creation.`));
-          } else {
-            fastify.log.error(
-              `Failed to create NIM secret. ${secretError.response?.body?.message}`,
-            );
-            reply
-              .status(secretError.response?.statusCode || 500)
-              .send(
-                new Error(`Failed to create NIM secret, ${secretError.response?.body?.message}`),
-              );
-          }
+          const message = `Failed to create NIM secret. ${secretError.response?.body?.message}`;
+          fastify.log.error(message);
+          reply.status(secretError.response?.statusCode || 500).send(new Error(message));
         }
       },
     ),

--- a/backend/src/routes/api/integrations/nim/nimUtils.ts
+++ b/backend/src/routes/api/integrations/nim/nimUtils.ts
@@ -15,8 +15,7 @@ export const isAppEnabled = (app: NIMAccountKind): boolean => {
 export const getNIMAccount = async (
   fastify: KubeFastifyInstance,
 ): Promise<NIMAccountKind | undefined> => {
-  const { customObjectsApi } = fastify.kube;
-  const { namespace } = fastify.kube;
+  const { customObjectsApi, namespace } = fastify.kube;
   try {
     const response = await customObjectsApi.listNamespacedCustomObject(
       'nim.opendatahub.io',
@@ -36,8 +35,7 @@ export const getNIMAccount = async (
 };
 
 export const createNIMAccount = async (fastify: KubeFastifyInstance): Promise<NIMAccountKind> => {
-  const { customObjectsApi } = fastify.kube;
-  const { namespace } = fastify.kube;
+  const { customObjectsApi, namespace } = fastify.kube;
   const account = {
     apiVersion: 'nim.opendatahub.io/v1',
     kind: 'Account',
@@ -68,8 +66,7 @@ export const createNIMSecret = async (
   fastify: KubeFastifyInstance,
   enableValues: { [key: string]: string },
 ): Promise<{ secret: SecretKind; createdNew: boolean }> => {
-  const { coreV1Api } = fastify.kube;
-  const { namespace } = fastify.kube;
+  const { coreV1Api, namespace } = fastify.kube;
   const nimSecret = {
     apiVersion: 'v1',
     kind: 'Secret',

--- a/backend/src/routes/api/integrations/nim/nimUtils.ts
+++ b/backend/src/routes/api/integrations/nim/nimUtils.ts
@@ -14,9 +14,9 @@ export const isAppEnabled = (app: NIMAccountKind): boolean => {
 
 export const getNIMAccount = async (
   fastify: KubeFastifyInstance,
-  namespace: string,
 ): Promise<NIMAccountKind | undefined> => {
   const { customObjectsApi } = fastify.kube;
+  const { namespace } = fastify.kube;
   try {
     const response = await customObjectsApi.listNamespacedCustomObject(
       'nim.opendatahub.io',
@@ -35,11 +35,9 @@ export const getNIMAccount = async (
   }
 };
 
-export const createNIMAccount = async (
-  fastify: KubeFastifyInstance,
-  namespace: string,
-): Promise<NIMAccountKind> => {
+export const createNIMAccount = async (fastify: KubeFastifyInstance): Promise<NIMAccountKind> => {
   const { customObjectsApi } = fastify.kube;
+  const { namespace } = fastify.kube;
   const account = {
     apiVersion: 'nim.opendatahub.io/v1',
     kind: 'Account',
@@ -68,10 +66,10 @@ export const createNIMAccount = async (
 
 export const createNIMSecret = async (
   fastify: KubeFastifyInstance,
-  namespace: string,
   enableValues: { [key: string]: string },
 ): Promise<{ secret: SecretKind; createdNew: boolean }> => {
   const { coreV1Api } = fastify.kube;
+  const { namespace } = fastify.kube;
   const nimSecret = {
     apiVersion: 'v1',
     kind: 'Secret',

--- a/backend/src/routes/api/integrations/nim/nimUtils.ts
+++ b/backend/src/routes/api/integrations/nim/nimUtils.ts
@@ -65,7 +65,7 @@ export const createNIMAccount = async (fastify: KubeFastifyInstance): Promise<NI
 export const createNIMSecret = async (
   fastify: KubeFastifyInstance,
   enableValues: { [key: string]: string },
-): Promise<{ secret: SecretKind; createdNew: boolean }> => {
+): Promise<{ secret: SecretKind }> => {
   const { coreV1Api, namespace } = fastify.kube;
   const nimSecret = {
     apiVersion: 'v1',
@@ -84,7 +84,7 @@ export const createNIMSecret = async (
   try {
     // Try to create the secret
     const response = await coreV1Api.createNamespacedSecret(namespace, nimSecret);
-    return { secret: response.body as SecretKind, createdNew: true };
+    return { secret: response.body as SecretKind };
   } catch (e: any) {
     if (e.response?.statusCode === 409) {
       // Secret already exists, so update it (replace)
@@ -93,7 +93,7 @@ export const createNIMSecret = async (
         namespace,
         nimSecret,
       );
-      return { secret: updateResponse.body as SecretKind, createdNew: false };
+      return { secret: updateResponse.body as SecretKind };
     } else {
       throw e;
     }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-77

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added the ability to update the existing secret with the new API key.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Tested by updating the secret. 
- Tested by removing the account and trying to update the secret.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
