### PR TITLE
Cypress e2e - Workbenches (new e2e tests) and unquarantine existing tests 

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml
@@ -1,0 +1,2 @@
+# testWorkbenchNegativeTests.cy.ts Test Data #
+  wbNegativeTestNamespace: 'dsp-wb-negative-test'

--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml
@@ -1,2 +1,33 @@
 # testWorkbenchNegativeTests.cy.ts Test Data #
   wbNegativeTestNamespace: 'dsp-wb-negative-test'
+  invalidResourceNames:
+  - Test-workbench
+  - test workbench
+  - test.workbench
+  - test:workbench
+  - test/workbench
+  - test"workbench
+  - test[workbench]
+  - test(workbench)
+  - test&workbench
+  - test*workbench
+  - test?workbench
+  - largeworkbenchnametestthatshouldnotwork
+  - Test-workbench-Invalid
+  - test workbench with spaces
+  - test.workbench.with.dots
+  - test:workbench:with:colons
+  - test/workbench/with/slashes
+  - test"workbench"with"quotes
+  - test[workbench]with[brackets]
+  - test(workbench)with(parentheses)
+  - test&workbench&with&ampersands
+  - test*workbench*with*asterisks
+  - test?workbench?with?questions
+  - -testworkbenchstartshyphen
+  - testworkbenchendswithhyphen-
+  - TestworkbenchUpperCase
+  - $testworkbenchspecialstart
+  - ^testworkbenchspecialstart
+  - (testworkbench)parentheses
+  - testworkbenchtoooooooooooooooooooooooooooooooooooooooooooooooooooolong

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -314,6 +314,14 @@ class CreateSpawnerPage {
     return cy.findByTestId('workbench-name');
   }
 
+  getEditResourceLink() {
+    return cy.findByTestId('workbench-editResourceLink');
+  }
+
+  getResourceInput() {
+    return cy.findByTestId('workbench-resourceName');
+  }
+
   getDescriptionInput() {
     return cy.findByTestId('workbench-description');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
@@ -2,7 +2,7 @@ import * as yaml from 'js-yaml';
 import { isUrlExcluded } from '~/__tests__/cypress/cypress/utils/urlExtractor';
 import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Known Bug: RHOAIENG-9235] Verify that all the URLs referenced in the Manifest directory are operational', () => {
