### PR TITLE
Node resource table and modals

### DIFF
--- a/frontend/src/__mocks__/mockHardwareProfile.ts
+++ b/frontend/src/__mocks__/mockHardwareProfile.ts
@@ -29,9 +29,9 @@ export const mockHardwareProfile = ({
     {
       displayName: 'Memory',
       identifier: 'memory',
-      minCount: 5,
-      maxCount: 2,
-      defaultCount: 2,
+      minCount: '5Gi',
+      maxCount: '2Gi',
+      defaultCount: '2Gi',
     },
   ],
   description = '',

--- a/frontend/src/api/k8s/__tests__/hardwareProfiles.spec.ts
+++ b/frontend/src/api/k8s/__tests__/hardwareProfiles.spec.ts
@@ -40,9 +40,9 @@ const data: HardwareProfileKind['spec'] = {
     {
       displayName: 'Memory',
       identifier: 'memory',
-      minCount: 5,
-      maxCount: 2,
-      defaultCount: 2,
+      minCount: '5Gi',
+      maxCount: '2Gi',
+      defaultCount: '2Gi',
     },
   ],
   description: 'test description',

--- a/frontend/src/pages/hardwareProfiles/ManageNodeResourceSection.tsx
+++ b/frontend/src/pages/hardwareProfiles/ManageNodeResourceSection.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  FormSection,
+  Flex,
+  FlexItem,
+  Button,
+  Content,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Identifier } from '~/types';
+import NodeResourceTable from './nodeResource/NodeResourceTable';
+import ManageNodeResourceModal from './nodeResource/ManageNodeResourceModal';
+
+type ManageNodeResourceSectionProps = {
+  nodeResources: Identifier[];
+  setNodeResources: (identifiers: Identifier[]) => void;
+};
+
+const ManageNodeResourceSection: React.FC<ManageNodeResourceSectionProps> = ({
+  nodeResources,
+  setNodeResources,
+}) => {
+  const [isNodeResourceModalOpen, setIsNodeResourceModalOpen] = React.useState<boolean>(false);
+  return (
+    <>
+      <FormSection
+        title={
+          <Flex>
+            <FlexItem>Node resources</FlexItem>
+            <FlexItem>
+              <Button
+                variant="secondary"
+                onClick={() => setIsNodeResourceModalOpen(true)}
+                data-testid="add-node-resource-button"
+              >
+                Add resource
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Content component="p" className="odh-form-section__desc">
+                Every hardware profile must include CPU and memory resources. Additional resources,
+                such as GPUs, can be added here.
+              </Content>
+            </FlexItem>
+          </Flex>
+        }
+      >
+        <Stack hasGutter>
+          <StackItem>
+            <NodeResourceTable
+              nodeResources={nodeResources}
+              onUpdate={(newIdentifiers) => setNodeResources(newIdentifiers)}
+            />
+          </StackItem>
+        </Stack>
+      </FormSection>
+      {isNodeResourceModalOpen ? (
+        <ManageNodeResourceModal
+          onClose={() => setIsNodeResourceModalOpen(false)}
+          onSave={(identifier) => setNodeResources([...nodeResources, identifier])}
+          nodeResources={nodeResources}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default ManageNodeResourceSection;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/CountFormField.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/CountFormField.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
+import MemoryField from '~/components/MemoryField';
+import CPUField from '~/components/CPUField';
+import NumberInputWrapper from '~/components/NumberInputWrapper';
+
+type CountFormFieldProps = {
+  label: string;
+  fieldId: string;
+  size: number | string;
+  setSize: (value: number | string) => void;
+  identifier: string;
+  errorMessage?: string;
+  isValid?: boolean;
+};
+
+const CountFormField: React.FC<CountFormFieldProps> = ({
+  label,
+  fieldId,
+  size,
+  setSize,
+  identifier,
+  errorMessage,
+  isValid = true,
+}) => {
+  const renderInputField = () => {
+    switch (identifier) {
+      case 'cpu':
+        return <CPUField onChange={(value) => setSize(value)} value={size} />;
+      case 'memory':
+        return <MemoryField onChange={(value) => setSize(value)} value={String(size)} />;
+      default:
+        return (
+          <NumberInputWrapper
+            min={0}
+            value={Number(size)}
+            onChange={(value) => {
+              if (value) {
+                setSize(value);
+              }
+            }}
+          />
+        );
+    }
+  };
+
+  return (
+    <FormGroup label={label} fieldId={fieldId} data-testid={fieldId}>
+      {renderInputField()}
+      {!isValid && errorMessage && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem data-testid={`${fieldId}-error`} variant="error">
+              {errorMessage}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+    </FormGroup>
+  );
+};
+
+export default CountFormField;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/ManageNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/ManageNodeResourceModal.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Modal } from '@patternfly/react-core/deprecated';
+import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
+import { Identifier } from '~/types';
+import useGenericObjectState from '~/utilities/useGenericObjectState';
+import { CPU_UNITS, MEMORY_UNITS_FOR_SELECTION, UnitOption } from '~/utilities/valueUnits';
+import { EMPTY_IDENTIFIER } from './const';
+import NodeResourceForm from './NodeResourceForm';
+import { validateDefaultCount, validateMinCount } from './utils';
+
+type ManageNodeResourceModalProps = {
+  onClose: () => void;
+  existingIdentifier?: Identifier;
+  onSave: (identifier: Identifier) => void;
+  nodeResources: Identifier[];
+};
+
+const ManageNodeResourceModal: React.FC<ManageNodeResourceModalProps> = ({
+  onClose,
+  existingIdentifier,
+  onSave,
+  nodeResources,
+}) => {
+  const [identifier, setIdentifier] = useGenericObjectState<Identifier>(
+    existingIdentifier || EMPTY_IDENTIFIER,
+  );
+
+  const [unitOptions, setUnitOptions] = React.useState<UnitOption[]>();
+
+  const isUniqueIdentifier =
+    identifier.identifier === existingIdentifier?.identifier ||
+    !nodeResources.some((i) => i.identifier === identifier.identifier);
+
+  React.useEffect(() => {
+    switch (identifier.identifier) {
+      case 'cpu':
+        setUnitOptions(CPU_UNITS);
+        break;
+      case 'memory':
+        setUnitOptions(MEMORY_UNITS_FOR_SELECTION);
+        break;
+      default:
+        setUnitOptions(undefined);
+    }
+  }, [identifier]);
+
+  const isValidCounts = unitOptions
+    ? validateDefaultCount(identifier, unitOptions) && validateMinCount(identifier, unitOptions)
+    : true;
+
+  const isButtonDisabled =
+    !identifier.displayName || !identifier.identifier || !isUniqueIdentifier || !isValidCounts;
+
+  const handleSubmit = () => {
+    onSave(identifier);
+    onClose();
+  };
+
+  return (
+    <Modal
+      title={existingIdentifier ? 'Edit node resource' : 'Add node resource'}
+      variant="medium"
+      isOpen
+      onClose={onClose}
+      footer={
+        <DashboardModalFooter
+          submitLabel={existingIdentifier ? 'Update' : 'Add'}
+          onSubmit={handleSubmit}
+          onCancel={onClose}
+          isSubmitDisabled={isButtonDisabled}
+        />
+      }
+    >
+      <NodeResourceForm
+        identifier={identifier}
+        setIdentifier={setIdentifier}
+        unitOptions={unitOptions}
+        isExistingIdentifier={!!existingIdentifier}
+        isUniqueIdentifier={isUniqueIdentifier}
+      />
+    </Modal>
+  );
+};
+
+export default ManageNodeResourceModal;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  TextInput,
+  FormGroup,
+  Form,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { Identifier } from '~/types';
+import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
+import { UnitOption } from '~/utilities/valueUnits';
+import { validateDefaultCount, validateMinCount } from './utils';
+import CountFormField from './CountFormField';
+
+type NodeResourceFormProps = {
+  identifier: Identifier;
+  setIdentifier: UpdateObjectAtPropAndValue<Identifier>;
+  unitOptions?: UnitOption[];
+  isExistingIdentifier?: boolean;
+  isUniqueIdentifier?: boolean;
+};
+
+const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
+  identifier,
+  setIdentifier,
+  unitOptions,
+  isExistingIdentifier,
+  isUniqueIdentifier,
+}) => {
+  const validated = isUniqueIdentifier ? 'default' : 'error';
+
+  return (
+    <Form>
+      <FormGroup isRequired label="Resource label" fieldId="resource-label">
+        <TextInput
+          value={identifier.displayName || ''}
+          onChange={(_, value) => setIdentifier('displayName', value)}
+        />
+      </FormGroup>
+
+      <FormGroup isRequired label="Resource identifier" fieldId="resource-identifier">
+        <TextInput
+          value={identifier.identifier || ''}
+          onChange={(_, value) => setIdentifier('identifier', value)}
+          isDisabled={
+            isExistingIdentifier &&
+            (identifier.identifier === 'cpu' || identifier.identifier === 'memory')
+          }
+          validated={validated}
+        />
+        {!isUniqueIdentifier && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem data-testid="resource-identifier-error" variant="error">
+                Another resource with the same identifier already exists. The resource identifier
+                must be unique.
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
+      </FormGroup>
+
+      <CountFormField
+        label="Default"
+        fieldId="default"
+        identifier={identifier.identifier}
+        size={identifier.defaultCount}
+        setSize={(value) => setIdentifier('defaultCount', value)}
+        isValid={unitOptions ? validateDefaultCount(identifier, unitOptions) : true}
+        errorMessage="Default must be equal to or between the minimum and maximum allowed limits."
+      />
+
+      <CountFormField
+        label="Minimum allowed"
+        fieldId="minimum-allowed"
+        identifier={identifier.identifier}
+        size={identifier.minCount}
+        setSize={(value) => setIdentifier('minCount', value)}
+        isValid={unitOptions ? validateMinCount(identifier, unitOptions) : true}
+        errorMessage="Minimum allowed value cannot exceed the maximum allowed value."
+      />
+
+      <CountFormField
+        label="Maximum allowed"
+        fieldId="maximum-allowed"
+        identifier={identifier.identifier}
+        size={identifier.maxCount}
+        setSize={(value) => setIdentifier('maxCount', value)}
+      />
+    </Form>
+  );
+};
+export default NodeResourceForm;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTableRow.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Td, Tr } from '@patternfly/react-table';
+import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import { MinusCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
+import { Identifier } from '~/types';
+
+type NodeResourceTableRowProps = {
+  identifier: Identifier;
+  onDelete: (identifier: Identifier) => void;
+  onEdit: (identifier: Identifier) => void;
+  showActions: boolean;
+};
+
+const NodeResourceTableRow: React.FC<NodeResourceTableRowProps> = ({
+  identifier,
+  onEdit,
+  onDelete,
+  showActions,
+}) => (
+  <Tr>
+    <Td dataLabel="Resource label">{identifier.displayName}</Td>
+    <Td dataLabel="Resource identifier">{identifier.identifier}</Td>
+    <Td dataLabel="Default">{identifier.defaultCount}</Td>
+    <Td dataLabel="Minimum allowed">{identifier.minCount}</Td>
+    <Td dataLabel="Maximum allowed">{identifier.maxCount}</Td>
+    {showActions && (
+      <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
+        <ActionList isIconList>
+          <ActionListItem>
+            <Button
+              icon={<PencilAltIcon />}
+              data-testid="edit-node-resource-button"
+              aria-label="Edit node resource"
+              variant="plain"
+              onClick={() => onEdit(identifier)}
+            />
+          </ActionListItem>
+          <ActionListItem>
+            <Button
+              icon={<MinusCircleIcon />}
+              data-testid="remove-node-resource-button"
+              aria-label="Remove node resource"
+              variant="plain"
+              isDisabled={identifier.identifier === 'cpu' || identifier.identifier === 'memory'}
+              onClick={() => onDelete(identifier)}
+            />
+          </ActionListItem>
+        </ActionList>
+      </Td>
+    )}
+  </Tr>
+);
+
+export default NodeResourceTableRow;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/__tests__/utils.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/__tests__/utils.spec.ts
@@ -1,0 +1,65 @@
+import { Identifier } from '~/types';
+import {
+  validateDefaultCount,
+  validateMinCount,
+} from '~/pages/hardwareProfiles/nodeResource/utils';
+import { MEMORY_UNITS_FOR_SELECTION } from '~/utilities/valueUnits';
+
+const identifier: Identifier = {
+  displayName: 'test',
+  identifier: 'test',
+  defaultCount: '2Gi',
+  minCount: '1Gi',
+  maxCount: '4Gi',
+};
+
+describe('validateDefaultCount', () => {
+  it('should return true if defaultCount is between minCount and maxCount', () => {
+    const result = validateDefaultCount(identifier, MEMORY_UNITS_FOR_SELECTION);
+    expect(result).toBe(true);
+  });
+
+  it('should return false if defaultCount is less than minCount', () => {
+    const result = validateDefaultCount(
+      {
+        ...identifier,
+        defaultCount: '512Mi',
+      },
+      MEMORY_UNITS_FOR_SELECTION,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if defaultCount is greater than maxCount', () => {
+    const result = validateDefaultCount(
+      {
+        ...identifier,
+        defaultCount: '8Gi',
+      },
+      MEMORY_UNITS_FOR_SELECTION,
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('validateMinCount', () => {
+  it('should return true if minCount is less than maxCount', () => {
+    const result = validateMinCount(identifier, MEMORY_UNITS_FOR_SELECTION);
+    expect(result).toBe(true);
+  });
+
+  it('should return false if minCount is greater than maxCount', () => {
+    const result = validateMinCount(
+      {
+        ...identifier,
+        minCount: '8Gi',
+        maxCount: '4Gi',
+      },
+      MEMORY_UNITS_FOR_SELECTION,
+    );
+
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
@@ -1,0 +1,43 @@
+import { SortableData } from '~/components/table';
+import { Identifier } from '~/types';
+
+export const nodeResourceColumns: SortableData<Identifier>[] = [
+  {
+    field: 'resourceLabel',
+    label: 'Resource label',
+    sortable: false,
+  },
+  {
+    field: 'identifier',
+    label: 'Resource identifier',
+    sortable: false,
+  },
+  {
+    field: 'defaultCount',
+    label: 'Default',
+    sortable: false,
+  },
+  {
+    field: 'minCount',
+    label: 'Minimum allowed',
+    sortable: false,
+  },
+  {
+    field: 'minCount',
+    label: 'Maximum allowed',
+    sortable: false,
+  },
+  {
+    field: 'kebab',
+    label: '',
+    sortable: false,
+  },
+];
+
+export const EMPTY_IDENTIFIER: Identifier = {
+  displayName: '',
+  identifier: '',
+  minCount: 1,
+  maxCount: 1,
+  defaultCount: 1,
+};

--- a/frontend/src/pages/hardwareProfiles/nodeResource/utils.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/utils.ts
@@ -1,0 +1,9 @@
+import { Identifier } from '~/types';
+import { isLarger, UnitOption } from '~/utilities/valueUnits';
+
+export const validateDefaultCount = (identifier: Identifier, unitOption: UnitOption[]): boolean =>
+  isLarger(String(identifier.defaultCount), String(identifier.minCount), unitOption, true) &&
+  isLarger(String(identifier.maxCount), String(identifier.defaultCount), unitOption, true);
+
+export const validateMinCount = (identifier: Identifier, unitOption: UnitOption[]): boolean =>
+  isLarger(String(identifier.maxCount), String(identifier.minCount), unitOption, true);


### PR DESCRIPTION
[RHOAIENG-16256](https://issues.redhat.com/browse/RHOAIENG-16256)

## Description
Added table and modal for Node resource for Hardware profile

![image](https://github.com/user-attachments/assets/0a6318b5-cf4d-4511-b57a-a9478a61eef7)
![Screenshot 2024-12-24 at 2 20 50 PM](https://github.com/user-attachments/assets/178dc45c-edd8-4ea3-8e8c-44a2d7fdd9db)
![Screenshot 2024-12-24 at 2 26 36 PM](https://github.com/user-attachments/assets/78b95ede-1d0f-4482-88f2-b7b8a14005eb)
![Screenshot 2024-12-24 at 2 26 46 PM](https://github.com/user-attachments/assets/4b9b6815-9091-4fb5-9046-1d1c7d0e675c)
![Screenshot 2024-12-24 at 2 27 18 PM](https://github.com/user-attachments/assets/b1e6d3e7-8ece-47a8-abfb-850aa8999113)



## How Has This Been Tested?
Currently this table and modal are standalone components and are not used anywhere, to tests you can import `<ManageNodeResourceSection />` to any form page, like i have tested this in `ManageAcceleratorProfile` 

## Test Impact
Add unit tests for validation utility functions

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@vconzola 