### PR TITLE
Use local storage to remember user's theme preference

### DIFF
--- a/frontend/src/app/ThemeContext.tsx
+++ b/frontend/src/app/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useBrowserStorage } from '~/components/browserStorage';
 
 type ThemeContextProps = {
   theme: string;
@@ -14,7 +15,7 @@ type ThemeProviderProps = {
   children: React.ReactNode;
 };
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
-  const [theme, setTheme] = React.useState('light');
+  const [theme, setTheme] = useBrowserStorage<string>('odh.dashboard.ui.theme', 'light');
 
   const contextValue = React.useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
 


### PR DESCRIPTION
Closes [RHOAIENG-16682](https://issues.redhat.com/browse/RHOAIENG-16682)

## Description
Use local storage to remember users' theme preference

## How Has This Been Tested?
Set the theme to dark
Refresh the UI
Verify the theme remains dark

## Test Impact
Uses simple utility no additional tests necessary

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
