### PR TITLE
Enhancement to ODS-1218 'Verify That Usage Data Collection Can Be Set In Cluster Settings'

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts
@@ -52,6 +52,19 @@ describe('Verify That Usage Data Collection Can Be Set In Cluster Settings', () 
       cy.step('Refresh settings view');
       cy.reload();
       telemetrySettings.findEnabledCheckbox().should('not.be.checked');
+
+      // Re-enable data usage collection
+      cy.step('re-enable usage data collection');
+      telemetrySettings.findEnabledCheckbox().click();
+
+      // Save changes in cluster settings
+      cy.step('Save changes and wait for changes to be applied');
+      clusterSettings.findSubmitButton().click();
+
+      // Refresh and verify data collection is re-enabled
+      cy.step('Refresh settings view');
+      cy.reload();
+      telemetrySettings.findEnabledCheckbox().should('be.checked');
     },
   );
 });


### PR DESCRIPTION
## Description
Enhancement for test ODS-1218 to improve the scenario for when a cluster is not torn down

## How Has This Been Tested?

- An oc login should be performed in the cluster before running the test

- test-variables.yml should be configured properly

- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml

- Tested against ODH-Nightly & RHOAI nightly

![image](https://github.com/user-attachments/assets/523c1d2b-139b-47be-91b6-f1b6d7234140)

## How to Run
After exporting the test-variables.yml we have 2 different ways:

Using the UI
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress open . This will open the Cypress UI where testDataCollection.cy.ts can be run.

Headless
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress run --spec "cypress/tests/e2e/settings/clusterSettings/testDataCollection.cy.ts --browser chrome

## Test Impact:

- This is already a test

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`