### PR TITLE
InstructLab pipeline upload flow microcopy

### DIFF
--- a/frontend/src/concepts/pipelines/content/ManageSamplePipelinesModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ManageSamplePipelinesModal.tsx
@@ -55,15 +55,9 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
       .then((dspa) => {
         const isEnabled = dspa.spec.apiServer?.managedPipelines?.instructLab?.state === 'Managed';
         if (isEnabled) {
-          notification.info(
-            'InstructLab pipeline enabled',
-            'The server will restart for this process.',
-          );
+          notification.info('Restarting pipeline server');
         } else {
-          notification.success(
-            'Automatic updates for InstructLab pipeline disabled',
-            'Your InstructLab pipeline will no longer receive automatic updates.',
-          );
+          notification.success('Automatic updates for InstructLab pipeline disabled');
         }
         unregisterNotification(ilabPipelineNotificationWatcher);
         if (isEnabled && !notificationWatcherRef.current) {
@@ -82,14 +76,14 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
                   const serverReady = !!dspaResponse.status?.conditions?.find(
                     (c) => c.type === 'APIServerReady' && c.status === 'True',
                   );
+                  const title = `InstructLab pipeline installed on ${namespace} project`;
                   if (iLabPipelineReady && serverReady) {
                     notificationWatcherRef.current = false;
                     // Refresh the pipelines list to make the ilab pipeline shown
                     refreshAllAPI();
                     return {
                       status: 'success',
-                      title: 'InstructLab pipeline available',
-                      message: 'Your instructlab pipeline is now available.',
+                      title,
                     };
                   }
                   if (iLabPipelineResponse.error) {
@@ -120,8 +114,16 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
 
   return (
     <Modal
-      title="Manage sample pipelines"
-      description="Select a sample pipeline to enable it. Deselect a pipeline to disable. Enabled pipelines will be accessible and automatically updated within your pipeline server. This process might take a few minutes."
+      title="Manage preconfigured pipelines"
+      description={
+        <>
+          Select a preconfigured pipeline to install it on your project and enable automatic
+          updates. After installation, you can deselect the pipeline to disable automatic updates.
+          <br />
+          <br />
+          Note: You can manually delete preconfigured pipelines after installation.
+        </>
+      }
       isOpen
       variant="small"
       onClose={() => onClose()}
@@ -147,7 +149,7 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
             <Alert
               isInline
               variant="warning"
-              title="The pipeline server will restart, this could take a few minutes. When it restarts, the new pipeline will be available."
+              title="Installing the InstructLab pipeline will cause the pipeline server to restart."
             />
           </StackItem>
         ) : null}
@@ -156,7 +158,7 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
             <Alert
               isInline
               variant="warning"
-              title="If you wish to no longer have the InstructLab pipeline, you must manually delete it."
+              title="If you want to remove the InstructLab pipeline, you must manually delete it."
             />
           </StackItem>
         ) : null}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/InstructLabPipelineEnablement.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/InstructLabPipelineEnablement.tsx
@@ -10,7 +10,6 @@ const InstructLabPipelineEnablement: React.FC<InstructLabPipelineEnablementProps
   isEnabled,
   setEnabled,
 }) => (
-  // TODO: add description for the instruct lab pipeline
   <Checkbox
     label="InstructLab pipeline"
     isChecked={isEnabled}
@@ -21,6 +20,7 @@ const InstructLabPipelineEnablement: React.FC<InstructLabPipelineEnablementProps
     id="instructlab-enabled-checkbox"
     data-testid="instructlab-enabled-checkbox"
     name="instructLabEnabledCheckbox"
+    description="The InstructLab pipeline contains the steps and instructions that make up LAB-tuning runs."
   />
 );
 

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/SamplePipelineSettingsSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/SamplePipelineSettingsSection.tsx
@@ -13,10 +13,15 @@ const SamplePipelineSettingsSection: React.FC<SamplePipelineSettingsSectionProps
   setConfig,
 }) => (
   <FormSection
-    title="Enable sample pipelines"
-    description="Enabled pipelines will be accessible and automatically updated within your pipeline server."
+    title="Install preconfigured pipelines"
+    description={
+      <>
+        The selected preconfigured pipelines will be installed on your project, and updates will be
+        applied to them automatically. To turn off automatic updates, click{' '}
+        <b>Manage preconfigured pipelines</b> in the action dropdown on the <b>Pipelines</b> page.
+      </>
+    }
   >
-    {/* TODO: add description for the instruct lab pipeline */}
     <InstructLabPipelineEnablement
       isEnabled={config.enableInstructLab}
       setEnabled={(enabled) => {

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineSplitButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineSplitButton.tsx
@@ -101,7 +101,7 @@ const ImportPipelineSplitButton: React.FC<ImportPipelineSplitButtonProps> = ({
               isAriaDisabled={!apiAvailable}
               onClick={() => setManageSamplePipelinesModalOpen(true)}
             >
-              Manage sample pipelines
+              Manage preconfigured pipelines
             </DropdownItem>
           )}
         </DropdownList>


### PR DESCRIPTION
[RHOAIENG-21256](https://issues.redhat.com/browse/RHOAIENG-21256)

## Description

![Screenshot 2025-03-10 at 6 35 57 PM](https://github.com/user-attachments/assets/31ac37df-0d89-4c62-8eb4-0dec7eda1065)
![Screenshot 2025-03-10 at 6 36 28 PM](https://github.com/user-attachments/assets/24d6011b-5db6-4821-b9d3-b41f8d98dce6)
![Screenshot 2025-03-10 at 6 43 04 PM](https://github.com/user-attachments/assets/ece1072e-ac8e-4165-8bbd-f09b4090ab90)
![Screenshot 2025-03-10 at 6 44 08 PM](https://github.com/user-attachments/assets/51f04420-f47d-433b-a089-e88680a1b54f)
![Screenshot 2025-03-10 at 7 17 26 PM](https://github.com/user-attachments/assets/0b3f4c6b-5074-4bae-bc02-b5905b57abf9)
![Screenshot 2025-03-10 at 7 19 40 PM](https://github.com/user-attachments/assets/43525e8f-5fa5-4387-a93c-f61e60128702)
![Screenshot 2025-03-10 at 7 20 15 PM](https://github.com/user-attachments/assets/5763e5a2-a8af-40ae-b754-bd347abbf874)


## How Has This Been Tested?
Check that area in dashboard and verify the text change

## Test Impact
None, just text change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@yannnz @kaedward 