### PR TITLE
fix cluster storage class dropdown

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -88,6 +88,10 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
     };
   });
 
+  if (storageClassesLoaded && !hasStorageClassConfigs) {
+    return null;
+  }
+
   return hasStorageClassConfigs ? (
     <FormGroup label="Storage class" fieldId="storage-class">
       <SimpleSelect


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-16609

## Description
show only the storageClass which are enabled  ( already addressed in  in this PR https://github.com/opendatahub-io/odh-dashboard/pull/3547 )
hide the storageClass dropdown when no storageClass is enabled or all of them dont have the openshift storage config annotations
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Remove the openshift config annotations from  all storageClass in the console
2. Check if the  storageClass dropdown is hidden

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
