### PR TITLE
Add URI field advanced settings to restrict prefix

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/UriFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/UriFormField.tsx
@@ -17,7 +17,10 @@ const validateUrl = (url?: string, supportedSchemes?: string[]) => {
     return true;
   }
   try {
-    if (supportedSchemes?.length && !supportedSchemes.some((scheme) => url.startsWith(scheme))) {
+    if (
+      supportedSchemes?.length &&
+      !supportedSchemes.some((scheme) => url.toLowerCase().startsWith(scheme.toLowerCase()))
+    ) {
       return false;
     }
     return !!new URL(url);

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/UriFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/UriFormField.spec.tsx
@@ -117,4 +117,39 @@ describe('UriFormField', () => {
       renderResult.unmount();
     });
   });
+
+  it('should validate allow only specified schemes', async () => {
+    let renderResult = render(
+      <UriFormField
+        id="test"
+        field={{
+          type: 'uri',
+          name: 'test-name',
+          envVar: 'test_envVar',
+          properties: {
+            schemes: ['oci://'],
+          },
+        }}
+        value="http://bar.com"
+      />,
+    );
+    expect(screen.queryByTestId('uri-form-field-helper-text')).toBeInTheDocument();
+    renderResult.unmount();
+
+    renderResult = render(
+      <UriFormField
+        id="test"
+        field={{
+          type: 'uri',
+          name: 'test-name',
+          envVar: 'test_envVar',
+          properties: {
+            schemes: ['oci://'],
+          },
+        }}
+        value="oci://quay.io/someregistry/containername:tag"
+      />,
+    );
+    expect(screen.queryByTestId('uri-form-field-helper-text')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/concepts/connectionTypes/fields/fieldUtils.ts
+++ b/frontend/src/concepts/connectionTypes/fields/fieldUtils.ts
@@ -1,5 +1,7 @@
 export const EXTENSION_REGEX = /^\.[a-zA-Z0-9]+(^.[a-zA-Z0-9]+)?$/;
 
+export const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:(\/\/)?$/;
+
 export const isDuplicateExtension = (index: number, values: string[]): boolean =>
   index !== 0 &&
   values.slice(0, index).some((val) => values[index].toLowerCase() === val.toLowerCase());

--- a/frontend/src/concepts/connectionTypes/types.ts
+++ b/frontend/src/concepts/connectionTypes/types.ts
@@ -71,7 +71,11 @@ export type SectionField = Field<ConnectionTypeFieldType.Section | 'section'>;
 export type HiddenField = DataField<ConnectionTypeFieldType.Hidden | 'hidden'>;
 export type ShortTextField = DataField<ConnectionTypeFieldType.ShortText | 'short-text'>;
 export type TextField = DataField<ConnectionTypeFieldType.Text | 'text'>;
-export type UriField = DataField<ConnectionTypeFieldType.URI | 'uri'>;
+export type UriField = DataField<
+  ConnectionTypeFieldType.URI | 'uri',
+  string,
+  { schemes?: string[] }
+>;
 export type FileField = DataField<
   ConnectionTypeFieldType.File | 'file',
   string,

--- a/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/DataFieldAdvancedPropertiesForm.tsx
@@ -5,6 +5,7 @@ import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/type
 import NumericAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/NumericAdvancedPropertiesForm';
 import FileUploadAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm';
 import DropdownAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/DropdownAdvancedPropertiesForm';
+import UriAdvancedPropertiesForm from './UriAdvancedPropertiesForm';
 
 const DataFieldAdvancedPropertiesForm = <T extends ConnectionTypeDataField>(
   props: AdvancedFieldProps<T>,
@@ -23,6 +24,9 @@ const DataFieldAdvancedPropertiesForm = <T extends ConnectionTypeDataField>(
 
       case ConnectionTypeFieldType.Dropdown:
         return DropdownAdvancedPropertiesForm;
+
+      case ConnectionTypeFieldType.URI:
+        return UriAdvancedPropertiesForm;
     }
     return undefined;
   })();

--- a/frontend/src/pages/connectionTypes/manage/advanced/FieldRegexValidationRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/FieldRegexValidationRow.tsx
@@ -9,29 +9,41 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
-import { EXTENSION_REGEX } from '~/concepts/connectionTypes/fields/fieldUtils';
 
-type FileUploadExtensionRowProps = {
-  extension?: string;
+type FieldRegexValidationRowProps = {
+  id: string;
+  value?: string;
   isDuplicate?: boolean;
   onChange: (newValue: string) => void;
   onRemove?: () => void;
   allowRemove: boolean;
   textRef?: React.RefObject<HTMLInputElement>;
+  ariaLabelItem: string;
+  placeholder: string;
+  regexValidation: RegExp;
+  errorMessage: {
+    invalid: string;
+    duplicate: string;
+  };
 };
 
-const FileUploadExtensionRow: React.FC<FileUploadExtensionRowProps> = ({
-  extension,
+const FieldRegexValidationRow: React.FC<FieldRegexValidationRowProps> = ({
+  id,
+  value,
   isDuplicate,
   onRemove,
   allowRemove,
   onChange,
   textRef,
+  ariaLabelItem,
+  placeholder,
+  regexValidation,
+  errorMessage,
 }) => {
   const [isValid, setIsValid] = React.useState<boolean>(!isDuplicate);
 
   React.useEffect(
-    () => setIsValid(extension ? !isDuplicate && EXTENSION_REGEX.test(extension) : true),
+    () => setIsValid(value ? !isDuplicate && regexValidation.test(value) : true),
     // only run on entry or if a duplicate, otherwise wait for blur
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isDuplicate],
@@ -39,25 +51,25 @@ const FileUploadExtensionRow: React.FC<FileUploadExtensionRowProps> = ({
 
   return (
     <>
-      <InputGroup data-testid="file-upload-extension-row">
+      <InputGroup data-testid={`${id}-row`}>
         <InputGroupItem isFill>
           <TextInput
-            name="file-extension"
-            data-testid="file-upload-extension-row-input"
+            name={id}
+            data-testid={`${id}-row-input`}
             type="text"
-            aria-label="allowed extension"
+            aria-label={`allowed ${ariaLabelItem}`}
             ref={textRef}
-            value={extension || ''}
+            value={value || ''}
             style={{ textTransform: 'lowercase' }}
-            placeholder="Example: .json"
+            placeholder={placeholder}
             onChange={(_ev, val) => {
-              if (!isValid && !isDuplicate && EXTENSION_REGEX.test(val)) {
+              if (!isValid && !isDuplicate && regexValidation.test(val)) {
                 setIsValid(true);
               }
               onChange(val);
             }}
             onBlur={() => {
-              setIsValid(extension ? !isDuplicate && EXTENSION_REGEX.test(extension) : true);
+              setIsValid(value ? !isDuplicate && regexValidation.test(value) : true);
             }}
           />
         </InputGroupItem>
@@ -65,8 +77,8 @@ const FileUploadExtensionRow: React.FC<FileUploadExtensionRowProps> = ({
           <Button
             icon={<MinusCircleIcon />}
             variant="plain"
-            data-testid="file-upload-extension-row-remove"
-            aria-label="remove extension"
+            data-testid={`${id}-row-remove`}
+            aria-label={`remove ${ariaLabelItem}`}
             isDisabled={!allowRemove}
             onClick={onRemove}
           />
@@ -78,11 +90,9 @@ const FileUploadExtensionRow: React.FC<FileUploadExtensionRowProps> = ({
             <HelperTextItem
               icon={<ExclamationCircleIcon />}
               variant="error"
-              data-testid="file-upload-extension-row-error"
+              data-testid={`${id}-row-error`}
             >
-              {isDuplicate
-                ? 'Extension has already been specified.'
-                : `Please enter a valid extension starting with '.'`}
+              {isDuplicate ? errorMessage.duplicate : errorMessage.invalid}
             </HelperTextItem>
           </HelperText>
         </FormHelperText>
@@ -91,4 +101,4 @@ const FileUploadExtensionRow: React.FC<FileUploadExtensionRowProps> = ({
   );
 };
 
-export default FileUploadExtensionRow;
+export default FieldRegexValidationRow;

--- a/frontend/src/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/FileUploadAdvancedPropertiesForm.tsx
@@ -8,7 +8,7 @@ import {
 } from '~/concepts/connectionTypes/fields/fieldUtils';
 import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/types';
 import ExpandableFormSection from '~/components/ExpandableFormSection';
-import FileUploadExtensionRow from '~/pages/connectionTypes/manage/advanced/FileUploadExtensionRow';
+import FieldRegexValidationRow from '~/pages/connectionTypes/manage/advanced/FieldRegexValidationRow';
 
 const FileUploadAdvancedPropertiesForm: React.FC<AdvancedFieldProps<FileField>> = ({
   properties,
@@ -44,9 +44,10 @@ const FileUploadAdvancedPropertiesForm: React.FC<AdvancedFieldProps<FileField>> 
     >
       <FormGroup label="Allow specific files" fieldId="file-types" isStack>
         {displayedExtensions.map((extension, index) => (
-          <FileUploadExtensionRow
+          <FieldRegexValidationRow
+            id="file-upload-extension"
             key={index}
-            extension={extension}
+            value={extension}
             isDuplicate={isDuplicateExtension(index, displayedExtensions)}
             textRef={index === displayedExtensions.length - 1 ? lastTextRef : undefined}
             onChange={(val) => {
@@ -74,6 +75,13 @@ const FileUploadAdvancedPropertiesForm: React.FC<AdvancedFieldProps<FileField>> 
               });
             }}
             allowRemove={displayedExtensions.length > 1 || !!displayedExtensions[0]}
+            ariaLabelItem="extension"
+            placeholder="Example .json"
+            regexValidation={EXTENSION_REGEX}
+            errorMessage={{
+              invalid: `Please enter a valid extension starting with '.'`,
+              duplicate: 'Extension has already been specified.',
+            }}
           />
         ))}
         <Button

--- a/frontend/src/pages/connectionTypes/manage/advanced/UriAdvancedPropertiesForm.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/UriAdvancedPropertiesForm.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { Button, FormGroup } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { UriField } from '~/concepts/connectionTypes/types';
+import {
+  URI_SCHEME_REGEX,
+  isDuplicateExtension,
+} from '~/concepts/connectionTypes/fields/fieldUtils';
+import { AdvancedFieldProps } from '~/pages/connectionTypes/manage/advanced/types';
+import ExpandableFormSection from '~/components/ExpandableFormSection';
+import FieldRegexValidationRow from './FieldRegexValidationRow';
+
+const UriAdvancedPropertiesForm: React.FC<AdvancedFieldProps<UriField>> = ({
+  properties,
+  onChange,
+  onValidate,
+}) => {
+  const displayedSchemes = React.useMemo(
+    () => [...(properties.schemes?.length ? properties.schemes : [''])],
+    [properties.schemes],
+  );
+  const lastTextRef = React.useRef<HTMLInputElement | null>(null);
+
+  React.useEffect(() => {
+    if (!properties.schemes?.length) {
+      onValidate(true);
+      return;
+    }
+    const valid = properties.schemes.every(
+      (extension, i) =>
+        !extension ||
+        (URI_SCHEME_REGEX.test(extension) && !isDuplicateExtension(i, properties.schemes || [])),
+    );
+    onValidate(valid);
+    // do not run when callback changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [properties.schemes]);
+
+  return (
+    <ExpandableFormSection
+      toggleText="Advanced settings"
+      initExpanded={!!properties.schemes?.length}
+      data-testid="advanced-settings-toggle"
+    >
+      <FormGroup label="Allow specific schemes" fieldId="scheme-types" isStack>
+        {displayedSchemes.map((scheme, index) => (
+          <FieldRegexValidationRow
+            key={index}
+            id="scheme-types"
+            value={scheme}
+            isDuplicate={isDuplicateExtension(index, displayedSchemes)}
+            textRef={index === displayedSchemes.length - 1 ? lastTextRef : undefined}
+            onChange={(val) => {
+              if (!val && displayedSchemes.length === 1) {
+                onChange({ ...properties, schemes: [] });
+              } else {
+                onChange({
+                  ...properties,
+                  schemes: [
+                    ...displayedSchemes.slice(0, index),
+                    val,
+                    ...displayedSchemes.slice(index + 1),
+                  ],
+                });
+              }
+            }}
+            onRemove={() => {
+              const exts = [
+                ...displayedSchemes.slice(0, index),
+                ...displayedSchemes.slice(index + 1),
+              ];
+              onChange({
+                ...properties,
+                schemes: exts.length === 1 && exts[0].length === 0 ? [] : exts,
+              });
+            }}
+            allowRemove={displayedSchemes.length > 1 || !!displayedSchemes[0]}
+            ariaLabelItem="scheme"
+            placeholder="Example https://"
+            regexValidation={URI_SCHEME_REGEX}
+            errorMessage={{
+              invalid: 'Please enter a valid scheme.',
+              duplicate: 'Scheme has already been specified.',
+            }}
+          />
+        ))}
+        <Button
+          variant="link"
+          data-testid="add-variable-button"
+          isInline
+          icon={<PlusCircleIcon />}
+          iconPosition="left"
+          onClick={() => {
+            onChange({ ...properties, schemes: [...displayedSchemes, ''] });
+            requestAnimationFrame(() => lastTextRef.current?.focus());
+          }}
+        >
+          Add uri scheme type
+        </Button>
+      </FormGroup>
+    </ExpandableFormSection>
+  );
+};
+
+export default UriAdvancedPropertiesForm;

--- a/frontend/src/pages/connectionTypes/manage/advanced/__tests__/UriAdvancedPropertiesForm.spec.tsx
+++ b/frontend/src/pages/connectionTypes/manage/advanced/__tests__/UriAdvancedPropertiesForm.spec.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act } from 'react';
+import { ConnectionTypeFieldType, UriField } from '~/concepts/connectionTypes/types';
+import UriAdvancedPropertiesForm from '~/pages/connectionTypes/manage/advanced/UriAdvancedPropertiesForm';
+
+let onChange: jest.Mock;
+let onValidate: jest.Mock;
+let field: UriField;
+
+describe('FileUploadAdvancedPropertiesForm', () => {
+  beforeEach(() => {
+    onChange = jest.fn();
+    onValidate = jest.fn();
+    field = {
+      type: ConnectionTypeFieldType.URI,
+      name: 'URI',
+      envVar: 'URI',
+      properties: {},
+    };
+  });
+
+  it('should show the empty state', () => {
+    render(
+      <UriAdvancedPropertiesForm
+        properties={{}}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(true);
+
+    const advancedToggle = screen.getByTestId('advanced-settings-toggle');
+    const toggleButton = within(advancedToggle).getByRole('button');
+
+    act(() => {
+      toggleButton.click();
+    });
+
+    // there should only be one row
+    const schemeRow = screen.getByTestId('scheme-types-row');
+    expect(schemeRow).toBeVisible();
+    // there should only be one remove button and it should be disabled
+    const removeButton = screen.getByTestId('scheme-types-row-remove');
+    expect(removeButton).toBeDisabled();
+
+    const input = screen.getByTestId('scheme-types-row-input');
+    act(() => {
+      fireEvent.change(input, { target: { value: 'https://' } });
+    });
+    expect(onChange).toHaveBeenCalledWith({ schemes: ['https://'] });
+  });
+
+  it('should show the given schemes', () => {
+    render(
+      <UriAdvancedPropertiesForm
+        properties={{ schemes: ['oci://', 'one+two://', 'another:'] }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(true);
+
+    // there should be 3 visible rows
+    const schemeRows = screen.getAllByTestId('scheme-types-row');
+    expect(schemeRows).toHaveLength(3);
+    schemeRows.forEach((schemeRow) => expect(schemeRow).toBeVisible());
+
+    // there should only be three remove buttons and all should be enabled
+    const removeButtons = screen.getAllByTestId('scheme-types-row-remove');
+    expect(removeButtons).toHaveLength(3);
+    removeButtons.forEach((removeButton) => expect(removeButton).toBeEnabled());
+
+    act(() => {
+      removeButtons[0].click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ schemes: ['one+two://', 'another:'] });
+
+    act(() => {
+      removeButtons[1].click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ schemes: ['oci://', 'another:'] });
+
+    act(() => {
+      removeButtons[2].click();
+    });
+    expect(onChange).toHaveBeenCalledWith({ schemes: ['oci://', 'one+two://'] });
+
+    const addButton = screen.getByTestId('add-variable-button');
+    act(() => {
+      addButton.click();
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      schemes: ['oci://', 'one+two://', 'another:', ''],
+    });
+  });
+
+  it('should invalidate invalid schemes', () => {
+    render(
+      <UriAdvancedPropertiesForm
+        properties={{ schemes: ['1://', '][][]', 'http://'] }}
+        field={field}
+        onChange={onChange}
+        onValidate={onValidate}
+      />,
+    );
+
+    expect(onValidate).toHaveBeenCalledWith(false);
+    expect(screen.getAllByTestId('scheme-types-row-error')).toHaveLength(2);
+  });
+});

--- a/frontend/src/utilities/__tests__/string.spec.ts
+++ b/frontend/src/utilities/__tests__/string.spec.ts
@@ -192,4 +192,10 @@ describe('joinWithCommaAnd', () => {
       }),
     ).toBe('Prefix item1 suffix.');
   });
+
+  it('should join items with custom join word "or"', () => {
+    expect(joinWithCommaAnd(['item1', 'item2', 'item3'], undefined, 'or')).toBe(
+      'item1, item2, or item3',
+    );
+  });
 });

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -67,12 +67,13 @@ export const joinWithCommaAnd = (
     multiPrefix?: string;
     multiSuffix?: string;
   },
+  joinWord = 'and',
 ): string =>
   items.length > 1
     ? `${options?.multiPrefix ?? ''}${items
         .slice(0, items.length - 1)
         .map((i) => i)
-        .join(', ')}${items.length > 2 ? ',' : ''} and ${items[items.length - 1]}${
+        .join(', ')}${items.length > 2 ? ',' : ''} ${joinWord} ${items[items.length - 1]}${
         options?.multiSuffix ?? ''
       }`
     : `${options?.singlePrefix ?? ''}${items[0]}${options?.singleSuffix ?? ''}`;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-18724

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
If a user is making an OCI connection type, kserve requires you to start the uri with `oci://...`. This PR adds a way to restrict the types that a URI can start with (similar to file extensions). Once this is added, we can create an ootb OCI connection type that will take only OCI URIs

Admin connection types editing field
![image](https://github.com/user-attachments/assets/8e9716ba-47b5-4224-b1e7-25e8671c388a)

User creating a connection on a project
![image](https://github.com/user-attachments/assets/45797e4a-3cbb-43b9-80c8-2098cad632a2)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a new connection type, add a URI field, go to advanced settings and add some scheme types.
Use the connection type when making a connection to verify

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
jest tests were added for new functionality (similar to specifiying file extension types)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.
@kywalker-rh 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
