### PR TITLE
refractor UsageBar and StorageSizeBar

### DIFF
--- a/frontend/src/components/ProgressBarWithLabels.scss
+++ b/frontend/src/components/ProgressBarWithLabels.scss
@@ -1,4 +1,4 @@
-.dw-workload-resource-usage-bar {
+.progress-bar {
   // Prevents extra whitespace to the right of the bar when combining measureLocation="none" with no title prop
   // TODO: can remove this after https://github.com/patternfly/patternfly-react/issues/10278 is in place
   grid-gap: 0;

--- a/frontend/src/components/ProgressBarWithLabels.tsx
+++ b/frontend/src/components/ProgressBarWithLabels.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Progress,
+  ProgressProps,
+} from '@patternfly/react-core';
+import './ProgressBarWithLabels.scss';
+
+type ProgressBarWithLabelsProps = Omit<ProgressProps, 'ref' | 'measureLocation'> & {
+  inUseLabel: React.ReactNode;
+  maxValueLabel: number | string;
+  contentComponentVariant?: ContentVariants;
+};
+
+const ProgressBarWithLabels: React.FC<ProgressBarWithLabelsProps> = ({
+  inUseLabel,
+  maxValueLabel,
+  contentComponentVariant,
+  ...props
+}) => (
+  <Flex alignItems={{ default: 'alignItemsCenter' }}>
+    <FlexItem>
+      <Content component={contentComponentVariant}>{inUseLabel}</Content>
+    </FlexItem>
+    <FlexItem grow={{ default: 'grow' }}>
+      <Progress measureLocation="none" className="progress-bar" {...props} />
+    </FlexItem>
+    <FlexItem>
+      <Content component={contentComponentVariant}>{maxValueLabel}</Content>
+    </FlexItem>
+  </Flex>
+);
+
+export default ProgressBarWithLabels;

--- a/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.tsx
+++ b/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Progress, Tooltip, Stack, StackItem, Flex, FlexItem } from '@patternfly/react-core';
+import { Tooltip, Stack, StackItem } from '@patternfly/react-core';
 import { roundNumber } from '~/utilities/number';
-import './WorkloadResourceUsageBar.scss';
+import ProgressBarWithLabels from '~/components/ProgressBarWithLabels';
 
 type WorkloadResourceUsageBarProps = {
   showData?: boolean;
@@ -37,20 +37,14 @@ export const WorkloadResourceUsageBar: React.FC<WorkloadResourceUsageBarProps> =
         </Stack>
       }
     >
-      <Flex alignItems={{ default: 'alignItemsCenter' }}>
-        <FlexItem>{roundNumber(used)}</FlexItem>
-        <FlexItem grow={{ default: 'grow' }}>
-          <Progress
-            className="dw-workload-resource-usage-bar"
-            value={used}
-            min={0}
-            max={requested}
-            measureLocation="none"
-            aria-label={progressBarAriaLabel}
-          />
-        </FlexItem>
-        <FlexItem>{roundNumber(requested)}</FlexItem>
-      </Flex>
+      <ProgressBarWithLabels
+        inUseLabel={roundNumber(used)}
+        maxValueLabel={roundNumber(requested)}
+        value={used}
+        min={0}
+        max={requested}
+        aria-label={progressBarAriaLabel}
+      />
     </Tooltip>
   );
 };

--- a/frontend/src/pages/projects/components/StorageSizeBars.tsx
+++ b/frontend/src/pages/projects/components/StorageSizeBars.tsx
@@ -1,22 +1,12 @@
 import * as React from 'react';
-import {
-  Bullseye,
-  Popover,
-  Progress,
-  ProgressMeasureLocation,
-  Spinner,
-  Split,
-  SplitItem,
-  Content,
-  Tooltip,
-  Flex,
-} from '@patternfly/react-core';
+import { Popover, Spinner, Content, Tooltip, Flex, ContentVariants } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import { getPvcRequestSize, getPvcTotalSize } from '~/pages/projects/utils';
 import { usePVCFreeAmount } from '~/api';
 import { bytesAsRoundedGiB } from '~/utilities/number';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import ProgressBarWithLabels from '~/components/ProgressBarWithLabels';
 
 type StorageSizeBarProps = {
   pvc: PersistentVolumeClaimKind;
@@ -74,31 +64,16 @@ const StorageSizeBar: React.FC<StorageSizeBarProps> = ({ pvc }) => {
   }
 
   const progressBar = (
-    <Progress
+    <ProgressBarWithLabels
+      inUseLabel={inUseRender}
+      contentComponentVariant={ContentVariants.small}
+      maxValueLabel={maxValue}
       aria-label={percentageLabel || 'Storage progress bar'}
-      measureLocation={ProgressMeasureLocation.none}
       value={Number(percentage)}
-      style={{ gridGap: 0 }} // PF issue with split & measureLocation
     />
   );
 
-  return (
-    <Split hasGutter>
-      <SplitItem>
-        <Bullseye>
-          <Content component="small">{inUseRender}</Content>
-        </Bullseye>
-      </SplitItem>
-      <SplitItem isFilled style={{ maxWidth: 200 }}>
-        {percentageLabel ? <Tooltip content={percentageLabel}>{progressBar}</Tooltip> : progressBar}
-      </SplitItem>
-      <SplitItem>
-        <Bullseye>
-          <Content component="small">{maxValue}</Content>
-        </Bullseye>
-      </SplitItem>
-    </Split>
-  );
+  return percentageLabel ? <Tooltip content={percentageLabel}>{progressBar}</Tooltip> : progressBar;
 };
 
 export default StorageSizeBar;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-5147

## Description
Refractor the cluster storage progress bar and distributed workload progress bar to share component

<img width="1151" alt="Screenshot 2025-01-22 at 11 46 49 AM" src="https://github.com/user-attachments/assets/ccf65ec8-7d8c-4a00-97ac-758a8b5f3530" />

<img width="1151" alt="Screenshot 2025-01-22 at 11 43 03 AM" src="https://github.com/user-attachments/assets/3e3aed1e-05c7-47c1-8ccd-508ada81f995" />

<img width="1151" alt="Screenshot 2025-01-22 at 11 43 16 AM" src="https://github.com/user-attachments/assets/9111fb0a-336d-49b9-8a2c-cf48f70ffe28" />


<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Check the storage cluster progress bar
- Check the distributed workload progress bar from distributed workload metrics table

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
No UI changes just the refractor
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
