### PR TITLE
Deploy models with OCI from model registry

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -153,6 +153,10 @@ class InferenceServiceModal extends Modal {
     return this.find().findByTestId('alt-form-checkbox-auth');
   }
 
+  findExistingUriOption() {
+    return this.find().findByTestId('existing-uri-radio');
+  }
+
   findNewConnectionOption() {
     return this.find().findByTestId('new-connection-radio');
   }
@@ -177,6 +181,10 @@ class InferenceServiceModal extends Modal {
     return this.findExistingConnectionSelect().findByRole('combobox', {
       name: 'Type to filter',
     });
+  }
+
+  findModelURITextBox() {
+    return this.find().findByTestId('model-uri');
   }
 
   selectExistingConnectionSelectOptionByResourceName() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -46,7 +46,6 @@ type HandlersProps = {
   modelVersions?: ModelVersion[];
   modelMeshInstalled?: boolean;
   kServeInstalled?: boolean;
-  disableOci?: boolean;
 };
 
 const registeredModelMocked = mockRegisteredModel({ name: 'test-1' });
@@ -73,13 +72,11 @@ const initIntercepts = ({
   ],
   modelMeshInstalled = true,
   kServeInstalled = true,
-  disableOci = true,
 }: HandlersProps) => {
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({
       disableModelRegistry: false,
-      disableKServeOCIModels: disableOci,
     }),
   );
   cy.interceptOdh(
@@ -377,7 +374,7 @@ describe('Deploy model version', () => {
   });
 
   it('Selects Create Connection in case of no matching OCI connections', () => {
-    initIntercepts({ disableOci: false });
+    initIntercepts({});
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version 3');
     modelVersionRow.findKebabAction('Deploy').click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -375,23 +375,6 @@ describe('Deploy model version', () => {
 
   it('Selects Create Connection in case of no matching OCI connections', () => {
     initIntercepts({});
-    cy.interceptK8sList(
-      SecretModel,
-      mockK8sResourceList([
-        mockCustomSecretK8sResource({
-          namespace: 'kserve-project',
-          name: 'test-secret',
-          annotations: {
-            'opendatahub.io/connection-type': 'oci-v1',
-            'openshift.io/display-name': 'Test Secret',
-          },
-          data: {
-            '.dockerconfigjson': 'aHR0cHM6Ly9kZW1vLW1vZGVscy9zb21lLXBhdGguemlw',
-            OCI_HOST: 'aHR0cHM6Ly9kZW1vLW1vZGVscy9zb21lLXBhdGguemlw',
-          },
-        }),
-      ]),
-    );
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version 3');
     modelVersionRow.findKebabAction('Deploy').click();

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -279,7 +279,9 @@ export const getMRConnectionValues = (
     });
     return defaults;
   }
-  defaults.URI = connectionValues;
+  if (!connectionValues.startsWith('oci:')) {
+    defaults.URI = connectionValues;
+  }
 
   return defaults;
 };

--- a/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
@@ -91,6 +91,7 @@ describe('uriToStorageFields', () => {
         path: 'demo-models/flan-t5-small-caikit',
       },
       uri: null,
+      ociUri: null,
     });
   });
 
@@ -106,6 +107,7 @@ describe('uriToStorageFields', () => {
         region: undefined,
       },
       uri: null,
+      ociUri: null,
     });
   });
 
@@ -137,6 +139,15 @@ describe('uriToStorageFields', () => {
     expect(fields).toEqual({
       s3Fields: null,
       uri: 'https://model-repository/folder.zip',
+      ociUri: null,
+    });
+  });
+  it('returns ociUri in case URI is OCI', () => {
+    const fields = uriToStorageFields('oci://quay.io/test');
+    expect(fields).toEqual({
+      s3Fields: null,
+      uri: null,
+      ociUri: 'oci://quay.io/test',
     });
   });
 });

--- a/frontend/src/concepts/modelRegistry/utils.ts
+++ b/frontend/src/concepts/modelRegistry/utils.ts
@@ -10,6 +10,7 @@ export type ObjectStorageFields = {
 export type RegisteredModelLocation = {
   s3Fields: ObjectStorageFields | null;
   uri: string | null;
+  ociUri: string | null;
 } | null;
 
 export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string | null => {
@@ -38,11 +39,18 @@ export const uriToStorageFields = (uri: string): RegisteredModelLocation => {
       const endpoint = searchParams.get('endpoint');
       const region = searchParams.get('defaultRegion');
       if (endpoint && bucket && path) {
-        return { s3Fields: { endpoint, bucket, region: region || undefined, path }, uri: null };
+        return {
+          s3Fields: { endpoint, bucket, region: region || undefined, path },
+          uri: null,
+          ociUri: null,
+        };
       }
       return null;
     }
-    return { s3Fields: null, uri };
+    if (uri.startsWith('oci:')) {
+      return { s3Fields: null, uri: null, ociUri: uri };
+    }
+    return { s3Fields: null, uri, ociUri: null };
   } catch {
     return null;
   }

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -248,20 +248,21 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
                   </DashboardDescriptionListGroup>
                 </>
               )}
