### PR TITLE
Model registry name truncation

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelRegistrySelector.tsx
@@ -12,6 +12,7 @@ import {
   Popover,
   PopoverPosition,
   Tooltip,
+  Truncate,
 } from '@patternfly/react-core';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 import truncateStyles from '@patternfly/react-styles/css/components/Truncate/truncate';
@@ -155,7 +156,11 @@ const ModelRegistrySelector: React.FC<ModelRegistrySelectorProps> = ({
             aria-label="Model registry description popover"
             data-testid="mr-details-popover"
             position="right"
-            headerContent={`${getDisplayNameFromK8sResource(selection)} details`}
+            headerContent={
+              // FIXME 'Truncate' can be removed once PF bug is resolved
+              // https://github.com/patternfly/patternfly/issues/7340
+              <Truncate content={`${getDisplayNameFromK8sResource(selection)} details`} />
+            }
             bodyContent={
               <DescriptionList>
                 <DescriptionListGroup>


### PR DESCRIPTION
Closes: [RHOAIENG-16089](https://issues.redhat.com/browse/RHOAIENG-16089)

## Description
When creating a model registry with one long string for a name, the name will exceed past the popover box. Currently this is a bug in PatternFly (https://github.com/patternfly/patternfly/issues/7340). For now, I've implemented a workaround by truncating the name.

## How Has This Been Tested?
Tested locally

- In settings under Model Registry, create a model with a very long name, specifically just one long string.
- Go back to the Model Registry tab and in the top, click 'View details' by your model registry. 
- The name should now truncate, and you should be able to hover to see the full name. 

## Test Impact
No tests changed

## Screenshots 
Before:
<img width="313" alt="Screenshot 2025-02-13 at 10 12 07 AM" src="https://github.com/user-attachments/assets/cfb8992a-7947-442c-8e01-d39b93ff3b21" />

After:
<img width="268" alt="Screenshot 2025-02-13 at 11 47 21 AM" src="https://github.com/user-attachments/assets/f2520a3c-b3e4-4fef-a4cd-af252ea68dbf" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
