### PR TITLE
Use the fully qualified name `window.location.host` and not just `location.host`

### DIFF
--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -5,7 +5,7 @@ import {
   OdhDocumentType,
 } from '~/types';
 
-const WS_HOSTNAME = process.env.WS_HOSTNAME || location.host;
+const WS_HOSTNAME = process.env.WS_HOSTNAME || window.location.host;
 const DEV_MODE = process.env.APP_ENV === 'development';
 const API_PORT = process.env.BACKEND_PORT || 8080;
 const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTERVAL) : 30000;


### PR DESCRIPTION
## Description

I was trying some things with jest and babel, and I encountered the following error when trying to compile the frontend code

```
ReferenceError: location is not defined
```

The Dashboard code is not suffering from this, because
1. `location` is defined as a global in the actual browsers
2. the Jest config defines `testEnvironment: 'jest-environment-jsdom',` and besides sprucing up the runtime env, this also (somehow) instructs babel to assume browser env

I want to compile without defining `testEnvironment`, and since there is no harm in referencing `location` though `window`, why not just do it that way?

## How Has This Been Tested?

GitHub Actions

## Test Impact

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability in determining the hostname for WebSocket connections, ensuring consistent behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->