### PR TITLE
Update doc link

### DIFF
--- a/frontend/src/concepts/pipelines/content/InvalidArgoDeploymentAlert.tsx
+++ b/frontend/src/concepts/pipelines/content/InvalidArgoDeploymentAlert.tsx
@@ -5,10 +5,10 @@ import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
 import { ODH_PRODUCT_NAME } from '~/utilities/const';
 
 const INVALID_ARGO_DEPLOYMENT_SELF_DOCUMENTATION_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html/working_with_data_science_pipelines/enabling-data-science-pipelines-2_ds-pipelines';
+  'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html/working_with_data_science_pipelines/migrating-to-data-science-pipelines-2_ds-pipelines';
 
 const INVALID_ARGO_DEPLOYMENT_CLOUD_DOCUMENTATION_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/working_with_data_science_pipelines/enabling-data-science-pipelines-2_ds-pipelines';
+  'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/working_with_data_science_pipelines/migrating-to-data-science-pipelines-2_ds-pipelines';
 
 export const InvalidArgoDeploymentAlert: React.FC = () => {
   const [invalidArgoDeploymentAlertDismissed, setInvalidArgoDeploymentAlertDismissed] =


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16973 , fix version is 2.17.0

## Description
We want to rename the "Enabling data science pipelines 2.0" section in the RHOAI docs to "Migrating to data science pipelines 2.0" to more accurately reflect the content/procedure. 
As a workaround for the 2.16 docs, I updated the title to "Migrating to data science pipelines 2.0" but I did not change the filename or id so that these links would not break. 
When the links are updated here, I can rename the file and update the id in the doc repo.

## How Has This Been Tested?
The links will be broken until the updated docs are published, but the preview links will be available when I know which release this change is implemented in.