### PR TITLE
fix: add unit test for getNIMResourcesToDelete function

### DIFF
--- a/frontend/src/concepts/nimServing/NIMAvailabilityContext.tsx
+++ b/frontend/src/concepts/nimServing/NIMAvailabilityContext.tsx
@@ -18,11 +18,7 @@ export const NIMAvailabilityContext = React.createContext<NIMAvailabilityContext
 export const NimContextProvider: React.FC<NIMAvailabilityContextProviderProps> = ({
   children,
   ...props
-}) => {
-  return <EnabledNimContextProvider {...props}>{children}</EnabledNimContextProvider>;
-
-  return children;
-};
+}) => <EnabledNimContextProvider {...props}>{children}</EnabledNimContextProvider>;
 
 const EnabledNimContextProvider: React.FC<NIMAvailabilityContextProviderProps> = ({ children }) => {
   const [isNIMAvailable, loaded] = useIsNIMAvailable();

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/nimUtils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/nimUtils.spec.ts
@@ -6,6 +6,7 @@ import {
   getNIMResourcesToDelete,
 } from '~/pages/modelServing/screens/projects/nimUtils';
 import { mockNimAccount } from '~/__mocks__/mockNimAccount';
+import { mockServingRuntimeK8sResource } from '~/__mocks__';
 
 jest.mock('~/pages/modelServing/screens/projects/utils', () => ({
   fetchInferenceServiceCount: jest.fn(),
@@ -17,39 +18,31 @@ jest.mock('~/api', () => ({
 }));
 describe('getNIMResourcesToDelete', () => {
   const projectName = 'test-project';
-  const mockServingRuntime: ServingRuntimeKind = {
-    apiVersion: 'serving.kserve.io/v1alpha1',
-    kind: 'ServingRuntime',
-    metadata: {
-      name: 'test-serving-runtime',
-      namespace: 'test-namespace',
+  const mockServingRuntime = mockServingRuntimeK8sResource({});
+
+  mockServingRuntime.spec.volumes = [
+    {
+      name: 'nim-pvc-volume',
+      persistentVolumeClaim: { claimName: 'nim-pvc-123' },
     },
-    spec: {
-      volumes: [
+  ];
+  mockServingRuntime.spec.imagePullSecrets = [{ name: 'ngc-secret' }];
+  mockServingRuntime.spec.containers = [
+    {
+      name: 'test-container',
+      env: [
         {
-          name: 'nim-pvc-volume',
-          persistentVolumeClaim: { claimName: 'nim-pvc-123' },
-        },
-      ],
-      imagePullSecrets: [{ name: 'ngc-secret' }],
-      containers: [
-        {
-          name: 'test-container',
-          env: [
-            {
+          name: 'some-key',
+          valueFrom: {
+            secretKeyRef: {
               name: 'nvidia-nim-secrets',
-              valueFrom: {
-                secretKeyRef: {
-                  name: 'nvidia-nim-secrets',
-                  key: 'some-key',
-                },
-              },
+              key: 'some-key',
             },
-          ],
+          },
         },
       ],
     },
-  };
+  ];
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/nimUtils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/nimUtils.spec.ts
@@ -46,7 +46,6 @@ describe('getNIMResourcesToDelete', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   it('should add deletePvc to resources if pvcName exists', async () => {
@@ -130,7 +129,6 @@ describe('fetchNIMAccountTemplateName', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   it('should return the template name when available', async () => {

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/nimUtils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/nimUtils.spec.ts
@@ -1,0 +1,177 @@
+import { ServingRuntimeKind } from '~/k8sTypes';
+import { fetchInferenceServiceCount } from '~/pages/modelServing/screens/projects/utils';
+import { deletePvc, deleteSecret, listNIMAccounts } from '~/api';
+import {
+  fetchNIMAccountTemplateName,
+  getNIMResourcesToDelete,
+} from '~/pages/modelServing/screens/projects/nimUtils';
+import { mockNimAccount } from '~/__mocks__/mockNimAccount';
+
+jest.mock('~/pages/modelServing/screens/projects/utils', () => ({
+  fetchInferenceServiceCount: jest.fn(),
+}));
+jest.mock('~/api', () => ({
+  deletePvc: jest.fn(),
+  deleteSecret: jest.fn(),
+  listNIMAccounts: jest.fn(),
+}));
+describe('getNIMResourcesToDelete', () => {
+  const projectName = 'test-project';
+  const mockServingRuntime: ServingRuntimeKind = {
+    apiVersion: 'serving.kserve.io/v1alpha1',
+    kind: 'ServingRuntime',
+    metadata: {
+      name: 'test-serving-runtime',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      volumes: [
+        {
+          name: 'nim-pvc-volume',
+          persistentVolumeClaim: { claimName: 'nim-pvc-123' },
+        },
+      ],
+      imagePullSecrets: [{ name: 'ngc-secret' }],
+      containers: [
+        {
+          name: 'test-container',
+          env: [
+            {
+              name: 'nvidia-nim-secrets',
+              valueFrom: {
+                secretKeyRef: {
+                  name: 'nvidia-nim-secrets',
+                  key: 'some-key',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('should add deletePvc to resources if pvcName exists', async () => {
+    const resultMock = jest.mocked(fetchInferenceServiceCount);
+    resultMock.mockResolvedValue(0);
+    (deletePvc as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await getNIMResourcesToDelete(projectName, mockServingRuntime);
+
+    expect(fetchInferenceServiceCount).toHaveBeenCalledWith(projectName);
+    expect(deletePvc).toHaveBeenCalledWith('nim-pvc-123', projectName);
+    expect(result.length).toBe(1); // Only deletePvc in resources
+  });
+
+  it('should add deleteSecret for both secrets if count is 1', async () => {
+    const resultMock = jest.mocked(fetchInferenceServiceCount);
+    resultMock.mockResolvedValue(1);
+    (deletePvc as jest.Mock).mockResolvedValue(undefined);
+    (deleteSecret as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await getNIMResourcesToDelete(projectName, mockServingRuntime);
+
+    expect(fetchInferenceServiceCount).toHaveBeenCalledWith(projectName);
+    expect(deletePvc).toHaveBeenCalledWith('nim-pvc-123', projectName);
+    expect(deleteSecret).toHaveBeenCalledWith(projectName, 'nvidia-nim-secrets');
+    expect(deleteSecret).toHaveBeenCalledWith(projectName, 'ngc-secret');
+    expect(result.length).toBe(3); // deletePvc + 2 deleteSecret
+  });
+
+  it('should not add deleteSecret if count is not 1', async () => {
+    const resultMock = jest.mocked(fetchInferenceServiceCount);
+    resultMock.mockResolvedValue(2);
+    (deletePvc as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await getNIMResourcesToDelete(projectName, mockServingRuntime);
+
+    expect(fetchInferenceServiceCount).toHaveBeenCalledWith(projectName);
+    expect(deletePvc).toHaveBeenCalledWith('nim-pvc-123', projectName);
+    expect(deleteSecret).not.toHaveBeenCalled();
+    expect(result.length).toBe(1); // Only deletePvc
+  });
+
+  it('should handle errors from fetchInferenceServiceCount and still add deletePvc if pvcName exists', async () => {
+    const resultMock = jest.mocked(fetchInferenceServiceCount);
+    resultMock.mockRejectedValue(new Error('Fetch error'));
+    (deletePvc as jest.Mock).mockResolvedValue(undefined);
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const result = await getNIMResourcesToDelete(projectName, mockServingRuntime);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `Failed to fetch inference service count for project "${projectName}": Fetch error`,
+    );
+    expect(deletePvc).toHaveBeenCalledWith('nim-pvc-123', projectName);
+    expect(deleteSecret).not.toHaveBeenCalled();
+    expect(result.length).toBe(1); // Only deletePvc
+    consoleSpy.mockRestore();
+  });
+
+  it('should return an empty array if pvcName does not exist and fetchInferenceServiceCount is 0', async () => {
+    const servingRuntimeNoPvc: ServingRuntimeKind = {
+      ...mockServingRuntime,
+      spec: {
+        ...mockServingRuntime.spec,
+        volumes: [{ name: 'other-volume', persistentVolumeClaim: { claimName: 'not-nim-pvc' } }],
+      },
+    };
+    const resultMock = jest.mocked(fetchInferenceServiceCount);
+    resultMock.mockResolvedValue(0);
+
+    const result = await getNIMResourcesToDelete(projectName, servingRuntimeNoPvc);
+
+    expect(fetchInferenceServiceCount).toHaveBeenCalledWith(projectName);
+    expect(deletePvc).not.toHaveBeenCalled();
+    expect(result).toEqual([]); // No PVC or secrets to delete
+  });
+});
+
+describe('fetchNIMAccountTemplateName', () => {
+  const dashboardNamespace = 'test-namespace';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('should return the template name when available', async () => {
+    const mockAccount = mockNimAccount({ runtimeTemplateName: 'test-template' });
+    (listNIMAccounts as jest.Mock).mockResolvedValueOnce([mockAccount]);
+
+    const result = await fetchNIMAccountTemplateName(dashboardNamespace);
+
+    expect(result).toBe('test-template');
+    expect(listNIMAccounts).toHaveBeenCalledWith(dashboardNamespace);
+  });
+
+  it('should return undefined when no accounts exist', async () => {
+    (listNIMAccounts as jest.Mock).mockResolvedValueOnce([]);
+
+    const result = await fetchNIMAccountTemplateName(dashboardNamespace);
+
+    expect(result).toBeUndefined();
+    expect(listNIMAccounts).toHaveBeenCalledWith(dashboardNamespace);
+  });
+
+  it('should handle errors from listNIMAccounts', async () => {
+    const mockError = new Error('Server Error');
+    (listNIMAccounts as jest.Mock).mockRejectedValue(mockError);
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const result = await fetchNIMAccountTemplateName(dashboardNamespace);
+
+    expect(result).toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Error fetching NIM account template name: ${mockError.message}`,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -257,7 +257,6 @@ describe('createNIMSecret', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   it('should create NGC secret when isNGC is true', async () => {
@@ -327,7 +326,6 @@ describe('createNIMSecret', () => {
 describe('fetchNIMModelNames', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
   const configMapMock = {
     data: {
@@ -423,7 +421,6 @@ describe('createNIMPVC', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   it('should call createPvc with correct arguments and return the result', async () => {

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -12,22 +12,19 @@ import {
 import { LabeledDataConnection, ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
 import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
-import { createPvc, createSecret, listNIMAccounts } from '~/api';
+import { createPvc, createSecret } from '~/api';
 import { PersistentVolumeClaimKind, ServingRuntimeKind } from '~/k8sTypes';
 import {
-  fetchNIMAccountTemplateName,
   getNIMData,
   getNIMResource,
   updateServingRuntimeTemplate,
 } from '~/pages/modelServing/screens/projects/nimUtils';
-import { mockNimAccount } from '~/__mocks__/mockNimAccount';
 
 jest.mock('~/api', () => ({
   getSecret: jest.fn(),
   createSecret: jest.fn(),
   createPvc: jest.fn(),
   getInferenceServiceContext: jest.fn(),
-  listNIMAccounts: jest.fn(),
 }));
 
 jest.mock('~/pages/modelServing/screens/projects/nimUtils', () => ({
@@ -260,6 +257,7 @@ describe('createNIMSecret', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('should create NGC secret when isNGC is true', async () => {
@@ -329,6 +327,7 @@ describe('createNIMSecret', () => {
 describe('fetchNIMModelNames', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
   const configMapMock = {
     data: {
@@ -424,6 +423,7 @@ describe('createNIMPVC', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('should call createPvc with correct arguments and return the result', async () => {
@@ -536,48 +536,5 @@ describe('updateServingRuntimeTemplate', () => {
     const result = updateServingRuntimeTemplate(servingRuntimeWithoutVolumeMounts, pvcName);
 
     expect(result.spec.containers[0].volumeMounts).toBeUndefined();
-  });
-});
-
-describe('fetchNIMAccountTemplateName', () => {
-  const dashboardNamespace = 'test-namespace';
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should return the template name when available', async () => {
-    const mockAccount = mockNimAccount({ runtimeTemplateName: 'test-template' });
-    (listNIMAccounts as jest.Mock).mockResolvedValueOnce([mockAccount]);
-
-    const result = await fetchNIMAccountTemplateName(dashboardNamespace);
-
-    expect(result).toBe('test-template');
-    expect(listNIMAccounts).toHaveBeenCalledWith(dashboardNamespace);
-  });
-
-  it('should return undefined when no accounts exist', async () => {
-    (listNIMAccounts as jest.Mock).mockResolvedValueOnce([]);
-
-    const result = await fetchNIMAccountTemplateName(dashboardNamespace);
-
-    expect(result).toBeUndefined();
-    expect(listNIMAccounts).toHaveBeenCalledWith(dashboardNamespace);
-  });
-
-  it('should handle errors from listNIMAccounts', async () => {
-    const mockError = new Error('Server Error');
-    (listNIMAccounts as jest.Mock).mockRejectedValue(mockError);
-
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-    const result = await fetchNIMAccountTemplateName(dashboardNamespace);
-
-    expect(result).toBeUndefined();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      `Error fetching NIM account template name: ${mockError.message}`,
-    );
-
-    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-39

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a unit test for the getNIMResourcesToDelete function and relocated the fetchNIMAccountTemplateName unit test to a new file alongside the newly created test for better organization.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Ran all the unit tests to make sure nothing was broken.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
