### PR TITLE
Show 'Storage size' column directly in the storage table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -32,9 +32,8 @@ class ClusterStorageRow extends TableRow {
     return this.find().find('[data-label="Storage class"]');
   }
 
-  shouldHaveStorageSize(name: string) {
-    this.find().siblings().find('[data-label=Size]').contains(name).should('exist');
-    return this;
+  findSizeColumn() {
+    return this.find().find('[data-label="Storage size"]');
   }
 
   showStorageClassDetails() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -338,11 +338,9 @@ describe('ClusterStorage', () => {
     clusterStorageRow.findStorageClassColumn().should('not.exist');
     clusterStorageRow.shouldHaveStorageTypeValue('Persistent storage');
     clusterStorageRow.findConnectedWorkbenches().should('have.text', 'No connections');
-    clusterStorageRow.toggleExpandableContent();
-    clusterStorageRow.shouldHaveStorageSize('5Gi');
+    clusterStorageRow.findSizeColumn().contains('5GiB');
 
     //sort by Name
-    clusterStorage.findClusterStorageTableHeaderButton('Name').click();
     clusterStorage.findClusterStorageTableHeaderButton('Name').should(be.sortAscending);
     clusterStorage.findClusterStorageTableHeaderButton('Name').click();
     clusterStorage.findClusterStorageTableHeaderButton('Name').should(be.sortDescending);
@@ -354,8 +352,7 @@ describe('ClusterStorage', () => {
     const clusterStorageRow = clusterStorage.getClusterStorageRow(
       'Updated storage with no workbench',
     );
-    clusterStorageRow.toggleExpandableContent();
-    clusterStorageRow.shouldHaveStorageSize('Max 13Gi');
+    clusterStorageRow.findSizeColumn().should('have.text', 'Max 13GiB');
     clusterStorageRow.findStorageSizeWarning();
     clusterStorageRow.findStorageSizeWarning().should('exist');
   });

--- a/frontend/src/pages/projects/components/StorageSizeBars.tsx
+++ b/frontend/src/pages/projects/components/StorageSizeBars.tsx
@@ -64,10 +64,7 @@ const StorageSizeBar: React.FC<StorageSizeBarProps> = ({ pvc }) => {
   if (error) {
     inUseRender = (
       <Tooltip content={`Unable to get storage data. ${error.message}`}>
-        <ExclamationCircleIcon
-          color="var(--pf-t--global--icon--color--status--danger--default)"
-          tabIndex={0}
-        />
+        <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
       </Tooltip>
     );
   } else if (!loaded) {

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTable.tsx
@@ -76,7 +76,6 @@ const StorageTable: React.FC<StorageTableProps> = ({ pvcs, refresh, onAddPVC }) 
       <Table
         data={storageTableData}
         columns={getStorageColumns()}
-        disableRowRenderSupport
         data-testid="storage-table"
         variant="compact"
         rowRenderer={(data, i) => (

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -5,11 +5,6 @@ import { StorageTableData } from './types';
 
 export const columns: SortableData<StorageTableData>[] = [
   {
-    field: 'expand',
-    label: '',
-    sortable: false,
-  },
-  {
     field: 'name',
     label: 'Name',
     width: 30,
@@ -33,6 +28,12 @@ export const columns: SortableData<StorageTableData>[] = [
   {
     field: 'type',
     label: 'Type',
+    width: 20,
+    sortable: false,
+  },
+  {
+    field: 'storage_size',
+    label: 'Storage size',
     width: 20,
     sortable: false,
   },


### PR DESCRIPTION
[RHOAIENG-16283](https://issues.redhat.com/browse/RHOAIENG-16283)

## Description
Removed expandable row content from the cluster storage table and added new column for size.

![Screenshot 2025-01-07 at 2 43 30 PM](https://github.com/user-attachments/assets/7554101e-40de-40cd-aa06-46bb62772dbc)


## How Has This Been Tested?
Check the cluster storage table page.

## Test Impact
Changed the reference of expandable row to table column in cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@xianli123 