### PR TITLE
Add safeExecute utility for error handling in InstructLab feature check

### DIFF
--- a/frontend/src/pages/clusterSettings/utils.ts
+++ b/frontend/src/pages/clusterSettings/utils.ts
@@ -1,6 +1,7 @@
 import { DataScienceClusterKind } from '~/k8sTypes';
 import { safeExecute } from '~/utilities/utils';
 
+// TODO: Remove safeExecute usage in https://issues.redhat.com/browse/RHOAIENG-19825
 export const isInstructLabEnabled = (dsc: DataScienceClusterKind | null): boolean =>
   safeExecute(
     () =>

--- a/frontend/src/pages/clusterSettings/utils.ts
+++ b/frontend/src/pages/clusterSettings/utils.ts
@@ -1,9 +1,10 @@
 import { DataScienceClusterKind } from '~/k8sTypes';
 import { safeExecute } from '~/utilities/utils';
 
-// TODO: Remove safeExecute usage in https://issues.redhat.com/browse/RHOAIENG-19825
 export const isInstructLabEnabled = (dsc: DataScienceClusterKind | null): boolean =>
   safeExecute(
+    'Safely checking new DSC DataScienceOperator InstructLab spec field that may not exist in current operator version',
+    'https://issues.redhat.com/browse/RHOAIENG-19825',
     () =>
       dsc?.spec.components?.datasciencepipelines?.managedPipelines.instructLab.state === 'Managed',
     false,

--- a/frontend/src/pages/clusterSettings/utils.ts
+++ b/frontend/src/pages/clusterSettings/utils.ts
@@ -1,4 +1,9 @@
 import { DataScienceClusterKind } from '~/k8sTypes';
+import { safeExecute } from '~/utilities/utils';
 
 export const isInstructLabEnabled = (dsc: DataScienceClusterKind | null): boolean =>
-  dsc?.spec.components?.datasciencepipelines?.managedPipelines.instructLab.state === 'Managed';
+  safeExecute(
+    () =>
+      dsc?.spec.components?.datasciencepipelines?.managedPipelines.instructLab.state === 'Managed',
+    false,
+  );

--- a/frontend/src/utilities/__tests__/utils.spec.ts
+++ b/frontend/src/utilities/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { asEnumMember, enumIterator, isEnumMember } from '~/utilities/utils';
+import { asEnumMember, enumIterator, isEnumMember, safeExecute } from '~/utilities/utils';
 
 enum Test {
   first = '1st',
@@ -103,5 +103,44 @@ describe('enumIterator', () => {
       ['first', 0],
       ['second', 1],
     ]);
+  });
+});
+
+describe('safeExecute', () => {
+  it('should return function result when successful', () => {
+    const result = safeExecute('test', 'test-link', () => 'success', 'default');
+    expect(result).toBe('success');
+  });
+
+  it('should return default value when function throws', () => {
+    const result = safeExecute(
+      'test',
+      'test-link',
+      () => {
+        throw new Error('test error');
+      },
+      'default',
+    );
+    expect(result).toBe('default');
+  });
+
+  it('should log error when function throws', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    safeExecute(
+      'test explanation',
+      'test-link',
+      () => {
+        throw new Error('test error');
+      },
+      'default',
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Development safety wrapper used: test explanation tracking removal in test-link',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
   });
 });

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -195,3 +195,13 @@ export const isInternalRouteIntegrationsApp = (internalRoute?: string): internal
 
 export const isIntegrationApp = (app: OdhApplication): app is OdhIntegrationApplication =>
   isInternalRouteIntegrationsApp(app.spec.internalRoute);
+
+export const safeExecute = <T>(fn: () => T, defaultValue: T): T => {
+  try {
+    return fn();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('An error occurred:', error);
+    return defaultValue;
+  }
+};

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -204,27 +204,27 @@ export const isIntegrationApp = (app: OdhApplication): app is OdhIntegrationAppl
  * before features are released.
  *
  * @param usageExplanation Required explanation of why this temporary safety wrapper is needed
+ * @param removalTrackingLink Required link to issue/ticket tracking removal of this usage
  * @param fn The function to safely execute
  * @param defaultValue Fallback value if execution fails
