### PR TITLE
Add fine-tuned model section to ilab form

### DIFF
--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -181,6 +181,7 @@ const modelServingCompatibleTypesMetadata: Record<
 export const isModelServingCompatible = (
   input: string[] | Connection | ConnectionTypeConfigMapObj,
   type?: ModelServingCompatibleTypes,
+  connectionAccessType = 'Pull',
 ): boolean => {
   if (!type) {
     return getModelServingCompatibility(input).length > 0;
@@ -189,7 +190,9 @@ export const isModelServingCompatible = (
     if (type === ModelServingCompatibleTypes.OCI) {
       const accessType =
         input.stringData?.ACCESS_TYPE || window.atob(input.data?.ACCESS_TYPE ?? '');
-      if (!(accessType.includes('Pull') || accessType === '[]' || accessType === '')) {
+      if (
+        !(accessType.includes(connectionAccessType) || accessType === '[]' || accessType === '')
+      ) {
         return false;
       }
     }

--- a/frontend/src/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils.ts
+++ b/frontend/src/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils.ts
@@ -10,6 +10,7 @@ import {
   PipelineInputParameters,
   RunTypeFormat,
 } from '~/pages/pipelines/global/modelCustomization/const';
+import { InferenceServiceStorageType } from '~/pages/modelServing/screens/types';
 import { FineTuneTaxonomyType, ModelCustomizationEndpointType } from './types';
 
 export const uriFieldSchemaBase = (
@@ -33,10 +34,25 @@ export const baseModelSchema = z.object({
   sdgBaseModel: uriFieldSchemaBase(true),
 });
 
+export const connectionFormDataScheme = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal(InferenceServiceStorageType.EXISTING_STORAGE),
+    uri: uriFieldSchemaBase(true).optional(),
+    connection: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal(InferenceServiceStorageType.NEW_STORAGE),
+    uri: uriFieldSchemaBase(true).optional(),
+  }),
+]);
+
 export const outputModelSchema = z.object({
-  outputModelName: z.string().trim().min(1, 'Model name is required'),
-  outputModelRegistryApiUrl: z.string().trim().min(1, 'Model registry API URL is required'),
-  // TODO more output model fields
+  addToRegistryEnabled: z.boolean(),
+  outputModelRegistryName: z.string().optional(),
+  outputModelName: z.string().optional(),
+  outputModelVersion: z.string().optional(),
+  outputModelRegistryApiUrl: z.string().optional(),
+  connectionData: connectionFormDataScheme,
 });
 
 const teacherJudgeBaseSchema = z.object({
@@ -196,3 +212,4 @@ export type BaseModelFormData = z.infer<typeof baseModelSchema>;
 export type OutputModelFormData = z.infer<typeof outputModelSchema>;
 export type TeacherJudgeFormData = z.infer<typeof teacherJudgeModel>;
 export type HardwareFormData = z.infer<typeof hardwareSchema>;
+export type ConnectionFormData = z.infer<typeof connectionFormDataScheme>;

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePage.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePage.tsx
@@ -16,6 +16,9 @@ import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import { ModelCustomizationRouterState } from '~/routes';
 import RunTypeSection from '~/pages/pipelines/global/modelCustomization/RunTypeSection';
 import { ValidationContext } from '~/utilities/useValidation';
+import FineTunedModelSection from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelSection';
+import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
+import { FineTunedModelNewConnectionContextProvider } from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionContext';
 import { FineTuneTaxonomySection } from './FineTuneTaxonomySection';
 import TrainingHardwareSection from './trainingHardwareSection/TrainingHardwareSection';
 import { FineTunePageSections, fineTunePageSectionTitles } from './const';
@@ -48,83 +51,96 @@ const FineTunePage: React.FC<FineTunePageProps> = ({
   const { getAllValidationIssues } = React.useContext(ValidationContext);
   const hasValidationErrors =
     Object.keys(getAllValidationIssues(['inputPipelineParameters'])).length > 0;
+  const [connectionTypes] = useWatchConnectionTypes();
+  const ociConnectionType = React.useMemo(
+    () => connectionTypes.find((c) => c.metadata.name === 'oci-v1'),
+    [connectionTypes],
+  );
+
   return (
-    <Form data-testid="fineTunePageForm" maxWidth="500px">
-      <FormSection
-        id={FineTunePageSections.PROJECT_DETAILS}
-        title={fineTunePageSectionTitles[FineTunePageSections.PROJECT_DETAILS]}
-      >
-        This project is used for running your pipeline
-        <FormGroup
-          label="Data Science Project"
-          fieldId="model-customization-projectName"
-          isRequired
+    <FineTunedModelNewConnectionContextProvider connectionType={ociConnectionType}>
+      <Form data-testid="fineTunePageForm" maxWidth="500px">
+        <FormSection
+          id={FineTunePageSections.PROJECT_DETAILS}
+          title={fineTunePageSectionTitles[FineTunePageSections.PROJECT_DETAILS]}
         >
-          <div>{getDisplayNameFromK8sResource(project)}</div>
-        </FormGroup>
-      </FormSection>
-      <PipelineDetailsSection
-        ilabPipeline={ilabPipeline}
-        ilabPipelineLoaded={ilabPipelineLoaded}
-        ilabPipelineVersion={ilabPipelineVersion}
-        hasValidationErrors={hasValidationErrors}
-      />
-
-      {!hasValidationErrors && (
-        <>
-          <BaseModelSection
-            data={data.baseModel}
-            setData={(baseModelData) => setData('baseModel', baseModelData)}
-            registryName={state?.modelRegistryDisplayName}
-            inputModelName={state?.registeredModelName}
-            inputModelVersionName={state?.modelVersionName}
-          />
-          <FineTuneTaxonomySection
-            data={data.taxonomy}
-            setData={(dataTaxonomy: FineTuneTaxonomyFormData) => {
-              setData('taxonomy', dataTaxonomy);
-            }}
-          />
-          <TeacherModelSection
-            data={data.teacher}
-            setData={(teacherData) => setData('teacher', teacherData)}
-          />
-          <JudgeModelSection
-            data={data.judge}
-            setData={(judgeData) => setData('judge', judgeData)}
-          />
-          <TrainingHardwareSection
-            ilabPipelineLoaded={ilabPipelineLoaded}
-            ilabPipelineVersion={ilabPipelineVersion}
-            trainingNode={data.trainingNode}
-            setTrainingNode={(trainingNodeValue: number) =>
-              setData('trainingNode', trainingNodeValue)
-            }
-            storageClass={data.storageClass}
-            setStorageClass={(storageClassName: string) =>
-              setData('storageClass', storageClassName)
-            }
-            setHardwareFormData={(hardwareFormData) => setData('hardware', hardwareFormData)}
-          />
-          <RunTypeSection data={data} setData={setData} />
-          <HyperparameterPageSection
-            data={data}
-            hyperparameters={hyperparameters}
-            setData={setData}
-          />
-        </>
-      )}
-
-      <FormSection>
-        <FineTunePageFooter
-          canSubmit={canSubmit}
-          onSuccess={onSuccess}
-          data={data}
+          This project is used for running your pipeline
+          <FormGroup
+            label="Data Science Project"
+            fieldId="model-customization-projectName"
+            isRequired
+          >
+            <div>{getDisplayNameFromK8sResource(project)}</div>
+          </FormGroup>
+        </FormSection>
+        <PipelineDetailsSection
           ilabPipeline={ilabPipeline}
+          ilabPipelineLoaded={ilabPipelineLoaded}
           ilabPipelineVersion={ilabPipelineVersion}
+          hasValidationErrors={hasValidationErrors}
         />
-      </FormSection>
-    </Form>
+
+        {!hasValidationErrors && (
+          <>
+            <BaseModelSection
+              data={data.baseModel}
+              setData={(baseModelData) => setData('baseModel', baseModelData)}
+              registryName={state?.modelRegistryDisplayName}
+              inputModelName={state?.registeredModelName}
+              inputModelVersionName={state?.modelVersionName}
+            />
+            <FineTuneTaxonomySection
+              data={data.taxonomy}
+              setData={(dataTaxonomy: FineTuneTaxonomyFormData) => {
+                setData('taxonomy', dataTaxonomy);
+              }}
+            />
+            <TeacherModelSection
+              data={data.teacher}
+              setData={(teacherData) => setData('teacher', teacherData)}
+            />
+            <JudgeModelSection
+              data={data.judge}
+              setData={(judgeData) => setData('judge', judgeData)}
+            />
+            <TrainingHardwareSection
+              ilabPipelineLoaded={ilabPipelineLoaded}
+              ilabPipelineVersion={ilabPipelineVersion}
+              trainingNode={data.trainingNode}
+              setTrainingNode={(trainingNodeValue: number) =>
+                setData('trainingNode', trainingNodeValue)
+              }
+              storageClass={data.storageClass}
+              setStorageClass={(storageClassName: string) =>
+                setData('storageClass', storageClassName)
+              }
+              setHardwareFormData={(hardwareFormData) => setData('hardware', hardwareFormData)}
+            />
+            <RunTypeSection data={data} setData={setData} />
+            <HyperparameterPageSection
+              data={data}
+              hyperparameters={hyperparameters}
+              setData={setData}
+            />
+            <FineTunedModelSection
+              data={data.outputModel}
+              setData={(outputModelData) => setData('outputModel', outputModelData)}
+              connectionTypes={connectionTypes}
+            />
+          </>
+        )}
+        <FormSection>
+          <FineTunePageFooter
+            ociConnectionType={ociConnectionType}
+            canSubmit={canSubmit}
+            onSuccess={onSuccess}
+            data={data}
+            ilabPipeline={ilabPipeline}
+            ilabPipelineVersion={ilabPipelineVersion}
+          />
+        </FormSection>
+      </Form>
+    </FineTunedModelNewConnectionContextProvider>
   );
 };
 

--- a/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/ModelCustomizationForm.tsx
@@ -28,6 +28,7 @@ import {
 import { ModelCustomizationRouterState } from '~/routes';
 import { createHyperParametersSchema } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/hyperparameterValidationUtils';
 import { getInputDefinitionParams } from '~/concepts/pipelines/content/createRun/utils';
+import { InferenceServiceStorageType } from '~/pages/modelServing/screens/types';
 import FineTunePage from './FineTunePage';
 import { FineTunePageSections, fineTunePageSectionTitles } from './const';
 import { filterHyperparameters, getParamsValueFromPipelineInput } from './utils';
@@ -46,8 +47,13 @@ const ModelCustomizationForm: React.FC = () => {
   const [data, setData] = useGenericObjectState<ModelCustomizationFormData>({
     projectName: { value: project.metadata.name },
     outputModel: {
-      outputModelName: state?.registeredModelName ?? '',
-      outputModelRegistryApiUrl: state?.outputModelRegistryApiUrl ?? '',
+      addToRegistryEnabled: false,
+      outputModelRegistryName: state?.modelRegistryName,
+      outputModelName: state?.registeredModelName,
+      outputModelRegistryApiUrl: state?.outputModelRegistryApiUrl,
+      connectionData: {
+        type: InferenceServiceStorageType.EXISTING_STORAGE,
+      },
     },
     baseModel: {
       sdgBaseModel: state?.inputModelLocationUri ?? '',
@@ -180,7 +186,7 @@ const ModelCustomizationForm: React.FC = () => {
             <GenericSidebar
               sections={Object.values(filteredFineTunePageSections)}
               titles={fineTunePageSectionTitles}
-              maxWidth={175}
+              maxWidth={200}
             >
               <FineTunePage
                 canSubmit={!!ilabPipelineLoadError}

--- a/frontend/src/pages/pipelines/global/modelCustomization/baseModelSection/BaseModelSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/baseModelSection/BaseModelSection.tsx
@@ -44,19 +44,19 @@ const BaseModelSection: React.FC<BaseModelSectionProps> = ({
         </Alert>
       </FlexItem>
     </Flex>
-    <FormGroup label="Model registry" fieldId={`${FIELD_ID_PREFIX}-registryName`} required>
+    <FormGroup label="Model registry" fieldId={`${FIELD_ID_PREFIX}-registryName`}>
       {registryName ?? '-'}
     </FormGroup>
-    <FormGroup label="Model name" fieldId={`${FIELD_ID_PREFIX}-name`} required>
+    <FormGroup label="Model name" fieldId={`${FIELD_ID_PREFIX}-name`}>
       {inputModelName ?? '-'}
     </FormGroup>
-    <FormGroup label="Model version" fieldId={`${FIELD_ID_PREFIX}-version`} required>
+    <FormGroup label="Model version" fieldId={`${FIELD_ID_PREFIX}-version`}>
       {inputModelVersionName ?? '-'}
     </FormGroup>
     <FormGroup
       label="Model input storage location URI"
       fieldId={`${FIELD_ID_PREFIX}-inputStorageLocationUri`}
-      required
+      isRequired
     >
       <InlineEditText
         onSave={(text) => {

--- a/frontend/src/pages/pipelines/global/modelCustomization/const.ts
+++ b/frontend/src/pages/pipelines/global/modelCustomization/const.ts
@@ -8,6 +8,7 @@ export enum FineTunePageSections {
   TRAINING_HARDWARE = 'fine-tune-section-training-hardware',
   RUN_TYPE = 'fine-tune-section-run-type',
   HYPERPARAMETERS = 'fun-tune-hyperparameters',
+  FINE_TUNED_MODEL_DETAILS = 'fine-tune-section-fine-tuned-model-details',
 }
 
 export enum PipelineInputParameters {
@@ -32,6 +33,7 @@ export const fineTunePageSectionTitles: Record<FineTunePageSections, string> = {
   [FineTunePageSections.TRAINING_HARDWARE]: 'Training hardware',
   [FineTunePageSections.RUN_TYPE]: 'Run type',
   [FineTunePageSections.HYPERPARAMETERS]: 'Hyperparameters',
+  [FineTunePageSections.FINE_TUNED_MODEL_DETAILS]: 'Fine-tuned model details',
 };
 
 export const ILAB_PIPELINE_NAME = 'instructlab';

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelConnectionSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelConnectionSection.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Alert, Radio, Skeleton, Stack, StackItem } from '@patternfly/react-core';
+import { getResourceNameFromK8sResource } from '~/concepts/k8s/utils';
+import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+import { InferenceServiceStorageType } from '~/pages/modelServing/screens/types';
+import useConnections from '~/pages/projects/screens/detail/connections/useConnections';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { ConnectionFormData } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
+import FineTunedModelExistingConnectionField from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelExistingConnectionField';
+import {
+  isModelServingCompatible,
+  ModelServingCompatibleTypes,
+} from '~/concepts/connectionTypes/utils';
+import { FineTunedModelNewConnectionField } from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionField';
+import FineTunedModelOciPathField from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelOciPathField';
+
+type FineTunedModelConnectionSectionProps = {
+  data: ConnectionFormData;
+  setData: (connectionData: ConnectionFormData) => void;
+  connectionTypes: ConnectionTypeConfigMapObj[];
+};
+
+const FineTunedModelConnectionSection: React.FC<FineTunedModelConnectionSectionProps> = ({
+  data,
+  setData,
+  connectionTypes,
+}) => {
+  const { project } = usePipelinesAPI();
+  const [fetchedConnections, connectionsLoaded, connectionsLoadError] = useConnections(
+    project.metadata.name,
+  );
+  const ociConnections: Connection[] = React.useMemo(
+    () =>
+      fetchedConnections.filter((c) =>
+        // For fine-tuned, we only fetch the connections that contain "Push" as the access type or don't contain any access type
+        isModelServingCompatible(c, ModelServingCompatibleTypes.OCI, 'Push'),
+      ),
+    [fetchedConnections],
+  );
+  const [selectedConnection, setSelectedConnection] = React.useState<Connection>();
+
+  if (connectionsLoadError) {
+    return (
+      <Alert title="Error loading connections" variant="danger">
+        {connectionsLoadError.message}
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Radio
+          name="existing-connection-radio"
+          id="existing-connection-radio"
+          data-testid="existing-connection-radio"
+          label="Existing connection"
+          isChecked={data.type === InferenceServiceStorageType.EXISTING_STORAGE}
+          onChange={() => {
+            setData({
+              ...data,
+              type: InferenceServiceStorageType.EXISTING_STORAGE,
+            });
+          }}
+          body={
+            data.type === InferenceServiceStorageType.EXISTING_STORAGE &&
+            (!connectionsLoaded && project.metadata.name !== '' ? (
+              <Skeleton />
+            ) : (
+              <>
+                <FineTunedModelExistingConnectionField
+                  connectionTypes={connectionTypes}
+                  connections={ociConnections}
+                  selectedConnection={selectedConnection}
+                  onSelect={(selection) => {
+                    setSelectedConnection(selection);
+                    setData({
+                      ...data,
+                      connection: getResourceNameFromK8sResource(selection),
+                    });
+                  }}
+                />
+                <FineTunedModelOciPathField
+                  modelUri={data.uri}
+                  setModelUri={(uri) =>
+                    setData({
+                      ...data,
+                      uri,
+                    })
+                  }
+                />
+              </>
+            ))
+          }
+        />
+      </StackItem>
+      <StackItem>
+        <Radio
+          name="new-connection-radio"
+          id="new-connection-radio"
+          data-testid="new-connection-radio"
+          label="Create connection"
+          className="pf-v6-u-mb-lg"
+          isChecked={data.type === InferenceServiceStorageType.NEW_STORAGE}
+          onChange={() => {
+            setData({ ...data, type: InferenceServiceStorageType.NEW_STORAGE });
+          }}
+          body={
+            data.type === InferenceServiceStorageType.NEW_STORAGE && (
+              <>
+                <FineTunedModelNewConnectionField connectionTypes={connectionTypes} />
+                <FineTunedModelOciPathField
+                  modelUri={data.uri}
+                  setModelUri={(uri) =>
+                    setData({
+                      ...data,
+                      uri,
+                    })
+                  }
+                />
+              </>
+            )
+          }
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default FineTunedModelConnectionSection;

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelExistingConnectionField.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelExistingConnectionField.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  FormGroup,
+  FormHelperText,
+  Popover,
+  Truncate,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import TypeaheadSelect, { TypeaheadSelectOption } from '~/components/TypeaheadSelect';
+import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+import {
+  getDescriptionFromK8sResource,
+  getDisplayNameFromK8sResource,
+  getResourceNameFromK8sResource,
+} from '~/concepts/k8s/utils';
+import {
+  getConnectionTypeDisplayName,
+  getConnectionTypeRef,
+} from '~/concepts/connectionTypes/utils';
+import { ConnectionDetailsHelperText } from '~/concepts/connectionTypes/ConnectionDetailsHelperText';
+
+type FineTunedModelExistingConnectionFieldProps = {
+  connectionTypes: ConnectionTypeConfigMapObj[];
+  connections: Connection[];
+  selectedConnection?: Connection;
+  onSelect: (connection: Connection) => void;
+};
+
+const FineTunedModelExistingConnectionField: React.FC<
+  FineTunedModelExistingConnectionFieldProps
+> = ({ connectionTypes, connections, selectedConnection, onSelect }) => {
+  const options: TypeaheadSelectOption[] = React.useMemo(
+    () =>
+      connections.map((connection) => {
+        const displayName = getDisplayNameFromK8sResource(connection);
+
+        return {
+          content: displayName,
+          value: getResourceNameFromK8sResource(connection),
+          description: (
+            <Flex direction={{ default: 'column' }} rowGap={{ default: 'rowGapNone' }}>
+              {getDescriptionFromK8sResource(connection) && (
+                <FlexItem>
+                  <Truncate content={getDescriptionFromK8sResource(connection)} />
+                </FlexItem>
+              )}
+              <FlexItem>
+                <Truncate
+                  content={`Type: ${
+                    getConnectionTypeDisplayName(connection, connectionTypes) || 'Unknown'
+                  }`}
+                />
+              </FlexItem>
+            </Flex>
+          ),
+          isSelected:
+            !!selectedConnection &&
+            getResourceNameFromK8sResource(connection) ===
+              getResourceNameFromK8sResource(selectedConnection),
+        };
+      }),
+    [connectionTypes, connections, selectedConnection],
+  );
+
+  const selectedConnectionType = React.useMemo(
+    () =>
+      connectionTypes.find(
+        (t) => getResourceNameFromK8sResource(t) === getConnectionTypeRef(selectedConnection),
+      ),
+    [connectionTypes, selectedConnection],
+  );
+
+  return (
+    <>
+      <Popover
+        aria-label="Hoverable popover"
+        bodyContent="This list includes only connections that are OCI compatible."
+      >
+        <Button
+          style={{ paddingLeft: 0 }}
+          icon={<OutlinedQuestionCircleIcon />}
+          variant="link"
+          disabled
+        >
+          Not seeing what you&apos;re looking for?
+        </Button>
+      </Popover>
+      <FormGroup label="Connection" className="pf-v6-u-mb-lg">
+        <TypeaheadSelect
+          selectOptions={options}
+          onSelect={(_, value) => {
+            const newConnection = connections.find(
+              (c) => getResourceNameFromK8sResource(c) === value,
+            );
+            if (newConnection) {
+              onSelect(newConnection);
+            }
+          }}
+          popperProps={{ appendTo: 'inline' }}
+          previewDescription={false}
+          placeholder={options.length === 0 ? 'No connections available' : 'Select a connection'}
+        />
+        {selectedConnection && (
+          <FormHelperText>
+            <ConnectionDetailsHelperText
+              connection={selectedConnection}
+              connectionType={selectedConnectionType}
+            />
+          </FormHelperText>
+        )}
+      </FormGroup>
+    </>
+  );
+};
+
+export default FineTunedModelExistingConnectionField;

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionContext.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionContext.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import {
+  K8sNameDescriptionFieldData,
+  K8sNameDescriptionFieldUpdateFunction,
+} from '~/concepts/k8s/K8sNameDescriptionField/types';
+import {
+  ConnectionTypeConfigMapObj,
+  ConnectionTypeDataField,
+  ConnectionTypeFieldType,
+  ConnectionTypeValueType,
+} from '~/concepts/connectionTypes/types';
+import { useK8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { getDefaultValues, isConnectionTypeDataField } from '~/concepts/connectionTypes/utils';
+import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescriptionField/utils';
+
+type FineTunedModelNewConnectionContextType = {
+  isValid: boolean;
+  nameDescData: K8sNameDescriptionFieldData;
+  setNameDescData: K8sNameDescriptionFieldUpdateFunction;
+  onValidate: (field: ConnectionTypeDataField, error: boolean) => void;
+  connectionValues: { [key: string]: ConnectionTypeValueType };
+  setConnectionValues: React.Dispatch<
+    React.SetStateAction<{
+      [key: string]: ConnectionTypeValueType;
+    }>
+  >;
+};
+
+export const FineTunedModelNewConnectionContext =
+  React.createContext<FineTunedModelNewConnectionContextType>({
+    isValid: false,
+    nameDescData: {
+      name: '',
+      description: '',
+      k8sName: {
+        value: '',
+        state: {
+          immutable: false,
+          invalidCharacters: false,
+          invalidLength: false,
+          maxLength: 0,
+          touched: false,
+        },
+      },
+    },
+    setNameDescData: () => undefined,
+    onValidate: () => undefined,
+    connectionValues: {},
+    setConnectionValues: () => undefined,
+  });
+
+type FineTunedModelNewConnectionContextProviderProps = {
+  children: React.ReactNode;
+  /** Prometheus query strings computed and ready to use */
+  connectionType?: ConnectionTypeConfigMapObj;
+};
+
+export const FineTunedModelNewConnectionContextProvider: React.FC<
+  FineTunedModelNewConnectionContextProviderProps
+> = ({ connectionType, children }) => {
+  const { data: nameDescData, onDataChange: setNameDescData } = useK8sNameDescriptionFieldData();
+  const [connectionTypeFieldValidations, setConnectionTypeFieldValidations] = React.useState<{
+    [key: string]: boolean;
+  }>({});
+  const [connectionValues, setConnectionValues] = React.useState<{
+    [key: string]: ConnectionTypeValueType;
+  }>(connectionType ? getDefaultValues(connectionType) : {});
+
+  const isValid = React.useMemo(
+    () =>
+      isK8sNameDescriptionDataValid(nameDescData) &&
+      !connectionType?.data?.fields?.find(
+        (field) =>
+          isConnectionTypeDataField(field) &&
+          field.required &&
+          !connectionValues[field.envVar] &&
+          field.type !== ConnectionTypeFieldType.Boolean,
+      ) &&
+      !Object.values(connectionTypeFieldValidations).includes(false),
+    [nameDescData, connectionType?.data?.fields, connectionTypeFieldValidations, connectionValues],
+  );
+
+  const onValidate = React.useCallback(
+    (field: ConnectionTypeDataField, isFieldValid: boolean) =>
+      setConnectionTypeFieldValidations((prev) => ({ ...prev, [field.envVar]: isFieldValid })),
+    [],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      isValid,
+      onValidate,
+      setConnectionValues,
+      connectionValues,
+      nameDescData,
+      setNameDescData,
+    }),
+    [connectionValues, isValid, nameDescData, onValidate, setNameDescData],
+  );
+
+  return (
+    <FineTunedModelNewConnectionContext.Provider value={contextValue}>
+      {children}
+    </FineTunedModelNewConnectionContext.Provider>
+  );
+};

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionField.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionField.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
+import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+import { FineTunedModelNewConnectionContext } from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionContext';
+
+type FineTunedModelNewConnectionFieldProps = {
+  connectionTypes: ConnectionTypeConfigMapObj[];
+};
+
+export const FineTunedModelNewConnectionField: React.FC<FineTunedModelNewConnectionFieldProps> = ({
+  connectionTypes,
+}) => {
+  const { nameDescData, setNameDescData, connectionValues, setConnectionValues, onValidate } =
+    React.useContext(FineTunedModelNewConnectionContext);
+
+  const ociConnectionType = React.useMemo(
+    () =>
+      connectionTypes
+        .filter((t) => t.metadata.annotations?.['opendatahub.io/disabled'] !== 'true')
+        // We only use OCI connection here for the ilab
+        .find((c) => c.metadata.name === 'oci-v1'),
+    [connectionTypes],
+  );
+
+  return (
+    <ConnectionTypeForm
+      options={ociConnectionType ? [ociConnectionType] : []}
+      connectionType={ociConnectionType}
+      connectionNameDesc={nameDescData}
+      setConnectionNameDesc={setNameDescData}
+      connectionValues={connectionValues}
+      onChange={(field, value) => {
+        setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
+      }}
+      onValidate={onValidate}
+    />
+  );
+};

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelOciPathField.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelOciPathField.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  FormGroup,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  InputGroupText,
+  InputGroup,
+  InputGroupItem,
+  FormSection,
+} from '@patternfly/react-core';
+
+type FineTunedModelOciPathFieldProps = {
+  ociHost?: string;
+  modelUri?: string;
+  setModelUri: (modelPath?: string) => void;
+};
+
+const FineTunedModelOciPathField: React.FC<FineTunedModelOciPathFieldProps> = ({
+  ociHost,
+  modelUri,
+  setModelUri,
+}) => {
+  const hideUriPrefix = (text?: string) => {
+    if (text?.includes('://')) {
+      return text.substring(text.indexOf('://') + 3);
+    }
+    return text;
+  };
+
+  const addUriPrefix = (text?: string) => {
+    if (text && !text.includes('://')) {
+      return `oci://${text}`;
+    }
+    return text;
+  };
+
+  return (
+    <FormSection title="Deployment details">
+      {ociHost && (
+        <FormGroup label="Registry host" className="pf-v6-u-mb-lg">
+          {ociHost}
+        </FormGroup>
+      )}
+      <FormGroup fieldId="model-uri" label="Model URI">
+        <InputGroup>
+          <InputGroupText>oci://</InputGroupText>
+          <InputGroupItem isFill>
+            <TextInput
+              id="model-uri"
+              aria-label="Model URI"
+              data-testid="model-uri"
+              type="text"
+              value={hideUriPrefix(modelUri)}
+              onChange={(e, value: string) => {
+                setModelUri(addUriPrefix(value));
+              }}
+            />
+          </InputGroupItem>
+        </InputGroup>
+
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Example model path structure is Base URL / Registry organization / Model Name:Model
+              Version
+            </HelperTextItem>
+            <HelperTextItem>
+              Example: registry.connect.redhat.com/redhat-test/test-mymodel:v3.2
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </FormSection>
+  );
+};
+
+export default FineTunedModelOciPathField;

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelOciPathField.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelOciPathField.tsx
@@ -37,7 +37,8 @@ const FineTunedModelOciPathField: React.FC<FineTunedModelOciPathFieldProps> = ({
   };
 
   return (
-    <FormSection title="Deployment details">
+    <FormSection title="OCI storage location">
+      Provide the location of the model. This is not part of your connection instance.
       {ociHost && (
         <FormGroup label="Registry host" className="pf-v6-u-mb-lg">
           {ociHost}
@@ -63,11 +64,11 @@ const FineTunedModelOciPathField: React.FC<FineTunedModelOciPathFieldProps> = ({
         <FormHelperText>
           <HelperText>
             <HelperTextItem>
-              Example model path structure is Base URL / Registry organization / Model Name:Model
-              Version
+              Example of recommended path structure is
+              registryHost/registryOrganization/modelName:modelVersion
             </HelperTextItem>
             <HelperTextItem>
-              Example: registry.connect.redhat.com/redhat-test/test-mymodel:v3.2
+              Example, registry.redhat.io/rhelai1/modelcar-granite-7b-starter:1.4.0
             </HelperTextItem>
           </HelperText>
         </FormHelperText>

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelSection.tsx
@@ -56,12 +56,20 @@ const FineTunedModelSection: React.FC<FineTunedModelSectionProps> = ({
         id={`${FIELD_ID_PREFIX}-add-model-to-registry-checkbox`}
         isChecked={data.addToRegistryEnabled}
         onChange={(_, checked) => setData({ ...data, addToRegistryEnabled: checked })}
-        label={`Add model to ${state?.modelRegistryName ?? 'registry'}`}
+        label={
+          <>
+            Add model to <strong>{state?.modelRegistryName ?? 'registry'}</strong>
+          </>
+        }
         body={
           data.addToRegistryEnabled && (
             <Stack hasGutter>
               <StackItem>
-                <Alert title="Model registry feature is in tech preview" isInline variant="info" />
+                <Alert
+                  title="OpenShift AI’s model registry is a technology preview."
+                  isInline
+                  variant="info"
+                />
               </StackItem>
               <StackItem>
                 <FormGroup label="Model name" fieldId={`${FIELD_ID_PREFIX}-name`}>
@@ -75,7 +83,9 @@ const FineTunedModelSection: React.FC<FineTunedModelSectionProps> = ({
                   />
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem>Current version is {state?.modelVersionName}</HelperTextItem>
+                      <HelperTextItem>
+                        Current version is <strong>{state?.modelVersionName}</strong>
+                      </HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 </FormGroup>

--- a/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelSection.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  Alert,
+  Checkbox,
+  FormGroup,
+  FormHelperText,
+  FormSection,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { useLocation } from 'react-router';
+import { OutputModelFormData } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
+import {
+  FineTunePageSections,
+  fineTunePageSectionTitles,
+} from '~/pages/pipelines/global/modelCustomization/const';
+import { ModelCustomizationRouterState } from '~/routes';
+import FineTunedModelConnectionSection from '~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelConnectionSection';
+import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
+
+const FIELD_ID_PREFIX = 'model-customization-fineTunedModel';
+
+type FineTunedModelSectionProps = {
+  data: OutputModelFormData;
+  setData: (data: OutputModelFormData) => void;
+  connectionTypes: ConnectionTypeConfigMapObj[];
+};
+
+const FineTunedModelSection: React.FC<FineTunedModelSectionProps> = ({
+  data,
+  setData,
+  connectionTypes,
+}) => {
+  const { state }: { state?: ModelCustomizationRouterState } = useLocation();
+
+  return (
+    <FormSection
+      id={FineTunePageSections.FINE_TUNED_MODEL_DETAILS}
+      title={fineTunePageSectionTitles[FineTunePageSections.FINE_TUNED_MODEL_DETAILS]}
+    >
+      Configure details for the fine-tuned version of the base model.
+      <FormGroup
+        label="Model output storage location"
+        fieldId={`${FIELD_ID_PREFIX}-storage-location`}
+      >
+        <FineTunedModelConnectionSection
+          data={data.connectionData}
+          setData={(connectionData) => setData({ ...data, connectionData })}
+          connectionTypes={connectionTypes}
+        />
+      </FormGroup>
+      <Checkbox
+        id={`${FIELD_ID_PREFIX}-add-model-to-registry-checkbox`}
+        isChecked={data.addToRegistryEnabled}
+        onChange={(_, checked) => setData({ ...data, addToRegistryEnabled: checked })}
+        label={`Add model to ${state?.modelRegistryName ?? 'registry'}`}
+        body={
+          data.addToRegistryEnabled && (
+            <Stack hasGutter>
+              <StackItem>
+                <Alert title="Model registry feature is in tech preview" isInline variant="info" />
+              </StackItem>
+              <StackItem>
+                <FormGroup label="Model name" fieldId={`${FIELD_ID_PREFIX}-name`}>
+                  {state?.registeredModelName ?? '-'}
+                </FormGroup>
+                <FormGroup label="Model version name" fieldId={`${FIELD_ID_PREFIX}-version`}>
+                  <TextInput
+                    id={`${FIELD_ID_PREFIX}-version`}
+                    value={data.outputModelVersion}
+                    onChange={(_event, value) => setData({ ...data, outputModelVersion: value })}
+                  />
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem>Current version is {state?.modelVersionName}</HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                </FormGroup>
+              </StackItem>
+            </Stack>
+          )
+        }
+      />
+    </FormSection>
+  );
+};
+
+export default FineTunedModelSection;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-19025](https://issues.redhat.com/browse/RHOAIENG-19025)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a section on the ilab form to allow fine-tuned model.

1. It has an existing connection field, which allows users to select all the OCI connections with `PUSH` access type as a field or without any access type
<img width="1510" alt="Screenshot 2025-03-10 at 12 58 59 PM" src="https://github.com/user-attachments/assets/0e54715e-5222-4593-9fce-0bb05f5a79c1" />

2. It has a new connection field, which allows users to create an OCI connection with all the required fields. It will dry run a secret creation call if the user is creating a new one.
<img width="1510" alt="Screenshot 2025-03-10 at 1 07 18 PM" src="https://github.com/user-attachments/assets/b987113e-6387-4fb2-95b0-af101af74ab5" />
<img width="1510" alt="Screenshot 2025-03-10 at 1 09 18 PM" src="https://github.com/user-attachments/assets/09c01560-6c10-41e8-bc4e-b008993dde1b" />

3. It has an optional "Add model to registry" checkbox, to set fields `output_model_name`, `output_model_version`, `output_model_registry_api_url` and `output_model_registry_name` if it's checked.
<img width="1510" alt="Screenshot 2025-03-10 at 1 09 33 PM" src="https://github.com/user-attachments/assets/fddb1e71-463c-4e98-9e01-4fb676cba203" />

All the fields are optional expect the secret creation fields, which will be used to create an OCI connection. If a field is not set, then it will be set to undefined. Follow https://docs.google.com/spreadsheets/d/16G5r6tV1TsgKbk-WoRoe0ZW9LsCWp093rnVDfySM33s for the optional parameters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For existing connection field:
1. Create some OCI connections, with access type only "PULL" or all the other types, and other types of connections
2. Go to the ilab form, and make sure the existing connection field dropdown only shows OCI connections, and don't show the OCI connections with only "PULL" access type.

For new connection field:
Make sure all the required fields are met, then the submit button is enabled.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
