### PR TITLE
Fix for hover state on workbench status labels

### DIFF
--- a/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
+++ b/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
@@ -15,6 +15,7 @@ type NotebookStateStatusProps = {
   isRunning: boolean;
   notebookStatus?: NotebookStatus | null;
   isCompact?: boolean;
+  onClick?: LabelProps['onClick'];
 };
 
 const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
@@ -23,6 +24,7 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
   isRunning,
   notebookStatus,
   isCompact,
+  onClick,
 }) => {
   const isError = notebookStatus?.currentStatus === EventStatus.ERROR;
 
@@ -63,6 +65,7 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
       icon={statusLabelSettings.icon}
       data-testid="notebook-status-text"
       style={{ width: 'fit-content' }}
+      onClick={onClick}
     >
       {statusLabelSettings.label}
     </Label>

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Flex, FlexItem, Tooltip, Truncate } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Truncate } from '@patternfly/react-core';
 import {
   t_global_text_color_regular as RegularColor,
   t_global_text_color_status_danger_default as DangerColor,
@@ -56,46 +56,34 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
   const isStopped = !isError && !isRunning && !isStarting && !isStopping;
   const [isStartModalOpen, setStartModalOpen] = React.useState(false);
 
-  const renderContent = () => {
-    const StatusLabel = (
-      <NotebookStatusLabel
-        isCompact
-        isStarting={isStarting}
-        isRunning={isRunning}
-        isStopping={isStopping}
-        notebookStatus={notebookStatus}
-      />
-    );
-
-    return (
-      <Button variant="link" isInline onClick={() => setStartModalOpen(true)}>
-        <Flex
-          direction={{ default: isVertical ? 'column' : 'row' }}
-          gap={{ default: isVertical ? 'gapXs' : 'gapMd' }}
-        >
-          <FlexItem>
-            {notebookStatus?.currentStatus === EventStatus.ERROR ? (
-              <Tooltip content={notebookStatus.currentEvent}>{StatusLabel}</Tooltip>
-            ) : (
-              StatusLabel
-            )}
-          </FlexItem>
-          {isStarting ? (
+  return (
+    <>
+      <Flex
+        direction={{ default: isVertical ? 'column' : 'row' }}
+        gap={{ default: isVertical ? 'gapXs' : 'gapMd' }}
+        onClick={() => setStartModalOpen(true)}
+      >
+        <FlexItem>
+          <NotebookStatusLabel
+            isCompact
+            isStarting={isStarting}
+            isRunning={isRunning}
+            isStopping={isStopping}
+            notebookStatus={notebookStatus}
+            onClick={() => setStartModalOpen(true)}
+          />
+        </FlexItem>
+        {isStarting ? (
+          <Button variant="link" isInline onClick={() => setStartModalOpen(true)}>
             <FlexItem>
               <Truncate
                 content={notebookStatus?.currentEvent || 'Waiting for server request to start...'}
                 style={getNotebookStatusStyles(notebookStatus, isStarting)}
               />
             </FlexItem>
-          ) : null}
-        </Flex>
-      </Button>
-    );
-  };
-
-  return (
-    <>
-      {renderContent()}
+          </Button>
+        ) : null}
+      </Flex>
       {isStartModalOpen ? (
         <StartNotebookModal
           notebook={notebook}


### PR DESCRIPTION
Fixes [RHOAIENG-17784](https://issues.redhat.com/browse/RHOAIENG-17784)

## Description
Updates the status labels in the workbench rows to show the hover treatment.
Removes the tooltip for failed status as the text is already shown.

## Screen shot
![StatusLabelHover](https://github.com/user-attachments/assets/f43c1a22-a382-4c96-8041-caf2b5ed3fcf)

## How Has This Been Tested?
Navigate to the `Data science projects` page
Expand one of the rows workbenches column
Hover over the status labels for the workbenches
Verify the background color changes on hover

## Test Impact
No test impact, purely visual

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

/cc @tobiastal 