### PR TITLE
Add backend route for Configmaps and secrets for MR namespace

### DIFF
--- a/backend/src/routes/api/modelRegistryCertificates/index.ts
+++ b/backend/src/routes/api/modelRegistryCertificates/index.ts
@@ -1,0 +1,25 @@
+import { secureAdminRoute } from '../../../utils/route-security';
+import { KubeFastifyInstance, ListConfigSecretsResponse } from '../../../types';
+import { getModelRegistryNamespace } from '../modelRegistries/modelRegistryUtils';
+import { listModelRegistryCertificateNames } from './modelRegistryCertificatesUtils';
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.get(
+    '/',
+    secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
+      console.log('in backend route');
+      try {
+        const modelRegistryNamespace = getModelRegistryNamespace(fastify);
+        return listModelRegistryCertificateNames(fastify, modelRegistryNamespace);
+      } catch (e) {
+        fastify.log.error(
+          `Model registry certificate names could not be listed, ${
+            e.response?.body?.message || e.message
+          }`,
+        );
+        reply.send(e);
+      }
+    }),
+  );
+};

--- a/backend/src/routes/api/modelRegistryCertificates/index.ts
+++ b/backend/src/routes/api/modelRegistryCertificates/index.ts
@@ -8,7 +8,6 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
   fastify.get(
     '/',
     secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
-      console.log('in backend route');
       try {
         const modelRegistryNamespace = getModelRegistryNamespace(fastify);
         return listModelRegistryCertificateNames(fastify, modelRegistryNamespace);

--- a/backend/src/routes/api/modelRegistryCertificates/index.ts
+++ b/backend/src/routes/api/modelRegistryCertificates/index.ts
@@ -1,5 +1,5 @@
 import { secureAdminRoute } from '../../../utils/route-security';
-import { KubeFastifyInstance, ListConfigSecretsResponse } from '../../../types';
+import { KubeFastifyInstance } from '../../../types';
 import { getModelRegistryNamespace } from '../modelRegistries/modelRegistryUtils';
 import { listModelRegistryCertificateNames } from './modelRegistryCertificatesUtils';
 import { FastifyReply, FastifyRequest } from 'fastify';

--- a/backend/src/routes/api/modelRegistryCertificates/modelRegistryCertificatesUtils.ts
+++ b/backend/src/routes/api/modelRegistryCertificates/modelRegistryCertificatesUtils.ts
@@ -1,0 +1,60 @@
+import { V1ConfigMap, V1Secret } from '@kubernetes/client-node';
+import { ConfigSecretItem, KubeFastifyInstance } from '../../../types';
+
+export const listSecrets = async (
+  fastify: KubeFastifyInstance,
+  modelRegistryNamespace: string,
+): Promise<{ items: V1Secret[] }> => {
+  const response = await (fastify.kube.coreV1Api.listNamespacedSecret(
+    modelRegistryNamespace,
+  ) as Promise<{ body: { items: V1Secret[] } }>);
+  return response.body;
+};
+
+export const listConfigMaps = async (
+  fastify: KubeFastifyInstance,
+  modelRegistryNamespace: string,
+): Promise<{ items: V1ConfigMap[] }> => {
+  const response = await (fastify.kube.coreV1Api.listNamespacedConfigMap(
+    modelRegistryNamespace,
+  ) as Promise<{ body: { items: V1ConfigMap[] } }>);
+  return response.body;
+};
+
+export const listModelRegistryCertificateNames = async (
+  fastify: KubeFastifyInstance,
+  namespace: string,
+): Promise<{
+  secrets: ConfigSecretItem[];
+  configMaps: ConfigSecretItem[];
+}> => {
+  try {
+    const [secretsResponse, configMapsResponse] = await Promise.all([
+      listSecrets(fastify, namespace),
+      listConfigMaps(fastify, namespace),
+    ]);
+
+    const secrets = secretsResponse.items
+      .filter((secret) => secret.type === 'Opaque')
+      .map((secret) => {
+        const keys = Object.keys(secret.data || {}).filter(
+          (key) => secret.data?.[key] !== undefined && secret.data[key] !== '',
+        );
+        return { name: secret.metadata?.name || 'unknown', keys };
+      });
+
+    const configMaps = configMapsResponse.items.map((configMap) => {
+      const keys = Object.keys(configMap.data || {}).filter(
+        (key) => configMap.data?.[key] !== undefined && configMap.data[key] !== '',
+      );
+      return { name: configMap.metadata?.name || 'unknown', keys };
+    });
+
+    return { secrets, configMaps };
+  } catch (e: any) {
+    fastify.log.error(
+      `Error fetching config maps and secrets, ${e.response?.body?.message || e.message}`,
+    );
+    throw e;
+  }
+};

--- a/backend/src/routes/api/modelRegistryCertificates/modelRegistryCertificatesUtils.ts
+++ b/backend/src/routes/api/modelRegistryCertificates/modelRegistryCertificatesUtils.ts
@@ -41,14 +41,17 @@ export const listModelRegistryCertificateNames = async (
           (key) => secret.data?.[key] !== undefined && secret.data[key] !== '',
         );
         return { name: secret.metadata?.name || 'unknown', keys };
-      });
+      })
+      .filter((secret) => secret.keys.length > 0);
 
