### PR TITLE
Add default deployment mode selector as read only

### DIFF
--- a/frontend/src/__mocks__/mockDscStatus.ts
+++ b/frontend/src/__mocks__/mockDscStatus.ts
@@ -2,21 +2,23 @@ import { DataScienceClusterKindStatus, K8sCondition } from '~/k8sTypes';
 import { StackComponent } from '~/concepts/areas/types';
 
 export type MockDscStatus = {
+  components?: DataScienceClusterKindStatus['components'];
   conditions?: K8sCondition[];
   phase?: string;
   installedComponents?: DataScienceClusterKindStatus['installedComponents'];
 };
 
 export const mockDscStatus = ({
-  installedComponents,
-  conditions = [],
-  phase = 'Ready',
-}: MockDscStatus): DataScienceClusterKindStatus => ({
-  components: {
+  components = {
     modelregistry: {
       registriesNamespace: 'odh-model-registries',
     },
   },
+  installedComponents,
+  conditions = [],
+  phase = 'Ready',
+}: MockDscStatus): DataScienceClusterKindStatus => ({
+  components,
   conditions: [
     ...[
       {

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
@@ -32,6 +32,10 @@ class ModelSergingSettings extends ClusterSettings {
     return cy.findByTestId('single-model-serving-platform-enabled-checkbox');
   }
 
+  findSinglePlatformDeploymentModeSelect() {
+    return cy.findByTestId('default-deployment-mode-select');
+  }
+
   findMultiPlatformCheckbox() {
     return cy.findByTestId('multi-model-serving-platform-enabled-checkbox');
   }

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -9,6 +9,7 @@ import {
   ModelServingPlatformEnabled,
   NotebookTolerationFormSettings,
 } from '~/types';
+import { DeploymentMode } from '~/k8sTypes';
 import { addNotification } from '~/redux/actions/actions';
 import { useCheckJupyterEnabled } from '~/utilities/notebookControllerUtils';
 import { useAppDispatch } from '~/redux/hooks';
@@ -17,6 +18,7 @@ import CullerSettings from '~/pages/clusterSettings/CullerSettings';
 import TelemetrySettings from '~/pages/clusterSettings/TelemetrySettings';
 import TolerationSettings from '~/pages/clusterSettings/TolerationSettings';
 import ModelServingPlatformSettings from '~/pages/clusterSettings/ModelServingPlatformSettings';
+import { useDefaultDeploymentMode } from '~/pages/modelServing/useDefaultDeploymentMode';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
@@ -29,6 +31,8 @@ import {
 } from './const';
 
 const ClusterSettings: React.FC = () => {
+  const defaultSingleModelDeploymentMode = useDefaultDeploymentMode();
+
   const [loaded, setLoaded] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error>();
@@ -46,6 +50,9 @@ const ClusterSettings: React.FC = () => {
     });
   const [modelServingEnabledPlatforms, setModelServingEnabledPlatforms] =
     React.useState<ModelServingPlatformEnabled>(clusterSettings.modelServingPlatformEnabled);
+  const [defaultDeploymentMode, setDefaultDeploymentMode] = React.useState<DeploymentMode>(
+    defaultSingleModelDeploymentMode,
+  );
   const dispatch = useAppDispatch();
 
   React.useEffect(() => {
@@ -152,6 +159,8 @@ const ClusterSettings: React.FC = () => {
               initialValue={clusterSettings.modelServingPlatformEnabled}
               enabledPlatforms={modelServingEnabledPlatforms}
               setEnabledPlatforms={setModelServingEnabledPlatforms}
+              defaultDeploymentMode={defaultDeploymentMode}
+              setDefaultDeploymentMode={setDefaultDeploymentMode}
             />
           </StackItem>
         )}

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -8,11 +8,9 @@ import {
   Flex,
   FlexItem,
   FormGroup,
-  Popover,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import SettingSection from '~/components/SettingSection';
 import SimpleSelect from '~/components/SimpleSelect';
 import { ModelServingPlatformEnabled } from '~/types';
@@ -21,6 +19,7 @@ import { useAccessReview } from '~/api';
 import { AccessReviewResourceAttributes, DeploymentMode } from '~/k8sTypes';
 import { useOpenShiftURL } from '~/utilities/clusterUtils';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import DashboardHelpTooltip from '~/concepts/dashboard/DashboardHelpTooltip';
 
 type ModelServingPlatformSettingsProps = {
   initialValue: ModelServingPlatformEnabled;
@@ -87,8 +86,8 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
           <FlexItem>
             Select the serving platforms that can be used for deploying models on this cluster.
           </FlexItem>
-          <Popover
-            bodyContent={
+          <DashboardHelpTooltip
+            content={
               <>
                 To modify the availability of model serving platforms, ask your cluster admin to
                 manage the respective components in the{' '}
@@ -110,9 +109,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
                 resource.
               </>
             }
-          >
-            <OutlinedQuestionCircleIcon />
-          </Popover>
+          />
         </Flex>
       }
     >
@@ -141,9 +138,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
                   fieldId="default-deployment-mode-select"
                   label="Default deployment mode"
                   labelHelp={
-                    <Popover bodyContent="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability. The default deployment mode will be automatically selected during deployment.">
-                      <OutlinedQuestionCircleIcon />
-                    </Popover>
+                    <DashboardHelpTooltip content="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability. The default deployment mode will be automatically selected during deployment." />
                   }
                 >
                   <SimpleSelect
@@ -169,7 +164,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
                       },
                     ]}
                     isDisabled={!enabledPlatforms.kServe}
-                    popperProps={{ appendTo: 'inline' }}
+                    popperProps={{ maxWidth: undefined }}
                   />
                 </FormGroup>
               )

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -7,22 +7,27 @@ import {
   Checkbox,
   Flex,
   FlexItem,
+  FormGroup,
   Popover,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import SettingSection from '~/components/SettingSection';
+import SimpleSelect from '~/components/SimpleSelect';
 import { ModelServingPlatformEnabled } from '~/types';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
 import { useAccessReview } from '~/api';
-import { AccessReviewResourceAttributes } from '~/k8sTypes';
+import { AccessReviewResourceAttributes, DeploymentMode } from '~/k8sTypes';
 import { useOpenShiftURL } from '~/utilities/clusterUtils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 type ModelServingPlatformSettingsProps = {
   initialValue: ModelServingPlatformEnabled;
   enabledPlatforms: ModelServingPlatformEnabled;
   setEnabledPlatforms: (platforms: ModelServingPlatformEnabled) => void;
+  defaultDeploymentMode: DeploymentMode;
+  setDefaultDeploymentMode: (mode: DeploymentMode) => void;
 };
 
 const accessReviewResource: AccessReviewResourceAttributes = {
@@ -35,7 +40,10 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
   initialValue,
   enabledPlatforms,
   setEnabledPlatforms,
+  defaultDeploymentMode,
+  setDefaultDeploymentMode,
 }) => {
+  const isKServeRawEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_RAW).status;
   const [alert, setAlert] = React.useState<{ variant: AlertVariant; message: string }>();
   const {
     kServe: { installed: kServeInstalled },
@@ -112,6 +120,7 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
         <StackItem>
           <Checkbox
             label="Single-model serving platform"
+            description="Each model is deployed on its own model server. Choose this option when you want to deploy a large model such as a large language model (LLM)."
             isDisabled={!kServeInstalled}
             isChecked={kServeInstalled && enabledPlatforms.kServe}
             onChange={(e, enabled) => {
@@ -125,11 +134,52 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
             id="single-model-serving-platform-enabled-checkbox"
             data-testid="single-model-serving-platform-enabled-checkbox"
             name="singleModelServingPlatformEnabledCheckbox"
+            body={
+              kServeInstalled &&
+              isKServeRawEnabled && (
+                <FormGroup
+                  fieldId="default-deployment-mode-select"
+                  label="Default deployment mode"
+                  labelHelp={
+                    <Popover bodyContent="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability. The default deployment mode will be automatically selected during deployment.">
+                      <OutlinedQuestionCircleIcon />
+                    </Popover>
+                  }
+                >
+                  <SimpleSelect
+                    toggleProps={{ id: 'default-deployment-mode-select' }}
+                    dataTestId="default-deployment-mode-select"
+                    value={defaultDeploymentMode}
+                    onChange={(key: string) => {
+                      const mode = Object.values(DeploymentMode).find((v) => key === v);
+                      if (mode) {
+                        setDefaultDeploymentMode(mode);
+                      }
+                    }}
+                    options={[
+                      {
+                        key: DeploymentMode.RawDeployment,
+                        label: 'Standard (No additional dependencies)',
+                        isDisabled: true, // todo: allow admin to update dsc
+                      },
+                      {
+                        key: DeploymentMode.Serverless,
+                        label: 'Advanced (Serverless and Service Mesh)',
+                        isDisabled: true, // todo: allow admin to update dsc
+                      },
+                    ]}
+                    isDisabled={!enabledPlatforms.kServe}
+                    popperProps={{ appendTo: 'inline' }}
+                  />
+                </FormGroup>
+              )
+            }
           />
         </StackItem>
         <StackItem>
           <Checkbox
             label="Multi-model serving platform"
+            description="Multiple models can be deployed on one shared model server. Useful for deploying a number of small or medium-sized models that can share the server resources."
             isDisabled={!modelMeshInstalled}
             isChecked={modelMeshInstalled && enabledPlatforms.modelMesh}
             onChange={(e, enabled) => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16491

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This adds the admin page default deployment mode dropdown. It's set to read only as setting the mode requires new dashboard functionality that was a WIP. It will be updated in a future story before release.

![image](https://github.com/user-attachments/assets/cb5481da-7410-4127-9574-db4a6d1d9bb7)

![image](https://github.com/user-attachments/assets/c4e95981-de25-4f73-ac70-b782e870c02b)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This requires a nightly odh operator or the likes to have a default deployment mode other than serverless
    Uncheck the devFlag disableKServeRaw
    Go to the cluster settings page
    Verify the button is selected with the correct deployment mode

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
A cypress test has been added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@yih-wang 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
