### PR TITLE
fix return type when creating dashboard config

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -121,10 +121,10 @@ const createDashboardCR = (fastify: KubeFastifyInstance): Promise<DashboardConfi
       DASHBOARD_CONFIG.plural,
       blankDashboardCR,
     )
-    .then((result) => [result.body])
+    .then((result) => result.body as DashboardConfig)
     .catch((e) => {
       fastify.log.error('Error creating Dashboard CR: ', e);
-      return null;
+      return blankDashboardCR;
     });
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-15388

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fixes error `Cannot read properties of undefined (reading 'notebookController')`

The `resourceUtils.ts#createDashboardCR` function returned an array instead of the dashboard config itself, therefore when attempting to read `spec.notebookController` from the config, it would fail since `spec` is `undefined` on the array. At the same time, also returned the `blankDashboardCR` in case creation were to fail.

This points to a bigger issue where our tsconfig needs to be made strict.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Spin down the dashboard deployment or stop your local backend server. 
- Delete the OdhDashboardConfig
- Start the dashboard backend
- Immediately hit the frontend URL.
- Page should load without error.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
