### PR TITLE
Fix/10950 dw req resource chart colors

### DIFF
--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/RequestedResourcesBulletChart.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/RequestedResourcesBulletChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { capitalize } from '@patternfly/react-core';
-import { ChartBullet, ChartLegend } from '@patternfly/react-charts/victory';
+import { ChartBullet } from '@patternfly/react-charts/victory';
 import { DistributedWorkloadsContext } from '~/concepts/distributedWorkloads/DistributedWorkloadsContext';
 import { roundNumber } from '~/utilities/number';
 
@@ -62,17 +62,15 @@ export const RequestedResourcesBulletChart: React.FC<RequestedResourcesBulletCha
     tooltipValue: roundNumber(args.preciseValue, 3),
     cappedValue: roundNumber(Math.min(args.preciseValue, maxDomain)),
   });
-  const getChartData = (data: CappedBulletChartDataItem[]) => {
-    return data.map(({ name, cappedValue }) => ({
+  const getChartData = (data: CappedBulletChartDataItem[]) =>
+    data.map(({ name, cappedValue }) => ({
       name,
       y: cappedValue,
     }));
-  };
-  const getLegendData = (data: CappedBulletChartDataItem[]) => {
-    return data.map(({ name, hideValueInLegend, legendValue }) => ({
+  const getLegendData = (data: CappedBulletChartDataItem[]) =>
+    data.map(({ name, hideValueInLegend, legendValue }) => ({
       name: hideValueInLegend ? name : `${name}: ${legendValue}`,
     }));
-  };
 
   const requestedByThisProjectData = getDataItem({
     name: `Requested by ${projectDisplayName}`,


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/RHOAIENG-10950

## Description
colors were off as the pf chart flips colors in dark/light mode and our custom legend was not doing that. this pr uses pf chart's `...MeasureLegendData` props which will automatically use the same colors for the chart and legend.
![image](https://github.com/user-attachments/assets/547dce6d-1c6f-4c7a-9a2d-2b05f4f68666)
![image](https://github.com/user-attachments/assets/6661b9e1-9a3d-4aa7-afc0-fb6a5e144d0a)



## How Has This Been Tested?
i tested by mocking data and making sure the colors on the chart and legend matched up correctly in both dark and light mode.

also tested by running some yaml files to create real data

## Test Impact
none

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
