### PR TITLE
Fix for page header layout when page has long description

### DIFF
--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -59,8 +59,11 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
     <PageSection hasBodyWrapper={false}>
       <Stack hasGutter>
         <StackItem>
-          <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-            <Content>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsFlexStart' }}
+          >
+            <FlexItem flex={{ default: 'flex_1' }}>
               <Content component="h1" data-testid="app-page-title">
                 {title}
               </Content>
@@ -68,8 +71,8 @@ const ApplicationsPage: React.FC<ApplicationsPageProps> = ({
                 {subtext && <StackItem>{subtext}</StackItem>}
                 {description && <StackItem>{description}</StackItem>}
               </Stack>
-            </Content>
-            {headerAction}
+            </FlexItem>
+            <FlexItem>{headerAction}</FlexItem>
           </Flex>
         </StackItem>
         {headerContent && <StackItem>{headerContent}</StackItem>}


### PR DESCRIPTION
Closes [RHOAIENG-18227](https://issues.redhat.com/browse/RHOAIENG-18227)

## Description
Prevents the actions button from wrapping in a page header when the description is very long.

## How Has This Been Tested?
- Navigate to `Data Science Projects` and select a project
- Use the `Actions` button and `Edit project` 
- Set the project's description to a something very long
- Save
- Verify the project details page continues to show the `Actions` button aligned with the title and not wrapped below the description.

## Test Impact
None, visual change only

## Screen shot
![image](https://github.com/user-attachments/assets/cd21d965-44cf-4545-9a31-26c7a46d16ce)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
