### PR TITLE
Increase timeout for disabling recurring run in Cypress test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
@@ -951,7 +951,7 @@ describe('Pipeline runs', () => {
           .getRowByName(mockRecurringRuns[0].display_name)
           .findStatusSwitchByRowName()
           .click();
-        cy.wait('@disableRecurringRun');
+        cy.wait('@disableRecurringRun', { timeout: 10000 });
       });
 
       it('schedules toggle should be disabled for the schedules with archived experiment', () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16871

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
a flaky test has been occurring in pipeline recurring runs table
```
Pipeline runs - Schedules - with data - can disable a recurring run: timed out waiting `5000ms` for the 1st request to the route: `disableRecurringRun`. No request ever occurred.
```
There is nothing wrong with the test but on occasion it will timeout waiting for the post call. I have increased that timeout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests pass

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updates test timeout

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
