### PR TITLE
converted connection information alert to button

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -5,9 +5,10 @@ import {
   InputGroup,
   Tooltip,
   InputGroupItem,
-  Alert,
   Popover,
+  Button,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { DataConnection } from '~/pages/projects/types';
 import { AwsKeys, PIPELINE_AWS_FIELDS } from '~/pages/projects/dataConnections/const';
 import { FieldListField } from '~/components/FieldList';
@@ -89,28 +90,26 @@ export const ObjectStorageSection = ({
             />
 
             {field.key === AwsKeys.AWS_S3_BUCKET && (
-              <Popover
-                aria-label="bucket tooltip"
-                headerContent="Where is my data stored within the bucket?"
-                position="right"
-                hasAutoWidth
-                bodyContent={
-                  <div className="pf-v6-u-mt-md">
-                    Uploaded pipelines will be stored in the <b>/pipelines</b> directory.
-                    <br />
-                    When running a pipeline, artifacts will be stored in dedicated folders at the{' '}
-                    <b>/root</b> directory.
-                  </div>
-                }
-              >
-                <Alert
-                  variant="info"
-                  isInline
-                  isPlain
-                  title="Where is my data stored within the bucket?"
-                  style={{ width: 'fit-content' }}
-                />
-              </Popover>
+              <div>
+                <Popover
+                  aria-label="bucket tooltip"
+                  headerContent="Where is my data stored within the bucket?"
+                  position="right"
+                  hasAutoWidth
+                  bodyContent={
+                    <div className="pf-v6-u-mt-md">
+                      Uploaded pipelines will be stored in the <b>/pipelines</b> directory.
+                      <br />
+                      When running a pipeline, artifacts will be stored in dedicated folders at the{' '}
+                      <b>/root</b> directory.
+                    </div>
+                  }
+                >
+                  <Button icon={<OutlinedQuestionCircleIcon />} variant="link">
+                    Where is my data stored within the bucket?
+                  </Button>
+                </Popover>
+              </div>
             )}
           </React.Fragment>
         ),

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
@@ -47,6 +47,7 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
     <Form>
       <FormGroup isRequired label="Resource label" fieldId="resource-label">
         <TextInput
+          id="node-resource-label-input"
           value={identifier.displayName || ''}
           onChange={(_, value) => setIdentifier('displayName', value)}
           data-testid="node-resource-label-input"
@@ -55,6 +56,7 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
 
       <FormGroup isRequired label="Resource identifier" fieldId="resource-identifier">
         <TextInput
+          id="node-resource-identifier-input"
           value={identifier.identifier || ''}
           onChange={(_, value) => setIdentifier('identifier', value)}
           validated={validated}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-20481

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

• added id to text inputs to remove console errors in the node resource form
• Changed the 'where is my data stored button' to be more user accessible

<img width="873" alt="Screenshot 2025-03-10 at 3 57 23 PM" src="https://github.com/user-attachments/assets/7aeefe90-8230-4dd9-a455-0e36b7cb7c6c" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

create a project, go to pipeline server, and press configure pipeline server

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

simple button change, no tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
