### PR TITLE
Fix project overview layout when no deployed models

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/PlatformSelectSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Content, Gallery, Stack } from '@patternfly/react-core';
+import { Alert, Content, Flex, FlexItem, Gallery } from '@patternfly/react-core';
 import CollapsibleSection from '~/concepts/design/CollapsibleSection';
 import ModelServingPlatformSelectErrorAlert from '~/pages/modelServing/screens/ModelServingPlatformSelectErrorAlert';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
@@ -27,39 +27,46 @@ const PlatformSelectSection: React.FC = () => {
 
   return (
     <CollapsibleSection title="Serve models" data-testid="section-model-server">
-      <Stack hasGutter>
-        <Content
-          data-testid="no-model-serving-platform-selected"
-          style={{ paddingLeft: 'var(--pf-t--global--spacer--md)' }}
-        >
-          <Content component="small">
+      <Flex gap={{ default: 'gapMd' }} direction={{ default: 'column' }}>
+        <FlexItem>
+          <Content
+            data-testid="no-model-serving-platform-selected"
+            style={{ paddingLeft: 'var(--pf-t--global--spacer--md)' }}
+            component="small"
+          >
             Select the type of model serving platform to be used when deploying models from this
             project.
           </Content>
-        </Content>
-        <Gallery hasGutter {...galleryWidths}>
-          {kServeEnabled && (
-            <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
-          )}
-          {modelMeshEnabled && (
-            <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
-          )}
-          {isNIMAvailable && (
-            <SelectNIMCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
-          )}
-        </Gallery>
+        </FlexItem>
+        <FlexItem>
+          <Gallery hasGutter {...galleryWidths}>
+            {kServeEnabled && (
+              <SelectSingleModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+            )}
+            {modelMeshEnabled && (
+              <SelectMultiModelCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+            )}
+            {isNIMAvailable && (
+              <SelectNIMCard setErrorSelectingPlatform={setErrorSelectingPlatform} />
+            )}
+          </Gallery>
+        </FlexItem>
         {errorSelectingPlatform && (
-          <ModelServingPlatformSelectErrorAlert
-            error={errorSelectingPlatform}
-            clearError={() => setErrorSelectingPlatform(undefined)}
-          />
+          <FlexItem>
+            <ModelServingPlatformSelectErrorAlert
+              error={errorSelectingPlatform}
+              clearError={() => setErrorSelectingPlatform(undefined)}
+            />
+          </FlexItem>
         )}
-        <Alert
-          isInline
-          variant="info"
-          title="You can change the model serving type before the first model is deployed from this project. After deployment, switching types requires deleting all models and servers."
-        />
-      </Stack>
+        <FlexItem>
+          <Alert
+            isInline
+            variant="info"
+            title="You can change the model serving type before the first model is deployed from this project. After deployment, switching types requires deleting all models and servers."
+          />
+        </FlexItem>
+      </Flex>
     </CollapsibleSection>
   );
 };


### PR DESCRIPTION
Closes [RHOAIENG-17776](https://issues.redhat.com/browse/RHOAIENG-17776)

## Description
Change the layout of the Platform selection section in the project overview page to be `flex` rather than `stack`. `stack` sets the height to be 100% which causes it to utilize extra space.

## How Has This Been Tested?
- From the Projects page, select a project that has no deployed models or model server selections.
- Scroll to the bottom of the Overview section
  - Verify the `Project configuration` section is shown correctly.

## Test Impact
No impact to tests, visual change only

## Screen shots

![image](https://github.com/user-attachments/assets/2d6e26cd-1ae9-4170-960e-4240b06ed561)


![image](https://github.com/user-attachments/assets/80ab831e-8d8f-46a0-be1d-42b68b9ba6a7)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @jgiardino 