### PR TITLE
Unit tests parsecommandline util

### DIFF
--- a/frontend/src/api/k8s/__tests__/utils.spec.ts
+++ b/frontend/src/api/k8s/__tests__/utils.spec.ts
@@ -1,6 +1,11 @@
 import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
 import { AcceleratorProfileState } from '~/utilities/useReadAcceleratorState';
-import { assemblePodSpecOptions, getshmVolume, getshmVolumeMount } from '~/api/k8s/utils';
+import {
+  assemblePodSpecOptions,
+  getshmVolume,
+  getshmVolumeMount,
+  parseCommandLine,
+} from '~/api/k8s/utils';
 import { ContainerResources, TolerationEffect, TolerationOperator } from '~/types';
 import { AcceleratorProfileFormData } from '~/utilities/useAcceleratorProfileFormState';
 
@@ -326,5 +331,58 @@ describe('getshmVolume', () => {
       },
       name: 'shm',
     });
+  });
+});
+
+describe('parseCommandLine', () => {
+  test('parses simple space-separated arguments', () => {
+    expect(parseCommandLine('arg1 arg2 arg3')).toEqual(['arg1', 'arg2', 'arg3']);
+  });
+
+  test('handles double-quoted arguments', () => {
+    expect(parseCommandLine('"arg1 with spaces" arg2')).toEqual(['arg1 with spaces', 'arg2']);
+  });
+
+  test('handles single-quoted arguments', () => {
+    expect(parseCommandLine("'arg1 with spaces' arg2")).toEqual(['arg1 with spaces', 'arg2']);
+  });
+
+  test('handles mixed quotes', () => {
+    expect(parseCommandLine('\'single quoted\' "double quoted"')).toEqual([
+      'single quoted',
+      'double quoted',
+    ]);
+  });
+
+  test('handles nested quotes', () => {
+    expect(parseCommandLine("'nested\"'")).toEqual(['nested"']);
+  });
+
+  test('handles empty input', () => {
+    expect(parseCommandLine('')).toEqual([]);
+  });
+
+  test('handles arguments with special characters', () => {
+    expect(parseCommandLine('arg1 arg2!@#$%^&*()')).toEqual(['arg1', 'arg2!@#$%^&*()']);
+  });
+
+  test('handles arguments with escaped spaces', () => {
+    expect(parseCommandLine('arg1 "arg with spaces" arg3')).toEqual([
+      'arg1',
+      'arg with spaces',
+      'arg3',
+    ]);
+  });
+
+  test('removes surrounding quotes from single-quoted arguments', () => {
+    expect(parseCommandLine("'arg with spaces'")).toEqual(['arg with spaces']);
+  });
+
+  test('removes surrounding quotes from double-quoted arguments', () => {
+    expect(parseCommandLine('"arg with spaces"')).toEqual(['arg with spaces']);
+  });
+
+  test('handles multiple consecutive spaces', () => {
+    expect(parseCommandLine('arg1   arg2    arg3')).toEqual(['arg1', 'arg2', 'arg3']);
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Follow up for #3592 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add unit tests for parseCommandline util function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the unit test for parseCommandline added in this PR.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
This PR only adds unit tests 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