-    const configMaps = configMapsResponse.items.map((configMap) => {
-      const keys = Object.keys(configMap.data || {}).filter(
-        (key) => configMap.data?.[key] !== undefined && configMap.data[key] !== '',
-      );
-      return { name: configMap.metadata?.name || 'unknown', keys };
-    });
+    const configMaps = configMapsResponse.items
+      .map((configMap) => {
+        const keys = Object.keys(configMap.data || {}).filter(
+          (key) => configMap.data?.[key] !== undefined && configMap.data[key] !== '',
+        );
+        return { name: configMap.metadata?.name || 'unknown', keys };
+      })
+      .filter((configMap) => configMap.keys.length > 0);
 
     return { secrets, configMaps };
   } catch (e: any) {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1261,3 +1261,13 @@ export type ResourceAccessReviewResponse = {
   groups?: string[];
   users?: string[];
 };
+
+export type ConfigSecretItem = {
+  name: string;
+  keys: string[];
+};
+
+export type ListConfigSecretsResponse = {
+  secrets: ConfigSecretItem[];
+  configMaps: ConfigSecretItem[];
+};

--- a/frontend/src/concepts/modelRegistrySettings/useModelRegistryCertificateNames.ts
+++ b/frontend/src/concepts/modelRegistrySettings/useModelRegistryCertificateNames.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import useFetchState, { FetchState, NotReadyError } from '~/utilities/useFetchState';
+import { ListConfigSecretsResponse } from '~/k8sTypes';
+import { listModelRegistryCertificateNames } from '~/services/modelRegistrySettingsService';
+
+const useModelRegistryCertificateNames = (
+  isDisabled?: boolean,
+): FetchState<ListConfigSecretsResponse> => {
+  const fetchData = React.useCallback(() => {
+    if (isDisabled) {
+      return Promise.reject(new NotReadyError('Model registry certificate names is disabled'));
+    }
+
+    return listModelRegistryCertificateNames();
+  }, [isDisabled]);
+
+  return useFetchState(fetchData, {
+    secrets: [],
+    configMaps: [],
+  });
+};
+
+export default useModelRegistryCertificateNames;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1362,3 +1362,13 @@ export type NIMAccountKind = K8sResourceCommon & {
     conditions?: K8sCondition[];
   };
 };
+
+export type ConfigSecretItem = {
+  name: string;
+  keys: string[];
+};
+
+export type ListConfigSecretsResponse = {
+  secrets: ConfigSecretItem[];
+  configMaps: ConfigSecretItem[];
+};

