### PR TITLE
fix(secureDb): undo debugging boolean flip

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -282,7 +282,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh }) => {
               </HelperText>
             )}
           </FormGroup>
-          {!secureDbEnabled && (
+          {secureDbEnabled && (
             <>
               <FormGroup>
                 <Checkbox


### PR DESCRIPTION

## Description
accidentally left a boolean flipped after debugging, undoing that.

## How Has This Been Tested?
secureDB section in create MR modal should not exist without the feature flag.

## Test Impact
none

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
