### PR TITLE
Make model customization side drawer inline

### DIFF
--- a/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomization.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomization.tsx
@@ -55,7 +55,7 @@ const ModelCustomization: React.FC = () => {
   };
 
   return (
-    <Drawer isExpanded={isDrawerExpanded} data-testid="drawer-model-customization">
+    <Drawer isExpanded={isDrawerExpanded} data-testid="drawer-model-customization" isInline>
       <DrawerContent
         panelContent={
           <ModelCustomizationDrawerContent


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-20338](https://issues.redhat.com/browse/RHOAIENG-20338)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Easy one-liner. Make the Drawer inline so the drawer content can push the page content to the side when it's open instead of covering the content.

<img width="1512" alt="Screenshot 2025-02-24 at 2 49 58 PM" src="https://github.com/user-attachments/assets/5e76355c-851d-4610-97d4-73e05d108643" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the model customization page, expand the taxonomy section, and click on "Learn more", see how the drawer pushes the content to the side.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
