### PR TITLE
Fix: workbenches e2e test. Use PVC Display Name

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
@@ -90,9 +90,7 @@ describe('Workbench and PVSs tests', () => {
 
       cy.step(`Check the cluster storage ${PVCDisplayName} is now connected to ${workbenchName}`);
       projectDetails.findSectionTab('cluster-storages').click();
-      // TODO: Bug RHOAIENG-16239
-      // const csRow = clusterStorage.getClusterStorageRow(PVCDisplayName);
-      const csRow = clusterStorage.getClusterStorageRow(PVCName);
+      const csRow = clusterStorage.getClusterStorageRow(PVCDisplayName);
       csRow.findConnectedWorkbenches().should('have.text', workbenchName);
     },
   );


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-18051

## Description
As the issue with the PVC showing it's name instead of the Display Name in the UI (https://issues.redhat.com/browse/RHOAIENG-16239) has been fixed, we need to update the Workbenches test.
It's been failing in the lasts nightlies
![image](https://github.com/user-attachments/assets/a3998f33-72df-4f88-88d5-63132e9cc1c2)


## How Has This Been Tested?
`$ npx cypress run --spec "**/workbenches.cy.ts" --browser chrome`
![image](https://github.com/user-attachments/assets/14fb06d5-5046-4009-8c26-dcde79ec51db)

## Test Impact
Fix for workbenches.ct.ts test

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
