### PR TITLE
Fix for notebook route link font size

### DIFF
--- a/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookRouteLink.tsx
@@ -13,7 +13,6 @@ type NotebookRouteLinkProps = {
   notebook: NotebookKind;
   isRunning: boolean;
   variant?: ButtonVariant;
-  isLarge?: boolean;
 };
 
 const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
@@ -22,7 +21,6 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
   notebook,
   isRunning,
   variant,
-  isLarge,
 }) => {
   const [routeLink, loaded, error] = useRouteForNotebook(
     notebook.metadata.name,
@@ -45,12 +43,7 @@ const NotebookRouteLink: React.FC<NotebookRouteLinkProps> = ({
           variant={variant || 'link'}
           icon={!error && <ExternalLinkAltIcon />}
           iconPosition="end"
-          style={{
-            whiteSpace: 'nowrap',
-            fontSize: isLarge
-              ? 'var(--pf-t--global--font--size--body--default)'
-              : 'var(--pf-t--global--font--size--body--sm)',
-          }}
+          style={{ whiteSpace: 'nowrap' }}
           onClick={() => {
             fireMiscTrackingEvent('Workbench Opened', {
               wbName: getDisplayNameFromK8sResource(notebook),

--- a/frontend/src/pages/projects/notebook/StopNotebookConfirmModal.tsx
+++ b/frontend/src/pages/projects/notebook/StopNotebookConfirmModal.tsx
@@ -57,12 +57,7 @@ const StopNotebookConfirmModal: React.FC<StopNotebookConfirmProps> = ({
             <Flex>
               <FlexItem spacer={{ default: 'spacerXs' }}>To save changes, </FlexItem>
               <FlexItem spacer={{ default: 'spacerNone' }}>
-                <NotebookRouteLink
-                  label="open the workbench"
-                  notebook={notebook}
-                  isRunning
-                  isLarge
-                />
+                <NotebookRouteLink label="open the workbench" notebook={notebook} isRunning />
               </FlexItem>
               <FlexItem spacer={{ default: 'spacerNone' }}>.</FlexItem>
             </Flex>

--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/NotebooksCardItems.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/NotebooksCardItems.tsx
@@ -47,7 +47,6 @@ const NotebooksCardItems: React.FC<NotebooksCardItemsProps> = ({
           label={getDisplayNameFromK8sResource(notebookState.notebook)}
           notebook={notebookState.notebook}
           isRunning={notebookState.isRunning}
-          isLarge
         />
       ))}
       <Flex key="count" gap={{ default: 'gapMd' }}>


### PR DESCRIPTION
Closes [RHOAIENG-18073](https://issues.redhat.com/browse/RHOAIENG-18073)

## Description
Remove style overrides for the `NotebookRouteLink` component. Font size should be standard in all cases.

## How Has This Been Tested?
Navigate to the Data Science Projects page, expand the workbenches for a project. Verify the link font size is correct.
Navigate to a project's overview page, verify the workbench links in the Workbenches card have the correct font size.
Navigate to a project's Workbenches page, verify the `Open` links in the table have the correct font size.
Click `Stop` on a workbench row, verify the workbench link in the confirmation dialog has the correct font size

## Test Impact
No test impact, visual change only

## Screen shots
![image](https://github.com/user-attachments/assets/84701d61-572f-434c-acfa-ff1bbb9284b9)


![image](https://github.com/user-attachments/assets/73e9fc28-5244-4e3e-ac3a-dcc0097ebea0)


![image](https://github.com/user-attachments/assets/9d71da46-935b-4ab2-a5d8-23d2dd68c2b4)


![image](https://github.com/user-attachments/assets/1ffabafe-58b8-47a4-bd69-4c34794f1f20)

## Request review criteria:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @jgiardino 