### PR TITLE
Fix to show all model registries in selector, limit the selection list width

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -65,3 +65,13 @@ body,
   max-height: 65vh;
   overflow: auto;
 }
+
+// Necessary to scroll select menus with grouped sections. Remove when https://github.com/patternfly/patternfly/issues/7256 is resolved
+.pf-v6-c-menu {
+  &.pf-m-scrollable .pf-v6-c-menu__content {
+    overflow: auto;
+  }
+  &.pf-m-drilldown:not(.pf-m-scrollable) {
+    overflow: hidden;
+  }
+}

--- a/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
@@ -101,7 +101,8 @@ const ModelRegistrySelector: React.FC<ModelRegistrySelectorProps> = ({
         );
         onSelection(key);
       }}
-      popperProps={{ maxWidth: undefined }}
+      maxMenuHeight="300px"
+      popperProps={{ maxWidth: '400px' }}
       value={selection?.metadata.name}
       groupedOptions={[
         ...(favorites.length > 0


### PR DESCRIPTION
Closes [RHOAIENG-16867](https://issues.redhat.com/browse/RHOAIENG-16867)

## Description
Adds some custom CSS to provide scrolling for Select menus that have grouped sections. Sets a maximum width on the model registry selector so that long descriptions are truncated rather that making the select menu fit the width.

## How Has This Been Tested?
- Using the model registry dashboard, navigate to `Model Registry`
- Open the Model registry selector
  - Verify the list scrolls to see all available model registries
  - Verify the width of the select menu is reasonable and long descriptions are truncated

## Test Impact
No test impact as changes are purely visual

## Screen shot
[RHOAIENG-16867](https://issues.redhat.com/browse/RHOAIENG-16867)

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
