### PR TITLE
Update ownedByDSC to use correct label for checking what is created by the operator

### DIFF
--- a/frontend/src/__mocks__/mockConnectionType.ts
+++ b/frontend/src/__mocks__/mockConnectionType.ts
@@ -38,27 +38,17 @@ export const mockConnectionTypeConfigMapObj = ({
     namespace,
     resourceVersion: '173155965',
     creationTimestamp: '2024-08-29T00:00:00Z',
-    labels: { 'opendatahub.io/dashboard': 'true', 'opendatahub.io/connection-type': 'true' },
+    labels: {
+      'opendatahub.io/dashboard': 'true',
+      'opendatahub.io/connection-type': 'true',
+      ...(preInstalled && { 'platform.opendatahub.io/part-of': 'dashboard' }),
+    },
     annotations: {
       'openshift.io/display-name': displayName,
       'openshift.io/description': description,
       'opendatahub.io/disabled': enabled ? 'false' : 'true',
       'opendatahub.io/username': username || '',
     },
-    ...(preInstalled
-      ? {
-          ownerReferences: [
-            {
-              apiVersion: 'datasciencecluster.opendatahub.io/v1',
-              kind: 'DataScienceCluster',
-              name: 'default-dsc',
-              uid: '06dd5a40-8473-4d5f-8afa-36885aa26ca9',
-              controller: true,
-              blockOwnerDeletion: true,
-            },
-          ],
-        }
-      : undefined),
   },
   data: {
     category: 'category' in rest ? rest.category : ['Database', 'Testing'],

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -5,8 +5,7 @@ import { genRandomChars } from '~/utilities/string';
 export const PreInstalledName = 'Pre-installed';
 
 export const ownedByDSC = (resource: K8sResourceCommon): boolean =>
-  !!resource.metadata?.ownerReferences?.find((owner) => owner.kind === 'DataScienceCluster');
-
+  !!resource.metadata?.labels?.['platform.opendatahub.io/part-of'];
 export const isK8sDSGResource = (x?: K8sResourceCommon): x is K8sDSGResource =>
   x?.metadata?.name != null;
 export const getDisplayNameFromK8sResource = (resource: K8sDSGResource): string =>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-18622

## Description
Simply changing to check for the existence of the `platform.opendatahub.io/part-of` label. Also updating mocks to reflect this change. Personally wouldn't mind changing the name of the function since we aren't using the ownership to determine if something is created by the DSC. 

![image](https://github.com/user-attachments/assets/a9d6a308-6de6-4d57-b119-ad2dc806c0d4)


<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Manually tested. Should see the changes from [this PR](https://github.com/opendatahub-io/odh-dashboard/pull/3642) once it's working (correct label for pre-installed and no kebab actions for edit and delete if preinstalled). User created connection types should show the username as the creator and still allow editing and deleting in the kebab. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated mocks for data connection config maps. Wouldn't be a bad idea to add a line to the mock test to ensure there's no kebab actions for edit and delete but since that wasn't the point of this PR I'll leave it out.
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
