### PR TITLE
Name, resource label, tolerations and Node selector fields - Unlimited size string

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -6,7 +6,14 @@ import {
   Timestamp,
   TimestampTooltipVariant,
 } from '@patternfly/react-core';
-import { ActionsColumn, ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
+import {
+  ActionsColumn,
+  ExpandableRowContent,
+  TableText,
+  Tbody,
+  Td,
+  Tr,
+} from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { relativeTime } from '~/utilities/time';
 import { TableRowTitleDescription } from '~/components/table';
@@ -47,7 +54,9 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
         />
         <Td dataLabel="Name">
           <TableRowTitleDescription
-            title={hardwareProfile.spec.displayName}
+            title={
+              <TableText wrapModifier="truncate">{hardwareProfile.spec.displayName}</TableText>
+            }
             description={hardwareProfile.spec.description}
             truncateDescriptionLines={2}
           />

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Td, Tr } from '@patternfly/react-table';
-import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import { ActionList, ActionListItem, Button, Truncate } from '@patternfly/react-core';
 import { MinusCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
 import { Identifier } from '~/types';
 
@@ -18,8 +18,12 @@ const NodeResourceTableRow: React.FC<NodeResourceTableRowProps> = ({
   showActions,
 }) => (
   <Tr>
-    <Td dataLabel="Resource label">{identifier.displayName}</Td>
-    <Td dataLabel="Resource identifier">{identifier.identifier}</Td>
+    <Td dataLabel="Resource label">
+      <Truncate content={identifier.displayName} />
+    </Td>
+    <Td dataLabel="Resource identifier">
+      <Truncate content={identifier.identifier} />
+    </Td>
     <Td dataLabel="Resource type">{identifier.resourceType ?? 'Other'}</Td>
     <Td dataLabel="Default">{identifier.defaultCount}</Td>
     <Td dataLabel="Minimum allowed">{identifier.minCount}</Td>

--- a/frontend/src/pages/hardwareProfiles/nodeSelector/NodeSelectorTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeSelector/NodeSelectorTableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Td, Tr } from '@patternfly/react-table';
-import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import { ActionList, ActionListItem, Button, Truncate } from '@patternfly/react-core';
 import { MinusCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
 import { NodeSelector } from '~/types';
 
@@ -18,8 +18,12 @@ const NodeSelectorTableRow: React.FC<NodeSelectorTableRowProps> = ({
   onDelete,
 }) => (
   <Tr>
-    <Td dataLabel="Key">{nodeSelector.key}</Td>
-    <Td dataLabel="Value">{nodeSelector.value}</Td>
+    <Td dataLabel="Key">
+      <Truncate content={nodeSelector.key} />
+    </Td>
+    <Td dataLabel="Value">
+      <Truncate content={nodeSelector.value} />
+    </Td>
     {showActions && (
       <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
         <ActionList isIconList>

--- a/frontend/src/pages/hardwareProfiles/toleration/TolerationTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/toleration/TolerationTableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Td, Tr } from '@patternfly/react-table';
-import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import { ActionList, ActionListItem, Button, Truncate } from '@patternfly/react-core';
 import { MinusCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
 import { Toleration } from '~/types';
 
@@ -19,8 +19,12 @@ const TolerationTableRow: React.FC<TolerationTableRowProps> = ({
 }) => (
   <Tr>
     <Td dataLabel="Operator">{toleration.operator ?? '-'}</Td>
-    <Td dataLabel="Key">{toleration.key}</Td>
-    <Td dataLabel="Value">{toleration.value ?? '-'}</Td>
+    <Td dataLabel="Key">
+      <Truncate content={toleration.key} />
+    </Td>
+    <Td dataLabel="Value">
+      <Truncate content={toleration.value ?? '-'} />
+    </Td>
     <Td dataLabel="Effect">{toleration.effect ?? '-'}</Td>
     <Td dataLabel="Toleration seconds">
       {toleration.tolerationSeconds === undefined


### PR DESCRIPTION
[RHOAIENG-18090](https://issues.redhat.com/browse/RHOAIENG-18090)

## Description
Added truncate to form table fields

![Screenshot 2025-01-23 at 4 05 14 PM](https://github.com/user-attachments/assets/cb980406-7aa4-4149-8db3-23748c36341a)


## How Has This Been Tested?
When creating hardware profile enter large entry for those field, they should be truncated.

## Test Impact
None, just added truncate

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
