### PR TITLE
Update prefilled connections data to persist correctly

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -187,6 +187,13 @@ class InferenceServiceModal extends Modal {
     return this.find().findByTestId('model-uri');
   }
 
+  selectConnectionType(name: string) {
+    this.findExistingConnectionSelect()
+      .findByRole('button', { name: 'Typeahead menu toggle' })
+      .findSelectOption(name)
+      .click();
+  }
+
   selectExistingConnectionSelectOptionByResourceName() {
     this.find().findByText('Test Secret').click();
   }

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -53,6 +53,7 @@ import {
 } from '~/pages/modelServing/screens/types';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { isModelPathValid } from '~/pages/modelServing/screens/projects/utils';
+import usePersistentData from '~/pages/projects/screens/detail/connections/usePersistentData';
 import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 import ConnectionOciPathField from './ConnectionOciPathField';
 
@@ -314,6 +315,14 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
     setNewConnection,
   ]);
 
+  const { changeSelectionType } = usePersistentData({
+    setConnectionValues,
+    setValidations,
+    setSelectedConnectionType,
+    connectionValues,
+    selectedConnectionType,
+  });
+
   return (
     <FormSection>
       <ConnectionTypeForm
@@ -326,6 +335,8 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
               S3ConnectionTypeKeys,
             ),
           );
+          const obj = connectionTypes.find((c) => c.metadata.name === type);
+          changeSelectionType(obj);
         }}
         connectionNameDesc={nameDescData}
         setConnectionNameDesc={setNameDescData}

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -21,6 +21,7 @@ import {
   isConnectionTypeDataField,
   parseConnectionSecretValues,
 } from '~/concepts/connectionTypes/utils';
+import usePersistentData from './usePersistentData';
 
 type Props = {
   connection?: Connection;
@@ -98,33 +99,13 @@ export const ManageConnectionModal: React.FC<Props> = ({
     [connectionTypeName, selectedConnectionType, nameDescData, connectionValues, validations],
   );
 
-  // if user changes connection types, don't discard previous entries in case of accident
-  const previousValues = React.useRef<{
-    [connectionTypeName: string]: {
-      [key: string]: ConnectionTypeValueType;
-    };
-  }>({});
-  const changeSelectionType = React.useCallback(
-    (type?: ConnectionTypeConfigMapObj) => {
-      // save previous connection values
-      if (selectedConnectionType) {
-        previousValues.current[selectedConnectionType.metadata.name] = connectionValues;
-        // clear previous values
-        setConnectionValues({});
-        setValidations({});
-      }
-      // load saved values?
-      if (type?.metadata.name && type.metadata.name in previousValues.current) {
-        setConnectionValues(previousValues.current[type.metadata.name]);
-      } else if (type) {
-        // first time load, so add default values
-        setConnectionValues(getDefaultValues(type));
-      }
-
-      setSelectedConnectionType(type);
-    },
-    [selectedConnectionType, connectionValues],
-  );
+  const { changeSelectionType } = usePersistentData({
+    setConnectionValues,
+    setValidations,
+    setSelectedConnectionType,
+    connectionValues,
+    selectedConnectionType,
+  });
 
   return (
     <Modal

--- a/frontend/src/pages/projects/screens/detail/connections/usePersistentData.ts
+++ b/frontend/src/pages/projects/screens/detail/connections/usePersistentData.ts
@@ -1,0 +1,62 @@
+import React, { useCallback } from 'react';
+import {
+  ConnectionTypeConfigMapObj,
+  ConnectionTypeValueType,
+} from '~/concepts/connectionTypes/types';
+import { getDefaultValues } from '~/concepts/connectionTypes/utils';
+
+type UsePersistentDataProps = {
+  setConnectionValues: (name: { [key: string]: ConnectionTypeValueType }) => void;
+  setValidations: (validation: { [key: string]: boolean }) => void;
+  setSelectedConnectionType: (name: ConnectionTypeConfigMapObj | undefined) => void;
+  connectionValues: { [key: string]: ConnectionTypeValueType };
+  selectedConnectionType: ConnectionTypeConfigMapObj | undefined;
+};
+
+const usePersistentData = ({
+  setConnectionValues,
+  setValidations,
+  setSelectedConnectionType,
+  connectionValues,
+  selectedConnectionType,
+}: UsePersistentDataProps): {
+  changeSelectionType: (type?: ConnectionTypeConfigMapObj) => void;
+} => {
+  // if user changes connection types, don't discard previous entries in case of accident
+  const previousValues = React.useRef<{
+    [connectionTypeName: string]: {
+      [key: string]: ConnectionTypeValueType;
+    };
+  }>({});
+
+  const changeSelectionType = useCallback(
+    (type?: ConnectionTypeConfigMapObj) => {
+      // save previous connection values
+      if (selectedConnectionType) {
+        previousValues.current[selectedConnectionType.metadata.name] = connectionValues;
+        // clear previous values
+        setConnectionValues({});
+        setValidations({});
+      }
+      // load saved values?
+      if (type?.metadata.name && type.metadata.name in previousValues.current) {
+        setConnectionValues(previousValues.current[type.metadata.name]);
+      } else if (type) {
+        // first time load, so add default values
+        setConnectionValues(getDefaultValues(type));
+      }
+      setSelectedConnectionType(type);
+    },
+    [
+      selectedConnectionType,
+      connectionValues,
+      setConnectionValues,
+      setValidations,
+      setSelectedConnectionType,
+    ],
+  );
+
+  return { changeSelectionType };
+};
+
+export default usePersistentData;


### PR DESCRIPTION
Closes: [RHOAIENG-20546](https://issues.redhat.com/browse/RHOAIENG-20546)

## Description
This PR aims to update the prefilled connection type to show respective fields and prefilled connections data to persist, when user changes connection type 

https://github.com/user-attachments/assets/d0d112ce-0b49-4c27-8a03-93497cc88dda


https://github.com/user-attachments/assets/2b2a71ac-8ded-467f-b4bf-e9ecb3bd5f02


## How Has This Been Tested?
1. Navigate to Model Registry
2. Select a registered model
3. Select 'Deploy' via the kebab menu for the version
4. Deploy to a project with no matching connections
5. Switch the connection type and observe that the prefilled data remains from the previous type
6. Also, check that the data will persist if user changes the connection type

## Test Impact
Added cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
