### PR TITLE
Less strict connection field env variable names

### DIFF
--- a/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
@@ -258,13 +258,14 @@ describe('isValidEnvVar', () => {
     expect(isValidEnvVar('NAME')).toBe(true);
     expect(isValidEnvVar('UNDERSCORE_NAME')).toBe(true);
     expect(isValidEnvVar('has_digits_1234')).toBe(true);
+    expect(isValidEnvVar('.dockerconfigjson')).toBe(true);
   });
 
   it('should be invalid env var', () => {
-    expect(isValidEnvVar('.dot')).toBe(false);
-    expect(isValidEnvVar('has-dash')).toBe(false);
-    expect(isValidEnvVar('1_digit_as_first_char')).toBe(false);
     expect(isValidEnvVar('has space')).toBe(false);
+    expect(isValidEnvVar('has+=')).toBe(false);
+    expect(isValidEnvVar('has!$@#*')).toBe(false);
+    expect(isValidEnvVar('')).toBe(false);
   });
 });
 

--- a/frontend/src/concepts/connectionTypes/fields/UriFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/UriFormField.tsx
@@ -56,7 +56,7 @@ const UriFormField: React.FC<FieldProps<UriField>> = ({
             : (_e, v) => {
                 onChange(v);
                 if (!isValid) {
-                  setIsValid(validateUrl(value));
+                  setIsValid(validateUrl(v));
                 }
               }
         }

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -118,7 +118,7 @@ export const fieldNameToEnvVar = (name: string): string => {
   return allUppercase;
 };
 
-export const ENV_VAR_NAME_REGEX = new RegExp('^[_a-zA-Z][_a-zA-Z0-9]*$');
+export const ENV_VAR_NAME_REGEX = new RegExp('^[-_.a-zA-Z0-9]+$');
 export const isValidEnvVar = (name: string): boolean => ENV_VAR_NAME_REGEX.test(name);
 
 export const isUriConnectionType = (connectionType: ConnectionTypeConfigMapObj): boolean =>

--- a/frontend/src/concepts/connectionTypes/validationUtils.ts
+++ b/frontend/src/concepts/connectionTypes/validationUtils.ts
@@ -5,7 +5,7 @@ import {
   isDuplicateExtension,
 } from '~/concepts/connectionTypes/fields/fieldUtils';
 import { ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
-import { ENV_VAR_NAME_REGEX, isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
+import { isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
 
 const baseFieldSchema = z.object({
   name: z.string().min(1, { message: 'Name is required' }),
@@ -17,10 +17,7 @@ const baseFieldPropertiesSchema = z.object({
 });
 
 const baseDataFieldPropertiesSchema = baseFieldSchema.extend({
-  envVar: z.string().regex(ENV_VAR_NAME_REGEX, {
-    message:
-      'Must start with a letter or underscore. Valid characters include letters, numbers, and underscores ( _ ).',
-  }),
+  envVar: z.string(),
   required: z.boolean().optional(),
 });
 

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -11,11 +11,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
-import {
-  ExclamationCircleIcon,
-  OutlinedQuestionCircleIcon,
-  WarningTriangleIcon,
-} from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import {
   ConnectionTypeDataField,
@@ -81,7 +77,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
 
   const isEnvVarValid = !envVar || isValidEnvVar(envVar);
 
-  const isValid = isPropertiesValid && !!name && !!envVar && isEnvVarValid;
+  const isValid = isPropertiesValid && !!name && !!envVar;
 
   // Cast from specific type to generic type
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-explicit-any
@@ -183,16 +179,16 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
               setData('envVar', value);
             }}
             data-testid="field-env-var-input"
-            validated={!isEnvVarValid ? 'error' : isEnvVarConflict ? 'warning' : 'default'}
+            validated={!isEnvVarValid || isEnvVarConflict ? 'warning' : 'default'}
           />
           <FormHelperText>
             <HelperText>
               <HelperTextItem
-                variant={isEnvVarValid ? 'default' : 'error'}
-                icon={isEnvVarValid ? undefined : <ExclamationCircleIcon />}
+                variant={isEnvVarValid ? 'default' : 'warning'}
+                icon={isEnvVarValid ? undefined : <WarningTriangleIcon />}
               >
-                Must start with a letter or underscore. Valid characters include letters, numbers,
-                and underscores ( _ ).
+                For highest compatibility, field must consist of alphanumeric characters, ( - ), ( _
+                ), or ( . )
               </HelperTextItem>
             </HelperText>
             {isEnvVarConflict ? (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-19860

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This allows setting the env var of connection type fields to match this https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data so this will allow us to use `.dockerconfigjson` as an env var in connections

![image](https://github.com/user-attachments/assets/cb574df5-f113-47a3-9293-e7571638ecc2)

![image](https://github.com/user-attachments/assets/843e0458-3652-49eb-9319-7a5553d4b446)

![image](https://github.com/user-attachments/assets/11b712ab-d593-4f5f-a150-db53c32866a3)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create / edit connection type
2. add a new field named `.dockerconfigjson` and save
3. go to project and create a connection with that field

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Update jest validation tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@simrandhaliw 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
