### PR TITLE
remove node version matrix from Tests job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,16 @@
 name: Test
 on: [push, pull_request]
+env:
+  NODE_VERSION: 20.x
 jobs:
   Setup:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.x]
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.1.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Node.js modules cache
         uses: actions/cache@v4
         id: modules-cache
@@ -21,7 +20,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/backend/node_modules
             ${{ github.workspace }}/frontend/node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Install dependencies
         if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm install
@@ -41,7 +40,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/backend/node_modules
             ${{ github.workspace }}/frontend/node_modules
-          key: ${{ runner.os }}-20.x-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run linting and formatting checks
         run: npm run lint:frontend:backend
 
@@ -58,7 +57,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/backend/node_modules
             ${{ github.workspace }}/frontend/node_modules
-          key: ${{ runner.os }}-20.x-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run backend unit tests with coverage
         run: |
           npm run test:backend:unit-coverage
@@ -108,10 +107,10 @@ jobs:
         shell: bash
         run: |
           set -x  # Enable debug mode to see each command
-          
+
           echo "Checking directory structure..."
           ls -la frontend/src/__tests__/cypress/cypress/tests/ || echo "Base test directory not found"
-          
+
           if [ -d "frontend/src/__tests__/cypress/cypress/tests/mocked" ]; then
             echo "Found mocked tests directory"
             
@@ -147,7 +146,7 @@ jobs:
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/backend/node_modules
             ${{ github.workspace }}/frontend/node_modules
-          key: ${{ runner.os }}-20.x-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run Cypress Mock tests
         run: |
           if [ "${{ matrix.test-group }}" == "default" ]; then
@@ -168,7 +167,7 @@ jobs:
           path: ./frontend/src/__tests__/cypress/coverage
 
   Combine-Results-and-Upload:
-    needs: [Unit-Tests, Cypress-Mock-Tests] 
+    needs: [Unit-Tests, Cypress-Mock-Tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -209,23 +208,20 @@ jobs:
         run: |
           rm -rf ./coverage/unit-coverage-final.json
           rm -rf ./coverage/backend-coverage-final.json
-          find ./coverage -name "*-coverage-final.json" -type f -delete 
+          find ./coverage -name "*-coverage-final.json" -type f -delete
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           name: frontend-and-backend
-          file: ./coverage/merged-coverage.json 
+          file: ./coverage/merged-coverage.json
           disable_search: true
           directory: ./coverage
           verbose: true
 
   Tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.x]
     needs:
       - Setup
       - Lint
@@ -235,4 +231,4 @@ jobs:
       - Combine-Results-and-Upload
     steps:
       - name: Verify all jobs succeeded
-        run: echo "All required jobs have successfully completed for Node.js ${{ matrix.node-version }}."
+        run: echo "All required jobs have successfully completed for Node.js ${{ env.NODE_VERSION }}."


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-21067

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removes the strategy matrix for node versions from the `Tests` job.
Should allow branch protection rules to target a status check for `Tests` instead of `Tests (20.x)`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
PR status checks

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
