### PR TITLE
Update Deploy from model registry form pre-fill behavior

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
@@ -28,8 +28,8 @@ const useRegisteredModelDeployInfo = (
     useModelArtifactsByVersionId(modelVersion.id);
 
   const registeredModelDeployInfo = React.useMemo(() => {
-    const dateString = new Date().toISOString();
-    const modelName = `${registeredModel?.name ?? ''} - ${modelVersion.name} - ${dateString}`;
+    const modelName = `${registeredModel?.name ?? ''} - ${modelVersion.name}`.slice(0, 63);
+
     if (modelArtifactList.size === 0) {
       return {
         registeredModelDeployInfo: {


### PR DESCRIPTION
Closes: [RHOAIENG-15827](https://issues.redhat.com/browse/RHOAIENG-15827)

## Description
This PR aims to update the pre-fill behavior of "Deploy from model registry" form (KServe modal). The generated model name no longer includes a timestamp and is trimmed to a max of 63 characters. 
The character limit validation piece of this has been moved to a backend issue [RHOAIENG-18603](https://issues.redhat.com/browse/RHOAIENG-18603).

## How Has This Been Tested?
1. Click on Deploy from Model Registry (with long version name or registered model name).
2. Select project with single model serving platform enabled.
3. Check that the model name is pre-filled and the characters limit is 63.

## Test Impact
added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
