### PR TITLE
Link pipeline run from MR version details page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -20,6 +20,14 @@ class ModelVersionDetails {
     return cy.findByTestId('model-version-id');
   }
 
+  findRegisteredFrom() {
+    return cy.findByTestId('registered-from');
+  }
+
+  findPipelineRunLink() {
+    return cy.findByTestId('pipeline-run-link');
+  }
+
   findDescription() {
     return cy.findByTestId('model-version-description');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -98,6 +98,18 @@ const mockModelVersions = mockModelVersion({
       metadataType: ModelRegistryMetadataType.STRING,
       string_value: '',
     },
+    _registeredFromPipelineProject: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'test-project',
+    },
+    _registeredFromPipelineRunId: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'pipelinerun1',
+    },
+    _registeredFromPipelineRunName: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'pipeline-run-test',
+    },
   },
 });
 
@@ -238,11 +250,21 @@ describe('Model version details', () => {
 
     it('Model version details tab', () => {
       modelVersionDetails.findVersionId().contains('1');
+      modelVersionDetails.findRegisteredFrom().should('exist');
+      modelVersionDetails.findExpandControlButton().should('have.text', 'Show 2 more properties');
+      modelVersionDetails.findExpandControlButton().click();
+      modelVersionDetails.findPropertiesTableRows().should('have.length', 7);
+      modelVersionDetails
+        .findRegisteredFrom()
+        .should('have.text', 'Run pipeline-run-test intest-project');
       modelVersionDetails.findDescription().should('have.text', 'Description of model version');
       modelVersionDetails.findStorageEndpoint().contains('test-endpoint');
       modelVersionDetails.findStorageRegion().contains('test-region');
       modelVersionDetails.findStorageBucket().contains('test-bucket');
       modelVersionDetails.findStoragePath().contains('demo-models/test-path');
+      modelVersionDetails.findPipelineRunLink().should('have.text', 'Run pipeline-run-test in');
+      modelVersionDetails.findPipelineRunLink().click();
+      verifyRelativeURL('/pipelineRuns/test-project/runs/pipelinerun1');
     });
 
     it('should add a property', () => {
@@ -290,6 +312,18 @@ describe('Model version details', () => {
             'Label x': { metadataType: 'MetadataStringValue', string_value: '' },
             'Label y': { metadataType: 'MetadataStringValue', string_value: '' },
             'Label z': { metadataType: 'MetadataStringValue', string_value: '' },
+            _registeredFromPipelineProject: {
+              metadataType: 'MetadataStringValue',
+              string_value: 'test-project',
+            },
+            _registeredFromPipelineRunId: {
+              metadataType: 'MetadataStringValue',
+              string_value: 'pipelinerun1',
+            },
+            _registeredFromPipelineRunName: {
+              metadataType: 'MetadataStringValue',
+              string_value: 'pipeline-run-test',
+            },
             edit_key: { string_value: 'edit_value', metadataType: 'MetadataStringValue' },
           },
         });
@@ -321,6 +355,18 @@ describe('Model version details', () => {
             'Label x': { metadataType: 'MetadataStringValue', string_value: '' },
             'Label y': { metadataType: 'MetadataStringValue', string_value: '' },
             'Label z': { metadataType: 'MetadataStringValue', string_value: '' },
+            _registeredFromPipelineProject: {
+              metadataType: 'MetadataStringValue',
+              string_value: 'test-project',
+            },
+            _registeredFromPipelineRunId: {
+              metadataType: 'MetadataStringValue',
+              string_value: 'pipelinerun1',
+            },
+            _registeredFromPipelineRunName: {
+              metadataType: 'MetadataStringValue',
+              string_value: 'pipeline-run-test',
+            },
           },
         });
       });

--- a/frontend/src/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
@@ -7,7 +7,8 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import { ModelRegistryCustomProperties } from '~/concepts/modelRegistry/types';
 import ModelPropertiesTableRow from './ModelPropertiesTableRow';
