### PR TITLE
fix: set default Model Server size to 'Custom' and update helper text

### DIFF
--- a/frontend/src/__mocks__/mockNimResource.ts
+++ b/frontend/src/__mocks__/mockNimResource.ts
@@ -52,8 +52,8 @@ export const mockNimInferenceService = (): InferenceServiceKind => {
     displayName: 'Test Name',
     kserveInternalLabel: true,
     resources: {
-      limits: { cpu: '2', memory: '8Gi' },
-      requests: { cpu: '1', memory: '4Gi' },
+      limits: { cpu: '16', memory: '64Gi' },
+      requests: { cpu: '8', memory: '32Gi' },
     },
   });
   delete inferenceService.metadata.labels?.name;

--- a/frontend/src/__mocks__/mockNimResource.ts
+++ b/frontend/src/__mocks__/mockNimResource.ts
@@ -56,6 +56,7 @@ export const mockNimInferenceService = (): InferenceServiceKind => {
       requests: { cpu: '8', memory: '32Gi' },
     },
   });
+
   delete inferenceService.metadata.labels?.name;
   delete inferenceService.metadata.creationTimestamp;
   delete inferenceService.metadata.generation;

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
@@ -116,15 +116,15 @@ describe('NIM Model Serving', () => {
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Model server size')
-        .should('contain.text', 'Small');
+        .should('contain.text', 'Custom');
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Model server size')
-        .should('contain.text', '1 CPUs, 4GiB Memory requested');
+        .should('contain.text', '8 CPUs, 32GiB Memory requested');
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Model server size')
-        .should('contain.text', '2 CPUs, 8GiB Memory limit');
+        .should('contain.text', '16 CPUs, 64GiB Memory limit');
       projectDetails
         .getKserveTableRow('Test Name')
         .findInfoValueFor('Accelerator')

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -140,8 +140,20 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
   }, [currentProjectName, setCreateDataInferenceService]);
 
   React.useEffect(() => {
-    setCreateDataInferenceService('modelSize', { name: 'Custom', resources: sizes[0].resources });
-  }, [setCreateDataInferenceService, sizes]);
+    setCreateDataInferenceService('modelSize', {
+      name: 'Custom',
+      resources: {
+        limits: {
+          cpu: '16',
+          memory: '64Gi',
+        },
+        requests: {
+          cpu: '8',
+          memory: '32Gi',
+        },
+      },
+    });
+  }, [setCreateDataInferenceService]);
 
   // Serving Runtime Validation
   const isDisabledServingRuntime =

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -139,6 +139,10 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     }
   }, [currentProjectName, setCreateDataInferenceService]);
 
+  React.useEffect(() => {
+    setCreateDataInferenceService('modelSize', { name: 'Custom', resources: sizes[0].resources });
+  }, [setCreateDataInferenceService, sizes]);
+
   // Serving Runtime Validation
   const isDisabledServingRuntime =
     namespace === '' || actionInProgress || createDataServingRuntime.imageName === undefined;
@@ -381,7 +385,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
             acceleratorProfileState={initialAcceleratorProfileState}
             selectedAcceleratorProfile={selectedAcceleratorProfile}
             setSelectedAcceleratorProfile={setSelectedAcceleratorProfile}
-            infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
+            infoContent="Select CPU and memory resources large enough to support the NIM being deployed."
           />
           {isAuthorinoEnabled && (
             <AuthServingRuntimeSection


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-101

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Set default Model Server size to 'Custom' and update helper text.

<img width="875" alt="image" src="https://github.com/user-attachments/assets/3aa1a18f-05a2-4aa4-a5c9-70a137517832" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Verified that the default Model Server size for NIM deployment is set to 'Custom', while for KServe, it defaults to 'Small'. Also confirmed that the helper text is correctly updated.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
