### PR TITLE
remove duplicate prop to fix lint error

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -357,7 +357,6 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
                   id="add-secure-db"
                   data-testid="add-secure-db-mr-checkbox"
                   name="add-secure-db"
-                  data-testid="add-secure-db-checkbox"
                 />
               </FormGroup>
               {addSecureDB &&


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Two commits were recently merged that added the same `data-testid` prop causing a lint error.

Since we do not use prow ci jobs, the checks previously passed and no rebase was required by git to merge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test:lint`

Check CI test job.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