-import { getProperties, mergeUpdatedProperty } from './utils';
+import { filterCustomProperties, getProperties, mergeUpdatedProperty } from './utils';
+import { pipelineRunSpecificKeys } from './ModelVersionDetails/const';
 
 type ModelPropertiesDescriptionListGroupProps = {
   customProperties: ModelRegistryCustomProperties;
@@ -30,9 +31,13 @@ const ModelPropertiesDescriptionListGroup: React.FC<ModelPropertiesDescriptionLi
   const isEditingSomeRow = isAdding || editingPropertyKeys.length > 0;
 
   const [isSavingEdits, setIsSavingEdits] = React.useState(false);
+  const filteredCustomProperties = filterCustomProperties(
+    customProperties,
+    pipelineRunSpecificKeys,
+  );
 
   // We only show string properties with a defined value (no labels or other property types)
-  const filteredProperties = getProperties(customProperties);
+  const filteredProperties = getProperties(filteredCustomProperties);
 
   const [isShowingMoreProperties, setIsShowingMoreProperties] = React.useState(false);
   const keys = Object.keys(filteredProperties);

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -10,12 +10,18 @@ import {
   Spinner,
   Alert,
 } from '@patternfly/react-core';
+import { Link } from 'react-router';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import EditableTextDescriptionListGroup from '~/components/EditableTextDescriptionListGroup';
 import { EditableLabelsDescriptionListGroup } from '~/components/EditableLabelsDescriptionListGroup';
 import ModelPropertiesDescriptionListGroup from '~/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup';
-import { getLabels, mergeUpdatedLabels } from '~/pages/modelRegistry/screens/utils';
+import {
+  getLabels,
+  getProperties,
+  isPipelineRunExist,
+  mergeUpdatedLabels,
+} from '~/pages/modelRegistry/screens/utils';
 import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
 import { ModelRegistryContext } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import ModelTimestamp from '~/pages/modelRegistry/screens/components/ModelTimestamp';
@@ -26,6 +32,9 @@ import {
   bumpRegisteredModelTimestamp,
 } from '~/concepts/modelRegistry/utils/updateTimestamps';
 import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegisteredModelById';
+import { globalPipelineRunDetailsRoute } from '~/routes';
+import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
+import { pipelineRunSpecificKeys } from './const';
 
 type ModelVersionDetailsViewProps = {
   modelVersion: ModelVersion;
@@ -44,6 +53,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
   const modelArtifact = modelArtifacts.items.length ? modelArtifacts.items[0] : null;
   const { apiState } = React.useContext(ModelRegistryContext);
   const storageFields = uriToStorageFields(modelArtifact?.uri || '');
+  const filteredProperties = getProperties(mv.customProperties);
   const [registeredModel, registeredModelLoaded, registeredModelLoadError, refreshRegisteredModel] =
     useRegisteredModelById(mv.registeredModelId);
 
@@ -142,7 +152,48 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
           >
             <InlineTruncatedClipboardCopy testId="model-version-id" textToCopy={mv.id} />
           </DashboardDescriptionListGroup>
+          {isPipelineRunExist(mv.customProperties, pipelineRunSpecificKeys) && (
+            <DashboardDescriptionListGroup title="Registered from">
+              <Flex
+                spaceItems={{ default: 'spaceItemsXs' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+                data-testid="registered-from"
+              >
+                <FlexItem data-testid="pipeline-run-link">
+                  Run{' '}
+                  {
+                    <Link
+                      style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}
+                      to={globalPipelineRunDetailsRoute(
+                        filteredProperties[pipelineRunSpecificKeys[0]].string_value,
+                        filteredProperties[pipelineRunSpecificKeys[1]].string_value,
+                      )}
+                    >
+                      {filteredProperties[pipelineRunSpecificKeys[2]].string_value}
+                    </Link>
+                  }{' '}
+                  in
+                </FlexItem>
+                <FlexItem style={{ display: 'flex' }}>
+                  <img
+                    style={{ height: 24 }}
+                    src={typedObjectImage(ProjectObjectType.project)}
+                    alt=""
+                  />
+                </FlexItem>
+                <FlexItem
+                  style={{
+                    display: 'flex',
+                    fontWeight: 'var(--pf-t--global--font--weight--body--bold)',
+                  }}
+                >
+                  {filteredProperties[pipelineRunSpecificKeys[0]].string_value}
+                </FlexItem>
+              </Flex>
+            </DashboardDescriptionListGroup>
+          )}
         </DescriptionList>
+
         <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>
           Model location
         </Title>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/const.ts
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/const.ts
@@ -7,3 +7,9 @@ export enum ModelVersionDetailsTabTitle {
   DETAILS = 'Details',
   DEPLOYMENTS = 'Deployments',
 }
+
+export const pipelineRunSpecificKeys: string[] = [
+  '_registeredFromPipelineProject',
+  '_registeredFromPipelineRunId',
+  '_registeredFromPipelineRunName',
+];

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -18,8 +18,11 @@ import {
   filterRegisteredModels,
   sortModelVersionsByCreateTime,
   isValidHttpUrl,
+  filterCustomProperties,
+  isPipelineRunExist,
 } from '~/pages/modelRegistry/screens/utils';
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
+import { pipelineRunSpecificKeys } from '~/pages/modelRegistry/screens/ModelVersionDetails/const';
 
 describe('getLabels', () => {
   it('should return an empty array when customProperties is empty', () => {
@@ -402,5 +405,73 @@ describe('isValidHttpUrl', () => {
 
   it('should return false for a URL with an invalid format', () => {
     expect(isValidHttpUrl('http://example..com')).toBe(false);
+  });
+});
+
+describe('filterCustomProperties', () => {
+  it('filter pipeline specific keys from custom properties', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      'Label x': {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: '',
+      },
+      _registeredFromPipelineProject: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'test-project',
+      },
+      _registeredFromPipelineRunId: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'pipelinerun1',
+      },
+      _registeredFromPipelineRunName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'pipeline-run-test',
+      },
+    };
+    const result = filterCustomProperties(customProperties, pipelineRunSpecificKeys);
+    expect(result).toStrictEqual({
+      'Label x': {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: '',
+      },
+    });
+  });
+});
+
+describe('isPipelineRunExist', () => {
+  it('return True when pipeline run specific key exist in custom properties', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      'Label x': {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: '',
+      },
+      _registeredFromPipelineProject: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'test-project',
+      },
+      _registeredFromPipelineRunId: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'pipelinerun1',
+      },
+      _registeredFromPipelineRunName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'pipeline-run-test',
+      },
+    };
+    const result = isPipelineRunExist(customProperties, pipelineRunSpecificKeys);
+    expect(result).toEqual(true);
+  });
+
+  it('return false, when pipeline run specific key doesnot exist in custom properties', () => {
+    const result = isPipelineRunExist(
+      {
+        'Label x': {
+          metadataType: ModelRegistryMetadataType.STRING,
+          string_value: '',
+        },
+      },
+      pipelineRunSpecificKeys,
+    );
+    expect(result).toEqual(false);
   });
 });

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -176,3 +176,21 @@ export const isValidHttpUrl = (value: string): boolean => {
     return false;
   }
 };
