### PR TITLE
DOMPurify CVE fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "axios": "^1.6.4",
         "classnames": "^2.2.6",
         "compare-versions": "^3.6.0",
-        "dompurify": "^2.2.6",
+        "dompurify": "^3.2.4",
         "google-protobuf": "^3.11.2",
         "grpc-web": "^1.2.1",
         "lodash-es": "^4.17.15",
@@ -4000,11 +4000,6 @@
         "showdown": ">=2.1.0"
       }
     },
-    "node_modules/@patternfly/quickstarts/node_modules/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-AMdOzK44oFWqHEi0wpOqix/fUNY707OmoeFDnbi3Q5I8uOpy21ufUA5cDJPr0bosxrflOVD/H2DMSvuGKJGfmQ=="
-    },
     "node_modules/@patternfly/react-catalog-view-extension": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-6.0.0.tgz",
@@ -5852,7 +5847,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -9984,9 +9979,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
-      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "2.8.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,7 @@
     "axios": "^1.6.4",
     "classnames": "^2.2.6",
     "compare-versions": "^3.6.0",
-    "dompurify": "^2.2.6",
+    "dompurify": "^3.2.4",
     "google-protobuf": "^3.11.2",
     "grpc-web": "^1.2.1",
     "lodash-es": "^4.17.15",
@@ -237,6 +237,7 @@
     "@patternfly/quickstarts": {
       "@patternfly/react-core": "^6.0.0"
     },
-    "ws": "^8.17.1"
+    "ws": "^8.17.1",
+    "dompurify": "^3.2.4"
   }
 }

--- a/frontend/src/utilities/markdown.ts
+++ b/frontend/src/utilities/markdown.ts
@@ -14,7 +14,11 @@ export const markdownConverter = {
     // add hook to transform anchor tags
     DOMPurify.addHook('beforeSanitizeElements', (node) => {
       // nodeType 1 = element type
-      if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'a') {
+      if (
+        node instanceof HTMLElement &&
+        node.nodeType === 1 &&
+        node.nodeName.toLowerCase() === 'a'
+      ) {
         node.setAttribute('rel', 'noopener noreferrer');
       }
     });


### PR DESCRIPTION
[RHOAIENG-20371](https://issues.redhat.com/browse/RHOAIENG-20371)

## Description
Upgraded the `dompurify` package to version 3.2.4 to address the CVE. Updated the code accordingly to accommodate the package upgrade. Since the package is also used as a sub-package, added an override as well.

## How Has This Been Tested?
Check the npm audit in the frontend, no vulnerabilities should be listed.
Also, review the markdown view in the dashboard, as it is directly affected by this change.

## Test Impact
No changes required, just verify that the existing `markdown.spec.ts` tests pass.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
