### PR TITLE
Model registry ilab fine tune button on version details, and kebab action on model versions table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -158,6 +158,14 @@ class ModelVersionDetails {
   findSaveLabelsButton() {
     return cy.findByTestId('editable-labels-group-save');
   }
+
+  findLabTuneButton() {
+    return cy.findByTestId('lab-tune-button');
+  }
+
+  findStartRunModal() {
+    return cy.findByTestId('start-run-modal');
+  }
 }
 
 class PropertyRow extends TableRow {}

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/application.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/application.cy.ts
@@ -76,12 +76,12 @@ describe('Application', () => {
       dataScienceStackComponentMap[DataScienceStackComponent.MODEL_REGISTRY],
     );
     row1.find().findByText('Kubeflow Model Registry').should('exist');
-    row1.find().findByText('1.14.0').should('exist');
+    row1.find().findByText('v0.2.13').should('exist');
     const row2 = aboutDialog.getComponentReleasesRow(
       dataScienceStackComponentMap[DataScienceStackComponent.K_SERVE],
     );
-    row2.find().findByText('KServe Operator').should('exist');
-    row2.find().findByText('v0.2.13').should('exist');
+    row2.find().findByText('KServe').should('exist');
+    row2.find().findByText('v0.14.0').should('exist');
   });
 
   it('should show the about modal correctly when release name is not available', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/application.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/application.cy.ts
@@ -76,12 +76,12 @@ describe('Application', () => {
       dataScienceStackComponentMap[DataScienceStackComponent.MODEL_REGISTRY],
     );
     row1.find().findByText('Kubeflow Model Registry').should('exist');
-    row1.find().findByText('v0.2.13').should('exist');
+    row1.find().findByText('1.14.0').should('exist');
     const row2 = aboutDialog.getComponentReleasesRow(
       dataScienceStackComponentMap[DataScienceStackComponent.K_SERVE],
     );
-    row2.find().findByText('KServe').should('exist');
-    row2.find().findByText('v0.14.0').should('exist');
+    row2.find().findByText('KServe Operator').should('exist');
+    row2.find().findByText('v0.2.13').should('exist');
   });
 
   it('should show the about modal correctly when release name is not available', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersions.cy.ts
@@ -316,6 +316,6 @@ describe('Model Versions', () => {
     registeredModelRow.findName().contains('Fraud detection model').click();
 
     const modelVersionRow = modelRegistry.getModelVersionRow('model version');
-    modelVersionRow.findKebabAction('Lab tune').click();
+    modelVersionRow.findKebabAction('LAB tune').click();
   });
 });

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -61,7 +61,7 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChild
       modelRegistryServicesLoaded: isLoaded,
       modelRegistryServicesLoadError: error,
       modelRegistryServices,
-      preferredModelRegistry,
+      preferredModelRegistry: preferredModelRegistry ?? modelRegistryServices[0],
       updatePreferredModelRegistry,
       refreshRulesReview,
     }),

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -21,7 +21,7 @@ export const ModelRegistrySelectorContext = React.createContext<ModelRegistrySel
   modelRegistryServicesLoaded: false,
   modelRegistryServicesLoadError: undefined,
   modelRegistryServices: [],
-  preferredModelRegistry:  null,
+  preferredModelRegistry: null,
   updatePreferredModelRegistry: () => undefined,
   refreshRulesReview: () => undefined,
 });
@@ -39,7 +39,9 @@ export const ModelRegistrySelectorContextProvider: React.FC<
   return children;
 };
 
-const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
   const { dscStatus } = React.useContext(AreaContext);
   const {
     modelRegistryServices = [],
@@ -47,9 +49,11 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChild
     error,
     refreshRulesReview,
   } = useModelRegistryServices(dscStatus?.components?.modelregistry?.registriesNamespace || '');
-  const [preferredModelRegistry, setPreferredModelRegistry] = React.useState<ServiceKind | null>(null);
+  const [preferredModelRegistry, setPreferredModelRegistry] = React.useState<ServiceKind | null>(
+    null,
+  );
 
-  const updatePreferredModelRegistry = (modelRegistry: ServiceKind | undefined) => 
+  const updatePreferredModelRegistry = (modelRegistry: ServiceKind | undefined) =>
     setPreferredModelRegistry(modelRegistry ?? null);
 
   const contextValue = React.useMemo(

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -4,14 +4,14 @@ import useModelRegistryEnabled from '~/concepts/modelRegistry/useModelRegistryEn
 import { useModelRegistryServices } from '~/concepts/modelRegistry/apiHooks/useModelRegistryServices';
 import { AreaContext } from '~/concepts/areas/AreaContext';
 
-export type ModelRegistrySelectorContextType = {
+export interface ModelRegistrySelectorContextType {
   modelRegistryServicesLoaded: boolean;
   modelRegistryServicesLoadError?: Error;
   modelRegistryServices: ServiceKind[];
-  preferredModelRegistry: ServiceKind | undefined;
+  preferredModelRegistry: ServiceKind | null;
   updatePreferredModelRegistry: (modelRegistry: ServiceKind | undefined) => void;
   refreshRulesReview: () => void;
-};
+}
 
 type ModelRegistrySelectorContextProviderProps = {
   children: React.ReactNode;
@@ -21,7 +21,7 @@ export const ModelRegistrySelectorContext = React.createContext<ModelRegistrySel
   modelRegistryServicesLoaded: false,
   modelRegistryServicesLoadError: undefined,
   modelRegistryServices: [],
-  preferredModelRegistry: undefined,
+  preferredModelRegistry:  null,
   updatePreferredModelRegistry: () => undefined,
   refreshRulesReview: () => undefined,
 });
