### PR TITLE
stashed home hint banner for hardware profiles

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/home/home.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/home/home.ts
@@ -17,12 +17,20 @@ class HomePage {
     cy.testA11y();
   }
 
+  findJupyterIcon() {
+    return cy.findByTestId('jupyter-hint-icon');
+  }
+
   findHint() {
     return cy.findByTestId('home-page-hint');
   }
 
   findHintText() {
     return cy.findByTestId('hint-body-text');
+  }
+
+  findHintLink() {
+    return cy.findByTestId('home-page-hint-navigate');
   }
 
   findHintCloseButton() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/home/home.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/home/home.cy.ts
@@ -1,33 +1,47 @@
 import { enabledPage } from '~/__tests__/cypress/cypress/pages/enabled';
 import { mockComponents } from '~/__mocks__/mockComponents';
 import { homePage } from '~/__tests__/cypress/cypress/pages/home/home';
+import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 
 describe('Home page', () => {
   beforeEach(() => {
     cy.interceptOdh('GET /api/components', { query: { installed: 'true' } }, mockComponents());
     homePage.initHomeIntercepts();
   });
-
+  it('should be shown by default', () => {
+    homePage.visit();
+    // enabled applications page is still navigable
+    enabledPage.visit();
+  });
   it('should be not shown when disabled', () => {
-    homePage.initHomeIntercepts({ disableHardwareProfiles: true });
+    homePage.initHomeIntercepts({ disableHome: true });
+    homePage.visit(false);
+    enabledPage.shouldHaveEnabledPageSection();
+  });
+  it('should show the home page hint', () => {
+    homePage.visit();
+    homePage.findJupyterIcon().should('be.visible');
+    homePage.findHintText().should('contain', 'Jupyter');
+
+    // // enabled applications page is still navigable
+    homePage.findHintLink().click();
+    verifyRelativeURL('/enabled');
+  });
+
+  it('should hide the home page hint when the notebook controller is disabled.', () => {
+    homePage.initHomeIntercepts({ disableNotebookController: true });
     homePage.visit();
     homePage.findHint().should('not.exist');
   });
 
-  it('should show the home page hint', () => {
-    homePage.initHomeIntercepts({ disableHardwareProfiles: false });
-    homePage.visit();
-    homePage.findHint().should('exist');
-    homePage.findHintText().should('contain', 'Hardware profiles');
-  });
-
   it('should hide the home page hint when closed', () => {
-    homePage.initHomeIntercepts({ disableHardwareProfiles: false });
     homePage.visit();
     homePage.findHintCloseButton().click();
     homePage.findHint().should('not.exist');
 
+    // hint should not reappear when home page is navigated to
     enabledPage.visit();
+    enabledPage.shouldHaveEnabledPageSection();
     homePage.returnToHome();
     homePage.findHint().should('not.exist');
   });

--- a/frontend/src/pages/home/HardwareProfilesHomeHint.tsx
+++ b/frontend/src/pages/home/HardwareProfilesHomeHint.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Content } from '@patternfly/react-core';
+import TitleWithIcon from '~/concepts/design/TitleWithIcon';
+import { ProjectObjectType } from '~/concepts/design/utils';
+import ExternalLink from '~/components/ExternalLink';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import HomeHint from './HomeHint';
+
+const HardwareProfilesHomeHint: React.FC = () => {
+  const releaseNoteDocumentation =
+    'https://docs.redhat.com/en/documentation/red_hat_openshift_ai/2025';
+
+  return (
+    <HomeHint
+      title={
+        <TitleWithIcon
+          title={
+            <>Hardware profiles, formerly &quot;Accelerator profiles&quot;, have new features</>
+          }
+          objectType={ProjectObjectType.acceleratorProfile}
+        />
+      }
+      body={
+        <>
+          <Content component="p" data-testid="hint-body-text">
+            Hardware profiles offer more flexibility by enabling administrators to create profiles
+            for additional types of identifiers, limit workload resource allocations, and target
+            workloads to specific nodes by including tolerations and nodeSelectors in profiles.
+          </Content>
+          <ExternalLink
+            text="Find the 2.19 release notes in the documentation"
+            to={releaseNoteDocumentation}
+          />
+        </>
+      }
+      homeHintKey="hardware-profiles-intro"
+      isDisplayed={useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status}
+    />
+  );
+};
+
+export default HardwareProfilesHomeHint;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -8,7 +8,7 @@ import ProjectsSection from './projects/ProjectsSection';
 import { useAIFlows } from './aiFlows/useAIFlows';
 import { useResourcesSection } from './resources/useResourcesSection';
 import { useEnableTeamSection } from './useEnableTeamSection';
-import HomeHint from './HomeHint';
+import LandingPageHomeHint from './LandingPageHomeHint';
 
 const Home: React.FC = () => {
   const { status: projectsAvailable } = useIsAreaAvailable(SupportedArea.DS_PROJECTS_VIEW);
@@ -18,7 +18,7 @@ const Home: React.FC = () => {
 
   return (
     <div data-testid="home-page">
-      <HomeHint />
+      <LandingPageHomeHint />
       {!projectsAvailable && !aiFlows && !resourcesSection && !enableTeamSection ? (
         <PageSection
           hasBodyWrapper={false}

--- a/frontend/src/pages/home/HomeHint.tsx
+++ b/frontend/src/pages/home/HomeHint.tsx
@@ -4,28 +4,29 @@ import {
   Card,
   CardBody,
   CardHeader,
+  Content,
   Flex,
   FlexItem,
   PageSection,
-  Content,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import { useBrowserStorage } from '~/components/browserStorage';
-import TitleWithIcon from '~/concepts/design/TitleWithIcon';
-import { ProjectObjectType } from '~/concepts/design/utils';
-import ExternalLink from '~/components/ExternalLink';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
-const HomeHint: React.FC = () => {
+type HomeHintProps = {
+  title: React.ReactNode;
+  body: React.ReactNode;
+  isDisplayed: boolean;
+  homeHintKey: string;
+  image?: React.ReactNode;
+};
+
+const HomeHint: React.FC<HomeHintProps> = ({ title, body, isDisplayed, homeHintKey, image }) => {
   const [hintHidden, setHintHidden] = useBrowserStorage<boolean>(
-    'odh.dashboard.landing.hint',
+    `odh.dashboard.landing.hint-${homeHintKey}`,
     false,
   );
-  const isHardwareProfileAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
 
-  const releaseNoteDocumentation =
-    'https://docs.redhat.com/en/documentation/red_hat_openshift_ai/2025';
-  if (hintHidden || !isHardwareProfileAvailable) {
+  if (hintHidden || !isDisplayed) {
     return null;
   }
 
@@ -38,19 +39,7 @@ const HomeHint: React.FC = () => {
             justifyContent={{ default: 'justifyContentSpaceBetween' }}
           >
             <FlexItem>
-              <Content>
-                <Content component="h2">
-                  <TitleWithIcon
-                    title={
-                      <>
-                        Hardware profiles, formerly &quot;Accelerator profiles&quot;, have new
-                        features
-                      </>
-                    }
-                    objectType={ProjectObjectType.acceleratorProfile}
-                  />
-                </Content>
-              </Content>
+              <Content component="h2">{title}</Content>
             </FlexItem>
             <FlexItem>
               <Button
@@ -70,20 +59,8 @@ const HomeHint: React.FC = () => {
             gap={{ default: 'gapMd' }}
             flexWrap={{ default: 'nowrap' }}
           >
-            <FlexItem>
-              <Content>
-                <Content component="p" data-testid="hint-body-text">
-                  Hardware profiles offer more flexibility by enabling administrators to create
-                  profiles for additional types of identifiers, limit workload resource allocations,
-                  and target workloads to specific nodes by including tolerations and nodeSelectors
-                  in profiles.
-                </Content>
-                <ExternalLink
-                  text="Find the 2.19 release notes in the documentation"
-                  to={releaseNoteDocumentation}
-                />
-              </Content>
-            </FlexItem>
+            {image}
+            <FlexItem>{body}</FlexItem>
           </Flex>
         </CardBody>
       </Card>

--- a/frontend/src/pages/home/LandingPageHomeHint.tsx
+++ b/frontend/src/pages/home/LandingPageHomeHint.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Content } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import jupyterImg from '~/images/jupyter.svg';
+import { ODH_PRODUCT_NAME } from '~/utilities/const';
+import { useCheckJupyterEnabled } from '~/utilities/notebookControllerUtils';
+import HomeHint from './HomeHint';
+
+const LandingPageHomeHint: React.FC = () => (
+  <HomeHint
+    title={<>Looking for the previous landing page?</>}
+    body={
+      <Content component="p" data-testid="hint-body-text">
+        {ODH_PRODUCT_NAME} has a new landing page. You can access applications that are enabled for
+        your organization, such as Jupyter, from the{' '}
+        <Link to="/enabled" data-testid="home-page-hint-navigate">
+          Enabled applications
+        </Link>{' '}
+        page.
+      </Content>
+    }
+    isDisplayed={useCheckJupyterEnabled()}
+    homeHintKey="new-landing-page-intro"
+    image={
+      <img
+        data-testid="jupyter-hint-icon"
+        src={jupyterImg}
+        alt="Jupyter"
+        style={{
+          height: 42,
+          maxWidth: 'unset',
+          backgroundColor: 'var(--pf-t--color--white)',
+          padding: 'var(--pf-t--global--spacer--xs)',
+          borderRadius: 'var(--pf-t--global--border--radius--small)',
+        }}
+      />
+    }
+  />
+);
+
+export default LandingPageHomeHint;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-21273

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1546" alt="Screenshot 2025-03-13 at 12 19 21 PM" src="https://github.com/user-attachments/assets/137b44db-6825-4702-afb7-27f3fe54301d" />

Stashed the home hint banner for hardware profiles for future use. It no longer appears.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

set feature flag for hardware profiles and visit the home page. the banner should not appear.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

I reverted the cypress tests that enforce their disappearance

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
