### PR TITLE
fix: add NIM specific API key validation messages

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -338,6 +338,7 @@ export type OdhApplication = {
       variableDisplayText?: { [key: string]: string };
       variableHelpText?: { [key: string]: string };
       variables?: { [key: string]: string };
+      inProgressText?: string;
     };
     enableCR: {
       field?: string;

--- a/frontend/src/__mocks__/mockOdhApplication.ts
+++ b/frontend/src/__mocks__/mockOdhApplication.ts
@@ -40,6 +40,7 @@ type MockOdhApplicationConfig = {
     validationSecret: string;
     validationJob: string;
     validationConfigMap?: string;
+    inProgressText?: string;
   };
   featureFlag?: string;
   internalRoute?: string;

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -148,7 +148,15 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
                 variant="info"
                 title={
                   <div className="odh-enable-modal__progress-title">
-                    <Spinner size="md" /> Validating your entries
+                    <Spinner size="md" />
+                    {selectedApp.metadata.name === 'nvidia-nim' ? (
+                      <div>
+                        Contacting NVIDIA to validate the license key.
+                        <div>This can take a few minutes.</div>
+                      </div>
+                    ) : (
+                      'Validating your entries'
+                    )}
                   </div>
                 }
                 aria-live="polite"

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -150,7 +150,7 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
                   <div className="odh-enable-modal__progress-title">
                     <Spinner size="md" />
                     {enable.inProgressText ? (
-                      <div>{enable.inProgressText}</div>
+                      <div style={{ whiteSpace: 'pre-line' }}>{enable.inProgressText}</div>
                     ) : (
                       'Validating your entries'
                     )}

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -149,11 +149,8 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
                 title={
                   <div className="odh-enable-modal__progress-title">
                     <Spinner size="md" />
-                    {selectedApp.metadata.name === 'nvidia-nim' ? (
-                      <div>
-                        Contacting NVIDIA to validate the license key.
-                        <div>This can take a few minutes.</div>
-                      </div>
+                    {enable.inProgressText ? (
+                      <div>{enable.inProgressText}</div>
                     ) : (
                       'Validating your entries'
                     )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -169,6 +169,7 @@ export type OdhApplication = {
       validationSecret: string;
       validationJob: string;
       validationConfigMap?: string;
+      inProgressText?: string;
     };
     featureFlag?: string;
     internalRoute?: string;

--- a/manifests/common/crd/odhapplications.dashboard.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhapplications.dashboard.opendatahub.io.crd.yaml
@@ -69,6 +69,8 @@ spec:
                       type: string
                     title:
                       type: string
+                    inProgressText:
+                      type: string
                     validationConfigMap:
                       type: string
                     validationJob:

--- a/manifests/rhoai/shared/apps/nvidia-nim/nvidia-nim-app.yaml
+++ b/manifests/rhoai/shared/apps/nvidia-nim/nvidia-nim-app.yaml
@@ -23,6 +23,7 @@ spec:
     title: Enter NVIDIA AI Enterprise license key
     actionLabel: Submit
     description: ''
+    inProgressText: Contacting NVIDIA to validate the license key. This can take a few minutes.
     variables:
       api_key: password
     variableDisplayText:

--- a/manifests/rhoai/shared/apps/nvidia-nim/nvidia-nim-app.yaml
+++ b/manifests/rhoai/shared/apps/nvidia-nim/nvidia-nim-app.yaml
@@ -23,7 +23,9 @@ spec:
     title: Enter NVIDIA AI Enterprise license key
     actionLabel: Submit
     description: ''
-    inProgressText: Contacting NVIDIA to validate the license key. This can take a few minutes.
+    inProgressText: |
+      Contacting NVIDIA to validate the license key.
+      This can take a few minutes.
     variables:
       api_key: password
     variableDisplayText:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-176

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added NIM-specific API key validation messages during validation in progress.
<img width="571" alt="image" src="https://github.com/user-attachments/assets/0f004449-020c-47a2-9ed5-4093f0c1cb69" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested by enabling the NIM application and verifying that the new message is displayed. Also tested a non-NIM application to ensure the general message 'Validating your entries' is shown correctly.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
