### PR TITLE
Add ilab route helper

### DIFF
--- a/frontend/src/pages/pipelines/GlobalModelCustomizationRoutes.tsx
+++ b/frontend/src/pages/pipelines/GlobalModelCustomizationRoutes.tsx
@@ -10,7 +10,7 @@ const GlobalModelCustomizationRoutes: React.FC = () => (
   <ProjectsRoutes>
     <Route path="/" element={<GlobalModelCustomization />} />
     <Route
-      path="instructlab/:namespace?/*"
+      path="fine-tune/:modelRegistry/:registeredModelId/:modelVersionId/:namespace"
       element={<GlobalPipelineCoreLoader strict getInvalidRedirectPath={getInvalidRedirectPath} />}
     >
       <Route index element={<ModelCustomizationForm />} />

--- a/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
@@ -15,12 +15,16 @@ import {
   modelCustomizationFormSchema,
 } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { modelCustomizationRootPath } from '~/routes';
 import { useIlabPipeline } from '~/concepts/pipelines/content/modelCustomizationForm/useIlabPipeline';
 import {
   ModelCustomizationEndpointType,
   FineTuneTaxonomyType,
 } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/types';
+import {
+  registeredModelUrl,
+  modelVersionUrl,
+  modelRegistryUrl,
+} from '~/pages/modelRegistry/screens/routeUtils';
 import FineTunePage from './FineTunePage';
 import {
   BASE_MODEL_INPUT_STORAGE_LOCATION_URI_KEY,
@@ -82,7 +86,27 @@ const ModelCustomizationForm: React.FC = () => {
         description={modelCustomizationFormPageDescription}
         breadcrumb={
           <Breadcrumb>
-            <BreadcrumbItem to={modelCustomizationRootPath}>Model customization</BreadcrumbItem>
+            <BreadcrumbItem to={modelRegistry ? modelRegistryUrl(modelRegistry) : undefined}>
+              {modelRegistry}
+            </BreadcrumbItem>
+            <BreadcrumbItem
+              to={
+                registeredModelId && modelRegistry
+                  ? registeredModelUrl(registeredModelId, modelRegistry)
+                  : undefined
+              }
+            >
+              {registeredModelId}
+            </BreadcrumbItem>
+            <BreadcrumbItem
+              to={
+                modelVersionId && registeredModelId && modelRegistry
+                  ? modelVersionUrl(modelVersionId, registeredModelId, modelRegistry)
+                  : undefined
+              }
+            >
+              {modelVersionId}
+            </BreadcrumbItem>
             <BreadcrumbItem>Start an InstructLab run</BreadcrumbItem>
           </Breadcrumb>
         }

--- a/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
@@ -1,7 +1,6 @@
 import { Breadcrumb, BreadcrumbItem, PageSection } from '@patternfly/react-core';
 import * as React from 'react';
-import { useNavigate } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import {
   modelCustomizationFormPageDescription,
@@ -39,14 +38,14 @@ const ModelCustomizationForm: React.FC = () => {
   } = useIlabPipeline();
 
   const [searchParams] = useSearchParams();
+  const { modelRegistry, modelVersionId, registeredModelId } = useParams();
 
   const [data, setData] = useGenericObjectState<ModelCustomizationFormData>({
     projectName: { value: project.metadata.name },
     baseModel: {
-      // TODO: Replace values with actual data
-      registryName: 'Registry1',
-      name: 'my-granite-model',
-      version: 'myModel-v0.0.2',
+      registryName: modelRegistry ?? '',
+      name: registeredModelId ?? '',
+      version: modelVersionId ?? '',
       inputStorageLocationUri: searchParams.get(BASE_MODEL_INPUT_STORAGE_LOCATION_URI_KEY) ?? '',
     },
     taxonomy: {

--- a/frontend/src/routes/pipelines/modelCustomization.ts
+++ b/frontend/src/routes/pipelines/modelCustomization.ts
@@ -1,2 +1,13 @@
+import { BASE_MODEL_INPUT_STORAGE_LOCATION_URI_KEY } from '~/pages/pipelines/global/modelCustomization/const';
+
 export const modelCustomizationRootPath = '/modelCustomization';
 export const globModelCustomizationAll = `${modelCustomizationRootPath}/*`;
+
+export const getModelCustomizationPath = (
+  namespace: string,
+  modelRegistry: string,
+  registeredModelId: string,
+  modelVersionId: string,
+  inputStorageLocationUri: string,
+): string =>
+  `${modelCustomizationRootPath}/fine-tune/${modelRegistry}/${registeredModelId}/${modelVersionId}/${namespace}?${BASE_MODEL_INPUT_STORAGE_LOCATION_URI_KEY}=${inputStorageLocationUri}`;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-20978

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. prefills fields based on url
2. updates breadcrumbs
3. creates helper for route

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make sure route still is accessible and prefill works 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
adjust tests if needed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
