### PR TITLE
Fix runtime config parameter handling in pipeline run creation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
@@ -276,7 +276,6 @@ describe('Pipeline create runs', () => {
         runtime_config: {
           parameters: {
             string_param: 'String default value',
-            double_param: undefined,
             int_param: 1,
             struct_param: { default: 'value' },
             list_param: [{ default: 'value' }],

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
@@ -276,7 +276,7 @@ describe('Pipeline create runs', () => {
         runtime_config: {
           parameters: {
             string_param: 'String default value',
-            double_param: null,
+            double_param: undefined,
             int_param: 1,
             struct_param: { default: 'value' },
             list_param: [{ default: 'value' }],

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -86,7 +86,7 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) 
         'params',
         Object.entries(getInputDefinitionParams(version) || {}).reduce(
           (acc: RuntimeConfigParameters, [paramKey, paramValue]) => {
-            acc[paramKey] = paramsRef.current?.[paramKey] ?? paramValue.defaultValue ?? '';
+            acc[paramKey] = paramsRef.current?.[paramKey] ?? paramValue.defaultValue;
             return acc;
           },
           {},

--- a/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
@@ -148,6 +148,11 @@ const normalizeInputParams = (
     const inputDefinitionParams = getInputDefinitionParams(version);
     const paramType = inputDefinitionParams?.[paramKey].parameterType;
 
+    if (paramValue === undefined || paramValue === '') {
+      acc[paramKey] = undefined;
+      return acc;
+    }
+
     switch (paramType) {
       case InputDefinitionParameterType.INTEGER:
         acc[paramKey] = parseInt(String(paramValue));

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -41,7 +41,9 @@ const runTypeSafeDates = (runType: RunFormData['runType']): boolean =>
 export const isFilledRunFormData = (formData: RunFormData): formData is SafeRunFormData => {
   const inputDefinitionParams = getInputDefinitionParams(formData.version);
   const hasRequiredInputParams = Object.entries(formData.params || {}).every(
-    ([paramKey, paramValue]) => inputDefinitionParams?.[paramKey]?.isOptional || paramValue !== '',
+    ([paramKey, paramValue]) =>
+      inputDefinitionParams?.[paramKey]?.isOptional ||
+      (paramValue !== undefined && paramValue !== ''),
   );
 
   return (

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils.tsx
@@ -89,7 +89,7 @@ export const isEmptyDateKF = (date: DateTimeKF): boolean => {
 
 export const normalizeInputParamValue = (
   initialValue: RuntimeConfigParamValue,
-): string | number => {
+): string | number | undefined => {
   let value = initialValue;
 
   if (typeof value === 'boolean') {

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -326,7 +326,13 @@ export type UrlKF = {
   pipeline_url: string;
 };
 
-export type RuntimeConfigParamValue = string | number | boolean | object | Array<object> | null;
+export type RuntimeConfigParamValue =
+  | string
+  | number
+  | boolean
+  | object
+  | Array<object>
+  | undefined;
 export type RuntimeConfigParameters = Record<string, RuntimeConfigParamValue>;
 
 export type PipelineSpecRuntimeConfig = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-21131

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Update RuntimeConfigParamValue type to allow undefined values
- Modify parameter initialization to use undefined instead of empty string
- Enhance parameter normalization to handle undefined and empty values
- Update validation logic to consider undefined values as valid input

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a new pipeline run
2. Select a pipeline version with numeric parameters
3. Leave numeric parameters empty
4. Submit the form
5. Observe the parameter values in the submitted request

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
update any broken tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
