### PR TITLE
Hardware Profile Display Name is not trimmed

### DIFF
--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
@@ -63,7 +63,7 @@ const ManageHardwareProfile: React.FC<ManageHardwareProfileProps> = ({
     () => ({
       ...state,
       name: profileNameDesc.k8sName.value,
-      displayName: profileNameDesc.name,
+      displayName: profileNameDesc.name.trim(),
       description: profileNameDesc.description,
     }),
     [state, profileNameDesc],


### PR DESCRIPTION
[RHOAIENG-18106](https://issues.redhat.com/browse/RHOAIENG-18106)

## Description
Display name was not trimmed, which caused the issue of improper sorting.

## How Has This Been Tested?
Create a hardware profile with leading and trailing spaces in the name and check the sorting in the list.

## Test Impact
None, just added trim to display name.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
