### PR TITLE
Version Deploy not updating timestamp

### DIFF
--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/updateTimestamps.test.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/updateTimestamps.test.ts
@@ -43,7 +43,16 @@ describe('updateTimestamps', () => {
 
       expect(mockApi.patchModelVersion).toHaveBeenCalledWith(
         {},
-        { state: ModelState.LIVE },
+        {
+          state: ModelState.LIVE,
+          customProperties: {
+            _lastModified: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              // eslint-disable-next-line camelcase
+              string_value: '2024-01-01T00:00:00.000Z',
+            },
+          },
+        },
         fakeModelVersionId,
       );
     });

--- a/frontend/src/concepts/modelRegistry/utils/updateTimestamps.ts
+++ b/frontend/src/concepts/modelRegistry/utils/updateTimestamps.ts
@@ -15,7 +15,23 @@ export const bumpModelVersionTimestamp = async (
   }
 
   try {
-    await api.patchModelVersion({}, { state: ModelState.LIVE }, modelVersionId);
+    const currentTime = new Date().toISOString();
+    await api.patchModelVersion(
+      {},
+      {
+        // This is a workaround to update the timestamp on the backend. There is a bug opened for model registry team
+        // to fix this issue. see https://issues.redhat.com/browse/RHOAIENG-17614
+        state: ModelState.LIVE,
+        customProperties: {
+          _lastModified: {
+            metadataType: ModelRegistryMetadataType.STRING,
+            // eslint-disable-next-line camelcase
+            string_value: currentTime,
+          },
+        },
+      },
+      modelVersionId,
+    );
   } catch (error) {
     throw new Error(
       `Failed to update model version timestamp: ${


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16481

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
related to [RHOAIENG-16077](https://issues.redhat.com/browse/RHOAIENG-16077) 
Fixed all the scenarios for point 3
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploy a version and verify that the deploy updates the Lat modified field in both versions and models list 
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated the test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
