### PR TITLE
fix(test): add wait in deploy model test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -11,7 +11,7 @@ class ModelVersionDeployModal extends Modal {
 
   selectProjectByName(name: string) {
     this.findProjectSelector().click();
-    this.find().findByRole('option', { name }).click();
+    this.find().findByRole('option', { name, timeout: 5000 }).click();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -135,7 +135,7 @@ const initIntercepts = ({
       }),
       mockProjectK8sResource({ k8sName: 'test-project', displayName: 'Test project' }),
     ]),
-  );
+  ).as('getProjects');
 
   cy.interceptOdh(
     `GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts`,
@@ -185,8 +185,10 @@ describe('Deploy model version', () => {
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
     modelVersionRow.findKebabAction('Deploy').click();
+    cy.wait('@getProjects');
     modelVersionDeployModal.selectProjectByName('Model mesh project');
     cy.findByText('Multi-model platform is not installed').should('exist');
+    cy.wait('@getProjects');
     modelVersionDeployModal.selectProjectByName('KServe project');
     cy.findByText('Single-model platform is not installed').should('exist');
   });


### PR DESCRIPTION
fixes issue with a flakey deploy model test

## Description
When switching projects in the deploy version modal of the UI, I notice there are new network calls and some changes on the UI. This may have caused the test to fail if the option to select didn't exist yet.

I added a `wait` on the network call for getting projects before attempting to select.

I also changed increased the `timeout` of finding the project name to select to 5 seconds.

## How Has This Been Tested?
ran tests locally several times, passed

## Test Impact
hopefully won't intermittently fail anymore

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