-              {storageFields?.uri && (
-                <>
-                  <DashboardDescriptionListGroup
-                    title="URI"
-                    isEmpty={!modelArtifact?.uri}
-                    contentWhenEmpty="No URI"
-                  >
-                    <InlineTruncatedClipboardCopy
-                      testId="storage-uri"
-                      textToCopy={modelArtifact?.uri || ''}
-                    />
-                  </DashboardDescriptionListGroup>
-                </>
-              )}
+              {storageFields?.uri ||
+                (storageFields?.ociUri && (
+                  <>
+                    <DashboardDescriptionListGroup
+                      title="URI"
+                      isEmpty={!modelArtifact?.uri}
+                      contentWhenEmpty="No URI"
+                    >
+                      <InlineTruncatedClipboardCopy
+                        testId="storage-uri"
+                        textToCopy={modelArtifact?.uri || ''}
+                      />
+                    </DashboardDescriptionListGroup>
+                  </>
+                ))}
             </DescriptionList>
             <Divider style={{ marginTop: '1em' }} />
             <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useLabeledConnections.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useLabeledConnections.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { convertObjectStorageSecretData } from '~/concepts/connectionTypes/utils';
-import { ObjectStorageFields, uriToStorageFields } from '~/concepts/modelRegistry/utils';
+import { RegisteredModelLocation, uriToStorageFields } from '~/concepts/modelRegistry/utils';
 import { LabeledConnection } from '~/pages/modelServing/screens/types';
 import { AwsKeys } from '~/pages/projects/dataConnections/const';
 