- * @param removalTrackingLink Required link to issue/ticket tracking removal of this usage
  * @returns The function result or default value
  *
  * @example
  * // Good: Clear explanation of temporary development need with tracking
  * safeExecute(
  *   'Safely checking new DSC spec field that may not exist in current operator version',
+ *   'https://issues.redhat.com/browse/RHOAIENG-####',
  *   () => dsc.spec.newField.value,
  *   false,
- *   'https://issues.redhat.com/browse/RHOAIENG-12345'
  * )
  *
  * @example
  * // Bad: Using as general error handling - use proper error handling instead
  * safeExecute(
  *   'Checking user permissions',
+ *   'https://issues.redhat.com/browse/RHOAIENG-####',
  *   () => user.canEdit,
  *   false,
- *   'https://issues.redhat.com/browse/RHOAIENG-####'
  * )
  */
 export const safeExecute = <T>(

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -197,15 +197,50 @@ export const isIntegrationApp = (app: OdhApplication): app is OdhIntegrationAppl
   isInternalRouteIntegrationsApp(app.spec.internalRoute);
 
 /**
- * DO NOT KEEP USING this  beyond a release.
- * Useful for when we are writing code against fresh devFlag or custom Operator installations. Unreleased backend features.
+ * DO NOT KEEP USING this beyond a release.
+ *
+ * This function is intended ONLY for temporary use during active development against
+ * unreleased backend features or custom operator installations. It should be removed
+ * before features are released.
+ *
+ * @param usageExplanation Required explanation of why this temporary safety wrapper is needed
+ * @param fn The function to safely execute
+ * @param defaultValue Fallback value if execution fails
+ * @param removalTrackingLink Required link to issue/ticket tracking removal of this usage
+ * @returns The function result or default value
+ *
+ * @example
+ * // Good: Clear explanation of temporary development need with tracking
+ * safeExecute(
+ *   'Safely checking new DSC spec field that may not exist in current operator version',
+ *   () => dsc.spec.newField.value,
+ *   false,
+ *   'https://issues.redhat.com/browse/RHOAIENG-12345'
+ * )
+ *
+ * @example
+ * // Bad: Using as general error handling - use proper error handling instead
+ * safeExecute(
+ *   'Checking user permissions',
+ *   () => user.canEdit,
+ *   false,
+ *   'https://issues.redhat.com/browse/RHOAIENG-####'
+ * )
  */
-export const safeExecute = <T>(fn: () => T, defaultValue: T): T => {
+export const safeExecute = <T>(
+  usageExplanation: string,
+  removalTrackingLink: string,
+  fn: () => T,
+  defaultValue: T,
+): T => {
   try {
     return fn();
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error('An error occurred:', error);
+    console.error(
+      `Development safety wrapper used: ${usageExplanation} tracking removal in ${removalTrackingLink}`,
+      error,
+    );
     return defaultValue;
   }
 };

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -222,7 +222,7 @@ export const isIntegrationApp = (app: OdhApplication): app is OdhIntegrationAppl
  * // Bad: Using as general error handling - use proper error handling instead
  * safeExecute(
  *   'Checking user permissions',
- *   'https://issues.redhat.com/browse/RHOAIENG-####',
+ *   'FooBar not a link',
  *   () => user.canEdit,
  *   false,
  * )

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -196,6 +196,10 @@ export const isInternalRouteIntegrationsApp = (internalRoute?: string): internal
 export const isIntegrationApp = (app: OdhApplication): app is OdhIntegrationApplication =>
   isInternalRouteIntegrationsApp(app.spec.internalRoute);
 
+/**
+ * DO NOT KEEP USING this  beyond a release.
+ * Useful for when we are writing code against fresh devFlag or custom Operator installations. Unreleased backend features.
+ */
 export const safeExecute = <T>(fn: () => T, defaultValue: T): T => {
   try {
     return fn();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-19803

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds a safe execute around a new early development feature.
also adds a safe execute helper function to be used

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
without the latest DSC schema, open cluster settings page and see no error

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
should fix e2e tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
