### PR TITLE
added form limits for workbench, PVC, and project resource names

### DIFF
--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/__tests__/utils.spec.ts
@@ -2,6 +2,7 @@ import {
   handleUpdateLogic,
   isK8sNameDescriptionDataValid,
   LimitNameResourceType,
+  resourceTypeLimits,
   setupDefaults,
 } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
@@ -69,6 +70,81 @@ describe('setupDefaults', () => {
           value: 'display-name',
           state: {
             immutable: false,
+          },
+        },
+      }),
+    );
+  });
+
+  it('should limit PVC resource name', () => {
+    expect(
+      setupDefaults({
+        initialData: mockProjectK8sResource({
+          displayName:
+            'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test ',
+          k8sName: '',
+          description: 'my description',
+        }),
+        limitNameResourceType: LimitNameResourceType.PVC,
+      }),
+    ).toEqual(
+      mockK8sNameDescriptionFieldData({
+        name: 'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test ',
+        description: 'my description',
+        k8sName: {
+          value: 'this-is-a-test-this-is-a-test-this-is-a-test-this-is-a-test-thi',
+          state: {
+            immutable: false,
+            maxLength: resourceTypeLimits[LimitNameResourceType.PVC],
+          },
+        },
+      }),
+    );
+  });
+
+  it('should limit project/workbench resource name', () => {
+    expect(
+      setupDefaults({
+        initialData: mockProjectK8sResource({
+          displayName:
+            'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test ',
+          k8sName: '',
+          description: 'my description',
+        }),
+        limitNameResourceType: LimitNameResourceType.PROJECT,
+      }),
+    ).toEqual(
+      mockK8sNameDescriptionFieldData({
+        name: 'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test ',
+        description: 'my description',
+        k8sName: {
+          value: 'this-is-a-test-this-is-a-test',
+          state: {
+            immutable: false,
+            maxLength: resourceTypeLimits[LimitNameResourceType.PROJECT],
+          },
+        },
+      }),
+    );
+    expect(
+      setupDefaults({
+        initialData: mockProjectK8sResource({
+          displayName:
+            'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test ',
+          k8sName: '',
+          description: 'my description',
+        }),
+        limitNameResourceType: LimitNameResourceType.WORKBENCH,
+      }),
+    ).toEqual(
+      mockK8sNameDescriptionFieldData({
+        name: 'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test ',
+        description: 'my description',
+        k8sName: {
+          value: 'this-is-a-test-this-is-a-test',
+          state: {
+            immutable: false,
+            maxLength: resourceTypeLimits[LimitNameResourceType.WORKBENCH],
           },
         },
       }),

--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -31,9 +31,18 @@ export enum LimitNameResourceType {
   /** Workbenches create routes */
   WORKBENCH,
   // TODO: Support Model Serving?
+  PVC,
 }
 /** K8s max DNS subdomain name length */
 const MAX_RESOURCE_NAME_LENGTH = 253;
+
+const MAX_PVC_NAME_LENGTH = 63;
+
+export const resourceTypeLimits: Record<LimitNameResourceType, number> = {
+  [LimitNameResourceType.PROJECT]: ROUTE_BASED_NAME_LENGTH,
+  [LimitNameResourceType.WORKBENCH]: ROUTE_BASED_NAME_LENGTH,
+  [LimitNameResourceType.PVC]: MAX_PVC_NAME_LENGTH,
+};
 
 export const isK8sNameDescriptionType = (
   x?: K8sNameDescriptionType | K8sResourceCommon,
@@ -64,7 +73,7 @@ export const setupDefaults = ({
   }
 
   if (limitNameResourceType != null) {
-    configuredMaxLength = ROUTE_BASED_NAME_LENGTH;
+    configuredMaxLength = resourceTypeLimits[limitNameResourceType];
   }
 
   return handleUpdateLogic({

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -8,7 +8,10 @@ import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
-import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescriptionField/utils';
+import {
+  isK8sNameDescriptionDataValid,
+  LimitNameResourceType,
+} from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import StorageClassSelect from './StorageClassSelect';
 
 type CreateNewStorageSectionProps<D extends StorageData> = {
@@ -44,6 +47,7 @@ const CreateNewStorageSection = <D extends StorageData>({
         k8sName: data.k8sName,
         description: data.description,
       },
+      limitNameResourceType: LimitNameResourceType.PVC,
       editableK8sName,
     });
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
[RHOAIENG-13679](https://issues.redhat.com/browse/RHOAIENG-13679)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Workbench storage resource names are now capped at 63 characters. Project and workbench resource names are now capped at 30 characters.

<img width="1690" alt="Screenshot 2025-01-29 at 11 56 28 AM" src="https://github.com/user-attachments/assets/58b1c03c-e563-48aa-9c3c-01af3bd484d4" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Visually, you can see the resource name enforcement if you make a new PVC in workbench, make a new workbench, and make a new Project. If you put in absurd values for names, it should be converted with the max length.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
