### PR TITLE
Fix Jupyter Tile env var readback

### DIFF
--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -3,6 +3,7 @@ import { KnownLabels, NotebookKind } from '~/k8sTypes';
 import { DEFAULT_NOTEBOOK_SIZES } from '~/pages/projects/screens/spawner/const';
 import {
   ContainerResources,
+  EnvironmentVariable,
   TolerationEffect,
   TolerationOperator,
   Volume,
@@ -19,6 +20,7 @@ type MockResourceConfigType = {
   user?: string;
   description?: string;
   envFrom?: EnvironmentFromVariable[];
+  additionalEnvs?: EnvironmentVariable[];
   resources?: ContainerResources;
   image?: string;
   lastImageSelection?: string;
@@ -38,7 +40,7 @@ export const mockNotebookK8sResource = ({
       },
     },
   ],
-
+  additionalEnvs = [],
   namespace = 'test-project',
   user = 'test-user',
   description = '',
@@ -114,6 +116,7 @@ export const mockNotebookK8sResource = ({
                     value:
                       'image-registry.openshift-image-registry.svc:5000/opendatahub/code-server-notebook:2023.2',
                   },
+                  ...additionalEnvs,
                 ],
                 envFrom,
                 image,

--- a/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
@@ -1,3 +1,10 @@
+enum EnvVarItemType {
+  KEY = 'key',
+  VALUE = 'value',
+  SECRET_TOGGLE = 'is-secret',
+  SHOW_PASSWORD_TOGGLE = 'show-password',
+}
+
 class NotebookServer {
   visit() {
     cy.visitWithLogin('/notebookController/spawner');
@@ -11,6 +18,30 @@ class NotebookServer {
 
   findAppTitle() {
     return cy.findByTestId('app-page-title');
+  }
+
+  findEnvVarAdd() {
+    return cy.findByTestId('add-env-var');
+  }
+
+  private findEnvVarGroupItem(groupIndex: number, type: EnvVarItemType) {
+    return cy.findByTestId(`environment-variable-row-${groupIndex}-0-${type}`);
+  }
+
+  findEnvVarKey(groupIndex: number) {
+    return this.findEnvVarGroupItem(groupIndex, EnvVarItemType.KEY);
+  }
+
+  findEnvVarValue(groupIndex: number) {
+    return this.findEnvVarGroupItem(groupIndex, EnvVarItemType.VALUE);
+  }
+
+  findEnvVarIsSecretCheckbox(groupIndex: number) {
+    return this.findEnvVarGroupItem(groupIndex, EnvVarItemType.SECRET_TOGGLE);
+  }
+
+  findEnvVarSecretEyeToggle(groupIndex: number) {
+    return this.findEnvVarGroupItem(groupIndex, EnvVarItemType.SHOW_PASSWORD_TOGGLE);
   }
 
   findAdministrationTab() {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -10,6 +10,7 @@ import type {
   RegisteredModelList,
 } from '~/concepts/modelRegistry/types';
 import type {
+  ConfigMapKind,
   ConsoleLinkKind,
   DashboardConfigKind,
   DataScienceClusterInitializationKindStatus,
@@ -18,6 +19,7 @@ import type {
   NotebookKind,
   OdhQuickStart,
   RoleBindingKind,
+  SecretKind,
   ServingRuntimeKind,
   TemplateKind,
 } from '~/k8sTypes';
@@ -607,6 +609,20 @@ declare global {
             path: { username: string };
           },
           response: OdhResponse<{ notebook: NotebookKind; isRunning: boolean }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/envs/configmap/openshift-ai-notebooks/:filename',
+          options: {
+            path: { filename: string };
+          },
+          response: OdhResponse<ConfigMapKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/envs/secret/openshift-ai-notebooks/:filename',
+          options: {
+            path: { filename: string };
+          },
+          response: OdhResponse<SecretKind>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/artifacts/:artifactId',

--- a/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesField.tsx
@@ -58,7 +58,8 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
       >
         <TextInput
           id={`${fieldIndex}-${variable.name}`}
-          data-id={`${fieldIndex}-${variable.name}`}
+          data-id={`${fieldIndex}-${variable.name}`} // @deprecated
+          data-testid={`${fieldIndex}-key`}
           type={TextInputTypes.text}
           onChange={(e, newKey) =>
             onUpdateVariable({ name: newKey, type: variable.type, value: variable.value })
@@ -86,7 +87,8 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
             <InputGroupItem isFill>
               <TextInput
                 id={`${fieldIndex}-${variable.name}-value`}
-                data-id={`${fieldIndex}-${variable.name}-value`}
+                data-id={`${fieldIndex}-${variable.name}-value`} // @deprecated
+                data-testid={`${fieldIndex}-value`}
                 type={
                   showPassword && variableType === 'password'
                     ? TextInputTypes.text
@@ -101,6 +103,7 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
             {variable.type === 'password' ? (
               <Button
                 data-id="show-password-button"
+                data-testid={`${fieldIndex}-show-password`}
                 variant="control"
                 onClick={() => setShowPassword(!showPassword)}
               >
@@ -110,7 +113,8 @@ const EnvironmentVariablesField: React.FC<EnvironmentVariablesFieldProps> = ({
           </InputGroup>
           {variableRow.variableType === CUSTOM_VARIABLE ? (
             <Checkbox
-              data-id={`${fieldIndex}-${variable.name}-secret`}
+              data-id={`${fieldIndex}-${variable.name}-secret`} // @deprecated
+              data-testid={`${fieldIndex}-is-secret`}
               className={variableType === 'password' ? ' m-is-secret' : ''}
               label="Secret"
               isChecked={variableType === 'password'}

--- a/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesRow.tsx
+++ b/frontend/src/pages/notebookController/screens/server/EnvironmentVariablesRow.tsx
@@ -38,6 +38,11 @@ const EnvironmentVariablesRow: React.FC<EnvironmentVariablesRowProps> = ({
   };
 
   const updateVariableType = (newType: string) => {
+    if (variableRow.variableType === newType) {
+      // If the type changing is the same as the current type, we don't want to do anything
+      // TODO: Variable Types seems to be dead code; probably not worth removing it until Jupyter Tile gets a refactor
+      return;
+    }
     const newCategory = categories.find((category) => category.name === newType);
     let variables: EnvVarType[] = [];
     if (newCategory) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-17122

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When we did a change for the selects in our app to select the first item and disable itself it had a side-effect to Jupyter tile where it triggered a re-selection and emptying of the secret/configmap details. This occurred in all env var groups but it seems due to poor reference mapping, we updated the values with in-memory old data and thus only ended up applying the last set state. 

Fix was to just not allow the selecting of the same dropdown item to reset the data. But I'm fairly certain this dropdown is obsolete in the code and maybe never did anything in the first place (unimplemented logic?). We'll have to swing back and clean this up later or more likely do a refactor of this page to a new design (like Workbenches).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fire up Jupyter tile, add env vars (at least one) and then start the notebook.
Stop the notebook and refresh the page or "leave and return" to the page.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests added to make sure response data is properly rendered. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
