### PR TITLE
Pipeline run details page input parameters correctly parse string object

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/topology.ts
@@ -152,6 +152,11 @@ class DetailsItem extends Contextual<HTMLElement> {
   findValue() {
     return this.find().findByTestId('detail-item-value');
   }
+
+  shouldHaveCodeEditorValue(name: string) {
+    this.findValue().find('section').contains(name);
+    return this;
+  }
 }
 
 class PipelineDetails extends PipelinesTopology {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
@@ -50,6 +50,13 @@ const mockVersion2 = buildMockPipelineVersion({
 const mockRun = buildMockRunKF({
   display_name: 'test-pipeline-run',
   run_id: 'test-pipeline-run-id',
+  runtime_config: {
+    parameters: {
+      min_max_scaler: false,
+      neighbors: 1,
+      standard_scaler: '["test-1", "test-2", "test-3", "test-4"]',
+    },
+  },
   pipeline_version_reference: {
     pipeline_id: mockPipeline.pipeline_id,
     pipeline_version_id: mockVersion.pipeline_version_id,
@@ -482,6 +489,9 @@ describe('Pipeline topology', () => {
       pipelineRunDetails.findInputParameterTab().click();
       pipelineRunDetails.findDetailItem('min_max_scaler').findValue().contains('False');
       pipelineRunDetails.findDetailItem('neighbors').findValue().contains('1');
+      pipelineRecurringRunDetails
+        .findDetailItem('standard_scaler')
+        .shouldHaveCodeEditorValue('test-1');
     });
 
     it('Test pipeline triggered run YAML output', () => {

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabParameters.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunTabParameters.tsx
@@ -11,6 +11,7 @@ import {
   renderDetailItems,
 } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
 import { ExecutionDetailsPropertiesValueCode } from '~/pages/pipelines/global/experiments/executions/details/ExecutionDetailsPropertiesValue';
+import { NoValue } from '~/components/NoValue';
 
 type PipelineRunTabParametersProps = {
   run: PipelineRecurringRunKF | PipelineRunKF | null;
@@ -71,7 +72,17 @@ const PipelineRunTabParameters: React.FC<PipelineRunTabParametersProps> = ({
         value = initialValue ? 'True' : 'False';
         break;
       case InputDefinitionParameterType.STRING:
-        value = String(initialValue);
+        try {
+          const jsonStringValue = JSON.parse(String(initialValue));
+          if (parseFloat(jsonStringValue)) {
+            throw initialValue;
+          }
+          value = (
+            <ExecutionDetailsPropertiesValueCode code={JSON.stringify(jsonStringValue, null, 2)} />
+          );
+        } catch {
+          value = String(initialValue) || <NoValue />;
+        }
         break;
       case InputDefinitionParameterType.LIST:
         value = (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-16418

## Description

- The input parameter scroll is already been addressed in some other PR
- This pr aims at correctly parsing the string object

https://github.com/user-attachments/assets/d4b276eb-75e5-4b44-8a4c-75b5d785733c





- 
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Import a pipeline with more than 20 parameter, verify if the scrolling is present
- Import a pipeline with parameter of string value object and check if the code block is present

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added Cypress test cases
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