+describe('[Product bugs: RHOAIENG-9365,RHOAIENG-9187,RHOAIENG-16956, RHOAIENG-16959] Verify that all the URLs referenced in the Manifest directory are operational', () => {
   let excludedSubstrings: string[];
 
   // Setup: Load test data

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
@@ -16,7 +16,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Automation Bug RHOAIENG-20128] Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
+describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
   let controlSuiteTestNamespace: string;
   let controlSuiteTestDescription: string;
 
@@ -53,7 +53,7 @@ describe('[Automation Bug RHOAIENG-20128] Start, Stop, Launch and Delete a Workb
   it(
     'Starting, Stopping, Launching and Deleting a Workbench',
     {
-      tags: ['@Sanity', '@SanitySet2', '@ODS-1818', '@ODS-1823', '@ODS-1975', '@Dashboard', '@Bug'],
+      tags: ['@Sanity', '@SanitySet2', '@ODS-1818', '@ODS-1823', '@ODS-1975', '@Dashboard', '@Workbenches'],
     },
     () => {
       const workbenchName = controlSuiteTestNamespace.replace('dsp-', '');
@@ -109,7 +109,7 @@ describe('[Automation Bug RHOAIENG-20128] Start, Stop, Launch and Delete a Workb
   it(
     'Verify that a Workbench can be started and stopped using the Event log controls',
     {
-      tags: ['@Sanity', '@SanitySet2', '@ODS-1818', '@ODS-1823', '@ODS-1975', '@Dashboard', '@Bug'],
+      tags: ['@Sanity', '@SanitySet2', '@ODS-1818', '@ODS-1823', '@ODS-1975', '@Dashboard', '@Workbenches'],
     },
     () => {
       const workbenchName = controlSuiteTestNamespace.replace('dsp-', 'secondwb-');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
@@ -53,7 +53,15 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
   it(
     'Starting, Stopping, Launching and Deleting a Workbench',
     {
-      tags: ['@Sanity', '@SanitySet2', '@ODS-1818', '@ODS-1823', '@ODS-1975', '@Dashboard', '@Workbenches'],
+      tags: [
+        '@Sanity',
+        '@SanitySet2',
+        '@ODS-1818',
+        '@ODS-1823',
+        '@ODS-1975',
+        '@Dashboard',
+        '@Workbenches',
+      ],
     },
     () => {
       const workbenchName = controlSuiteTestNamespace.replace('dsp-', '');
@@ -109,7 +117,15 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
   it(
     'Verify that a Workbench can be started and stopped using the Event log controls',
     {
-      tags: ['@Sanity', '@SanitySet2', '@ODS-1818', '@ODS-1823', '@ODS-1975', '@Dashboard', '@Workbenches'],
+      tags: [
+        '@Sanity',
+        '@SanitySet2',
+        '@ODS-1818',
+        '@ODS-1823',
+        '@ODS-1975',
+        '@Dashboard',
+        '@Workbenches',
+      ],
     },
     () => {
       const workbenchName = controlSuiteTestNamespace.replace('dsp-', 'secondwb-');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchEditing.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchEditing.cy.ts
@@ -15,7 +15,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Automation Bug RHOAIENG-20128] Edit and Update a Workbench in RHOAI', () => {
+describe('Edit and Update a Workbench in RHOAI', () => {
   let editTestNamespace: string;
   let editedTestNamespace: string;
   let editedTestDescription: string;
@@ -53,7 +53,7 @@ describe('[Automation Bug RHOAIENG-20128] Edit and Update a Workbench in RHOAI',
 
   it(
     'Editing Workbench Name and Description',
-    { tags: ['@Sanity', '@SanitySet1', '@ODS-1931', '@Dashboard', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1931', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = editTestNamespace.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
@@ -1,0 +1,84 @@
+import type { WBNegativeTestsData } from '~/__tests__/cypress/cypress/types';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import {
+  workbenchPage,
+  createSpawnerPage,
+  workbenchStatusModal,
+} from '~/__tests__/cypress/cypress/pages/workbench';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import { loadWBNegativeTestsFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
+import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
+import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
+import {
+  retryableBefore,
+  wasSetupPerformed,
+} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+
+describe('Workbenches - negative tests', () => {
+  let projectName: string;
+
+  // Setup: Load test data and ensure clean state
+  retryableBefore(() => {
+    return loadWBNegativeTestsFixture('e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml')
+      .then((fixtureData: WBNegativeTestsData) => {
+        projectName = fixtureData.wbNegativeTestNamespace;
+
+        if (!projectName) {
+          throw new Error('Project name is undefined or empty in the loaded fixture');
+        }
+        cy.log(`Loaded project name: ${projectName}`);
+        return createCleanProject(projectName);
+      })
+      .then(() => {
+        cy.log(`Project ${projectName} confirmed to be created and verified successfully`);
+      });
+  });
+
+  after(() => {
+    //Check if the Before Method was executed to perform the setup
+    if (!wasSetupPerformed()) return;
+
+    // Delete provisioned Project
+    if (projectName) {
+      cy.log(`Deleting Project ${projectName} after the test has finished.`);
+      deleteOpenShiftProject(projectName);
+    }
+  });
+
+  it(
+    'Verify UI informs users about workbenches failed to start',
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches'] },
+    () => {
+      const workbenchName = projectName.replace('dsp-', '');
+
+      // Authentication and navigation
+      cy.step('Log into the application');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      // Project navigation and select workbenches
+      cy.step(`Navigate to workbenches tab of Project ${projectName}`);
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+      projectDetails.findSectionTab('workbenches').click();
+
+      // Create workbench
+      cy.step(`Create workbench ${workbenchName}`);
+      workbenchPage.findCreateButton().click();
+      createSpawnerPage.getNameInput().fill(workbenchName);
+      createSpawnerPage.findNotebookImage('code-server-notebook').click();
+      createSpawnerPage.findContainerSizeInput('Small').click();
+      cy.contains('X Large').click();
+
+      createSpawnerPage.findSubmitButton().click();
+
+      // Confirm that the Workbench does not start
+      cy.step(`Wait for workbench ${workbenchName} to display a "Failed" status`);
+      const notebookRow = workbenchPage.getNotebookRow(workbenchName);
+      notebookRow.expectStatusLabelToBe('Failed', 120000);
+
+      notebookRow.findHaveNotebookStatusText().click();
+      workbenchStatusModal.getNotebookStatus('Failed');
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
@@ -1,3 +1,4 @@
+import yaml from 'js-yaml';
 import type { WBNegativeTestsData } from '~/__tests__/cypress/cypress/types';
 import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
@@ -6,22 +7,24 @@ import {
   workbenchStatusModal,
 } from '~/__tests__/cypress/cypress/pages/workbench';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { loadWBNegativeTestsFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import {
-  retryableBefore,
+  retryableBeforeEach,
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
 describe('Workbenches - negative tests', () => {
+  let testData: WBNegativeTestsData;
   let projectName: string;
 
   // Setup: Load test data and ensure clean state
-  retryableBefore(() => {
-    return loadWBNegativeTestsFixture('e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml')
-      .then((fixtureData: WBNegativeTestsData) => {
-        projectName = fixtureData.wbNegativeTestNamespace;
+  retryableBeforeEach(() => {
+    return cy
+      .fixture('e2e/dataScienceProjects/testWorkbenchNegativeTests.yaml', 'utf8')
+      .then((yamlContent: string) => {
+        testData = yaml.load(yamlContent) as WBNegativeTestsData;
+        projectName = testData.wbNegativeTestNamespace;
 
         if (!projectName) {
           throw new Error('Project name is undefined or empty in the loaded fixture');
@@ -69,16 +72,54 @@ describe('Workbenches - negative tests', () => {
       createSpawnerPage.findNotebookImage('code-server-notebook').click();
       createSpawnerPage.findContainerSizeInput('Small').click();
       cy.contains('X Large').click();
-
       createSpawnerPage.findSubmitButton().click();
 
-      // Confirm that the Workbench does not start
+      // Confirm that the Workbench does not start and is at Failed status
       cy.step(`Wait for workbench ${workbenchName} to display a "Failed" status`);
       const notebookRow = workbenchPage.getNotebookRow(workbenchName);
       notebookRow.expectStatusLabelToBe('Failed', 120000);
-
+      cy.step(`Open the Modal and confirm the status is Failed`);
       notebookRow.findHaveNotebookStatusText().click();
       workbenchStatusModal.getNotebookStatus('Failed');
+    },
+  );
+  it(
+    'Verify User cannot create a workbench using special characters or long names in the Resource name field',
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches'] },
+    () => {
+      const workbenchName = projectName.replace('dsp-', '');
+
+      // Authentication and navigation
+      cy.step('Log into the application');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      // Project navigation and select workbenches
+      cy.step(`Navigate to workbenches tab of Project ${projectName}`);
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+      projectDetails.findSectionTab('workbenches').click();
+
+      // Create workbench
+      cy.step(`Create workbench ${workbenchName}`);
+      workbenchPage.findCreateButton().click();
+      createSpawnerPage.getNameInput().fill(workbenchName);
+      createSpawnerPage.findNotebookImage('code-server-notebook').click();
+      createSpawnerPage.getEditResourceLink().click();
+
+      // Test each invalid resource name
+      cy.step('Test invalid resource name and verify that project creation is prevented');
+
+      testData.invalidResourceNames.forEach((invalidResourceName) => {
+        cy.log(`Testing invalid resource name: ${invalidResourceName}`);
+
+        // Clear input, type invalid resource name, and validate behavior
+        createSpawnerPage.getResourceInput().clear().type(invalidResourceName);
+        createSpawnerPage.getResourceInput().should('have.attr', 'aria-invalid', 'true');
+        createSpawnerPage.findSubmitButton().should('be.disabled');
+        // Log success message for invalid resources names being rejected
+        cy.log(`✅ ${invalidResourceName}: not authorised as a Resource Name`);
+      });
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
@@ -14,7 +14,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Automation Bug RHOAIENG-20128] Workbenches - status tests', () => {
+describe('Workbenches - status tests', () => {
   let projectName: string;
   let projectDescription: string;
 
@@ -49,7 +49,7 @@ describe('[Automation Bug RHOAIENG-20128] Workbenches - status tests', () => {
 
   it(
     'Verify user can access progress and event log - validate status and successful workbench creation',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1970', '@Dashboard', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1970', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchTolerations.cy.ts
@@ -25,7 +25,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Automation bug RHOAIENG-20099] Workbenches - tolerations tests', () => {
+describe('[Automation Bug RHOAIENG-20099] Workbenches - tolerations tests', () => {
   let testData: WBTolerationsTestData;
   let projectName: string;
   let projectDescription: string;

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -7,17 +7,17 @@ import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChe
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { validateWorkbenchEnvironmentVariables } from '~/__tests__/cypress/cypress/utils/oc_commands/workbench';
 import {
-  retryableBefore,
+  retryableBeforeEach,
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Automation Bug RHOAIENG-20128] Workbenches - variable tests', () => {
+describe('Workbenches - variable tests', () => {
   let projectName: string;
   let projectDescription: string;
   let testData: WBVariablesTestData;
 
   // Setup: Load test data and ensure clean state
-  retryableBefore(() => {
+  retryableBeforeEach(() => {
     return loadWBVariablesFixture('e2e/dataScienceProjects/testWorkbenchVariables.yaml')
       .then((fixtureData: WBVariablesTestData) => {
         testData = fixtureData;
@@ -46,7 +46,7 @@ describe('[Automation Bug RHOAIENG-20128] Workbenches - variable tests', () => {
   });
   it(
     'Verify user can set environment variables in their workbenches by uploading a yaml Secret and Config Map file.',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = projectName;
       const workbenchName2 = projectName.replace('dsp-', 'secondwb-');
@@ -122,7 +122,7 @@ describe('[Automation Bug RHOAIENG-20128] Workbenches - variable tests', () => {
   );
   it(
     'Verify that the user can inject environment variables manually into a workbench using Key / Value',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = projectName;
       const workbenchName2 = projectName.replace('dsp-', 'secondwb-');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/learningResources/testCustomResourceCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/learningResources/testCustomResourceCreation.cy.ts
@@ -13,7 +13,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Known Product Bug: RHOAIENG-5317]Create a custom resource Quickstart by using Dashboard CRDs', () => {
+describe('[Product Bug: RHOAIENG-5317]Create a custom resource Quickstart by using Dashboard CRDs', () => {
   let resourcesData: ResourcesData;
   let resourceNames: ReturnType<typeof getResourceValues>;
 

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -125,9 +125,7 @@ export type WBStatusTestData = {
 
 export type WBNegativeTestsData = {
   wbNegativeTestNamespace: string;
-  pvcNegativeTestName: string;
-  pvcNegativeTestDisplayName: string;
-  pvcNegativeSize: string;
+  invalidResourceNames: string[];
 };
 
 export type CommandLineResult = {

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -123,6 +123,13 @@ export type WBStatusTestData = {
   wbStatusTestDescription: string;
 };
 
+export type WBNegativeTestsData = {
+  wbNegativeTestNamespace: string;
+  pvcNegativeTestName: string;
+  pvcNegativeTestDisplayName: string;
+  pvcNegativeSize: string;
+};
+
 export type CommandLineResult = {
   code: number;
   stdout: string;

--- a/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
@@ -9,7 +9,6 @@ import type {
   WBStatusTestData,
   OOTBConnectionTypesData,
   WBTolerationsTestData,
-  WBNegativeTestsData,
 } from '~/__tests__/cypress/cypress/types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -84,16 +83,6 @@ export const loadWBTolerationsFixture = (
 ): Cypress.Chainable<WBTolerationsTestData> => {
   return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBTolerationsTestData;
-
-    return data;
-  });
-};
-
-export const loadWBNegativeTestsFixture = (
-  fixturePath: string,
-): Cypress.Chainable<WBNegativeTestsData> => {
-  return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
-    const data = yaml.load(yamlContent) as WBNegativeTestsData;
 
     return data;
   });

--- a/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
@@ -9,6 +9,7 @@ import type {
   WBStatusTestData,
   OOTBConnectionTypesData,
   WBTolerationsTestData,
+  WBNegativeTestsData,
 } from '~/__tests__/cypress/cypress/types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -83,6 +84,16 @@ export const loadWBTolerationsFixture = (
 ): Cypress.Chainable<WBTolerationsTestData> => {
   return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBTolerationsTestData;
+
+    return data;
+  });
+};
+
+export const loadWBNegativeTestsFixture = (
+  fixturePath: string,
+): Cypress.Chainable<WBNegativeTestsData> => {
+  return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
+    const data = yaml.load(yamlContent) as WBNegativeTestsData;
 
     return data;
   });

--- a/frontend/src/__tests__/cypress/cypress/utils/retryableHooks.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/retryableHooks.ts
@@ -1,5 +1,5 @@
 /**
- * Ensures that the provided setup logic in the `before` block is re-executed on test retries.
+ * Ensures that the provided setup logic in the `before` and 'beforeEach' block is re-executed on test retries.
  * This utility modifies the behavior of Cypress's `beforeEach` hook to conditionally run the setup
  * logic only when necessary (e.g., on test retries after a failure).
  *
@@ -13,6 +13,25 @@ export const retryableBefore = <T>(fn: () => void | Promise<void> | Cypress.Chai
   beforeEach(function retryableBeforeEach() {
     if (this.currentTest?.isPending() || !shouldRun) return;
     shouldRun = false;
+    setupPerformed = true;
+    cy.wrap(null).then(fn);
+  });
+
+  Cypress.on('test:after:run', (result) => {
+    if (result.state === 'failed' && result.currentRetry < result.retries) {
+      shouldRun = true;
+    }
+  });
+};
+
+export const retryableBeforeEach = <T>(
+  fn: () => void | Promise<void> | Cypress.Chainable<T>,
+): void => {
+  let shouldRun = true;
+
+  beforeEach(function retryableBeforeEachHook() {
+    if (this.currentTest?.isPending() || !shouldRun) return;
+    shouldRun = true;
     setupPerformed = true;
     cy.wrap(null).then(fn);
   });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-20128
https://issues.redhat.com/browse/RHOAIENG-17421

## Description
- Migrate ODS-1973 to Cypress
- Created a new test also that validates that Workbenches cannot be created using invalid resources 
- Removes a number of tests from quarantine and corrected some titles

## How Has This Been Tested?
- An oc login should be performed in the cluster before running the test
- test-variables.yml should be configured properly
- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml
- Locally against a PSI cluster and ODH-Nightly also on Jenkins cypress/job/dashboard-tests/619/ 
![image](https://github.com/user-attachments/assets/86807811-f73b-46d3-b7a9-a4961687f8d8)
![image](https://github.com/user-attachments/assets/b6f37705-0ed0-4fb5-baf0-394cb263f754)
![image](https://github.com/user-attachments/assets/46cefec6-2808-4d9e-a633-ca2712e7e870)

## Test Impact
- None - this is a test

## How to run?
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress open . This will open the Cypress UI where the various workbenches tests can be run.

or Execute 'npx cypress run --env grepTags=@Workbenches --browser chrome'

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
