### PR TITLE
Fix: Remove Non-Existent Video File in after:spec Handler

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -124,7 +124,7 @@ export default defineConfig({
           );
           if (!failures) {
             // delete the video if the spec passed and no tests retried
-            fs.unlinkSync(results.video);
+            fs.rmSync(results.video);
           }
         }
       });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
During test execution with the Firefox browser, Cypress was failing with the following error:

```
> npm run cypress:run:mock -- --browser=firefox 
Warning: We failed capturing this video.

This error will not affect or change the exit code.

Error: Insufficient frames captured to create video.
    at ChildProcess.<anonymous> (<embedded>:778:16306)
    at ChildProcess.emit (node:events:514:28)
    at Process.onexit (node:internal/child_process:291:12)
An error was thrown in your plugins file while executing the handler for the after:spec event.

The error we received was:

Error: ENOENT: no such file or directory, unlink '<path-to-workdir>/odh-dashboard/frontend/src/__tests__/cypress/results/mocked/videos/application.cy.ts.mp4'
    at Object.unlinkSync (node:fs:1954:11)
    at Object.handler (<path-to-workdir>/odh-dashboard/frontend/src/__tests__/cypress/cypress.config.ts:127:16)
    at RunPlugins.invoke (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:185:25)
    at /Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/util.js:59:14
    at tryCatcher (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.attempt.Promise.try (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/node_modules/bluebird/js/release/method.js:39:29)
    at Object.wrapChildPromise (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/util.js:58:23)
    at RunPlugins.execute (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:164:21)
    at EventEmitter.<anonymous> (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:56:12)
    at EventEmitter.emit (node:events:507:28)
    at EventEmitter.emit (node:domain:489:12)
    at process.<anonymous> (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/util.js:33:26)
    at process.emit (node:events:507:28)
    at process.emit (node:domain:489:12)
    at process.emit.sharedData.processEmitHook.installedValue [as emit] (/Library/Caches/Cypress/13.16.0/Cypress.app/Contents/Resources/app/node_modules/@cspotcode/source-map-support/source-map-support.js:745:40)
    at emit (node:internal/child_process:949:14)
    at processTicksAndRejections (node:internal/process/task_queues:91:21)
```
This occurred due to insufficient frames being captured by Cypress (likely caused by Firefox being unable to record videos). Since the video file was not created, unlinkSync failed when trying to delete it. This led to an ENOENT error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The fix was tested by running Cypress tests with Firefox with the command `npm run cypress:run:mock -- --browser=firefox`
- After applying the fix, tests were rerun, and the error no longer occurred when the video file was missing.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- The fix only impacts the video file removal in tests using Firefox.
- No other tests were affected.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [] Included any necessary screenshots or gifs if it was a UI change.
- [] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
