### PR TITLE
Cypress e2e Test - Updates for 'Verify User Can Access Jupyter Launcher From DS Project Page' & 'Verify That Usage Data Collection Can Be Set In Cluster Settings'

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
@@ -81,7 +81,7 @@ class NotebookServer {
   }
 
   findSuccessAlert() {
-    return cy.findByText('Success', { timeout: 120000 });
+    return cy.findByText('Running', { timeout: 120000 });
   }
 
   findNotebookImage(notebook: string) {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testLaunchStandaloneNotebook.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testLaunchStandaloneNotebook.cy.ts
@@ -8,7 +8,7 @@ import {
   deleteNotebook,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/baseCommands';
 
-describe('[Known Bugs: RHOAIENG-19280]Verify a Jupyter Notebook can be launched directly from the Data Science Project List View', () => {
+describe('Verify a Jupyter Notebook can be launched directly from the Data Science Project List View', () => {
   let testData: NotebookImageData;
 
   before(() => {
@@ -23,7 +23,7 @@ describe('[Known Bugs: RHOAIENG-19280]Verify a Jupyter Notebook can be launched 
 
   it(
     'Verify User Can Access Jupyter Launcher From DS Project Page',
-    { tags: ['@Smoke', '@SmokeSet1', '@ODS-1877', '@Dashboard', '@Bug'] },
+    { tags: ['@Smoke', '@SmokeSet1', '@ODS-1877', '@Dashboard'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
@@ -5,7 +5,7 @@ import {
 } from '~/__tests__/cypress/cypress/pages/clusterSettings';
 import { getCustomResource } from '~/__tests__/cypress/cypress/utils/oc_commands/customResources';
 
-describe('[Known Bug: RHOAIENG-18495] Verify That Usage Data Collection Can Be Set In Cluster Settings', () => {
+describe('Verify That Usage Data Collection Can Be Set In Cluster Settings', () => {
   let skipTest = false;
 
   before(() => {
@@ -23,7 +23,7 @@ describe('[Known Bug: RHOAIENG-18495] Verify That Usage Data Collection Can Be S
 
   it(
     'Verify Usage Data Collection can be Enabled/Disabled',
-    { tags: ['@Sanity', '@SanitySet1', '@ODS-1218', '@Dashboard', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1218', '@Dashboard'] },
     () => {
       if (skipTest) {
         cy.log('Skipping test confirmed');

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -88,7 +88,7 @@ export const waitForPodReady = (
 export const deleteNotebook = (
   notebookNameContains: string,
 ): Cypress.Chainable<CommandLineResult> => {
-  const ocCommand = `oc get notebook -A -o custom-columns=":metadata.namespace,:metadata.name" | grep ${notebookNameContains} | xargs -I {} sh -c 'oc delete notebook -n $(echo {} | cut -d " " -f1) $(echo {} | cut -d " " -f2) --ignore-not-found'`;
+  const ocCommand = `oc get notebooks.kubeflow.org -A -o custom-columns=":metadata.namespace,:metadata.name" | grep ${notebookNameContains} | xargs -I {} sh -c 'oc delete notebook.kubeflow.org -n $(echo {} | cut -d " " -f1) $(echo {} | cut -d " " -f2) --ignore-not-found'`;
   cy.log(`Executing: ${ocCommand}`);
 
   return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-19271

## Description
Maintenance required for ODS-1877 due to UI changes & bug fix
Reactivating ODS-1218 after bug fix

## How Has This Been Tested?

- An oc login should be performed in the cluster before running the test

- test-variables.yml should be configured properly

- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml

- Tested against ODH-Nightly & RHOAI nightly

![image](https://github.com/user-attachments/assets/b1e7b74d-696d-4eed-8c5e-591945f4d8a2)

## How to Run
After exporting the test-variables.yml we have 2 different ways:

Using the UI
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress open . This will open the Cypress UI where testLaunchStandaloneNotebook.cy.ts can be run.

Headless
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress run --spec "cypress/tests/e2e/dataScienceProjects/testLaunchStandaloneNotebook.cy.ts" --browser chrome

## Test Impact:

- This is already a test

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`