### PR TITLE
Improve hardware profiles permission state

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfileEnableToggle.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfileEnableToggle.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Switch } from '@patternfly/react-core';
 import useNotification from '~/utilities/useNotification';
-import { toggleHardwareProfileEnablement } from '~/api';
+import { HardwareProfileModel, toggleHardwareProfileEnablement } from '~/api';
 import { HardwareProfileKind } from '~/k8sTypes';
 import { HardwareProfileWarningType } from '~/concepts/hardwareProfiles/types';
+import { useAccessAllowed, verbModelAccess } from '~/concepts/userSSAR';
 import { validateProfileWarning } from './utils';
 
 type HardwareProfileEnableToggleProps = {
@@ -20,6 +21,10 @@ const HardwareProfileEnableToggle: React.FC<HardwareProfileEnableToggleProps> = 
   );
   const [isLoading, setLoading] = React.useState(false);
   const notification = useNotification();
+  const [hasAccess, hasLoadedAccess] = useAccessAllowed(
+    verbModelAccess('patch', HardwareProfileModel),
+  );
+  const canToggleSwitch = warning || isLoading || !hasAccess || !hasLoadedAccess;
 
   const handleChange = (checked: boolean) => {
     setLoading(true);
@@ -45,7 +50,7 @@ const HardwareProfileEnableToggle: React.FC<HardwareProfileEnableToggleProps> = 
       data-testid="enable-switch"
       id={`${hardwareProfile.metadata.name}-enable-switch`}
       isChecked={enabled && !warning}
-      isDisabled={warning || isLoading}
+      isDisabled={canToggleSwitch}
       onChange={(_e, checked) => handleChange(checked)}
     />
   );

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesRoutes.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesRoutes.tsx
@@ -19,6 +19,7 @@ const HardwareProfilesRoutes: React.FC = () => (
   </Routes>
 );
 
-export default accessAllowedRouteHoC(verbModelAccess('list', HardwareProfileModel))(
+// TODO: Determine if create is the best value -- RHOAIENG-21129
+export default accessAllowedRouteHoC(verbModelAccess('create', HardwareProfileModel))(
   HardwareProfilesRoutes,
 );

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -280,7 +280,8 @@ const useHardwareProfilesNav = (): {
           href: '/hardwareProfiles',
         },
       ],
-      verbModelAccess('list', HardwareProfileModel),
+      // TODO: Determine if create is the best value -- RHOAIENG-21129
+      verbModelAccess('create', HardwareProfileModel),
     ),
   };
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-21069

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Shifts the page & navigation to `create` Hardware Profiles to avoid it accidentally listing/visible to basic users.
Add support for the patch toggle (disable the toggle)

UX will need to comment more on the effort for where we will go and proper guidance for read-only values (like the toggle). https://issues.redhat.com/browse/RHOAIENG-21129 will cover the future of those features and come with documentation for the team.

Also spent some time investigating the performance issues -- apparently we didn't cache the values at all fast enough and made a ton of quick "while loading" calls before the state settled. I wrestled with it, tried to also fix the not unloading properly stuff and then ended up in a spot where it's a bit of a mess. I have put all these into the first commit. The 2nd one reverts everything down to a smaller state (and takes a win from the improving cache responsiveness).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the Hardware Profiles page (needs to be enabled on your cluster or via dev flags query).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
