### PR TITLE
Add optional flag to Elyra volume secret configuration

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -86,7 +86,7 @@ describe('assembleNotebook', () => {
     expect(result.kind).toBe('Notebook');
     expect(result.spec.template.spec.volumes).toStrictEqual([
       { name: 'test-volume', persistentVolumeClaim: { claimName: 'test-volume' } },
-      { name: ELYRA_VOLUME_NAME, secret: { secretName: 'ds-pipeline-config' } },
+      { name: ELYRA_VOLUME_NAME, secret: { secretName: 'ds-pipeline-config', optional: true } },
       { emptyDir: { medium: 'Memory' }, name: 'shm' },
     ]);
     expect(result.spec.template.spec.containers[0].volumeMounts).toStrictEqual([
@@ -109,7 +109,7 @@ describe('assembleNotebook', () => {
 
     expect(result.spec.template.spec.volumes).toStrictEqual([
       { name: 'shm', persistentVolumeClaim: { claimName: 'shm' } },
-      { name: 'elyra-dsp-details', secret: { secretName: 'ds-pipeline-config' } },
+      { name: 'elyra-dsp-details', secret: { secretName: 'ds-pipeline-config', optional: true } },
     ]);
     expect(result.spec.template.spec.containers[0].volumeMounts).toStrictEqual([
       { mountPath: '/opt/app-root/src/data', name: 'shm' },

--- a/frontend/src/concepts/pipelines/elyra/utils.ts
+++ b/frontend/src/concepts/pipelines/elyra/utils.ts
@@ -42,6 +42,7 @@ export const getElyraVolume = (): Volume => ({
   name: ELYRA_VOLUME_NAME,
   secret: {
     secretName: ELYRA_SECRET_NAME,
+    optional: true,
   },
 });
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -553,6 +553,7 @@ export type Volume = {
   };
   secret?: {
     secretName: string;
+    optional?: boolean;
   };
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-19973

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
adds optional to volume for elrya secret in notebooks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create pipeline server
2. make sure elrya secret is created: `ds-pipeline-config`
3. create a workbench in same project
4. ensure elrya secret volume is added to notebook
5. delete pipeline server and make sure elrya secret is removed
6. make sure that workbench can still be started

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
non, k8s notebook spec change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
