### PR TITLE
Add model registry name label when creating an inferenceservice

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -61,6 +61,10 @@ class ModelServingGlobal {
     return this.findModelsTable().find(`[data-label=Name]`).contains(name).parents('tr');
   }
 
+  findRows() {
+    return this.findModelsTable().find('[data-label=Name]').parents('tr');
+  }
+
   getModelMetricLink(name: string) {
     return this.findModelsTable().findByTestId(`metrics-link-${name}`);
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -26,6 +26,7 @@ import { modelVersionDetails } from '~/__tests__/cypress/cypress/pages/modelRegi
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
 import { modelServingGlobal } from '~/__tests__/cypress/cypress/pages/modelServing';
 import { ModelRegistryMetadataType, ModelState } from '~/concepts/modelRegistry/types';
+import { KnownLabels } from '~/k8sTypes';
 
 const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
 const mockModelVersions = mockModelVersion({
@@ -444,6 +445,32 @@ describe('Model version details', () => {
           mockInferenceServiceK8sResource({
             url: 'test-inference-status.url.com',
             activeModelState: InferenceServiceModelState.LOADED,
+            additionalLabels: {
+              [KnownLabels.REGISTERED_MODEL_ID]: '1',
+              [KnownLabels.MODEL_VERSION_ID]: '1',
+            },
+          }),
+          mockInferenceServiceK8sResource({
+            url: 'test-inference-status.url.com',
+            displayName: 'Test Inference Service-2',
+            name: 'Test Inference Service-2',
+            activeModelState: InferenceServiceModelState.LOADED,
+            additionalLabels: {
+              [KnownLabels.REGISTERED_MODEL_ID]: '1',
+              [KnownLabels.MODEL_VERSION_ID]: '1',
+              [KnownLabels.MODEL_REGISTRY_NAME]: 'modelregistry-sample',
+            },
+          }),
+          mockInferenceServiceK8sResource({
+            url: 'test-inference-status.url.com',
+            displayName: 'Test Inference Service-3',
+            name: 'Test Inference Service-3',
+            activeModelState: InferenceServiceModelState.LOADED,
+            additionalLabels: {
+              [KnownLabels.REGISTERED_MODEL_ID]: '1',
+              [KnownLabels.MODEL_VERSION_ID]: '1',
+              [KnownLabels.MODEL_REGISTRY_NAME]: 'modelregistry-sample-1',
+            },
           }),
         ]),
       );
@@ -456,6 +483,8 @@ describe('Model version details', () => {
       modelVersionDetails.findRegisteredDeploymentsTab().click();
 
       modelServingGlobal.getModelRow('Test Inference Service').should('exist');
+      modelServingGlobal.getModelRow('Test Inference Service-2').should('exist');
+      modelServingGlobal.findRows().should('have.length', 2);
     });
   });
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -28,6 +28,7 @@ export enum KnownLabels {
   PROJECT_SUBJECT = 'opendatahub.io/rb-project-subject',
   REGISTERED_MODEL_ID = 'modelregistry.opendatahub.io/registered-model-id',
   MODEL_VERSION_ID = 'modelregistry.opendatahub.io/model-version-id',
+  MODEL_REGISTRY_NAME = 'modelregistry.opendatahub.io/name',
 }
 
 export type K8sVerb =

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
@@ -37,7 +37,12 @@ const ModelVersionsDetails: React.FC<ModelVersionsDetailProps> = ({ tab, ...page
   const [rm] = useRegisteredModelById(rmId);
   const [mv, mvLoaded, mvLoadError, refreshModelVersion] = useModelVersionById(mvId);
   const inferenceServices = useMakeFetchObject(
-    useInferenceServices(undefined, mv?.registeredModelId, mv?.id),
+    useInferenceServices(
+      undefined,
+      mv?.registeredModelId,
+      mv?.id,
+      preferredModelRegistry?.metadata.name,
+    ),
   );
   const servingRuntimes = useMakeFetchObject(useServingRuntimes());
 

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersions.tsx
@@ -29,7 +29,9 @@ const ModelVersions: React.FC<ModelVersionsProps> = ({ tab, ...pageProps }) => {
   const loadError = mvLoadError || rmLoadError;
   const loaded = mvLoaded && rmLoaded;
   const navigate = useNavigate();
-  const inferenceServices = useMakeFetchObject(useInferenceServices(undefined, rmId));
+  const inferenceServices = useMakeFetchObject(
+    useInferenceServices(undefined, rmId, undefined, preferredModelRegistry?.metadata.name),
+  );
 
   useEffect(() => {
     if (rm?.state === ModelState.ARCHIVED) {

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
@@ -23,8 +23,10 @@ const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
   isArchiveModel,
   refresh,
 }) => {
-  const { registeredModelId } = useParams();
-  const inferenceServices = useMakeFetchObject(useInferenceServices(undefined, registeredModelId));
+  const { mrName, registeredModelId } = useParams();
+  const inferenceServices = useMakeFetchObject(
+    useInferenceServices(undefined, registeredModelId, undefined, mrName),
+  );
   const hasDeploys = (mvId: string) =>
     !!inferenceServices.data.some(
       (s) => s.metadata.labels?.[KnownLabels.MODEL_VERSION_ID] === mvId,

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ArchiveModelVersionDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ArchiveModelVersionDetails.tsx
@@ -30,7 +30,12 @@ const ArchiveModelVersionDetails: React.FC<ArchiveModelVersionDetailsProps> = ({
   const [rm] = useRegisteredModelById(rmId);
   const [mv, mvLoaded, mvLoadError, refreshModelVersion] = useModelVersionById(mvId);
   const inferenceServices = useMakeFetchObject(
-    useInferenceServices(undefined, mv?.registeredModelId, mv?.id),
+    useInferenceServices(
+      undefined,
+      mv?.registeredModelId,
+      mv?.id,
+      preferredModelRegistry?.metadata.name,
+    ),
   );
   const navigate = useNavigate();
   const servingRuntimes = useMakeFetchObject(useServingRuntimes());

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetails.tsx
@@ -40,7 +40,12 @@ const ModelVersionsArchiveDetails: React.FC<ModelVersionsArchiveDetailsProps> = 
   const [mv, mvLoaded, mvLoadError, refreshModelVersion] = useModelVersionById(mvId);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
   const inferenceServices = useMakeFetchObject(
-    useInferenceServices(undefined, mv?.registeredModelId, mv?.id),
+    useInferenceServices(
+      undefined,
+      mv?.registeredModelId,
+      mv?.id,
+      preferredModelRegistry?.metadata.name,
+    ),
   );
   const servingRuntimes = useMakeFetchObject(useServingRuntimes());
 

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useParams } from 'react-router-dom';
 import { Table } from '~/components/table';
 import { RegisteredModel } from '~/concepts/modelRegistry/types';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
@@ -20,7 +21,10 @@ const RegisteredModelTable: React.FC<RegisteredModelTableProps> = ({
   toolbarContent,
   refresh,
 }) => {
-  const inferenceServices = useMakeFetchObject(useInferenceServices());
+  const { mrName } = useParams();
+  const inferenceServices = useMakeFetchObject(
+    useInferenceServices(undefined, undefined, undefined, mrName),
+  );
   const hasDeploys = (rmId: string) =>
     !!inferenceServices.data.some(
       (s) => s.metadata.labels?.[KnownLabels.REGISTERED_MODEL_ID] === rmId,

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
@@ -10,10 +10,12 @@ export type RegisteredModelDeployInfo = {
   modelArtifactStorageKey?: string;
   modelVersionId?: string;
   registeredModelId?: string;
+  mrName?: string;
 };
 
 const useRegisteredModelDeployInfo = (
   modelVersion: ModelVersion,
+  mrName?: string,
 ): {
   registeredModelDeployInfo: RegisteredModelDeployInfo;
   loaded: boolean;
@@ -48,6 +50,7 @@ const useRegisteredModelDeployInfo = (
         modelArtifactStorageKey: modelArtifact.storageKey,
         modelVersionId: modelVersion.id,
         registeredModelId: modelVersion.registeredModelId,
+        mrName,
       },
       loaded: registeredModelLoaded && modelArtifactListLoaded,
       error: registeredModelError || modelArtifactListError,
@@ -63,6 +66,7 @@ const useRegisteredModelDeployInfo = (
     registeredModel?.name,
     registeredModelError,
     registeredModelLoaded,
+    mrName,
   ]);
 
   return registeredModelDeployInfo;

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -54,7 +54,7 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
     registeredModelDeployInfo,
     loaded: deployInfoLoaded,
     error: deployInfoError,
-  } = useRegisteredModelDeployInfo(modelVersion);
+  } = useRegisteredModelDeployInfo(modelVersion, preferredModelRegistry?.metadata.name);
 
   const handleSubmit = React.useCallback(async () => {
     if (!modelVersion.registeredModelId) {

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -729,10 +729,12 @@ export const createNIMPVC = (
   );
 
 export const getCreateInferenceServiceLabels = (
-  data: Pick<RegisteredModelDeployInfo, 'registeredModelId' | 'modelVersionId'> | undefined,
+  data:
+    | Pick<RegisteredModelDeployInfo, 'registeredModelId' | 'modelVersionId' | 'mrName'>
+    | undefined,
 ): { labels: Record<string, string> } | undefined => {
-  if (data?.registeredModelId || data?.modelVersionId) {
-    const { registeredModelId, modelVersionId } = data;
+  if (data?.registeredModelId || data?.modelVersionId || data?.mrName) {
+    const { registeredModelId, modelVersionId, mrName } = data;
 
     return {
       labels: {
@@ -741,6 +743,9 @@ export const getCreateInferenceServiceLabels = (
         }),
         ...(modelVersionId && {
           'modelregistry.opendatahub.io/model-version-id': modelVersionId,
+        }),
+        ...(mrName && {
+          'modelregistry.opendatahub.io/name': mrName,
         }),
       },
     };

--- a/frontend/src/pages/modelServing/useInferenceServices.ts
+++ b/frontend/src/pages/modelServing/useInferenceServices.ts
@@ -19,6 +19,7 @@ const useInferenceServices = (
   namespace?: string,
   registeredModelId?: string,
   modelVersionId?: string,
+  mrName?: string,
 ): FetchState<InferenceServiceKind[]> => {
   const modelServingEnabled = useModelServingEnabled();
 
@@ -38,7 +39,7 @@ const useInferenceServices = (
 
       const getInferenceServices = allowCreate ? listInferenceService : getInferenceServiceContext;
 
-      return getInferenceServices(
+      const inferenceServiceList = getInferenceServices(
         namespace,
         [
           LABEL_SELECTOR_DASHBOARD_RESOURCE,
@@ -47,8 +48,28 @@ const useInferenceServices = (
         ].join(','),
         opts,
       );
+
+      if (mrName) {
+        return inferenceServiceList.then((inferenceServices) =>
+          inferenceServices.filter(
+            (inferenceService) =>
+              inferenceService.metadata.labels?.[KnownLabels.MODEL_REGISTRY_NAME] === mrName ||
+              !inferenceService.metadata.labels?.[KnownLabels.MODEL_REGISTRY_NAME],
+          ),
+        );
+      }
+
+      return inferenceServiceList;
     },
-    [modelServingEnabled, rbacLoaded, allowCreate, namespace, registeredModelId, modelVersionId],
+    [
+      modelServingEnabled,
+      rbacLoaded,
+      allowCreate,
+      namespace,
+      registeredModelId,
+      modelVersionId,
+      mrName,
+    ],
   );
 
   return useFetchState(callback, [], {


### PR DESCRIPTION
Closes: [RHOAIENG-16989](https://issues.redhat.com/browse/RHOAIENG-16989)

## Description
This PR aims to add model registry name label when creating an inference service

## How Has This Been Tested?
1. deploy a model from the model registry UI.
2. test that the deployed model won't show up in other model registry deployments.
3. Also, make sure that the model deployments which does not have label (modelregistry.opendatahub.io/name) will show up in deployments. As we are returning all ISVCs that either have modelregistry.opendatahub.io/name === registryName or do not have the modelregistry.opendatahub.io/name label.

## Test Impact
Added unit test and cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
