### PR TITLE
[RHOAIENG-1141] remove the deprecated nvidia GPU Addon manifest from rhoai

### DIFF
--- a/manifests/rhoai/addon/apps/nvidia/nvidia-app.yaml
+++ b/manifests/rhoai/addon/apps/nvidia/nvidia-app.yaml
@@ -20,14 +20,6 @@ spec:
   docsLink: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/contents.html
   quickStart: gpu-quickstart
   getStartedLink: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/managing_openshift_ai/enabling_accelerators#enabling-nvidia-gpus_managing-rhoai
-  enable:
-    title: Enable NVIDIA GPUs
-    actionLabel: Enable
-    description: Clicking enable adds the NVIDIA GPU Add-on card to the Enabled page
-    linkPreface: |-
-      Before enabling, be sure you have installed the NVIDIA GPU Add-on:
-    link: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/managing_openshift_ai/enabling_accelerators#enabling-nvidia-gpus_managing-rhoai
-    validationConfigMap: nvidia-validation-result
   getStartedMarkDown: >-
     # NVIDIA GPU Add-on
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-1141

## Description
See the comments in the Jira story for how we uncovered that this is deprecated and safe to remove. 
Support link re: [this operator](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/managing_openshift_ai/enabling_accelerators#enabling-nvidia-gpus_managing-rhoai) is no longer supported. 

## How Has This Been Tested?
- [x] Need to validate that this passes CI/CD
- [x] validated this via a ROSA cluster, following the methodology of: 
`wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/81fc54e3d4a3068289c0dc7f54b1d56070418e37/manifests/rhoai/addon/apps/nvidia/nvidia-app.yaml` 

![Screenshot 2025-01-21 at 17 01 29](https://github.com/user-attachments/assets/59757251-a012-431e-9e20-1bc663937fb9)


Create a new `OdhApplication` in the cluster with the modified payload. Validated that the `enabled` button no longer appear
![Screenshot 2025-01-21 at 16 58 49](https://github.com/user-attachments/assets/017ac92d-ffdb-4d14-ab9e-a671a874cf8d)




## Test Impact
-- The `enable` button for the `NVIDIA GPU addon`  in RHOAI should no longer be displayed. 


Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
