### PR TITLE
fix(serving): change raw label to annotation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -1458,10 +1458,10 @@ describe('Serving Runtime List', () => {
             annotations: {
               'openshift.io/display-name': 'Test Name',
               'serving.kserve.io/deploymentMode': DeploymentMode.RawDeployment,
+              'security.opendatahub.io/enable-auth': 'true',
             },
             labels: {
               'opendatahub.io/dashboard': 'true',
-              'security.opendatahub.io/enable-auth': 'true',
               'networking.kserve.io/visibility': 'exposed',
             },
           },
@@ -1603,10 +1603,10 @@ describe('Serving Runtime List', () => {
             annotations: {
               'openshift.io/display-name': 'Test Name',
               'serving.kserve.io/deploymentMode': DeploymentMode.RawDeployment,
+              'security.opendatahub.io/enable-auth': 'true',
             },
             labels: {
               'opendatahub.io/dashboard': 'true',
-              'security.opendatahub.io/enable-auth': 'true',
               'networking.kserve.io/visibility': 'exposed',
             },
           },

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -388,7 +388,6 @@ describe('assembleInferenceService', () => {
     expect(annotations?.['sidecar.istio.io/inject']).toBe(undefined);
     expect(annotations?.['sidecar.istio.io/rewriteAppHTTPProbers']).toBe(undefined);
     expect(annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
-    expect(labels?.['security.opendatahub.io/enable-auth']).toBe(undefined);
     expect(labels?.['networking.kserve.io/visibility']).toBe(undefined);
     expect(labels?.['networking.knative.dev/visibility']).toBe(undefined);
   });
@@ -401,7 +400,7 @@ describe('assembleInferenceService', () => {
       DeploymentMode.RawDeployment,
     );
     expect(ext.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
-    expect(ext.metadata.labels?.['security.opendatahub.io/enable-auth']).toBe(undefined);
+    expect(ext.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
     expect(ext.metadata.labels?.['networking.kserve.io/visibility']).toBe('exposed');
     expect(ext.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
 
@@ -411,8 +410,7 @@ describe('assembleInferenceService', () => {
     expect(auth.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe(
       DeploymentMode.RawDeployment,
     );
-    expect(auth.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
-    expect(auth.metadata.labels?.['security.opendatahub.io/enable-auth']).toBe('true');
+    expect(auth.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe('true');
     expect(auth.metadata.labels?.['networking.kserve.io/visibility']).toBe(undefined);
     expect(auth.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
 
@@ -426,8 +424,7 @@ describe('assembleInferenceService', () => {
     expect(both.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe(
       DeploymentMode.RawDeployment,
     );
-    expect(both.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe(undefined);
-    expect(both.metadata.labels?.['security.opendatahub.io/enable-auth']).toBe('true');
+    expect(both.metadata.annotations?.['security.opendatahub.io/enable-auth']).toBe('true');
     expect(both.metadata.labels?.['networking.kserve.io/visibility']).toBe('exposed');
     expect(both.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
   });

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -20,26 +20,16 @@ const applyAuthToInferenceService = (
   inferenceService: InferenceServiceKind,
   tokenAuth: boolean,
   isModelMesh?: boolean,
-  isKServeRaw?: boolean,
 ) => {
   const updateInferenceService = structuredClone(inferenceService);
-  if (!updateInferenceService.metadata.labels) {
-    updateInferenceService.metadata.labels = {};
-  }
   if (!updateInferenceService.metadata.annotations) {
     updateInferenceService.metadata.annotations = {};
   }
   delete updateInferenceService.metadata.annotations['security.opendatahub.io/enable-auth'];
-  delete updateInferenceService.metadata.labels['security.opendatahub.io/enable-auth'];
 
   // KServe
   if (!isModelMesh && tokenAuth) {
-    if (isKServeRaw) {
-      updateInferenceService.metadata.labels['security.opendatahub.io/enable-auth'] = 'true';
-    } else {
-      // serverless
-      updateInferenceService.metadata.annotations['security.opendatahub.io/enable-auth'] = 'true';
-    }
+    updateInferenceService.metadata.annotations['security.opendatahub.io/enable-auth'] = 'true';
   }
 
   return updateInferenceService;
@@ -203,7 +193,6 @@ export const assembleInferenceService = (
     updateInferenceService,
     tokenAuth,
     isModelMesh,
-    data.isKServeRawDeployment,
   );
   updateInferenceService = applyRoutingToInferenceService(
     updateInferenceService,

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -469,7 +469,6 @@ export type InferenceServiceAnnotations = Partial<{
 
 export type InferenceServiceLabels = Partial<{
   'networking.knative.dev/visibility': string;
-  'security.opendatahub.io/enable-auth': 'true';
   'networking.kserve.io/visibility': 'exposed';
 }>;
 

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -69,9 +69,7 @@ export const isInferenceServiceKServeRaw = (inferenceService: InferenceServiceKi
   DeploymentMode.RawDeployment;
 
 export const isInferenceServiceTokenEnabled = (inferenceService: InferenceServiceKind): boolean =>
-  isInferenceServiceKServeRaw(inferenceService)
-    ? inferenceService.metadata.labels?.['security.opendatahub.io/enable-auth'] === 'true'
-    : inferenceService.metadata.annotations?.['security.opendatahub.io/enable-auth'] === 'true';
+  inferenceService.metadata.annotations?.['security.opendatahub.io/enable-auth'] === 'true';
 
 export const isInferenceServiceRouteEnabled = (inferenceService: InferenceServiceKind): boolean =>
   isInferenceServiceKServeRaw(inferenceService)


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-20355

Depends on https://github.com/opendatahub-io/kserve/pull/509 and https://github.com/opendatahub-io/odh-model-controller/pull/382

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The backend is moving the auth label to the annotation to align with kserve serverless
Deploy the latest operator image with the latest kserve and model contollers

![image](https://github.com/user-attachments/assets/16395277-7272-4543-a48a-5a1561967774)
![image](https://github.com/user-attachments/assets/7893047a-ec70-442f-8c1a-83811b0524ad)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploy kserve raw with public and auth, also check serverless is still normal

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Corrected existing tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