@@ -10,7 +10,7 @@ const useLabeledConnections = (
   connections: Connection[] = [],
 ): {
   connections: LabeledConnection[];
-  storageFields: { s3Fields: ObjectStorageFields | null; uri: string | null } | null;
+  storageFields: RegisteredModelLocation;
 } =>
   React.useMemo(() => {
     if (!modelArtifactUri) {
@@ -37,6 +37,12 @@ const useLabeledConnections = (
           endpoint === storageFields.s3Fields.endpoint &&
           (region === storageFields.s3Fields.region || !storageFields.s3Fields.region)
         ) {
+          return { connection, isRecommended: true };
+        }
+      }
+      if (storageFields.ociUri && connection.data?.OCI_HOST) {
+        const findURI = storageFields.ociUri.includes(window.atob(connection.data.OCI_HOST));
+        if (findURI) {
           return { connection, isRecommended: true };
         }
       }

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -42,125 +42,123 @@ const usePrefillDeployModalFromModelRegistry = (
         (dataConnection) => dataConnection.isRecommended,
       );
 
-      if (connectionsLoaded) {
-        if (!storageFields) {
+      if (!storageFields) {
+        setCreateData('storage', {
+          awsData: EMPTY_AWS_SECRET_DATA,
+          dataConnection: '',
+          path: '',
+          type: InferenceServiceStorageType.EXISTING_STORAGE,
+        });
+      } else if (storageFields.s3Fields) {
+        const prefilledKeys: (typeof EMPTY_AWS_SECRET_DATA)[number]['key'][] = [
+          AwsKeys.NAME,
+          AwsKeys.AWS_S3_BUCKET,
+          AwsKeys.S3_ENDPOINT,
+          AwsKeys.DEFAULT_REGION,
+        ];
+        const prefilledAWSData = [
+          { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
+          { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.s3Fields.bucket },
+          { key: AwsKeys.S3_ENDPOINT, value: storageFields.s3Fields.endpoint },
+          { key: AwsKeys.DEFAULT_REGION, value: storageFields.s3Fields.region || '' },
+          ...EMPTY_AWS_SECRET_DATA.filter((item) => !prefilledKeys.includes(item.key)),
+        ];
+        if (recommendedConnections.length === 0) {
+          setCreateData('storage', {
+            awsData: prefilledAWSData,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: storageFields.s3Fields.path,
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            alert,
+          });
+        } else if (recommendedConnections.length === 1) {
+          setCreateData('storage', {
+            awsData: prefilledAWSData,
+            dataConnection: recommendedConnections[0].connection.metadata.name,
+            path: storageFields.s3Fields.path,
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        } else {
+          setCreateData('storage', {
+            awsData: prefilledAWSData,
+            dataConnection: '',
+            path: storageFields.s3Fields.path,
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        }
+      } else if (storageFields.uri) {
+        if (recommendedConnections.length === 0) {
           setCreateData('storage', {
             awsData: EMPTY_AWS_SECRET_DATA,
+            uri: storageFields.uri,
             dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: '',
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            alert,
+          });
+        } else if (recommendedConnections.length === 1) {
+          setCreateData('storage', {
+            uri: storageFields.uri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: recommendedConnections[0].connection.metadata.name,
             path: '',
             type: InferenceServiceStorageType.EXISTING_STORAGE,
           });
-        } else if (storageFields.s3Fields) {
-          const prefilledKeys: (typeof EMPTY_AWS_SECRET_DATA)[number]['key'][] = [
-            AwsKeys.NAME,
-            AwsKeys.AWS_S3_BUCKET,
-            AwsKeys.S3_ENDPOINT,
-            AwsKeys.DEFAULT_REGION,
-          ];
-          const prefilledAWSData = [
-            { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
-            { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.s3Fields.bucket },
-            { key: AwsKeys.S3_ENDPOINT, value: storageFields.s3Fields.endpoint },
-            { key: AwsKeys.DEFAULT_REGION, value: storageFields.s3Fields.region || '' },
-            ...EMPTY_AWS_SECRET_DATA.filter((item) => !prefilledKeys.includes(item.key)),
-          ];
-          if (recommendedConnections.length === 0) {
-            setCreateData('storage', {
-              awsData: prefilledAWSData,
-              dataConnection: '',
-              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-              connectionType: registeredModelDeployInfo.modelLocationType,
-              path: storageFields.s3Fields.path,
-              type: InferenceServiceStorageType.NEW_STORAGE,
-              alert,
-            });
-          } else if (recommendedConnections.length === 1) {
-            setCreateData('storage', {
-              awsData: prefilledAWSData,
-              dataConnection: recommendedConnections[0].connection.metadata.name,
-              path: storageFields.s3Fields.path,
-              type: InferenceServiceStorageType.EXISTING_STORAGE,
-            });
-          } else {
-            setCreateData('storage', {
-              awsData: prefilledAWSData,
-              dataConnection: '',
-              path: storageFields.s3Fields.path,
-              type: InferenceServiceStorageType.EXISTING_STORAGE,
-            });
-          }
-        } else if (storageFields.uri) {
-          if (recommendedConnections.length === 0) {
-            setCreateData('storage', {
-              awsData: EMPTY_AWS_SECRET_DATA,
-              uri: storageFields.uri,
-              dataConnection: '',
-              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-              connectionType: registeredModelDeployInfo.modelLocationType,
-              path: '',
-              type: InferenceServiceStorageType.NEW_STORAGE,
-              alert,
-            });
-          } else if (recommendedConnections.length === 1) {
-            setCreateData('storage', {
-              uri: storageFields.uri,
-              awsData: EMPTY_AWS_SECRET_DATA,
-              dataConnection: recommendedConnections[0].connection.metadata.name,
-              path: '',
-              type: InferenceServiceStorageType.EXISTING_STORAGE,
-            });
-          } else {
-            setCreateData('storage', {
-              uri: storageFields.uri,
-              awsData: EMPTY_AWS_SECRET_DATA,
-              dataConnection: '',
-              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-              connectionType: registeredModelDeployInfo.modelLocationType,
-              path: '',
-              type: InferenceServiceStorageType.EXISTING_STORAGE,
-            });
-          }
-        } else if (storageFields.ociUri) {
-          if (isRedHatRegistryUri(storageFields.ociUri)) {
-            setCreateData('storage', {
-              uri: storageFields.ociUri,
-              awsData: EMPTY_AWS_SECRET_DATA,
-              dataConnection: '',
-              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-              connectionType: '',
-              path: '',
-              type: InferenceServiceStorageType.EXISTING_URI,
-            });
-          } else if (recommendedConnections.length === 0) {
-            setCreateData('storage', {
-              awsData: EMPTY_AWS_SECRET_DATA,
-              uri: storageFields.ociUri,
-              dataConnection: '',
-              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-              connectionType: registeredModelDeployInfo.modelLocationType,
-              path: '',
-              type: InferenceServiceStorageType.NEW_STORAGE,
-              alert,
-            });
-          } else if (recommendedConnections.length === 1) {
-            setCreateData('storage', {
-              uri: storageFields.ociUri,
-              awsData: EMPTY_AWS_SECRET_DATA,
-              dataConnection: recommendedConnections[0].connection.metadata.name,
-              path: '',
-              type: InferenceServiceStorageType.EXISTING_STORAGE,
-            });
-          } else {
-            setCreateData('storage', {
-              uri: storageFields.ociUri,
-              awsData: EMPTY_AWS_SECRET_DATA,
-              dataConnection: '',
-              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-              connectionType: registeredModelDeployInfo.modelLocationType,
-              path: '',
-              type: InferenceServiceStorageType.EXISTING_STORAGE,
-            });
-          }
+        } else {
+          setCreateData('storage', {
+            uri: storageFields.uri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        }
+      } else if (storageFields.ociUri) {
+        if (isRedHatRegistryUri(storageFields.ociUri)) {
+          setCreateData('storage', {
+            uri: storageFields.ociUri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: '',
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_URI,
+          });
+        } else if (recommendedConnections.length === 0) {
+          setCreateData('storage', {
+            awsData: EMPTY_AWS_SECRET_DATA,
+            uri: storageFields.ociUri,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: '',
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            alert,
+          });
+        } else if (recommendedConnections.length === 1) {
+          setCreateData('storage', {
+            uri: storageFields.ociUri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: recommendedConnections[0].connection.metadata.name,
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        } else {
+          setCreateData('storage', {
+            uri: storageFields.ociUri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
         }
       }
     }

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -118,6 +118,47 @@ const usePrefillDeployModalFromModelRegistry = (
             type: InferenceServiceStorageType.EXISTING_STORAGE,
           });
         }
+      } else if (storageFields.ociUri) {
+        if (storageFields.ociUri.includes('oci://registry.redhat.io/')) {
+          setCreateData('storage', {
+            uri: storageFields.ociUri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: '',
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_URI,
+          });
+        } else if (recommendedConnections.length === 0) {
+          setCreateData('storage', {
+            awsData: EMPTY_AWS_SECRET_DATA,
+            uri: storageFields.ociUri,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: '',
+            type: InferenceServiceStorageType.NEW_STORAGE,
+            alert,
+          });
+        } else if (recommendedConnections.length === 1) {
+          setCreateData('storage', {
+            uri: storageFields.ociUri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: recommendedConnections[0].connection.metadata.name,
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        } else {
+          setCreateData('storage', {
+            uri: storageFields.ociUri,
+            awsData: EMPTY_AWS_SECRET_DATA,
+            dataConnection: '',
+            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+            connectionType: registeredModelDeployInfo.modelLocationType,
+            path: '',
+            type: InferenceServiceStorageType.EXISTING_STORAGE,
+          });
+        }
       }
     }
   }, [connections, storageFields, registeredModelDeployInfo, setCreateData]);

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/usePrefillDeployModalFromModelRegistry.ts
@@ -11,6 +11,7 @@ import {
 import { AwsKeys, EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import useConnections from '~/pages/projects/screens/detail/connections/useConnections';
+import { isRedHatRegistryUri } from '~/pages/modelRegistry/screens/utils';
 import useLabeledConnections from './useLabeledConnections';
 
 const usePrefillDeployModalFromModelRegistry = (
@@ -41,127 +42,129 @@ const usePrefillDeployModalFromModelRegistry = (
         (dataConnection) => dataConnection.isRecommended,
       );
 
-      if (!storageFields) {
-        setCreateData('storage', {
-          awsData: EMPTY_AWS_SECRET_DATA,
-          dataConnection: '',
-          path: '',
-          type: InferenceServiceStorageType.EXISTING_STORAGE,
-        });
-      } else if (storageFields.s3Fields) {
-        const prefilledKeys: (typeof EMPTY_AWS_SECRET_DATA)[number]['key'][] = [
-          AwsKeys.NAME,
-          AwsKeys.AWS_S3_BUCKET,
-          AwsKeys.S3_ENDPOINT,
-          AwsKeys.DEFAULT_REGION,
-        ];
-        const prefilledAWSData = [
-          { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
-          { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.s3Fields.bucket },
-          { key: AwsKeys.S3_ENDPOINT, value: storageFields.s3Fields.endpoint },
-          { key: AwsKeys.DEFAULT_REGION, value: storageFields.s3Fields.region || '' },
-          ...EMPTY_AWS_SECRET_DATA.filter((item) => !prefilledKeys.includes(item.key)),
-        ];
-        if (recommendedConnections.length === 0) {
-          setCreateData('storage', {
-            awsData: prefilledAWSData,
-            dataConnection: '',
-            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-            connectionType: registeredModelDeployInfo.modelLocationType,
-            path: storageFields.s3Fields.path,
-            type: InferenceServiceStorageType.NEW_STORAGE,
-            alert,
-          });
-        } else if (recommendedConnections.length === 1) {
-          setCreateData('storage', {
-            awsData: prefilledAWSData,
-            dataConnection: recommendedConnections[0].connection.metadata.name,
-            path: storageFields.s3Fields.path,
-            type: InferenceServiceStorageType.EXISTING_STORAGE,
-          });
-        } else {
-          setCreateData('storage', {
-            awsData: prefilledAWSData,
-            dataConnection: '',
-            path: storageFields.s3Fields.path,
-            type: InferenceServiceStorageType.EXISTING_STORAGE,
-          });
-        }
-      } else if (storageFields.uri) {
-        if (recommendedConnections.length === 0) {
+      if (connectionsLoaded) {
+        if (!storageFields) {
           setCreateData('storage', {
             awsData: EMPTY_AWS_SECRET_DATA,
-            uri: storageFields.uri,
             dataConnection: '',
-            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-            connectionType: registeredModelDeployInfo.modelLocationType,
-            path: '',
-            type: InferenceServiceStorageType.NEW_STORAGE,
-            alert,
-          });
-        } else if (recommendedConnections.length === 1) {
-          setCreateData('storage', {
-            uri: storageFields.uri,
-            awsData: EMPTY_AWS_SECRET_DATA,
-            dataConnection: recommendedConnections[0].connection.metadata.name,
             path: '',
             type: InferenceServiceStorageType.EXISTING_STORAGE,
           });
-        } else {
-          setCreateData('storage', {
-            uri: storageFields.uri,
-            awsData: EMPTY_AWS_SECRET_DATA,
-            dataConnection: '',
-            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-            connectionType: registeredModelDeployInfo.modelLocationType,
-            path: '',
-            type: InferenceServiceStorageType.EXISTING_STORAGE,
-          });
-        }
-      } else if (storageFields.ociUri) {
-        if (storageFields.ociUri.includes('oci://registry.redhat.io/')) {
-          setCreateData('storage', {
-            uri: storageFields.ociUri,
-            awsData: EMPTY_AWS_SECRET_DATA,
-            dataConnection: '',
-            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-            connectionType: '',
-            path: '',
-            type: InferenceServiceStorageType.EXISTING_URI,
-          });
-        } else if (recommendedConnections.length === 0) {
-          setCreateData('storage', {
-            awsData: EMPTY_AWS_SECRET_DATA,
-            uri: storageFields.ociUri,
-            dataConnection: '',
-            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-            connectionType: registeredModelDeployInfo.modelLocationType,
-            path: '',
-            type: InferenceServiceStorageType.NEW_STORAGE,
-            alert,
-          });
-        } else if (recommendedConnections.length === 1) {
-          setCreateData('storage', {
-            uri: storageFields.ociUri,
-            awsData: EMPTY_AWS_SECRET_DATA,
-            dataConnection: recommendedConnections[0].connection.metadata.name,
-            path: '',
-            type: InferenceServiceStorageType.EXISTING_STORAGE,
-          });
-        } else {
-          setCreateData('storage', {
-            uri: storageFields.ociUri,
-            awsData: EMPTY_AWS_SECRET_DATA,
-            dataConnection: '',
-            // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
-            connectionType: registeredModelDeployInfo.modelLocationType,
-            path: '',
-            type: InferenceServiceStorageType.EXISTING_STORAGE,
-          });
+        } else if (storageFields.s3Fields) {
+          const prefilledKeys: (typeof EMPTY_AWS_SECRET_DATA)[number]['key'][] = [
+            AwsKeys.NAME,
+            AwsKeys.AWS_S3_BUCKET,
+            AwsKeys.S3_ENDPOINT,
+            AwsKeys.DEFAULT_REGION,
+          ];
+          const prefilledAWSData = [
+            { key: AwsKeys.NAME, value: registeredModelDeployInfo.modelArtifactStorageKey || '' },
+            { key: AwsKeys.AWS_S3_BUCKET, value: storageFields.s3Fields.bucket },
+            { key: AwsKeys.S3_ENDPOINT, value: storageFields.s3Fields.endpoint },
+            { key: AwsKeys.DEFAULT_REGION, value: storageFields.s3Fields.region || '' },
+            ...EMPTY_AWS_SECRET_DATA.filter((item) => !prefilledKeys.includes(item.key)),
+          ];
+          if (recommendedConnections.length === 0) {
+            setCreateData('storage', {
+              awsData: prefilledAWSData,
+              dataConnection: '',
+              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+              connectionType: registeredModelDeployInfo.modelLocationType,
+              path: storageFields.s3Fields.path,
+              type: InferenceServiceStorageType.NEW_STORAGE,
+              alert,
+            });
+          } else if (recommendedConnections.length === 1) {
+            setCreateData('storage', {
+              awsData: prefilledAWSData,
+              dataConnection: recommendedConnections[0].connection.metadata.name,
+              path: storageFields.s3Fields.path,
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          } else {
+            setCreateData('storage', {
+              awsData: prefilledAWSData,
+              dataConnection: '',
+              path: storageFields.s3Fields.path,
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          }
+        } else if (storageFields.uri) {
+          if (recommendedConnections.length === 0) {
+            setCreateData('storage', {
+              awsData: EMPTY_AWS_SECRET_DATA,
+              uri: storageFields.uri,
+              dataConnection: '',
+              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+              connectionType: registeredModelDeployInfo.modelLocationType,
+              path: '',
+              type: InferenceServiceStorageType.NEW_STORAGE,
+              alert,
+            });
+          } else if (recommendedConnections.length === 1) {
+            setCreateData('storage', {
+              uri: storageFields.uri,
+              awsData: EMPTY_AWS_SECRET_DATA,
+              dataConnection: recommendedConnections[0].connection.metadata.name,
+              path: '',
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          } else {
+            setCreateData('storage', {
+              uri: storageFields.uri,
+              awsData: EMPTY_AWS_SECRET_DATA,
+              dataConnection: '',
+              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+              connectionType: registeredModelDeployInfo.modelLocationType,
+              path: '',
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          }
+        } else if (storageFields.ociUri) {
+          if (isRedHatRegistryUri(storageFields.ociUri)) {
+            setCreateData('storage', {
+              uri: storageFields.ociUri,
+              awsData: EMPTY_AWS_SECRET_DATA,
+              dataConnection: '',
+              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+              connectionType: '',
+              path: '',
+              type: InferenceServiceStorageType.EXISTING_URI,
+            });
+          } else if (recommendedConnections.length === 0) {
+            setCreateData('storage', {
+              awsData: EMPTY_AWS_SECRET_DATA,
+              uri: storageFields.ociUri,
+              dataConnection: '',
+              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+              connectionType: registeredModelDeployInfo.modelLocationType,
+              path: '',
+              type: InferenceServiceStorageType.NEW_STORAGE,
+              alert,
+            });
+          } else if (recommendedConnections.length === 1) {
+            setCreateData('storage', {
+              uri: storageFields.ociUri,
+              awsData: EMPTY_AWS_SECRET_DATA,
+              dataConnection: recommendedConnections[0].connection.metadata.name,
+              path: '',
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          } else {
+            setCreateData('storage', {
+              uri: storageFields.ociUri,
+              awsData: EMPTY_AWS_SECRET_DATA,
+              dataConnection: '',
+              // FIXME: Remove connectionType: Look at https://issues.redhat.com/browse/RHOAIENG-19991 for more details
+              connectionType: registeredModelDeployInfo.modelLocationType,
+              path: '',
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          }
         }
       }
     }
-  }, [connections, storageFields, registeredModelDeployInfo, setCreateData]);
+  }, [connections, storageFields, registeredModelDeployInfo, setCreateData, connectionsLoaded]);
 
   return [connections, connectionsLoaded, connectionsLoadError];
 };

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/useRegisteredModelDeployInfo.ts
@@ -50,6 +50,9 @@ const useRegisteredModelDeployInfo = (
     if (storageFields?.s3Fields) {
       modelLocationType = 's3';
     }
+    if (storageFields?.ociUri) {
+      modelLocationType = 'oci-v1';
+    }
     return {
       registeredModelDeployInfo: {
         modelName,

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -20,6 +20,7 @@ import {
   isValidHttpUrl,
   filterCustomProperties,
   isPipelineRunExist,
+  isRedHatRegistryUri,
 } from '~/pages/modelRegistry/screens/utils';
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import { pipelineRunSpecificKeys } from '~/pages/modelRegistry/screens/ModelVersionDetails/const';
@@ -473,5 +474,15 @@ describe('isPipelineRunExist', () => {
       pipelineRunSpecificKeys,
     );
     expect(result).toEqual(false);
+  });
+});
+
+describe('isRedHatRegistryUri', () => {
+  it('should return true for RedHat registry URI', () => {
+    expect(isRedHatRegistryUri('oci://registry.redhat.io/test/test')).toBe(true);
+  });
+
+  it('should return false for non-RedHat registry URI', () => {
+    expect(isValidHttpUrl('http://example.com')).toBe(true);
   });
 });

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -21,6 +21,7 @@ import useDataConnections from '~/pages/projects/screens/detail/data-connections
 import { bumpBothTimestamps } from '~/concepts/modelRegistry/utils/updateTimestamps';
 import useConnections from '~/pages/projects/screens/detail/connections/useConnections';
 import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegisteredModelById';
+import { isRedHatRegistryUri } from '~/pages/modelRegistry/screens/utils';
 
 interface DeployRegisteredModelModalProps {
   modelVersion: ModelVersion;
@@ -168,7 +169,12 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
         registeredModelDeployInfo={registeredModelDeployInfo}
         projectContext={{ currentProject: selectedProject, connections }}
         projectSection={projectSection}
-        existingUriOption={registeredModelDeployInfo.modelArtifactUri}
+        existingUriOption={
+          registeredModelDeployInfo.modelArtifactUri &&
+          isRedHatRegistryUri(registeredModelDeployInfo.modelArtifactUri)
+            ? registeredModelDeployInfo.modelArtifactUri
+            : undefined
+        }
       />
     );
   }

--- a/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/DeployRegisteredModelModal.tsx
@@ -121,6 +121,7 @@ const DeployRegisteredModelModal: React.FC<DeployRegisteredModelModalProps> = ({
         ) : isOciModel ? (
           <FormSection title="Model deployment">
             <Alert
+              data-testid="oci-deploy-kserve-alert"
               variant="info"
               isInline
               title="This model uses an OCI storage location which supports deploying to only the single-model serving platform. Projects using the multi-model serving platform are excluded from the project selector."

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -194,3 +194,5 @@ export const isPipelineRunExist = (
   customProperties: ModelRegistryCustomProperties,
   keys: string[],
 ): boolean => keys.every((key) => key in customProperties);
+export const isRedHatRegistryUri = (uri: string): boolean =>
+  uri.startsWith('oci://registry.redhat.io/');

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -38,7 +38,9 @@ import {
   isConnectionTypeDataField,
   isModelServingCompatible,
   ModelServingCompatibleTypes,
+  OCIConnectionTypeKeys,
   S3ConnectionTypeKeys,
+  URIConnectionTypeKeys,
   withRequiredFields,
 } from '~/concepts/connectionTypes/utils';
 import { ConnectionDetailsHelperText } from '~/concepts/connectionTypes/ConnectionDetailsHelperText';
@@ -248,10 +250,20 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
             connectionTypes.find(
               (t) => getResourceNameFromK8sResource(t) === data.storage.connectionType,
             ),
-            ['URI'],
+            URIConnectionTypeKeys,
           ),
         );
         setConnectionValues(getMRConnectionValues(data.storage.uri));
+      }
+      if (data.storage.uri?.startsWith('oci:')) {
+        setSelectedConnectionType(
+          withRequiredFields(
+            connectionTypes.find(
+              (t) => getResourceNameFromK8sResource(t) === data.storage.connectionType,
+            ),
+            OCIConnectionTypeKeys,
+          ),
+        );
       }
     }
   }, [data.storage.connectionType, connectionTypes, data.storage.uri, data.storage.awsData]);

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -410,6 +410,7 @@ export const ConnectionSection: React.FC<Props> = ({
         <Radio
           id="existing-uri-radio"
           name="existing-uri-radio"
+          data-testid="existing-uri-radio"
           label="Current URI"
           isChecked={data.storage.type === InferenceServiceStorageType.EXISTING_URI}
           onChange={() => {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -3,7 +3,7 @@ import { Alert, FormGroup, Stack, StackItem } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
-import { ProjectKind } from '~/k8sTypes';
+import { KnownLabels, ProjectKind } from '~/k8sTypes';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
 import SimpleSelect from '~/components/SimpleSelect';
 
@@ -14,6 +14,7 @@ type ProjectSelectorProps = {
   modelRegistryName?: string;
   registeredModelId?: string;
   modelVersionId?: string;
+  isOciModel?: boolean;
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
@@ -23,8 +24,14 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   modelRegistryName,
   registeredModelId,
   modelVersionId,
+  isOciModel,
 }) => {
   const { projects } = React.useContext(ProjectsContext);
+  const kserveProjects = projects.filter(
+    (project) =>
+      !project.metadata.labels?.[KnownLabels.MODEL_SERVING_PROJECT] ||
+      project.metadata.labels[KnownLabels.MODEL_SERVING_PROJECT] === 'false',
+  );
 
   const projectLinkUrlParams = new URLSearchParams();
   projectLinkUrlParams.set('section', ProjectSectionID.MODEL_SERVER);
@@ -50,11 +57,19 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
               }
             }}
             value={selectedProject?.metadata.name}
-            options={projects.map((project) => ({
-              key: project.metadata.name,
-              value: project.metadata.name,
-              label: getDisplayNameFromK8sResource(project),
-            }))}
+            options={
+              isOciModel
+                ? kserveProjects.map((project) => ({
+                    key: project.metadata.name,
+                    value: project.metadata.name,
+                    label: getDisplayNameFromK8sResource(project),
+                  }))
+                : projects.map((project) => ({
+                    key: project.metadata.name,
+                    value: project.metadata.name,
+                    label: getDisplayNameFromK8sResource(project),
+                  }))
+            }
             dataTestId="deploy-model-project-selector"
             toggleLabel={
               selectedProject

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -57,19 +57,11 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
               }
             }}
             value={selectedProject?.metadata.name}
-            options={
-              isOciModel
-                ? kserveProjects.map((project) => ({
-                    key: project.metadata.name,
-                    value: project.metadata.name,
-                    label: getDisplayNameFromK8sResource(project),
-                  }))
-                : projects.map((project) => ({
-                    key: project.metadata.name,
-                    value: project.metadata.name,
-                    label: getDisplayNameFromK8sResource(project),
-                  }))
-            }
+            options={(isOciModel ? kserveProjects : projects).map((project) => ({
+              key: project.metadata.name,
+              value: project.metadata.name,
+              label: getDisplayNameFromK8sResource(project),
+            }))}
             dataTestId="deploy-model-project-selector"
             toggleLabel={
               selectedProject

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -73,6 +73,7 @@ type ManageKServeModalProps = {
   registeredModelDeployInfo?: RegisteredModelDeployInfo;
   shouldFormHidden?: boolean;
   projectSection?: React.ReactNode;
+  existingUriOption?: string;
 } & EitherOrNone<
   {
     projectContext?: {
@@ -97,6 +98,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   projectSection,
   registeredModelDeployInfo,
   shouldFormHidden: hideForm,
+  existingUriOption,
 }) => {
   const { isRawAvailable, isServerlessAvailable } = useKServeDeploymentMode();
 
@@ -413,6 +415,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
           <FormSection title="Source model location" id="model-location">
             <ConnectionSection
               existingUriOption={
+                existingUriOption ||
                 editInfo?.inferenceServiceEditInfo?.spec.predictor.model?.storageUri
               }
               data={createDataInferenceService}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-19258](https://issues.redhat.com/browse/RHOAIENG-19258)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The Deploy model project dropdown should show the info alert and only show projects that have either no model serving platform enabled or single-serving platform enabled(not any modelmesh/multi-serving platform projects). To test this, change any project's model serving platform to multi-model. You should not find this multi-model project in the dropdown.
<img width="699" alt="Screenshot 2025-03-06 at 3 56 07 PM" src="https://github.com/user-attachments/assets/847ba648-d103-49a4-b4de-3ad402a715d1" />

### Screen recordings/Scenarios to test:
1. Try deploying any Granite model registered from Model catalog, all have OCI URIs containing `oci://registry.redhat.io`, you will find "Current URI" with the read-only OCI - URI. (You can test this by deploying the version inside "granite-8b-code-base-from-catalog" model on the "mdas" project or any project - a project without any connection and/or project without a model serving platform selected("mdas-new" project) - even if there are no connections and model-serving platform selected 
 - you should see "Current URI" preselected and read-only URI filled in [ui-green](https://console-openshift-console.apps.ui-green.dev.datahub.redhat.com/) cluster)
 
https://github.com/user-attachments/assets/fd9a4626-2a4b-483f-8e31-b3cb8fbef342


2. Try deploying any model registered using an OCI - URI but not containing`oci://registry.redhat.io`, you will find "Existing connection" with the fields filled. When you click on the connection name dropdown, you should see the "Recommended" label as shown in the screenshot.(You can test this by deploying the version inside "oci-model" model on the "mdas" project - you should see "Existing connection" preselected and fields filled [ui-green](https://console-openshift-console.apps.ui-green.dev.datahub.redhat.com/) cluster)

https://github.com/user-attachments/assets/7fc4533d-54b9-4dc4-b9f3-4b0bd73bebf4

<img width="648" alt="Screenshot 2025-03-06 at 5 57 18 PM" src="https://github.com/user-attachments/assets/b6ee9036-ad12-4280-b8a1-d948951e8c24" />

3. Try deploying any model registered using an OCI - URI but not containing`oci://registry.redhat.io` and not containing any matching connection, you will find "Create connection" with the "Model URI" field filled. (You can test this by deploying the version inside "oci-model" model on the "mdas-new" project - you should see "Create connection" preselected and "Model URI" field filled [ui-green](https://console-openshift-console.apps.ui-green.dev.datahub.redhat.com/) cluster)

https://github.com/user-attachments/assets/400ae062-04b7-4748-bd98-9942ce61fe95

4. Additionally, check all the same test cases as described in https://github.com/opendatahub-io/odh-dashboard/pull/3590 (S3 and URI ones) to make sure they haven't regressed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing instructions added in description along with screenshots/screen recordings

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests, Cypress tests are on the way.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
