### PR TITLE
Fix layout for token disabled warning

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTableRow.tsx
@@ -94,7 +94,12 @@ const KServeInferenceServiceTableRow: React.FC<KServeInferenceServiceTableRowPro
               )}
               {isAuthorinoEnabled && (
                 <StackItem>
-                  <DescriptionList>
+                  <DescriptionList
+                    {...(!isInferenceServiceTokenEnabled(obj) && {
+                      isHorizontal: true,
+                      horizontalTermWidthModifier: { default: '250px' },
+                    })}
+                  >
                     <DescriptionListGroup>
                       <DescriptionListTerm>Token authentication</DescriptionListTerm>
                       <DescriptionListDescription>


### PR DESCRIPTION
Closes: [RHOAIENG-5256](https://issues.redhat.com/browse/RHOAIENG-5256)

## Description
Fixes the layout for the token disabled warning. It will now be on the right, inline with the token authentication, instead of below. 

## How Has This Been Tested?
Tested locally on cluster.

- Navigate to the models tab in your data science project. 
- Deploy a model with tokens disabled
- Inspect the model to see the change in layout

## Test Impact
No tests changed

## Screenshots
Before:
![Screenshot 2024-12-19 at 9 59 33 AM](https://github.com/user-attachments/assets/bf362d91-fd03-45c7-ba3f-16a011e0d444)

After:
![Screenshot 2024-12-19 at 9 59 09 AM](https://github.com/user-attachments/assets/78920429-8e45-4c1a-af79-fbc2027ee083)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
