### PR TITLE
feat(serving): add "Model URI" field to deployment modal

### DIFF
--- a/frontend/src/__mocks__/mockConnectionType.ts
+++ b/frontend/src/__mocks__/mockConnectionType.ts
@@ -569,3 +569,39 @@ export const mockModelServingFields: ConnectionTypeField[] = [
     properties: {},
   },
 ];
+
+export const mockOciConnectionType = (): ConnectionTypeConfigMapObj =>
+  mockConnectionTypeConfigMapObj({
+    name: 'oci',
+    fields: [
+      {
+        type: 'dropdown',
+        name: 'Access type',
+        description:
+          'Access type can be push (push for uploading data), pull (pull for accessing resources), or both depending on the use case. E.g. Pull/both for deploying a model, push/both for InstructLab fine-tune runs.',
+        envVar: 'ACCESS_TYPE',
+        required: false,
+        properties: {
+          variant: 'multi',
+          items: [
+            { label: 'Push secret', value: 'Push' },
+            { label: 'Pull secret', value: 'Pull' },
+          ],
+        },
+      },
+      {
+        type: 'file',
+        name: 'Secret details',
+        envVar: '.dockerconfigjson',
+        required: true,
+        properties: { extensions: ['.dockerconfigjson', '.json'] },
+      },
+      {
+        type: 'short-text',
+        name: 'Registry host',
+        envVar: 'OCI_HOST',
+        required: true,
+        properties: {},
+      },
+    ],
+  });

--- a/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
@@ -1,5 +1,8 @@
 import { mockConnection } from '~/__mocks__/mockConnection';
