### PR TITLE
Update the positions of DW tabs

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -204,43 +204,43 @@ describe('Distributed Workload Metrics root page', () => {
     globalDistributedWorkloads.shouldHavePageTitle();
   });
 
-  it('Defaults to Project Metrics tab and automatically selects a project', () => {
+  it('Defaults to Distributed workload status tab and automatically selects a project', () => {
     initIntercepts({});
     globalDistributedWorkloads.visit();
 
-    cy.url().should('include', '/projectMetrics/test-project');
-    cy.findByText('Top resource-consuming distributed workloads').should('exist');
+    cy.url().should('include', '/workloadStatus/test-project');
+    globalDistributedWorkloads.findStatusOverviewCard().should('exist');
   });
 
   it('Tabs navigate to corresponding routes and render their contents', () => {
     initIntercepts({});
     globalDistributedWorkloads.visit();
 
-    cy.findByLabelText('Distributed workload status tab').click();
-    cy.url().should('include', '/workloadStatus/test-project');
-    globalDistributedWorkloads.findStatusOverviewCard().should('exist');
-
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/projectMetrics/test-project');
     cy.findByText('Top resource-consuming distributed workloads').should('exist');
+
+    cy.findByLabelText('Distributed workload status tab').click();
+    cy.url().should('include', '/workloadStatus/test-project');
+    globalDistributedWorkloads.findStatusOverviewCard().should('exist');
   });
 
   it('Changing the project and navigating between tabs or to the root of the page retains the new project', () => {
     initIntercepts({});
     globalDistributedWorkloads.visit();
-    cy.url().should('include', '/projectMetrics/test-project');
+    cy.url().should('include', '/workloadStatus/test-project');
 
     globalDistributedWorkloads.projectDropdown.openAndSelectItem('Test Project 2', true);
-    cy.url().should('include', '/projectMetrics/test-project-2');
-
-    cy.findByLabelText('Distributed workload status tab').click();
     cy.url().should('include', '/workloadStatus/test-project-2');
 
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/projectMetrics/test-project-2');
 
+    cy.findByLabelText('Distributed workload status tab').click();
+    cy.url().should('include', '/workloadStatus/test-project-2');
+
     globalDistributedWorkloads.navigate();
-    cy.url().should('include', '/projectMetrics/test-project-2');
+    cy.url().should('include', '/workloadStatus/test-project-2');
   });
 
   it('Changing the refresh interval and reloading the page should retain the selection', () => {

--- a/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/useDistributedWorkloadsTabs.tsx
@@ -20,18 +20,18 @@ export const useDistributedWorkloadsTabs = (): DistributedWorkloadsTabConfig[] =
   const dwAreaIsAvailable = useDistributedWorkloadsEnabled();
   return [
     {
-      id: DistributedWorkloadsTabId.PROJECT_METRICS,
-      title: 'Project metrics',
-      path: 'projectMetrics',
-      isAvailable: dwAreaIsAvailable,
-      ContentComponent: GlobalDistributedWorkloadsProjectMetricsTab,
-    },
-    {
       id: DistributedWorkloadsTabId.WORKLOAD_STATUS,
       title: 'Distributed workload status',
       path: 'workloadStatus',
       isAvailable: dwAreaIsAvailable,
       ContentComponent: GlobalDistributedWorkloadsWorkloadStatusTab,
+    },
+    {
+      id: DistributedWorkloadsTabId.PROJECT_METRICS,
+      title: 'Project metrics',
+      path: 'projectMetrics',
+      isAvailable: dwAreaIsAvailable,
+      ContentComponent: GlobalDistributedWorkloadsProjectMetricsTab,
     },
   ];
 };


### PR DESCRIPTION
Closes: [RHOAIENG-7711](https://issues.redhat.com/browse/RHOAIENG-7711)

## Description
This PR aims to update the positions of DW tabs. Distributed workload status as the first tab and metrics next.

<img width="990" alt="Screenshot 2025-01-23 at 9 54 44 PM" src="https://github.com/user-attachments/assets/4120b6ea-c5bc-4403-adfb-f2d23862dd8c" />


## How Has This Been Tested?
Test that, Distributed workload status is the first tab and metrics next.

## Test Impact
Updated cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
