### PR TITLE
Alternative for models' info and the drop down list

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/NIMDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/NIMDeployModal.ts
@@ -14,7 +14,7 @@ class NIMDeployModal extends Modal {
   }
 
   findNIMToDeploy() {
-    return this.find().findByTestId('nim-model-list-selection');
+    return this.find().findByTestId('typeahead-menu-toggle').find('input');
   }
 
   findNimStorageSizeInput() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
@@ -44,22 +44,43 @@ describe('NIM Model Serving', () => {
 
       // test filling in minimum required fields
       nimDeployModal.findModelNameInput().type('Test Name');
-      nimDeployModal
-        .findNIMToDeploy()
-        .findSelectOption('Snowflake Arctic Embed Large Embedding - 1.0.0')
-        .click();
+      // Click to activate the Typeahead input field
+      nimDeployModal.findNIMToDeploy().click();
+
+      // Type the model name to filter results
+      nimDeployModal.findNIMToDeploy().type('Snowflake Arctic');
+
+      // Wait for dropdown to appear and select the correct option
+      cy.get('[role="listbox"]').contains('Snowflake Arctic Embed Large Embedding - 1.0.0').click();
+
       nimDeployModal.findSubmitButton().should('be.enabled');
 
       nimDeployModal.findNimStorageSizeInput().should('have.value', '30');
-      nimDeployModal.findStorageSizeMinusButton().click();
+
+      // Fix: Ensure Minus button exists before clicking
+      cy.get('[data-testid="pvc-size"] button[aria-label="Minus"]', { timeout: 10000 })
+        .should('exist')
+        .should('be.visible')
+        .click();
+
       nimDeployModal.findNimStorageSizeInput().should('have.value', '29');
-      nimDeployModal.findStorageSizePlusButton().click();
+
+      cy.get('[data-testid="pvc-size"] button[aria-label="Plus"]', { timeout: 10000 })
+        .should('exist')
+        .should('be.visible')
+        .click();
+
       nimDeployModal.findNimStorageSizeInput().should('have.value', '30');
 
+      // Validate model replicas
       nimDeployModal.findNimModelReplicas().should('have.value', '1');
-      nimDeployModal.findNimModelReplicasPlusButton().click();
+
+      cy.get('button[aria-label="Plus"]').eq(1).should('exist').should('be.visible').click();
+
       nimDeployModal.findNimModelReplicas().should('have.value', '2');
-      nimDeployModal.findNimModelReplicasMinusButton().click();
+
+      cy.get('button[aria-label="Minus"]').eq(1).should('exist').should('be.visible').click();
+
       nimDeployModal.findNimModelReplicas().should('have.value', '1');
 
       nimDeployModal.findSubmitButton().click();

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -110,6 +110,7 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
       <TypeaheadSelect
         selectOptions={options}
         selected={selectedModel}
+        isScrollable
         isDisabled={isEditing}
         onSelect={onSelect}
         placeholder={isEditing ? selectedModel : 'Select NVIDIA NIM to deploy'}

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
-import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { HelperText, HelperTextItem, FormGroup } from '@patternfly/react-core';
+import { fetchNIMModelNames, ModelInfo } from '~/pages/modelServing/screens/projects/utils';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import {
   CreatingInferenceServiceObject,
   CreatingServingRuntimeObject,
 } from '~/pages/modelServing/screens/types';
-import SimpleSelect from '~/components/SimpleSelect';
-import { fetchNIMModelNames, ModelInfo } from '~/pages/modelServing/screens/projects/utils';
+import TypeaheadSelect, { TypeaheadSelectOption } from '~/components/TypeaheadSelect';
 
 type NIMModelListSectionProps = {
   inferenceServiceData: CreatingInferenceServiceObject;
@@ -22,103 +21,107 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
   setServingRuntimeData,
   isEditing,
 }) => {
-  const [options, setOptions] = useState<{ key: string; label: string }[]>([]);
-  const [modelList, setModelList] = useState<ModelInfo[]>([]);
-  const [error, setError] = useState<string>('');
-  const [selectedModel, setSelectedModel] = useState(
-    isEditing ? `${inferenceServiceData.format.name}` : '',
-  );
+  const [modelList, setModelList] = React.useState<ModelInfo[]>([]);
+  const [options, setOptions] = React.useState<TypeaheadSelectOption[]>([]);
+  const [selectedModel, setSelectedModel] = React.useState<string>('');
+  const [error, setError] = React.useState<string>('');
 
-  useEffect(() => {
-    if (!isEditing) {
-      const getModelNames = async () => {
-        try {
-          const modelInfos = await fetchNIMModelNames();
-          if (modelInfos && modelInfos.length > 0) {
-            const fetchedOptions = modelInfos.flatMap((modelInfo) =>
-              modelInfo.tags.map((tag) => ({
-                key: `${modelInfo.name}-${tag}`,
-                label: `${modelInfo.displayName} - ${tag}`,
-              })),
-            );
-            setModelList(modelInfos);
-            setOptions(fetchedOptions);
-            setError('');
-          } else {
-            setError('No NVIDIA NIM models found. Please check the installation.');
-            setOptions([]);
+  React.useEffect(() => {
+    const getModelNames = async () => {
+      try {
+        const modelInfos = await fetchNIMModelNames();
+        if (modelInfos && modelInfos.length > 0) {
+          const fetchedOptions = modelInfos.flatMap((modelInfo) =>
+            modelInfo.tags.map((tag) => ({
+              value: `${modelInfo.name}-${tag}`,
+              content: `${modelInfo.displayName} - ${tag}`,
+            })),
+          );
+
+          setModelList(modelInfos);
+          setOptions(fetchedOptions);
+          setError('');
+
+          if (isEditing) {
+            const modelName = inferenceServiceData.format.name;
+            const modelInfo = modelInfos.find((model) => model.name === modelName);
+            if (modelInfo && modelInfo.tags.length > 0) {
+              setSelectedModel(`${modelInfo.name}-${modelInfo.tags[0]}`);
+            } else {
+              setSelectedModel(modelName);
+            }
           }
-        } catch (err) {
-          setError('There was a problem fetching the NIM models. Please try again later.');
+        } else {
+          setError('No NVIDIA NIM models found. Please check the installation.');
           setOptions([]);
         }
-      };
-      getModelNames();
-    } else {
-      setOptions([
-        { key: inferenceServiceData.format.name, label: inferenceServiceData.format.name },
-      ]);
-      setSelectedModel(inferenceServiceData.format.name);
-    }
+      } catch (err) {
+        setError('There was a problem fetching the NIM models. Please try again later.');
+        setOptions([]);
+      }
+    };
+
+    getModelNames();
   }, [isEditing, inferenceServiceData.format.name]);
 
   const getSupportedModelFormatsInfo = (key: string) => {
     const lastHyphenIndex = key.lastIndexOf('-');
+    if (lastHyphenIndex === -1) {
+      return null;
+    }
     const name = key.slice(0, lastHyphenIndex);
     const version = key.slice(lastHyphenIndex + 1);
-
     const modelInfo = modelList.find((model) => model.name === name);
-    if (modelInfo) {
-      return {
-        name: modelInfo.name,
-        version,
-      };
-    }
-    return null;
+    return modelInfo ? { name: modelInfo.name, version } : null;
   };
 
   const getNIMImageName = (key: string) => {
     const lastHyphenIndex = key.lastIndexOf('-');
+    if (lastHyphenIndex === -1) {
+      return '';
+    }
     const name = key.slice(0, lastHyphenIndex);
     const version = key.slice(lastHyphenIndex + 1);
-
     const imageInfo = modelList.find((model) => model.name === name);
-    if (imageInfo) {
-      return `nvcr.io/${imageInfo.namespace}/${name}:${version}`;
+    return imageInfo ? `nvcr.io/${imageInfo.namespace}/${name}:${version}` : '';
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | undefined,
+    key: string | number,
+  ) => {
+    if (typeof key !== 'string' || isEditing) {
+      return;
     }
-    return '';
+    setSelectedModel(key);
+    const modelInfo = getSupportedModelFormatsInfo(key);
+    if (modelInfo) {
+      setServingRuntimeData('supportedModelFormatsInfo', modelInfo);
+      setServingRuntimeData('imageName', getNIMImageName(key));
+      setInferenceServiceData('format', { name: modelInfo.name });
+      setError('');
+    } else {
+      setError('Error: Model not found.');
+    }
   };
 
   return (
     <FormGroup label="NVIDIA NIM" fieldId="nim-model-list-selection" isRequired>
-      <SimpleSelect
-        isScrollable
-        isFullWidth
+      <TypeaheadSelect
+        selectOptions={options}
+        selected={selectedModel}
         isDisabled={isEditing}
-        id="nim-model-list-selection"
-        dataTestId="nim-model-list-selection"
-        aria-label="Select NVIDIA NIM to deploy"
-        options={options}
-        placeholder={
-          options.length === 0
-            ? 'No NIM models available'
-            : isEditing
-            ? inferenceServiceData.format.name
-            : 'Select NVIDIA NIM to deploy'
-        }
-        value={selectedModel}
-        onChange={(key) => {
+        onSelect={onSelect}
+        placeholder={isEditing ? selectedModel : 'Select NVIDIA NIM to deploy'}
+        noOptionsFoundMessage={(filter) => `No results found for "${filter}"`}
+        isCreatable={false}
+        allowClear={!isEditing}
+        onClearSelection={() => {
           if (!isEditing) {
-            setSelectedModel(key);
-            const supportedModelInfo = getSupportedModelFormatsInfo(key);
-            if (supportedModelInfo) {
-              setServingRuntimeData('supportedModelFormatsInfo', supportedModelInfo);
-              setServingRuntimeData('imageName', getNIMImageName(key));
-              setInferenceServiceData('format', { name: supportedModelInfo.name });
-              setError('');
-            } else {
-              setError('Error: Model not found.');
-            }
+            setSelectedModel('');
+            setServingRuntimeData('supportedModelFormatsInfo', undefined);
+            setServingRuntimeData('imageName', undefined);
+            setInferenceServiceData('format', { name: '' });
           }
         }}
       />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
JIRA - https://issues.redhat.com/browse/NVPE-93
In this PR I replaced the current PF dropdown component with the [Select component with Typeahead variant](https://v5-archive.patternfly.org/components/menus/select#typeahead) in order to allow the user to start typing in the name of the model to reduce the size of the list.

Before there was no option to type and search in the model's dropdown (NVIDIA NIM):

![image](https://github.com/user-attachments/assets/489c294f-ec3b-4527-a344-bb53b4c436b8)

This improves the user experience and will help in searching through the list as you start typing.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Tested locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
When trying to deploy a model using NIM, you should be able to search through the NVIDIA NIM dropdown as you start typing.
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
