### PR TITLE
changed the ilab pipeline status from warning to danger to match Figma

### DIFF
--- a/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/MissingConditionAlert.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/MissingConditionAlert.tsx
@@ -16,13 +16,13 @@ type PickedAlertProps = Pick<AlertProps, 'variant' | 'children' | 'title'>;
 
 const ALERT_CONFIG: Record<ContinueCondition, PickedAlertProps> = {
   ilabPipelineInstalled: {
-    variant: 'warning',
+    variant: 'danger',
     title: 'InstructLab pipeline not installed',
     children:
       'This project is missing an InstructLab pipeline. You can import the InstructLab pipeline into your project.',
   },
   pipelineServerConfigured: {
-    variant: 'warning',
+    variant: 'danger',
     title: 'Pipeline server not configured',
     children:
       'To utilize InstructLab fine-tuning you need a pipeline server configured with an InstructLab pipeline.',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes [RHOAIENG-20675](https://issues.redhat.com/browse/RHOAIENG-20675)

1. Changed the Ilab Pipeline Status message from warning to danger to match the Figma.
2. [Figma Link](https://www.figma.com/design/Pk0BnnzSoaplpGU6jcFX8i/End-to-End---Phase-4?node-id=1362-39785&p=f&t=Wl8L4VKp7GwgzTS6-0)

https://github.com/user-attachments/assets/f38024df-bc62-4f8b-bd33-c476ce6b0e4e




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add the StartRunModal component somewhere in the code and select the projects.

import StartRunModal from '~/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal';
```
<StartRunModal onSubmit={(selectedProject) => {}} onCancel={() => {}} />
```

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Visually tested

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
