### PR TITLE
Add external routes to AppRoutes component

### DIFF
--- a/docs/external-redirects.md
+++ b/docs/external-redirects.md
@@ -1,0 +1,23 @@
+# External Redirects
+
+The supported external redirect paths in the application.
+
+## Supported Redirects
+
+### Pipeline SDK Redirects
+
+Redirecting from Pipeline SDK output URLs to internal dashboard routes.
+
+#### Supported URL Patterns
+
+1. **Experiment Details**
+   ```
+   /external/pipelinesSdk/{namespace}/#/experiments/details/{experimentId}
+   ```
+   Redirects to the internal experiment runs route for the specified experiment.
+
+2. **Run Details**
+   ```
+   /external/pipelinesSdk/{namespace}/#/runs/details/{runId}
+   ```
+   Redirects to the internal pipeline run details route for the specified run.

--- a/frontend/src/__tests__/cypress/cypress/pages/externalRedirect.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/externalRedirect.ts
@@ -1,0 +1,32 @@
+class ExternalRedirect {
+  visit(path: string) {
+    cy.visitWithLogin(path);
+    this.wait();
+  }
+
+  private wait() {
+    cy.findByTestId('redirect-error').should('not.exist');
+    cy.testA11y();
+  }
+
+  findErrorState() {
+    return cy.findByTestId('redirect-error');
+  }
+
+  findHomeButton() {
+    return cy.findByRole('button', { name: 'Go to Home' });
+  }
+}
+
+class PipelinesSdkRedirect {
+  findPipelinesButton() {
+    return cy.findByRole('button', { name: 'Go to Pipelines' });
+  }
+
+  findExperimentsButton() {
+    return cy.findByRole('button', { name: 'Go to Experiments' });
+  }
+}
+
+export const externalRedirect = new ExternalRedirect();
+export const pipelinesSdkRedirect = new PipelinesSdkRedirect();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/externalRedirects.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/externalRedirects.cy.ts
@@ -1,0 +1,41 @@
+import {
+  externalRedirect,
+  pipelinesSdkRedirect,
+} from '~/__tests__/cypress/cypress/pages/externalRedirect';
+
+describe('External Redirects', () => {
+  describe('Pipeline SDK Redirects', () => {
+    it('should redirect experiment URLs correctly', () => {
+      // Test experiment URL redirect
+      externalRedirect.visit('/external/pipelinesSdk/test-namespace/#/experiments/details/123');
+      cy.url().should('include', '/experiments/test-namespace/123/runs');
+    });
+
+    it('should redirect run URLs correctly', () => {
+      // Test run URL redirect
+      externalRedirect.visit('/external/pipelinesSdk/test-namespace/#/runs/details/456');
+      cy.url().should('include', '/pipelineRuns/test-namespace/runs/456');
+    });
+
+    it('should handle invalid URL format', () => {
+      externalRedirect.visit('/external/pipelinesSdk/test-namespace/#/invalid');
+      externalRedirect.findErrorState().should('exist');
+      pipelinesSdkRedirect.findPipelinesButton().should('exist');
+      pipelinesSdkRedirect.findExperimentsButton().should('exist');
+    });
+  });
+
+  describe('External Redirect Not Found', () => {
+    it('should show not found page for invalid external routes', () => {
+      externalRedirect.visit('/external/invalid-path');
+      externalRedirect.findErrorState().should('exist');
+      externalRedirect.findHomeButton().should('exist');
+    });
+
+    it('should allow navigation back to home', () => {
+      externalRedirect.visit('/external/invalid-path');
+      externalRedirect.findHomeButton().click();
+      cy.url().should('include', '/');
+    });
+  });
+});

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -76,6 +76,8 @@ const StorageClassesPage = React.lazy(() => import('../pages/storageClasses/Stor
 
 const ModelRegistryRoutes = React.lazy(() => import('../pages/modelRegistry/ModelRegistryRoutes'));
 
+const ExternalRoutes = React.lazy(() => import('../pages/external/ExternalRoutes'));
+
 const AppRoutes: React.FC = () => {
   const { isAdmin, isAllowed } = useUser();
   const isJupyterEnabled = useCheckJupyterEnabled();
@@ -94,6 +96,7 @@ const AppRoutes: React.FC = () => {
     <React.Suspense fallback={<ApplicationsPage title="" description="" loaded={false} empty />}>
       <InvalidArgoDeploymentAlert />
       <Routes>
+        <Route path="/external/*" element={<ExternalRoutes />} />
         {isHomeAvailable ? (
           <>
             <Route path="/" element={<HomePage />} />

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -21,6 +21,7 @@ type ApplicationsPageProps = {
   loaded: boolean;
   empty: boolean;
   loadError?: Error;
+  loadErrorPage?: React.ReactNode;
   children?: React.ReactNode;
   errorMessage?: string;
   emptyMessage?: string;
@@ -41,6 +42,7 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
   loaded,
   empty,
   loadError,
+  loadErrorPage,
   children,
   errorMessage,
   emptyMessage,
@@ -77,7 +79,7 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
 
   const renderContents = () => {
     if (loadError) {
-      return (
+      return !loadErrorPage ? (
         <PageSection hasBodyWrapper={false} isFilled>
           <EmptyState
             headingLevel="h1"
@@ -89,6 +91,8 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
             <EmptyStateBody>{loadError.message}</EmptyStateBody>
           </EmptyState>
         </PageSection>
+      ) : (
+        loadErrorPage
       );
     }
 

--- a/frontend/src/pages/external/ExternalRoutes.tsx
+++ b/frontend/src/pages/external/ExternalRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import PipelinesSdkRedirect from './redirectComponents/PipelinesSdkRedirects';
+
+const ExternalRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/pipelinesSdk/:namespace/*" element={<PipelinesSdkRedirect />} />
+    <Route path="*" element={<Navigate to="/not-found" replace />} />
+  </Routes>
+);
+
+export default ExternalRoutes;

--- a/frontend/src/pages/external/ExternalRoutes.tsx
+++ b/frontend/src/pages/external/ExternalRoutes.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import PipelinesSdkRedirect from './redirectComponents/PipelinesSdkRedirects';
+import ExternalRedirectNotFound from './redirectComponents/ExternalRedirectNotFound';
 
 const ExternalRoutes: React.FC = () => (
   <Routes>
     <Route path="/pipelinesSdk/:namespace/*" element={<PipelinesSdkRedirect />} />
-    <Route path="*" element={<Navigate to="/not-found" replace />} />
+    <Route path="*" element={<ExternalRedirectNotFound />} />
   </Routes>
 );
 

--- a/frontend/src/pages/external/ExternalRoutes.tsx
+++ b/frontend/src/pages/external/ExternalRoutes.tsx
@@ -3,6 +3,9 @@ import { Route, Routes } from 'react-router-dom';
 import PipelinesSdkRedirect from './redirectComponents/PipelinesSdkRedirects';
 import ExternalRedirectNotFound from './redirectComponents/ExternalRedirectNotFound';
 
+/**
+ * Be sure to keep this file in sync with the documentation in `docs/external-redirects.md`.
+ */
 const ExternalRoutes: React.FC = () => (
   <Routes>
     <Route path="/pipelinesSdk/:namespace/*" element={<PipelinesSdkRedirect />} />

--- a/frontend/src/pages/external/RedirectErrorState.tsx
+++ b/frontend/src/pages/external/RedirectErrorState.tsx
@@ -81,7 +81,7 @@ const RedirectErrorState: React.FC<RedirectErrorStateProps> = ({
         icon={ExclamationCircleIcon}
         titleText={title ?? 'Error redirecting'}
         variant={EmptyStateVariant.lg}
-        data-id="redirect-error"
+        data-testid="redirect-error"
       >
         {errorMessage && <EmptyStateBody>{errorMessage}</EmptyStateBody>}
         {fallbackUrl && (

--- a/frontend/src/pages/external/RedirectErrorState.tsx
+++ b/frontend/src/pages/external/RedirectErrorState.tsx
@@ -1,0 +1,106 @@
+import {
+  PageSection,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
+  Button,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { EitherOrNone } from '~/typeHelpers';
+
+type RedirectErrorStateProps = {
+  title?: string;
+  errorMessage?: string;
+} & EitherOrNone<
+  {
+    fallbackUrl: string;
+    fallbackText: string;
+  },
+  {
+    actions: React.ReactNode | React.ReactNode[];
+  }
+>;
+
+/**
+ * A component that displays an error state with optional title, message and actions
+ * Used for showing redirect/navigation errors with fallback options
+ *
+ * Props for the RedirectErrorState component
+ * @property {string} [title] - Optional title text to display in the error state
+ * @property {string} [errorMessage] - Optional error message to display
+ * @property {string} [fallbackUrl] - URL to navigate to when fallback button is clicked
+ * @property {React.ReactNode | React.ReactNode[]} [actions] - Custom action buttons/elements to display
+ *
+ * Note: The component accepts either fallbackUrl OR actions prop, but not both.
+ * This is enforced by the EitherOrNone type helper.
+ *
+ * @example
+ * ```tsx
+ * // With fallback URL
+ * <RedirectErrorState
+ *   title="Error redirecting to pipelines"
+ *   errorMessage={error.message}
+ *   fallbackUrl="/pipelines"
+ * />
+ *
+ * // With custom actions
+ * <RedirectErrorState
+ *   title="Error redirecting to pipelines"
+ *   errorMessage={error.message}
+ *   actions={
+ *     <>
+ *       <Button variant="link" onClick={() => navigate('/pipelines')}>
+ *         Go to pipelines
+ *       </Button>
+ *       <Button variant="link" onClick={() => navigate('/experiments')}>
+ *         Go to experiments
+ *       </Button>
+ *     </>
+ *   }
+ * />
+ * ```
+ */
+
+const RedirectErrorState: React.FC<RedirectErrorStateProps> = ({
+  title,
+  errorMessage,
+  fallbackUrl,
+  fallbackText,
+  actions,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <PageSection hasBodyWrapper={false} isFilled>
+      <EmptyState
+        headingLevel="h1"
+        icon={ExclamationCircleIcon}
+        titleText={title ?? 'Error redirecting'}
+        variant={EmptyStateVariant.lg}
+        data-id="redirect-error"
+      >
+        {errorMessage && <EmptyStateBody>{errorMessage}</EmptyStateBody>}
+        {fallbackUrl && (
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button variant="link" onClick={() => navigate(fallbackUrl)}>
+                {fallbackText}
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        )}
+        {actions && (
+          <EmptyStateFooter>
+            <EmptyStateActions>{actions}</EmptyStateActions>
+          </EmptyStateFooter>
+        )}
+      </EmptyState>
+    </PageSection>
+  );
+};
+
+export default RedirectErrorState;

--- a/frontend/src/pages/external/RedirectErrorState.tsx
+++ b/frontend/src/pages/external/RedirectErrorState.tsx
@@ -5,25 +5,15 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   EmptyStateActions,
-  Button,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { EitherOrNone } from '~/typeHelpers';
 
 type RedirectErrorStateProps = {
   title?: string;
   errorMessage?: string;
-} & EitherOrNone<
-  {
-    fallbackUrl: string;
-    fallbackText: string;
-  },
-  {
-    actions: React.ReactNode | React.ReactNode[];
-  }
->;
+  actions?: React.ReactNode | React.ReactNode[];
+};
 
 /**
  * A component that displays an error state with optional title, message and actions
@@ -32,21 +22,11 @@ type RedirectErrorStateProps = {
  * Props for the RedirectErrorState component
  * @property {string} [title] - Optional title text to display in the error state
  * @property {string} [errorMessage] - Optional error message to display
- * @property {string} [fallbackUrl] - URL to navigate to when fallback button is clicked
  * @property {React.ReactNode | React.ReactNode[]} [actions] - Custom action buttons/elements to display
  *
- * Note: The component accepts either fallbackUrl OR actions prop, but not both.
- * This is enforced by the EitherOrNone type helper.
  *
  * @example
  * ```tsx
- * // With fallback URL
- * <RedirectErrorState
- *   title="Error redirecting to pipelines"
- *   errorMessage={error.message}
- *   fallbackUrl="/pipelines"
- * />
- *
  * // With custom actions
  * <RedirectErrorState
  *   title="Error redirecting to pipelines"
@@ -68,39 +48,24 @@ type RedirectErrorStateProps = {
 const RedirectErrorState: React.FC<RedirectErrorStateProps> = ({
   title,
   errorMessage,
-  fallbackUrl,
-  fallbackText,
   actions,
-}) => {
-  const navigate = useNavigate();
-
-  return (
-    <PageSection hasBodyWrapper={false} isFilled>
-      <EmptyState
-        headingLevel="h1"
-        icon={ExclamationCircleIcon}
-        titleText={title ?? 'Error redirecting'}
-        variant={EmptyStateVariant.lg}
-        data-testid="redirect-error"
-      >
-        {errorMessage && <EmptyStateBody>{errorMessage}</EmptyStateBody>}
-        {fallbackUrl && (
-          <EmptyStateFooter>
-            <EmptyStateActions>
-              <Button variant="link" onClick={() => navigate(fallbackUrl)}>
-                {fallbackText}
-              </Button>
-            </EmptyStateActions>
-          </EmptyStateFooter>
-        )}
-        {actions && (
-          <EmptyStateFooter>
-            <EmptyStateActions>{actions}</EmptyStateActions>
-          </EmptyStateFooter>
-        )}
-      </EmptyState>
-    </PageSection>
-  );
-};
+}) => (
+  <PageSection hasBodyWrapper={false} isFilled>
+    <EmptyState
+      headingLevel="h1"
+      icon={ExclamationCircleIcon}
+      titleText={title ?? 'Error redirecting'}
+      variant={EmptyStateVariant.lg}
+      data-testid="redirect-error"
+    >
+      {errorMessage && <EmptyStateBody>{errorMessage}</EmptyStateBody>}
+      {actions && (
+        <EmptyStateFooter>
+          <EmptyStateActions>{actions}</EmptyStateActions>
+        </EmptyStateFooter>
+      )}
+    </EmptyState>
+  </PageSection>
+);
 
 export default RedirectErrorState;

--- a/frontend/src/pages/external/redirectComponents/ExternalRedirectNotFound.tsx
+++ b/frontend/src/pages/external/redirectComponents/ExternalRedirectNotFound.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import RedirectErrorState from '~/pages/external/RedirectErrorState';
+
+const ExternalRedirectNotFound: React.FC = () => (
+  <ApplicationsPage
+    loaded
+    empty
+    emptyStatePage={
+      <RedirectErrorState
+        title="Not Found"
+        errorMessage="There is no external redirect for this URL"
+        fallbackText="Go to home"
+        fallbackUrl="/"
+      />
+    }
+  />
+);
+
+export default ExternalRedirectNotFound;

--- a/frontend/src/pages/external/redirectComponents/ExternalRedirectNotFound.tsx
+++ b/frontend/src/pages/external/redirectComponents/ExternalRedirectNotFound.tsx
@@ -1,20 +1,32 @@
+import { Button } from '@patternfly/react-core';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import RedirectErrorState from '~/pages/external/RedirectErrorState';
 
-const ExternalRedirectNotFound: React.FC = () => (
-  <ApplicationsPage
-    loaded
-    empty
-    emptyStatePage={
-      <RedirectErrorState
-        title="Page not found"
-        errorMessage="There is no external redirect for this URL."
-        fallbackText="Go to Home"
-        fallbackUrl="/"
-      />
-    }
-  />
-);
+const ExternalRedirectNotFound: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <ApplicationsPage
+      loaded
+      empty={false}
+      loadError={new Error()}
+      loadErrorPage={
+        <RedirectErrorState
+          title="Page not found"
+          errorMessage="There is no external redirect for this URL."
+          actions={
+            <>
+              <Button variant="link" onClick={() => navigate('/')}>
+                Go to Home
+              </Button>
+            </>
+          }
+        />
+      }
+    />
+  );
+};
 
 export default ExternalRedirectNotFound;

--- a/frontend/src/pages/external/redirectComponents/ExternalRedirectNotFound.tsx
+++ b/frontend/src/pages/external/redirectComponents/ExternalRedirectNotFound.tsx
@@ -8,9 +8,9 @@ const ExternalRedirectNotFound: React.FC = () => (
     empty
     emptyStatePage={
       <RedirectErrorState
-        title="Not Found"
-        errorMessage="There is no external redirect for this URL"
-        fallbackText="Go to home"
+        title="Page not found"
+        errorMessage="There is no external redirect for this URL."
+        fallbackText="Go to Home"
         fallbackUrl="/"
       />
     }

--- a/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
+++ b/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '@patternfly/react-core';
 import { experimentRunsRoute, globalPipelineRunDetailsRoute } from '~/routes';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { useRedirect } from '~/utilities/useRedirect';
+import RedirectErrorState from '~/pages/external/RedirectErrorState';
 
 /**
  * Handles redirects from Pipeline SDK URLs to internal routes.
@@ -14,6 +16,7 @@ import { useRedirect } from '~/utilities/useRedirect';
 const PipelinesSdkRedirects: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const createRedirectPath = React.useCallback(() => {
     if (!namespace) {
@@ -37,14 +40,33 @@ const PipelinesSdkRedirects: React.FC = () => {
     throw new Error('Invalid URL format');
   }, [namespace, location.hash]);
 
-  const [redirect, { loaded }] = useRedirect(createRedirectPath);
+  const [redirect, { loaded, error }] = useRedirect(createRedirectPath);
 
   React.useEffect(() => {
     redirect();
   }, [redirect]);
 
   return (
-    <ApplicationsPage title="Redirecting..." description={null} loaded={loaded} empty={false} />
+    <ApplicationsPage
+      loaded={loaded}
+      empty={!!error}
+      emptyStatePage={
+        <RedirectErrorState
+          title="Error redirecting to pipelines"
+          errorMessage={error?.message}
+          actions={
+            <>
+              <Button variant="link" onClick={() => navigate('/pipelines')}>
+                Go to pipelines
+              </Button>
+              <Button variant="link" onClick={() => navigate('/experiments')}>
+                Go to experiments
+              </Button>
+            </>
+          }
+        />
+      }
+    />
   );
 };
 

--- a/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
+++ b/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
@@ -37,7 +37,7 @@ const PipelinesSdkRedirects: React.FC = () => {
       return globalPipelineRunDetailsRoute(namespace, runId);
     }
 
-    throw new Error('Invalid URL format');
+    throw new Error('The URL format is invalid.');
   }, [namespace, location.hash]);
 
   const [redirect, { loaded, error }] = useRedirect(createRedirectPath);
@@ -57,10 +57,10 @@ const PipelinesSdkRedirects: React.FC = () => {
           actions={
             <>
               <Button variant="link" onClick={() => navigate('/pipelines')}>
-                Go to pipelines
+                Go to Pipelines
               </Button>
               <Button variant="link" onClick={() => navigate('/experiments')}>
-                Go to experiments
+                Go to Experiments
               </Button>
             </>
           }

--- a/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
+++ b/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
@@ -40,17 +40,14 @@ const PipelinesSdkRedirects: React.FC = () => {
     throw new Error('The URL format is invalid.');
   }, [namespace, location.hash]);
 
-  const [redirect, { loaded, error }] = useRedirect(createRedirectPath);
-
-  React.useEffect(() => {
-    redirect();
-  }, [redirect]);
+  const { error } = useRedirect(createRedirectPath);
 
   return (
     <ApplicationsPage
-      loaded={loaded}
-      empty={!!error}
-      emptyStatePage={
+      loaded
+      empty={false}
+      loadError={error}
+      loadErrorPage={
         <RedirectErrorState
           title="Error redirecting to pipelines"
           errorMessage={error?.message}

--- a/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
+++ b/frontend/src/pages/external/redirectComponents/PipelinesSdkRedirects.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useParams, useLocation } from 'react-router-dom';
+import { experimentRunsRoute, globalPipelineRunDetailsRoute } from '~/routes';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import { useRedirect } from '~/utilities/useRedirect';
+
+/**
+ * Handles redirects from Pipeline SDK URLs to internal routes.
+ *
+ * Matches and redirects:
+ * - Experiment URL: /external/pipelinesSdk/{namespace}/#/experiments/details/{experimentId}
+ * - Run URL: /external/pipelinesSdk/{namespace}/#/runs/details/{runId}
+ */
+const PipelinesSdkRedirects: React.FC = () => {
+  const { namespace } = useParams<{ namespace: string }>();
+  const location = useLocation();
+
+  const createRedirectPath = React.useCallback(() => {
+    if (!namespace) {
+      throw new Error('Missing namespace parameter');
+    }
+
+    // Extract experimentId from hash
+    const experimentMatch = location.hash.match(/\/experiments\/details\/([^/]+)$/);
+    if (experimentMatch) {
+      const experimentId = experimentMatch[1];
+      return experimentRunsRoute(namespace, experimentId);
+    }
+
+    // Extract runId from hash
+    const runMatch = location.hash.match(/\/runs\/details\/([^/]+)$/);
+    if (runMatch) {
+      const runId = runMatch[1];
+      return globalPipelineRunDetailsRoute(namespace, runId);
+    }
+
+    throw new Error('Invalid URL format');
+  }, [namespace, location.hash]);
+
+  const [redirect, { loaded }] = useRedirect(createRedirectPath);
+
+  React.useEffect(() => {
+    redirect();
+  }, [redirect]);
+
+  return (
+    <ApplicationsPage title="Redirecting..." description={null} loaded={loaded} empty={false} />
+  );
+};
+
+export default PipelinesSdkRedirects;

--- a/frontend/src/utilities/__tests__/useRedirect.spec.ts
+++ b/frontend/src/utilities/__tests__/useRedirect.spec.ts
@@ -67,7 +67,6 @@ describe('useRedirect', () => {
     renderResult.rerender(createRedirectPath, { onError });
 
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
-    expect(mockNavigate).toHaveBeenCalledWith('/not-found', { replace: true });
     expect(renderResult.result.current[1].loaded).toBe(true);
     expect(renderResult.result.current[1].error).toBeInstanceOf(Error);
   });
@@ -84,7 +83,6 @@ describe('useRedirect', () => {
     renderResult.rerender(createRedirectPath, { onError });
 
     expect(onError).toHaveBeenCalledWith(error);
-    expect(mockNavigate).toHaveBeenCalledWith('/not-found', { replace: true });
     expect(renderResult.result.current[1].loaded).toBe(true);
     expect(renderResult.result.current[1].error).toBe(error);
   });

--- a/frontend/src/utilities/__tests__/useRedirect.spec.ts
+++ b/frontend/src/utilities/__tests__/useRedirect.spec.ts
@@ -1,0 +1,113 @@
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import { useRedirect } from '~/utilities/useRedirect';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('useRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle successful redirect', async () => {
+    const createRedirectPath = jest.fn().mockReturnValue('/success-path');
+    const onComplete = jest.fn();
+    const renderResult = testHook(useRedirect)(createRedirectPath, { onComplete });
+
+    const [redirect, state] = renderResult.result.current;
+    expect(state.loaded).toBe(false);
+    expect(state.error).toBeUndefined();
+
+    await redirect();
+    renderResult.rerender(createRedirectPath, { onComplete });
+
+    expect(createRedirectPath).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/success-path', undefined);
+    expect(onComplete).toHaveBeenCalled();
+    expect(renderResult.result.current[1].loaded).toBe(true);
+    expect(renderResult.result.current[1].error).toBeUndefined();
+  });
+
+  it('should handle async redirect path creation', async () => {
+    const createRedirectPath = jest.fn().mockResolvedValue('/async-path');
+    const renderResult = testHook(useRedirect)(createRedirectPath);
+    const [redirect] = renderResult.result.current;
+
+    await redirect();
+    renderResult.rerender(createRedirectPath);
+
+    expect(createRedirectPath).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/async-path', undefined);
+    expect(renderResult.result.current[1].loaded).toBe(true);
+    expect(renderResult.result.current[1].error).toBeUndefined();
+  });
+
+  it('should handle redirect with navigation options', async () => {
+    const createRedirectPath = jest.fn().mockReturnValue('/path');
+    const navigateOptions = { replace: true };
+    const renderResult = testHook(useRedirect)(createRedirectPath, { navigateOptions });
+    const [redirect] = renderResult.result.current;
+
+    await redirect();
+    renderResult.rerender(createRedirectPath, { navigateOptions });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/path', navigateOptions);
+  });
+
+  it('should handle error when path is undefined', async () => {
+    const createRedirectPath = jest.fn().mockReturnValue(undefined);
+    const onError = jest.fn();
+    const renderResult = testHook(useRedirect)(createRedirectPath, { onError });
+
+    const [redirect] = renderResult.result.current;
+
+    await redirect();
+    renderResult.rerender(createRedirectPath, { onError });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockNavigate).toHaveBeenCalledWith('/not-found', { replace: true });
+    expect(renderResult.result.current[1].loaded).toBe(true);
+    expect(renderResult.result.current[1].error).toBeInstanceOf(Error);
+  });
+
+  it('should handle error in path creation', async () => {
+    const error = new Error('Failed to create path');
+    const createRedirectPath = jest.fn().mockRejectedValue(error);
+    const onError = jest.fn();
+    const renderResult = testHook(useRedirect)(createRedirectPath, { onError });
+
+    const [redirect] = renderResult.result.current;
+
+    await redirect();
+    renderResult.rerender(createRedirectPath, { onError });
+
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(mockNavigate).toHaveBeenCalledWith('/not-found', { replace: true });
+    expect(renderResult.result.current[1].loaded).toBe(true);
+    expect(renderResult.result.current[1].error).toBe(error);
+  });
+
+  it('should not redirect to not-found when notFoundOnError is false', async () => {
+    const createRedirectPath = jest.fn().mockRejectedValue(new Error());
+    const renderResult = testHook(useRedirect)(createRedirectPath);
+
+    const [redirect] = renderResult.result.current;
+
+    await redirect(false);
+    renderResult.rerender(createRedirectPath);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(renderResult.result.current[1].loaded).toBe(true);
+    expect(renderResult.result.current[1].error).toBeInstanceOf(Error);
+  });
+
+  it('should be stable', () => {
+    const createRedirectPath = jest.fn().mockReturnValue('/path');
+    const renderResult = testHook(useRedirect)(createRedirectPath);
+    renderResult.rerender(createRedirectPath);
+    expect(renderResult).hookToBeStable([true, true]);
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+});

--- a/frontend/src/utilities/useRedirect.ts
+++ b/frontend/src/utilities/useRedirect.ts
@@ -1,0 +1,59 @@
+import { NavigateOptions, useNavigate } from 'react-router-dom';
+import React from 'react';
+
+export type RedirectState = {
+  loaded: boolean;
+  error?: Error;
+};
+
+export type RedirectOptions = {
+  /** Additional options for the navigate function */
+  navigateOptions?: NavigateOptions;
+  /** Callback when redirect is complete */
+  onComplete?: () => void;
+  /** Callback when redirect fails */
+  onError?: (error: Error) => void;
+};
+
+/**
+ * Hook for managing redirects with loading states
+ * @param createRedirectPath Function that creates the redirect path, can be async for data fetching
+ * @param options Redirect options
+ * @returns Array of [redirect function, redirect state]
+ */
+export const useRedirect = (
+  createRedirectPath: () => string | Promise<string | undefined> | undefined,
+  options: RedirectOptions = {},
+): [(notFoundOnError?: boolean) => Promise<void>, RedirectState] => {
+  const { navigateOptions, onComplete, onError } = options;
+
+  const navigate = useNavigate();
+  const [state, setState] = React.useState<RedirectState>({
+    loaded: false,
+    error: undefined,
+  });
+
+  const redirect = React.useCallback(
+    async (notFoundOnError = true) => {
+      try {
+        const path = await createRedirectPath();
+        if (!path) {
+          throw new Error('No redirect path available');
+        }
+        navigate(path, navigateOptions);
+        setState({ loaded: true, error: undefined });
+        onComplete?.();
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error('Failed to redirect');
+        setState({ loaded: true, error });
+        onError?.(error);
+        if (notFoundOnError) {
+          navigate('/not-found', { replace: true });
+        }
+      }
+    },
+    [createRedirectPath, navigate, navigateOptions, onComplete, onError],
+  );
+
+  return [redirect, state];
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-8476

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR adds a system to handle external URL redirects in a centralized way, with the first implementation handling Pipeline SDK URLs.

WIP bc waiting for backend to confirm some things but could probably merge before them

## What's Added
- External routes system under `/external/*`
- Redirect handling with loading and error states
- Pipeline SDK URL support for experiments and runs

## How to Extend
1. Create a new redirect component in `frontend/src/pages/external/redirectComponents/`
2. Add your route to `ExternalRoutes.tsx`
3. Use `useRedirect` hook to handle the redirect logic

Example:
  ```tsx
  const [redirect, state] = useRedirect(() => '/foo');
 
  // With async path creation
  const [redirect, state] = useRedirect(async () => {
    const data = await fetchData();
    return `/bar/${data.id}`;
  });
 
  // With options
  const [redirect, state] = useRedirect(() => '/foobar', {
    navigateOptions: { replace: true },
    onComplete: () => console.log('Redirected'),
    onError: (error) => console.error(error)
  });
 
  // Usage
  const createRedirectPath = React.useCallback(() => '/some/path', []);
 
  const [redirect, { loaded, error }] = useRedirect(createRedirectPath);
 
  React.useEffect(() => {
    redirect();
  }, [redirect]);
 
 
  return (
  	<ApplicationsPage
  		loaded={loaded}
  		empty={!!error}
  		emptyStatePage={<RedirectErrorState fallbackUrl="/foo/bar"/>}
  	/>
  );
  ```

**Error state when parsing pipelinesSdk url fails**
_ex) `external/pipelinesSdk/gages-proj/#/some/unexpected/route`_
![image](https://github.com/user-attachments/assets/7668135f-9dd0-4ea6-a4b1-478a5fcf463b)

**Custom not found page when incorrect**
_ex) `external/someUndefinedRoute`_
![image](https://github.com/user-attachments/assets/5955ba4c-3419-4f96-8126-c057c0d230fd)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test these URLs locally:
For experiments
http://localhost:4010/external/pipelinesSdk/your-namespace/#/experiments/details/your-experiment-id
For runs
http://localhost:4010/external/pipelinesSdk/your-namespace/#/runs/details/your-run-id

The URLs will redirect to their respective internal routes while handling loading and error states.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a test for the hook

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

@kaedward @kywalker-rh 
Yall should look over wording and button styling for this.
- wording for both error messages and buttons (the description text comes from the error message which could be updated to if you want, but basically is generic we couldn't not match the path)
- where should the pipelines redirect one point to
   - they are given something like this when a run completes in the sdk
```bash
Experiment details: http://ml-pipeline-ui-kubeflow.apps.rmartine.dev.datahub.redhat.com/#/experiments/details/2b36adf0-cf2a-4c63-af8e-0d44c731b598
Run details: http://ml-pipeline-ui-kubeflow.apps.rmartine.dev.datahub.redhat.com/#/runs/details/f20096dd-669f-476f-ace3-c33fe7e0864a
```
   - should there be two buttons becuase we dont know if the user was trying to come from one or the other (pipelines or experiment)
- where should the not found button point to if anywhere


After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
