### PR TITLE
Fix for extra line in storage classes table

### DIFF
--- a/frontend/src/pages/storageClasses/StorageClassesTable.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTable.tsx
@@ -41,7 +41,6 @@ export const StorageClassesTable: React.FC = () => {
       enablePagination
       variant="compact"
       data={filteredStorageClasses}
-      hasNestedHeader
       columns={columns}
       emptyTableView={
         <DashboardEmptyTableView onClearFilters={() => setFilterData(initialScFilterData)} />


### PR DESCRIPTION
Closes [RHOAIENG-16679](https://issues.redhat.com/browse/RHOAIENG-16679)

## Description
Removes the extra line below the header in the Storage Classes table

## How Has This Been Tested?
- Navigate to `Settings -> Storage Classes`
- Verify there is no line between the table header and the first row

## Test Impact
No impact, purely a visual change

## Screen shot
![image](https://github.com/user-attachments/assets/cc749cbd-f47a-436b-8d1a-080e7b42ef06)

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
