### PR TITLE
Update encodeParams util and fix modelName prefill in Register model form

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -79,7 +79,7 @@ describe('Model Catalog core', () => {
     modelCatalog.findModelCatalogModelDetailLink('granite-8b-code-instruct').click();
     cy.location('pathname').should(
       'equal',
-      '/modelCatalog/Red%20Hat/rhelai1/granite-8b-code-instruct/1.3.0',
+      '/modelCatalog/Red%20Hat/rhelai1/granite-8b-code-instruct/1%252E3%252E0',
     );
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
@@ -66,6 +66,8 @@ describe('Model details page', () => {
         'have.text',
         'Granite-8B-Code-Instruct is a 8B parameter model fine tuned from\nGranite-8B-Code-Base on a combination of permissively licensed instruction\ndata to enhance instruction following capabilities including logical\nreasoning and problem-solving skills.',
       );
+    cy.reload();
+    verifyRelativeURL('/modelCatalog/Red%20Hat/rhelai1/granite-8b-code-instruct/1%252E3%252E0');
     modelDetailsPage
       .findModelCardMarkdown()
       .should('include.text', 'ibm-granite/granite-3.1-8b-base');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
@@ -197,7 +197,7 @@ describe('Register catalog model page', () => {
     registerModelPage.findSubmitButton().should('be.enabled');
     registerModelPage
       .findFormField(FormFieldSelector.MODEL_NAME)
-      .should('have.value', 'granite-8b-code-instruct');
+      .should('have.value', 'granite-8b-code-instruct-1.3.0');
     registerModelPage
       .findFormField(FormFieldSelector.MODEL_DESCRIPTION)
       .should(
@@ -217,7 +217,7 @@ describe('Register catalog model page', () => {
     registerModelPage.findSubmitButton().click();
     cy.wait('@createRegisteredModel').then((interception) => {
       expect(interception.request.body).to.containSubset({
-        name: 'granite-8b-code-instruct',
+        name: 'granite-8b-code-instruct-1.3.0',
         description:
           'Granite-8B-Code-Instruct is a 8B parameter model fine tuned from Granite-8B-Code-Base on a combination of permissively licensed instruction data to enhance instruction following capabilities including logical reasoning and problem-solving skills.',
         customProperties: {

--- a/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
@@ -52,7 +52,7 @@ describe('encodeParams', () => {
     });
     expect(result).toEqual({
       sourceName: 'sample%20test',
-      tag: '1.33-44',
+      tag: '1%252E33-44',
       repositoryName: 'test%4012',
       modelName: 'test',
     });

--- a/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
+++ b/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
@@ -33,7 +33,11 @@ import { ModelCatalogContext } from '~/concepts/modelCatalog/context/ModelCatalo
 import { CatalogModel } from '~/concepts/modelCatalog/types';
 import ModelRegistrySelector from '~/pages/modelRegistry/screens/ModelRegistrySelector';
 import useModelRegistryAPIState from '~/concepts/modelRegistry/context/useModelRegistryAPIState';
-import { decodeParams, findModelFromModelCatalogSources } from '~/pages/modelCatalog/utils';
+import {
+  decodeParams,
+  findModelFromModelCatalogSources,
+  getTagFromModel,
+} from '~/pages/modelCatalog/utils';
 import {
   ModelRegistryCustomProperties,
   ModelRegistryMetadataType,
@@ -84,7 +88,7 @@ const RegisterCatalogModel: React.FC = () => {
   React.useEffect(() => {
     if (model) {
       const labels: ModelRegistryCustomProperties = {};
-      setData('modelName', model.name);
+      setData('modelName', `${model.name}-${getTagFromModel(model) || ''}`);
       setData('modelDescription', model.longDescription?.replace(/\s*\n\s*/g, ' ') ?? '');
       setData('versionName', 'Version 1');
       setData('modelLocationType', ModelLocationType.URI);

--- a/frontend/src/pages/modelCatalog/utils.ts
+++ b/frontend/src/pages/modelCatalog/utils.ts
@@ -26,7 +26,10 @@ export const findModelFromModelCatalogSources = (
 
 export const encodeParams = (params: ModelDetailsRouteParams): ModelDetailsRouteParams =>
   Object.fromEntries(
-    Object.entries(params).map(([key, value]) => [key, encodeURIComponent(value)]),
+    Object.entries(params).map(([key, value]) => [
+      key,
+      encodeURIComponent(value).replace(/\./g, '%252E'),
+    ]),
   );
 
 export const decodeParams = (params: Readonly<ModelDetailsRouteParams>): ModelDetailsRouteParams =>


### PR DESCRIPTION
Closes: [RHOAIENG-21028](https://issues.redhat.com/browse/RHOAIENG-21028) and will fix the modelName prefill, when we register a model from model catalog.

## Description
1. Make sure the model name in Register model form prefills names as `modelName-versionNumber` and not just the `modelName`
  - To test this:
    - Go to Model catalog details page, click on Register model button
    - see that the model name prefills as modelName-versionNumber
2. Make sure model details page won't throw error on refresh.


https://github.com/user-attachments/assets/53910268-c054-4f24-9926-670a0b88954f


## How Has This Been Tested?
Tested this on ui-green cluster.

## Test Impact
Added, update both unit and cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