+
+export const filterCustomProperties = (
+  customProperties: ModelRegistryCustomProperties,
+  keys: string[],
+): ModelRegistryCustomProperties => {
+  const filteredCustomProperties: ModelRegistryCustomProperties = {};
+  Object.keys(customProperties).forEach((key) => {
+    if (!keys.includes(key)) {
+      filteredCustomProperties[key] = customProperties[key];
+    }
+  });
+  return filteredCustomProperties;
+};
+
+export const isPipelineRunExist = (
+  customProperties: ModelRegistryCustomProperties,
+  keys: string[],
+): boolean => keys.every((key) => key in customProperties);


### PR DESCRIPTION
Closes: [RHOAIENG-19017](https://issues.redhat.com/browse/RHOAIENG-19017)

## Description
This PR aims to add link to pipeline run from MR version details page.


https://github.com/user-attachments/assets/e9e65a48-5b31-4208-a681-829c1723db7b





## How Has This Been Tested?
 - Register a version with a reference to a pipelinerun. You can do this by actually running the InstructLab pipeline, or you can manually add customProperties referencing a pipelinerun. See the issue description for the relevant properties.
 - On the version details page, verify that you see the "Registered from" link as shown in the screenshot above and the customProperties referencing a pipelinerun should not present in the properties table, as we filtering them out.
 - Click the link to the run and verify that you are taken to the run details page.
 - Look at a version that was not registered from a pipeline, and verify that the "Registered from" section is not shown.

## Test Impact
Added cypress and unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
