### PR TITLE
fix(17779): misaligned deploy model modal buttons

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
@@ -76,6 +76,7 @@ const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = (
   const labelInfo = () => {
     const button = (
       <Button
+        isInline
         data-testid="view-predefined-vars-button"
         variant="link"
         isAriaDisabled={!predefinedVars}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ServingRuntimeArgsSection.tsx
@@ -32,6 +32,7 @@ const ServingRuntimeArgsSection: React.FC<ServingRuntimeArgsSectionType> = ({
   const servingRuntimeArgsLabelInfo = () => {
     const button = (
       <Button
+        isInline
         data-testid="view-predefined-args-button"
         variant="link"
         isAriaDisabled={!predefinedArgs}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17779

## Description
made the buttons within `labelInfo` inline. 

this also makes it so that disabled buttons still show up as links instead of buttons. it also adds the underline styling. i imagine these changes are also preferred. @yih-wang @jgiardino 

disabled with this change:
![image](https://github.com/user-attachments/assets/af5147ce-44a6-455a-8e37-b155f221ae4a)

disabled PRIOR TO this change:
![image](https://github.com/user-attachments/assets/f8827173-ee89-454e-ab11-d09837b5671a)

enabled with this change:
![image](https://github.com/user-attachments/assets/f00eb064-14a9-4e9b-a710-29e60417ac51)

enabled PRIOR TO this change:
![image](https://github.com/user-attachments/assets/c3e982b0-992f-4dd8-8ee3-d7684f87a178)


no test impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
