### PR TITLE
Fix child routing for model catalog

### DIFF
--- a/frontend/src/pages/modelCatalog/ModelCatalogCoreLoader.tsx
+++ b/frontend/src/pages/modelCatalog/ModelCatalogCoreLoader.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Outlet } from 'react-router';
 import { conditionalArea, SupportedArea } from '~/concepts/areas';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
@@ -23,14 +24,17 @@ const ModelCatalogCoreLoader: React.FC = conditionalArea(
   };
 
   return (
-    <ApplicationsPage
-      title={
-        <TitleWithIcon title="Model Catalog" objectType={ProjectObjectType.registeredModels} />
-      }
-      {...renderStateProps}
-      loaded
-      provideChildrenPadding
-    />
+    <>
+      <ApplicationsPage
+        title={
+          <TitleWithIcon title="Model Catalog" objectType={ProjectObjectType.registeredModels} />
+        }
+        {...renderStateProps}
+        loaded
+        provideChildrenPadding
+      />
+      <Outlet />
+    </>
   );
 });
 

--- a/frontend/src/pages/modelCatalog/ModelCatalogRoutes.tsx
+++ b/frontend/src/pages/modelCatalog/ModelCatalogRoutes.tsx
@@ -5,8 +5,11 @@ import ModelDetailsPage from './ModelDetailsPage';
 
 const ModelCatalogRoutes: React.FC = () => (
   <Routes>
-    <Route path={'/:modelCatalog?/*'} element={<ModelCatalogCoreLoader />} />
-    <Route path="tempDetails" element={<ModelDetailsPage />} />
+    <Route path="/:modelCatalog?/*" element={<ModelCatalogCoreLoader />}>
+      <Route path="tempDetails">
+        <Route index element={<ModelDetailsPage />} />
+      </Route>
+    </Route>
     <Route path="*" element={<Navigate to="." />} />
   </Routes>
 );

--- a/frontend/src/pages/modelCatalog/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/ModelDetailsPage.tsx
@@ -1,36 +1,15 @@
 import React from 'react';
-import ApplicationsPage from '~/pages/ApplicationsPage';
-import TitleWithIcon from '~/concepts/design/TitleWithIcon';
-import { ProjectObjectType } from '~/concepts/design/utils';
 import { conditionalArea, SupportedArea } from '~/concepts/areas';
 import EmptyModelCatalogState from './EmptyModelCatalogState';
-
-const renderStateProps = {
-  empty: true,
-  emptyStatePage: (
-    <EmptyModelCatalogState
-      testid="empty-model-catalog-details-state"
-      title="Request access to model catalog"
-      description="To request access to model catalog, contact your administrator."
-    />
-  ),
-  headerContent: null,
-};
 
 const ModelDetailsPage: React.FC = conditionalArea(
   SupportedArea.MODEL_CATALOG,
   true,
 )(() => (
-  <ApplicationsPage
-    title={
-      <TitleWithIcon
-        title="Model Catalog - Model Details"
-        objectType={ProjectObjectType.registeredModels}
-      />
-    }
-    {...renderStateProps}
-    loaded
-    provideChildrenPadding
+  <EmptyModelCatalogState
+    testid="empty-model-catalog-details-state"
+    title="Request access to model catalog"
+    description="To request access to model catalog, contact your administrator."
   />
 ));
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Follow up #3712 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Render `ModelDetails` inside the core loader in a sub-route.

https://github.com/user-attachments/assets/19e54db4-8724-4e71-9857-3a1aef403a33

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Same as #3712 but you should just see the details content inside the core loader content when you navigate to `/tempDetails`

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests added to #3712 already

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
