### PR TITLE
disableKServeOCIModels filters out ootb type

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
@@ -12,7 +12,7 @@ import { connectionsPage } from '~/__tests__/cypress/cypress/pages/connections';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import { ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
 
-const initIntercepts = (isEmpty = false) => {
+const initIntercepts = ({ isEmpty = false, disableOci = true }) => {
   cy.interceptK8sList(
     ProjectModel,
     mockK8sResourceList([mockProjectK8sResource({ k8sName: 'test-project' })]),
@@ -39,6 +39,7 @@ const initIntercepts = (isEmpty = false) => {
     'GET /api/config',
     mockDashboardConfig({
       disableConnectionTypes: false,
+      disableKServeOCIModels: disableOci,
     }),
   );
   cy.interceptOdh('GET /api/connection-types', [mockConnectionTypeConfigMap({})]);
@@ -46,13 +47,13 @@ const initIntercepts = (isEmpty = false) => {
 
 describe('Connections', () => {
   it('Empty state when no data connections are available', () => {
-    initIntercepts(true);
+    initIntercepts({ isEmpty: true });
     projectDetails.visitSection('test-project', 'connections');
     projectDetails.shouldBeEmptyState('Connections', 'connections', true);
   });
 
   it('List connections', () => {
-    initIntercepts();
+    initIntercepts({});
     projectDetails.visitSection('test-project', 'connections');
     projectDetails.shouldBeEmptyState('Connections', 'connections', false);
     const row1 = connectionsPage.getConnectionRow('test1');
@@ -66,7 +67,7 @@ describe('Connections', () => {
   });
 
   it('Delete a connection', () => {
-    initIntercepts();
+    initIntercepts({});
     cy.interceptK8s(
       'DELETE',
       {
@@ -88,7 +89,7 @@ describe('Connections', () => {
   });
 
   it('Add a connection', () => {
-    initIntercepts();
+    initIntercepts({});
     cy.interceptOdh('GET /api/connection-types', [
       mockConnectionTypeConfigMap({
         name: 'test',
@@ -137,7 +138,7 @@ describe('Connections', () => {
   });
 
   it('Edit a connection', () => {
-    initIntercepts();
+    initIntercepts({});
     cy.interceptOdh('GET /api/connection-types', [
       mockConnectionTypeConfigMap({
         name: 'postgres',
@@ -195,7 +196,7 @@ describe('Connections', () => {
   });
 
   it('Create an OCI connection', () => {
-    initIntercepts();
+    initIntercepts({ disableOci: false });
     cy.interceptOdh('GET /api/connection-types', [
       mockConnectionTypeConfigMap({
         name: 'oci-v1',

--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/usePrefillDeployModalFromModelRegistry.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/usePrefillDeployModalFromModelRegistry.spec.ts
@@ -5,6 +5,15 @@ import { mockInferenceServiceModalData } from '~/__mocks__/mockInferenceServiceM
 import { Connection } from '~/concepts/connectionTypes/types';
 import usePrefillDeployModalFromModelRegistry from '~/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry';
 
+jest.mock('~/concepts/areas/useIsAreaAvailable', () => () => ({
+  status: true,
+  featureFlags: {},
+  reliantAreas: {},
+  requiredComponents: {},
+  requiredCapabilities: {},
+  customCondition: jest.fn(),
+}));
+
 describe('usePrefillDeployModalFromModelRegistry', () => {
   const mockProjectContext = {
     currentProject: {

--- a/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
@@ -8,11 +8,14 @@ import useFetchState, {
 import { Connection } from '~/concepts/connectionTypes/types';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE } from '~/const';
 import { isConnection, isModelServingCompatibleConnection } from '~/concepts/connectionTypes/utils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 const useConnections = (
   namespace?: string,
   modelServingCompatible?: boolean,
 ): FetchState<Connection[]> => {
+  const isOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
+
   const callback = React.useCallback<FetchStateCallbackPromise<Connection[]>>(
     async (opts) => {
       if (!namespace) {
@@ -29,10 +32,15 @@ const useConnections = (
       if (modelServingCompatible) {
         connections = connections.filter(isModelServingCompatibleConnection);
       }
+      if (!isOciEnabled) {
+        connections = connections.filter(
+          (c) => c.metadata.annotations['opendatahub.io/connection-type-ref'] !== 'oci-v1',
+        );
+      }
 
       return connections;
     },
-    [namespace, modelServingCompatible],
+    [namespace, modelServingCompatible, isOciEnabled],
   );
 
   return useFetchState(callback, []);

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { isModelServingCompatibleConnectionType } from '~/concepts/connectionTypes/utils';
 import { fetchConnectionTypes } from '~/services/connectionTypesService';
@@ -7,6 +8,8 @@ import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilitie
 export const useWatchConnectionTypes = (
   modelServingCompatible?: boolean,
 ): FetchState<ConnectionTypeConfigMapObj[]> => {
+  const isOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
+
   const callback = React.useCallback<
     FetchStateCallbackPromise<ConnectionTypeConfigMapObj[]>
   >(async () => {
@@ -14,9 +17,12 @@ export const useWatchConnectionTypes = (
     if (modelServingCompatible) {
       connectionTypes = connectionTypes.filter(isModelServingCompatibleConnectionType);
     }
+    if (!isOciEnabled) {
+      connectionTypes = connectionTypes.filter((ct) => ct.metadata.name !== 'oci-v1');
+    }
 
     return connectionTypes;
-  }, [modelServingCompatible]);
+  }, [modelServingCompatible, isOciEnabled]);
 
   return useFetchState<ConnectionTypeConfigMapObj[]>(callback, []);
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Enhances https://issues.redhat.com/browse/RHOAIENG-18657 and https://issues.redhat.com/browse/RHOAIENG-18659

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Update the OCI feature flag to filter out the ootb connection type. This also removes it from the model serving compatible list check for connections. 

A user could duplicate this and still use OCI though if it's a different name. 

![image](https://github.com/user-attachments/assets/57d84726-e571-499b-b609-a6c4d0aeff41)
![image](https://github.com/user-attachments/assets/3626ee3f-0d03-4092-ae66-27ab23fc89d7)

![image](https://github.com/user-attachments/assets/af3f3249-476c-4114-a369-8a24c3898b86)
![image](https://github.com/user-attachments/assets/c4bd4598-bc52-4360-94a0-013206f8db2b)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Toggle the feature flag back and forth in the admin page, connections details tab, and model deployment

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Most tests are using mocks so no tests have been added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
