### PR TITLE
disable "Disabled" NIM Link for Non-Admins with Tooltip

### DIFF
--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -14,6 +14,7 @@ import {
   Label,
   MenuToggle,
   Popover,
+  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { EllipsisVIcon, ExclamationCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
@@ -31,6 +32,7 @@ import { deleteIntegrationApp } from '~/services/integrationAppService';
 import { useQuickStartCardSelected } from './useQuickStartCardSelected';
 import SupportedAppTitle from './SupportedAppTitle';
 import BrandImage from './BrandImage';
+import { useUser } from '~/redux/selectors';
 
 import './OdhCard.scss';
 
@@ -49,6 +51,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
   const disabled = !odhApp.spec.isEnabled;
   const { dashboardConfig } = useAppContext();
   const dispatch = useAppDispatch();
+  const { isAdmin } = useUser();
 
   const onOpenKebab = () => {
     setIsOpen(!isOpen);
@@ -192,6 +195,12 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
     </div>
   );
 
+  const disableButton = (
+    <Button variant="link" className="odh-card__disabled-text" isDisabled={!isAdmin}>
+      Disabled
+    </Button>
+  );
+
   const disabledPopover = (
     <Popover
       headerContent={
@@ -204,9 +213,13 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
       headerIcon={<ExclamationCircleIcon />}
       alertSeverityVariant="danger"
     >
-      <Button variant="link" className="odh-card__disabled-text">
-        Disabled
-      </Button>
+      {!isAdmin ? (
+        <Tooltip content="To enable this application, contact your administrator.">
+          <span>{disableButton}</span>
+        </Tooltip>
+      ) : (
+        disableButton
+      )}
     </Popover>
   );
 

--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -29,11 +29,10 @@ import { useAppDispatch } from '~/redux/hooks';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { isInternalRouteIntegrationsApp } from '~/utilities/utils';
 import { deleteIntegrationApp } from '~/services/integrationAppService';
+import { useUser } from '~/redux/selectors';
 import { useQuickStartCardSelected } from './useQuickStartCardSelected';
 import SupportedAppTitle from './SupportedAppTitle';
 import BrandImage from './BrandImage';
-import { useUser } from '~/redux/selectors';
-
 import './OdhCard.scss';
 
 type OdhAppCardProps = {
@@ -201,7 +200,11 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
     </Button>
   );
 
-  const disabledPopover = (
+  const disabledContent = !isAdmin ? (
+    <Tooltip content="To enable this application, contact your administrator.">
+      <span>{disableButton}</span>
+    </Tooltip>
+  ) : (
     <Popover
       headerContent={
         <div className="odh-card__disabled-popover-title">
@@ -213,13 +216,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
       headerIcon={<ExclamationCircleIcon />}
       alertSeverityVariant="danger"
     >
-      {!isAdmin ? (
-        <Tooltip content="To enable this application, contact your administrator.">
-          <span>{disableButton}</span>
-        </Tooltip>
-      ) : (
-        disableButton
-      )}
+      {disableButton}
     </Popover>
   );
 
@@ -236,7 +233,7 @@ const OdhAppCard: React.FC<OdhAppCardProps> = ({ odhApp }) => {
         actions={{
           actions: (
             <>
-              {disabled ? disabledPopover : null}
+              {disabled ? disabledContent : null}
               <Dropdown
                 onSelect={onOpenKebab}
                 onOpenChange={(isOpened) => setIsOpen(isOpened)}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
JIRA - [https://issues.redhat.com/browse/NVPE-136](https://issues.redhat.com/browse/NVPE-136)

This PR ensures that the "Disabled" NIM link is no longer clickable for non-admin users and provides a tooltip to inform them of the restriction.

**Before:**
Non-admin users could click on the "Disabled" NIM link, leading to confusion.
![Before](https://github.com/user-attachments/assets/6114135f-2af1-4de0-aa80-9dfc04f1873d)
**After:**
The link is now disabled for non-admin users and a tooltip provides context on why the action is unavailable.
![image (13)](https://github.com/user-attachments/assets/ce75b784-a8d0-47a8-9a95-3460724adbb6)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by logging in as an admin and non-admin user.
Verified that:
- Admin users still have access to the link.
- Non-admin users see the disabled link with a tooltip.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Log in as a non-admin user.
- Navigate to the Enable page.
- Ensure that the "Disabled" NIM link is disabled and shows the tooltip when hovered over.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