--- a/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { FormGroup, Radio, Alert, MenuItem, MenuGroup } from '@patternfly/react-core';
+import { FormGroup, Radio, Alert, MenuItem, MenuGroup, Tooltip } from '@patternfly/react-core';
 import SearchSelector from '~/components/searchSelector/SearchSelector';
 import { translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { RecursivePartial } from '~/typeHelpers';
@@ -27,7 +27,6 @@ interface CreateMRSecureDBSectionProps {
   secureDBInfo: SecureDBInfo;
   modelRegistryNamespace: string;
   nameDesc: { name: string };
-  existingCertKeys: string[];
   existingCertConfigMaps: ConfigSecretItem[];
   existingCertSecrets: ConfigSecretItem[];
   setSecureDBInfo: (info: SecureDBInfo) => void;
@@ -37,12 +36,16 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
   secureDBInfo,
   modelRegistryNamespace,
   nameDesc,
-  existingCertKeys,
   existingCertConfigMaps,
   existingCertSecrets,
   setSecureDBInfo,
 }) => {
-  const [searchValue, setSearchValue] = useState('');
+  const [configSecretName, setConfigSecretName] = useState('');
+  const [key, setKey] = useState('');
+  const [existingCertKeys, setExistingCertKeys] = useState<string[]>([]);
+  const ODH_TRUSTED_BUNDLE = 'odh-trusted-ca-bundle';
+  const CA_BUNDLE_CRT = 'ca-bundle.crt';
+  const ODH_CA_BUNDLE_CRT = 'odh-ca-bundle.crt';
 
   const hasContent = (value: string): boolean => !!value.trim().length;
 
@@ -61,18 +64,37 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
   };
 
   const clusterWideCABundle = existingCertConfigMaps.find(
-    (configMap) =>
-      configMap.name === 'odh-trusted-ca-bundle' && configMap.keys.includes('ca-bundle.crt'),
+    (configMap) => configMap.name === ODH_TRUSTED_BUNDLE && configMap.keys.includes(CA_BUNDLE_CRT),
   );
 
   const isClusterWideCABundleAvailable = !!clusterWideCABundle;
 
   const openshiftCAbundle = existingCertConfigMaps.find(
     (configMap) =>
-      configMap.name === 'odh-trusted-ca-bundle' && configMap.keys.includes('odh-ca-bundle.crt'),
+      configMap.name === ODH_TRUSTED_BUNDLE && configMap.keys.includes(ODH_CA_BUNDLE_CRT),
   );
 
-  const isOpenshiftCABundleAvailable = !!openshiftCAbundle;
+  const isProductCABundleAvailable = !!openshiftCAbundle;
+
+  const getKeysByName = (
+    configMaps: ConfigSecretItem[],
+    secrets: ConfigSecretItem[],
+    targetName: string,
+  ): string[] => {
+    let keys: string[] = [];
+    // Search in ConfigMaps first
+    const configMap = configMaps.find((item) => item.name === targetName);
+    if (configMap) {
+      keys = configMap.keys;
+    }
+
+    // If not found, search in Secrets
+    const secret = secrets.find((item) => item.name === targetName);
+    if (secret) {
+      keys = secret.keys;
+    }
+    return keys;
+  };
 
   const handleSecureDBTypeChange = (type: SecureDBRType) => {
     const newInfo = {
@@ -88,26 +110,31 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
     });
   };
 
