### PR TITLE
add title icon to hardware profiles

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
@@ -22,6 +22,8 @@ import { useAccessAllowed, verbModelAccess } from '~/concepts/userSSAR';
 import { HardwareProfileModel } from '~/api';
 import { generateWarningForHardwareProfiles } from '~/pages/hardwareProfiles/utils';
 import { useWatchHardwareProfiles } from '~/utilities/useWatchHardwareProfiles';
+import { ProjectObjectType } from '~/concepts/design/utils';
+import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 
 const description = `Manage hardware profile settings for users in your organization.`;
 
@@ -81,7 +83,12 @@ const HardwareProfiles: React.FC = () => {
 
   return (
     <ApplicationsPage
-      title="Hardware profiles"
+      title={
+        <TitleWithIcon
+          title="Hardware profiles"
+          objectType={ProjectObjectType.acceleratorProfile}
+        />
+      }
       description={description}
       loaded={loaded && loadedAllowed}
       empty={isEmpty}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-20592

## Description
Added the title icon to hardware profile page

![Screenshot 2025-02-28 at 3 07 38 PM](https://github.com/user-attachments/assets/98859ce8-3af0-421a-8aa6-5f46fd49e9bf)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Check for the title icon in the hardware profiles
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A Added icon
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
