### PR TITLE
remove disableKServeOCIModels

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -20,7 +20,6 @@ export type MockDashboardConfigType = {
   disableKServeAuth?: boolean;
   disableKServeMetrics?: boolean;
   disableKServeRaw?: boolean;
-  disableKServeOCIModels?: boolean;
   disableModelMesh?: boolean;
   disableAcceleratorProfiles?: boolean;
   disableHardwareProfiles?: boolean;
@@ -59,7 +58,6 @@ export const mockDashboardConfig = ({
   disableKServeAuth = false,
   disableKServeMetrics = true,
   disableKServeRaw = true,
-  disableKServeOCIModels = true,
   disableModelMesh = false,
   disableAcceleratorProfiles = false,
   disableHardwareProfiles = true,
@@ -215,7 +213,6 @@ export const mockDashboardConfig = ({
       disableKServeAuth,
       disableKServeMetrics,
       disableKServeRaw,
-      disableKServeOCIModels,
       disableModelMesh,
       disableAcceleratorProfiles,
       disableHardwareProfiles,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/connections.cy.ts
@@ -12,7 +12,7 @@ import { connectionsPage } from '~/__tests__/cypress/cypress/pages/connections';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import { ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
 
-const initIntercepts = ({ isEmpty = false, disableOci = true }) => {
+const initIntercepts = ({ isEmpty = false }) => {
   cy.interceptK8sList(
     ProjectModel,
     mockK8sResourceList([mockProjectK8sResource({ k8sName: 'test-project' })]),
@@ -39,7 +39,6 @@ const initIntercepts = ({ isEmpty = false, disableOci = true }) => {
     'GET /api/config',
     mockDashboardConfig({
       disableConnectionTypes: false,
-      disableKServeOCIModels: disableOci,
     }),
   );
   cy.interceptOdh('GET /api/connection-types', [mockConnectionTypeConfigMap({})]);
@@ -196,7 +195,7 @@ describe('Connections', () => {
   });
 
   it('Create an OCI connection', () => {
-    initIntercepts({ disableOci: false });
+    initIntercepts({});
     cy.interceptOdh('GET /api/connection-types', [
       mockConnectionTypeConfigMap({
         name: 'oci-v1',

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -29,7 +29,6 @@ export const allFeatureFlags: string[] = Object.keys({
   disableKServeAuth: false,
   disableKServeMetrics: false,
   disableKServeRaw: true,
-  disableKServeOCIModels: true,
   disableModelMesh: false,
   disableAcceleratorProfiles: false,
   disableHardwareProfiles: false,
@@ -93,10 +92,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.K_SERVE_RAW]: {
     featureFlags: ['disableKServeRaw'],
-    reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
-  },
-  [SupportedArea.K_SERVE_OCI]: {
-    featureFlags: ['disableKServeOCIModels'],
     reliantAreas: [SupportedArea.K_SERVE, SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.MODEL_MESH]: {

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -53,7 +53,6 @@ export enum SupportedArea {
   K_SERVE_AUTH = 'kserve-auth',
   K_SERVE_METRICS = 'kserve-metrics',
   K_SERVE_RAW = 'kserve-raw',
-  K_SERVE_OCI = 'kserve-oci',
   MODEL_MESH = 'model-mesh',
   BIAS_METRICS = 'bias-metrics',
   PERFORMANCE_METRICS = 'performance-metrics',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1208,7 +1208,6 @@ export type DashboardCommonConfig = {
   disableKServeAuth: boolean;
   disableKServeMetrics: boolean;
   disableKServeRaw: boolean;
-  disableKServeOCIModels: boolean;
   disableModelMesh: boolean;
   disableAcceleratorProfiles: boolean;
   disableHardwareProfiles: boolean;

--- a/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/useConnections.ts
@@ -8,14 +8,11 @@ import useFetchState, {
 import { Connection } from '~/concepts/connectionTypes/types';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE } from '~/const';
 import { isConnection, isModelServingCompatible } from '~/concepts/connectionTypes/utils';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 const useConnections = (
   namespace?: string,
   modelServingCompatible?: boolean,
 ): FetchState<Connection[]> => {
-  const isOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
-
   const callback = React.useCallback<FetchStateCallbackPromise<Connection[]>>(
     async (opts) => {
       if (!namespace) {
@@ -32,15 +29,10 @@ const useConnections = (
       if (modelServingCompatible) {
         connections = connections.filter((c) => isModelServingCompatible(c));
       }
-      if (!isOciEnabled) {
-        connections = connections.filter(
-          (c) => c.metadata.annotations['opendatahub.io/connection-type-ref'] !== 'oci-v1',
-        );
-      }
 
       return connections;
     },
-    [namespace, modelServingCompatible, isOciEnabled],
+    [namespace, modelServingCompatible],
   );
 
   return useFetchState(callback, []);

--- a/frontend/src/utilities/useWatchConnectionTypes.tsx
+++ b/frontend/src/utilities/useWatchConnectionTypes.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { isModelServingCompatible } from '~/concepts/connectionTypes/utils';
 import { fetchConnectionTypes } from '~/services/connectionTypesService';
@@ -8,8 +7,6 @@ import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilitie
 export const useWatchConnectionTypes = (
   modelServingCompatible?: boolean,
 ): FetchState<ConnectionTypeConfigMapObj[]> => {
-  const isOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
-
   const callback = React.useCallback<
     FetchStateCallbackPromise<ConnectionTypeConfigMapObj[]>
   >(async () => {
@@ -17,12 +14,9 @@ export const useWatchConnectionTypes = (
     if (modelServingCompatible) {
       connectionTypes = connectionTypes.filter((ct) => isModelServingCompatible(ct));
     }
-    if (!isOciEnabled) {
-      connectionTypes = connectionTypes.filter((ct) => ct.metadata.name !== 'oci-v1');
-    }
 
     return connectionTypes;
-  }, [modelServingCompatible, isOciEnabled]);
+  }, [modelServingCompatible]);
 
   return useFetchState<ConnectionTypeConfigMapObj[]>(callback, []);
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Updates https://issues.redhat.com/browse/RHOAIENG-18657 and https://issues.redhat.com/browse/RHOAIENG-18659 again

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
based off convo in https://redhat-internal.slack.com/archives/C05SMJ09DD2/p1741194826349979
you can just enable or disable the ootb connection type to toggle this, so this is duplicative and not needed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
removed from tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
