### PR TITLE
fix: set disableNIMModelServing to false as required for GA

### DIFF
--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -72,7 +72,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableServingRuntimeParams: false,
       disableConnectionTypes: false,
       disableStorageClasses: false,
-      disableNIMModelServing: true,
+      disableNIMModelServing: false,
       disableAdminConnectionTypes: false,
       disableFineTuning: true,
     },

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -41,7 +41,7 @@ The following are a list of features that are supported, along with there defaul
 | disableModelRegistrySecureDB | false   | Disables Model Registry Secure DB from the dashboard.                                                |
 | disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
 | disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
-| disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |
+| disableNIMModelServing       | false   | Disables components of NIM Model UI from the dashboard.                                              |
 | disableFineTuning            | true    | Disables Fine tuning from the dashboard.                                                             |
 
 ## Defaults
@@ -73,7 +73,7 @@ spec:
     disablePerformanceMetrics: false
     disableDistributedWorkloads: false
     disableStorageClasses: false
-    disableNIMModelServing: true
+    disableNIMModelServing: false
     disableFineTuning: true
 ```
 
@@ -169,7 +169,7 @@ spec:
     disableKServeMetrics: true
     disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
-    disableNIMModelServing: true
+    disableNIMModelServing: false
   notebookController:
     enabled: true
     gpuSetting: autodetect

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -70,7 +70,7 @@ export const mockDashboardConfig = ({
   disableServingRuntimeParams = false,
   disableStorageClasses = false,
   disableNotebookController = false,
-  disableNIMModelServing = true,
+  disableNIMModelServing = false,
   disableFineTuning = true,
   notebookSizes = [
     {

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -33,7 +33,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableModelRegistrySecureDB: false,
   disableServingRuntimeParams: false,
   disableStorageClasses: false,
-  disableNIMModelServing: true,
+  disableNIMModelServing: false,
   disableAdminConnectionTypes: false,
   disableFineTuning: true,
 } satisfies DashboardCommonConfig);

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -31,7 +31,7 @@ spec:
     disableModelRegistrySecureDB: false
     disableServingRuntimeParams: false
     disableStorageClasses: false
-    disableNIMModelServing: true
+    disableNIMModelServing: false
   groupsConfig:
     adminGroups: "$(admin_groups)"
     allowedGroups: "system:authenticated"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/NVPE-157

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Set disableNIMModelServing to false as required for GA to enable the NIM feature. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested by making sure NIM is available with the setting set to false. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
