### PR TITLE
Fix selecting all projects for global model page

### DIFF
--- a/frontend/src/concepts/projects/ProjectSelectorNavigator.tsx
+++ b/frontend/src/concepts/projects/ProjectSelectorNavigator.tsx
@@ -19,7 +19,8 @@ const ProjectSelectorNavigator: React.FC<ProjectSelectorProps> = ({
     <ProjectSelector
       {...projectSelectorProps}
       onSelection={(projectName) => {
-        updatePreferredProject(projects.find(byName(projectName)) || null);
+        const match = projectName ? projects.find(byName(projectName)) ?? null : null;
+        updatePreferredProject(match);
         navigate(getRedirectPath(projectName));
       }}
       namespace={namespace ?? ''}

--- a/frontend/src/concepts/projects/ProjectSelectorNavigator.tsx
+++ b/frontend/src/concepts/projects/ProjectSelectorNavigator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
+import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import ProjectSelector from './ProjectSelector';
 
 type ProjectSelectorProps = {
@@ -13,15 +13,13 @@ const ProjectSelectorNavigator: React.FC<ProjectSelectorProps> = ({
 }) => {
   const navigate = useNavigate();
   const { namespace } = useParams();
-  const { updatePreferredProject } = React.useContext(ProjectsContext);
+  const { projects, updatePreferredProject } = React.useContext(ProjectsContext);
 
   return (
     <ProjectSelector
       {...projectSelectorProps}
       onSelection={(projectName) => {
-        if (!projectName) {
-          updatePreferredProject(null);
-        }
+        updatePreferredProject(projects.find(byName(projectName)) || null);
         navigate(getRedirectPath(projectName));
       }}
       namespace={namespace ?? ''}

--- a/frontend/src/pages/modelServing/ModelServingContext.tsx
+++ b/frontend/src/pages/modelServing/ModelServingContext.tsx
@@ -21,7 +21,6 @@ import { useContextResourceData } from '~/utilities/useContextResourceData';
 import { useDashboardNamespace } from '~/redux/selectors';
 import { DataConnection } from '~/pages/projects/types';
 import useDataConnections from '~/pages/projects/screens/detail/data-connections/useDataConnections';
-import useSyncPreferredProject from '~/concepts/projects/useSyncPreferredProject';
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import { conditionalArea, SupportedArea } from '~/concepts/areas';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
@@ -81,7 +80,6 @@ const ModelServingContextProvider = conditionalArea<ModelServingContextProviderP
   const navigate = useNavigate();
   const { projects, preferredProject } = React.useContext(ProjectsContext);
   const project = projects.find(byName(namespace)) ?? null;
-  useSyncPreferredProject(project);
   const servingRuntimeTemplates = useTemplates(dashboardNamespace);
 
   const servingRuntimeTemplateOrder = useContextResourceData<string>(


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-20051

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The `preferredProject` is a thing in the `ProjectsContext` to so a user doesn't always have to reselect their project. It's basically the last project you visited. The global model serving page used `useSyncPreferredProject` and would set the preferred project to the current project you are on (the project name in the url). 
If you tried to set `preferredProject` to something else (like null all projects), it would be overwritten by the current page you are on, never changing. The `preferredProject` logic navigation is used when you nav to the global `/modelServing` without any project, so this is why it was only happening here.

![image](https://github.com/user-attachments/assets/a8c50ec3-9e61-4a33-9beb-bd11f01bf650)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. go to `/modelServing` (it should be defaulting to "All projects")
2. select a project
3. Select "All projects"
4. It should have gone to "All projects" (the before it would be stuck at the project you are at)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No changes, it's a really small hook change, and there are no existing tests for the hook

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
