### PR TITLE
Read and show default deployment mode in deploy modal

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1271,6 +1271,9 @@ export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> 
 /** We don't need or should ever get the full kind, this is the status section */
 export type DataScienceClusterKindStatus = {
   components?: {
+    kserve?: {
+      defaultDeploymentMode?: string;
+    };
     modelregistry?: {
       registriesNamespace?: string;
     };

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
@@ -2,22 +2,8 @@ import { FormGroup, Icon, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
-
-enum DeploymentMode {
-  Advanced = 'advanced',
-  Standard = 'standard',
-}
-
-const options: SimpleSelectOption[] = [
-  {
-    label: 'Standard',
-    key: DeploymentMode.Standard,
-  },
-  {
-    label: 'Advanced (default)',
-    key: DeploymentMode.Advanced,
-  },
-];
+import { DeploymentMode } from '~/k8sTypes';
+import { useDefaultDeploymentMode } from '~/pages/modelServing/useDefaultDeploymentMode';
 
 type Props = {
   isRaw: boolean;
@@ -25,28 +11,48 @@ type Props = {
   isDisabled?: boolean;
 };
 
-export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw, isDisabled }) => (
-  <FormGroup
-    label="Deployment mode"
-    fieldId="deployment-mode"
-    isRequired
-    labelHelp={
-      <Popover bodyContent="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability.">
-        <Icon aria-label="Model server replicas info" role="button">
-          <OutlinedQuestionCircleIcon />
-        </Icon>
-      </Popover>
-    }
-  >
-    <SimpleSelect
-      dataTestId="deployment-mode-select"
-      isDisabled={isDisabled}
-      value={isRaw ? DeploymentMode.Standard : DeploymentMode.Advanced}
-      options={options}
-      onChange={(key) => {
-        setIsRaw(key === DeploymentMode.Standard);
-      }}
-      isFullWidth
-    />
-  </FormGroup>
-);
+export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw, isDisabled }) => {
+  const defaultDeploymentMode = useDefaultDeploymentMode();
+
+  const options: SimpleSelectOption[] = React.useMemo(
+    () => [
+      {
+        label: `Standard${
+          defaultDeploymentMode === DeploymentMode.RawDeployment ? ' (default)' : ''
+        }`,
+        key: DeploymentMode.RawDeployment,
+      },
+      {
+        label: `Advanced${defaultDeploymentMode === DeploymentMode.Serverless ? ' (default)' : ''}`,
+        key: DeploymentMode.Serverless,
+      },
+    ],
+    [defaultDeploymentMode],
+  );
+
+  return (
+    <FormGroup
+      label="Deployment mode"
+      fieldId="deployment-mode"
+      isRequired
+      labelHelp={
+        <Popover bodyContent="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability.">
+          <Icon aria-label="Model server replicas info" role="button">
+            <OutlinedQuestionCircleIcon />
+          </Icon>
+        </Popover>
+      }
+    >
+      <SimpleSelect
+        dataTestId="deployment-mode-select"
+        isDisabled={isDisabled}
+        value={isRaw ? DeploymentMode.RawDeployment : DeploymentMode.Serverless}
+        options={options}
+        onChange={(key) => {
+          setIsRaw(key === DeploymentMode.RawDeployment);
+        }}
+        isFullWidth
+      />
+    </FormGroup>
+  );
+};

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -50,6 +50,7 @@ import { isDataConnectionAWS } from '~/pages/projects/screens/detail/data-connec
 import { containsOnlySlashes, isS3PathValid, removeLeadingSlash } from '~/utilities/string';
 import { RegisteredModelDeployInfo } from '~/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo';
 import { getNIMData, getNIMResource } from '~/pages/modelServing/screens/projects/nimUtils';
+import { useDefaultDeploymentMode } from '~/pages/modelServing/useDefaultDeploymentMode';
 import { AcceleratorProfileFormData } from '~/utilities/useAcceleratorProfileFormState';
 import { Connection } from '~/concepts/connectionTypes/types';
 
@@ -219,12 +220,14 @@ export const useCreateInferenceServiceObject = (
   sizes: ModelServingSize[],
 ] => {
   const { dashboardConfig } = useAppContext();
+  const defaultDeploymentMode = useDefaultDeploymentMode();
 
   const sizes = useDeepCompareMemoize(getServingRuntimeSizes(dashboardConfig));
 
   const createInferenceServiceState = useGenericObjectState<CreatingInferenceServiceObject>({
     ...defaultInferenceService,
     modelSize: sizes[0],
+    isKServeRawDeployment: defaultDeploymentMode === DeploymentMode.RawDeployment,
   });
 
   const [, setCreateData] = createInferenceServiceState;

--- a/frontend/src/pages/modelServing/useDefaultDeploymentMode.ts
+++ b/frontend/src/pages/modelServing/useDefaultDeploymentMode.ts
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { AreaContext } from '~/concepts/areas/AreaContext';
+import { DeploymentMode } from '~/k8sTypes';
+
+const toDeploymentMode = (mode?: string) => Object.values(DeploymentMode).find((v) => mode === v);
+
+export const useDefaultDeploymentMode = (): DeploymentMode => {
+  const { dscStatus } = React.useContext(AreaContext);
+  // should be "Serverless" or "RawDeployment" or blank from the operator
+  const defaultDeploymentMode = toDeploymentMode(
+    dscStatus?.components?.kserve?.defaultDeploymentMode,
+  );
+
+  const isKServeRawEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_RAW).status;
+
+  if (!defaultDeploymentMode || !isKServeRawEnabled) {
+    return DeploymentMode.Serverless;
+  }
+
+  return defaultDeploymentMode;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16489

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Read the kserve `defaultDeploymentMode` value on the DSC status. Then use this value for preselecting the default mode and also show which one is the default.

![image](https://github.com/user-attachments/assets/4401ea70-d958-447f-9bbd-2f0f036154f7)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This requires a nightly odh operator or the likes to have a default deployment mode other than serverless
1. Uncheck the devFlag `disableKServeRaw`
2. deploy a model
3. check the "... (default)" and the preselected value in the modal

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests added. the pulling of the DSC status value is pretty simple. and creating a cypress test for a different preselection seemed like overkill, but lmk.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@yih-wang 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
