### PR TITLE
feat(15898): create MR secure db feature flag, skeleton for form elements

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -40,7 +40,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableHardwareProfiles: boolean;
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
-      disableModelRegistrySecureDBEA: boolean;
+      disableModelRegistrySecureDB: boolean;
       disableServingRuntimeParams: boolean;
       disableConnectionTypes: boolean;
       disableStorageClasses: boolean;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -40,6 +40,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableHardwareProfiles: boolean;
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
+      disableModelRegistrySecureDB: boolean;
       disableServingRuntimeParams: boolean;
       disableConnectionTypes: boolean;
       disableStorageClasses: boolean;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -40,7 +40,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableHardwareProfiles: boolean;
       disableDistributedWorkloads: boolean;
       disableModelRegistry: boolean;
-      disableModelRegistrySecureDB: boolean;
+      disableModelRegistrySecureDBEA: boolean;
       disableServingRuntimeParams: boolean;
       disableConnectionTypes: boolean;
       disableStorageClasses: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -65,6 +65,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableHardwareProfiles: true,
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
+      disableModelRegistrySecureDB: true,
       disableServingRuntimeParams: false,
       disableConnectionTypes: false,
       disableStorageClasses: false,

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -65,7 +65,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableHardwareProfiles: true,
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
-      disableModelRegistrySecureDB: true,
+      disableModelRegistrySecureDBEA: true,
       disableServingRuntimeParams: false,
       disableConnectionTypes: false,
       disableStorageClasses: false,

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -65,7 +65,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableHardwareProfiles: true,
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
-      disableModelRegistrySecureDBEA: true,
+      disableModelRegistrySecureDB: true,
       disableServingRuntimeParams: false,
       disableConnectionTypes: false,
       disableStorageClasses: false,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -36,6 +36,7 @@ The following are a list of features that are supported, along with there defaul
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
+| disableModelRegistrySecureDB | true    | Disables Model Registry Secure DB from the dashboard.                                                |
 | disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
 | disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
 | disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -36,7 +36,7 @@ The following are a list of features that are supported, along with there defaul
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
-| disableModelRegistrySecureDBEA | true    | Disables Model Registry Secure DB from the dashboard.                                                |
+| disableModelRegistrySecureDB | true    | Disables Model Registry Secure DB from the dashboard.                                                |
 | disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
 | disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
 | disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -36,7 +36,7 @@ The following are a list of features that are supported, along with there defaul
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
-| disableModelRegistrySecureDB | true    | Disables Model Registry Secure DB from the dashboard.                                                |
+| disableModelRegistrySecureDBEA | true    | Disables Model Registry Secure DB from the dashboard.                                                |
 | disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
 | disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
 | disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -26,6 +26,7 @@ export type MockDashboardConfigType = {
   disableTrustyBiasMetrics?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
+  disableModelRegistrySecureDB?: boolean;
   disableServingRuntimeParams?: boolean;
   disableConnectionTypes?: boolean;
   disableStorageClasses?: boolean;
@@ -59,6 +60,7 @@ export const mockDashboardConfig = ({
   disableTrustyBiasMetrics = false,
   disableDistributedWorkloads = false,
   disableModelRegistry = false,
+  disableModelRegistrySecureDB = true,
   disableServingRuntimeParams = false,
   disableConnectionTypes = true,
   disableStorageClasses = false,
@@ -169,6 +171,7 @@ export const mockDashboardConfig = ({
       disableHardwareProfiles,
       disableDistributedWorkloads,
       disableModelRegistry,
+      disableModelRegistrySecureDB,
       disableServingRuntimeParams,
       disableConnectionTypes,
       disableStorageClasses,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -26,7 +26,7 @@ export type MockDashboardConfigType = {
   disableTrustyBiasMetrics?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
-  disableModelRegistrySecureDB?: boolean;
+  disableModelRegistrySecureDBEA?: boolean;
   disableServingRuntimeParams?: boolean;
   disableConnectionTypes?: boolean;
   disableStorageClasses?: boolean;
@@ -60,7 +60,7 @@ export const mockDashboardConfig = ({
   disableTrustyBiasMetrics = false,
   disableDistributedWorkloads = false,
   disableModelRegistry = false,
-  disableModelRegistrySecureDB = true,
+  disableModelRegistrySecureDBEA = true,
   disableServingRuntimeParams = false,
   disableConnectionTypes = true,
   disableStorageClasses = false,
@@ -171,7 +171,7 @@ export const mockDashboardConfig = ({
       disableHardwareProfiles,
       disableDistributedWorkloads,
       disableModelRegistry,
-      disableModelRegistrySecureDB,
+      disableModelRegistrySecureDBEA,
       disableServingRuntimeParams,
       disableConnectionTypes,
       disableStorageClasses,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -26,7 +26,7 @@ export type MockDashboardConfigType = {
   disableTrustyBiasMetrics?: boolean;
   disableDistributedWorkloads?: boolean;
   disableModelRegistry?: boolean;
-  disableModelRegistrySecureDBEA?: boolean;
+  disableModelRegistrySecureDB?: boolean;
   disableServingRuntimeParams?: boolean;
   disableConnectionTypes?: boolean;
   disableStorageClasses?: boolean;
@@ -60,7 +60,7 @@ export const mockDashboardConfig = ({
   disableTrustyBiasMetrics = false,
   disableDistributedWorkloads = false,
   disableModelRegistry = false,
-  disableModelRegistrySecureDBEA = true,
+  disableModelRegistrySecureDB = true,
   disableServingRuntimeParams = false,
   disableConnectionTypes = true,
   disableStorageClasses = false,
@@ -171,7 +171,7 @@ export const mockDashboardConfig = ({
       disableHardwareProfiles,
       disableDistributedWorkloads,
       disableModelRegistry,
-      disableModelRegistrySecureDBEA,
+      disableModelRegistrySecureDB,
       disableServingRuntimeParams,
       disableConnectionTypes,
       disableStorageClasses,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -28,7 +28,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableHardwareProfiles: false,
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
-  disableModelRegistrySecureDBEA: true,
+  disableModelRegistrySecureDB: true,
   disableServingRuntimeParams: false,
   disableConnectionTypes: false,
   disableStorageClasses: false,
@@ -131,7 +131,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.MODEL_REGISTRY_SECURE_DB]: {
-    featureFlags: ['disableModelRegistrySecureDBEA'],
+    featureFlags: ['disableModelRegistrySecureDB'],
     reliantAreas: [SupportedArea.MODEL_REGISTRY],
   },
   [SupportedArea.NIM_MODEL]: {

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -28,7 +28,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableHardwareProfiles: false,
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
-  disableModelRegistrySecureDB: true,
+  disableModelRegistrySecureDBEA: true,
   disableServingRuntimeParams: false,
   disableConnectionTypes: false,
   disableStorageClasses: false,
@@ -131,7 +131,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.MODEL_REGISTRY_SECURE_DB]: {
-    featureFlags: ['disableModelRegistrySecureDB'],
+    featureFlags: ['disableModelRegistrySecureDBEA'],
     reliantAreas: [SupportedArea.MODEL_REGISTRY],
   },
   [SupportedArea.NIM_MODEL]: {

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -28,6 +28,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableHardwareProfiles: false,
   disableDistributedWorkloads: false,
   disableModelRegistry: false,
+  disableModelRegistrySecureDB: true,
   disableServingRuntimeParams: false,
   disableConnectionTypes: false,
   disableStorageClasses: false,
@@ -128,6 +129,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.SERVING_RUNTIME_PARAMS]: {
     featureFlags: ['disableServingRuntimeParams'],
     reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
+  },
+  [SupportedArea.MODEL_REGISTRY_SECURE_DB]: {
+    featureFlags: ['disableModelRegistrySecureDB'],
+    reliantAreas: [SupportedArea.MODEL_REGISTRY],
   },
   [SupportedArea.NIM_MODEL]: {
     featureFlags: ['disableNIMModelServing'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -57,17 +57,13 @@ export enum SupportedArea {
   PERFORMANCE_METRICS = 'performance-metrics',
   TRUSTY_AI = 'trusty-ai',
   NIM_MODEL = 'nim-model',
+  SERVING_RUNTIME_PARAMS = 'serving-runtime-params',
 
   /* Distributed Workloads areas */
   DISTRIBUTED_WORKLOADS = 'distributed-workloads',
 
   /* Model Registry areas */
   MODEL_REGISTRY = 'model-registry',
-
-  /* Alter parameters areas */
-  SERVING_RUNTIME_PARAMS = 'serving-runtime-params',
-
-  /* Alter secure db areas */
   MODEL_REGISTRY_SECURE_DB = 'model-registry-secure-db',
 }
 

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -66,6 +66,9 @@ export enum SupportedArea {
 
   /* Alter parameters areas */
   SERVING_RUNTIME_PARAMS = 'serving-runtime-params',
+
+  /* Alter secure db areas */
+  MODEL_REGISTRY_SECURE_DB = 'model-registry-secure-db',
 }
 
 /** Components deployed by the Operator. Part of the DSC Status. */

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1192,7 +1192,7 @@ export type DashboardCommonConfig = {
   disableHardwareProfiles: boolean;
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
-  disableModelRegistrySecureDB: boolean;
+  disableModelRegistrySecureDBEA: boolean;
   disableServingRuntimeParams: boolean;
   disableConnectionTypes: boolean;
   disableStorageClasses: boolean;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1192,7 +1192,7 @@ export type DashboardCommonConfig = {
   disableHardwareProfiles: boolean;
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
-  disableModelRegistrySecureDBEA: boolean;
+  disableModelRegistrySecureDB: boolean;
   disableServingRuntimeParams: boolean;
   disableConnectionTypes: boolean;
   disableStorageClasses: boolean;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1192,6 +1192,7 @@ export type DashboardCommonConfig = {
   disableHardwareProfiles: boolean;
   disableDistributedWorkloads: boolean;
   disableModelRegistry: boolean;
+  disableModelRegistrySecureDB: boolean;
   disableServingRuntimeParams: boolean;
   disableConnectionTypes: boolean;
   disableStorageClasses: boolean;

--- a/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
@@ -1,0 +1,260 @@
+import React, { useState } from 'react';
+import { FormGroup, Radio, Alert, MenuItem, MenuGroup } from '@patternfly/react-core';
+import SearchSelector from '~/components/searchSelector/SearchSelector';
+import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
+import { RecursivePartial } from '~/typeHelpers';
+import { PemFileUpload } from './PemFileUpload';
+
+export enum SecureDBRType {
+  CLUSTER_WIDE = 'cluster-wide',
+  OPENSHIFT = 'openshift',
+  EXISTING = 'existing',
+  NEW = 'new',
+}
+
+export interface SecureDBInfo {
+  type: SecureDBRType;
+  configMap: string;
+  key: string;
+  certificate: string;
+  nameSpace: string;
+  isValid: boolean;
+}
+
+interface CreateMRSecureDBSectionProps {
+  secureDBInfo: SecureDBInfo;
+  modelRegistryNamespace: string;
+  nameDesc: { name: string };
+  existingCertKeys: string[];
+  existingCertConfigMaps: string[];
+  existingCertSecrets: string[];
+  setSecureDBInfo: (info: SecureDBInfo) => void;
+}
+
+export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = ({
+  secureDBInfo,
+  modelRegistryNamespace,
+  nameDesc,
+  existingCertKeys,
+  existingCertConfigMaps,
+  existingCertSecrets,
+  setSecureDBInfo,
+}) => {
+  const [searchValue, setSearchValue] = useState('');
+
+  const hasContent = (value: string): boolean => !!value.trim().length;
+
+  const isValid = (info?: RecursivePartial<SecureDBInfo>) => {
+    const fullInfo: SecureDBInfo = { ...secureDBInfo, ...info };
+    if ([SecureDBRType.CLUSTER_WIDE, SecureDBRType.OPENSHIFT].includes(fullInfo.type)) {
+      return true;
+    }
+    if (fullInfo.type === SecureDBRType.EXISTING) {
+      return hasContent(fullInfo.configMap) && hasContent(fullInfo.key);
+    }
+    if (fullInfo.type === SecureDBRType.NEW) {
+      return hasContent(fullInfo.certificate);
+    }
+    return false;
+  };
+
+  const handleSecureDBTypeChange = (type: SecureDBRType) => {
+    const newInfo = {
+      type,
+      nameSpace: '',
+      key: '',
+      configMap: '',
+      certificate: '',
+    };
+    setSecureDBInfo({
+      ...newInfo,
+      isValid: isValid(newInfo),
+    });
+  };
+
+  const getFilteredExistingCAResources = () => (
+    <>
+      <MenuGroup label="ConfigMaps">
+        {existingCertConfigMaps
+          .filter((configMap) => configMap.toLowerCase().includes(searchValue.toLowerCase()))
+          .map((configMap, index) => (
+            <MenuItem
+              key={`configmap-${index}`}
+              onClick={() => {
+                setSearchValue('');
+                const newInfo = {
+                  ...secureDBInfo,
+                  configMap,
+                  key: '',
+                };
+                setSecureDBInfo({
+                  ...newInfo,
+                  isValid: isValid(newInfo),
+                });
+              }}
+            >
+              {configMap}
+            </MenuItem>
+          ))}
+      </MenuGroup>
+      <MenuGroup label="Secrets">
+        {existingCertSecrets
+          .filter((secret) => secret.toLowerCase().includes(searchValue.toLowerCase()))
+          .map((secret, index) => (
+            <MenuItem
+              key={`secret-${index}`}
+              onClick={() => {
+                setSearchValue('');
+                const newInfo = {
+                  ...secureDBInfo,
+                  configMap: secret,
+                  key: '',
+                };
+                setSecureDBInfo({
+                  ...newInfo,
+                  isValid: isValid(newInfo),
+                });
+              }}
+            >
+              {secret}
+            </MenuItem>
+          ))}
+      </MenuGroup>
+    </>
+  );
+
+  return (
+    <>
+      <Radio
+        isChecked={secureDBInfo.type === SecureDBRType.CLUSTER_WIDE}
+        name="cluster-wide-ca"
+        onChange={() => handleSecureDBTypeChange(SecureDBRType.CLUSTER_WIDE)}
+        label="Use cluster-wide CA bundle"
+        description={
+          <>
+            Use the <strong>ca-bundle.crt</strong> bundle in the{' '}
+            <strong>odh-trusted-ca-bundle</strong> ConfigMap.
+          </>
+        }
+        id="cluster-wide-ca"
+      />
+      <Radio
+        isChecked={secureDBInfo.type === SecureDBRType.OPENSHIFT}
+        name="openshift-ca"
+        onChange={() => handleSecureDBTypeChange(SecureDBRType.OPENSHIFT)}
+        label="Use OpenShift AI CA bundle"
+        description={
+          <>
+            Use the <strong>odh-ca-bundle.crt</strong> bundle in the{' '}
+            <strong>odh-trusted-ca-bundle</strong> ConfigMap.
+          </>
+        }
+        id="openshift-ca"
+      />
+      <Radio
+        isChecked={secureDBInfo.type === SecureDBRType.EXISTING}
+        name="existing-ca"
+        onChange={() => handleSecureDBTypeChange(SecureDBRType.EXISTING)}
+        label="Choose from existing certificates"
+        description={
+          <>
+            You can select the key of any ConfigMap or Secret in the{' '}
+            <strong>{modelRegistryNamespace}</strong> namespace.
+          </>
+        }
+        id="existing-ca"
+      />
+      {secureDBInfo.type === SecureDBRType.EXISTING && (
+        <>
+          <FormGroup
+            label="Resource"
+            isRequired
+            fieldId="existing-ca-resource"
+            style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
+          >
+            <SearchSelector
+              isFullWidth
+              dataTestId="existing-ca-resource-selector"
+              onSearchChange={(newValue) => setSearchValue(newValue)}
+              onSearchClear={() => setSearchValue('')}
+              searchValue={searchValue}
+              toggleText={secureDBInfo.configMap || 'Select a ConfigMap or a Secret'}
+            >
+              {getFilteredExistingCAResources()}
+            </SearchSelector>
+          </FormGroup>
+          <FormGroup
+            label="Key"
+            isRequired
+            fieldId="existing-ca-key"
+            style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
+          >
+            <SearchSelector
+              isFullWidth
+              dataTestId="existing-ca-key-selector"
+              onSearchChange={(newValue) => setSearchValue(newValue)}
+              onSearchClear={() => setSearchValue('')}
+              searchValue={searchValue}
+              toggleText={secureDBInfo.key || 'Select a key'}
+            >
+              {existingCertKeys
+                .filter((item) => item.toLowerCase().includes(searchValue.toLowerCase()))
+                .map((item, index) => (
+                  <MenuItem
+                    key={`key-${index}`}
+                    onClick={() => {
+                      setSearchValue('');
+                      const newInfo = {
+                        ...secureDBInfo,
+                        key: item,
+                      };
+                      setSecureDBInfo({ ...newInfo, isValid: isValid(newInfo) });
+                    }}
+                  >
+                    {item}
+                  </MenuItem>
+                ))}
+            </SearchSelector>
+          </FormGroup>
+        </>
+      )}
+      <Radio
+        isChecked={secureDBInfo.type === SecureDBRType.NEW}
+        name="new-ca"
+        onChange={() => handleSecureDBTypeChange(SecureDBRType.NEW)}
+        label="Upload new certificate"
+        id="new-ca"
+      />
+      {secureDBInfo.type === SecureDBRType.NEW && (
+        <>
+          <Alert
+            isInline
+            title="Note"
+            variant="info"
+            style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
+          >
+            Uploading a certificate below creates the{' '}
+            <strong>{translateDisplayNameForK8s(nameDesc.name)}-db-credential</strong> ConfigMap
+            with the <strong>ca.crt</strong> key. If you&apos;d like to upload the certificate as a
+            Secret instead, see the documentation for more details.
+          </Alert>
+          <FormGroup
+            label="Certificate"
+            required
+            style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
+          >
+            <PemFileUpload
+              onChange={(value) => {
+                const newInfo = {
+                  ...secureDBInfo,
+                  certificate: value,
+                };
+                setSecureDBInfo({ ...newInfo, isValid: isValid(newInfo) });
+              }}
+            />
+          </FormGroup>
+        </>
+      )}
+    </>
+  );
+};

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -79,6 +79,8 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
   const secureDbEnabled = useIsAreaAvailable(SupportedArea.MODEL_REGISTRY_SECURE_DB).status;
 
   const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace;
+
+  // the 3 following consts are temporary hard-coded values to be replaced as part of RHOAIENG-15899
   const existingCertConfigMaps = [
     'config-service-cabundle',
     'odh-trusted-ca-bundle',
@@ -384,7 +386,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
                     description={
                       <>
                         Use the <strong>ca-bundle.crt</strong> bundle in the{' '}
-                        <strong>odh-trusted-ca-bundle</strong> ConfigMap. {secureDBInfo.radio}
+                        <strong>odh-trusted-ca-bundle</strong> ConfigMap.
                       </>
                     }
                     id="cluster-wide-ca"

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -18,6 +18,7 @@ import NameDescriptionField from '~/concepts/k8s/NameDescriptionField';
 import { NameDescType } from '~/pages/projects/types';
 import FormSection from '~/components/pf-overrides/FormSection';
 import { AreaContext } from '~/concepts/areas/AreaContext';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 type CreateModalProps = {
   onClose: () => void;
@@ -44,6 +45,9 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
   const [isDatabaseTouched, setIsDatabaseTouched] = React.useState(false);
   const [showPassword, setShowPassword] = React.useState(false);
   const { dscStatus } = React.useContext(AreaContext);
+  const secureDbEnabled = true || useIsAreaAvailable(
+    SupportedArea.MODEL_REGISTRY_SECURE_DB
+  ).status;
 
   const onBeforeClose = () => {
     setIsSubmitting(false);
@@ -257,6 +261,11 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
               </HelperText>
             )}
           </FormGroup>
+          {secureDbEnabled && (
+            <>
+              SECURE DB STUFF
+            </>
+          )}
         </FormSection>
       </Form>
     </Modal>

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -421,7 +421,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
                         label="Resource"
                         isRequired
                         fieldId="existing-ca-resource"
-                        style={{ marginLeft: 'var(--pf-v6-global--spacer--lg)' }}
+                        style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
                       >
                         <SearchSelector
                           isFullWidth
@@ -438,7 +438,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
                         label="Key"
                         isRequired
                         fieldId="existing-ca-key"
-                        style={{ marginLeft: 'var(--pf-v6-global--spacer--lg)' }}
+                        style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
                       >
                         <SearchSelector
                           isFullWidth
@@ -480,7 +480,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
                         isInline
                         title="Note"
                         variant="info"
-                        style={{ marginLeft: 'var(--pf-v6-global--spacer--lg)' }}
+                        style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
                       >
                         Uploading a certificate below creates the{' '}
                         <strong>{translateDisplayNameForK8s(nameDesc.name)}-db-credential</strong>{' '}
@@ -490,7 +490,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
                       <FormGroup
                         label="Certificate"
                         required
-                        style={{ marginLeft: 'var(--pf-v6-global--spacer--lg)' }}
+                        style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
                       >
                         <PemFileUpload
                           onChange={(value) =>

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import {
+  Alert,
   Button,
   Checkbox,
+  FileUpload,
   Form,
   FormGroup,
+  FormHelperText,
   HelperText,
   HelperTextItem,
   MenuGroup,
@@ -448,6 +451,35 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
                     label="Upload new certificate"
                     id="new-ca"
                   ></Radio>
+                  {secureDBInfo.radio === SecureDBRadios.NEW && (
+                    <>
+                      <Alert isInline title="Note" variant="info" style={{ marginLeft: 'var(--pf-v5-global--spacer--lg)' }}>
+                        Uploading a certificate below creates the{' '}
+                        <strong>{translateDisplayNameForK8s(nameDesc.name)}-db-credential</strong> ConfigMap with the{' '}
+                        <strong>ca.crt</strong> key. If you'd like to upload the certificate as a
+                        Secret instead, see the documentation for more details.
+                      </Alert>
+                      <FormGroup label="Certificate" required style={{ marginLeft: 'var(--pf-v5-global--spacer--lg)' }}>
+                        <FileUpload id={''} 
+                          type='text'
+                          filenamePlaceholder='Drag and drop a file or upload one'
+                          dropzoneProps={{
+                            accept: { 'text/pem': ['.pem'] },
+                            maxSize: 1024,
+                            onDropRejected: (e) => {console.log({e})}
+                          }}
+                          browseButtonText="Upload"
+                        />
+                                <FormHelperText>
+          <HelperText>
+            <HelperTextItem variant={'default'}>
+              {'Upload a PEM file'}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+                      </FormGroup>
+                    </>
+                  )}
                 </>
               )}
             </>

--- a/frontend/src/pages/modelRegistrySettings/PemFileUpload.tsx
+++ b/frontend/src/pages/modelRegistrySettings/PemFileUpload.tsx
@@ -1,0 +1,80 @@
+import {
+  DropEvent,
+  FileUpload,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import React from 'react';
+
+export const PemFileUpload: React.FC<{onChange: (value: string) => void}> = ({onChange}) => {
+  const [value, setValue] = React.useState('');
+  const [filename, setFilename] = React.useState('');
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [isRejected, setIsRejected] = React.useState(false);
+
+  const handleFileInputChange = (_event: DropEvent, file: File) => {
+    setFilename(file.name);
+  };
+
+  const handleTextChange = (_event: React.ChangeEvent<HTMLTextAreaElement>, value: string) => {
+    setValue(value);
+  };
+
+  const handleDataChange = (_event: DropEvent, value: string) => {
+    onChange(value);
+    setValue(value);
+  };
+
+  const handleClear = (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    setFilename('');
+    setValue('');
+    setIsRejected(false);
+  };
+
+  const handleFileRejected = () => {
+    setIsRejected(true);
+  };
+
+  const handleFileReadStarted = (_event: DropEvent, _fileHandle: File) => {
+    setIsLoading(true);
+  };
+
+  const handleFileReadFinished = (_event: DropEvent, _fileHandle: File) => {
+    setIsLoading(false);
+  };
+
+  return (
+    <>
+      <FileUpload
+        id="pemFileUpload"
+        type="text"
+        value={value}
+        filename={filename}
+        filenamePlaceholder="Drag and drop a file or upload one"
+        onFileInputChange={handleFileInputChange}
+        onDataChange={handleDataChange}
+        onTextChange={handleTextChange}
+        onReadStarted={handleFileReadStarted}
+        onReadFinished={handleFileReadFinished}
+        onClearClick={handleClear}
+        isLoading={isLoading}
+        dropzoneProps={{
+          accept: { 'text/pem': ['.pem'] },
+          onDropRejected: handleFileRejected,
+        }}
+        browseButtonText="Upload"
+      />
+      <FormHelperText>
+        <HelperText isLiveRegion>
+          <HelperTextItem
+            id="restricted-file-example-helpText"
+            variant={isRejected ? 'error' : 'default'}
+          >
+            {isRejected ? 'Must be a PEM file' : 'Upload a PEM file'}
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    </>
+  );
+};

--- a/frontend/src/pages/modelRegistrySettings/PemFileUpload.tsx
+++ b/frontend/src/pages/modelRegistrySettings/PemFileUpload.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 
-export const PemFileUpload: React.FC<{onChange: (value: string) => void}> = ({onChange}) => {
+export const PemFileUpload: React.FC<{ onChange: (value: string) => void }> = ({ onChange }) => {
   const [value, setValue] = React.useState('');
   const [filename, setFilename] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
@@ -17,16 +17,16 @@ export const PemFileUpload: React.FC<{onChange: (value: string) => void}> = ({on
     setFilename(file.name);
   };
 
-  const handleTextChange = (_event: React.ChangeEvent<HTMLTextAreaElement>, value: string) => {
-    setValue(value);
+  const handleTextChange = (_event: React.ChangeEvent<HTMLTextAreaElement>, val: string) => {
+    setValue(val);
   };
 
-  const handleDataChange = (_event: DropEvent, value: string) => {
-    onChange(value);
-    setValue(value);
+  const handleDataChange = (_event: DropEvent, val: string) => {
+    onChange(val);
+    setValue(val);
   };
 
-  const handleClear = (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleClear = () => {
     setFilename('');
     setValue('');
     setIsRejected(false);
@@ -36,11 +36,11 @@ export const PemFileUpload: React.FC<{onChange: (value: string) => void}> = ({on
     setIsRejected(true);
   };
 
-  const handleFileReadStarted = (_event: DropEvent, _fileHandle: File) => {
+  const handleFileReadStarted = () => {
     setIsLoading(true);
   };
 
-  const handleFileReadFinished = (_event: DropEvent, _fileHandle: File) => {
+  const handleFileReadFinished = () => {
     setIsLoading(false);
   };
 

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -73,7 +73,7 @@ spec:
                       type: boolean
                     disableModelRegistry:
                       type: boolean
-                    disableModelRegistrySecureDBEA:
+                    disableModelRegistrySecureDB:
                       type: boolean
                     disableServingRuntimeParams:
                       type: boolean

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -73,7 +73,7 @@ spec:
                       type: boolean
                     disableModelRegistry:
                       type: boolean
-                    disableModelRegistrySecureDB:
+                    disableModelRegistrySecureDBEA:
                       type: boolean
                     disableServingRuntimeParams:
                       type: boolean

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -73,6 +73,8 @@ spec:
                       type: boolean
                     disableModelRegistry:
                       type: boolean
+                    disableModelRegistrySecureDB:
+                      type: boolean
                     disableServingRuntimeParams:
                       type: boolean
                     disableStorageClasses:

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -28,7 +28,7 @@ spec:
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: false
-    disableModelRegistrySecureDB: true
+    disableModelRegistrySecureDBEA: true
     disableServingRuntimeParams: false
     disableStorageClasses: false
     disableNIMModelServing: true

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -28,7 +28,6 @@ spec:
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: false
-    disableModelRegistrySecureDBEA: true
     disableServingRuntimeParams: false
     disableStorageClasses: false
     disableNIMModelServing: true

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -28,6 +28,7 @@ spec:
     disableModelMesh: false
     disableDistributedWorkloads: false
     disableModelRegistry: false
+    disableModelRegistrySecureDB: true
     disableServingRuntimeParams: false
     disableStorageClasses: false
     disableNIMModelServing: true


### PR DESCRIPTION
closes https://issues.redhat.com/browse/RHOAIENG-15898

## Description
implement feature flag for securedb, which when enabled will show newly implemented "Add CA certificate to secure database connection" at the bottom of the create mr modal. checking that will give 4 ways that a certificate can be added.

this looks different than the mocks as "Note" was added to the file upload alert and we've since upgraded to pf6. @yih-wang 

before checking
![image](https://github.com/user-attachments/assets/9d2837b3-56d7-4b1b-803f-a05828d01859)
after check
![image](https://github.com/user-attachments/assets/f7ad700a-e81b-41e0-8dc3-b20ec9fe1731)
clicking existing
![image](https://github.com/user-attachments/assets/7ad9c56f-95f1-49ff-bbb2-a6d85f0a0a9a)
the searchable drop menu
![image](https://github.com/user-attachments/assets/014a2e36-19a4-4ef2-a522-a77931abb976)
the file upload
![image](https://github.com/user-attachments/assets/27087eed-0d24-4f17-b3dc-c28683c8ccf4)



## How Has This Been Tested?
tested locally by triggering the new flag and checking the box at the bottom of the create mr form. check that form can be submitted if one of the first two radios are selected. if one of the last two are selected, you'll need to supply info before you can submit the form.

no real data yet, so that's about the extent of testing it.

## Test Impact
none yet, this is just skeleton stuff

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
