### PR TITLE
Hide disabled kebab for connections owned by DSC

### DIFF
--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -146,21 +146,27 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
               title: 'Preview',
               onClick: () => setShowPreview(true),
             },
-            {
-              title: 'Edit',
-              onClick: () => navigate(`/connectionTypes/edit/${obj.metadata.name}`),
-              isDisabled: ownedByDSC(obj),
-            },
+            ...(!ownedByDSC(obj)
+              ? [
+                  {
+                    title: 'Edit',
+                    onClick: () => navigate(`/connectionTypes/edit/${obj.metadata.name}`),
+                  },
+                ]
+              : []),
             {
               title: 'Duplicate',
               onClick: () => navigate(`/connectionTypes/duplicate/${obj.metadata.name}`),
             },
-            { isSeparator: true },
-            {
-              title: 'Delete',
-              onClick: () => handleDelete(obj),
-              isDisabled: ownedByDSC(obj),
-            },
+            ...(!ownedByDSC(obj)
+              ? [
+                  { isSeparator: true },
+                  {
+                    title: 'Delete',
+                    onClick: () => handleDelete(obj),
+                  },
+                ]
+              : []),
           ]}
         />
       </Td>


### PR DESCRIPTION
Closes: [RHOAIENG-17142](https://issues.redhat.com/browse/RHOAIENG-17142)

## Description
Hides the edit and delete options for connections owned by DSC. Since the admin will never be able to enable these actions, there's no need for them to be visible. 

## How Has This Been Tested?
Tested locally 

## Test Impact
No tests changed

## Screenshots
Before, with edit and delete disabled:
![Screenshot 2025-01-14 at 11 19 20 AM](https://github.com/user-attachments/assets/476a25fa-9158-40dc-80e0-3a55afb9d500)

After, edit and delete hidden:
![Screenshot 2025-01-14 at 11 20 04 AM](https://github.com/user-attachments/assets/1b8ca101-ae69-46ea-9eea-9b3d9f459cdf)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
