### PR TITLE
FIX : Title and Project Selector Overflow on Data Science Pages 

### DIFF
--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -112,7 +112,11 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             height: 'var(--pf-t--global--icon--size--font--2xl)',
           }}
         />
-        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }} style={{width: 'calc(50% - 1rem / 2)'}}>
+        <Flex
+          spaceItems={{ default: 'spaceItemsSm' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+          style={{ width: 'calc(50% - 1rem / 2)' }}
+        >
           <FlexItem>
             <Bullseye>{selectorLabel}</Bullseye>
           </FlexItem>

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -115,12 +115,12 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
         <Flex
           spaceItems={{ default: 'spaceItemsSm' }}
           alignItems={{ default: 'alignItemsCenter' }}
-          style={{ width: 'calc(50% - 1rem / 2)' }}
+          flex={{ default: 'flex_2' }}
         >
           <FlexItem>
             <Bullseye>{selectorLabel}</Bullseye>
           </FlexItem>
-          <FlexItem style={{ maxWidth: '90%' }}>{selector}</FlexItem>
+          <FlexItem style={{ maxWidth: 'min(90%, 50vw)' }}>{selector}</FlexItem>
         </Flex>
       </Flex>
     );

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -112,11 +112,11 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             height: 'var(--pf-t--global--icon--size--font--2xl)',
           }}
         />
-        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }} style={{width: 'calc(50% - 1rem / 2)'}}>
           <FlexItem>
             <Bullseye>{selectorLabel}</Bullseye>
           </FlexItem>
-          <FlexItem>{selector}</FlexItem>
+          <FlexItem style={{ maxWidth: '90%' }}>{selector}</FlexItem>
         </Flex>
       </Flex>
     );

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -120,7 +120,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           <FlexItem>
             <Bullseye>{selectorLabel}</Bullseye>
           </FlexItem>
-          <FlexItem style={{ maxWidth: 'min(90%, 50vw)' }}>{selector}</FlexItem>
+          <FlexItem flex={{ default: 'flex_1' }}>{selector}</FlexItem>
         </Flex>
       </Flex>
     );

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -56,7 +56,7 @@ const ProjectDetails: React.FC = () => {
       title={
         <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
           <HeaderIcon type={ProjectObjectType.projectContext} sectionType={SectionType.general} />
-          <FlexItem style={{ maxWidth: 'calc(100% - var(--pf-t--global--spacer--2xl))' }}>
+          <FlexItem flex={{ default: 'flex_1' }}>
             <ResourceNameTooltip resource={currentProject} wrap={false}>
               <Truncate content={displayName} />
             </ResourceNameTooltip>

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Breadcrumb, BreadcrumbItem, Flex, FlexItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Flex, FlexItem, Truncate } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
@@ -56,9 +56,9 @@ const ProjectDetails: React.FC = () => {
       title={
         <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
           <HeaderIcon type={ProjectObjectType.projectContext} sectionType={SectionType.general} />
-          <FlexItem>
+          <FlexItem style={{ maxWidth: 'calc(100% - var(--pf-t--global--spacer--2xl))' }}>
             <ResourceNameTooltip resource={currentProject} wrap={false}>
-              {displayName}
+              <Truncate content={displayName} />
             </ResourceNameTooltip>
           </FlexItem>
         </Flex>

--- a/frontend/src/pages/projects/screens/projects/ProjectLink.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectLink.tsx
@@ -1,3 +1,4 @@
+import { Truncate } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
@@ -12,7 +13,7 @@ const ProjectLink: React.FC<Omit<LinkProps, 'to'> & ProjectLinkProps> = ({ proje
 
   return (
     <Link to={`/projects/${project.metadata.name}`} {...props}>
-      {projectName}
+      <Truncate content={projectName} />
     </Link>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Closes https://issues.redhat.com/browse/RHOAIENG-12842 Project Selector Overflow onto the next line in the data science pipeline Page in case of a project name with a long name, added a fixed width calculated with calc
<img width="1489" alt="Screenshot 2025-03-03 at 5 42 42 PM" src="https://github.com/user-attachments/assets/ad127cbb-80be-468e-bc80-d67d6ae2675a" />

**Project Selector Text Overflow** 

2. Resolves Issue related to title overflow onto next line.
<img width="1489" alt="Screenshot 2025-03-03 at 10 02 00 PM" src="https://github.com/user-attachments/assets/dc209eb5-998a-49f1-90bb-ef7c30eb98c4" />

**Data Science Pipeline Text Overflow** 
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually adding screenshots for reference.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
