### PR TITLE
Add back the notification for auth resource updates

### DIFF
--- a/frontend/src/concepts/userConfigs/useWatchGroups.tsx
+++ b/frontend/src/concepts/userConfigs/useWatchGroups.tsx
@@ -98,6 +98,12 @@ export const useWatchGroups = (): {
         updateAuthGroups(group, groupsData)
           .then((groupsResponse) => {
             setGroupSettings(groupsResponse);
+            // The permissions are immediate -- the cache of the old world ResourceWatcher is 2 mins
+            // Update this to direct permissions with RHOAIENG-16988 -- it will be immediate
+            notification.success(
+              'Group settings changes saved',
+              'It may take up to 2 minutes for configuration changes to be applied.',
+            );
           })
           .catch((error) => {
             setLoadError(error);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-20458

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Notification was returned saying saving would take up to 2 mins.

Reasoning is tied to how we figure out admins (2mins ResourceWatcher cache).

Should be fixed in properly with https://issues.redhat.com/browse/RHOAIENG-16988

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Simply use the user management page as any (admin) user. Make a change & save.

Extra verification will need to use impersonate or log in as two different users using the `dev:start:ext` frontend start

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
