### PR TITLE
Create a connection with secret type 'kubernetes.io/dockerconfigjson'

### DIFF
--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -267,6 +267,8 @@ export const assembleConnectionSecret = (
     (t) => modelServingCompatibleTypesMetadata[t].managedType,
   )[0];
 
+  const isPullSecret = !!values['.dockerconfigjson'];
+
   return {
     apiVersion: 'v1',
     kind: 'Secret',
@@ -285,6 +287,7 @@ export const assembleConnectionSecret = (
       },
     },
     stringData: connectionValuesAsStrings,
+    ...(isPullSecret && { type: 'kubernetes.io/dockerconfigjson' }),
   };
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-19053

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a connection, checks if there is stuff in the .dockerconfigfile, and instead of an "Opaque" secret it will be "kubeneties.io/dockerconfigjson"

![Screenshot From 2025-02-12 16-31-04](https://github.com/user-attachments/assets/8f3b2dd0-15af-4fca-b103-804efd2cab5a)

![Screenshot From 2025-02-12 16-37-18](https://github.com/user-attachments/assets/c42409ff-b9f3-4236-a9c1-287b784f7854)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  Create / edit connection type
-  add a new field named .dockerconfigjson and save
-  go to project and create a connection
-  upload a file for the .dockerconfigjson field and submit
-  check the created secret in openshift console has type "kubeneties.io/dockerconfigjson"

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Cypress test added for flow

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
