### PR TITLE
List only Pull OCI Connections in ConnectionSection

### DIFF
--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -22,7 +22,7 @@ import {
 } from '~/concepts/k8s/utils';
 import { connectionTypeColumns } from '~/pages/connectionTypes/columns';
 import CategoryLabel from '~/concepts/connectionTypes/CategoryLabel';
-import { getConnectionTypeModelServingCompatibleTypes } from '~/concepts/connectionTypes/utils';
+import { getModelServingCompatibility } from '~/concepts/connectionTypes/utils';
 import CompatibilityLabel from '~/concepts/connectionTypes/CompatibilityLabel';
 import ConnectionTypePreviewModal from '~/concepts/connectionTypes/ConnectionTypePreviewModal';
 
@@ -78,10 +78,7 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
       });
   };
 
-  const compatibleTypes = React.useMemo(
-    () => getConnectionTypeModelServingCompatibleTypes(obj),
-    [obj],
-  );
+  const compatibleTypes = React.useMemo(() => getModelServingCompatibility(obj), [obj]);
 
   return (
     <Tr>

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypePage.tsx
@@ -41,7 +41,7 @@ import {
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
 import {
   filterModelServingConnectionTypes,
-  getConnectionTypeModelServingCompatibleTypes,
+  getModelServingCompatibility,
 } from '~/concepts/connectionTypes/utils';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import SimpleMenuActions from '~/components/SimpleMenuActions';
@@ -130,7 +130,7 @@ const ManageConnectionTypePage: React.FC<Props> = ({ prefill, isEdit, onSave }) 
   );
 
   const modelServingCompatibleTypes = React.useMemo(
-    () => getConnectionTypeModelServingCompatibleTypes(connectionTypeObj),
+    () => getModelServingCompatibility(connectionTypeObj),
     [connectionTypeObj],
   );
 

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -20,13 +20,12 @@ const usePrefillDeployModalFromModelRegistry = (
   registeredModelDeployInfo?: RegisteredModelDeployInfo,
 ): [LabeledConnection[], boolean, Error | undefined] => {
   const [fetchedConnections, connectionsLoaded, connectionsLoadError] = useConnections(
-    projectContext ? undefined : createData.project,
+    projectContext ? projectContext.currentProject.metadata.name : createData.project,
     true,
   );
-  const allConnections = projectContext?.connections || fetchedConnections;
   const { connections, storageFields } = useLabeledConnections(
     registeredModelDeployInfo?.modelArtifactUri,
-    allConnections,
+    fetchedConnections,
   );
 
   React.useEffect(() => {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -36,7 +36,7 @@ import {
   getDefaultValues,
   getMRConnectionValues,
   isConnectionTypeDataField,
-  isModelServingTypeCompatible,
+  isModelServingCompatible,
   ModelServingCompatibleTypes,
   S3ConnectionTypeKeys,
   withRequiredFields,
@@ -50,7 +50,6 @@ import {
   LabeledConnection,
 } from '~/pages/modelServing/screens/types';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
-import useConnections from '~/pages/projects/screens/detail/connections/useConnections';
 import { isModelPathValid } from '~/pages/modelServing/screens/projects/utils';
 import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 import ConnectionOciPathField from './ConnectionOciPathField';
@@ -175,12 +174,12 @@ const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = ({
         )}
       </FormGroup>
       {selectedConnection &&
-        isModelServingTypeCompatible(
+        isModelServingCompatible(
           selectedConnection,
           ModelServingCompatibleTypes.S3ObjectStorage,
         ) && <ConnectionS3FolderPathField folderPath={folderPath} setFolderPath={setFolderPath} />}
       {selectedConnection &&
-        isModelServingTypeCompatible(selectedConnection, ModelServingCompatibleTypes.OCI) && (
+        isModelServingCompatible(selectedConnection, ModelServingCompatibleTypes.OCI) && (
           <ConnectionOciPathField
             ociHost={window.atob(selectedConnection.data?.OCI_HOST ?? '')}
             modelUri={modelUri}
@@ -327,7 +326,7 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
         }
       />
       {selectedConnectionType &&
-        isModelServingTypeCompatible(
+        isModelServingCompatible(
           selectedConnectionType,
           ModelServingCompatibleTypes.S3ObjectStorage,
         ) && (
@@ -337,7 +336,7 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
           />
         )}
       {selectedConnectionType &&
-        isModelServingTypeCompatible(selectedConnectionType, ModelServingCompatibleTypes.OCI) && (
+        isModelServingCompatible(selectedConnectionType, ModelServingCompatibleTypes.OCI) && (
           <ConnectionOciPathField modelUri={modelUri} setModelUri={setModelUri} />
         )}
     </FormSection>
@@ -368,21 +367,20 @@ export const ConnectionSection: React.FC<Props> = ({
   connections,
 }) => {
   const [connectionTypes] = useWatchConnectionTypes(true);
-  const [projectConnections] = useConnections(data.project, true);
 
   const hasImagePullSecret = React.useMemo(() => !!data.imagePullSecrets, [data.imagePullSecrets]);
 
   const selectedConnection = React.useMemo(
     () =>
-      projectConnections.find(
-        (c) => getResourceNameFromK8sResource(c) === data.storage.dataConnection,
+      connections?.find(
+        (c) => getResourceNameFromK8sResource(c.connection) === data.storage.dataConnection,
       ),
-    [projectConnections, data.storage.dataConnection],
+    [connections, data.storage.dataConnection],
   );
 
   React.useEffect(() => {
     if (selectedConnection && !connection) {
-      setConnection(selectedConnection);
+      setConnection(selectedConnection.connection);
     }
   }, [selectedConnection, connection, setConnection]);
 
@@ -438,7 +436,7 @@ export const ConnectionSection: React.FC<Props> = ({
               <ExistingConnectionField
                 connectionTypes={connectionTypes}
                 projectConnections={connections}
-                selectedConnection={selectedConnection}
+                selectedConnection={selectedConnection?.connection}
                 onSelect={(selection) => {
                   setConnection(selection);
                   setData('storage', {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
@@ -84,7 +84,17 @@ describe('ConnectionsFormSection', () => {
         setIsConnectionValid={() => undefined}
         loaded
         connections={[
-          { connection: mockConnection({ name: 's3-connection' }) },
+          {
+            connection: mockConnection({
+              name: 's3-connection',
+              data: {
+                AWS_ACCESS_KEY_ID: 'test',
+                AWS_SECRET_ACCESS_KEY: 'test',
+                AWS_S3_ENDPOINT: 'test',
+                AWS_S3_BUCKET: 'test',
+              },
+            }),
+          },
           { connection: mockConnection({ name: 'uri-connection' }) },
         ]}
       />,
@@ -120,7 +130,17 @@ describe('ConnectionsFormSection', () => {
         setIsConnectionValid={() => undefined}
         loaded
         connections={[
-          { connection: mockConnection({ name: 's3-connection' }) },
+          {
+            connection: mockConnection({
+              name: 's3-connection',
+              data: {
+                AWS_ACCESS_KEY_ID: 'test',
+                AWS_SECRET_ACCESS_KEY: 'test',
+                AWS_S3_ENDPOINT: 'test',
+                AWS_S3_BUCKET: 'test',
+              },
+            }),
+          },
           { connection: mockConnection({ name: 'uri-connection' }) },
         ]}
       />,

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -46,7 +46,7 @@ import { useKServeDeploymentMode } from '~/pages/modelServing/useKServeDeploymen
 import { Connection } from '~/concepts/connectionTypes/types';
 import { ModelServingPodSpecOptions } from '~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
 import {
-  isModelServingTypeCompatible,
+  isModelServingCompatible,
   ModelServingCompatibleTypes,
 } from '~/concepts/connectionTypes/utils';
 
@@ -708,20 +708,20 @@ export const getCreateInferenceServiceLabels = (
 };
 
 export const isModelPathValid = (connection: Connection, path: string, uri?: string): boolean => {
-  if (isModelServingTypeCompatible(connection, ModelServingCompatibleTypes.URI)) {
+  if (isModelServingCompatible(connection, ModelServingCompatibleTypes.URI)) {
     return true;
   }
   if (containsOnlySlashes(path)) {
     return false;
   }
   if (
-    isModelServingTypeCompatible(connection, ModelServingCompatibleTypes.S3ObjectStorage) &&
+    isModelServingCompatible(connection, ModelServingCompatibleTypes.S3ObjectStorage) &&
     !isS3PathValid(path)
   ) {
     return false;
   }
   if (
-    isModelServingTypeCompatible(connection, ModelServingCompatibleTypes.OCI) &&
+    isModelServingCompatible(connection, ModelServingCompatibleTypes.OCI) &&
     (!uri || uri.length <= 'oci://'.length)
   ) {
     return false;

--- a/frontend/src/pages/projects/screens/detail/connections/ConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ConnectionsTableRow.tsx
@@ -6,8 +6,8 @@ import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTyp
 import { TableRowTitleDescription } from '~/components/table';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import {
-  getConnectionModelServingCompatibleTypes,
   getConnectionTypeDisplayName,
+  getModelServingCompatibility,
 } from '~/concepts/connectionTypes/utils';
 import CompatibilityLabel from '~/concepts/connectionTypes/CompatibilityLabel';
 import ConnectedResources from '~/pages/projects/screens/detail/connections/ConnectedResources';
@@ -34,7 +34,7 @@ const ConnectionsTableRow: React.FC<ConnectionsTableRowProps> = ({
     [obj, connectionTypes],
   );
 
-  const compatibleTypes = getConnectionModelServingCompatibleTypes(obj);
+  const compatibleTypes = getModelServingCompatibility(obj);
 
   return (
     <Tr>

--- a/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
@@ -7,7 +7,7 @@ import useFetchState, {
 } from '~/utilities/useFetchState';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE } from '~/const';
-import { isConnection, isModelServingCompatibleConnection } from '~/concepts/connectionTypes/utils';
+import { isConnection, isModelServingCompatible } from '~/concepts/connectionTypes/utils';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 const useConnections = (
@@ -30,7 +30,7 @@ const useConnections = (
       let connections = secrets.filter((secret) => isConnection(secret));
 
       if (modelServingCompatible) {
-        connections = connections.filter(isModelServingCompatibleConnection);
+        connections = connections.filter((c) => isModelServingCompatible(c));
       }
       if (!isOciEnabled) {
         connections = connections.filter(

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
-import { isModelServingCompatibleConnectionType } from '~/concepts/connectionTypes/utils';
+import { isModelServingCompatible } from '~/concepts/connectionTypes/utils';
 import { fetchConnectionTypes } from '~/services/connectionTypesService';
 import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
 
@@ -15,7 +15,7 @@ export const useWatchConnectionTypes = (
   >(async () => {
     let connectionTypes = await fetchConnectionTypes();
     if (modelServingCompatible) {
-      connectionTypes = connectionTypes.filter(isModelServingCompatibleConnectionType);
+      connectionTypes = connectionTypes.filter((ct) => isModelServingCompatible(ct));
     }
     if (!isOciEnabled) {
       connectionTypes = connectionTypes.filter((ct) => ct.metadata.name !== 'oci-v1');


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-20228
## Description
Only allow Pull OCI Connections to show up in the Existing Connections part of the ConnectionSection in the deploy kserve model modal. 
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
* Create a random non-model serving connection type
* Create an instance for S3 connection, URI connection, OCI connection, and the random one you made in a project
* Go to single serving and deploy model
* Existing connections should only show S3, URI, and OCI
* Play around with OCI access type (none selected, pull selected, push & pull selected should show in modal, push only should not show in the modal)
* Make sure other connections deploy properly (S3 and URI)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Edited utils test to check for OCI connections being serving compatible
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
