### PR TITLE
parseCommandLine: Add unit test for multi-line input, remove incorrect help text

### DIFF
--- a/frontend/src/api/k8s/__tests__/utils.spec.ts
+++ b/frontend/src/api/k8s/__tests__/utils.spec.ts
@@ -385,4 +385,8 @@ describe('parseCommandLine', () => {
   test('handles multiple consecutive spaces', () => {
     expect(parseCommandLine('arg1   arg2    arg3')).toEqual(['arg1', 'arg2', 'arg3']);
   });
+
+  test('handles multi-line input', () => {
+    expect(parseCommandLine('arg1 arg2\narg3 arg4')).toEqual(['arg1', 'arg2', 'arg3', 'arg4']);
+  });
 });

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -107,8 +107,8 @@ const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({
       <FormHelperText>
         <HelperText>
           <HelperTextItem>
-            {`Enter one argument and its values per line. Overwriting the runtime's predefined
-            listening port or model location will likely result in a failed deployment.`}
+            {`Overwriting the runtime's predefined listening port or
+            model location will likely result in a failed deployment.`}
           </HelperTextItem>
         </HelperText>
       </FormHelperText>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Followup to https://github.com/opendatahub-io/odh-dashboard/pull/3592 and https://github.com/opendatahub-io/odh-dashboard/pull/3633.
Resolves https://issues.redhat.com/browse/RHOAIENG-16900.

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds one more test based on comments on #3633, and removes the now-incorrect help text directing users to only have one argument per line now that we support single-line arg lists.

Help text before:

<img width="855" alt="Screenshot 2025-01-10 at 12 06 25 PM" src="https://github.com/user-attachments/assets/7349eca4-9d3d-44d1-aa81-fbfadcc40422" />

Help text after:

<img width="858" alt="Screenshot 2025-01-10 at 12 13 50 PM" src="https://github.com/user-attachments/assets/e93308c9-d125-41bc-9218-cde12f814ed5" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No manual testing, this is just a unit test and a microcopy change.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

See new unit test - just making sure the util still handles multi-line args properly.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
