### PR TITLE
Give default title and action label to the application enable modal

### DIFF
--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -99,7 +99,7 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
       className="odh-enable-modal"
       data-id="enable-modal"
       variant={ModalVariant.small}
-      title={enable.title}
+      title={enable.title || `Enable ${selectedApp.spec.displayName}`}
       isOpen
       onClose={handleClose}
       actions={[
@@ -107,9 +107,9 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
           key="confirm"
           variant="primary"
           onClick={onDoEnableApp}
-          isDisabled={validationInProgress || isEnableValuesHasEmptyValue}
+          isDisabled={validationInProgress || (enable.variables && isEnableValuesHasEmptyValue)}
         >
-          {enable.actionLabel}
+          {enable.actionLabel || 'Enable'}
         </Button>,
         <Button key="cancel" variant="link" onClick={handleClose}>
           {validationInProgress ? 'Close' : 'Cancel'}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-425

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In `OdhApplication` CRD, the field `spec.enable` may not contain `title` and `actionLabel` fields. Give them default value to show the enable modal correctly. Default fallback title is `spec.displayName` and default fallback actionLabel is `Enable`

<img width="1512" alt="Screenshot 2025-01-15 at 1 37 06 PM" src="https://github.com/user-attachments/assets/71664291-4a53-402d-9b90-a1e0174d5558" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Import the following YAML to your cluster using OpenShift console `opendatahub` namespace (or the namespace where you deployed the ODH dashboard)
```
apiVersion: dashboard.opendatahub.io/v1
kind: OdhApplication
metadata:
  annotations:
    opendatahub.io/categories: 'Data management,Data preprocessing,Model training'
  name: mlflow-server
  labels:
    app: odh-dashboard
spec:
  enable:
    validationConfigMap: mlflow-enable
  img: '<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M18.9509 2.17634C14.0635 -1.24345 7.40926 -0.571051 3.30485 3.75735C-0.799556 8.08576 -1.11776 14.7663 2.55667 19.4652L6.22524 16.7724C4.40423 14.5134 4.03437 11.4124 5.27298 8.78843C6.51159 6.16448 9.1408 4.47914 12.0422 4.44929L11.9554 7.31581L18.9509 2.17634Z" fill="#43C9ED"/> <path d="M21.6639 4.85176C21.5423 4.68382 21.4149 4.51878 21.2846 4.35953L17.7521 6.96546C19.7463 9.17232 20.2637 12.3424 19.0746 15.0688C17.8856 17.7952 15.2104 19.5728 12.2362 19.6129L12.3231 16.7493L5.24945 21.9611C10.0971 25.2255 16.5896 24.5337 20.6406 20.3213C24.6917 16.1089 25.1295 9.59437 21.6784 4.87782L21.6639 4.85176Z" fill="#0194E2"/> </svg>'
  getStartedLink: 'https://mlflow.org/docs/latest/quickstart.html'
  route: test
  displayName: MLflow
  kfdefApplications: []
  support: third party support
  csvName: ''
  provider: MLflow
  routeNamespace: test
  docsLink: 'https://mlflow.org/docs/latest/index.html'
  quickStart: ''
  getStartedMarkDown: |-
    # MLFlow
    MLflow is an open source platform for managing the end-to-end machine learning lifecycle. It tackles four primary functions:
    - Tracking experiments to record and compare parameters and results (MLflow Tracking). - Packaging ML code in a reusable, reproducible form in order to share with other data scientists or transfer to production (MLflow Projects). - Managing and deploying models from a variety of ML libraries to a variety of model serving and inference platforms (MLflow Models). - Providing a central model store to collaboratively manage the full lifecycle of an MLflow Model, including model versioning, stage transitions, and annotations (MLflow Model Registry).
  description: MLflow is an open source platform for managing the end-to-end machine learning lifecycle.
  category: Self-managed
```
Validate if the title is `Enable {displayName}` and the button is showing `Enable` as expected.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, we don't have a test for the enable modal because it's an old component, not sure if it worth the effort to write tests for that.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
