### PR TITLE
show display name instead of pvc metadata name

### DIFF
--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
@@ -64,6 +64,7 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
     if (hasExistingNotebookConnections) {
       const addData = connectedNotebooks.map((connectedNotebook) => ({
         name: connectedNotebook.metadata.name,
+        notebookDisplayName: connectedNotebook.metadata.annotations?.['openshift.io/display-name'],
         mountPath: {
           value: existingPvc
             ? getNotebookPVCMountPathMap(connectedNotebook)[existingPvc.metadata.name]

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
@@ -97,7 +97,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
           />
         ) : (
           <>
-            {obj.name}{' '}
+            {obj.notebookDisplayName ?? obj.name}{' '}
             <Label isCompact color="green">
               Connected
             </Label>

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -392,7 +392,9 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   {
                     storageType: StorageType.EXISTING_PVC,
                     id: storageData.length + 1,
-                    name: attachData.storage,
+                    name: attachData.pvc
+                      ? getDisplayNameFromK8sResource(attachData.pvc)
+                      : attachData.storage,
                     existingPvc: attachData.pvc,
                     mountPath: attachData.mountPath.value,
                     description: attachData.pvc?.metadata.annotations?.['openshift.io/description'],

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -35,7 +35,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
     () =>
       loaded
         ? storages.reduce((acc: TypeaheadSelectOption[], pvc) => {
-            if (!existingStorageNames?.includes(pvc.metadata.name)) {
+            if (!existingStorageNames?.includes(getDisplayNameFromK8sResource(pvc))) {
               acc.push({
                 value: pvc.metadata.name,
                 content: getDisplayNameFromK8sResource(pvc),
@@ -64,7 +64,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
 
   if (!loaded) {
     placeholderText = 'Loading storages';
-  } else if (storages.length === 0) {
+  } else if (selectOptions.length === 0) {
     placeholderText = 'No existing storages available';
   } else {
     placeholderText = 'Select a persistent storage';
@@ -82,7 +82,6 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
         selected={data.storage}
         onSelect={(_, storage) => {
           const pvc = storages.find((pvcData) => pvcData.metadata.name === storage);
-
           setData({
             ...data,
             pvc,

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -40,6 +40,7 @@ export type ForNotebookSelection = {
 
 export type ClusterStorageNotebookSelection = ForNotebookSelection & {
   existingPvc: boolean;
+  notebookDisplayName?: string;
   isUpdatedValue: boolean;
   newRowId?: number;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-16239

## Description
Cluster storage is now showing the displayname before  and after creation of a workbench  
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Create a PVC with displayName ( you can find the example in the jira issue)
2. Create a workbench 
3. Attach the created PVC, check if the displayed name of attached PVC is attached to workbench
4. Once created, go to cluster storage and check if the display name is still showing instead of metadata name

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
