### PR TITLE
fix: prevent useEffect from overwriting model server size selection

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -21,7 +21,7 @@ import {
 import { requestsUnderLimits, resourcesArePositive } from '~/pages/modelServing/utils';
 import useCustomServingRuntimesEnabled from '~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
-import { ServingRuntimeEditInfo } from '~/pages/modelServing/screens/types';
+import { ModelServingSize, ServingRuntimeEditInfo } from '~/pages/modelServing/screens/types';
 import ServingRuntimeSizeSection from '~/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection';
 import NIMModelListSection from '~/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection';
 import NIMModelDeploymentNameSection from '~/pages/modelServing/screens/projects/NIMServiceModal/NIMModelDeploymentNameSection';
@@ -132,21 +132,25 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     }
   }, [currentProjectName, setCreateDataInferenceService]);
 
-  React.useEffect(() => {
-    podSpecOptionsState.modelSize.setSelectedSize({
+  const NIM_CUSTOM_DEFAULTS: ModelServingSize = React.useMemo(
+    () => ({
       name: 'Custom',
       resources: {
-        limits: {
-          cpu: '16',
-          memory: '64Gi',
-        },
-        requests: {
-          cpu: '8',
-          memory: '32Gi',
-        },
+        limits: { cpu: '16', memory: '64Gi' },
+        requests: { cpu: '8', memory: '32Gi' },
       },
-    });
-  }, [podSpecOptionsState]);
+    }),
+    [],
+  );
+
+  const hasSetDefault = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!hasSetDefault.current) {
+      podSpecOptionsState.modelSize.setSelectedSize(NIM_CUSTOM_DEFAULTS);
+      hasSetDefault.current = true;
+    }
+  }, [NIM_CUSTOM_DEFAULTS, podSpecOptionsState.modelSize]);
 
   // Serving Runtime Validation
   const isDisabledServingRuntime =
@@ -373,6 +377,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
             servingRuntimeSelected={servingRuntimeSelected}
             podSpecOptionState={podSpecOptionsState}
             infoContent="Select CPU and memory resources large enough to support the NIM being deployed."
+            nimDefaults={NIM_CUSTOM_DEFAULTS}
           />
           {isAuthAvailable && (
             <AuthServingRuntimeSection

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -377,7 +377,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
             servingRuntimeSelected={servingRuntimeSelected}
             podSpecOptionState={podSpecOptionsState}
             infoContent="Select CPU and memory resources large enough to support the NIM being deployed."
-            nimDefaults={NIM_CUSTOM_DEFAULTS}
+            customDefaults={NIM_CUSTOM_DEFAULTS}
           />
           {isAuthAvailable && (
             <AuthServingRuntimeSection

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormGroup, Stack, StackItem, Popover, Icon } from '@patternfly/react-core';
+import { FormGroup, Icon, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { HardwareProfileKind, ServingRuntimeKind } from '~/k8sTypes';
 import { isGpuDisabled } from '~/pages/modelServing/screens/projects/utils';
@@ -10,6 +10,7 @@ import { formatMemory } from '~/utilities/valueUnits';
 import { ModelServingPodSpecOptionsState } from '~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import HardwareProfileFormSection from '~/concepts/hardwareProfiles/HardwareProfileFormSection';
+import { ModelServingSize } from '~/pages/modelServing/screens/types';
 import ServingRuntimeSizeExpandedField from './ServingRuntimeSizeExpandedField';
 
 type ServingRuntimeSizeSectionProps = {
@@ -17,6 +18,7 @@ type ServingRuntimeSizeSectionProps = {
   servingRuntimeSelected?: ServingRuntimeKind;
   infoContent?: string;
   isEditing?: boolean;
+  nimDefaults?: ModelServingSize;
 };
 
 const ServingRuntimeSizeSection = ({
@@ -24,15 +26,21 @@ const ServingRuntimeSizeSection = ({
   servingRuntimeSelected,
   infoContent,
   isEditing = false,
+  nimDefaults,
 }: ServingRuntimeSizeSectionProps): React.ReactNode => {
   const isHardwareProfileEnabled = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
 
   const gpuDisabled = servingRuntimeSelected ? isGpuDisabled(servingRuntimeSelected) : false;
+
+  const customResources = nimDefaults
+    ? nimDefaults.resources
+    : podSpecOptionState.modelSize.sizes[0].resources;
+
   const sizeCustom = [
     ...podSpecOptionState.modelSize.sizes,
     {
       name: 'Custom',
-      resources: podSpecOptionState.modelSize.sizes[0].resources,
+      resources: customResources,
     },
   ];
 

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -18,7 +18,7 @@ type ServingRuntimeSizeSectionProps = {
   servingRuntimeSelected?: ServingRuntimeKind;
   infoContent?: string;
   isEditing?: boolean;
-  nimDefaults?: ModelServingSize;
+  customDefaults?: ModelServingSize;
 };
 
 const ServingRuntimeSizeSection = ({
@@ -26,14 +26,14 @@ const ServingRuntimeSizeSection = ({
   servingRuntimeSelected,
   infoContent,
   isEditing = false,
-  nimDefaults,
+  customDefaults,
 }: ServingRuntimeSizeSectionProps): React.ReactNode => {
   const isHardwareProfileEnabled = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
 
   const gpuDisabled = servingRuntimeSelected ? isGpuDisabled(servingRuntimeSelected) : false;
 
-  const customResources = nimDefaults
-    ? nimDefaults.resources
+  const customResources = customDefaults
+    ? customDefaults.resources
     : podSpecOptionState.modelSize.sizes[0].resources;
 
   const sizeCustom = [


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-179
https://issues.redhat.com/browse/NVPE-180

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Prevent useEffect from overwriting model server size selection, allowing users to switch options in the dropdown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Verified that the **NIM default model server size** is initially set to `'Custom'` with predefined default values that can be modified.  
- Confirmed that users can successfully switch from `'Custom'` to any other available options in the dropdown.  
- Ensured that in **edit mode**, the initial value is retained, and if modified, it correctly displays **NIM Defaults** instead of the generic defaults.  

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
