### PR TITLE
Allow override of the path to oauth for impersonate user

### DIFF
--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -3,7 +3,11 @@ import https from 'https';
 import createError from 'http-errors';
 import { setImpersonateAccessToken } from '../../../devFlags';
 import { KubeFastifyInstance } from '../../../types';
-import { DEV_IMPERSONATE_PASSWORD, DEV_IMPERSONATE_USER } from '../../../utils/constants';
+import {
+  DEV_IMPERSONATE_PASSWORD,
+  DEV_IMPERSONATE_USER,
+  DEV_OATH_PREFIX,
+} from '../../../utils/constants';
 import { createCustomError } from '../../../utils/requestUtils';
 import { devRoute } from '../../../utils/route-security';
 
@@ -16,7 +20,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         if (doImpersonate) {
           const apiPath = fastify.kube.config.getCurrentCluster().server;
           const namedHost = apiPath.slice('https://api.'.length).split(':')[0];
-          const url = `https://oauth-openshift.apps.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
+          const url = `https://${DEV_OATH_PREFIX}.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
           // Custom call, don't use proxy
           const httpsRequest = https
             .get(

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -10,6 +10,7 @@ export const DEV_MODE = process.env.APP_ENV === 'development';
 /** Allows a username to be impersonated in place of the logged in user for testing purposes -- impacts only some API */
 export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 export const DEV_IMPERSONATE_PASSWORD = DEV_MODE ? process.env.DEV_IMPERSONATE_PASSWORD : undefined;
+export const DEV_OATH_PREFIX = process.env.DEV_OAUTH_PREFIX || 'oauth-openshift.apps';
 export const APP_ENV = process.env.APP_ENV;
 
 export const USER_ACCESS_TOKEN = 'x-forwarded-access-token';


### PR DESCRIPTION
## Description
Fixes the URL path to `oath` when the dev server is running agains an RHOAI dashboard

## How Has This Been Tested?
- For a cluster whose oath route is not `oauth-openshift`, Edit `.env.local` and set `DEV_IMPERSONATE_USER` and `DEV_IMPERSONATE_PASSWORD` to a valid combo and set `DEV_OAUTH_PREFIX` to the correct route.
- Run the dev server
- In the dev dashboard, select the user menu and `Start impersonate`
- Verify there are no errors and you now see only projects that `DEV_IMPERSONATE_USER` should see.

## Test Impact
None, dev mode only

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
