### PR TITLE
Fixing multiple models deploy 

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -344,7 +344,7 @@ describe('Model Serving Global', () => {
       'POST',
       InferenceServiceModel,
       mockInferenceServiceK8sResource({
-        name: 'test-name',
+        name: 'test-model',
         path: 'test-model/',
         displayName: 'Test Name',
         isModelMesh: true,
@@ -403,7 +403,7 @@ describe('Model Serving Global', () => {
         apiVersion: 'serving.kserve.io/v1beta1',
         kind: 'InferenceService',
         metadata: {
-          name: 'test-model',
+          name: 'test-name',
           namespace: 'test-project',
           labels: { 'opendatahub.io/dashboard': 'true' },
           annotations: {
@@ -468,7 +468,7 @@ describe('Model Serving Global', () => {
         apiVersion: 'serving.kserve.io/v1beta1',
         kind: 'InferenceService',
         metadata: {
-          name: 'test-model',
+          name: 'trigger-error',
           namespace: 'test-project',
           labels: { 'opendatahub.io/dashboard': 'true' },
           annotations: {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -478,7 +478,7 @@ describe('Serving Runtime List', () => {
         expect(interception.request.url).to.include('?dryRun=All');
         expect(interception.request.body).to.containSubset({
           metadata: {
-            name: 'test-model-legacy',
+            name: 'test-name',
             namespace: 'test-project',
             labels: { 'opendatahub.io/dashboard': 'true' },
             annotations: {

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -140,7 +140,7 @@ describe('assembleInferenceService', () => {
 
   it('should handle name and display name', async () => {
     const displayName = 'Llama model';
-    const resourceName = 'llama-model';
+    const resourceName = 'my-inference-service-test';
 
     const inferenceService = assembleInferenceService(
       mockInferenceServiceModalData({ name: displayName, servingRuntimeName: resourceName }),

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -140,10 +140,10 @@ describe('assembleInferenceService', () => {
 
   it('should handle name and display name', async () => {
     const displayName = 'Llama model';
-    const resourceName = 'my-inference-service-test';
+    const resourceName = 'llama-model';
 
     const inferenceService = assembleInferenceService(
-      mockInferenceServiceModalData({ name: displayName, servingRuntimeName: resourceName }),
+      mockInferenceServiceModalData({ name: displayName, k8sName: resourceName }),
     );
 
     expect(inferenceService.metadata.annotations).toBeDefined();

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -40,7 +40,7 @@ export const assembleInferenceService = (
     servingRuntimeArgs,
     servingRuntimeEnvVars,
   } = data;
-  const name = editName || servingRuntimeName;
+  const name = editName || data.k8sName;
   const { path, dataConnection, uri } = storage;
   const dataConnectionKey = secretKey || dataConnection;
 

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -104,7 +104,6 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
   const [servingRuntimeSelected, setServingRuntimeSelected] = React.useState<
     ServingRuntimeKind | undefined
   >(undefined);
-
   const {
     formData: selectedAcceleratorProfile,
     setFormData: setSelectedAcceleratorProfile,
@@ -224,8 +223,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
       false,
     );
 
-    const inferenceServiceName = translateDisplayNameForK8s(createDataInferenceService.name);
-
+    const inferenceServiceName = createDataInferenceService.k8sName;
     const submitInferenceServiceResource = getSubmitInferenceServiceResourceFn(
       createDataInferenceService,
       editInfo?.inferenceServiceEditInfo,

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelDeploymentNameSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelDeploymentNameSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FormGroup, TextInput } from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
+import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 
 type NIMModelDeploymentNameSectionProps = {
   data: CreatingInferenceServiceObject;
@@ -18,7 +19,10 @@ const NIMModelDeploymentNameSection: React.FC<NIMModelDeploymentNameSectionProps
       id="model-deployment-name-section"
       data-testid="model-deployment-name-section"
       value={data.name}
-      onChange={(e, name) => setData('name', name)}
+      onChange={(e, name) => {
+        setData('name', name);
+        setData('k8sName', translateDisplayNameForK8s(name));
+      }}
     />
   </FormGroup>
 );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closing issue 2 from https://issues.redhat.com/browse/RHOAIENG-16540

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When selecting multiple models on a multi model server it was throwing and error when trying to deploy a second model.  Found on kserve cluster.
Before 
![image](https://github.com/user-attachments/assets/a6d245d1-15ba-424c-92eb-f20544aa29f7)
After 
<img width="1387" alt="Screenshot 2024-12-10 at 2 11 07 PM" src="https://github.com/user-attachments/assets/ee19bd54-f7e9-4949-8d3c-2d3650e3a52f">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
2 Scenarios
1. Any cluster - In Data Science projects go to models, choose Multi-model serving platform. Add a model server.Deploy a model. Try to deploy a 2nd mode. Make sure that no error appears. 
2. Cluster that has NIM enabled- we need to make sure that the InferenceService gets the right name when deploying a kserve model or a NIM model.



## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fixed the failing test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
