### PR TITLE
Patch DSC when Admin changes Default Deployment Mode

### DIFF
--- a/frontend/src/__mocks__/mockDsc.ts
+++ b/frontend/src/__mocks__/mockDsc.ts
@@ -27,6 +27,22 @@ export const mockDsc = ({
           },
         },
       },
+      kserve: {
+        defaultDeploymentMode: 'Severless',
+        managementState: 'Managed',
+        nim: {
+          managementState: 'Managed',
+        },
+        serving: {
+          ingressGateway: {
+            certificate: {
+              type: 'OpenshiftDefaultIngress',
+            },
+          },
+          managementState: 'Managed',
+          name: 'knative-serving',
+        },
+      },
     },
   },
   status: {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
@@ -129,7 +129,7 @@ describe('Cluster Settings', () => {
     instructLabSettings.findSubmitButton().should('be.disabled');
   });
 
-  it('View KServe defaultDeploymentMode', () => {
+  it('View and Patch KServe defaultDeploymentMode', () => {
     cy.interceptOdh(
       'GET /api/config',
       mockDashboardConfig({
@@ -144,6 +144,7 @@ describe('Cluster Settings', () => {
       }),
     );
     cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));
+    cy.interceptK8s('PATCH', DataScienceClusterModel, mockDsc({}));
 
     clusterSettings.visit();
 
@@ -159,5 +160,24 @@ describe('Cluster Settings', () => {
       .findSinglePlatformDeploymentModeSelect()
       .findSelectOption('Advanced (Serverless and Service Mesh)')
       .should('have.attr', 'aria-selected', 'false');
+
+    modelServingSettings.findSubmitButton().should('be.disabled');
+    modelServingSettings
+      .findSinglePlatformDeploymentModeSelect()
+      .findSelectOption('Advanced (Serverless and Service Mesh)')
+      .click();
+
+    modelServingSettings.findSubmitButton().should('be.enabled');
+    modelServingSettings.findSubmitButton().click();
+    modelServingSettings.findSubmitButton().should('be.disabled');
+
+    modelServingSettings
+      .findSinglePlatformDeploymentModeSelect()
+      .findSelectOption('Standard (No additional dependencies)')
+      .should('have.attr', 'aria-selected', 'false');
+    modelServingSettings
+      .findSinglePlatformDeploymentModeSelect()
+      .findSelectOption('Advanced (Serverless and Service Mesh)')
+      .should('have.attr', 'aria-selected', 'true');
   });
 });

--- a/frontend/src/api/k8s/dsc.ts
+++ b/frontend/src/api/k8s/dsc.ts
@@ -1,5 +1,5 @@
 import { k8sListResource, k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { DataScienceClusterKind } from '~/k8sTypes';
+import { DataScienceClusterKind, DeploymentMode } from '~/k8sTypes';
 import { DataScienceClusterModel } from '~/api/models';
 
 export const listDataScienceClusters = (): Promise<DataScienceClusterKind[]> =>
@@ -19,6 +19,22 @@ export const toggleInstructLabState = (
         op: 'replace',
         path: '/spec/components/datasciencepipelines/managedPipelines/instructLab/state',
         value: instructLabState,
+      },
+    ],
+  });
+
+export const patchDefaultDeploymentMode = (
+  deploymentMode: DeploymentMode,
+  dscName: string,
+): Promise<DataScienceClusterKind> =>
+  k8sPatchResource<DataScienceClusterKind>({
+    model: DataScienceClusterModel,
+    queryOptions: { name: dscName },
+    patches: [
+      {
+        op: 'replace',
+        path: '/spec/components/kserve/defaultDeploymentMode',
+        value: deploymentMode,
       },
     ],
   });

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1282,6 +1282,7 @@ export type DataScienceClusterKind = K8sResourceCommon & {
         managementState: string;
       };
       kserve?: {
+        defaultDeploymentMode: string;
         managementState: string;
         nim: {
           managementState: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16492
## Description
Adds the ability for odh admins and cluster admins to edit the cluster settings dropdown for KServe raw which changes the default deployment mode between RawDeployment (Standard) and Serverless (Advanced).
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Logging in as both privileged and unprivileged users to ensure cluster settings are unavailable.

Updating the setting and saving
Make sure DSC gets updated properly
Updating should work if `defaultDeploymentMode` is present or not present
After save, the button should be disabled
Reload after a few minutes should reflect proper change

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
There's already a test `View KServe defaultDeploymentMode` for default deployment mode. Not sure if we want to expand the testing here. @emilys314 thoughts?
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
