### PR TITLE
Fix for standalone notebook startup dialog looking stuck

### DIFF
--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -10,8 +10,6 @@ import {
 } from '~/concepts/__tests__/mockNotebookStates';
 
 describe('Start Notebook modal', () => {
-  const onCloseMock = jest.fn();
-
   it('should show initial notebook startup status', async () => {
     const mockData = mockInitialStates;
     render(
@@ -21,7 +19,6 @@ describe('Start Notebook modal', () => {
         isStopping={mockData.notebookState.isStopping}
         isRunning={mockData.notebookState.isRunning}
         events={mockData.events}
-        onClose={onCloseMock}
         buttons={null}
       />,
     );
@@ -63,7 +60,6 @@ describe('Start Notebook modal', () => {
         isStopping={mockData.notebookState.isStopping}
         isRunning={mockData.notebookState.isRunning}
         events={mockData.events}
-        onClose={onCloseMock}
         buttons={null}
       />,
     );
@@ -93,7 +89,6 @@ describe('Start Notebook modal', () => {
         isStopping={mockData.notebookState.isStopping}
         isRunning={mockData.notebookState.isRunning}
         events={mockData.events}
-        onClose={onCloseMock}
         buttons={null}
       />,
     );
@@ -122,7 +117,31 @@ describe('Start Notebook modal', () => {
         isStopping={mockData.notebookState.isStopping}
         isRunning={mockData.notebookState.isRunning}
         events={mockData.events}
-        onClose={onCloseMock}
+        buttons={null}
+      />,
+    );
+
+    // Validate the header contents
+    const header = screen.getByTestId('notebook-status-modal-header');
+    expect(header).toHaveTextContent('Workbench statusRunning');
+
+    // Validate the steps
+    const stepper = screen.getByTestId('notebook-startup-steps');
+    expect(stepper).toBeTruthy();
+    const steps = screen.getAllByRole('listitem');
+    expect(steps).toHaveLength(14);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(14);
+  });
+
+  it('should show completed notebook startup status for standalone notebooks', async () => {
+    const mockData = mockCompletedStates;
+    render(
+      <StartNotebookModal
+        notebookStatus={mockData.notebookStatus}
+        isStarting
+        isStopping={mockData.notebookState.isStopping}
+        isRunning={mockData.notebookState.isRunning}
+        events={mockData.events}
         buttons={null}
       />,
     );
@@ -147,7 +166,6 @@ describe('Start Notebook modal', () => {
         isStopping
         isRunning={false}
         events={[]}
-        onClose={onCloseMock}
         buttons={null}
       />,
     );

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -65,8 +65,7 @@ type StartNotebookModalProps = {
   isStopping: boolean;
   notebookStatus: NotebookStatus | null;
   events: EventKind[];
-  onClose: (stopped: boolean) => void;
-  showClose?: boolean;
+  onClose?: () => void;
   buttons: React.ReactNode;
 };
 
@@ -84,7 +83,6 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   isRunning,
   isStopping,
   onClose,
-  showClose = true,
   buttons,
 }) => {
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
@@ -119,7 +117,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   }, [isRunning, isStarting, notebookStatus]);
 
   const renderLastUpdate = () => {
-    if (isStopped || (spawnStatus?.status !== AlertVariant.danger && !inProgress)) {
+    if (isRunning || isStopped || (spawnStatus?.status !== AlertVariant.danger && !inProgress)) {
       return null;
     }
 
@@ -268,7 +266,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
       appendTo={document.body}
       variant={ModalVariant.small}
       isOpen
-      onClose={showClose ? () => onClose(false) : undefined}
+      onClose={onClose}
       data-testid="notebook-status-modal"
     >
       <ModalHeader
@@ -278,7 +276,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
             <FlexItem>Workbench status</FlexItem>
             <FlexItem>
               <NotebookStatusLabel
-                isStarting={isStarting}
+                isStarting={isStarting && !isRunning}
                 isStopping={isStopping}
                 isRunning={isRunning}
                 notebookStatus={notebookStatus}

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -115,7 +115,6 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ spawnInProgress, on
       isStopping={false}
       notebookStatus={notebookStatus}
       events={events}
-      onClose={onClose}
       buttons={renderButtons()}
     />
   );

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -92,10 +92,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
           isStopping={isStopping}
           notebookStatus={notebookStatus}
           events={events}
-          onClose={(stopped) => {
-            if (stopped) {
-              stopNotebook();
-            }
+          onClose={() => {
             setStartModalOpen(false);
           }}
           buttons={


### PR DESCRIPTION
Closes [RHOAIENG-19280](https://issues.redhat.com/browse/RHOAIENG-19280)

## Description
Fixes an issue where standalone notebook startup shows the server status modal as stuck on starting

## How Has This Been Tested?
Launch a standalone notebook
Monitor the startup status modal
Verify it updates to running once the notebook is running

## Test Impact
Added a test for the startup modal given the parameters passed by the standalone notebook

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
