### PR TITLE
fix(RHOAIENG-20551):added scrollable prop to the Hardware profiles dropdown

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -195,6 +195,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
             }
             isFullWidth
             isSkeleton={!hardwareProfilesLoaded && !hardwareProfilesError}
+            isScrollable
           />
         </FlexItem>
         <FlexItem>


### PR DESCRIPTION
Closes [RHOAIENG-20551](https://issues.redhat.com/browse/RHOAIENG-20551)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. On creation of new workbenches for hardware profile dropdown added scrollability.
2. Scrollable prop added to the Hardware Profiles dropdown on notebook creation when there are a lot of hardware profiles available.

https://github.com/user-attachments/assets/d61fd0bb-cee7-49a8-923b-ddbde161fffe



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
