### PR TITLE
Notebook tolerations box update

### DIFF
--- a/frontend/src/pages/clusterSettings/const.ts
+++ b/frontend/src/pages/clusterSettings/const.ts
@@ -23,6 +23,7 @@ export const DEFAULT_CONFIG: ClusterSettingsType = {
   },
 };
 export const DEFAULT_TOLERATION_VALUE = 'NotebooksOnly';
-export const TOLERATION_FORMAT = /^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/;
+export const TOLERATION_FORMAT =
+  /^(?!\/)([A-Za-z0-9][-A-Za-z0-9_/.]*[A-Za-z0-9]|[A-Za-z0-9])(?<!\/)$/;
 export const TOLERATION_FORMAT_ERROR =
-  "Toleration key must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character.";
+  "Toleration key must consist of alphanumeric characters, '-', '_', '.' or '/', and must start and end with an alphanumeric character.";


### PR DESCRIPTION
Closes: [RHOAIENG-381](https://issues.redhat.com/browse/RHOAIENG-381)

## Description
Small fix to allow ‘ / ‘ characters in the toleration box for notebooks. The error message was also modified to reflect this change. 

- Navigate to settings -> cluster settings
- Scroll to the bottom and check "Add a toleration to notebook pods .... "
- The toleration key box should now allow for ' / ' characters to be used

## How Has This Been Tested?
Tested locally

## Test Impact
No tests changed

## Screenshots
Before:
![Screenshot 2025-02-12 at 9 59 19 AM](https://github.com/user-attachments/assets/a46be22c-785c-4270-bdc2-2289021e5f1e)

After:
![Screenshot 2025-02-12 at 9 58 19 AM](https://github.com/user-attachments/assets/d6f8d7c9-b002-4fdf-b4d6-e21b0158b5b6)
![Screenshot 2025-02-12 at 9 58 47 AM](https://github.com/user-attachments/assets/9bbe859a-280e-416c-9993-e2552cc1d2e0)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
