### PR TITLE
Fixes for visual issues with Resources vertical tabs and Spawner page image selectors

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -38,6 +38,13 @@ body,
   --pf-v6-c-truncate__start--MinWidth: 0;
 }
 
+// TODO: Remove when PF bug is fixed. https://github.com/patternfly/react-catalog-view/issues/74
+.vertical-tabs-pf-tab {
+  > a {
+    text-decoration: none;
+  }
+}
+
 // TODO: Remove when PF bug is fixed. https://github.com/patternfly/patternfly-react/issues/11314
 .pf-v6-c-table__text.pf-m-truncate {
   min-width: max(100%, 5ch);

--- a/frontend/src/pages/notebookController/NotebookController.scss
+++ b/frontend/src/pages/notebookController/NotebookController.scss
@@ -87,9 +87,6 @@
       &-package-title {
         font-weight: var(--pf-t--global--font--weight--heading--bold);
       }
-      &-icon {
-        padding-left: 0px;
-      }
     }
   }
   &__start-server-modal {

--- a/frontend/src/pages/notebookController/screens/server/ImageTagPopover.tsx
+++ b/frontend/src/pages/notebookController/screens/server/ImageTagPopover.tsx
@@ -41,8 +41,8 @@ const ImageTagPopover: React.FC<ImageTagPopoverProps> = ({ tag, description }) =
     >
       <Button
         icon={<HelpIcon />}
+        hasNoPadding
         aria-label="More info for notebook image"
-        className="odh-notebook-controller__notebook-image-popover-icon"
         variant="plain"
       />
     </Popover>


### PR DESCRIPTION
Closes [RHOAIENG-16677](https://issues.redhat.com/browse/RHOAIENG-16677)

## Description
Removes underlines from text in resource category filter options. 
Fixes alignment of radio buttons in the Spawner page

## How Has This Been Tested?
- Navigate to `Resources` page
- Verify the category links are not underlined

- Navigate to `Data Science Projects`
- Select a project
- Select the `Workbenches` tab
- Select `Create workbench`
- Verify the alignment of the image selector radio buttons

## Test Impact
Not impact on tests as this is purely visual

## Screen shots
![image](https://github.com/user-attachments/assets/bb29eca1-b41a-43cd-ac93-49c308810189)

![image](https://github.com/user-attachments/assets/efeefa3e-1eb5-4efc-8530-e13f906de0c4)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
