### PR TITLE
Allow private/public route selection in KServe, when authorino is not enabled

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -189,6 +189,14 @@ class ServingRuntimeModal extends Modal {
     super(`${edit ? 'Edit' : 'Add'} model server`);
   }
 
+  findAuthorinoNotEnabledAlert() {
+    return this.find().findByTestId('no-authorino-installed-alert');
+  }
+
+  findTokenAuthAlert() {
+    return this.find().findByTestId('token-authentication-prerequisite-alert');
+  }
+
   findSubmitButton() {
     return this.findFooter().findByTestId('modal-submit-button');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -909,6 +909,28 @@ describe('Serving Runtime List', () => {
       kserveModal.findAuthenticationCheckbox().should('not.exist');
     });
 
+    it('show warning alert on modal, when authorino operator is not installed/enabled', () => {
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: false,
+        disableKServeAuthConfig: false,
+        servingRuntimes: [],
+        projectEnableModelMesh: false,
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+
+      modelServingSection.findDeployModelButton().click();
+
+      kserveModal.shouldBeOpen();
+      kserveModal.findAuthorinoNotEnabledAlert().should('exist');
+      kserveModal.findModelRouteCheckbox().should('not.be.checked');
+      kserveModal.findModelRouteCheckbox().check();
+      kserveModal.findTokenAuthAlert().should('exist');
+      kserveModal.findModelRouteCheckbox().uncheck();
+      kserveModal.findTokenAuthAlert().should('not.exist');
+    });
+
     it('Kserve auth should be hidden when no required capabilities', () => {
       initIntercepts({
         disableModelMeshConfig: false,

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/AuthServingRuntimeSection.tsx
@@ -20,6 +20,7 @@ type AuthServingRuntimeSectionProps<D extends CreatingModelServingObjectCommon> 
   setData: UpdateObjectAtPropAndValue<D>;
   allowCreate: boolean;
   publicRoute?: boolean;
+  showModelRoute?: boolean;
 };
 
 const AuthServingRuntimeSection = <D extends CreatingModelServingObjectCommon>({
@@ -27,6 +28,7 @@ const AuthServingRuntimeSection = <D extends CreatingModelServingObjectCommon>({
   setData,
   allowCreate,
   publicRoute,
+  showModelRoute = true,
 }: AuthServingRuntimeSectionProps<D>): React.ReactNode => {
   const createNewToken = React.useCallback(() => {
     const name = 'default-name';
@@ -85,14 +87,16 @@ const AuthServingRuntimeSection = <D extends CreatingModelServingObjectCommon>({
           </FormGroup>
         </StackItem>
       )}
-      <StackItem>
-        <ServingRuntimeTokenSection
-          data={data}
-          setData={setData}
-          allowCreate={allowCreate}
-          createNewToken={createNewToken}
-        />
-      </StackItem>
+      {showModelRoute && (
+        <StackItem>
+          <ServingRuntimeTokenSection
+            data={data}
+            setData={setData}
+            allowCreate={allowCreate}
+            createNewToken={createNewToken}
+          />
+        </StackItem>
+      )}
       {((publicRoute && data.externalRoute && !data.tokenAuth) ||
         (!publicRoute && !data.tokenAuth)) && (
         <StackItem>
@@ -104,6 +108,21 @@ const AuthServingRuntimeSection = <D extends CreatingModelServingObjectCommon>({
             title="Making models available by external routes without requiring authorization can lead to security vulnerabilities."
           />
         </StackItem>
+      )}
+      {publicRoute && data.externalRoute && !showModelRoute && (
+        <Alert
+          isInline
+          variant="warning"
+          title="Token authentication prerequisite not installed"
+          data-testid="token-authentication-prerequisite-alert"
+        >
+          <p>
+            Making models available through external routes without requiring token authentication
+            can lead to unauthorized access of your model. To enable token authentication, you must
+            first request that your cluster administrator install the Authorino operator on your
+            cluster.
+          </p>
+        </Alert>
       )}
     </Stack>
   );

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -418,14 +418,13 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 setSelectedAcceleratorProfile={setSelectedAcceleratorProfile}
                 infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
               />
-              {isAuthorinoEnabled && (
-                <AuthServingRuntimeSection
-                  data={createDataInferenceService}
-                  setData={setCreateDataInferenceService}
-                  allowCreate={allowCreate}
-                  publicRoute
-                />
-              )}
+              <AuthServingRuntimeSection
+                data={createDataInferenceService}
+                setData={setCreateDataInferenceService}
+                allowCreate={allowCreate}
+                publicRoute
+                showModelRoute={isAuthorinoEnabled}
+              />
             </>
           )}
         </FormSection>


### PR DESCRIPTION
Closes: [RHOAIENG-10060](https://issues.redhat.com/browse/RHOAIENG-10060)

## Description
This PR aims to allow private/public route selection in KServe, when authorino is not enabled.

https://github.com/user-attachments/assets/6e39d1bd-d36b-4779-8bf5-9714fc938ea7

<img width="874" alt="Screenshot 2024-12-16 at 4 10 14 PM" src="https://github.com/user-attachments/assets/e221c0ab-cdc1-426f-80f9-19cde7948720" />

## How Has This Been Tested?
In KServe, now we allow private/public route selection even when the authorino is not enabled.
when the model route checkbox is checked, we will show warning alert.

## Test Impact
Added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

