### PR TITLE
Add deployment mode select for kserve raw

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceModalData.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceModalData.ts
@@ -38,6 +38,7 @@ export const mockInferenceServiceModalData = ({
       },
     },
   },
+  isKServeRawDeployment,
 }: MockResourceConfigType): CreatingInferenceServiceObject => ({
   name,
   k8sName,
@@ -51,4 +52,5 @@ export const mockInferenceServiceModalData = ({
   tokenAuth,
   tokens,
   modelSize,
+  isKServeRawDeployment,
 });

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -101,6 +101,10 @@ class InferenceServiceModal extends Modal {
     return this.find().findByTestId('inference-service-framework-selection');
   }
 
+  findDeploymentModeSelect() {
+    return this.find().findByTestId('deployment-mode-select');
+  }
+
   findExistingDataConnectionOption() {
     return this.find().findByTestId('existing-data-connection-radio');
   }

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -344,7 +344,7 @@ describe('assembleInferenceService', () => {
     );
   });
 
-  it('should omit requests on mdoelmesh', async () => {
+  it('should omit requests on modelmesh', async () => {
     const acceleratorProfileState: AcceleratorProfileState = {
       acceleratorProfile: mockAcceleratorProfile({}),
       acceleratorProfiles: [mockAcceleratorProfile({})],
@@ -384,6 +384,56 @@ describe('assembleInferenceService', () => {
     );
 
     expect(inferenceService.spec.predictor.model?.resources).toBeUndefined();
+  });
+
+  it('should have base annotations for kserve raw', async () => {
+    const inferenceService = assembleInferenceService(
+      mockInferenceServiceModalData({ isKServeRawDeployment: true }),
+    );
+    const { annotations, labels } = inferenceService.metadata;
+
+    expect(annotations?.['serving.kserve.io/deploymentMode']).toBe('RawDeployment');
+
+    expect(annotations?.['serving.knative.openshift.io/enablePassthrough']).toBe(undefined);
+    expect(annotations?.['sidecar.istio.io/inject']).toBe(undefined);
+    expect(annotations?.['sidecar.istio.io/rewriteAppHTTPProbers']).toBe(undefined);
+    expect(annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(labels?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(labels?.['networking.kserve.io/visibility']).toBe(undefined);
+    expect(labels?.['networking.knative.dev/visibility']).toBe(undefined);
+  });
+
+  it('should have correct auth and routing for kserve raw', async () => {
+    const ext = assembleInferenceService(
+      mockInferenceServiceModalData({ isKServeRawDeployment: true, externalRoute: true }),
+    );
+    expect(ext.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe('RawDeployment');
+    expect(ext.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(ext.metadata.labels?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(ext.metadata.labels?.['networking.kserve.io/visibility']).toBe('exposed');
+    expect(ext.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
+
+    const auth = assembleInferenceService(
+      mockInferenceServiceModalData({ isKServeRawDeployment: true, tokenAuth: true }),
+    );
+    expect(auth.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe('RawDeployment');
+    expect(auth.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(auth.metadata.labels?.['security.opendatahub.io/enable-auth']).toBe('true');
+    expect(auth.metadata.labels?.['networking.kserve.io/visibility']).toBe(undefined);
+    expect(auth.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
+
+    const both = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+    );
+    expect(both.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe('RawDeployment');
+    expect(both.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(both.metadata.labels?.['security.opendatahub.io/enable-auth']).toBe('true');
+    expect(both.metadata.labels?.['networking.kserve.io/visibility']).toBe('exposed');
+    expect(both.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
   });
 });
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -458,6 +458,8 @@ export type InferenceServiceAnnotations = Partial<{
 
 export type InferenceServiceLabels = Partial<{
   'networking.knative.dev/visibility': string;
+  'security.opendatahub.io/enable-auth': 'true';
+  'networking.kserve.io/visibility': 'exposed';
 }>;
 
 export type InferenceServiceKind = K8sResourceCommon & {
@@ -468,7 +470,7 @@ export type InferenceServiceKind = K8sResourceCommon & {
       DisplayNameAnnotations &
       EitherOrNone<
         {
-          'serving.kserve.io/deploymentMode': 'ModelMesh';
+          'serving.kserve.io/deploymentMode': 'ModelMesh' | 'RawDeployment';
         },
         {
           'serving.knative.openshift.io/enablePassthrough': 'true';
@@ -476,6 +478,7 @@ export type InferenceServiceKind = K8sResourceCommon & {
           'sidecar.istio.io/rewriteAppHTTPProbers': 'true';
         }
       >;
+    labels?: InferenceServiceLabels;
   };
   spec: {
     predictor: {

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -53,6 +53,7 @@ import { getServingRuntimeFromTemplate } from '~/pages/modelServing/customServin
 import { useNIMPVC } from '~/pages/modelServing/screens/projects/NIMServiceModal/useNIMPVC';
 import AuthServingRuntimeSection from '~/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection';
 import { useNIMTemplateName } from '~/pages/modelServing/screens/projects/useNIMTemplateName';
+import { KServeDeploymentModeDropdown } from '~/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown';
 
 const NIM_SECRET_NAME = 'nvidia-nim-secrets';
 const NIM_NGC_SECRET_NAME = 'ngc-secret';
@@ -98,6 +99,8 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
   const isAuthorinoEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status;
   const currentProjectName = projectContext?.currentProject.metadata.name;
   const namespace = currentProjectName || createDataInferenceService.project;
+
+  const isKServeRawEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_RAW).status;
 
   const [translatedName] = translateDisplayNameForK8sAndReport(createDataInferenceService.name, {
     maxLength: 253,
@@ -353,6 +356,15 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
           <StackItem>
             <NIMPVCSizeSection pvcSize={pvcSize} setPvcSize={setPvcSize} />
           </StackItem>
+          {isKServeRawEnabled && (
+            <StackItem>
+              <KServeDeploymentModeDropdown
+                isRaw={!!createDataInferenceService.isKServeRawDeployment}
+                setIsRaw={(isRaw) => setCreateDataInferenceService('isKServeRawDeployment', isRaw)}
+                isDisabled={!!editInfo}
+              />
+            </StackItem>
+          )}
           <StackItem>
             <KServeAutoscalerReplicaSection
               data={createDataInferenceService}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
@@ -1,0 +1,52 @@
+import { FormGroup, Icon, Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
+
+enum DeploymentMode {
+  Advanced = 'advanced',
+  Standard = 'standard',
+}
+
+const options: SimpleSelectOption[] = [
+  {
+    label: 'Standard',
+    key: DeploymentMode.Standard,
+  },
+  {
+    label: 'Advanced (default)',
+    key: DeploymentMode.Advanced,
+  },
+];
+
+type Props = {
+  isRaw: boolean;
+  setIsRaw: (isRaw: boolean) => void;
+  isDisabled?: boolean;
+};
+
+export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw, isDisabled }) => (
+  <FormGroup
+    label="Deployment mode"
+    fieldId="deployment-mode"
+    isRequired
+    labelHelp={
+      <Popover bodyContent="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability.">
+        <Icon aria-label="Model server replicas info" role="button">
+          <OutlinedQuestionCircleIcon />
+        </Icon>
+      </Popover>
+    }
+  >
+    <SimpleSelect
+      dataTestId="deployment-mode-select"
+      isDisabled={isDisabled}
+      value={isRaw ? DeploymentMode.Standard : DeploymentMode.Advanced}
+      options={options}
+      onChange={(key) => {
+        setIsRaw(key === DeploymentMode.Standard);
+      }}
+      isFullWidth
+    />
+  </FormGroup>
+);

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -60,6 +60,7 @@ import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescription
 import KServeAutoscalerReplicaSection from './KServeAutoscalerReplicaSection';
 import EnvironmentVariablesSection from './EnvironmentVariablesSection';
 import ServingRuntimeArgsSection from './ServingRuntimeArgsSection';
+import { KServeDeploymentModeDropdown } from './KServeDeploymentModeDropdown';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'rbac.authorization.k8s.io',
@@ -124,6 +125,8 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const isAuthorinoEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status;
   const currentProjectName = projectContext?.currentProject.metadata.name;
   const namespace = currentProjectName || createDataInferenceService.project;
+
+  const isKServeRawEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_RAW).status;
 
   const {
     initialState: initialAcceleratorProfileState,
@@ -402,6 +405,15 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 modelContext={servingRuntimeSelected?.spec.supportedModelFormats}
                 registeredModelFormat={registeredModelDeployInfo?.modelFormat}
               />
+              {isKServeRawEnabled && (
+                <KServeDeploymentModeDropdown
+                  isRaw={!!createDataInferenceService.isKServeRawDeployment}
+                  setIsRaw={(isRaw) =>
+                    setCreateDataInferenceService('isKServeRawDeployment', isRaw)
+                  }
+                  isDisabled={!!editInfo}
+                />
+              )}
               <KServeAutoscalerReplicaSection
                 data={createDataInferenceService}
                 setData={setCreateDataInferenceService}

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -69,6 +69,7 @@ export type CreatingInferenceServiceObject = CreatingModelServingObjectCommon & 
   labels?: Record<string, string>;
   servingRuntimeArgs?: ServingContainer['args'];
   servingRuntimeEnvVars?: ServingContainer['env'];
+  isKServeRawDeployment?: boolean;
 };
 
 export type CreatingModelServingObjectCommon = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-16487
Figma https://www.figma.com/design/hKimcyeu6pgAoqKH1XrqmY/Support-KServe-RawDeployment-mode?node-id=231-2365&node-type=canvas&t=KepUcCxzaanRkMU8-0

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
First part of adding kserve raw model deployments. This adds the deployment mode dropdown to single serving (kserve) modals. What is done is basically adding `...DeploymentMode: RawDeployment` and the corresponding labels for auth / routing. The backend model controller takes care of the rest.
- Advanced -> Serverless / old behaviour
- Standard -> KServe raw / new


Changing the deployment mode on an existing deployment is not supported so it will be disabled on edit. However the `assembleInferenceService()` does properly replace the labels and annotations. 

The deployment mode dropdown will also show up in NIM


![image](https://github.com/user-attachments/assets/362764a9-7d3f-4a00-8bde-27beef128107)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Have a cluster with the latest backend controllers (I have DSC config dev flags or my cluster I can share)
```yaml
   kserve:
      # defaultDeploymentMode: RawDeployment
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: 'https://github.com/VedantMahabaleshwarkar/kserve/tarball/devflags'
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/VedantMahabaleshwarkar/odh-model-controller/tarball/devflags'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: OpenshiftDefaultIngress
        managementState: Managed
        name: knative-serving
```
3. add `?devFeatureFlags` to the URL and make sure the kserve raw is set to false
4. Go to a single model serving project, deploy a new or edit an existing model
5. The default selection should be advanced, but change it to standard (raw) 
6. Everything should work normally. In the console you can verify the inferenceService file, and check under the serverless tab on the sidebar it doesn't exist. Try inferencing the endpoint

(Public endpoint without auth doesn't work)

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
cypress and jest tests added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
