### PR TITLE
changed fields to be UTC and duration to be more descriptive

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
@@ -465,9 +465,15 @@ describe('Pipeline topology', () => {
         .findValue()
         .contains(mockRecurringRun.display_name);
       pipelineRunDetails.findDetailItem('Workflow name').findValue().contains('test-pipeline');
-      pipelineRunDetails.findDetailItem('Started').findValue().contains('March 15, 2024');
-      pipelineRunDetails.findDetailItem('Finished').findValue().contains('March 15, 2024');
-      pipelineRunDetails.findDetailItem('Duration').findValue().contains('0:50');
+      pipelineRunDetails
+        .findDetailItem('Started')
+        .findValue()
+        .contains('Friday, March 15, 2024 at 5:59:35 PM UTC');
+      pipelineRunDetails
+        .findDetailItem('Finished')
+        .findValue()
+        .contains('Friday, March 15, 2024 at 6:00:25 PM UTC');
+      pipelineRunDetails.findDetailItem('Duration').findValue().contains('50 seconds');
     });
 
     it('Test pipeline triggered run tab parameters', () => {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -52,7 +52,12 @@ export const asTimestamp = (date: Date): React.ReactNode => (
       </Icon>
     </FlexItem>
     <FlexItem>
-      <Timestamp date={date} dateFormat={TimestampFormat.full} timeFormat={TimestampFormat.full} />
+      <Timestamp
+        shouldDisplayUTC
+        date={date}
+        dateFormat={TimestampFormat.full}
+        timeFormat={TimestampFormat.medium}
+      />
     </FlexItem>
   </Flex>
 );

--- a/frontend/src/utilities/__tests__/time.spec.ts
+++ b/frontend/src/utilities/__tests__/time.spec.ts
@@ -14,11 +14,11 @@ import {
 
 describe('relativeDuration', () => {
   it('should convert milliseconds to minutes and seconds', () => {
-    expect(relativeDuration(123456)).toBe('2:03');
+    expect(relativeDuration(123456)).toBe('2 minutes, 3 seconds');
   });
 
   it('should calculate values if minutes is less than 0', () => {
-    expect(relativeDuration(-123456)).toBe('0:0-124');
+    expect(relativeDuration(-123456)).toBe('-124 seconds');
   });
 });
 
@@ -117,7 +117,7 @@ describe('ensureTimeFormat', () => {
 
 describe('printSeconds', () => {
   it('should print seconds', () => {
-    expect(printSeconds(3661)).toBe('1 second, 1 minute, 1 hour');
+    expect(printSeconds(3661)).toBe('1 hour, 1 minute, 1 second');
   });
 
   it('should handle a single unit', () => {
@@ -126,6 +126,10 @@ describe('printSeconds', () => {
 
   it('should handle a single unit at max', () => {
     expect(printSeconds(60)).toBe('1 minute');
+  });
+
+  it('should handle zero seconds', () => {
+    expect(printSeconds(0)).toBe('0 seconds');
   });
 });
 

--- a/frontend/src/utilities/time.ts
+++ b/frontend/src/utilities/time.ts
@@ -8,17 +8,8 @@ const printAgo = (time: number, unit: string) => `${time} ${unit}${time > 1 ? 's
 const printIn = (time: number, unit: string) => `in ${time} ${unit}${time > 1 ? 's' : ''}`;
 const leadZero = (v: number) => (v < 10 ? `0${v}` : `${v}`);
 
-export const relativeDuration = (valueInMs: number): string => {
-  let seconds = Math.floor(valueInMs / 1000);
-
-  let minutes = 0;
-  if (seconds > 60) {
-    minutes = Math.floor(seconds / 60);
-    seconds %= 60;
-  }
-
-  return `${minutes}:${leadZero(seconds)}`;
-};
+export const relativeDuration = (valueInMs: number): string =>
+  printSeconds(Math.floor(valueInMs / 1000));
 
 /** As YYYY-MM-DD */
 export const convertDateToSimpleDateString = (date?: Date): string | null => {
@@ -73,6 +64,9 @@ export const ensureTimeFormat = (time: string): string | null => {
 };
 
 export const printSeconds = (seconds: number): string => {
+  if (seconds === 0) {
+    return '0 seconds';
+  }
   const timeBlocks = [
     { unit: 'second', maxPer: 60 },
     { unit: 'minute', maxPer: 60 },
@@ -107,11 +101,10 @@ export const printSeconds = (seconds: number): string => {
         return [thisText, newUnit];
       }
 
-      return [`${currentText}, ${thisText}`, newUnit];
+      return [`${thisText}, ${currentText}`, newUnit];
     },
     ['', seconds],
   );
-
   return text;
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-13774

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1694" alt="Screenshot 2025-01-15 at 4 48 56 PM" src="https://github.com/user-attachments/assets/9c1914be-d86a-4219-b364-a26cf333945b" />
<img width="1694" alt="Screenshot 2025-01-15 at 4 49 52 PM" src="https://github.com/user-attachments/assets/265abb2f-f331-428f-ac87-25bdba3cede3" />

The pipeline runs detail pages are changed to UTC time zones and duration time is more consistent

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npm run test:unit **/time.spec.ts`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Edited the `time.spec.ts` file

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
