### PR TITLE
[wip] added limits to hwp node resource labels and identifiers

### DIFF
--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
@@ -23,15 +23,24 @@ import CountFormField from './CountFormField';
 type NodeResourceFormProps = {
   identifier: Identifier;
   setIdentifier: UpdateObjectAtPropAndValue<Identifier>;
+  setData: UpdateObjectAtPropAndValue<{
+    resourceLabel: string;
+    resourceIdentifier: string;
+  }>;
   unitOptions?: UnitOption[];
   isUniqueIdentifier?: boolean;
+  resourceLabelErrorMessage?: string;
+  resourceIdentifierErrorMessage?: string;
 };
 
 const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
   identifier,
   setIdentifier,
+  setData,
   unitOptions,
   isUniqueIdentifier,
+  resourceLabelErrorMessage,
+  resourceIdentifierErrorMessage,
 }) => {
   const validated = isUniqueIdentifier ? 'default' : 'error';
 
@@ -39,16 +48,33 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
     <Form>
       <FormGroup isRequired label="Resource label" fieldId="resource-label">
         <TextInput
+          id="node-resource-label-input"
           value={identifier.displayName || ''}
-          onChange={(_, value) => setIdentifier('displayName', value)}
+          onChange={(_, value) => {
+            setData('resourceLabel', value);
+            setIdentifier('displayName', value);
+          }}
           data-testid="node-resource-label-input"
         />
+        {resourceLabelErrorMessage && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem data-testid="resource-label-limits-error" variant="error">
+                {resourceLabelErrorMessage}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
 
       <FormGroup isRequired label="Resource identifier" fieldId="resource-identifier">
         <TextInput
+          id="node-resource-identifier-input"
           value={identifier.identifier || ''}
-          onChange={(_, value) => setIdentifier('identifier', value)}
+          onChange={(_, value) => {
+            setData('resourceIdentifier', value);
+            setIdentifier('identifier', value);
+          }}
           validated={validated}
           data-testid="node-resource-identifier-input"
         />
@@ -58,6 +84,15 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
               <HelperTextItem data-testid="resource-identifier-error" variant="error">
                 Another resource with the same identifier already exists. The resource identifier
                 must be unique.
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
+        {resourceIdentifierErrorMessage && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem data-testid="resource-identifier-limits-error" variant="error">
+                {resourceIdentifierErrorMessage}
               </HelperTextItem>
             </HelperText>
           </FormHelperText>

--- a/frontend/src/pages/hardwareProfiles/nodeResource/__tests__/validationUtils.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/__tests__/validationUtils.spec.ts
@@ -1,0 +1,66 @@
+import { resourceLabelIdentifierSchema } from '~/pages/hardwareProfiles/nodeResource/validationUtils';
+
+describe('resourceLabelIdentifierSchema', () => {
+  it('should not validate if fields are empty', () => {
+    const fields = {
+      resourceLabel: '',
+      resourceIdentifier: '',
+    };
+    const result = resourceLabelIdentifierSchema.safeParse(fields);
+    expect(result.error?.errors).toEqual([
+      {
+        code: 'too_small',
+        inclusive: true,
+        message: 'The resource label cannot be empty',
+        minimum: 1,
+        path: ['resourceLabel'],
+        type: 'string',
+      },
+      {
+        code: 'too_small',
+        inclusive: true,
+        message: 'The resource identifier cannot be empty',
+        minimum: 1,
+        path: ['resourceIdentifier'],
+        type: 'string',
+      },
+    ]);
+  });
+
+  it('should not validate if fields are over 500 characters', () => {
+    const fields = {
+      resourceLabel:
+        'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this i',
+      resourceIdentifier:
+        'this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this is a test this i',
+    };
+    const result = resourceLabelIdentifierSchema.safeParse(fields);
+    expect(result.error?.errors).toEqual([
+      {
+        code: 'too_big',
+        inclusive: true,
+        message: 'The resource label cannot have over 500 characters',
+        maximum: 500,
+        path: ['resourceLabel'],
+        type: 'string',
+      },
+      {
+        code: 'too_big',
+        inclusive: true,
+        message: 'The resource identifier cannot have over 500 characters',
+        maximum: 500,
+        path: ['resourceIdentifier'],
+        type: 'string',
+      },
+    ]);
+  });
+
+  it('should not validate if fields are within the limits', () => {
+    const fields = {
+      resourceLabel: 'this is a test',
+      resourceIdentifier: 'this is a test',
+    };
+    const result = resourceLabelIdentifierSchema.safeParse(fields);
+    expect(result.error?.errors).toEqual(undefined);
+  });
+});

--- a/frontend/src/pages/hardwareProfiles/nodeResource/validationUtils.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/validationUtils.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import { ValidationContextType } from '~/utilities/useValidation';
+
+const createResourceSchema = (field: string) =>
+  z
+    .string()
+    .trim()
+    .superRefine((data, ctx) => {
+      if (data.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          message: `The ${field} cannot be empty`,
+          minimum: 1,
+          inclusive: true,
+          type: 'string',
+        });
+      }
+      if (data.length > 500) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          message: `The ${field} cannot have over 500 characters`,
+          maximum: 500,
+          inclusive: true,
+          type: 'string',
+        });
+      }
+    });
+
+export const resourceLabelIdentifierSchema = z.object({
+  resourceLabel: createResourceSchema('resource label'),
+  resourceIdentifier: createResourceSchema('resource identifier'),
+});
+
+export type NodeResourceModalFormData = z.infer<typeof resourceLabelIdentifierSchema>;
+
+export const isResourceLabelValid = (
+  validation: ValidationContextType<{
+    resourceLabel: string;
+    resourceIdentifier: string;
+  }>,
+): boolean =>
+  validation.hasValidationIssue(['resourceLabel'], z.ZodIssueCode.too_small) ||
+  validation.hasValidationIssue(['resourceLabel'], z.ZodIssueCode.too_big);
+
+export const isResourceIdentifierValid = (
+  validation: ValidationContextType<{
+    resourceLabel: string;
+    resourceIdentifier: string;
+  }>,
+): boolean =>
+  validation.hasValidationIssue(['resourceIdentifier'], z.ZodIssueCode.too_small) ||
+  validation.hasValidationIssue(['resourceIdentifier'], z.ZodIssueCode.too_big);
+
+export const getResourceLabelErrorMessage = (
+  validation: ValidationContextType<{
+    resourceLabel: string;
+    resourceIdentifier: string;
+  }>,
+): string | undefined => {
+  if (validation.hasValidationIssue(['resourceLabel'], z.ZodIssueCode.too_small)) {
+    return validation.getValidationIssue(['resourceLabel'], z.ZodIssueCode.too_small)?.message;
+  }
+  if (validation.hasValidationIssue(['resourceLabel'], z.ZodIssueCode.too_big)) {
+    return validation.getValidationIssue(['resourceLabel'], z.ZodIssueCode.too_big)?.message;
+  }
+  return undefined;
+};
+
+export const getResourceIdentifierErrorMessage = (
+  validation: ValidationContextType<{
+    resourceLabel: string;
+    resourceIdentifier: string;
+  }>,
+): string | undefined => {
+  if (validation.hasValidationIssue(['resourceIdentifier'], z.ZodIssueCode.too_small)) {
+    return validation.getValidationIssue(['resourceIdentifier'], z.ZodIssueCode.too_small)?.message;
+  }
+  if (validation.hasValidationIssue(['resourceIdentifier'], z.ZodIssueCode.too_big)) {
+    return validation.getValidationIssue(['resourceIdentifier'], z.ZodIssueCode.too_big)?.message;
+  }
+  return undefined;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-20550

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
<img width="1333" alt="Screenshot 2025-03-07 at 3 35 58 PM" src="https://github.com/user-attachments/assets/d7d0df56-d50e-46d7-9af7-60f87c4559b5" />

• added id to text inputs to remove console errors
• added a 500 character input limit to remove overflow

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

made tests in `validationUtils.spec.ts`. You can also test by trying to input an empty string or a string over 500 characters into the resource label or identifier in node selectors.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

made tests in `validationUtils.spec.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