+  const handleResourceSelect = (selectedName: string) => {
+    setConfigSecretName('');
+    const newKeys = getKeysByName(existingCertConfigMaps, existingCertSecrets, selectedName);
+    setExistingCertKeys(newKeys); // Update keys for the second dropdown for existing certificate field
+
+    const newInfo = {
+      ...secureDBInfo,
+      configMap: selectedName,
+      key: '',
+    };
+
+    setSecureDBInfo({ ...newInfo, isValid: isValid(newInfo) });
+  };
+
   const getFilteredExistingCAResources = () => (
     <>
       <MenuGroup label="ConfigMaps">
         {existingCertConfigMaps
-          .filter((configMap) => configMap.name.toLowerCase().includes(searchValue.toLowerCase()))
+          .filter((configMap) =>
+            configMap.name.toLowerCase().includes(configSecretName.toLowerCase()),
+          )
           .map((configMap, index) => (
             <MenuItem
               key={`configmap-${index}`}
-              onClick={() => {
-                setSearchValue('');
-                const newInfo = {
-                  ...secureDBInfo,
-                  configMap: configMap.name,
-                  key: '',
-                };
-                setSecureDBInfo({
-                  ...newInfo,
-                  isValid: isValid(newInfo),
-                });
-              }}
+              onClick={() => handleResourceSelect(configMap.name)}
             >
               {configMap.name}
             </MenuItem>
@@ -115,23 +142,9 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
       </MenuGroup>
       <MenuGroup label="Secrets">
         {existingCertSecrets
-          .filter((secret) => secret.name.toLowerCase().includes(searchValue.toLowerCase()))
+          .filter((secret) => secret.name.toLowerCase().includes(configSecretName.toLowerCase()))
           .map((secret, index) => (
-            <MenuItem
-              key={`secret-${index}`}
-              onClick={() => {
-                setSearchValue('');
-                const newInfo = {
-                  ...secureDBInfo,
-                  configMap: secret.name,
-                  key: '',
-                };
-                setSecureDBInfo({
-                  ...newInfo,
-                  isValid: isValid(newInfo),
-                });
-              }}
-            >
+            <MenuItem key={`secret-${index}`} onClick={() => handleResourceSelect(secret.name)}>
               {secret.name}
             </MenuItem>
           ))}
@@ -141,34 +154,72 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
 
   return (
     <>
-      <Radio
-        isChecked={secureDBInfo.type === SecureDBRType.CLUSTER_WIDE}
-        name="cluster-wide-ca"
-        isDisabled={!isClusterWideCABundleAvailable}
-        onChange={() => handleSecureDBTypeChange(SecureDBRType.CLUSTER_WIDE)}
-        label="Use cluster-wide CA bundle"
-        description={
-          <>
-            Use the <strong>ca-bundle.crt</strong> bundle in the{' '}
-            <strong>odh-trusted-ca-bundle</strong> ConfigMap.
-          </>
-        }
-        id="cluster-wide-ca"
-      />
-      <Radio
-        isChecked={secureDBInfo.type === SecureDBRType.OPENSHIFT}
-        name="openshift-ca"
-        isDisabled={!isOpenshiftCABundleAvailable}
-        onChange={() => handleSecureDBTypeChange(SecureDBRType.OPENSHIFT)}
-        label={`Use ${ODH_PRODUCT_NAME} CA bundle`}
-        description={
-          <>
-            Use the <strong>odh-ca-bundle.crt</strong> bundle in the{' '}
-            <strong>odh-trusted-ca-bundle</strong> ConfigMap.
-          </>
-        }
-        id="openshift-ca"
-      />
+      {!isClusterWideCABundleAvailable ? (
+        <Tooltip content="No certificate is available in the cluster-wide CA bundle">
+          <Radio
+            isChecked={secureDBInfo.type === SecureDBRType.CLUSTER_WIDE}
+            name="cluster-wide-ca"
+            isDisabled={!isClusterWideCABundleAvailable}
+            onChange={() => handleSecureDBTypeChange(SecureDBRType.CLUSTER_WIDE)}
+            label="Use cluster-wide CA bundle"
+            description={
+              <>
+                Use the <strong>{CA_BUNDLE_CRT}</strong> bundle in the{' '}
+                <strong>{ODH_TRUSTED_BUNDLE}</strong> ConfigMap.
+              </>
+            }
+            id="cluster-wide-ca"
+          />
+        </Tooltip>
+      ) : (
+        <Radio
+          isChecked={secureDBInfo.type === SecureDBRType.CLUSTER_WIDE}
+          name="cluster-wide-ca"
+          isDisabled={!isClusterWideCABundleAvailable}
+          onChange={() => handleSecureDBTypeChange(SecureDBRType.CLUSTER_WIDE)}
+          label="Use cluster-wide CA bundle"
+          description={
+            <>
+              Use the <strong>{CA_BUNDLE_CRT}</strong> bundle in the{' '}
+              <strong>{ODH_TRUSTED_BUNDLE}</strong> ConfigMap.
+            </>
+          }
+          id="cluster-wide-ca"
+        />
+      )}
+      {!isProductCABundleAvailable ? (
+        <Tooltip content={`No certificate is available in the ${ODH_PRODUCT_NAME} CA bundle`}>
+          <Radio
+            isChecked={secureDBInfo.type === SecureDBRType.OPENSHIFT}
+            name="openshift-ca"
+            isDisabled={!isProductCABundleAvailable}
+            onChange={() => handleSecureDBTypeChange(SecureDBRType.OPENSHIFT)}
+            label={`Use ${ODH_PRODUCT_NAME} CA bundle`}
+            description={
+              <>
+                Use the <strong>{ODH_CA_BUNDLE_CRT}</strong> bundle in the{' '}
+                <strong>{ODH_TRUSTED_BUNDLE}</strong> ConfigMap.
+              </>
+            }
+            id="openshift-ca"
+          />
+        </Tooltip>
+      ) : (
+        <Radio
+          isChecked={secureDBInfo.type === SecureDBRType.OPENSHIFT}
+          name="openshift-ca"
+          isDisabled={!isProductCABundleAvailable}
+          onChange={() => handleSecureDBTypeChange(SecureDBRType.OPENSHIFT)}
+          label={`Use ${ODH_PRODUCT_NAME} CA bundle`}
+          description={
+            <>
+              Use the <strong>{ODH_CA_BUNDLE_CRT}</strong> bundle in the{' '}
+              <strong>{ODH_TRUSTED_BUNDLE}</strong> ConfigMap.
+            </>
+          }
+          id="openshift-ca"
+        />
+      )}
       <Radio
         isChecked={secureDBInfo.type === SecureDBRType.EXISTING}
         name="existing-ca"
@@ -193,9 +244,9 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
             <SearchSelector
               isFullWidth
               dataTestId="existing-ca-resource-selector"
-              onSearchChange={(newValue) => setSearchValue(newValue)}
-              onSearchClear={() => setSearchValue('')}
-              searchValue={searchValue}
+              onSearchChange={(newValue) => setConfigSecretName(newValue)}
+              onSearchClear={() => setConfigSecretName('')}
+              searchValue={configSecretName}
               toggleText={secureDBInfo.configMap || 'Select a ConfigMap or a Secret'}
             >
               {getFilteredExistingCAResources()}
@@ -210,18 +261,24 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
             <SearchSelector
               isFullWidth
               dataTestId="existing-ca-key-selector"
-              onSearchChange={(newValue) => setSearchValue(newValue)}
-              onSearchClear={() => setSearchValue('')}
-              searchValue={searchValue}
-              toggleText={secureDBInfo.key || 'Select a key'}
+              onSearchChange={(newValue) => setKey(newValue)}
+              isDisabled={!secureDBInfo.configMap}
+              onSearchClear={() => setKey('')}
+              searchValue={key}
+              toggleText={
+                secureDBInfo.key ||
+                (!secureDBInfo.configMap
+                  ? 'Select a resource to view its available keys'
+                  : 'Select a key')
+              }
             >
               {existingCertKeys
-                .filter((item) => item.toLowerCase().includes(searchValue.toLowerCase()))
+                .filter((item) => item.toLowerCase().includes(key.toLowerCase()))
                 .map((item, index) => (
                   <MenuItem
                     key={`key-${index}`}
                     onClick={() => {
-                      setSearchValue('');
+                      setKey('');
                       const newInfo = {
                         ...secureDBInfo,
                         key: item,

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -69,9 +69,6 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
 
   const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace || '';
 
-  // Delete this
-  const existingCertKeys = ['service-ca.crt', 'foo-ca.crt'];
-
   React.useEffect(() => {
     if (mr) {
       const dbSpec = mr.spec.mysql || mr.spec.postgres;
@@ -325,7 +322,6 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
                     secureDBInfo={secureDBInfo}
                     modelRegistryNamespace={modelRegistryNamespace}
                     nameDesc={nameDesc}
-                    existingCertKeys={existingCertKeys}
                     existingCertConfigMaps={configSecrets.configMaps}
                     existingCertSecrets={configSecrets.secrets}
                     setSecureDBInfo={setSecureDBInfo}

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -3,11 +3,12 @@ import {
   Alert,
   Button,
   Checkbox,
+  EmptyState,
   Form,
   FormGroup,
   HelperText,
   HelperTextItem,
-  Skeleton,
+  Spinner,
   TextInput,
 } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
@@ -316,7 +317,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
               </FormGroup>
               {addSecureDB &&
                 (!configSecretsLoaded && !configSecretsError ? (
-                  <Skeleton />
+                  <EmptyState icon={Spinner} />
                 ) : configSecretsLoaded ? (
                   <CreateMRSecureDBSection
                     secureDBInfo={secureDBInfo}

--- a/frontend/src/services/modelRegistrySettingsService.ts
+++ b/frontend/src/services/modelRegistrySettingsService.ts
@@ -1,11 +1,12 @@
 import * as _ from 'lodash-es';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import axios from '~/utilities/axios';
-import { ModelRegistryKind, RoleBindingKind } from '~/k8sTypes';
+import { ListConfigSecretsResponse, ModelRegistryKind, RoleBindingKind } from '~/k8sTypes';
 import { RecursivePartial } from '~/typeHelpers';
 
 const registriesUrl = '/api/modelRegistries';
 const mrRoleBindingsUrl = '/api/modelRegistryRoleBindings';
+const configSecretsUrl = '/api/modelRegistryCertificates';
 
 type ModelRegistryAndDBPassword = {
   modelRegistry: ModelRegistryKind;
@@ -86,6 +87,14 @@ export const createModelRegistryRoleBinding = (data: RoleBindingKind): Promise<R
 export const deleteModelRegistryRoleBinding = (roleBindingName: string): Promise<K8sStatus> =>
   axios
     .delete(`${mrRoleBindingsUrl}/${roleBindingName}`)
+    .then((response) => response.data)
+    .catch((e) => {
+      throw new Error(e.response.data.message);
+    });
+
+export const listModelRegistryCertificateNames = (): Promise<ListConfigSecretsResponse> =>
+  axios
+    .get<ListConfigSecretsResponse>(configSecretsUrl)
     .then((response) => response.data)
     .catch((e) => {
       throw new Error(e.response.data.message);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-15899](https://issues.redhat.com/browse/RHOAIENG-15899)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Fetch config maps and secrets in model registry namespace and added hook for the same
- Lazy loading(Skeleton) when one clicks on the checkbox
- Added logic to disable/enable the first two options 
   - If the data from the new hook has no ConfigMap with the name `odh-trusted-ca-bundle` or that ConfigMap does not include the key `ca-bundle.crt`, disable the "Use cluster-wide CA bundle" radio button and add a tooltip "No certificate is available in the cluster-wide CA bundle". 
  - If the data from the new hook has no ConfigMap with the name `odh-trusted-ca-bundle` or that ConfigMap does not include the key `odh-ca-bundle.crt`, disable the "Use ${ODH_PRODUCT_NAME} CA bundle" radio button and add a tooltip "No certificate is available in the ${ODH_PRODUCT_NAME} CA bundle".
- Under "Choose from existing certificates":
   - In the Resource dropdown, replaced the mock options with the names of the secrets and configmaps fetched with hook.
   - Make the Key field disabled with the placeholder "Select a resource to view its available keys" until a Resource is selected. When a Resource is selected, populate the Key dropdown from the keys of that secret or configmap.

Screen Recording:

https://github.com/user-attachments/assets/3cf2a631-5f56-4bc6-a7eb-71a0ba553fbb

Screenshots:

<img width="527" alt="Screenshot 2024-12-17 at 7 51 07 PM" src="https://github.com/user-attachments/assets/01aeff94-e2f5-4b32-a4a7-0bbe48158b07" />
<img width="485" alt="Screenshot 2024-12-17 at 7 51 37 PM" src="https://github.com/user-attachments/assets/7be002d0-5110-4a2e-b77d-73859ccafc5b" />
<img width="644" alt="Screenshot 2024-12-17 at 7 51 51 PM" src="https://github.com/user-attachments/assets/99c1e14f-6748-4607-9089-c0c6e3dd7ea2" />
<img width="641" alt="Screenshot 2024-12-17 at 7 52 23 PM" src="https://github.com/user-attachments/assets/64605373-f9ed-4194-94d3-78a22705ffd4" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Enable `disableModelRegistrySecureDB` feature flag on your cluster to see the checkbox in the Create model registry modal
- Once you click on the checkbox, you should see a loading state while the config maps and secrets load
- Once that is loaded, some checkboxes may be disabled based on the data provided in the description of the radio buttons(first two radio buttons)
- Third radio button: The config maps and secrets should be populated in the dropdown and the second dropdown should populate according to the config maps/secrets name selected in first dropdown.. second dropdown should be disabled if first dropdown is not selected.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests will be added in a later PR.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