@@ -39,9 +39,7 @@ export const ModelRegistrySelectorContextProvider: React.FC<
   return children;
 };
 
-const EnabledModelRegistrySelectorContextProvider: React.FC<
-  ModelRegistrySelectorContextProviderProps
-> = ({ children }) => {
+const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { dscStatus } = React.useContext(AreaContext);
   const {
     modelRegistryServices = [],
@@ -49,17 +47,18 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<
     error,
     refreshRulesReview,
   } = useModelRegistryServices(dscStatus?.components?.modelregistry?.registriesNamespace || '');
-  const [preferredModelRegistry, setPreferredModelRegistry] = React.useState<
-    ServiceKind | undefined
-  >(undefined);
+  const [preferredModelRegistry, setPreferredModelRegistry] = React.useState<ServiceKind | null>(null);
+
+  const updatePreferredModelRegistry = (modelRegistry: ServiceKind | undefined) => 
+    setPreferredModelRegistry(modelRegistry ?? null);
 
   const contextValue = React.useMemo(
     () => ({
       modelRegistryServicesLoaded: isLoaded,
       modelRegistryServicesLoadError: error,
       modelRegistryServices,
-      preferredModelRegistry: preferredModelRegistry ?? modelRegistryServices[0],
-      updatePreferredModelRegistry: setPreferredModelRegistry,
+      preferredModelRegistry,
+      updatePreferredModelRegistry,
       refreshRulesReview,
     }),
     [isLoaded, error, modelRegistryServices, preferredModelRegistry, refreshRulesReview],

--- a/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
+++ b/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import type { ModelVersion } from '~/concepts/modelRegistry/types';
+import type { ModelVersion, RegisteredModel } from '~/concepts/modelRegistry/types';
 import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { getServerAddress } from '~/pages/modelRegistry/screens/utils';
@@ -8,17 +8,9 @@ import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/M
 export const useModelVersionTuningData = (
   modelVersionId: string | null,
   modelVersion: ModelVersion | null,
+  registeredModel: RegisteredModel | null,
 ): {
-  tuningData: {
-    modelRegistryName: string;
-    modelRegistryDisplayName: string;
-    registeredModelId: string;
-    registeredModelName: string;
-    modelVersionId: string;
-    modelVersionName: string;
-    inputModelLocationUri: string;
-    outputModelRegistryApiUrl: string;
-  } | null;
+  tuningData: Record<string, string> | null;
   loaded: boolean;
   loadError: Error | null;
 } => {
@@ -39,15 +31,15 @@ export const useModelVersionTuningData = (
 
   return {
     tuningData:
-      modelVersionId && modelVersion && inputModelLocationUri
+      modelVersion && registeredModel
         ? {
             modelRegistryName: registryService?.metadata.name || '',
             modelRegistryDisplayName,
             registeredModelId: modelVersion.registeredModelId,
-            registeredModelName: modelVersion.name,
+            registeredModelName: registeredModel.name,
             modelVersionId: modelVersion.id,
             modelVersionName: modelVersion.name,
-            inputModelLocationUri,
+            inputModelLocationUri: inputModelLocationUri || '',
             outputModelRegistryApiUrl,
           }
         : null,

--- a/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
+++ b/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
@@ -1,0 +1,44 @@
+import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
+import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import { getServerAddress } from '~/pages/modelRegistry/screens/utils';
+import { useModelRegistryServices } from '~/concepts/modelRegistry/apiHooks/useModelRegistryServices';
+import { ModelRegistrySelectorContext } from '../context/ModelRegistrySelectorContext';
+import { useContext } from 'react';
+import type { ModelVersion } from '~/concepts/modelRegistry/types';
+
+export const useModelVersionTuningData = (
+  modelVersionId: string | null,
+  modelVersion: ModelVersion | null,
+) => {
+  const { preferredModelRegistry, modelRegistryServices } = useContext(ModelRegistrySelectorContext);
+  const registryService = modelRegistryServices.find(
+    (s) => s.metadata.name === preferredModelRegistry?.metadata?.name
+  );
+
+  const [artifacts, loaded, loadError] = useModelArtifactsByVersionId(modelVersionId || undefined);
+
+  const inputModelLocationUri = artifacts?.items?.[0]?.uri;
+  const modelRegistryDisplayName = registryService 
+    ? getDisplayNameFromK8sResource(registryService)
+    : '';
+  const outputModelRegistryApiUrl = registryService 
+    ? getServerAddress(registryService)
+    : '';
+
+  return {
+    tuningData: modelVersionId && modelVersion && inputModelLocationUri
+      ? {
+          modelRegistryName: registryService?.metadata.name || '',
+          modelRegistryDisplayName,
+          registeredModelId: modelVersion.registeredModelId,
+          registeredModelName: modelVersion.name,
+          modelVersionId: modelVersion.id,
+          modelVersionName: modelVersion.name,
+          inputModelLocationUri,
+          outputModelRegistryApiUrl,
+        }
+      : null,
+    loaded,
+    loadError,
+  };
+}; 

--- a/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
+++ b/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
@@ -1,44 +1,58 @@
+import { useContext } from 'react';
+import type { ModelVersion } from '~/concepts/modelRegistry/types';
 import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { getServerAddress } from '~/pages/modelRegistry/screens/utils';
-import { useModelRegistryServices } from '~/concepts/modelRegistry/apiHooks/useModelRegistryServices';
-import { ModelRegistrySelectorContext } from '../context/ModelRegistrySelectorContext';
-import { useContext } from 'react';
-import type { ModelVersion } from '~/concepts/modelRegistry/types';
+import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 
 export const useModelVersionTuningData = (
   modelVersionId: string | null,
   modelVersion: ModelVersion | null,
-) => {
-  const { preferredModelRegistry, modelRegistryServices } = useContext(ModelRegistrySelectorContext);
+): {
+  tuningData: {
+    modelRegistryName: string;
+    modelRegistryDisplayName: string;
+    registeredModelId: string;
+    registeredModelName: string;
+    modelVersionId: string;
+    modelVersionName: string;
+    inputModelLocationUri: string;
+    outputModelRegistryApiUrl: string;
+  } | null;
+  loaded: boolean;
+  loadError: Error | null;
+} => {
+  const { preferredModelRegistry, modelRegistryServices } = useContext(
+    ModelRegistrySelectorContext,
+  );
   const registryService = modelRegistryServices.find(
-    (s) => s.metadata.name === preferredModelRegistry?.metadata?.name
+    (s) => s.metadata.name === preferredModelRegistry?.metadata.name,
   );
 
   const [artifacts, loaded, loadError] = useModelArtifactsByVersionId(modelVersionId || undefined);
 
-  const inputModelLocationUri = artifacts?.items?.[0]?.uri;
-  const modelRegistryDisplayName = registryService 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const inputModelLocationUri = artifacts?.items[0]?.uri;
+  const modelRegistryDisplayName = registryService
     ? getDisplayNameFromK8sResource(registryService)
     : '';
-  const outputModelRegistryApiUrl = registryService 
-    ? getServerAddress(registryService)
-    : '';
+  const outputModelRegistryApiUrl = registryService ? getServerAddress(registryService) : '';
 
   return {
-    tuningData: modelVersionId && modelVersion && inputModelLocationUri
-      ? {
-          modelRegistryName: registryService?.metadata.name || '',
-          modelRegistryDisplayName,
-          registeredModelId: modelVersion.registeredModelId,
-          registeredModelName: modelVersion.name,
-          modelVersionId: modelVersion.id,
-          modelVersionName: modelVersion.name,
-          inputModelLocationUri,
-          outputModelRegistryApiUrl,
-        }
-      : null,
+    tuningData:
+      modelVersionId && modelVersion && inputModelLocationUri
+        ? {
+            modelRegistryName: registryService?.metadata.name || '',
+            modelRegistryDisplayName,
+            registeredModelId: modelVersion.registeredModelId,
+            registeredModelName: modelVersion.name,
+            modelVersionId: modelVersion.id,
+            modelVersionName: modelVersion.name,
+            inputModelLocationUri,
+            outputModelRegistryApiUrl,
+          }
+        : null,
     loaded,
-    loadError,
+    loadError: loadError || null,
   };
-}; 
+};

--- a/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
+++ b/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
@@ -10,7 +10,16 @@ export const useModelVersionTuningData = (
   modelVersion: ModelVersion | null,
   registeredModel: RegisteredModel | null,
 ): {
-  tuningData: Record<string, string> | null;
+  tuningData: {
+    modelRegistryName: string;
+    modelRegistryDisplayName: string;
+    registeredModelId: string;
+    registeredModelName: string;
+    modelVersionId: string;
+    modelVersionName: string;
+    inputModelLocationUri: string;
+    outputModelRegistryApiUrl: string;
+  } | null;
   loaded: boolean;
   loadError: Error | null;
 } => {
@@ -31,15 +40,15 @@ export const useModelVersionTuningData = (
 
   return {
     tuningData:
-      modelVersion && registeredModel
+      modelVersionId && modelVersion && inputModelLocationUri && registryService && registeredModel
         ? {
-            modelRegistryName: registryService?.metadata.name || '',
+            modelRegistryName: registryService.metadata.name,
             modelRegistryDisplayName,
             registeredModelId: modelVersion.registeredModelId,
             registeredModelName: registeredModel.name,
             modelVersionId: modelVersion.id,
             modelVersionName: modelVersion.name,
-            inputModelLocationUri: inputModelLocationUri || '',
+            inputModelLocationUri,
             outputModelRegistryApiUrl,
           }
         : null,

--- a/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
+++ b/frontend/src/concepts/modelRegistry/hooks/useModelVersionTuningData.ts
@@ -31,8 +31,7 @@ export const useModelVersionTuningData = (
 
   const [artifacts, loaded, loadError] = useModelArtifactsByVersionId(modelVersionId || undefined);
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const inputModelLocationUri = artifacts?.items[0]?.uri;
+  const inputModelLocationUri = artifacts.items[0]?.uri;
   const modelRegistryDisplayName = registryService
     ? getDisplayNameFromK8sResource(registryService)
     : '';

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
@@ -125,6 +125,7 @@ const ModelVersionsDetails: React.FC<ModelVersionsDetailProps> = ({ tab, ...page
             <FlexItem>
               <ModelVersionsDetailsHeaderActions
                 mv={mv}
+                registeredModel={rm}
                 hasDeployment={inferenceServices.data.length > 0}
                 refresh={refresh}
               />

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -124,11 +124,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
         <StartRunModal
           onCancel={() => setIsLabTuneModalOpen(false)}
           onSubmit={(selectedProject) => {
-            navigate(
-              `${getModelCustomizationPath(selectedProject)}?${new URLSearchParams(
-                tuningData!,
-              ).toString()}`,
-            );
+            navigate(getModelCustomizationPath(selectedProject), { state: tuningData });
           }}
           loaded={loaded}
           loadError={loadError}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -71,7 +71,11 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
           </Button>
         </ActionListItem>
         {isFineTuningEnabled && (
-          <ActionListItem className="pf-v5-u-w-100">
+          <ActionListItem
+            className="pf-v5-u-w-100"
+            data-testid="lab-tune-button"
+            aria-label="Lab tune version"
+          >
             <Button variant="secondary" onClick={() => setIsLabTuneModalOpen(true)}>
               LAB tune
             </Button>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -43,9 +43,8 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   const [isLabTuneModalOpen, setIsLabTuneModalOpen] = React.useState(false);
   const tooltipRef = React.useRef<HTMLButtonElement>(null);
 
-  const isKServeOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI);
-  const isFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING);
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const isKServeOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
+  const isFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING).status;
   const isLabTuneEnabled = isKServeOciEnabled && isFineTuningEnabled;
 
   const { tuningData, loaded, loadError } = useModelVersionTuningData(

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -7,6 +7,8 @@ import {
   Button,
   ButtonVariant,
   ActionList,
+  ActionListItem,
+  ActionListGroup,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
@@ -43,9 +45,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   const [isLabTuneModalOpen, setIsLabTuneModalOpen] = React.useState(false);
   const tooltipRef = React.useRef<HTMLButtonElement>(null);
 
-  const isKServeOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
   const isFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING).status;
-  const isLabTuneEnabled = isKServeOciEnabled && isFineTuningEnabled;
 
   const { tuningData, loaded, loadError } = useModelVersionTuningData(
     isLabTuneModalOpen ? mv.id : null,
@@ -67,17 +67,16 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
       >
         Deploy
       </Button>
-      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-      {isLabTuneEnabled && (
-        <Button
-          id="lab-tune-button"
-          aria-label="Lab tune version"
-          variant={ButtonVariant.secondary}
-          onClick={() => setIsLabTuneModalOpen(true)}
-          data-testid="lab-tune-button"
-        >
-          Lab tune
-        </Button>
+      {isFineTuningEnabled && (
+        <ActionListGroup>
+          <ActionList>
+            <ActionListItem data-testid="lab-tune-button" aria-label="Lab tune version">
+              <Button variant="secondary" onClick={() => setIsLabTuneModalOpen(true)}>
+                Lab tune
+              </Button>
+            </ActionListItem>
+          </ActionList>
+        </ActionListGroup>
       )}
       <Dropdown
         isOpen={isOpenActionDropdown}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -13,7 +13,7 @@ import {
 import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
-import { ModelVersion, ModelState } from '~/concepts/modelRegistry/types';
+import { ModelVersion, ModelState, RegisteredModel } from '~/concepts/modelRegistry/types';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import {
   modelVersionDeploymentsUrl,
@@ -27,12 +27,14 @@ import { getModelCustomizationPath } from '~/routes/pipelines/modelCustomization
 
 interface ModelVersionsDetailsHeaderActionsProps {
   mv: ModelVersion;
+  registeredModel: RegisteredModel | null;
   hasDeployment?: boolean;
   refresh: () => void;
 }
 
 const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActionsProps> = ({
   mv,
+  registeredModel,
   hasDeployment = false,
   refresh,
 }) => {
@@ -50,6 +52,7 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   const { tuningData, loaded, loadError } = useModelVersionTuningData(
     isLabTuneModalOpen ? mv.id : null,
     mv,
+    registeredModel,
   );
 
   if (!preferredModelRegistry) {

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -57,61 +57,65 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   }
 
   return (
-    <ActionList>
-      <Button
-        id="deploy-button"
-        aria-label="Deploy version"
-        ref={tooltipRef}
-        variant={ButtonVariant.primary}
-        onClick={() => setIsDeployModalOpen(true)}
-      >
-        Deploy
-      </Button>
-      {isFineTuningEnabled && (
-        <ActionListGroup>
-          <ActionList>
-            <ActionListItem data-testid="lab-tune-button" aria-label="Lab tune version">
-              <Button variant="secondary" onClick={() => setIsLabTuneModalOpen(true)}>
-                Lab tune
-              </Button>
-            </ActionListItem>
-          </ActionList>
-        </ActionListGroup>
-      )}
-      <Dropdown
-        isOpen={isOpenActionDropdown}
-        onSelect={() => setOpenActionDropdown(false)}
-        onOpenChange={(open) => setOpenActionDropdown(open)}
-        popperProps={{ position: 'right', appendTo: 'inline' }}
-        toggle={(toggleRef) => (
-          <MenuToggle
-            variant={ButtonVariant.secondary}
-            ref={toggleRef}
-            onClick={() => setOpenActionDropdown(!isOpenActionDropdown)}
-            isExpanded={isOpenActionDropdown}
-            aria-label="Model version details action toggle"
-            data-testid="model-version-details-action-button"
-          >
-            Actions
-          </MenuToggle>
-        )}
-      >
-        <DropdownList>
-          <DropdownItem
-            isAriaDisabled={hasDeployment}
-            id="archive-version-button"
-            aria-label="Archive model version"
-            key="archive-version-button"
-            onClick={() => setIsArchiveModalOpen(true)}
-            tooltipProps={
-              hasDeployment ? { content: 'Deployed model versions cannot be archived' } : undefined
-            }
+    <ActionList className="pf-v5-u-display-flex">
+      <ActionListGroup className="pf-v5-u-flex-1">
+        <ActionListItem>
+          <Button
+            id="deploy-button"
+            aria-label="Deploy version"
             ref={tooltipRef}
+            variant={ButtonVariant.primary}
+            onClick={() => setIsDeployModalOpen(true)}
           >
-            Archive model version
-          </DropdownItem>
-        </DropdownList>
-      </Dropdown>
+            Deploy
+          </Button>
+        </ActionListItem>
+        {isFineTuningEnabled && (
+          <ActionListItem className="pf-v5-u-w-100">
+            <Button variant="secondary" onClick={() => setIsLabTuneModalOpen(true)}>
+              LAB tune
+            </Button>
+          </ActionListItem>
+        )}
+        <ActionListItem>
+          <Dropdown
+            isOpen={isOpenActionDropdown}
+            onSelect={() => setOpenActionDropdown(false)}
+            onOpenChange={(open) => setOpenActionDropdown(open)}
+            popperProps={{ position: 'right', appendTo: 'inline' }}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                variant={ButtonVariant.secondary}
+                ref={toggleRef}
+                onClick={() => setOpenActionDropdown(!isOpenActionDropdown)}
+                isExpanded={isOpenActionDropdown}
+                aria-label="Model version details action toggle"
+                data-testid="model-version-details-action-button"
+              >
+                Actions
+              </MenuToggle>
+            )}
+          >
+            <DropdownList>
+              <DropdownItem
+                isAriaDisabled={hasDeployment}
+                id="archive-version-button"
+                aria-label="Archive model version"
+                key="archive-version-button"
+                onClick={() => setIsArchiveModalOpen(true)}
+                tooltipProps={
+                  hasDeployment
+                    ? { content: 'Deployed model versions cannot be archived' }
+                    : undefined
+                }
+                ref={tooltipRef}
+              >
+                Archive model version
+              </DropdownItem>
+            </DropdownList>
+          </Dropdown>
+        </ActionListItem>
+      </ActionListGroup>
       {isLabTuneModalOpen ? (
         <StartRunModal
           onCancel={() => setIsLabTuneModalOpen(false)}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionListView.tsx
@@ -126,6 +126,7 @@ const ModelVersionListView: React.FC<ModelVersionListViewProps> = ({
       <ModelVersionsTable
         refresh={refresh}
         isArchiveModel={isArchiveModel}
+        registeredModel={rm}
         clearFilters={() => setSearch('')}
         modelVersions={sortModelVersionsByCreateTime(filteredModelVersions)}
         toolbarContent={

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { Table } from '~/components/table';
-import { ModelVersion } from '~/concepts/modelRegistry/types';
+import { ModelVersion, RegisteredModel } from '~/concepts/modelRegistry/types';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import useInferenceServices from '~/pages/modelServing/useInferenceServices';
 import { useMakeFetchObject } from '~/utilities/useMakeFetchObject';
@@ -14,6 +14,7 @@ type ModelVersionsTableProps = {
   modelVersions: ModelVersion[];
   isArchiveModel?: boolean;
   refresh: () => void;
+  registeredModel: RegisteredModel;
 } & Partial<Pick<React.ComponentProps<typeof Table>, 'toolbarContent'>>;
 
 const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
@@ -22,6 +23,7 @@ const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
   toolbarContent,
   isArchiveModel,
   refresh,
+  registeredModel,
 }) => {
   const { mrName, registeredModelId } = useParams();
   const inferenceServices = useMakeFetchObject(
@@ -47,6 +49,7 @@ const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
           hasDeployment={hasDeploys(mv.id)}
           key={mv.name}
           modelVersion={mv}
+          registeredModel={registeredModel}
           isArchiveModel={isArchiveModel}
           refresh={refresh}
         />

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -70,7 +70,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
         ...(isFineTuningEnabled
           ? [
               {
-                title: 'Lab tune',
+                title: 'LAB tune',
                 onClick: () => setTuningModelVersionId(mv.id),
               },
             ]

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -39,9 +39,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   const navigate = useNavigate();
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const { apiState } = React.useContext(ModelRegistryContext);
-  const isKServeOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
   const isFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING).status;
-  const isLabTuneEnabled = isKServeOciEnabled && isFineTuningEnabled;
 
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
@@ -69,7 +67,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
           title: 'Deploy',
           onClick: () => setIsDeployModalOpen(true),
         },
-        ...(isLabTuneEnabled
+        ...(isFineTuningEnabled
           ? [
               {
                 title: 'Lab tune',

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -39,7 +39,9 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   const navigate = useNavigate();
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const { apiState } = React.useContext(ModelRegistryContext);
-  const isFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING);
+  const isKServeOciEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_OCI).status;
+  const isFineTuningEnabled = useIsAreaAvailable(SupportedArea.FINE_TUNING).status;
+  const isLabTuneEnabled = isKServeOciEnabled && isFineTuningEnabled;
 
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
@@ -67,14 +69,14 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
           title: 'Deploy',
           onClick: () => setIsDeployModalOpen(true),
         },
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        ...((isFineTuningEnabled && [
-          {
-            title: 'Lab tune',
-            onClick: () => setTuningModelVersionId(mv.id),
-          },
-        ]) ||
-          []),
+        ...(isLabTuneEnabled
+          ? [
+              {
+                title: 'Lab tune',
+                onClick: () => setTuningModelVersionId(mv.id),
+              },
+            ]
+          : []),
         { isSeparator: true },
         {
           title: 'Archive model version',

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -193,11 +193,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
             <StartRunModal
               onCancel={() => setTuningModelVersionId(null)}
               onSubmit={(selectedProject) => {
-                navigate(
-                  `${getModelCustomizationPath(selectedProject)}?${new URLSearchParams(
-                    tuningData,
-                  ).toString()}`,
-                );
+                navigate(getModelCustomizationPath(selectedProject), { state: tuningData });
               }}
               loaded={loaded}
               loadError={loadError}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -44,13 +44,16 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
   const [isDeployModalOpen, setIsDeployModalOpen] = React.useState(false);
-  const [isLabTuneModalOpen, setIsLabTuneModalOpen] = React.useState(false);
   const [tuningModelVersionId, setTuningModelVersionId] = React.useState<string | null>(null);
 
   const { tuningData, loaded, loadError } = useModelVersionTuningData(
     tuningModelVersionId,
     tuningModelVersionId === mv.id ? mv : null,
   );
+
+  if (!preferredModelRegistry) {
+    return null;
+  }
 
   const actions: IAction[] = isArchiveRow
     ? [
@@ -64,14 +67,14 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
           title: 'Deploy',
           onClick: () => setIsDeployModalOpen(true),
         },
-        ...(isFineTuningEnabled
-          ? [
-              {
-                title: 'Lab tune',
-                onClick: () => setTuningModelVersionId(mv.id),
-              },
-            ]
-          : []),
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        ...((isFineTuningEnabled && [
+          {
+            title: 'Lab tune',
+            onClick: () => setTuningModelVersionId(mv.id),
+          },
+        ]) ||
+          []),
         { isSeparator: true },
         {
           title: 'Archive model version',
@@ -94,18 +97,18 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
                   ? archiveModelVersionDetailsUrl(
                       mv.id,
                       mv.registeredModelId,
-                      preferredModelRegistry?.metadata?.name || undefined,
+                      preferredModelRegistry.metadata.name,
                     )
                   : isArchiveRow
                   ? modelVersionArchiveDetailsUrl(
                       mv.id,
                       mv.registeredModelId,
-                      preferredModelRegistry?.metadata?.name || undefined,
+                      preferredModelRegistry.metadata.name,
                     )
                   : modelVersionUrl(
                       mv.id,
                       mv.registeredModelId,
-                      preferredModelRegistry?.metadata?.name || undefined,
+                      preferredModelRegistry.metadata.name,
                     )
               }
             >
@@ -153,7 +156,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
                   modelVersionDeploymentsUrl(
                     mv.id,
                     mv.registeredModelId,
-                    preferredModelRegistry?.metadata?.name || undefined,
+                    preferredModelRegistry.metadata.name,
                   ),
                 );
               }}
@@ -178,7 +181,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
                       modelVersionUrl(
                         mv.id,
                         mv.registeredModelId,
-                        preferredModelRegistry?.metadata?.name || undefined,
+                        preferredModelRegistry.metadata.name,
                       ),
                     ),
                   )
@@ -186,17 +189,15 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
               modelVersionName={mv.name}
             />
           ) : null}
-          {tuningModelVersionId && (
+          {tuningModelVersionId && tuningData && (
             <StartRunModal
               onCancel={() => setTuningModelVersionId(null)}
               onSubmit={(selectedProject) => {
-                if (tuningData) {
-                  navigate(
-                    `${getModelCustomizationPath(selectedProject)}?${new URLSearchParams(
-                      tuningData as Record<string, string>,
-                    ).toString()}`,
-                  );
-                }
+                navigate(
+                  `${getModelCustomizationPath(selectedProject)}?${new URLSearchParams(
+                    tuningData,
+                  ).toString()}`,
+                );
               }}
               loaded={loaded}
               loadError={loadError}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import { Content, ContentVariants, Truncate, FlexItem } from '@patternfly/react-core';
 import { Link, useNavigate } from 'react-router-dom';
-import { ModelVersion, ModelState } from '~/concepts/modelRegistry/types';
+import { ModelVersion, ModelState, RegisteredModel } from '~/concepts/modelRegistry/types';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import ModelLabels from '~/pages/modelRegistry/screens/components/ModelLabels';
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
@@ -23,6 +23,7 @@ import { getModelCustomizationPath } from '~/routes/pipelines/modelCustomization
 
 type ModelVersionsTableRowProps = {
   modelVersion: ModelVersion;
+  registeredModel: RegisteredModel;
   isArchiveRow?: boolean;
   isArchiveModel?: boolean;
   hasDeployment?: boolean;
@@ -31,6 +32,7 @@ type ModelVersionsTableRowProps = {
 
 const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   modelVersion: mv,
+  registeredModel,
   isArchiveRow,
   isArchiveModel,
   hasDeployment = false,
@@ -49,6 +51,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   const { tuningData, loaded, loadError } = useModelVersionTuningData(
     tuningModelVersionId,
     tuningModelVersionId === mv.id ? mv : null,
+    registeredModel,
   );
 
   if (!preferredModelRegistry) {

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchive.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchive.tsx
@@ -51,10 +51,13 @@ const ModelVersionsArchive: React.FC<ModelVersionsArchiveProps> = ({ ...pageProp
       loaded={mvLoaded}
       provideChildrenPadding
     >
-      <ModelVersionsArchiveListView
-        modelVersions={filterArchiveVersions(modelVersions.items)}
-        refresh={refresh}
-      />
+      {rm && (
+        <ModelVersionsArchiveListView
+          modelVersions={filterArchiveVersions(modelVersions.items)}
+          registeredModel={rm}
+          refresh={refresh}
+        />
+      )}
     </ApplicationsPage>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveListView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveListView.tsx
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
-import { ModelVersion } from '~/concepts/modelRegistry/types';
+import { ModelVersion, RegisteredModel } from '~/concepts/modelRegistry/types';
 import SimpleSelect from '~/components/SimpleSelect';
 import { filterModelVersions } from '~/pages/modelRegistry/screens/utils';
 import EmptyModelRegistryState from '~/pages/modelRegistry/screens/components/EmptyModelRegistryState';
@@ -18,11 +18,13 @@ import ModelVersionsArchiveTable from './ModelVersionsArchiveTable';
 
 type ModelVersionsArchiveListViewProps = {
   modelVersions: ModelVersion[];
+  registeredModel: RegisteredModel;
   refresh: () => void;
 };
 
 const ModelVersionsArchiveListView: React.FC<ModelVersionsArchiveListViewProps> = ({
   modelVersions: unfilteredmodelVersions,
+  registeredModel,
   refresh,
 }) => {
   const [searchType, setSearchType] = React.useState<SearchType>(SearchType.KEYWORD);
@@ -46,6 +48,7 @@ const ModelVersionsArchiveListView: React.FC<ModelVersionsArchiveListViewProps> 
   return (
     <ModelVersionsArchiveTable
       refresh={refresh}
+      registeredModel={registeredModel}
       clearFilters={() => setSearch('')}
       modelVersions={filteredModelVersions}
       toolbarContent={

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveTable.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchiveTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Table } from '~/components/table';
-import { ModelVersion } from '~/concepts/modelRegistry/types';
+import { ModelVersion, RegisteredModel } from '~/concepts/modelRegistry/types';
 import DashboardEmptyTableView from '~/concepts/dashboard/DashboardEmptyTableView';
 import ModelVersionsTableRow from '~/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow';
 import { mvColumns } from '~/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableColumns';
@@ -8,12 +8,14 @@ import { mvColumns } from '~/pages/modelRegistry/screens/ModelVersions/ModelVers
 type ModelVersionsArchiveTableProps = {
   clearFilters: () => void;
   modelVersions: ModelVersion[];
+  registeredModel: RegisteredModel;
   refresh: () => void;
 } & Partial<Pick<React.ComponentProps<typeof Table>, 'toolbarContent'>>;
 
 const ModelVersionsArchiveTable: React.FC<ModelVersionsArchiveTableProps> = ({
   clearFilters,
   modelVersions,
+  registeredModel,
   toolbarContent,
   refresh,
 }) => (
@@ -27,7 +29,13 @@ const ModelVersionsArchiveTable: React.FC<ModelVersionsArchiveTableProps> = ({
     emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
     defaultSortColumn={1}
     rowRenderer={(mv) => (
-      <ModelVersionsTableRow key={mv.name} modelVersion={mv} isArchiveRow refresh={refresh} />
+      <ModelVersionsTableRow
+        key={mv.name}
+        modelVersion={mv}
+        registeredModel={registeredModel}
+        isArchiveRow
+        refresh={refresh}
+      />
     )}
   />
 );

--- a/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
@@ -13,11 +13,11 @@ export type StartRunModalProps = {
   loadError?: Error | null;
 };
 
-const StartRunModal: React.FC<StartRunModalProps> = ({ 
-  onSubmit, 
-  onCancel, 
-  loaded = true, 
-  loadError = null 
+const StartRunModal: React.FC<StartRunModalProps> = ({
+  onSubmit,
+  onCancel,
+  loaded = true,
+  loadError = null,
 }) => {
   const [selectedProject, setSelectedProject] = React.useState<string | null>(null);
   const [isLoadingProject, setIsLoadingProject] = React.useState<boolean>(false);

--- a/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Modal } from '@patternfly/react-core/deprecated';
-import { Button, Form, FormGroup, Stack, StackItem } from '@patternfly/react-core';
+import { Button, Form, FormGroup, Stack, StackItem, Alert } from '@patternfly/react-core';
 import ProjectSelector from '~/concepts/projects/ProjectSelector';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { PipelineContextProvider } from '~/concepts/pipelines/context';
@@ -9,9 +9,16 @@ import MissingConditionAlert from '~/pages/pipelines/global/modelCustomization/s
 export type StartRunModalProps = {
   onSubmit: (selectedProject: string) => void;
   onCancel: () => void;
+  loaded?: boolean;
+  loadError?: Error | null;
 };
 
-const StartRunModal: React.FC<StartRunModalProps> = ({ onSubmit, onCancel }) => {
+const StartRunModal: React.FC<StartRunModalProps> = ({ 
+  onSubmit, 
+  onCancel, 
+  loaded = true, 
+  loadError = null 
+}) => {
   const [selectedProject, setSelectedProject] = React.useState<string | null>(null);
   const [isLoadingProject, setIsLoadingProject] = React.useState<boolean>(false);
   const [canContinue, setCanContinue] = React.useState<boolean>(false);
@@ -30,7 +37,7 @@ const StartRunModal: React.FC<StartRunModalProps> = ({ onSubmit, onCancel }) => 
           }}
           onCancel={onCancel}
           submitLabel="Continue to run details"
-          isSubmitDisabled={!canContinue}
+          isSubmitDisabled={!canContinue || !loaded}
         />
       }
       variant="medium"
@@ -38,6 +45,13 @@ const StartRunModal: React.FC<StartRunModalProps> = ({ onSubmit, onCancel }) => 
     >
       <Form>
         <Stack hasGutter>
+          {loadError && (
+            <StackItem>
+              <Alert variant="danger" title="Error loading model data">
+                {loadError.message}
+              </Alert>
+            </StackItem>
+          )}
           <StackItem>
             Fine-tune your models to improve their performance, accuracy, and task specialization,
             using the{' '}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-19001](https://issues.redhat.com/browse/RHOAIENG-19001) and [RHOAIENG-17782](https://issues.redhat.com/browse/RHOAIENG-17782)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Enabled Fine tune button on the version details page as well as a kebab action
 

https://github.com/user-attachments/assets/e371bffb-ab53-45bb-8e12-472c4ee6b4e9


https://github.com/user-attachments/assets/9d7c45b2-7e87-47d7-892f-788966738cfc


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On shared green cluster. Make sure you have the feature flag on and the configmap.  Go to the version details page and verify that you see the LAB tune button that opens a modal, you can choose juntao as a project option and it will take to to the ilab form.  same on the kebab action for the version 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Will add tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
