### PR TITLE
 Fix: NIM Enable/Disable Behavior for Users in Enable & Explore Pages

### DIFF
--- a/backend/src/routes/api/integrations/nim/index.ts
+++ b/backend/src/routes/api/integrations/nim/index.ts
@@ -16,69 +16,66 @@ import {
 module.exports = async (fastify: KubeFastifyInstance) => {
   const PAGE_NOT_FOUND_MESSAGE = '404 page not found';
 
-  fastify.get(
-    '/',
-    secureAdminRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
-      await getNIMAccount(fastify)
-        .then((response) => {
-          if (response) {
-            // Installed
-            const isEnabled = isAppEnabled(response);
-            const keyValidationStatus: string = apiKeyValidationStatus(response);
-            const keyValidationTimestamp: string = apiKeyValidationTimestamp(response);
-            const errorMsg: string = errorMsgList(response)[0];
-            reply.send({
-              isInstalled: true,
-              isEnabled: isEnabled,
-              variablesValidationStatus: keyValidationStatus,
-              variablesValidationTimestamp: keyValidationTimestamp,
-              canInstall: !isEnabled,
-              error: errorMsg,
-            });
-          } else {
-            // Not installed
-            fastify.log.info(`NIM account does not exist`);
-            reply.send({
-              isInstalled: false,
-              isEnabled: false,
-              variablesValidationStatus: VariablesValidationStatus.UNKNOWN,
-              variablesValidationTimestamp: '',
-              canInstall: true,
-              error: '',
-            });
-          }
-        })
-        .catch((e) => {
-          if (e.response?.statusCode === 404) {
-            // 404 error means the Account CRD does not exist, so cannot create CR based on it.
-            if (
-              isString(e.response.body) &&
-              e.response.body.trim() === PAGE_NOT_FOUND_MESSAGE.trim()
-            ) {
-              fastify.log.info(`NIM not installed, ${e.response?.body}`);
-              reply.send({
-                isInstalled: false,
-                isEnabled: false,
-                variablesValidationStatus: VariablesValidationStatus.UNKNOWN,
-                variablesValidationTimestamp: '',
-                canInstall: false,
-                error: 'NIM not installed',
-              });
-            }
-          } else {
-            fastify.log.error(`An unexpected error occurred: ${e.response.body?.message}`);
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    await getNIMAccount(fastify)
+      .then((response) => {
+        if (response) {
+          // Installed
+          const isEnabled = isAppEnabled(response);
+          const keyValidationStatus: string = apiKeyValidationStatus(response);
+          const keyValidationTimestamp: string = apiKeyValidationTimestamp(response);
+          const errorMsg: string = errorMsgList(response)[0];
+          reply.send({
+            isInstalled: true,
+            isEnabled: isEnabled,
+            variablesValidationStatus: keyValidationStatus,
+            variablesValidationTimestamp: keyValidationTimestamp,
+            canInstall: !isEnabled,
+            error: errorMsg,
+          });
+        } else {
+          // Not installed
+          fastify.log.info(`NIM account does not exist`);
+          reply.send({
+            isInstalled: false,
+            isEnabled: false,
+            variablesValidationStatus: VariablesValidationStatus.UNKNOWN,
+            variablesValidationTimestamp: '',
+            canInstall: true,
+            error: '',
+          });
+        }
+      })
+      .catch((e) => {
+        if (e.response?.statusCode === 404) {
+          // 404 error means the Account CRD does not exist, so cannot create CR based on it.
+          if (
+            isString(e.response.body) &&
+            e.response.body.trim() === PAGE_NOT_FOUND_MESSAGE.trim()
+          ) {
+            fastify.log.info(`NIM not installed, ${e.response?.body}`);
             reply.send({
               isInstalled: false,
               isEnabled: false,
               variablesValidationStatus: VariablesValidationStatus.UNKNOWN,
               variablesValidationTimestamp: '',
               canInstall: false,
-              error: 'An unexpected error occurred. Please try again later.',
+              error: 'NIM not installed',
             });
           }
-        });
-    }),
-  );
+        } else {
+          fastify.log.error(`An unexpected error occurred: ${e.response.body?.message}`);
+          reply.send({
+            isInstalled: false,
+            isEnabled: false,
+            variablesValidationStatus: VariablesValidationStatus.UNKNOWN,
+            variablesValidationTimestamp: '',
+            canInstall: false,
+            error: 'An unexpected error occurred. Please try again later.',
+          });
+        }
+      });
+  });
 
   fastify.post(
     '/',

--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -47,7 +47,7 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
   }
 
   const renderEnableButton = () => {
-    if (!selectedApp.spec.enable || selectedApp.spec.isEnabled || isEnabled || !isAdmin) {
+    if (!selectedApp.spec.enable || selectedApp.spec.isEnabled || isEnabled) {
       return null;
     }
 
@@ -59,13 +59,13 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
       <Button
         variant={ButtonVariant.secondary}
         onClick={onEnable}
-        isDisabled={!enablement || !canInstall}
+        isDisabled={!enablement || !canInstall || !isAdmin}
       >
         Enable
       </Button>
     );
 
-    if (!enablement || !canInstall) {
+    if (!enablement || !canInstall || !isAdmin) {
       return (
         <Tooltip content="This feature has been disabled by an administrator.">
           <span>{button}</span>

--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -67,7 +67,7 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
 
     if (!enablement || !canInstall || !isAdmin) {
       return (
-        <Tooltip content="This feature has been disabled by an administrator.">
+        <Tooltip content="To enable this application, contact your administrator.">
           <span>{button}</span>
         </Tooltip>
       );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
JIRA - https://issues.redhat.com/browse/NVPE-103

This PR addresses implementing updates to the Enable Page and Explore Page Drawer behavior for user:

- For **users with NIM enabled**, the NIM card is now correctly displayed on the Enable page.
- For **users without NIM enabled**, a **disabled Enable button with a tooltip** is displayed on the Explore page drawer.

**When NIM in not enabled:**
Before fixing the problem - non-admin user does not see the Enable button or any indication of why it is missing:
![Before](https://github.com/user-attachments/assets/f155cd0f-7522-44c9-be12-26d75e6075a5)

After-non-admin user sees a disabled Enable button with a tooltip explaining why the button is not clickable:
![After](https://github.com/user-attachments/assets/46c4f831-7e69-4819-8e27-e3d16c1f2b5d)

**When NIM in enabled:**
Before fixing the problem - non-admin user doesn't see the NIM card, even though NIM is enabled:
![Before](https://github.com/user-attachments/assets/d13cf13d-f35b-4741-9210-6fce0d144f77)

After - NIM card is now visible to the non-admin user after NIM is enabled:
![After](https://github.com/user-attachments/assets/0aa6895b-f81f-4a2d-b88d-17cbb06b747e) 

This improves the user experience and ensures correct UI behavior based on NIM status.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Login as a user and make sure NIM is not enabled.
- Go to the Explore page and select the NVIDIA NIM tile.
- The Enable button should be visible but disabled and when hovering over the button, the tooltip should be displayed, explaining why the button is not clickable.
- Enable NIM for the user.
- Go to the Enable page.
- The NIM card should be displayed on the Enable page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
