### PR TITLE
Cypress e2e Test - Verify That "Usage Data Collection" Can Be Set In "Cluster Settings"

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
@@ -1,0 +1,56 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  clusterSettings,
+  telemetrySettings,
+} from '~/__tests__/cypress/cypress/pages/clusterSettings';
+import { getCustomResource } from '~/__tests__/cypress/cypress/utils/oc_commands/customResources';
+
+describe('Verify That Usage Data Collection Can Be Set In Cluster Settings', () => {
+  let skipTest = false;
+
+  before(() => {
+    // Check if the operator is RHOAI, if its not, skip the test
+    cy.step('Check if the operator is RHOAI');
+    getCustomResource('redhat-ods-operator', 'Deployment', 'name=rhods-operator').then((result) => {
+      if (!result.stdout.includes('rhods-operator')) {
+        cy.log('RHOAI operator not found, skipping the test.');
+        skipTest = true;
+      } else {
+        cy.log('RHOAI operator confirmed:', result.stdout);
+      }
+    });
+  });
+
+  it(
+    'Verify Usage Data Collection can be Enabled/Disabled',
+    { tags: ['@Sanity', '@ODS-1218', '@Dashboard', '@ExcludeOnODH'] },
+    () => {
+      if (skipTest) {
+        cy.log('Skipping test confirmed');
+        return;
+      }
+
+      // Authentication and navigation
+      cy.step('Log into the application');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+      clusterSettings.navigate();
+
+      // Check that usage data collection is enabled by default
+      cy.step('Data collection is enabled');
+      telemetrySettings.findEnabledCheckbox().should('be.checked');
+
+      // Disable data usage collection
+      cy.step('Disable usage data collection');
+      telemetrySettings.findEnabledCheckbox().click();
+
+      // Save changes in cluster settings
+      cy.step('Save changes and wait for changes to be applied');
+      clusterSettings.findSubmitButton().click();
+
+      // Refresh and verify data collection is still disabled
+      cy.step('Refresh settings view');
+      cy.reload();
+      telemetrySettings.findEnabledCheckbox().should('not.be.checked');
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
@@ -23,7 +23,7 @@ describe('Verify That Usage Data Collection Can Be Set In Cluster Settings', () 
 
   it(
     'Verify Usage Data Collection can be Enabled/Disabled',
-    { tags: ['@Sanity', '@ODS-1218', '@Dashboard', '@ExcludeOnODH'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1218', '@Dashboard', '@ExcludeOnODH'] },
     () => {
       if (skipTest) {
         cy.log('Skipping test confirmed');

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/customResources.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/customResources.ts
@@ -49,7 +49,7 @@ export const getCustomResource = (
   kind: string,
   labelSelector: string,
 ): Cypress.Chainable<CommandLineResult> => {
-  const ocCommand = `Oc Get kind=${kind}, label_selector=${labelSelector}, namespace=${resourceNamespace}`;
+  const ocCommand = `oc get ${kind} -l ${labelSelector} -n ${resourceNamespace}`;
   cy.log(`Executing command: ${ocCommand}`);
   return cy.exec(ocCommand, { failOnNonZeroExit: false });
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17801

## Description
Migrate ODS-1218 to Cypress

## How Has This Been Tested?

- An oc login should be performed in the cluster before running the test

- test-variables.yml should be configured properly

- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml

- Tested against ODH-Nightly & RHOAI nightly

![image](https://github.com/user-attachments/assets/01bb23b7-37e7-4127-a025-17fb9f1ac226)


## How to Run
After exporting the test-variables.yml we have 2 different ways:

Using the UI
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress open . This will open the Cypress UI where testDataCollection.cy.ts can be run.

Headless
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress run --spec "cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts" --browser chrome

## Test Impact:

- This is already a test

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`