### PR TITLE
Adds required to environment variables

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
+import { Button, FormGroup, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import { EnvironmentVariableType, EnvVariable } from '~/pages/projects/types';
 import IndentSection from '~/pages/projects/components/IndentSection';
@@ -18,50 +18,52 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
   onUpdate,
   onRemove,
 }) => (
-  <Split data-testid="environment-variable-field">
-    <SplitItem isFilled>
-      <Stack hasGutter>
-        <StackItem data-testid="environment-variable-type-select">
-          <SimpleSelect
-            popperProps={{ appendTo: getDashboardMainContainer() }}
-            isFullWidth
-            toggleLabel={envVariable.type || 'Select environment variable type'}
-            options={Object.values(EnvironmentVariableType).map((type) => ({
-              key: type,
-              label: type,
-            }))}
-            onChange={(value) => {
-              const enumValue = asEnumMember(value, EnvironmentVariableType);
-              if (enumValue !== null) {
-                onUpdate({
-                  type: enumValue,
-                });
-              }
-            }}
-          />
-        </StackItem>
-        {envVariable.type && (
-          <StackItem>
-            <IndentSection>
-              <EnvTypeSwitch
-                env={envVariable}
-                onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
-              />
-            </IndentSection>
+  <FormGroup isRequired label="Variable type">
+    <Split data-testid="environment-variable-field">
+      <SplitItem isFilled>
+        <Stack hasGutter>
+          <StackItem data-testid="environment-variable-type-select">
+            <SimpleSelect
+              popperProps={{ appendTo: getDashboardMainContainer() }}
+              isFullWidth
+              toggleLabel={envVariable.type || 'Select environment variable type'}
+              options={Object.values(EnvironmentVariableType).map((type) => ({
+                key: type,
+                label: type,
+              }))}
+              onChange={(value) => {
+                const enumValue = asEnumMember(value, EnvironmentVariableType);
+                if (enumValue !== null) {
+                  onUpdate({
+                    type: enumValue,
+                  });
+                }
+              }}
+            />
           </StackItem>
-        )}
-      </Stack>
-    </SplitItem>
-    <SplitItem>
-      <Button
-        variant="plain"
-        data-testid="remove-environment-variable-button"
-        aria-label="Remove environment variable"
-        icon={<MinusCircleIcon />}
-        onClick={() => onRemove()}
-      />
-    </SplitItem>
-  </Split>
+          {envVariable.type && (
+            <StackItem>
+              <IndentSection>
+                <EnvTypeSwitch
+                  env={envVariable}
+                  onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                />
+              </IndentSection>
+            </StackItem>
+          )}
+        </Stack>
+      </SplitItem>
+      <SplitItem>
+        <Button
+          variant="plain"
+          data-testid="remove-environment-variable-button"
+          aria-label="Remove environment variable"
+          icon={<MinusCircleIcon />}
+          onClick={() => onRemove()}
+        />
+      </SplitItem>
+    </Split>
+  </FormGroup>
 );
 
 export default EnvTypeSelectField;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -18,12 +18,13 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
   onUpdate,
   onRemove,
 }) => (
-  <FormGroup isRequired label="Variable type">
+  <FormGroup isRequired label="Variable type" fieldId="environment-variable-type-select">
     <Split data-testid="environment-variable-field">
       <SplitItem isFilled>
         <Stack hasGutter>
           <StackItem data-testid="environment-variable-type-select">
             <SimpleSelect
+              toggleProps={{ id: 'environment-variable-type-select' }}
               popperProps={{ appendTo: getDashboardMainContainer() }}
               isFullWidth
               toggleLabel={envVariable.type || 'Select environment variable type'}


### PR DESCRIPTION
Closes: [RHOAIENG-1201](https://issues.redhat.com/browse/RHOAIENG-1201)

## Description
Previously, when creating a workbench, if a user wanted to add an environment variable, a selection is required to complete the creation. There was no indication that this field was required. This PR adds a required star to the drop down if the user chooses to add the variable. 

## How Has This Been Tested?
Tested locally 

- Navigate to your data science projects, and choose one to create a workbench for. 
- In the create workbench page, scroll down to environment variables. It should be an optional field. But when you click to add variables, a title of "Variable type * " will now show. 

## Screenshots
Environment Variables field:
![Screenshot 2025-01-16 at 3 35 54 PM](https://github.com/user-attachments/assets/c87e4ef3-1a8a-4ef3-ae32-981a4d227ac2)

Before:
![Screenshot 2025-01-16 at 3 36 25 PM](https://github.com/user-attachments/assets/fa3eb3ef-2dea-4cb7-9953-276b76c4815f)

After:
![Screenshot 2025-01-16 at 3 36 02 PM](https://github.com/user-attachments/assets/3cabd00f-f1ef-4854-8b44-b52096937a6a)


## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
