### PR TITLE
Allow user to edit file field contents

### DIFF
--- a/frontend/src/concepts/connectionTypes/fields/FileFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/FileFormField.tsx
@@ -74,6 +74,7 @@ const FileFormField: React.FC<FieldProps<FileField>> = ({
         browseButtonText="Upload"
         clearButtonText="Clear"
         onDataChange={isPreview || !onChange ? undefined : (e, content) => onChange(content)}
+        onTextChange={isPreview || !onChange ? undefined : (e, content) => onChange(content)}
         onFileInputChange={(_e, file) => setFilename(file.name)}
         isClearButtonDisabled={rejectedReason ? false : undefined}
         onClearClick={() => {

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/FileFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/FileFormField.spec.tsx
@@ -89,6 +89,6 @@ describe('FileFormField', () => {
     act(() => {
       fireEvent.change(contentInput, { target: { value: 'new-value' } });
     });
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes: [RHOAIENG-20556](https://issues.redhat.com/browse/RHOAIENG-20556)

## Description
Allows users to modify the file field contents after upload. Previously the user was only able to view the contents. 

## How Has This Been Tested?
Tested locally on cluster.

- Create a connection that has the option for file upload
- After uploading the file, you should be able to modify and save the contents of the file within the upload box


https://github.com/user-attachments/assets/53de3095-d50f-4889-bb83-9e3588d41eb6


## Test Impact
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
