### PR TITLE
Pipeline logs are not appearing on run details page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesTopology.cy.ts
@@ -682,9 +682,15 @@ describe('Pipeline topology', () => {
 
       pipelineRunDetails
         .findLogs()
+        .should('be.visible')
         .contains(
           'sample log for namespace test-project, pod name iris-training-pipeline-v4zp7-2757091352 and for step step-main',
-        );
+        )
+        .and(($el) => {
+          expect($el.width()).to.be.greaterThan(0);
+          expect($el.height()).to.be.greaterThan(0);
+        });
+
       // test whether single step logs download dropdown item is enabled when logs are available
       pipelineRunDetails.findDownloadStepsToggle().click();
       pipelineRunDetails.findCurrentStepLogs().should('not.be.disabled');

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/runLogs/LogsTab.tsx
@@ -229,7 +229,14 @@ const LogsTab: React.FC<LogsTabProps> = ({ task, isCached }) => {
       </StackItem>
       <StackItem isFilled id="dashboard-logviewer" style={{ position: 'relative' }}>
         <div
-          style={{ position: 'absolute', left: 0, right: 0, top: 0, bottom: 0 }}
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0,
+            height: '50vh',
+          }}
           ref={logsTabRef}
         >
           <DashboardLogViewer


### PR DESCRIPTION
[RHOAIENG-18916](https://issues.redhat.com/browse/RHOAIENG-18916)

## Description
Pipeline logs were not appearing due to height and position issues. Added a height of 100vh for visibility.

![Screenshot 2025-01-29 at 6 44 22 PM](https://github.com/user-attachments/assets/44573b48-d6a0-4be4-bfc4-0daf70c9d4e6)

## How Has This Been Tested?
Run a pipeline and check its logs.

## Test Impact
Improved existing test to verify pipeline logs actually is visible to the user.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
