### PR TITLE
Add e2e test for OOTB connection types

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/connectionTypes/testOOTBConnectionType.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/connectionTypes/testOOTBConnectionType.yaml
@@ -1,0 +1,3 @@
+# connectionTypes.cy.ts Test Data #
+s3: "S3 compatible object storage - v1"
+uri: "URI - v1"

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/connectionTypes/connectionTypes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/connectionTypes/connectionTypes.cy.ts
@@ -1,0 +1,41 @@
+import { connectionTypesPage } from '~/__tests__/cypress/cypress/pages/connectionTypes';
+import type { OOTBConnectionTypesData } from '~/__tests__/cypress/cypress/types';
+import { loadOOTBConnectionTypesFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+
+describe('Verify OOTB Connection Types', () => {
+  let testData: OOTBConnectionTypesData;
+
+  before(() => {
+    return loadOOTBConnectionTypesFixture('e2e/connectionTypes/testOOTBConnectionType.yaml').then(
+      (fixtureData: OOTBConnectionTypesData) => {
+        testData = fixtureData;
+      },
+    );
+  });
+
+  it(
+    'should have pre-installed label and unable to be edited or deleted',
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard'] },
+    () => {
+      cy.step('Navigate to Connection Types view');
+      cy.visitWithLogin('/connectionTypes', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      connectionTypesPage.shouldHaveConnectionTypes();
+      const uri = connectionTypesPage.getConnectionTypeRow(testData.uri);
+      const s3 = connectionTypesPage.getConnectionTypeRow(testData.s3);
+
+      cy.step('Ensure Pre-installed label is present on OOTB Connections');
+      connectionTypesPage.shouldHaveConnectionTypes();
+      uri.shouldShowPreInstalledLabel();
+      s3.shouldShowPreInstalledLabel();
+
+      cy.step('Ensure OOTB connections are not editable or deletable');
+      ['Edit', 'Delete'].forEach((action) => {
+        s3.find().findKebabAction(action).should('not.exist');
+        s3.findKebab().click(); // need to close the kebab since the popup will block the next row's kebab
+        uri.find().findKebabAction(action).should('not.exist');
+      });
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -228,3 +228,13 @@ export type ResourcesData = {
 export type NamespaceConfig = {
   APPLICATIONS_NAMESPACE: string;
 };
+
+enum OOTBConnectionTypes {
+  s3 = 'S3 compatible object storage - v1',
+  uri = 'URI - v1',
+}
+
+export type OOTBConnectionTypesData = {
+  s3: OOTBConnectionTypes.s3;
+  uri: OOTBConnectionTypes.uri;
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
@@ -7,6 +7,7 @@ import type {
   WBControlSuiteTestData,
   WBVariablesTestData,
   WBStatusTestData,
+  OOTBConnectionTypesData,
 } from '~/__tests__/cypress/cypress/types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -61,6 +62,16 @@ export const loadWBVariablesFixture = (
 export const loadWBStatusFixture = (fixturePath: string): Cypress.Chainable<WBStatusTestData> => {
   return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBStatusTestData;
+
+    return data;
+  });
+};
+
+export const loadOOTBConnectionTypesFixture = (
+  fixturePath: string,
+): Cypress.Chainable<OOTBConnectionTypesData> => {
+  return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
+    const data = yaml.load(yamlContent) as OOTBConnectionTypesData;
 
     return data;
   });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-18736
## Description
Quick e2e test to verify our OOTB data connections are present. This will cover our common utils that we use to determine if something is installed by the operator. See https://github.com/opendatahub-io/odh-dashboard/pull/3682 for details on how that's done.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Ran the test against my cluster. Please note you will need ODH operator >= 1.22 and ODH dashboard latest.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
None
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