-import { mockConnectionTypeConfigMapObj } from '~/__mocks__/mockConnectionType';
+import {
+  mockConnectionTypeConfigMapObj,
+  mockModelServingFields,
+} from '~/__mocks__/mockConnectionType';
 import {
   ConnectionTypeFieldType,
   DropdownField,
@@ -442,5 +445,38 @@ describe('isModelServingTypeCompatible', () => {
     ).toBe(true);
     expect(isModelServingTypeCompatible(['invalid'], ModelServingCompatibleTypes.URI)).toBe(false);
     expect(isModelServingTypeCompatible(['URI'], ModelServingCompatibleTypes.URI)).toBe(true);
+  });
+
+  it('should identify model serving compatible connections', () => {
+    expect(
+      isModelServingTypeCompatible(mockConnection({}), ModelServingCompatibleTypes.S3ObjectStorage),
+    ).toBe(false);
+    expect(
+      isModelServingTypeCompatible(
+        mockConnection({
+          data: {
+            AWS_ACCESS_KEY_ID: 'keyid',
+            AWS_SECRET_ACCESS_KEY: 'accesskey',
+            AWS_S3_ENDPOINT: 'endpoint',
+            AWS_S3_BUCKET: 'bucket',
+          },
+        }),
+        ModelServingCompatibleTypes.S3ObjectStorage,
+      ),
+    ).toBe(true);
+  });
+
+  it('should identify model serving compatible connection types', () => {
+    expect(
+      isModelServingTypeCompatible(mockConnection({}), ModelServingCompatibleTypes.S3ObjectStorage),
+    ).toBe(false);
+    expect(
+      isModelServingTypeCompatible(
+        mockConnectionTypeConfigMapObj({
+          fields: mockModelServingFields,
+        }),
+        ModelServingCompatibleTypes.S3ObjectStorage,
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -123,9 +123,23 @@ export const fieldNameToEnvVar = (name: string): string => {
 export const ENV_VAR_NAME_REGEX = new RegExp('^[-_.a-zA-Z0-9]+$');
 export const isValidEnvVar = (name: string): boolean => ENV_VAR_NAME_REGEX.test(name);
 
-export const isUriConnectionType = (connectionType: ConnectionTypeConfigMapObj): boolean =>
-  !!connectionType.data?.fields?.find((f) => isConnectionTypeDataField(f) && f.envVar === 'URI');
-export const isUriConnection = (connection?: Connection): boolean => !!connection?.data?.URI;
+export const isS3Connection = (connection?: Connection): boolean =>
+  !!(
+    connection?.data?.AWS_ACCESS_KEY_ID &&
+    connection.data.AWS_ACCESS_KEY_ID &&
+    connection.data.AWS_S3_ENDPOINT &&
+    connection.data.AWS_S3_BUCKET
+  ) ||
+  !!(
+    connection?.stringData?.AWS_ACCESS_KEY_ID &&
+    connection.stringData.AWS_ACCESS_KEY_ID &&
+    connection.stringData.AWS_S3_ENDPOINT &&
+    connection.stringData.AWS_S3_BUCKET
+  );
+export const isUriConnection = (connection?: Connection): boolean =>
+  !!connection?.data?.URI || !!connection?.stringData?.URI;
+export const isOciConnection = (connection?: Connection): boolean =>
+  !!connection?.data?.OCI_HOST || !!connection?.stringData?.OCI_HOST;
 
 export const S3ConnectionTypeKeys = [
   'AWS_ACCESS_KEY_ID',

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -148,7 +148,7 @@ export const S3ConnectionTypeKeys = [
   'AWS_S3_BUCKET',
 ];
 
-export const OCIConnectionTypeKeys = ['ACCESS_TYPE', '.dockerconfigjson', 'OCI_HOST'];
+export const OCIConnectionTypeKeys = ['.dockerconfigjson', 'OCI_HOST'];
 
 export enum ModelServingCompatibleTypes {
   S3ObjectStorage = 'S3 compatible object storage',

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  InputGroupText,
+  InputGroup,
+  InputGroupItem,
+} from '@patternfly/react-core';
+
+type ConnectionOciPathFieldProps = {
+  ociHost?: string;
+  modelUri?: string;
+  setModelUri: (modelPath?: string) => void;
+};
+
+const ConnectionOciPathField: React.FC<ConnectionOciPathFieldProps> = ({
+  ociHost,
+  modelUri,
+  setModelUri,
+}) => {
+  const hideUriPrefix = (text?: string) => {
+    if (text?.includes('://')) {
+      return text.substring(text.indexOf('://') + 3);
+    }
+    return text;
+  };
+
+  const addUriPrefix = (text?: string) => {
+    if (text && !text.includes('://')) {
+      return `oci://${text}`;
+    }
+    return text;
+  };
+
+  return (
+    <>
+      {ociHost && (
+        <FormGroup label="Registry host" className="pf-v6-u-mb-lg">
+          {ociHost}
+        </FormGroup>
+      )}
+      <FormGroup fieldId="model-uri" label="Model URI" isRequired>
+        <InputGroup>
+          <InputGroupText>oci://</InputGroupText>
+          <InputGroupItem isFill>
+            <TextInput
+              id="model-uri"
+              aria-label="Model URI"
+              data-testid="model-uri"
+              type="text"
+              value={hideUriPrefix(modelUri)}
+              onChange={(e, value: string) => {
+                setModelUri(value);
+              }}
+              onBlur={() => setModelUri(addUriPrefix(modelUri))}
+            />
+          </InputGroupItem>
+        </InputGroup>
+
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Example model path structure is Base URL / Registry organization / Model Name:Model
+              Version
+            </HelperTextItem>
+            <HelperTextItem>
+              Example: registry.connect.redhat.com/redhat-test/test-mymodel:v3.2
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </>
+  );
+};
+
+export default ConnectionOciPathField;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx
@@ -10,12 +10,12 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/ex
 import { containsOnlySlashes, isS3PathValid } from '~/utilities/string';
 import useDebounceCallback from '~/utilities/useDebounceCallback';
 
-type DataConnectionFolderPathFieldProps = {
+type ConnectionFolderPathFieldProps = {
   folderPath: string;
   setFolderPath: (folderPath: string) => void;
 };
 
-const DataConnectionFolderPathField: React.FC<DataConnectionFolderPathFieldProps> = ({
+const ConnectionS3FolderPathField: React.FC<ConnectionFolderPathFieldProps> = ({
   folderPath,
   setFolderPath,
 }) => {
@@ -74,4 +74,4 @@ const DataConnectionFolderPathField: React.FC<DataConnectionFolderPathFieldProps
   );
 };
 
-export default DataConnectionFolderPathField;
+export default ConnectionS3FolderPathField;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -32,13 +32,11 @@ import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescription
 import {
   assembleConnectionSecret,
   getConnectionTypeDisplayName,
-  getConnectionTypeModelServingCompatibleTypes,
   getConnectionTypeRef,
   getDefaultValues,
   getMRConnectionValues,
   isConnectionTypeDataField,
-  isOciConnection,
-  isS3Connection,
+  isModelServingTypeCompatible,
   ModelServingCompatibleTypes,
   S3ConnectionTypeKeys,
   withRequiredFields,
@@ -176,16 +174,19 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
           />
         )}
       </FormGroup>
-      {selectedConnection && isS3Connection(selectedConnection) && (
-        <ConnectionS3FolderPathField folderPath={folderPath} setFolderPath={setFolderPath} />
-      )}
-      {selectedConnection && isOciConnection(selectedConnection) && (
-        <ConnectionOciPathField
-          ociHost={window.atob(selectedConnection.data?.OCI_HOST ?? '')}
-          modelUri={modelUri}
-          setModelUri={setModelUri}
-        />
-      )}
+      {selectedConnection &&
+        isModelServingTypeCompatible(
+          selectedConnection,
+          ModelServingCompatibleTypes.S3ObjectStorage,
+        ) && <ConnectionS3FolderPathField folderPath={folderPath} setFolderPath={setFolderPath} />}
+      {selectedConnection &&
+        isModelServingTypeCompatible(selectedConnection, ModelServingCompatibleTypes.OCI) && (
+          <ConnectionOciPathField
+            ociHost={window.atob(selectedConnection.data?.OCI_HOST ?? '')}
+            modelUri={modelUri}
+            setModelUri={setModelUri}
+          />
+        )}
     </>
   );
 };
@@ -326,16 +327,17 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
         }
       />
       {selectedConnectionType &&
-        getConnectionTypeModelServingCompatibleTypes(selectedConnectionType)[0] ===
-          ModelServingCompatibleTypes.S3ObjectStorage && (
+        isModelServingTypeCompatible(
+          selectedConnectionType,
+          ModelServingCompatibleTypes.S3ObjectStorage,
+        ) && (
           <ConnectionS3FolderPathField
             folderPath={data.storage.path}
             setFolderPath={(path) => setData('storage', { ...data.storage, path })}
           />
         )}
       {selectedConnectionType &&
-        getConnectionTypeModelServingCompatibleTypes(selectedConnectionType)[0] ===
-          ModelServingCompatibleTypes.OCI && (
+        isModelServingTypeCompatible(selectedConnectionType, ModelServingCompatibleTypes.OCI) && (
           <ConnectionOciPathField modelUri={modelUri} setModelUri={setModelUri} />
         )}
     </FormSection>

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionExistingField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionExistingField.tsx
@@ -18,7 +18,7 @@ import {
 import { filterOutConnectionsWithoutBucket } from '~/pages/modelServing/screens/projects/utils';
 import { getDataConnectionDisplayName } from '~/pages/projects/screens/detail/data-connections/utils';
 import SimpleSelect from '~/components/SimpleSelect';
-import DataConnectionFolderPathField from './DataConnectionFolderPathField';
+import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 
 type DataConnectionExistingFieldType = {
   data: CreatingInferenceServiceObject;
@@ -96,7 +96,7 @@ const DataConnectionExistingField: React.FC<DataConnectionExistingFieldType> = (
         </FormGroup>
       </StackItem>
       <StackItem>
-        <DataConnectionFolderPathField
+        <ConnectionS3FolderPathField
           folderPath={data.storage.path}
           setFolderPath={(path) => setData('storage', { ...data.storage, path })}
         />

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/DataConnectionSection.tsx
@@ -9,7 +9,7 @@ import {
 import AWSField from '~/pages/projects/dataConnections/AWSField';
 import { AwsKeys } from '~/pages/projects/dataConnections/const';
 import DataConnectionExistingField from './DataConnectionExistingField';
-import DataConnectionFolderPathField from './DataConnectionFolderPathField';
+import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 
 type DataConnectionSectionType = {
   data: CreatingInferenceServiceObject;
@@ -100,7 +100,7 @@ const DataConnectionSection: React.FC<DataConnectionSectionType> = ({
                     />
                   </StackItem>
                   <StackItem>
-                    <DataConnectionFolderPathField
+                    <ConnectionS3FolderPathField
                       folderPath={data.storage.path}
                       setFolderPath={(path) => setData('storage', { ...data.storage, path })}
                     />

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -190,6 +190,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
             />
             <FormSection title="Source model location" id="model-location">
               <ConnectionSection
+                existingUriOption={editInfo?.spec.predictor.model?.storageUri}
                 data={createData}
                 setData={setCreateData}
                 loaded={!!projectContext?.connections || connectionsLoaded}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -412,6 +412,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         {!hideForm && (
           <FormSection title="Source model location" id="model-location">
             <ConnectionSection
+              existingUriOption={
+                editInfo?.inferenceServiceEditInfo?.spec.predictor.model?.storageUri
+              }
               data={createDataInferenceService}
               setData={setCreateDataInferenceService}
               loaded={!!projectContext?.connections || connectionsLoaded}

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -30,7 +30,6 @@ import { getDisplayNameFromServingRuntimeTemplate } from '~/pages/modelServing/c
 import { getServingRuntimeTokens, setUpTokenAuth } from '~/pages/modelServing/utils';
 import {
   addSupportServingPlatformProject,
-  assembleSecret,
   createInferenceService,
   createPvc,
   createSecret,
@@ -336,22 +335,6 @@ export const getProjectModelServingPlatform = (
   };
 };
 
-export const createAWSSecret = (
-  createData: CreatingInferenceServiceObject,
-  dryRun: boolean,
-): Promise<SecretKind> =>
-  createSecret(
-    assembleSecret(
-      createData.project,
-      createData.storage.awsData.reduce<Record<string, string>>(
-        (acc, { key, value }) => ({ ...acc, [key]: value }),
-        {},
-      ),
-      'aws',
-    ),
-    { dryRun },
-  );
-
 const createInferenceServiceAndDataConnection = async (
   inferenceServiceData: CreatingInferenceServiceObject,
   editInfo?: InferenceServiceKind,
@@ -368,14 +351,14 @@ const createInferenceServiceAndDataConnection = async (
     secret = await createSecret(connection, { dryRun });
     if (connection.stringData?.URI) {
       storageUri = connection.stringData.URI;
-    } else {
+    } else if (inferenceServiceData.storage.uri) {
       storageUri = inferenceServiceData.storage.uri;
     }
   }
   if (inferenceServiceData.storage.type === InferenceServiceStorageType.EXISTING_STORAGE) {
     if (connection?.data?.URI) {
       storageUri = window.atob(connection.data.URI);
-    } else {
+    } else if (inferenceServiceData.storage.uri) {
       storageUri = inferenceServiceData.storage.uri;
     }
   }

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -45,7 +45,10 @@ import { getNIMData, getNIMResource } from '~/pages/modelServing/screens/project
 import { useKServeDeploymentMode } from '~/pages/modelServing/useKServeDeploymentMode';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { ModelServingPodSpecOptions } from '~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
-import { isOciConnection, isS3Connection, isUriConnection } from '~/concepts/connectionTypes/utils';
+import {
+  isModelServingTypeCompatible,
+  ModelServingCompatibleTypes,
+} from '~/concepts/connectionTypes/utils';
 
 export const getServingRuntimeSizes = (config: DashboardConfigKind): ModelServingSize[] => {
   let sizes = config.spec.modelServerSizes || [];
@@ -705,16 +708,22 @@ export const getCreateInferenceServiceLabels = (
 };
 
 export const isModelPathValid = (connection: Connection, path: string, uri?: string): boolean => {
-  if (isUriConnection(connection)) {
+  if (isModelServingTypeCompatible(connection, ModelServingCompatibleTypes.URI)) {
     return true;
   }
   if (containsOnlySlashes(path)) {
     return false;
   }
-  if (isS3Connection(connection) && !isS3PathValid(path)) {
+  if (
+    isModelServingTypeCompatible(connection, ModelServingCompatibleTypes.S3ObjectStorage) &&
+    !isS3PathValid(path)
+  ) {
     return false;
   }
-  if (isOciConnection(connection) && (!uri || uri.length <= 'oci://'.length)) {
+  if (
+    isModelServingTypeCompatible(connection, ModelServingCompatibleTypes.OCI) &&
+    (!uri || uri.length <= 'oci://'.length)
+  ) {
     return false;
   }
   return true;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-19881

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Prompt the user for the OCI Model URI when selecting a OCI connection for model deployment.
- If you paste in a URI with `<...>://...` it will remove the prefix
- requires you have a non empty value, other than that the validation is sparse

Existing connection:
![image](https://github.com/user-attachments/assets/450a980a-dcd1-43a8-bf6f-6da01f274a80)

New connection: 
![image](https://github.com/user-attachments/assets/3d62acd1-e612-41ca-8a83-b0911f3f8397)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create an ootb OCI connection deploy it
- deploy and create the connection inline
- test S3 and URI still work fine 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added jest test for the ConnectionSection.tsx

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

@simrandhaliw 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
