### PR TITLE
Error handling for incompatible ilab pipeline yaml

### DIFF
--- a/frontend/src/__mocks__/mockIlabPipelineVersionParameters.ts
+++ b/frontend/src/__mocks__/mockIlabPipelineVersionParameters.ts
@@ -1,0 +1,148 @@
+import {
+  HyperparameterFields,
+  NonDisplayedHyperparameterFields,
+} from '~/__tests__/cypress/cypress/types';
+import { InputDefinitionParameterType } from '~/concepts/pipelines/kfTypes';
+
+export const mockIlabPipelineVersionParameters = {
+  [NonDisplayedHyperparameterFields.EVAL_GPU_IDENTIFIER]: {
+    defaultValue: 'nvidia.com/gpu',
+    description:
+      'General evaluation parameter. The GPU type used for training pods, e.g. nvidia.com/gpu',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.EVAL_JUDGE_SECRET]: {
+    defaultValue: 'judge-secret',
+    description:
+      'General evaluation parameter: The name of the k8s secret key holding access credentials to the judge server.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.K8S_STORAGE_CLASS_NAME]: {
+    defaultValue: 'standard',
+    description:
+      'A Kubernetes StorageClass name for persistent volumes. Selected StorageClass must support RWX PersistentVolumes.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.SDG_BASE_MODEL]: {
+    description:
+      'SDG parameter. LLM model used to generate the synthetic dataset. E.g. "s3://\u003cBUCKET\u003e/\u003cPATH_TO_MODEL\u003e"',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.SDG_PIPELINE]: {
+    defaultValue: '/usr/share/instructlab/sdg/pipelines/agentic',
+    description:
+      "SDG parameter. Data generation pipeline to use. Available: 'simple', 'full', or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.SDG_REPO_BRANCH]: {
+    description:
+      'SDG parameter. Points to a branch within the taxonomy git repository. If set, has priority over sdg_repo_pr',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.SDG_REPO_SECRET]: {
+    defaultValue: 'taxonomy-repo-secret',
+    description:
+      'SDG parameter. The name of the k8s secret holding access credentials to the sdg_repo_url.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.SDG_SECRET_URL]: {
+    description:
+      'SDG parameter. Points to a taxonomy git repository. E.g. "https://github.com/instructlab/taxonomy.git"',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.SDG_TEACHER_SECRET]: {
+    defaultValue: 'teacher-secret',
+    description:
+      'SDG parameter. The name of the k8s secret key holding access credentials to the teacher server.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.TRAIN_CPU_PER_WORKER]: {
+    defaultValue: '2',
+    description: 'Training parameter. Number of CPUs per each node/worker to use for training.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.TRAIN_GPU_IDENTIFIER]: {
+    defaultValue: 'nvidia.com/gpu',
+    description: 'Training parameter. The GPU type used for training pods, e.g. nvidia.com/gpu',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.TRAIN_GPU_PER_WORKER]: {
+    defaultValue: 2,
+    description: 'Training parameter. Number of GPUs per each node/worker to use for training.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.INTEGER,
+  },
+  [NonDisplayedHyperparameterFields.TRAIN_MEMORY_PER_WORKER]: {
+    defaultValue: '2Gi',
+    description: 'Training parameter. Memory per GPU per each node/worker to use for training.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [NonDisplayedHyperparameterFields.TRAIN_NODE_SELECTORS]: {
+    description: 'Training parameter. A JSON containing node selectors applied to training pods.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.STRUCT,
+  },
+  [NonDisplayedHyperparameterFields.TRAIN_TOLERATIONS]: {
+    description: 'Training parameter. List of tolerations applied to training pods.',
+    isOptional: true,
+    parameterType: InputDefinitionParameterType.LIST,
+  },
+  [HyperparameterFields.SDG_SCALE_FACTOR]: {
+    defaultValue: 30,
+    description: 'SDG parameter. The total number of instructions to be generated.',
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.INTEGER,
+  },
+  [HyperparameterFields.TRAINING_WORKERS]: {
+    defaultValue: '2',
+    description: 'Training parameter. Number of nodes/workers to train on.',
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.INTEGER,
+  },
+  [HyperparameterFields.LEARNING_RATE_PHASE_1]: {
+    defaultValue: 0.00002,
+    description:
+      "Training parameter for in Phase 1. How fast we optimize the weights during gradient descent. Higher values may lead to unstable learning performance. It's generally recommended to have a low learning rate with a high effective batch size.",
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.DOUBLE,
+  },
+  [HyperparameterFields.LEARNING_RATE_PHASE_2]: {
+    defaultValue: 0.000006,
+    description:
+      "Training parameter for in Phase 2. How fast we optimize the weights during gradient descent. Higher values may lead to unstable learning performance. It's generally recommended to have a low learning rate with a high effective batch size.",
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.DOUBLE,
+  },
+  [HyperparameterFields.EVALUATION_WORKERS]: {
+    defaultValue: 'auto',
+    description:
+      "Final model evaluation parameter for MT Bench Branch. Number of workers to use for evaluation with mt_bench or mt_bench_branch. Must be a positive integer or 'auto'.",
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  [HyperparameterFields.EVALUATION_BATCH_SIZE]: {
+    defaultValue: 'auto',
+    description:
+      "Final model evaluation parameter for MMLU. Batch size for evaluation. Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory.",
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+  'test param': {
+    defaultValue: 'hi!',
+    description: 'this is a random parameter',
+    isOptional: false,
+    parameterType: InputDefinitionParameterType.STRING,
+  },
+};

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm.ts
@@ -23,6 +23,10 @@ class ModelCustomizationFormGlobal {
     }
   }
 
+  findErrorMessage() {
+    return cy.findByTestId('pipeline-error-message');
+  }
+
   invalidVisit() {
     cy.visitWithLogin('/modelCustomization/fine-tune');
     this.emptyWait();

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -291,3 +291,28 @@ export enum HyperparameterFields {
   EVALUATION_WORKERS = 'final_eval_max_workers',
   EVALUATION_BATCH_SIZE = 'final_eval_batch_size',
 }
+
+export enum NonDisplayedHyperparameterFields {
+  OUTPUT_OCI_MODEL_URI = 'output_oci_model_uri',
+  OUTPUT_OCI_REGISTRY_SECRET = 'output_oci_registry_secret',
+  OUTPUT_MODEL_NAME = 'output_model_name',
+  OUTPUT_MODEL_VERSION = 'output-model_version',
+  OUTPUT_MODEL_REGISTRY_API_URL = 'output_model_registry_api_url',
+  OUTPUT_MODEL_REGISTRY_NAME = 'output_model_registry_name',
+  OUTPUT_MODELCAR_BASE_IMAGE = 'output_modelcar_base_image',
+  SDG_SECRET_URL = 'sdg_repo_url',
+  SDG_REPO_SECRET = 'sdg_repo_secret',
+  SDG_REPO_BRANCH = 'sdg_repo_branch',
+  SDG_TEACHER_SECRET = 'sdg_teacher_secret',
+  SDG_BASE_MODEL = 'sdg_base_model',
+  TRAIN_TOLERATIONS = 'train_tolerations',
+  TRAIN_NODE_SELECTORS = 'train_node_selectors',
+  TRAIN_GPU_IDENTIFIER = 'train_gpu_identifier',
+  TRAIN_GPU_PER_WORKER = 'train_gpu_per_worker',
+  TRAIN_CPU_PER_WORKER = 'train_cpu_per_worker',
+  TRAIN_MEMORY_PER_WORKER = 'train_memory_per_worker',
+  EVAL_JUDGE_SECRET = 'eval_judge_secret',
+  SDG_PIPELINE = 'sdg_pipeline',
+  EVAL_GPU_IDENTIFIER = 'eval_gpu_identifier',
+  K8S_STORAGE_CLASS_NAME = 'k8s_storage_class_name',
+}

--- a/frontend/src/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/__tests__/validationUtils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/__tests__/validationUtils.spec.ts
@@ -1,12 +1,16 @@
+import { buildMockPipelineVersion } from '~/__mocks__';
+
 import { ModelCustomizationEndpointType } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/types';
 import {
   runTypeSchema,
+  pipelineParameterSchema,
   TeacherJudgeFormData,
   teacherJudgeModel,
 } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
 import { InputDefinitionParameterType } from '~/concepts/pipelines/kfTypes';
 import { RunTypeFormat } from '~/pages/pipelines/global/modelCustomization/const';
 import { createHyperParametersSchema } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/hyperparameterValidationUtils';
+import { mockIlabPipelineVersionParameters } from '~/__mocks__/mockIlabPipelineVersionParameters';
 
 describe('TeacherJudgeSchema', () => {
   it('should validate when it is public without token', () => {
@@ -210,5 +214,20 @@ describe('hyperparameterFieldSchema', () => {
     const runType = RunTypeFormat.SIMPLE;
     const result = runTypeSchema.safeParse(runType);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('Pipeline details', () => {
+  it('should validate when required parameters are present', () => {
+    const params = mockIlabPipelineVersionParameters;
+    const result = pipelineParameterSchema.safeParse(params);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate when required parameters are absent', () => {
+    const params =
+      buildMockPipelineVersion().pipeline_spec.pipeline_spec?.root.inputDefinitions?.parameters;
+    const result = pipelineParameterSchema.safeParse(params);
+    expect(result.success).toBe(false);
   });
 });

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePage.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePage.tsx
@@ -15,11 +15,13 @@ import JudgeModelSection from '~/pages/pipelines/global/modelCustomization/teach
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import { ModelCustomizationRouterState } from '~/routes';
 import RunTypeSection from '~/pages/pipelines/global/modelCustomization/RunTypeSection';
+import { ValidationContext } from '~/utilities/useValidation';
 import { FineTuneTaxonomySection } from './FineTuneTaxonomySection';
 import TrainingHardwareSection from './trainingHardwareSection/TrainingHardwareSection';
 import { FineTunePageSections, fineTunePageSectionTitles } from './const';
 import HyperparameterPageSection from './HyperparameterSection/HyperparameterPageSection';
 import { filterHyperparameters } from './utils';
+import { PipelineDetailsSection } from './baseModelSection/PipelineDetailsSection';
 
 type FineTunePageProps = {
   canSubmit: boolean;
@@ -43,7 +45,9 @@ const FineTunePage: React.FC<FineTunePageProps> = ({
   const { project } = usePipelinesAPI();
   const { state }: { state?: ModelCustomizationRouterState } = useLocation();
   const { hyperparameters } = filterHyperparameters(ilabPipelineVersion);
-
+  const { getAllValidationIssues } = React.useContext(ValidationContext);
+  const hasValidationErrors =
+    Object.keys(getAllValidationIssues(['inputPipelineParameters'])).length > 0;
   return (
     <Form data-testid="fineTunePageForm" maxWidth="500px">
       <FormSection
@@ -59,35 +63,58 @@ const FineTunePage: React.FC<FineTunePageProps> = ({
           <div>{getDisplayNameFromK8sResource(project)}</div>
         </FormGroup>
       </FormSection>
-      <BaseModelSection
-        data={data.baseModel}
-        setData={(baseModelData) => setData('baseModel', baseModelData)}
-        registryName={state?.modelRegistryDisplayName}
-        inputModelName={state?.registeredModelName}
-        inputModelVersionName={state?.modelVersionName}
-      />
-      <FineTuneTaxonomySection
-        data={data.taxonomy}
-        setData={(dataTaxonomy: FineTuneTaxonomyFormData) => {
-          setData('taxonomy', dataTaxonomy);
-        }}
-      />
-      <TeacherModelSection
-        data={data.teacher}
-        setData={(teacherData) => setData('teacher', teacherData)}
-      />
-      <JudgeModelSection data={data.judge} setData={(judgeData) => setData('judge', judgeData)} />
-      <TrainingHardwareSection
+      <PipelineDetailsSection
+        ilabPipeline={ilabPipeline}
         ilabPipelineLoaded={ilabPipelineLoaded}
         ilabPipelineVersion={ilabPipelineVersion}
-        trainingNode={data.trainingNode}
-        setTrainingNode={(trainingNodeValue: number) => setData('trainingNode', trainingNodeValue)}
-        storageClass={data.storageClass}
-        setStorageClass={(storageClassName: string) => setData('storageClass', storageClassName)}
-        setHardwareFormData={(hardwareFormData) => setData('hardware', hardwareFormData)}
+        hasValidationErrors={hasValidationErrors}
       />
-      <RunTypeSection data={data} setData={setData} />
-      <HyperparameterPageSection data={data} hyperparameters={hyperparameters} setData={setData} />
+
+      {!hasValidationErrors && (
+        <>
+          <BaseModelSection
+            data={data.baseModel}
+            setData={(baseModelData) => setData('baseModel', baseModelData)}
+            registryName={state?.modelRegistryDisplayName}
+            inputModelName={state?.registeredModelName}
+            inputModelVersionName={state?.modelVersionName}
+          />
+          <FineTuneTaxonomySection
+            data={data.taxonomy}
+            setData={(dataTaxonomy: FineTuneTaxonomyFormData) => {
+              setData('taxonomy', dataTaxonomy);
+            }}
+          />
+          <TeacherModelSection
+            data={data.teacher}
+            setData={(teacherData) => setData('teacher', teacherData)}
+          />
+          <JudgeModelSection
+            data={data.judge}
+            setData={(judgeData) => setData('judge', judgeData)}
+          />
+          <TrainingHardwareSection
+            ilabPipelineLoaded={ilabPipelineLoaded}
+            ilabPipelineVersion={ilabPipelineVersion}
+            trainingNode={data.trainingNode}
+            setTrainingNode={(trainingNodeValue: number) =>
+              setData('trainingNode', trainingNodeValue)
+            }
+            storageClass={data.storageClass}
+            setStorageClass={(storageClassName: string) =>
+              setData('storageClass', storageClassName)
+            }
+            setHardwareFormData={(hardwareFormData) => setData('hardware', hardwareFormData)}
+          />
+          <RunTypeSection data={data} setData={setData} />
+          <HyperparameterPageSection
+            data={data}
+            hyperparameters={hyperparameters}
+            setData={setData}
+          />
+        </>
+      )}
+
       <FormSection>
         <FineTunePageFooter
           canSubmit={canSubmit}

--- a/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
@@ -27,6 +27,7 @@ import {
 } from '~/pages/modelRegistry/screens/routeUtils';
 import { ModelCustomizationRouterState } from '~/routes';
 import { createHyperParametersSchema } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/hyperparameterValidationUtils';
+import { getInputDefinitionParams } from '~/concepts/pipelines/content/createRun/utils';
 import FineTunePage from './FineTunePage';
 import { FineTunePageSections, fineTunePageSectionTitles } from './const';
 import { filterHyperparameters, getParamsValueFromPipelineInput } from './utils';
@@ -51,6 +52,7 @@ const ModelCustomizationForm: React.FC = () => {
     baseModel: {
       sdgBaseModel: state?.inputModelLocationUri ?? '',
     },
+    inputPipelineParameters: {},
     taxonomy: {
       url: '',
 
@@ -96,6 +98,10 @@ const ModelCustomizationForm: React.FC = () => {
       setData('hyperparameters', {
         ...hyperparameterFormData,
       });
+      const parameters = getInputDefinitionParams(ilabPipelineVersion);
+      if (parameters) {
+        setData('inputPipelineParameters', parameters);
+      }
       const trainingNodeDefaultValue = getParamsValueFromPipelineInput(
         ilabPipelineVersion,
         'train_num_workers',
@@ -114,6 +120,20 @@ const ModelCustomizationForm: React.FC = () => {
   );
 
   const navigate = useNavigate();
+  const pipelineParameterErrors =
+    Object.keys(formValidation.getAllValidationIssues(['inputPipelineParameters'])).length > 0;
+
+  const filteredFineTunePageSections = React.useMemo(
+    () =>
+      pipelineParameterErrors
+        ? Object.values(FineTunePageSections).filter(
+            (section) =>
+              section === FineTunePageSections.PROJECT_DETAILS ||
+              section === FineTunePageSections.PIPELINE_DETAILS,
+          )
+        : FineTunePageSections,
+    [pipelineParameterErrors],
+  );
 
   return (
     <ValidationContext.Provider value={formValidation}>
@@ -158,7 +178,7 @@ const ModelCustomizationForm: React.FC = () => {
         <EnsureAPIAvailability>
           <PageSection hasBodyWrapper={false} isFilled>
             <GenericSidebar
-              sections={Object.values(FineTunePageSections)}
+              sections={Object.values(filteredFineTunePageSections)}
               titles={fineTunePageSectionTitles}
               maxWidth={175}
             >

--- a/frontend/src/pages/pipelines/global/modelCustomization/baseModelSection/PipelineDetailsSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/baseModelSection/PipelineDetailsSection.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import {
+  ActionList,
+  ActionListItem,
+  Alert,
+  Button,
+  FormGroup,
+  FormSection,
+  Skeleton,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { useNavigate } from 'react-router';
+import {
+  FineTunePageSections,
+  fineTunePageSectionTitles,
+} from '~/pages/pipelines/global/modelCustomization/const';
+import { createRunRoute } from '~/routes';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
+
+type PipelineDetailsSectionProps = {
+  ilabPipeline: PipelineKF | null;
+  ilabPipelineVersion: PipelineVersionKF | null;
+  ilabPipelineLoaded: boolean;
+  hasValidationErrors: boolean;
+};
+
+export const PipelineDetailsSection: React.FC<PipelineDetailsSectionProps> = ({
+  ilabPipeline,
+  ilabPipelineVersion,
+  ilabPipelineLoaded,
+  hasValidationErrors,
+}) => {
+  const { namespace } = usePipelinesAPI();
+  const navigate = useNavigate();
+
+  return (
+    //TODO: Pipeline description https://issues.redhat.com/browse/RHOAIENG-19187
+    <FormSection
+      id={FineTunePageSections.PIPELINE_DETAILS}
+      title={fineTunePageSectionTitles[FineTunePageSections.PIPELINE_DETAILS]}
+    >
+      {ilabPipelineLoaded ? (
+        <>
+          <FormGroup label="Pipeline name" fieldId="pipeline-name" isRequired>
+            {ilabPipeline?.display_name ?? '-'}
+          </FormGroup>
+          <FormGroup label="Pipeline version" fieldId="pipeline-version" isRequired>
+            <Stack hasGutter>
+              <StackItem>{ilabPipelineVersion?.display_name ?? '-'}</StackItem>
+              <StackItem>
+                {hasValidationErrors && (
+                  <Alert
+                    data-testid="pipeline-error-message"
+                    variant="danger"
+                    isInline
+                    title="This pipeline version is not compatible with this form."
+                  >
+                    <Stack hasGutter>
+                      <StackItem>
+                        The latest version of the <b>{ilabPipeline?.display_name ?? ''}</b> pipeline
+                        is not compatible with the <b>Start an InstructLab run</b> form. To create a
+                        run for this version, use the <b>Create run</b> form. Alternatively, manage
+                        this pipeline&apos;s versions in the <b>Pipelines</b> page for this project.
+                      </StackItem>
+                      <StackItem>
+                        <ActionList>
+                          <ActionListItem>
+                            <Button
+                              variant="link"
+                              isInline
+                              onClick={() => {
+                                navigate(createRunRoute(namespace), {
+                                  state: { contextData: { ilabPipeline, ilabPipelineVersion } },
+                                });
+                              }}
+                            >
+                              Use the <b>Create run</b> form
+                            </Button>
+                          </ActionListItem>
+                          <ActionListItem>
+                            <Button variant="link" isInline onClick={() => navigate('/pipelines')}>
+                              Go to <b>Pipelines</b>
+                            </Button>
+                          </ActionListItem>
+                        </ActionList>
+                      </StackItem>
+                    </Stack>
+                  </Alert>
+                )}
+              </StackItem>
+            </Stack>
+          </FormGroup>
+        </>
+      ) : (
+        <Skeleton />
+      )}
+    </FormSection>
+  );
+};

--- a/frontend/src/pages/pipelines/global/modelCustomization/const.ts
+++ b/frontend/src/pages/pipelines/global/modelCustomization/const.ts
@@ -1,6 +1,7 @@
 export enum FineTunePageSections {
   PROJECT_DETAILS = 'fine-tune-section-project-details',
   TAXONOMY_DETAILS = 'fine-tune-section-taxonomy-details',
+  PIPELINE_DETAILS = 'fine-tine-section-pipeline-details',
   BASE_MODEL = 'fine-tune-section-base-model',
   TEACHER_MODEL = 'fine-tune-section-teacher-model',
   JUDGE_MODEL = 'fine-tune-section-judge-model',
@@ -19,12 +20,11 @@ export enum PipelineInputParameters {
   TRAIN_NUM_WORKERS = 'train_num_workers',
   EVAL_GPU_IDENTIFIER = 'eval_gpu_identifier',
   K8S_STORAGE_CLASS_NAME = 'k8s_storage_class_name',
-  RUN_TYPE = 'fine-tune-section-run-type',
-  HYPERPARAMETERS = 'fun-tune-hyperparameters',
 }
 
 export const fineTunePageSectionTitles: Record<FineTunePageSections, string> = {
   [FineTunePageSections.PROJECT_DETAILS]: 'Project details',
+  [FineTunePageSections.PIPELINE_DETAILS]: 'Pipeline details',
   [FineTunePageSections.TAXONOMY_DETAILS]: 'Taxonomy details',
   [FineTunePageSections.BASE_MODEL]: 'Base model',
   [FineTunePageSections.TEACHER_MODEL]: 'Teacher model',
@@ -99,5 +99,8 @@ export enum NonDisplayedHyperparameterFields {
   TRAIN_GPU_PER_WORKER = 'train_gpu_per_worker',
   TRAIN_CPU_PER_WORKER = 'train_cpu_per_worker',
   TRAIN_MEMORY_PER_WORKER = 'train_memory_per_worker',
+  EVAL_JUDGE_SECRET = 'eval_judge_secret',
   SDG_PIPELINE = 'sdg_pipeline',
+  EVAL_GPU_IDENTIFIER = 'eval_gpu_identifier',
+  K8S_STORAGE_CLASS_NAME = 'k8s_storage_class_name',
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-20529

## Description
Added a alert message when the ilab pipeline required parameters are absent

![Screenshot 2025-03-10 at 5 48 03 PM](https://github.com/user-attachments/assets/64aa6108-ef43-4d99-a18e-506d2e283419)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

1. Get a pipeline which doesnt contain the required parameters
2. Check for the alert Error message

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added unit test and cypress test
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
