### PR TITLE
Enable/disable ilab feature

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -47,6 +47,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableConnectionTypes: boolean;
       disableStorageClasses: boolean;
       disableNIMModelServing: boolean;
+      disableFineTuning: boolean;
     };
     /** @deprecated -- replacing this with Platform Auth resource -- remove when this is no longer in the CRD */
     groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -73,6 +73,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableConnectionTypes: false,
       disableStorageClasses: false,
       disableNIMModelServing: true,
+      disableFineTuning: true,
     },
     notebookController: {
       enabled: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -42,6 +42,7 @@ The following are a list of features that are supported, along with there defaul
 | disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
 | disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
 | disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |
+| disableFineTuning            | true    | Disables Fine tuning from the dashboard.                                                             |
 
 ## Defaults
 
@@ -73,6 +74,7 @@ spec:
     disableDistributedWorkloads: false
     disableStorageClasses: false
     disableNIMModelServing: true
+    disableFineTuning: true
 ```
 
 ## Additional fields

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -35,6 +35,7 @@ export type MockDashboardConfigType = {
   disableNotebookController?: boolean;
   notebookSizes?: NotebookSize[];
   disableNIMModelServing?: boolean;
+  disableFineTuning?: boolean;
 };
 
 export const mockDashboardConfig = ({
@@ -69,6 +70,7 @@ export const mockDashboardConfig = ({
   disableStorageClasses = false,
   disableNotebookController = false,
   disableNIMModelServing = true,
+  disableFineTuning = true,
   notebookSizes = [
     {
       name: 'XSmall',
@@ -180,6 +182,7 @@ export const mockDashboardConfig = ({
       disableServingRuntimeParams,
       disableStorageClasses,
       disableNIMModelServing,
+      disableFineTuning,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/__mocks__/mockDsc.ts
+++ b/frontend/src/__mocks__/mockDsc.ts
@@ -1,0 +1,56 @@
+import { StackCapability } from '~/concepts/areas/types';
+import { DataScienceClusterKind, K8sCondition } from '~/k8sTypes';
+
+export type MockDsc = {
+  conditions?: K8sCondition[];
+  requiredCapabilities?: StackCapability[];
+  phase?: string;
+};
+
+export const mockDsc = ({
+  conditions = [],
+  requiredCapabilities = [],
+  phase = 'Ready',
+}: MockDsc): DataScienceClusterKind => ({
+  apiVersion: 'datascience.openshift.io/v1alpha1',
+  kind: 'DataScienceCluster',
+  metadata: {
+    name: 'default-dsc',
+  },
+  spec: {
+    components: {
+      datasciencepipelines: {
+        managementState: 'Managed',
+        managedPipelines: {
+          instructLab: {
+            state: 'Managed',
+          },
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      ...[
+        {
+          lastHeartbeatTime: '2023-10-20T11:45:04Z',
+          lastTransitionTime: '2023-10-20T11:45:04Z',
+          message: 'Reconcile completed successfully',
+          reason: 'ReconcileCompleted',
+          status: 'True',
+          type: 'ReconcileComplete',
+        },
+        ...requiredCapabilities.map((capability) => ({
+          lastHeartbeatTime: '2023-10-20T11:45:04Z',
+          lastTransitionTime: '2023-10-20T11:45:04Z',
+          message: `Capability ${capability} installed`,
+          reason: 'ReconcileCompleted',
+          status: 'True',
+          type: capability,
+        })),
+      ],
+      ...conditions,
+    ],
+    phase,
+  },
+});

--- a/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
@@ -109,9 +109,16 @@ class NotebookTolerationSettings extends ClusterSettings {
   }
 }
 
+class InstructLabSettings extends ClusterSettings {
+  findInstructLabCheckbox() {
+    return cy.findByTestId('instructlab-enabled-checkbox');
+  }
+}
+
 export const clusterSettings = new ClusterSettings();
 export const modelServingSettings = new ModelSergingSettings();
 export const pvcSizeSettings = new PVCSizeSettings();
 export const cullerSettings = new CullterSettings();
 export const telemetrySettings = new TelemetrySettings();
 export const notebookTolerationSettings = new NotebookTolerationSettings();
+export const instructLabSettings = new InstructLabSettings();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
@@ -3,6 +3,7 @@ import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import {
   clusterSettings,
   cullerSettings,
+  instructLabSettings,
   modelServingSettings,
   notebookTolerationSettings,
   pvcSizeSettings,
@@ -11,12 +12,14 @@ import {
 import { pageNotfound } from '~/__tests__/cypress/cypress/pages/pageNotFound';
 import { be } from '~/__tests__/cypress/cypress/utils/should';
 import {
-  asProductAdminUser,
+  asClusterAdminUser,
   asProjectAdminUser,
 } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import { StackComponent } from '~/concepts/areas/types';
 import { DeploymentMode } from '~/k8sTypes';
-import { mockDashboardConfig } from '~/__mocks__';
+import { mockDashboardConfig, mockK8sResourceList } from '~/__mocks__';
+import { DataScienceClusterModel } from '~/__tests__/cypress/cypress/utils/models';
+import { mockDsc } from '~/__mocks__/mockDsc';
 
 it('Cluster settings should not be available for non product admins', () => {
   asProjectAdminUser();
@@ -27,7 +30,8 @@ it('Cluster settings should not be available for non product admins', () => {
 
 describe('Cluster Settings', () => {
   beforeEach(() => {
-    asProductAdminUser();
+    asClusterAdminUser();
+    cy.interceptK8sList({ model: DataScienceClusterModel }, mockK8sResourceList([mockDsc({})]));
   });
 
   it('Edit cluster settings', () => {
@@ -106,6 +110,23 @@ describe('Cluster Settings', () => {
         }),
       );
     });
+  });
+
+  it('View instructLab settings', () => {
+    cy.interceptOdh(
+      'GET /api/config',
+      mockDashboardConfig({
+        disableFineTuning: false,
+      }),
+    );
+    cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
+
+    clusterSettings.visit();
+
+    instructLabSettings.findInstructLabCheckbox().click();
+    instructLabSettings.findSubmitButton().should('be.enabled');
+    instructLabSettings.findInstructLabCheckbox().click();
+    instructLabSettings.findSubmitButton().should('be.disabled');
   });
 
   it('View KServe defaultDeploymentMode', () => {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,6 +25,7 @@ export * from './k8s/hardwareProfiles';
 export * from './k8s/clusterQueues';
 export * from './k8s/localQueues';
 export * from './k8s/workloads';
+export * from './k8s/dsc';
 
 // Model registry
 export * from './modelRegistry/custom';

--- a/frontend/src/api/k8s/dsc.ts
+++ b/frontend/src/api/k8s/dsc.ts
@@ -1,0 +1,24 @@
+import { k8sListResource, k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { DataScienceClusterKind } from '~/k8sTypes';
+import { DataScienceClusterModel } from '~/api/models';
+
+export const listDataScienceClusters = (): Promise<DataScienceClusterKind[]> =>
+  k8sListResource<DataScienceClusterKind>({
+    model: DataScienceClusterModel,
+  }).then((dataScienceClusters) => dataScienceClusters.items);
+
+export const toggleInstructLabState = (
+  instructLabState: string,
+  dscName: string,
+): Promise<DataScienceClusterKind> =>
+  k8sPatchResource<DataScienceClusterKind>({
+    model: DataScienceClusterModel,
+    queryOptions: { name: dscName },
+    patches: [
+      {
+        op: 'replace',
+        path: '/spec/components/datasciencepipelines/managedPipelines/instructLab/state',
+        value: instructLabState,
+      },
+    ],
+  });

--- a/frontend/src/api/models/k8s.ts
+++ b/frontend/src/api/models/k8s.ts
@@ -89,3 +89,10 @@ export const ServiceAccountModel: K8sModelCommon = {
   kind: 'ServiceAccount',
   plural: 'serviceaccounts',
 };
+
+export const DataScienceClusterModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'datasciencecluster.opendatahub.io',
+  kind: 'DataScienceCluster',
+  plural: 'datascienceclusters',
+};

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -34,6 +34,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableServingRuntimeParams: false,
   disableStorageClasses: false,
   disableNIMModelServing: true,
+  disableFineTuning: true,
 } satisfies DashboardCommonConfig);
 
 export const SupportedAreasStateMap: SupportedAreasState = {
@@ -143,5 +144,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.NIM_MODEL]: {
     featureFlags: ['disableNIMModelServing'],
     reliantAreas: [SupportedArea.K_SERVE],
+  },
+  [SupportedArea.FINE_TUNING]: {
+    featureFlags: ['disableFineTuning'],
+    reliantAreas: [SupportedArea.DS_PIPELINES],
   },
 };

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -39,6 +39,7 @@ export enum SupportedArea {
   ACCELERATOR_PROFILES = 'accelerator-profiles',
   HARDWARE_PROFILES = 'hardware-profiles',
   STORAGE_CLASSES = 'storage-classes',
+  FINE_TUNING = 'fine-tuning',
 
   /* DS Projects specific areas */
   DS_PROJECTS_PERMISSIONS = 'ds-projects-permission',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1205,6 +1205,7 @@ export type DashboardCommonConfig = {
   disableServingRuntimeParams: boolean;
   disableStorageClasses: boolean;
   disableNIMModelServing: boolean;
+  disableFineTuning: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {
@@ -1268,6 +1269,64 @@ export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> 
     resourceVersion: string;
     continue: string;
   };
+};
+
+export type DataScienceClusterKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+  };
+  spec: {
+    components?: {
+      codeflare?: {
+        managementState: string;
+      };
+      kserve?: {
+        managementState: string;
+        nim: {
+          managementState: string;
+        };
+        serving: {
+          ingressGateway: {
+            certificate: {
+              type: string;
+            };
+          };
+          managementState: string;
+          name: string;
+        };
+      };
+      modelregistry?: {
+        managementState: string;
+        registriesNamespace: string;
+      };
+      trustyai?: {
+        managementState: string;
+      };
+      ray?: {
+        managementState: string;
+      };
+      kueue?: {
+        managementState: string;
+      };
+      workbenches?: {
+        managementState: string;
+      };
+      dashboard?: {
+        managementState: string;
+      };
+      modelmeshserving?: {
+        managementState: string;
+      };
+      datasciencepipelines?: {
+        managementState: string;
+        managedPipelines: { instructLab: { state: string } };
+      };
+      trainingoperator?: {
+        managementState: string;
+      };
+    };
+  };
+  status?: DataScienceClusterKindStatus;
 };
 
 /** We don't need or should ever get the full kind, this is the status section */

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -22,6 +22,7 @@ import { useKServeDeploymentMode } from '~/pages/modelServing/useKServeDeploymen
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
+import { toggleInstructLabState } from '~/api/';
 import {
   DEFAULT_CONFIG,
   DEFAULT_PVC_SIZE,
@@ -29,10 +30,13 @@ import {
   MIN_CULLER_TIMEOUT,
   DEFAULT_TOLERATION_VALUE,
 } from './const';
+import { isInstructLabEnabled } from './utils';
+import useDefaultDsc from './useDefaultDsc';
+import InstructLabSettings from './InstructLabSettings';
 
 const ClusterSettings: React.FC = () => {
   const { defaultMode: defaultSingleModelDeploymentMode } = useKServeDeploymentMode();
-
+  const [dsc, dscLoaded, dscError, refreshDsc] = useDefaultDsc();
   const [loaded, setLoaded] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error>();
@@ -42,6 +46,7 @@ const ClusterSettings: React.FC = () => {
   const [cullerTimeout, setCullerTimeout] = React.useState(DEFAULT_CULLER_TIMEOUT);
   const { dashboardConfig } = useAppContext();
   const modelServingEnabled = useIsAreaAvailable(SupportedArea.MODEL_SERVING).status;
+  const isAreaFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING).status;
   const isJupyterEnabled = useCheckJupyterEnabled();
   const [notebookTolerationSettings, setNotebookTolerationSettings] =
     React.useState<NotebookTolerationFormSettings>({
@@ -53,6 +58,9 @@ const ClusterSettings: React.FC = () => {
   const [defaultDeploymentMode, setDefaultDeploymentMode] = React.useState<DeploymentMode>(
     defaultSingleModelDeploymentMode,
   );
+  const instructLabDSCState = isInstructLabEnabled(dsc);
+  const [instructLabEnabled, setInstructLabEnabled] = React.useState<boolean>(instructLabDSCState);
+
   const dispatch = useAppDispatch();
 
   React.useEffect(() => {
@@ -79,14 +87,19 @@ const ClusterSettings: React.FC = () => {
           key: notebookTolerationSettings.key,
         },
         modelServingPlatformEnabled: modelServingEnabledPlatforms,
-      }),
+      }) ||
+      (isAreaFineTuningEnabled && instructLabEnabled !== instructLabDSCState),
     [
+      clusterSettings,
       pvcSize,
       cullerTimeout,
       userTrackingEnabled,
-      clusterSettings,
-      notebookTolerationSettings,
+      notebookTolerationSettings.enabled,
+      notebookTolerationSettings.key,
       modelServingEnabledPlatforms,
+      instructLabEnabled,
+      instructLabDSCState,
+      isAreaFineTuningEnabled,
     ],
   );
 
@@ -101,42 +114,65 @@ const ClusterSettings: React.FC = () => {
       },
       modelServingPlatformEnabled: modelServingEnabledPlatforms,
     };
-    if (!_.isEqual(clusterSettings, newClusterSettings)) {
-      if (
-        Number(newClusterSettings.pvcSize) !== 0 &&
-        Number(newClusterSettings.cullerTimeout) >= MIN_CULLER_TIMEOUT
-      ) {
-        setSaving(true);
-        updateClusterSettings(newClusterSettings)
-          .then((response) => {
-            setSaving(false);
-            if (response.success) {
-              setClusterSettings(newClusterSettings);
-              dispatch(
-                addNotification({
-                  status: AlertVariant.success,
-                  title: 'Cluster settings changes saved',
-                  message: 'It may take up to 2 minutes for configuration changes to be applied.',
-                  timestamp: new Date(),
-                }),
-              );
-            } else {
-              throw new Error(response.error);
-            }
-          })
-          .catch((e) => {
-            setSaving(false);
-            dispatch(
-              addNotification({
-                status: AlertVariant.danger,
-                title: 'Error',
-                message: e.message,
-                timestamp: new Date(),
-              }),
-            );
-          });
-      }
+
+    const clusterSettingsUnchanged = _.isEqual(clusterSettings, newClusterSettings);
+    const instructLabUnchanged = instructLabEnabled === instructLabDSCState;
+
+    if (clusterSettingsUnchanged && instructLabUnchanged) {
+      return;
     }
+
+    if (
+      Number(newClusterSettings.pvcSize) === 0 ||
+      Number(newClusterSettings.cullerTimeout) < MIN_CULLER_TIMEOUT
+    ) {
+      return;
+    }
+
+    setSaving(true);
+
+    const clusterSettingsPromise = clusterSettingsUnchanged
+      ? Promise.resolve()
+      : updateClusterSettings(newClusterSettings).then((response) => {
+          if (!response.success) {
+            throw new Error(response.error);
+          }
+          setClusterSettings(newClusterSettings);
+        });
+
+    const instructLabPromise = instructLabUnchanged
+      ? Promise.resolve()
+      : dsc &&
+        toggleInstructLabState(instructLabEnabled ? 'Managed' : 'Removed', dsc.metadata.name).then(
+          () => {
+            refreshDsc();
+          },
+        );
+
+    Promise.all([clusterSettingsPromise, instructLabPromise])
+      .then(() => {
+        dispatch(
+          addNotification({
+            status: AlertVariant.success,
+            title: 'Cluster settings changes saved',
+            message: 'It may take up to 2 minutes for configuration changes to be applied.',
+            timestamp: new Date(),
+          }),
+        );
+      })
+      .catch((error) => {
+        dispatch(
+          addNotification({
+            status: AlertVariant.danger,
+            title: 'Error',
+            message: error.message,
+            timestamp: new Date(),
+          }),
+        );
+      })
+      .finally(() => {
+        setSaving(false);
+      });
   };
 
   return (
@@ -145,9 +181,9 @@ const ClusterSettings: React.FC = () => {
         <TitleWithIcon title="Cluster settings" objectType={ProjectObjectType.clusterSettings} />
       }
       description="Manage global settings for all users."
-      loaded={loaded}
+      loaded={loaded && dscLoaded}
       empty={false}
-      loadError={loadError}
+      loadError={loadError || dscError}
       errorMessage="Unable to load cluster settings."
       emptyMessage="No cluster settings found."
       provideChildrenPadding
@@ -193,6 +229,15 @@ const ClusterSettings: React.FC = () => {
               initialValue={clusterSettings.notebookTolerationSettings}
               tolerationSettings={notebookTolerationSettings}
               setTolerationSettings={setNotebookTolerationSettings}
+            />
+          </StackItem>
+        )}
+        {isAreaFineTuningEnabled && (
+          <StackItem>
+            <InstructLabSettings
+              initialValue={instructLabDSCState}
+              enabled={instructLabEnabled}
+              setEnabled={setInstructLabEnabled}
             />
           </StackItem>
         )}

--- a/frontend/src/pages/clusterSettings/InstructLabSettings.tsx
+++ b/frontend/src/pages/clusterSettings/InstructLabSettings.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Checkbox, Stack, StackItem } from '@patternfly/react-core';
+import SettingSection from '~/components/SettingSection';
+
+type InstructLabSettingsProps = {
+  initialValue: boolean;
+  enabled: boolean;
+  setEnabled: (settings: boolean) => void;
+};
+
+const InstructLabSettings: React.FC<InstructLabSettingsProps> = ({
+  initialValue,
+  enabled,
+  setEnabled,
+}) => {
+  React.useEffect(() => {
+    if (initialValue) {
+      setEnabled(initialValue);
+    }
+  }, [initialValue, setEnabled]);
+
+  return (
+    <SettingSection title="InstrutLab pipeline">
+      <Stack hasGutter>
+        <StackItem>
+          <Checkbox
+            label="InstructLab flow for all Data Science Projects"
+            isChecked={enabled}
+            onChange={() => {
+              setEnabled(!enabled);
+            }}
+            aria-label="instructLabEnabledCheckbox"
+            id="instructlab-enabled-checkbox"
+            data-testid="instructlab-enabled-checkbox"
+            name="instructLabEnabledCheckbox"
+          />
+        </StackItem>
+      </Stack>
+    </SettingSection>
+  );
+};
+
+export default InstructLabSettings;

--- a/frontend/src/pages/clusterSettings/useDefaultDsc.ts
+++ b/frontend/src/pages/clusterSettings/useDefaultDsc.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
+import { DataScienceClusterKind } from '~/k8sTypes';
+import { listDataScienceClusters } from '~/api';
+
+const useDefaultDsc = (): FetchState<DataScienceClusterKind | null> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<DataScienceClusterKind | null>>(
+    () => listDataScienceClusters().then((dataScienceClusters) => dataScienceClusters[0]),
+    [],
+  );
+
+  return useFetchState(callback, null);
+};
+
+export default useDefaultDsc;

--- a/frontend/src/pages/clusterSettings/utils.ts
+++ b/frontend/src/pages/clusterSettings/utils.ts
@@ -1,0 +1,4 @@
+import { DataScienceClusterKind } from '~/k8sTypes';
+
+export const isInstructLabEnabled = (dsc: DataScienceClusterKind | null): boolean =>
+  dsc?.spec.components?.datasciencepipelines?.managedPipelines.instructLab.state === 'Managed';

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -85,6 +85,8 @@ spec:
                       type: boolean
                     disableNIMModelServing:
                       type: boolean
+                    disableFineTuning:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:


### PR DESCRIPTION
[RHOAISTRAT-436](https://issues.redhat.com/browse/RHOAISTRAT-436)

## Description
* Added feature flag `disableFineTuning` 
* Added section in Cluster settings to enable Instruct lab 
![Screenshot 2025-02-05 at 3 53 16 PM](https://github.com/user-attachments/assets/86db2dd6-3c51-403a-b07e-78411bdaf385)

## How Has This Been Tested?
Apply the updated odh-dashboard-config manifest
Disable the `disableFineTuning` flag via devFeatureFlags
Check the section to toggle instruct lab feature in cluster settings page

## Test Impact
Added cypress mock test to verify the section of instruct lab in cluster settings page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
