### PR TITLE
Fix for warnings from PF upgrade

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/acceleratorProfile.ts
@@ -6,7 +6,7 @@ import { TableRow } from './components/table';
 class AcceleratorTableToolbar extends TableToolbar {}
 class AcceleratorRow extends TableRow {
   findDescription() {
-    return this.find().findByTestId('description');
+    return this.find().findByTestId('table-row-title-description');
   }
 
   shouldHaveIdentifier(name: string) {

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfiles.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfiles.tsx
@@ -6,7 +6,6 @@ import {
   EmptyStateVariant,
   EmptyStateBody,
   PageSection,
-  Title,
   EmptyStateActions,
   EmptyStateFooter,
 } from '@patternfly/react-core';
@@ -33,10 +32,11 @@ const AcceleratorProfiles: React.FC = () => {
   const noAcceleratorProfilePageSection = (
     <PageSection hasBodyWrapper={false} isFilled>
       <EmptyState
+        headingLevel="h5"
         titleText={
-          <Title data-testid="no-available-accelerator-profiles" headingLevel="h5" size="lg">
+          <span data-testid="no-available-accelerator-profiles">
             No available accelerator profiles yet
-          </Title>
+          </span>
         }
         icon={PlusCircleIcon}
         variant={EmptyStateVariant.full}

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
-import {
-  Content,
-  ContentVariants,
-  Timestamp,
-  TimestampTooltipVariant,
-  Truncate,
-} from '@patternfly/react-core';
+import { Timestamp, TimestampTooltipVariant, Truncate } from '@patternfly/react-core';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import AcceleratorProfileEnableToggle from '~/pages/acceleratorProfiles/screens/list/AcceleratorProfileEnableToggle';
 import { relativeTime } from '~/utilities/time';
+import { TableRowTitleDescription } from '~/components/table';
 
 type AcceleratorProfilesTableRowType = {
   acceleratorProfile: AcceleratorProfileKind;
@@ -27,16 +22,12 @@ const AcceleratorProfilesTableRow: React.FC<AcceleratorProfilesTableRowType> = (
   return (
     <Tr>
       <Td dataLabel="Name">
-        <Content>
-          <Content component="p">
-            <Truncate content={acceleratorProfile.spec.displayName} />
-          </Content>
-          {acceleratorProfile.spec.description && (
-            <Content data-testid="description" component={ContentVariants.small}>
-              <Truncate content={acceleratorProfile.spec.description} />
-            </Content>
-          )}
-        </Content>
+        <TableRowTitleDescription
+          boldTitle={false}
+          title={<Truncate content={acceleratorProfile.spec.displayName} />}
+          description={acceleratorProfile.spec.description}
+          truncateDescriptionLines={2}
+        />
       </Td>
       <Td dataLabel="Identifier">{acceleratorProfile.spec.identifier}</Td>
       <Td dataLabel="Enable">

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationsTable.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EmptyState, Title, EmptyStateBody } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Table } from '~/components/table';
 import { Toleration } from '~/types';
@@ -19,12 +19,9 @@ export const TolerationsTable: React.FC<TolerationTableProps> = ({ tolerations, 
   if (tolerations.length === 0) {
     return (
       <EmptyState
-        titleText={
-          <Title headingLevel="h2" size="lg">
-            No tolerations
-          </Title>
-        }
+        titleText="No tolerations"
         icon={PlusCircleIcon}
+        headingLevel="h2"
         variant="xs"
         data-testid="tolerations-modal-empty-state"
       >


### PR DESCRIPTION
Closes [RHOAIENG-16464](https://issues.redhat.com/browse/RHOAIENG-16464)

## Description
Fix for warnings in the console cause by PF v6 upgrade. 

## How Has This Been Tested?
- Navigate to `Applications -> Explore`
- Open the dev console, verify there are no warnings generated

- Navigate to `Settings -> Accelerator profiles`
- Open the dev console, verify there are no warnings generated

## Test Impact
Test Id was updated from `description` to `table-row-title-description`
No additional tests required since there is merely a structural change.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
