### PR TITLE
Add cypress tests to MR secure DB section

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
@@ -1,5 +1,7 @@
 import { appChrome } from './appChrome';
+import { Contextual } from './components/Contextual';
 import { K8sNameDescriptionField } from './components/subComponents/K8sNameDescriptionField';
+import { SearchSelector } from './components/subComponents/SearchSelector';
 
 export enum FormFieldSelector {
   NAME = '#mr-name',
@@ -28,6 +30,10 @@ export enum DatabaseDetailsTestId {
 
 class ModelRegistrySettings {
   k8sNameDescription = new K8sNameDescriptionField('mr');
+
+  resourceNameSelect = new SearchSelector('existing-ca-resource-selector');
+
+  keySelect = new SearchSelector('existing-ca-key-selector');
 
   visit(wait = true) {
     cy.visitWithLogin('/modelRegistrySettings');
@@ -130,6 +136,10 @@ class ModelRegistrySettings {
     return cy.findByTestId('existing-ca-radio');
   }
 
+  findUploadNewCertificateRadio() {
+    return cy.findByTestId('new-certificate-ca-radio');
+  }
+
   findAddSecureDbMRCheckbox() {
     return cy.findByTestId('add-secure-db-mr-checkbox');
   }
@@ -140,6 +150,32 @@ class ModelRegistrySettings {
 
   findExistingCAKeyInputToggle() {
     return cy.findByTestId('existing-ca-key-selector-toggle');
+  }
+
+  getNewCertificateUpload() {
+    return new CertificateUpload(() => cy.findByTestId('certificate-upload'));
+  }
+
+  findErrorFetchingResourceAlert() {
+    return cy.findByTestId('error-fetching-resource-alert');
+  }
+
+  findCertificateNote() {
+    return cy.findByTestId('certificate-note');
+  }
+}
+
+class CertificateUpload extends Contextual<HTMLElement> {
+  findUploadCertificateInput() {
+    return this.find().find('[data-testid="new-certificate-upload"] input[type="file"]');
+  }
+
+  uploadPemFile(filePath: string) {
+    this.findUploadCertificateInput().selectFile([filePath], { force: true });
+  }
+
+  findRestrictedFileUploadHelptext() {
+    return cy.findByTestId('restricted-file-example-helpText');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -369,6 +369,10 @@ declare global {
           response: OdhResponse<K8sResourceListResult<ModelRegistryKind>>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'POST /api/modelRegistries',
+          response: OdhResponse<ModelRegistryKind>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'PATCH /api/modelRegistries/:modelRegistryName',
           options: {
             path: { modelRegistryName: string };
@@ -656,7 +660,7 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/modelRegistryCertificates',
-          response: ListConfigSecretsResponse,
+          response: OdhResponse<ListConfigSecretsResponse>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'POST /api/connection-types',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/mockCertificate.pem
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/mockCertificate.pem
@@ -1,0 +1,1 @@
+sample certificate

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/unSupportedFile.txt
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/unSupportedFile.txt
@@ -1,0 +1,1 @@
+file content

--- a/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
@@ -12,6 +12,7 @@ import {
   ResourceType,
   SecureDBRType,
 } from './const';
+import { isClusterWideCABundleEnabled, isOpenshiftCAbundleEnabled } from './utils';
 
 export interface SecureDBInfo {
   type: SecureDBRType;
@@ -71,18 +72,8 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
     return false;
   };
 
-  const clusterWideCABundle = existingCertConfigMaps.find(
-    (configMap) => configMap.name === ODH_TRUSTED_BUNDLE && configMap.keys.includes(CA_BUNDLE_CRT),
-  );
-
-  const isClusterWideCABundleAvailable = !!clusterWideCABundle;
-
-  const openshiftCAbundle = existingCertConfigMaps.find(
-    (configMap) =>
-      configMap.name === ODH_TRUSTED_BUNDLE && configMap.keys.includes(ODH_CA_BUNDLE_CRT),
-  );
-
-  const isProductCABundleAvailable = !!openshiftCAbundle;
+  const isClusterWideCABundleAvailable = isClusterWideCABundleEnabled(existingCertConfigMaps);
+  const isProductCABundleAvailable = isOpenshiftCAbundleEnabled(existingCertConfigMaps);
 
   const getKeysByName = (configMapsSecrets: ConfigSecretItem[], targetName: string): string[] => {
     const configMapSecret = configMapsSecrets.find(
@@ -306,6 +297,7 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
       <Radio
         isChecked={secureDBInfo.type === SecureDBRType.NEW}
         name="new-ca"
+        data-testid="new-certificate-ca-radio"
         onChange={() => handleSecureDBTypeChange(SecureDBRType.NEW)}
         label="Upload new certificate"
         id="new-ca"
@@ -316,6 +308,7 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
             isInline
             title="Note"
             variant="info"
+            data-testid="certificate-note"
             style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
           >
             Uploading a certificate below creates the <strong>{newConfigMapName}</strong> ConfigMap
@@ -324,6 +317,7 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
           </Alert>
           <FormGroup
             label="Certificate"
+            data-testid="certificate-upload"
             required
             style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
           >

--- a/frontend/src/pages/modelRegistrySettings/PemFileUpload.tsx
+++ b/frontend/src/pages/modelRegistrySettings/PemFileUpload.tsx
@@ -49,7 +49,9 @@ export const PemFileUpload: React.FC<{ onChange: (value: string) => void }> = ({
     <>
       <FileUpload
         id="pemFileUpload"
+        data-testid="new-certificate-upload"
         type="text"
+        isReadOnly
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
@@ -70,6 +72,7 @@ export const PemFileUpload: React.FC<{ onChange: (value: string) => void }> = ({
         <HelperText isLiveRegion>
           <HelperTextItem
             id="restricted-file-example-helpText"
+            data-testid="restricted-file-example-helpText"
             variant={isRejected ? 'error' : 'default'}
           >
             {isRejected ? 'Must be a PEM file' : 'Upload a PEM file'}

--- a/frontend/src/pages/modelRegistrySettings/utils.ts
+++ b/frontend/src/pages/modelRegistrySettings/utils.ts
@@ -1,5 +1,5 @@
 import { RecursivePartial } from '~/typeHelpers';
-import { ModelRegistryKind } from '~/k8sTypes';
+import { ConfigSecretItem, ModelRegistryKind } from '~/k8sTypes';
 import {
   CA_BUNDLE_CRT,
   ODH_CA_BUNDLE_CRT,
@@ -50,4 +50,21 @@ export const constructRequestBody = (
   }
 
   return mr;
+};
+
+export const isClusterWideCABundleEnabled = (
+  existingCertConfigMaps: ConfigSecretItem[],
+): boolean => {
+  const clusterWideCABundle = existingCertConfigMaps.find(
+    (configMap) => configMap.name === ODH_TRUSTED_BUNDLE && configMap.keys.includes(CA_BUNDLE_CRT),
+  );
+  return !!clusterWideCABundle;
+};
+
+export const isOpenshiftCAbundleEnabled = (existingCertConfigMaps: ConfigSecretItem[]): boolean => {
+  const openshiftCAbundle = existingCertConfigMaps.find(
+    (configMap) =>
+      configMap.name === ODH_TRUSTED_BUNDLE && configMap.keys.includes(ODH_CA_BUNDLE_CRT),
+  );
+  return !!openshiftCAbundle;
 };


### PR DESCRIPTION
followup PR to https://github.com/opendatahub-io/odh-dashboard/pull/3623 and https://github.com/opendatahub-io/odh-dashboard/pull/3618

## Description
This PR aims to add cypress test for MR secureDB section and address few bugs mentioned [here](https://redhat-internal.slack.com/archives/C07C0447EAV/p1736425171390769)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
1. Run the cypress tests
2. Also test these scenarios:
  - When fetching certificate names fail, Create model registry button should be disabled
  - PEM upload file under "Upload new certificate" section is readOnly 
  - when the first radio option is disabled the form will switch to second option. And when both first and second options are disabled the form selects the third option.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
