### PR TITLE
hopeful fix for flakey mr test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -10,7 +10,9 @@ class ModelVersionDeployModal extends Modal {
   }
 
   selectProjectByName(name: string) {
-    this.findProjectSelector().click();
+    const selector = this.findProjectSelector();
+    selector.should('have.attr', 'aria-expanded', 'false');
+    selector.click();
     this.find().findByRole('option', { name, timeout: 5000 }).click();
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -10,10 +10,7 @@ class ModelVersionDeployModal extends Modal {
   }
 
   selectProjectByName(name: string) {
-    const selector = this.findProjectSelector();
-    selector.should('have.attr', 'aria-expanded', 'false');
-    selector.click();
-    this.find().findByRole('option', { name, timeout: 5000 }).click();
+    this.findProjectSelector().findSelectOption(name).click();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -193,6 +193,8 @@ describe('Deploy model version', () => {
     modelVersionDeployModal.selectProjectByName('Model mesh project');
     cy.findByText('Multi-model platform is not installed').should('exist');
     cy.wait('@getProjects');
+    //make sure the selector is closed after previous selection
+    modelVersionDeployModal.findProjectSelector().should('have.attr', 'aria-expanded', 'false');
     modelVersionDeployModal.selectProjectByName('KServe project');
     cy.findByText('Single-model platform is not installed').should('exist');
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -184,17 +184,22 @@ const initIntercepts = ({
 };
 
 describe('Deploy model version', () => {
-  it('Deploy model version on unsupported platform', () => {
-    initIntercepts({ kServeInstalled: false, modelMeshInstalled: false });
+  it('Deploy model version on unsupported multi-model platform', () => {
+    initIntercepts({ modelMeshInstalled: false });
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
     modelVersionRow.findKebabAction('Deploy').click();
     cy.wait('@getProjects');
     modelVersionDeployModal.selectProjectByName('Model mesh project');
     cy.findByText('Multi-model platform is not installed').should('exist');
+  });
+
+  it('Deploy model version on unsupported single-model platform', () => {
+    initIntercepts({ kServeInstalled: false });
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
+    modelVersionRow.findKebabAction('Deploy').click();
     cy.wait('@getProjects');
-    //make sure the selector is closed after previous selection
-    modelVersionDeployModal.findProjectSelector().should('have.attr', 'aria-expanded', 'false');
     modelVersionDeployModal.selectProjectByName('KServe project');
     cy.findByText('Single-model platform is not installed').should('exist');
   });


### PR DESCRIPTION
## Description
thinking a possible reason for the failure (which i've never been able to reproduce locally) is that the dropdown menu gets clicked before it closes from the first selection.

originally tried a fix is to check for it to be closed before attempting to open it - but it was getting some "dom changed" error

this PR is now separating the two "unsupported platform" tests into their own so it doesn't have to deal with whatever issue is happening when flicking between two

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
