### PR TITLE
Update the Serving runtime templates to use correct label to identify preinstalled resources

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -7,6 +7,7 @@ type MockResourceConfigType = {
   displayName?: string;
   replicas?: number;
   platforms?: ServingRuntimePlatform[];
+  preInstalled?: boolean;
   apiProtocol?: ServingRuntimeAPIProtocol;
   isModelmesh?: boolean;
   containerName?: string;
@@ -21,6 +22,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
   isModelmesh = false,
   apiProtocol = ServingRuntimeAPIProtocol.REST,
   platforms,
+  preInstalled = false,
   containerName = 'ovms',
   containerEnvVars = undefined,
 }: MockResourceConfigType): TemplateKind => ({
@@ -31,6 +33,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
     namespace,
     labels: {
       'opendatahub.io/dashboard': 'true',
+      ...(preInstalled && { 'platform.opendatahub.io/part-of': 'modelcontroller' }),
     },
     annotations: {
       'opendatahub.io/modelServingSupport': JSON.stringify(platforms),

--- a/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
@@ -9,6 +9,13 @@ class ServingRuntimeRow {
     return cy.findByTestId(`serving-runtime ${this.id}`);
   }
 
+  shouldHavePreInstalledLabel(enabled = true) {
+    this.find()
+      .findByTestId('pre-installed-label')
+      .should(enabled ? 'exist' : 'not.exist');
+    return this;
+  }
+
   shouldBeMultiModel(enabled = true) {
     this.find()
       .findByTestId('serving-runtime-platform-label')

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
@@ -33,6 +33,18 @@ describe('Custom serving runtimes', () => {
     servingRuntimes.shouldBeSingleModel(true).shouldBeMultiModel(true);
   });
 
+  it('should test pre-installed label', () => {
+    servingRuntimes.getRowById('template-3').shouldHavePreInstalledLabel();
+    servingRuntimes.getRowById('template-3').find().findKebabAction('Edit').should('not.exist');
+    servingRuntimes.getRowById('template-3').find().findKebabAction('Delete').should('not.exist');
+    servingRuntimes.getRowById('template-3').find().findKebabAction('Duplicate').should('exist');
+
+    servingRuntimes.getRowById('template-2').shouldHavePreInstalledLabel(false);
+    servingRuntimes.getRowById('template-2').find().findKebabAction('Delete').should('exist');
+    servingRuntimes.getRowById('template-2').find().findKebabAction('Edit').should('exist');
+    servingRuntimes.getRowById('template-2').find().findKebabAction('Duplicate').should('exist');
+  });
+
   it('should display platform labels in table rows', () => {
     servingRuntimes.getRowById('template-1').shouldBeSingleModel(true);
     servingRuntimes.getRowById('template-2').shouldBeSingleModel(true);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUtils.ts
@@ -20,6 +20,7 @@ export const customServingRuntimesInitialMock = [
     name: 'template-3',
     displayName: 'OVMS',
     platforms: [ServingRuntimePlatform.MULTI],
+    preInstalled: true,
   }),
   mockServingRuntimeTemplateK8sResource({
     name: 'template-4',

--- a/frontend/src/api/k8s/__tests__/templates.spec.ts
+++ b/frontend/src/api/k8s/__tests__/templates.spec.ts
@@ -59,6 +59,9 @@ const createServingRuntime = (name: string): K8sDSGResource => ({
 describe('assembleServingRuntimeTemplate', () => {
   it('should assemble serving runtime template with templateName', () => {
     const servingRuntimeMock = JSON.stringify(createServingRuntime('template-1'));
+    const servingRuntimeTemplatesMock = mockServingRuntimeTemplateK8sResource({
+      platforms: [ServingRuntimePlatform.MULTI],
+    });
     const result = assembleServingRuntimeTemplate(
       servingRuntimeMock,
       namespace,
@@ -66,25 +69,23 @@ describe('assembleServingRuntimeTemplate', () => {
       ServingRuntimeAPIProtocol.REST,
       'template-1',
     );
-    expect(result).toStrictEqual(
-      mockServingRuntimeTemplateK8sResource({ platforms: [ServingRuntimePlatform.MULTI] }),
-    );
+    expect(result).toStrictEqual(servingRuntimeTemplatesMock);
   });
   it('should assemble serving runtime template without templateName', () => {
     genRandomCharsMock.mockReturnValue('123');
     const servingRuntimeMock = JSON.stringify(createServingRuntime('template-123'));
+    const servingRuntimeTemplatesMock = mockServingRuntimeTemplateK8sResource({
+      name: 'template-123',
+      platforms: [ServingRuntimePlatform.MULTI],
+    });
+
     const result = assembleServingRuntimeTemplate(
       servingRuntimeMock,
       namespace,
       [ServingRuntimePlatform.MULTI],
       ServingRuntimeAPIProtocol.REST,
     );
-    expect(result).toStrictEqual(
-      mockServingRuntimeTemplateK8sResource({
-        name: 'template-123',
-        platforms: [ServingRuntimePlatform.MULTI],
-      }),
-    );
+    expect(result).toStrictEqual(servingRuntimeTemplatesMock);
   });
 
   it('should throw an error when servingRuntime name doesnt exist', () => {

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -4,7 +4,7 @@ import { genRandomChars } from '~/utilities/string';
 
 export const PreInstalledName = 'Pre-installed';
 
-export const ownedByDSC = (resource: K8sResourceCommon): boolean =>
+export const isOOTB = (resource: K8sResourceCommon): boolean =>
   !!resource.metadata?.labels?.['platform.opendatahub.io/part-of'];
 export const isK8sDSGResource = (x?: K8sResourceCommon): x is K8sDSGResource =>
   x?.metadata?.name != null;
@@ -15,7 +15,7 @@ export const getResourceNameFromK8sResource = (resource: K8sDSGResource): string
 export const getDescriptionFromK8sResource = (resource: K8sDSGResource): string =>
   resource.metadata.annotations?.['openshift.io/description'] || '';
 export const getCreatorFromK8sResource = (resource: K8sDSGResource): string =>
-  ownedByDSC(resource)
+  isOOTB(resource)
     ? PreInstalledName
     : resource.metadata.annotations?.['opendatahub.io/username'] || 'unknown';
 

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -18,7 +18,7 @@ import {
   getCreatorFromK8sResource,
   getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
-  ownedByDSC,
+  isOOTB,
 } from '~/concepts/k8s/utils';
 import { connectionTypeColumns } from '~/pages/connectionTypes/columns';
 import CategoryLabel from '~/concepts/connectionTypes/CategoryLabel';
@@ -115,11 +115,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
         )}
       </Td>
       <Td dataLabel={connectionTypeColumns[3].label} data-testid="connection-type-creator">
-        {ownedByDSC(obj) ? (
-          <Label data-testid="connection-type-user-label">{creator}</Label>
-        ) : (
-          creator
-        )}
+        {isOOTB(obj) ? <Label data-testid="connection-type-user-label">{creator}</Label> : creator}
       </Td>
       <Td
         dataLabel={connectionTypeColumns[4].label}
@@ -146,7 +142,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
               title: 'Preview',
               onClick: () => setShowPreview(true),
             },
-            ...(!ownedByDSC(obj)
+            ...(!isOOTB(obj)
               ? [
                   {
                     title: 'Edit',
@@ -158,7 +154,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
               title: 'Duplicate',
               onClick: () => navigate(`/connectionTypes/duplicate/${obj.metadata.name}`),
             },
-            ...(!ownedByDSC(obj)
+            ...(!isOOTB(obj)
               ? [
                   { isSeparator: true },
                   {

--- a/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/EditConnectionTypePage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { useConnectionType } from '~/concepts/connectionTypes/useConnectionType';
 import { updateConnectionType } from '~/services/connectionTypesService';
-import { ownedByDSC } from '~/concepts/k8s/utils';
+import { isOOTB } from '~/concepts/k8s/utils';
 import ManageConnectionTypePage from './ManageConnectionTypePage';
 
 const EditConnectionTypePage: React.FC = () => {
@@ -12,7 +12,7 @@ const EditConnectionTypePage: React.FC = () => {
   const { name } = useParams();
   const [existingConnectionType, isLoaded, error] = useConnectionType(name);
 
-  if (existingConnectionType && ownedByDSC(existingConnectionType)) {
+  if (existingConnectionType && isOOTB(existingConnectionType)) {
     navigate('/connectionTypes');
     return null;
   }

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -5,11 +5,11 @@ import { Label } from '@patternfly/react-core';
 import { TemplateKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import CustomServingRuntimePlatformsLabelGroup from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup';
+import { isOOTB, PreInstalledName } from '~/concepts/k8s/utils';
 import CustomServingRuntimeEnabledToggle from './CustomServingRuntimeEnabledToggle';
 import {
   getServingRuntimeDisplayNameFromTemplate,
   getServingRuntimeNameFromTemplate,
-  isTemplateOOTB,
 } from './utils';
 import CustomServingRuntimeAPIProtocolLabel from './CustomServingRuntimeAPIProtocolLabel';
 
@@ -27,7 +27,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
 }) => {
   const navigate = useNavigate();
   const servingRuntimeName = getServingRuntimeNameFromTemplate(template);
-  const templateOOTB = isTemplateOOTB(template);
+  const templateOOTB = isOOTB(template);
 
   return (
     <Tr
@@ -46,7 +46,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
         <ResourceNameTooltip resource={template}>
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>
-        {templateOOTB && <Label>Pre-installed</Label>}
+        {templateOOTB && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
       </Td>
       <Td dataLabel="Enabled">
         <CustomServingRuntimeEnabledToggle template={template} />

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -14,9 +14,6 @@ export const getTemplateEnabledForPlatform = (
   platform: ServingRuntimePlatform,
 ): boolean => getEnabledPlatformsFromTemplate(template).includes(platform);
 
-export const isTemplateOOTB = (template: TemplateKind): boolean =>
-  template.metadata.labels?.['opendatahub.io/ootb'] === 'true';
-
 export const getSortedTemplates = (templates: TemplateKind[], order: string[]): TemplateKind[] =>
   templates.toSorted(
     (a, b) =>


### PR DESCRIPTION
Closes: [RHOAIENG-10686](https://issues.redhat.com/browse/RHOAIENG-10686)

## Description
This PR aims to Update the Serving runtime templates to use `platform.opendatahub.io/part-of` label to identify preinstalled resources.

<img width="1183" alt="Screenshot 2025-01-28 at 2 21 51 PM" src="https://github.com/user-attachments/assets/45f05f1a-4c54-4e65-aae3-2756ef563054" />


## How Has This Been Tested?
Make sure that the pre-installed label will display on serving runtime templates with `platform.opendatahub.io/part-of` label. 

## Test Impact
Updated cypress and unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
