### PR TITLE
fix: duplicated tags issue for models' info and the drop down list

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -59,7 +59,6 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
           setOptions(fetchedOptions);
           setError('');
           
-          console.log('First four models:', modelInfos);
           if (isEditing) {
             const modelName = inferenceServiceData.format.name;
             const modelInfo = modelInfos.find((model) => model.name === modelName);

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -32,33 +32,37 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
         const modelInfos = await fetchNIMModelNames();
         if (modelInfos && modelInfos.length > 0) {
           const normalizeVersion = (tag: string) => {
-            // Convert "1", "1.0" into "1.0.0"
             if (/^\d+(\.\d+)*$/.test(tag)) {
               const parts = tag.split('.').map(Number);
-              while (parts.length < 3) parts.push(0); // Ensure it's in "X.Y.Z" format
+              while (parts.length < 3) {
+                parts.push(0);
+              }
               return parts.join('.');
             }
-            return tag; // Keep non-numeric tags unchanged
+            return tag;
           };
           const seen = new Set<string>();
-          const fetchedOptions = modelInfos.flatMap((modelInfo) =>
-            modelInfo.tags.map((tag) => {
-              const normalizedTag = normalizeVersion(tag);
-              const value: string | number = `${modelInfo.name}-${normalizedTag}`; // Ensure it matches TypeaheadSelectOption
-              const content = `${modelInfo.displayName} - ${normalizedTag}`;
-  
-              if (!seen.has(value.toString())) {
-                seen.add(value.toString());
-                return { value, content } as TypeaheadSelectOption; // Explicitly cast as TypeaheadSelectOption
-              }
-              return null; // Mark duplicates as null
-            })
-          ).filter((option): option is TypeaheadSelectOption => option !== null); // Remove null values
-          
+          const fetchedOptions = modelInfos
+            .flatMap((modelInfo) =>
+              modelInfo.tags.map((tag) => {
+                const normalizedTag = normalizeVersion(tag);
+                const value: string | number = `${modelInfo.name}-${normalizedTag}`;
+                const content = `${modelInfo.displayName} - ${normalizedTag}`;
+
+                if (!seen.has(value.toString())) {
+                  seen.add(value.toString());
+                  const option: TypeaheadSelectOption = { value, content };
+                  return option;
+                }
+                return null;
+              }),
+            )
+            .filter((option): option is TypeaheadSelectOption => option !== null);
+
           setModelList(modelInfos);
           setOptions(fetchedOptions);
           setError('');
-          
+
           if (isEditing) {
             const modelName = inferenceServiceData.format.name;
             const modelInfo = modelInfos.find((model) => model.name === modelName);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Related to the following:
https://issues.redhat.com/browse/NVPE-177
(which is a sub-task for https://issues.redhat.com/browse/NVPE-93)
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixed the duplicated tags issue for models' info and the drop down list like in this model:
![image](https://github.com/user-attachments/assets/bd6dc936-148f-4741-a2c9-7c47ed1152ec)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Enable NIM
2. Go to Data Science Project
3. Click on the existing or create a new project and go over the NVIDIA NIM dropdown
 Here is a video where you can see the difference: On the right panel we see the issue of the the multiple tags (1/1.0/1.0.0). On the left panel is the solution.
 

https://github.com/user-attachments/assets/27665b8d-d082-4a21-b5cd-c87f8c46caf9


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
