### PR TITLE
Fixes for workbench startup modal stopping and starting states

### DIFF
--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -37,7 +37,7 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
+    expect(steps).toHaveLength(14);
     expect(steps[0]).toHaveTextContent('Server requested');
     expect(steps[1]).toHaveTextContent('Pod created');
     expect(steps[2]).toHaveTextContent('Pod assigned');
@@ -51,6 +51,7 @@ describe('Start Notebook modal', () => {
     expect(steps[10]).toHaveTextContent('Oauth proxy pulled');
     expect(steps[11]).toHaveTextContent('Oauth proxy container created');
     expect(steps[12]).toHaveTextContent('Oauth proxy container started');
+    expect(steps[13]).toHaveTextContent('Server started');
   });
 
   it('should show failed notebook startup status', async () => {
@@ -79,7 +80,7 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
+    expect(steps).toHaveLength(15);
     expect(steps[1]).toHaveTextContent('Failed to scale-up');
   });
 
@@ -107,9 +108,9 @@ describe('Start Notebook modal', () => {
     // Validate the steps
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    expect(screen.getAllByRole('listitem')).toHaveLength(13);
+    expect(screen.getAllByRole('listitem')).toHaveLength(14);
     expect(screen.getAllByTestId('step-status-Success')).toHaveLength(10);
-    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(3);
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(4);
   });
 
   it('should show completed notebook startup status', async () => {
@@ -134,7 +135,35 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13);
+    expect(steps).toHaveLength(14);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(14);
+  });
+
+  it('should show stopping notebook status', async () => {
+    render(
+      <StartNotebookModal
+        notebookStatus={null}
+        isStarting={false}
+        isStopping
+        isRunning={false}
+        events={[]}
+        onClose={onCloseMock}
+        buttons={null}
+      />,
+    );
+
+    // Validate the header contents
+    const header = screen.getByTestId('notebook-status-modal-header');
+    expect(header).toHaveTextContent('Workbench statusStopping');
+
+    const statusLabel = screen.getByTestId('notebook-latest-status');
+    expect(statusLabel).toHaveTextContent('Shutting down the server');
+
+    // Validate the steps
+    const stepper = screen.getByTestId('notebook-startup-steps');
+    expect(stepper).toBeTruthy();
+    const steps = screen.getAllByRole('listitem');
+    expect(steps).toHaveLength(14);
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(14);
   });
 });

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -90,7 +90,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
   const isError = notebookStatus?.currentStatus === EventStatus.ERROR;
   const isStopped = !isError && !isRunning && !isStarting && !isStopping;
-  const notebookProgress = useNotebookProgress(notebook, isRunning, isStopped, events);
+  const notebookProgress = useNotebookProgress(notebook, isRunning, isStopping, isStopped, events);
   const inProgress = !isStopped && (isStarting || isStopping || !isRunning);
   const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
 
@@ -137,7 +137,11 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
 
     const title =
       notebookStatus?.currentEvent ||
-      (isStarting ? 'Waiting for server request to start...' : 'Creating resources...');
+      (isStarting
+        ? 'Waiting for server request to start...'
+        : isStopping
+        ? 'Shutting down the server...'
+        : 'Creating resources...');
 
     return (
       <StackItem>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -618,6 +618,7 @@ export enum ProgressionStep {
   OAUTH_PULLED = 'OAUTH_PULLED',
   OAUTH_CONTAINER_CREATED = 'OAUTH_CONTAINER_CREATED',
   OAUTH_CONTAINER_STARTED = 'OAUTH_CONTAINER_STARTED',
+  SERVER_STARTED = 'SERVER_STARTED',
 }
 
 export const ProgressionStepTitles = {
@@ -634,6 +635,7 @@ export const ProgressionStepTitles = {
   [ProgressionStep.OAUTH_PULLED]: 'Oauth proxy pulled',
   [ProgressionStep.OAUTH_CONTAINER_CREATED]: 'Oauth proxy container created',
   [ProgressionStep.OAUTH_CONTAINER_STARTED]: 'Oauth proxy container started',
+  [ProgressionStep.SERVER_STARTED]: 'Server started',
 };
 
 export type NotebookProgressStep = {


### PR DESCRIPTION
Fixes [RHOAIENG-17784](https://issues.redhat.com/browse/RHOAIENG-17784)

## Description
Fixes events for notebooks that are starting and stopping.
Adds a final event `Server started` that doesn't get marked complete until the server is running.
Adds text to indicate the server is stopping and does not automatically mark the initial event complete

## Screen shot

![image](https://github.com/user-attachments/assets/ff043925-05b5-468f-935e-cf04ab9f9724)

## How Has This Been Tested?
- Stop a running workbench and click on the status label
  - Verify the status shows Stopping
  - Verify the status text shows `Shutting down the server...`
  - Verify all steps show incomplete
- Start a workbench
  - Verify the label show starting
- For the starting workbench, click the label or message text
  - Verify the workbench status dialog is shown
  - Verify the current status is shown and Progress steps show the current completed steps
  - Verify the steps update through the startup process
  - Verify the `Server started` step shows complete only when the server is running

## Test Impact
Updated jest tests accordingly

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @tobiastal 