### PR TITLE
Make quickstart functionality available outside cards

### DIFF
--- a/frontend/src/utilities/useQuickStart.ts
+++ b/frontend/src/utilities/useQuickStart.ts
@@ -1,0 +1,24 @@
+import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
+import * as React from 'react';
+import { launchQuickStart as launchQuickStartUtil } from './quickStartUtils';
+
+type UseQuickStartResult = {
+  launchQuickStart: (quickStartId: string) => void;
+  qsContext: QuickStartContextValues;
+};
+
+export const useQuickStart = (): UseQuickStartResult => {
+  const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
+
+  const launchQuickStart = React.useCallback(
+    (quickStartId: string) => {
+      launchQuickStartUtil(quickStartId, qsContext);
+    },
+    [qsContext],
+  );
+
+  return {
+    launchQuickStart,
+    qsContext,
+  };
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-20532

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR adds a `useQuickStart` hook that extracts the quickstart launch functionality from cards into a reusable hook. This allows any component to trigger quickstarts without being tied to card components.

Key changes:
- Adds new `useQuickStart` hook that provides:
  - `launchQuickStart` method to trigger quickstarts
  - Access to quickstart context values
- Uses existing `launchQuickStartUtil` under the hood
- Small, focused change to improve reusability
- No changes to existing quickstart behavior

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to any component that needs quickstart functionality
2. Add the hook:
   ```typescript
   const { launchQuickStart } = useQuickStart();
   ```
3. Add a trigger (e.g. button):
   ```typescript
   <Button onClick={() => launchQuickStart('create-jupyter-notebook')}>
     Launch Tutorial
   </Button>
   ```
4. Verify the quickstart launches and works as expected
5. Verify it works the same as the existing card-based quickstart launches

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none, just extracts functionality into hook

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
