### PR TITLE
NIM: remove nim card

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/nim/testRemoveNIMCard.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/nim/testRemoveNIMCard.cy.ts
@@ -1,0 +1,31 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import { enabledPage } from '~/__tests__/cypress/cypress/pages/enabled';
+import { patchOpenShiftNSResource } from '../../../utils/oc_commands/baseCommands';
+
+describe('Verify RHODS Explore Section Contains NIM card and verify card body', () => {
+  it('Enable and validate NIM flow', () => {
+    // use oc client to set odhDashboard disableNIMModelServing to false
+    patchOpenShiftNSResource(
+      'secrets',
+      'nvidia-nim-access',
+      '[{"op": "replace", "path": "/data/api_key", "value": "bm90IGEgdmFsaWQga2V5"}]',
+      'redhat-ods-applications',
+      'json',
+    );
+    // Authentication and navigation
+    cy.step('Login to the application');
+    cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+    enabledPage.visit();
+    cy.findByTestId('card nvidia-nim').contains(
+      'NVIDIA NIM is a set of easy-to-use microservices designed for secure, reliable deployment of high-performance AI model inferencing.',
+    );
+    cy.findByTestId('card nvidia-nim').within(() => {
+      cy.contains('button', 'Disabled', { timeout: 60000 }).click();
+    });
+    cy.get('.pf-v6-c-popover__body').within(() => {
+      cy.get('button:contains("here")').eq(1).click();
+    });
+    enabledPage.visit();
+    cy.findByTestId('card nvidia-nim').should('not.exist');
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -53,6 +53,42 @@ export const patchOpenShiftResource = (
 };
 
 /**
+ * Patches an OpenShift resource using the `oc patch` command.
+ *
+ * @param resourceType The type of resource to patch (e.g., 'storageclass')
+ * @param resourceName The name of the resource to patch
+ * @param patchContent The patch content as a JSON string
+ * @param namespace The namespace of the resource to patch, default is 'default'
+ * @param type The type of the resource to patch, default is json
+ * @returns Cypress Chainable
+ */
+export const patchOpenShiftNSResource = (
+  resourceType: string,
+  resourceName: string,
+  patchContent: string,
+  namespace: string = "default",
+  type: string = "json",
+): Cypress.Chainable<CommandLineResult> => {
+  // Escape single quotes in the patch content
+  const escapedPatchContent = patchContent.replace(/'/g, "'\\''");
+
+  const ocCommand = `oc -n ${namespace} patch ${resourceType} ${resourceName} --type=${type} -p '${escapedPatchContent}'`;
+
+  cy.log(ocCommand);
+
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      // If there is an error, log the error and fail the test
+      cy.log(`ERROR patching ${resourceType} ${resourceName}
+              stdout: ${result.stdout}
+              stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};
+
+/**
  * Wait for a specific pod to become ready across all namespaces.
  *
  * @param podNameContains A substring to partially match against the pod name (e.g., "jupyter-nb").


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Test to remove NIM card 
![image](https://github.com/user-attachments/assets/748f4521-62e5-47fb-b57e-738db33d5dbd)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- On AWS cluster with RHOAI Installed

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Added E2E test for removing NIM card

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ na ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
