### PR TITLE
Reduce Namespace Permissions

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -1,14 +1,6 @@
 import * as _ from 'lodash';
 import createError from 'http-errors';
-import {
-  PatchUtils,
-  V1ConfigMap,
-  V1Namespace,
-  V1NamespaceList,
-  V1Role,
-  V1RoleBinding,
-  V1RoleBindingList,
-} from '@kubernetes/client-node';
+import { V1ConfigMap, V1Role, V1RoleBinding, V1RoleBindingList } from '@kubernetes/client-node';
 import {
   AcceleratorProfileKind,
   BuildPhase,
@@ -40,7 +32,6 @@ import {
 import { getComponentFeatureFlags } from './features';
 import { blankDashboardCR } from './constants';
 import { getIsAppEnabled, getRouteForApplication, getRouteForClusterId } from './componentUtils';
-import { createCustomError } from './requestUtils';
 import { getDetectedAccelerators } from '../routes/api/accelerators/acceleratorUtils';
 import { FastifyRequest } from 'fastify';
 import { fetchClusterStatus } from './dsc';
@@ -907,124 +898,6 @@ export const cleanupGPU = async (fastify: KubeFastifyInstance): Promise<void> =>
 
     await createSuccessfulMigrationConfigMap(fastify, CONFIG_MAP_NAME, DESCRIPTION);
   }
-};
-/**
- * @deprecated - Look to remove asap (see comments below)
- * Converts namespaces that have a display-name annotation suffixed with `[DSP]` over to using a label.
- * This is migration code from 1.19 to 1.20+. When customers are no longer on 1.19, we should remove
- * this code.
- */
-export const cleanupDSPSuffix = async (fastify: KubeFastifyInstance): Promise<void> => {
-  const CONFIG_MAP_NAME = 'dsg-prune-flag';
-
-  const continueProcessing = await fastify.kube.coreV1Api
-    .readNamespacedConfigMap(CONFIG_MAP_NAME, fastify.kube.namespace)
-    .then(() => {
-      // Found configmap, we're note continuing
-      return false;
-    })
-    .catch((e) => {
-      if (e.statusCode === 404) {
-        // No config saying we have already pruned settings
-        return true;
-      }
-      throw e;
-    });
-
-  if (continueProcessing) {
-    const configMap: V1ConfigMap = {
-      metadata: {
-        name: CONFIG_MAP_NAME,
-        namespace: fastify.kube.namespace,
-      },
-      data: {
-        startedPrune: 'true',
-      },
-    };
-    await fastify.kube.coreV1Api
-      .createNamespacedConfigMap(fastify.kube.namespace, configMap)
-      .then(() => fastify.log.info('Successfully created prune setting'))
-      .catch((e) => {
-        throw createCustomError(
-          'Unable to create DSG prune setting configmap',
-          e.response?.body?.message || e.message,
-        );
-      });
-  } else {
-    // Already processed, exit early and save the processing
-    return;
-  }
-
-  let namespaces: V1Namespace[] = [];
-
-  let continueValue: string | undefined = undefined;
-  do {
-    const listNamespaces: V1NamespaceList = await fastify.kube.coreV1Api
-      .listNamespace(undefined, undefined, continueValue, undefined, undefined, 100)
-      .then((response) => response.body);
-
-    const {
-      metadata: { _continue: continueProp },
-      items,
-    } = listNamespaces;
-
-    namespaces = namespaces.concat(items);
-    continueValue = continueProp;
-  } while (continueValue);
-
-  const SUFFIX = '[DSP]';
-
-  const toChangeNamespaces = namespaces.filter(
-    (namespace) =>
-      // Don't touch any openshift or kube namespaces
-      !(
-        namespace.metadata.name.startsWith('openshift') ||
-        namespace.metadata.name.startsWith('kube')
-      ) &&
-      // Just get the namespaces who are suffixed so we can convert them
-      namespace.metadata.annotations?.['openshift.io/display-name']?.endsWith(SUFFIX),
-  );
-
-  if (toChangeNamespaces.length === 0) {
-    return;
-  }
-
-  fastify.log.info(`Updating ${toChangeNamespaces.length} Namespace(s) over to DSG with labels.`);
-
-  const data = (namespace: V1Namespace) => {
-    const displayName = namespace.metadata.annotations['openshift.io/display-name'];
-
-    return {
-      metadata: {
-        annotations: {
-          'openshift.io/display-name': displayName.slice(0, displayName.length - SUFFIX.length),
-        },
-        labels: {
-          'opendatahub.io/dashboard': 'true',
-        },
-      },
-    };
-  };
-
-  const calls = toChangeNamespaces.map((namespace) =>
-    fastify.kube.coreV1Api
-      .patchNamespace(
-        namespace.metadata.name,
-        data(namespace),
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
-        },
-      )
-      .then(() => fastify.log.info(`Converted ${namespace.metadata.name} over to using labels.`)),
-  );
-
-  Promise.all(calls).then(() => {
-    fastify.log.info('Completed updating Namespaces');
-  });
 };
 
 /**

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -127,13 +127,7 @@ rules:
   - apiGroups:
       - ''
     verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
       - patch
-      - delete
     resources:
       - namespaces
   - apiGroups:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16822

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Reduces permissions for the SA around Namespaces. Removed deprecated/unused code to assist with the permissions reduction.

We only PATCH namespaces for model serving today.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a cluster, should be fine to just deploy it with the DSC DevFlag as the code that is removed was never called.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
