### PR TITLE
fix overlap in hardware profiles table

### DIFF
--- a/frontend/src/components/ResourceNameTooltip.tsx
+++ b/frontend/src/components/ResourceNameTooltip.tsx
@@ -28,7 +28,11 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({
   wrap = true,
 }) => (
   <div style={{ display: wrap ? 'block' : 'inline-flex' }}>
-    <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+    <Flex
+      flexWrap={{ default: 'nowrap' }}
+      gap={{ default: 'gapXs' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+    >
       <FlexItem>{children}</FlexItem>
       {resource.metadata?.name && (
         <Popover

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -5,15 +5,9 @@ import {
   StackItem,
   Timestamp,
   TimestampTooltipVariant,
+  Truncate,
 } from '@patternfly/react-core';
-import {
-  ActionsColumn,
-  ExpandableRowContent,
-  TableText,
-  Tbody,
-  Td,
-  Tr,
-} from '@patternfly/react-table';
+import { ActionsColumn, ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { relativeTime } from '~/utilities/time';
 import { TableRowTitleDescription } from '~/components/table';
@@ -54,12 +48,11 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
         />
         <Td dataLabel="Name">
           <TableRowTitleDescription
-            title={
-              <TableText wrapModifier="truncate">{hardwareProfile.spec.displayName}</TableText>
-            }
+            title={<Truncate content={hardwareProfile.spec.displayName} />}
             description={hardwareProfile.spec.description}
             resource={hardwareProfile}
             truncateDescriptionLines={2}
+            wrapResourceTitle={false}
           />
         </Td>
         <Td dataLabel="Enabled">


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
[RHOAIENG-18874](https://issues.redhat.com/browse/RHOAIENG-18874)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

hardware profiles name no longer overlaps with tooltip

<img width="1702" alt="Screenshot 2025-01-29 at 1 13 59 PM" src="https://github.com/user-attachments/assets/95df51cf-bdac-43d1-8184-519d25846028" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

visually

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

n/a, simple change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
