### PR TITLE
Update routing flow for creating accelerator/hardware profile on custom notebook image table

### DIFF
--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -57,7 +57,7 @@ const CustomServingRuntimeRoutes = React.lazy(
 );
 const GroupSettingsPage = React.lazy(() => import('../pages/groupSettings/GroupSettings'));
 const LearningCenterPage = React.lazy(() => import('../pages/learningCenter/LearningCenter'));
-const BYONImagesPage = React.lazy(() => import('../pages/BYONImages/BYONImages'));
+const BYONImageRoutes = React.lazy(() => import('../pages/BYONImages/BYONImageRoutes'));
 const NotFound = React.lazy(() => import('../pages/NotFound'));
 
 const DependencyMissingPage = React.lazy(
@@ -135,7 +135,7 @@ const AppRoutes: React.FC = () => {
 
         {isAdmin && (
           <>
-            <Route path="/notebookImages" element={<BYONImagesPage />} />
+            <Route path="/notebookImages/*" element={<BYONImageRoutes />} />
             <Route path="/clusterSettings" element={<ClusterSettingsPage />} />
             <Route path="/acceleratorProfiles/*" element={<AcceleratorProfileRoutes />} />
             <Route path="/hardwareProfiles/*" element={<HardwareProfileRoutes />} />

--- a/frontend/src/pages/BYONImages/BYONImageAccelerators.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageAccelerators.tsx
@@ -70,7 +70,7 @@ export const BYONImageAccelerators: React.FC<BYONImageAcceleratorsProps> = ({
                 variant="outline"
                 render={({ className, content }) => (
                   <Link
-                    to={`/acceleratorProfiles/create?${new URLSearchParams({
+                    to={`/notebookImages/acceleratorProfile/create?${new URLSearchParams({
                       identifiers: image.recommendedAcceleratorIdentifiers.join(','),
                     }).toString()}`}
                     className={className}

--- a/frontend/src/pages/BYONImages/BYONImageHardwareProfiles.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageHardwareProfiles.tsx
@@ -70,7 +70,7 @@ const BYONImageHardwareProfiles: React.FC<BYONImageHardwareProfilesProps> = ({
               variant="outline"
               render={({ className, content }) => (
                 <Link
-                  to={`/hardwareProfiles/create?${new URLSearchParams({
+                  to={`/notebookImages/hardwareProfile/create?${new URLSearchParams({
                     identifiers: image.recommendedAcceleratorIdentifiers.join(','),
                   }).toString()}`}
                   className={className}

--- a/frontend/src/pages/BYONImages/BYONImageRoutes.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageRoutes.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import ManageAcceleratorProfile from '~/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfile';
+import BYONImages from '~/pages/BYONImages/BYONImages';
+import ManageHardwareProfile from '~/pages/hardwareProfiles/manage/ManageHardwareProfile';
+
+const BYONImageRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<BYONImages />} />
+    <Route
+      path="/hardwareProfile/create"
+      element={
+        <ManageHardwareProfile homepageTitle="Notebook images" contextPath="/notebookImages" />
+      }
+    />
+    <Route
+      path="/acceleratorProfile/create"
+      element={
+        <ManageAcceleratorProfile homepageTitle="Notebook images" contextPath="/notebookImages" />
+      }
+    />
+    <Route path="*" element={<Navigate to="." />} />
+  </Routes>
+);
+
+export default BYONImageRoutes;

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfile.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfile.tsx
@@ -18,16 +18,21 @@ import { ManageAcceleratorProfileDetailsSection } from './ManageAcceleratorProfi
 
 type ManageAcceleratorProfileProps = {
   existingAcceleratorProfile?: AcceleratorProfileKind;
+  contextPath?: string;
+  homepageTitle?: string;
 };
 
 const ManageAcceleratorProfile: React.FC<ManageAcceleratorProfileProps> = ({
   existingAcceleratorProfile,
+  contextPath = '/acceleratorProfiles',
+  homepageTitle = 'Accelerator profiles',
 }) => {
-  const [state, setState] = useGenericObjectState<AcceleratorProfileKind['spec']>({
+  const [state, setState] = useGenericObjectState<AcceleratorProfileFormData>({
     displayName: '',
     identifier: '',
     enabled: true,
     tolerations: [],
+    name: '',
   });
   const { data: profileNameDesc, onDataChange: setProfileNameDesc } =
     useK8sNameDescriptionFieldData({
@@ -71,9 +76,7 @@ const ManageAcceleratorProfile: React.FC<ManageAcceleratorProfileProps> = ({
       }
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem
-            render={() => <Link to="/acceleratorProfiles">Accelerator profiles</Link>}
-          />
+          <BreadcrumbItem render={() => <Link to={contextPath}>{homepageTitle}</Link>} />
           <BreadcrumbItem>
             {existingAcceleratorProfile ? 'Edit' : 'Create'} accelerator profile
           </BreadcrumbItem>
@@ -118,6 +121,7 @@ const ManageAcceleratorProfile: React.FC<ManageAcceleratorProfileProps> = ({
           state={formState}
           existingAcceleratorProfile={existingAcceleratorProfile}
           validFormData={validFormData}
+          redirectPath={contextPath}
         />
       </PageSection>
     </ApplicationsPage>

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileDetailsSection.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useSearchParams } from 'react-router-dom';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
-import { AcceleratorProfileKind } from '~/k8sTypes';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import { AcceleratorProfileFormData } from './types';
 import { IdentifierSelectField } from './IdentifierSelectField';
 
 type ManageAcceleratorProfileDetailsSectionProps = {
   state: AcceleratorProfileFormData;
-  setState: UpdateObjectAtPropAndValue<AcceleratorProfileKind['spec']>;
+  setState: UpdateObjectAtPropAndValue<AcceleratorProfileFormData>;
 };
 
 export const ManageAcceleratorProfileDetailsSection: React.FC<

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
@@ -14,28 +14,51 @@ import {
   updateAcceleratorProfile,
 } from '~/services/acceleratorProfileService';
 import { AcceleratorProfileFormData } from '~/pages/acceleratorProfiles/screens/manage/types';
+import useNotification from '~/utilities/useNotification';
 
 type ManageAcceleratorProfileFooterProps = {
   state: AcceleratorProfileFormData;
   existingAcceleratorProfile?: AcceleratorProfileKind;
   validFormData: boolean;
+  redirectPath: string;
 };
 
 export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFooterProps> = ({
   state,
   existingAcceleratorProfile,
   validFormData,
+  redirectPath,
 }) => {
   const [errorMessage, setErrorMessage] = React.useState<string>('');
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const navigate = useNavigate();
+  const notification = useNotification();
 
   const onCreateAcceleratorProfile = async () => {
     setIsLoading(true);
     createAcceleratorProfile(state)
       .then((res) => {
         if (res.success) {
-          navigate(`/acceleratorProfiles`);
+          if (redirectPath !== '/acceleratorProfiles') {
+            notification.success(
+              'Accelerator profile has been created.',
+              <Stack hasGutter>
+                <StackItem>
+                  A new accelerator profile <strong>{state.displayName}</strong> has been created.
+                </StackItem>
+                <StackItem>
+                  <Button
+                    isInline
+                    variant="link"
+                    onClick={() => navigate(`/acceleratorProfiles/edit/${state.name}`)}
+                  >
+                    View profile details
+                  </Button>
+                </StackItem>
+              </Stack>,
+            );
+          }
+          navigate(redirectPath);
         } else {
           setErrorMessage(res.error || 'Could not create accelerator profile');
         }
@@ -54,7 +77,7 @@ export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFo
       updateAcceleratorProfile(existingAcceleratorProfile.metadata.name, state)
         .then((res) => {
           if (res.success) {
-            navigate(`/acceleratorProfiles`);
+            navigate(redirectPath);
           } else {
             setErrorMessage(res.error || 'Could not update accelerator profile');
           }
@@ -103,7 +126,7 @@ export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFo
             <Button
               variant="link"
               id="cancel-button"
-              onClick={() => navigate(`/acceleratorProfiles`)}
+              onClick={() => navigate(redirectPath)}
               isDisabled={isLoading}
             >
               Cancel

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
@@ -47,11 +47,7 @@ export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFo
                   A new accelerator profile <strong>{state.displayName}</strong> has been created.
                 </StackItem>
                 <StackItem>
-                  <Button
-                    isInline
-                    variant="link"
-                    onClick={() => navigate(`/acceleratorProfiles`)}
-                  >
+                  <Button isInline variant="link"  onClick={() => navigate(`/acceleratorProfiles`)}>
                     View profile details
                   </Button>
                 </StackItem>

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
@@ -47,7 +47,7 @@ export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFo
                   A new accelerator profile <strong>{state.displayName}</strong> has been created.
                 </StackItem>
                 <StackItem>
-                  <Button isInline variant="link"  onClick={() => navigate(`/acceleratorProfiles`)}>
+                  <Button isInline variant="link" onClick={() => navigate(`/acceleratorProfiles`)}>
                     View profile details
                   </Button>
                 </StackItem>

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/ManageAcceleratorProfileFooter.tsx
@@ -50,7 +50,7 @@ export const ManageAcceleratorProfileFooter: React.FC<ManageAcceleratorProfileFo
                   <Button
                     isInline
                     variant="link"
-                    onClick={() => navigate(`/acceleratorProfiles/edit/${state.name}`)}
+                    onClick={() => navigate(`/acceleratorProfiles`)}
                   >
                     View profile details
                   </Button>

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/types.ts
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/types.ts
@@ -9,4 +9,4 @@ export type ManageAcceleratorProfileSectionTitlesType = {
   [key in ManageAcceleratorProfileSectionID]: string;
 };
 
-export type AcceleratorProfileFormData = { name?: string } & AcceleratorProfileKind['spec'];
+export type AcceleratorProfileFormData = { name: string } & AcceleratorProfileKind['spec'];

--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
@@ -21,11 +21,15 @@ import { HardwareProfileFormData, ManageHardwareProfileSectionID } from './types
 type ManageHardwareProfileProps = {
   existingHardwareProfile?: HardwareProfileKind;
   duplicatedHardwareProfile?: HardwareProfileKind;
+  contextPath?: string;
+  homepageTitle?: string;
 };
 
 const ManageHardwareProfile: React.FC<ManageHardwareProfileProps> = ({
   existingHardwareProfile,
   duplicatedHardwareProfile,
+  contextPath = '/hardwareProfiles',
+  homepageTitle = 'Hardware profiles',
 }) => {
   const [state, setState] = useGenericObjectState<HardwareProfileKind['spec']>(
     DEFAULT_HARDWARE_PROFILE_SPEC,
@@ -87,7 +91,7 @@ const ManageHardwareProfile: React.FC<ManageHardwareProfileProps> = ({
       }
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem render={() => <Link to="/hardwareProfiles">Hardware profiles</Link>} />
+          <BreadcrumbItem render={() => <Link to={contextPath}>{homepageTitle}</Link>} />
           <BreadcrumbItem isActive>
             {existingHardwareProfile ? 'Edit' : duplicatedHardwareProfile ? 'Duplicate' : 'Create'}{' '}
             hardware profile
@@ -133,6 +137,7 @@ const ManageHardwareProfile: React.FC<ManageHardwareProfileProps> = ({
           state={formState}
           existingHardwareProfile={existingHardwareProfile}
           validFormData={validFormData}
+          redirectPath={contextPath}
         />
       </PageSection>
     </ApplicationsPage>

--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfileFooter.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfileFooter.tsx
@@ -47,11 +47,7 @@ const ManageHardwareProfileFooter: React.FC<ManageHardwareProfileFooterProps> = 
                 A new hardware profile <strong>{state.displayName}</strong> has been created.
               </StackItem>
               <StackItem>
-                <Button
-                  isInline
-                  variant="link"
-                  onClick={() => navigate(`/hardwareProfiles`)}
-                >
+                <Button isInline variant="link" onClick={() => navigate(`/hardwareProfiles`)}>
                   View profile details
                 </Button>
               </StackItem>

--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfileFooter.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfileFooter.tsx
@@ -50,7 +50,7 @@ const ManageHardwareProfileFooter: React.FC<ManageHardwareProfileFooterProps> = 
                 <Button
                   isInline
                   variant="link"
-                  onClick={() => navigate(`/hardwareProfiles/edit/${state.name}`)}
+                  onClick={() => navigate(`/hardwareProfiles`)}
                 >
                   View profile details
                 </Button>

--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfileFooter.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfileFooter.tsx
@@ -12,29 +12,54 @@ import { HardwareProfileKind } from '~/k8sTypes';
 import { HardwareProfileFormData } from '~/pages/hardwareProfiles/manage/types';
 import { createHardwareProfile, updateHardwareProfile } from '~/api';
 import { useDashboardNamespace } from '~/redux/selectors';
+import useNotification from '~/utilities/useNotification';
 
 type ManageHardwareProfileFooterProps = {
   state: HardwareProfileFormData;
   existingHardwareProfile?: HardwareProfileKind;
   validFormData: boolean;
+  redirectPath: string;
 };
 
 const ManageHardwareProfileFooter: React.FC<ManageHardwareProfileFooterProps> = ({
   state,
   existingHardwareProfile,
   validFormData,
+  redirectPath,
 }) => {
   const [errorMessage, setErrorMessage] = React.useState<string>('');
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const { dashboardNamespace } = useDashboardNamespace();
   const navigate = useNavigate();
+  const notification = useNotification();
 
   const { name, ...spec } = state;
 
   const onCreateHardwareProfile = async () => {
     setIsLoading(true);
     createHardwareProfile(name, spec, dashboardNamespace)
-      .then(() => navigate('/hardwareProfiles'))
+      .then(() => {
+        if (redirectPath !== '/hardwareProfiles') {
+          notification.success(
+            'Hardware profile has been created.',
+            <Stack hasGutter>
+              <StackItem>
+                A new hardware profile <strong>{state.displayName}</strong> has been created.
+              </StackItem>
+              <StackItem>
+                <Button
+                  isInline
+                  variant="link"
+                  onClick={() => navigate(`/hardwareProfiles/edit/${state.name}`)}
+                >
+                  View profile details
+                </Button>
+              </StackItem>
+            </Stack>,
+          );
+        }
+        navigate(redirectPath);
+      })
       .catch((err) => {
         setErrorMessage(err.message);
       })
@@ -47,7 +72,7 @@ const ManageHardwareProfileFooter: React.FC<ManageHardwareProfileFooterProps> = 
     if (existingHardwareProfile) {
       setIsLoading(true);
       updateHardwareProfile(spec, existingHardwareProfile, dashboardNamespace)
-        .then(() => navigate(`/hardwareProfiles`))
+        .then(() => navigate(redirectPath))
         .catch((err) => {
           setErrorMessage(err.message);
         })
@@ -88,7 +113,7 @@ const ManageHardwareProfileFooter: React.FC<ManageHardwareProfileFooterProps> = 
             <Button
               variant="link"
               id="cancel-button"
-              onClick={() => navigate(`/hardwareProfiles`)}
+              onClick={() => navigate(redirectPath)}
               isDisabled={isLoading}
             >
               Cancel


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-1458](https://issues.redhat.com/browse/RHOAIENG-1458)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Create separate routes for creating accelerator profile and hardware profile on the notebook image table. In that case, when creating it, the navigation could be more reasonable and clear.

Take hardware profile as an example, click on "Create profile" on any row
<img width="1512" alt="Screenshot 2025-01-27 at 7 59 34 PM" src="https://github.com/user-attachments/assets/cf8a459a-fbbd-4dcb-a04e-408d4c3d74a2" />

Now the creation page still sits under the notebook image settings context - You can check the breadcrumb and the side nav highlight
<img width="1512" alt="Screenshot 2025-01-27 at 8 00 13 PM" src="https://github.com/user-attachments/assets/85268acb-ef4d-43bc-bb7f-2139c867b768" />

Click on "Cancel", it will take you back to the notebook settings table
When successfully creating, it will take you back to the notebook image table and show a notification with a link
<img width="1512" alt="Screenshot 2025-01-27 at 8 02 22 PM" src="https://github.com/user-attachments/assets/e2a93277-578d-45d1-b0c9-96b20e028c68" />

Clicking on the link, it will take you to the edit page of that hardware profile
<img width="1512" alt="Screenshot 2025-01-27 at 8 03 16 PM" src="https://github.com/user-attachments/assets/28278a65-ee75-472a-ba24-205ede00a338" />

It's the same flow for accelerator profile if the hardware profile is disabled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Disable hardware profile
2. Create a notebook image
3. Add accelerator identifier for that image
4. Click on "Create profile" button on that image row
5. Test the navigation, check whether it's still under notebook image context
6. Try to cancel to see if it returns back to the notebook image table
7. Try to create a profile to see if it returns back to the notebook image table and show a notification
8. Click on the link on the notification to see if it navigates to the edit accelerator profile page
9. Enable hardware profile and repeat step 4-8 and verify

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, there are currently no test cases for this row, not sure if it's worth the effort for the accelerator profile, we can do that later for the hardware profile.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
