### PR TITLE
made wording more consistent in storage dialog

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/storage/SpawnerMountPathField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/SpawnerMountPathField.tsx
@@ -143,8 +143,8 @@ const SpawnerMountPathField: React.FC<SpawnerMountPathFieldProps> = ({
                 {format === MountPathFormat.CUSTOM && (
                   <HelperTextItem variant="warning">
                     Depending on the workbench type, this location may not be visible or accessible.
-                    For example, the JupyterLab file browser only displays folders and files under
-                    /opt/app-root/src
+                    For example, the JupyterLab file browser only displays mount paths and files
+                    under /opt/app-root/src
                   </HelperTextItem>
                 )}
               </HelperText>

--- a/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
@@ -91,7 +91,7 @@ describe('validateMountPath', () => {
 
   it('should return error message for already in-use mount path', () => {
     const result = validateMountPath('/existing-folder', inUseMountPaths);
-    expect(result).toBe('Mount folder is already in use for this workbench.');
+    expect(result).toBe('Mount path is already in use for this workbench.');
   });
 
   it('should return an empty string for valid and unused mount path', () => {

--- a/frontend/src/pages/projects/screens/spawner/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/utils.ts
@@ -162,7 +162,7 @@ export const validateMountPath = (value: string, inUseMountPaths: string[]): str
       inUseMountPaths.includes(`${MOUNT_PATH_PREFIX}${value}`)) ||
     (format === MountPathFormat.CUSTOM && inUseMountPaths.includes(`/${value}`))
   ) {
-    return 'Mount folder is already in use for this workbench.';
+    return 'Mount path is already in use for this workbench.';
   }
 
   return '';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
[RHOAIENG-17252](https://issues.redhat.com/browse/RHOAIENG-17252)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1548" alt="Screenshot 2025-01-21 at 4 22 35 PM" src="https://github.com/user-attachments/assets/4c1fb333-5adf-40f1-aebb-18cb6d361593" />
<img width="1548" alt="Screenshot 2025-01-21 at 4 22 55 PM" src="https://github.com/user-attachments/assets/d8e3b21b-e93a-4a5c-bb25-2171d4b104df" />

I changed mentions of "folder(s)" to "mount path(s)"

@Gkrumbach07 mentioned that the other 2 criteria don't need to be met at this moment, but please correct me if I'm wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

visually. It is also included in unit tests. The reproduction instructions are in the jira ticket.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

edited a test in `utils.spec.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
