### PR TITLE
updated regex and validation to properly catch non-compliant DNS-1035…

### DIFF
--- a/frontend/src/concepts/k8s/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/k8s/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   translateDisplayNameForK8s,
   translateDisplayNameForK8sAndReport,
 } from '~/concepts/k8s/utils';
+import { K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR } from '~/pages/projects/screens/spawner/const';
 
 describe('getDisplayNameFromK8sResource', () => {
   it('gets the display name when present', () => {
@@ -49,6 +50,10 @@ describe('translateDisplayNameForK8s', () => {
     expect(translateDisplayNameForK8s('-1234', { safeK8sPrefix: 'wb-' })).toBe('wb-1234');
     expect(translateDisplayNameForK8s('-1-', { safeK8sPrefix: 'wb-' })).toBe('wb-1');
     expect(translateDisplayNameForK8s('1-', { safeK8sPrefix: 'wb-' })).toBe('wb-1');
+    expect(translateDisplayNameForK8s('213-workbench-1-tls', { safeK8sPrefix: 'wb-' })).toBe(
+      'wb-213-workbench-1-tls',
+    );
+    expect(translateDisplayNameForK8s('$-12hello', { safeK8sPrefix: 'wb-' })).toBe('wb-12hello');
     expect(translateDisplayNameForK8s('-validcharacters')).toBe(`validcharacters`);
   });
 });
@@ -158,5 +163,39 @@ describe('isValidK8sName', () => {
     expect(isValidK8sName('test-project-1')).toBe(true);
     expect(isValidK8sName('john-does-cool-project')).toBe(true);
     expect(isValidK8sName('ymbols--capitals-and-spaces-these-are-invalid')).toBe(true);
+  });
+});
+
+describe('isValidK8sName for Notebook resource names', () => {
+  it('identifies invalid names', () => {
+    expect(isValidK8sName('', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(false);
+    expect(isValidK8sName('Test Project 1', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(false);
+    expect(isValidK8sName("John Doe's Cool Project!", K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(
+      false,
+    );
+    expect(
+      isValidK8sName(
+        '$ymbols & Capitals and Spaces! (These are invalid!)',
+        K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR,
+      ),
+    ).toBe(false);
+    expect(isValidK8sName('--213-workbench-1-tls', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(
+      false,
+    );
+    expect(isValidK8sName('1234', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(false);
+    expect(isValidK8sName('213-workbench-1-tls', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(false);
+  });
+
+  it('identifies valid names', () => {
+    expect(isValidK8sName('test-project-1', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(true);
+    expect(isValidK8sName('john-does-cool-project', K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR)).toBe(
+      true,
+    );
+    expect(
+      isValidK8sName(
+        'ymbols--capitals-and-spaces-these-are-invalid',
+        K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR,
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -58,10 +58,10 @@ export const translateDisplayNameForK8sAndReport = (
   let translatedName = name
     .trim()
     .toLowerCase()
-    .replace(/^-*/, '') // remove any leading dashes
-    .replace(/-*$/, '') // remove any trailing dashes
     .replace(/\s/g, '-') // spaces to dashes
     .replace(/[^a-z0-9-]/g, '') // remove inverse of good k8s characters
+    .replace(/^-*/, '') // remove any leading dashes
+    .replace(/-*$/, '') // remove any trailing dashes
     .replace(/[-]+/g, '-'); // simplify double dashes ('A - B' turns into 'a---b' where 'a-b' is enough)
 
   /** Allows constant length checks -- modifies translatedName & appliedCriteria */
@@ -85,8 +85,8 @@ export const translateDisplayNameForK8sAndReport = (
       }
       appliedCriteria.safeK8sPrefix = true;
       appliedCriteria.staticPrefix = true;
-    } else if (/^\d+$/.test(translatedName)) {
-      // Avoid pure digit names
+    } else if (/^\d+/.test(translatedName)) {
+      // Avoid names that start with a digit
       translatedName = `${safeK8sPrefix}${translatedName}`;
       appliedCriteria.safeK8sPrefix = true;
     }

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -37,7 +37,11 @@ import useNotebookPVCItems from '~/pages/projects/pvc/useNotebookPVCItems';
 import { getNotebookPVCMountPathMap } from '~/pages/projects/notebook/utils';
 import { getNotebookPVCNames } from '~/pages/projects/pvc/utils';
 import { SpawnerPageSectionID } from './types';
-import { ScrollableSelectorID, SpawnerPageSectionTitles } from './const';
+import {
+  K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR,
+  ScrollableSelectorID,
+  SpawnerPageSectionTitles,
+} from './const';
 import SpawnerFooter from './SpawnerFooter';
 import ImageSelectorField from './imageSelector/ImageSelectorField';
 import ContainerSizeSelector from './deploymentSize/ContainerSizeSelector';
@@ -76,6 +80,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     initialData: existingNotebook,
     limitNameResourceType: LimitNameResourceType.WORKBENCH,
     safePrefix: 'wb-',
+    regexp: K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR,
   });
   const [isAttachStorageModalOpen, setIsAttachStorageModalOpen] = React.useState(false);
   const [isCreateStorageModalOpen, setIsCreateStorageModalOpen] = React.useState(false);

--- a/frontend/src/pages/projects/screens/spawner/const.ts
+++ b/frontend/src/pages/projects/screens/spawner/const.ts
@@ -14,6 +14,7 @@ export const ScrollableSelectorID = 'workbench-spawner-page';
 
 export const FAILED_PHASES = [BuildPhase.ERROR, BuildPhase.FAILED];
 export const PENDING_PHASES = [BuildPhase.NEW, BuildPhase.PENDING, BuildPhase.CANCELLED];
+export const K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
 
 // TODO: Convert to enum
 export const IMAGE_ANNOTATIONS = {


### PR DESCRIPTION
… labels

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
[RHOAIENG-15753](https://issues.redhat.com/browse/RHOAIENG-15753)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Previously, the dashboard did not catch invalid workbench names that started with numbers and had other characters in them as well. Now, the regex has been updated to catch them. Furthermore, I also reordered the `replace` order, since the trailing dashes were removed before non-compliant characters, which would fail a test like `$-123test`. The solution? We could either make the regex more complicated or simply reorder the `replace`. I chose the latter option.

For reference taken from the JIRA description:
```
 a DNS-1035 label must consist of lower case alphanumeric characters or '-', 
start with an alphabetic character, and end with an alphanumeric character 
(e.g. 'my-name', or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

You can try out some test cases manually. You can also run this command:

`npm run test:unit **/concepts/k8s/__tests__/utils.spec.ts`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I added tests in `/concepts/k8s/__tests__/utils.spec.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
