### PR TITLE
Feat/20077 link back to catalog

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -20,8 +20,12 @@ class ModelVersionDetails {
     return cy.findByTestId('model-version-id');
   }
 
-  findRegisteredFrom() {
-    return cy.findByTestId('registered-from');
+  findRegisteredFromCatalog() {
+    return cy.findByTestId('registered-from-catalog');
+  }
+
+  findRegisteredFromPipeline() {
+    return cy.findByTestId('registered-from-pipeline');
   }
 
   findPipelineRunLink() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -110,6 +110,22 @@ const mockModelVersions = mockModelVersion({
       metadataType: ModelRegistryMetadataType.STRING,
       string_value: 'pipeline-run-test',
     },
+    _registeredFromCatalogSourceName: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'test-catalog-source',
+    },
+    _registeredFromCatalogRepositoryName: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'test-catalog-repo',
+    },
+    _registeredFromCatalogModelName: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'test-catalog-model',
+    },
+    _registeredFromCatalogTag: {
+      metadataType: ModelRegistryMetadataType.STRING,
+      string_value: 'test-catalog-tag',
+    },
   },
 });
 
@@ -251,12 +267,21 @@ describe('Model version details', () => {
 
     it('Model version details tab', () => {
       modelVersionDetails.findVersionId().contains('1');
-      modelVersionDetails.findRegisteredFrom().should('exist');
+      modelVersionDetails.findRegisteredFromPipeline().should('exist');
+      modelVersionDetails.findRegisteredFromCatalog().should('exist');
+      modelVersionDetails
+        .findRegisteredFromCatalog()
+        .should('have.text', 'test-catalog-model (test-catalog-tag)');
+      modelVersionDetails.findRegisteredFromCatalog().click();
+      verifyRelativeURL(
+        '/modelCatalog/test-catalog-source/test-catalog-repo/test-catalog-model/test-catalog-tag',
+      );
+      cy.go('back');
       modelVersionDetails.findExpandControlButton().should('have.text', 'Show 2 more properties');
       modelVersionDetails.findExpandControlButton().click();
       modelVersionDetails.findPropertiesTableRows().should('have.length', 7);
       modelVersionDetails
-        .findRegisteredFrom()
+        .findRegisteredFromPipeline()
         .should('have.text', 'Run pipeline-run-test intest-project');
       modelVersionDetails.findDescription().should('have.text', 'Description of model version');
       modelVersionDetails.findStorageEndpoint().contains('test-endpoint');
@@ -325,6 +350,22 @@ describe('Model version details', () => {
               metadataType: 'MetadataStringValue',
               string_value: 'pipeline-run-test',
             },
+            _registeredFromCatalogSourceName: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-source',
+            },
+            _registeredFromCatalogRepositoryName: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-repo',
+            },
+            _registeredFromCatalogModelName: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-model',
+            },
+            _registeredFromCatalogTag: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-tag',
+            },
             edit_key: { string_value: 'edit_value', metadataType: 'MetadataStringValue' },
           },
         });
@@ -367,6 +408,22 @@ describe('Model version details', () => {
             _registeredFromPipelineRunName: {
               metadataType: 'MetadataStringValue',
               string_value: 'pipeline-run-test',
+            },
+            _registeredFromCatalogSourceName: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-source',
+            },
+            _registeredFromCatalogRepositoryName: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-repo',
+            },
+            _registeredFromCatalogModelName: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-model',
+            },
+            _registeredFromCatalogTag: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: 'test-catalog-tag',
             },
           },
         });

--- a/frontend/src/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/frontend/src/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -17,7 +17,7 @@ import {
 import { Link } from 'react-router-dom';
 import BrandImage from '~/components/BrandImage';
 import { CatalogModel } from '~/concepts/modelCatalog/types';
-import { modelDetailsUrlFromModel } from '~/pages/modelCatalog/routeUtils';
+import { getCatalogModelDetailsUrlFromModel } from '~/pages/modelCatalog/routeUtils';
 import { getTagFromModel } from '~/pages/modelCatalog/utils';
 import { RhUiTagIcon } from '~/images/icons';
 
@@ -43,7 +43,7 @@ export const ModelCatalogCard: React.FC<{ model: CatalogModel; source: string }>
         <StackItem>
           <Link
             data-testid="model-catalog-detail-link"
-            to={modelDetailsUrlFromModel(model, source) || '#'}
+            to={getCatalogModelDetailsUrlFromModel(model, source) || '#'}
             style={{
               fontSize: 'var(--pf-t--global--font--size--body--default)',
               fontWeight: 'var(--pf-t--global--font--weight--body--bold)',

--- a/frontend/src/pages/modelCatalog/const.ts
+++ b/frontend/src/pages/modelCatalog/const.ts
@@ -1,4 +1,4 @@
-export type ModelDetailsRouteParams = {
+export type CatalogModelCustomProps = {
   sourceName?: string;
   repositoryName?: string;
   modelName?: string;

--- a/frontend/src/pages/modelCatalog/const.ts
+++ b/frontend/src/pages/modelCatalog/const.ts
@@ -1,4 +1,4 @@
-export type CatalogModelCustomProps = {
+export type CatalogModelDetailsParams = {
   sourceName?: string;
   repositoryName?: string;
   modelName?: string;

--- a/frontend/src/pages/modelCatalog/routeUtils.ts
+++ b/frontend/src/pages/modelCatalog/routeUtils.ts
@@ -1,24 +1,24 @@
 import { CatalogModel } from '~/concepts/modelCatalog/types';
-import { CatalogModelCustomProps } from './const';
+import { CatalogModelDetailsParams } from './const';
 import { encodeParams, getTagFromModel } from './utils';
 
-export const modelCatalogUrl = (): string => `/modelCatalog`;
+export const modelCatalogUrl = `/modelCatalog`;
 
-export const getModelDetailsUrl = (params: CatalogModelCustomProps): string => {
+export const getCatalogModelDetailsUrl = (params: CatalogModelDetailsParams): string => {
   if (!params.sourceName || !params.repositoryName || !params.modelName || !params.tag) {
     return '';
   }
   const { sourceName = '', repositoryName = '', modelName = '', tag = '' } = encodeParams(params);
-  return `${modelCatalogUrl()}/${sourceName}/${repositoryName}/${modelName}/${tag}`;
+  return `${modelCatalogUrl}/${sourceName}/${repositoryName}/${modelName}/${tag}`;
 };
 
-export const modelDetailsUrlFromModel = (model: CatalogModel, source: string): string =>
-  getModelDetailsUrl({
+export const getCatalogModelDetailsUrlFromModel = (model: CatalogModel, source: string): string =>
+  getCatalogModelDetailsUrl({
     sourceName: source,
     repositoryName: model.repository,
     modelName: model.name,
     tag: getTagFromModel(model),
   });
 
-export const registerCatalogModel = (params: CatalogModelCustomProps): string =>
-  `${getModelDetailsUrl(params)}/register`;
+export const getRegisterCatalogModelUrl = (params: CatalogModelDetailsParams): string =>
+  `${getCatalogModelDetailsUrl(params)}/register`;

--- a/frontend/src/pages/modelCatalog/routeUtils.ts
+++ b/frontend/src/pages/modelCatalog/routeUtils.ts
@@ -1,10 +1,10 @@
 import { CatalogModel } from '~/concepts/modelCatalog/types';
-import { ModelDetailsRouteParams } from './const';
+import { CatalogModelCustomProps } from './const';
 import { encodeParams, getTagFromModel } from './utils';
 
 export const modelCatalogUrl = (): string => `/modelCatalog`;
 
-export const getModelDetailsUrl = (params: ModelDetailsRouteParams): string => {
+export const getModelDetailsUrl = (params: CatalogModelCustomProps): string => {
   if (!params.sourceName || !params.repositoryName || !params.modelName || !params.tag) {
     return '';
   }
@@ -20,5 +20,5 @@ export const modelDetailsUrlFromModel = (model: CatalogModel, source: string): s
     tag: getTagFromModel(model),
   });
 
-export const registerCatalogModel = (params: ModelDetailsRouteParams): string =>
+export const registerCatalogModel = (params: CatalogModelCustomProps): string =>
   `${getModelDetailsUrl(params)}/register`;

--- a/frontend/src/pages/modelCatalog/routeUtils.ts
+++ b/frontend/src/pages/modelCatalog/routeUtils.ts
@@ -4,13 +4,16 @@ import { encodeParams, getTagFromModel } from './utils';
 
 export const modelCatalogUrl = (): string => `/modelCatalog`;
 
-export const modelDetailsUrl = (params: ModelDetailsRouteParams): string => {
+export const getModelDetailsUrl = (params: ModelDetailsRouteParams): string => {
+  if (!params.sourceName || !params.repositoryName || !params.modelName || !params.tag) {
+    return '';
+  }
   const { sourceName = '', repositoryName = '', modelName = '', tag = '' } = encodeParams(params);
   return `${modelCatalogUrl()}/${sourceName}/${repositoryName}/${modelName}/${tag}`;
 };
 
 export const modelDetailsUrlFromModel = (model: CatalogModel, source: string): string =>
-  modelDetailsUrl({
+  getModelDetailsUrl({
     sourceName: source,
     repositoryName: model.repository,
     modelName: model.name,
@@ -18,4 +21,4 @@ export const modelDetailsUrlFromModel = (model: CatalogModel, source: string): s
   });
 
 export const registerCatalogModel = (params: ModelDetailsRouteParams): string =>
-  `${modelDetailsUrl(params)}/register`;
+  `${getModelDetailsUrl(params)}/register`;

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -29,10 +29,10 @@ import {
   findModelFromModelCatalogSources,
   getTagFromModel,
 } from '~/pages/modelCatalog/utils';
-import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
 import BrandImage from '~/components/BrandImage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
-import { registerCatalogModel } from '~/pages/modelCatalog/routeUtils';
+import { getRegisterCatalogModelUrl } from '~/pages/modelCatalog/routeUtils';
 import PopoverListContent from '~/components/PopoverListContent';
 import { FindAdministratorOptions } from '~/pages/projects/screens/projects/const';
 import { RhUiTagIcon } from '~/images/icons';
@@ -44,7 +44,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
   SupportedArea.MODEL_CATALOG,
   true,
 )(() => {
-  const params = useParams<CatalogModelCustomProps>();
+  const params = useParams<CatalogModelDetailsParams>();
   const navigate = useNavigate();
   const { modelCatalogSources } = React.useContext(ModelCatalogContext);
   const decodedParams = decodeParams(params);
@@ -92,7 +92,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
       <Button
         variant={isSecondary ? 'secondary' : 'primary'}
         data-testid="register-model-button"
-        onClick={() => navigate(registerCatalogModel(params))}
+        onClick={() => navigate(getRegisterCatalogModelUrl(params))}
       >
         Register model
       </Button>

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -29,7 +29,7 @@ import {
   findModelFromModelCatalogSources,
   getTagFromModel,
 } from '~/pages/modelCatalog/utils';
-import { ModelDetailsRouteParams } from '~/pages/modelCatalog/const';
+import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
 import BrandImage from '~/components/BrandImage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { registerCatalogModel } from '~/pages/modelCatalog/routeUtils';
@@ -44,7 +44,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
   SupportedArea.MODEL_CATALOG,
   true,
 )(() => {
-  const params = useParams<ModelDetailsRouteParams>();
+  const params = useParams<CatalogModelCustomProps>();
   const navigate = useNavigate();
   const { modelCatalogSources } = React.useContext(ModelCatalogContext);
   const decodedParams = decodeParams(params);

--- a/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
+++ b/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
@@ -116,11 +116,6 @@ const RegisterCatalogModel: React.FC = () => {
           return acc;
         }, {});
 
-      setData('modelName', model.name);
-      setData('modelDescription', model.longDescription?.replace(/\s*\n\s*/g, ' ') ?? '');
-      setData('versionName', 'Version 1');
-      setData('modelLocationType', ModelLocationType.URI);
-      setData('modelLocationURI', model.artifacts?.map((artifact) => artifact.uri)[0] || '');
       setData('modelCustomProperties', labels);
       setData('versionCustomProperties', {
         ...labels,

--- a/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
+++ b/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
@@ -24,8 +24,8 @@ import {
   registerModel,
 } from '~/pages/modelRegistry/screens/RegisterModel/utils';
 import { SubmitLabel } from '~/pages/modelRegistry/screens/RegisterModel/const';
-import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
-import { getModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
+import { getCatalogModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
 import RegisterModelDetailsFormSection from '~/pages/modelRegistry/screens/RegisterModel/RegisterModelDetailsFormSection';
 import RegistrationFormFooter from '~/pages/modelRegistry/screens/RegisterModel/RegistrationFormFooter';
 import { registeredModelUrl } from '~/pages/modelRegistry/screens/routeUtils';
@@ -46,7 +46,7 @@ import {
 
 const RegisterCatalogModel: React.FC = () => {
   const navigate = useNavigate();
-  const params = useParams<CatalogModelCustomProps>();
+  const params = useParams<CatalogModelDetailsParams>();
   const decodedParams = React.useMemo(() => decodeParams(params), [params]);
 
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
@@ -173,7 +173,7 @@ const RegisterCatalogModel: React.FC = () => {
       setSubmitError(errors[resourceName]);
     }
   };
-  const onCancel = () => navigate(getModelDetailsUrl(params));
+  const onCancel = () => navigate(getCatalogModelDetailsUrl(params));
 
   return (
     <ApplicationsPage
@@ -184,7 +184,7 @@ const RegisterCatalogModel: React.FC = () => {
           <BreadcrumbItem render={() => <Link to="/modelCatalog">Model catalog</Link>} />
           <BreadcrumbItem
             render={() => (
-              <Link to={getModelDetailsUrl(params)}>{params.modelName || 'Loading...'}</Link>
+              <Link to={getCatalogModelDetailsUrl(params)}>{params.modelName || 'Loading...'}</Link>
             )}
           />
           <BreadcrumbItem data-testid="breadcrumb-version-name" isActive>

--- a/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
+++ b/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
@@ -24,7 +24,7 @@ import {
   registerModel,
 } from '~/pages/modelRegistry/screens/RegisterModel/utils';
 import { SubmitLabel } from '~/pages/modelRegistry/screens/RegisterModel/const';
-import { ModelDetailsRouteParams } from '~/pages/modelCatalog/const';
+import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
 import { getModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
 import RegisterModelDetailsFormSection from '~/pages/modelRegistry/screens/RegisterModel/RegisterModelDetailsFormSection';
 import RegistrationFormFooter from '~/pages/modelRegistry/screens/RegisterModel/RegistrationFormFooter';
@@ -46,7 +46,7 @@ import {
 
 const RegisterCatalogModel: React.FC = () => {
   const navigate = useNavigate();
-  const params = useParams<ModelDetailsRouteParams>();
+  const params = useParams<CatalogModelCustomProps>();
   const decodedParams = React.useMemo(() => decodeParams(params), [params]);
 
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
@@ -107,8 +107,8 @@ const RegisterCatalogModel: React.FC = () => {
         .filter(([key]) => /^\w+$/.test(key))
         .reduce((acc: ModelRegistryCustomProperties, [key, value]) => {
           if (typeof value === 'string') {
-            // eslint-disable-next-line camelcase
             acc[`_registeredFromCatalog${capitalize(key)}`] = {
+              // eslint-disable-next-line camelcase
               string_value: value,
               metadataType: ModelRegistryMetadataType.STRING,
             };

--- a/frontend/src/pages/modelCatalog/utils.ts
+++ b/frontend/src/pages/modelCatalog/utils.ts
@@ -1,5 +1,5 @@
 import { CatalogArtifacts, CatalogModel, ModelCatalogSource } from '~/concepts/modelCatalog/types';
-import { CatalogModelCustomProps } from './const';
+import { CatalogModelDetailsParams } from './const';
 
 export const findModelFromModelCatalogSources = (
   modelCatalogSources: ModelCatalogSource[],
@@ -24,7 +24,7 @@ export const findModelFromModelCatalogSources = (
   return modelMatched || null;
 };
 
-export const encodeParams = (params: CatalogModelCustomProps): CatalogModelCustomProps =>
+export const encodeParams = (params: CatalogModelDetailsParams): CatalogModelDetailsParams =>
   Object.fromEntries(
     Object.entries(params).map(([key, value]) => [
       key,
@@ -32,7 +32,9 @@ export const encodeParams = (params: CatalogModelCustomProps): CatalogModelCusto
     ]),
   );
 
-export const decodeParams = (params: Readonly<CatalogModelCustomProps>): CatalogModelCustomProps =>
+export const decodeParams = (
+  params: Readonly<CatalogModelDetailsParams>,
+): CatalogModelDetailsParams =>
   Object.fromEntries(
     Object.entries(params).map(([key, value]) => [key, decodeURIComponent(value)]),
   );

--- a/frontend/src/pages/modelCatalog/utils.ts
+++ b/frontend/src/pages/modelCatalog/utils.ts
@@ -1,5 +1,5 @@
 import { CatalogArtifacts, CatalogModel, ModelCatalogSource } from '~/concepts/modelCatalog/types';
-import { ModelDetailsRouteParams } from './const';
+import { CatalogModelCustomProps } from './const';
 
 export const findModelFromModelCatalogSources = (
   modelCatalogSources: ModelCatalogSource[],
@@ -24,7 +24,7 @@ export const findModelFromModelCatalogSources = (
   return modelMatched || null;
 };
 
-export const encodeParams = (params: ModelDetailsRouteParams): ModelDetailsRouteParams =>
+export const encodeParams = (params: CatalogModelCustomProps): CatalogModelCustomProps =>
   Object.fromEntries(
     Object.entries(params).map(([key, value]) => [
       key,
@@ -32,7 +32,7 @@ export const encodeParams = (params: ModelDetailsRouteParams): ModelDetailsRoute
     ]),
   );
 
-export const decodeParams = (params: Readonly<ModelDetailsRouteParams>): ModelDetailsRouteParams =>
+export const decodeParams = (params: Readonly<CatalogModelCustomProps>): CatalogModelCustomProps =>
   Object.fromEntries(
     Object.entries(params).map(([key, value]) => [key, decodeURIComponent(value)]),
   );

--- a/frontend/src/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelPropertiesDescriptionListGroup.tsx
@@ -7,8 +7,7 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
 import { ModelRegistryCustomProperties } from '~/concepts/modelRegistry/types';
 import ModelPropertiesTableRow from './ModelPropertiesTableRow';
-import { filterCustomProperties, getProperties, mergeUpdatedProperty } from './utils';
-import { pipelineRunSpecificKeys } from './ModelVersionDetails/const';
+import { getProperties, mergeUpdatedProperty } from './utils';
 
 type ModelPropertiesDescriptionListGroupProps = {
   customProperties: ModelRegistryCustomProperties;
@@ -31,13 +30,9 @@ const ModelPropertiesDescriptionListGroup: React.FC<ModelPropertiesDescriptionLi
   const isEditingSomeRow = isAdding || editingPropertyKeys.length > 0;
 
   const [isSavingEdits, setIsSavingEdits] = React.useState(false);
-  const filteredCustomProperties = filterCustomProperties(
-    customProperties,
-    pipelineRunSpecificKeys,
-  );
 
   // We only show string properties with a defined value (no labels or other property types)
-  const filteredProperties = getProperties(filteredCustomProperties);
+  const filteredProperties = getProperties(customProperties);
 
   const [isShowingMoreProperties, setIsShowingMoreProperties] = React.useState(false);
   const keys = Object.keys(filteredProperties);

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -162,7 +162,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
               <Flex
                 spaceItems={{ default: 'spaceItemsXs' }}
                 alignItems={{ default: 'alignItemsCenter' }}
-                data-testid="registered-from"
+                data-testid="registered-from-pipeline"
               >
                 <FlexItem data-testid="pipeline-run-link">
                   Run{' '}
@@ -174,7 +174,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
                         pipelineCustomProperties.runId,
                       )}
                     >
-                      {pipelineCustomProperties.runId}
+                      {pipelineCustomProperties.runName}
                     </Link>
                   }{' '}
                   in
@@ -199,7 +199,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
           )}
           {modelDetailsUrl && (
             <DashboardDescriptionListGroup title="Registered from" isEmpty={!mv.id}>
-              <Link to={modelDetailsUrl}>
+              <Link to={modelDetailsUrl} data-testid="registered-from-catalog">
                 <span style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}>
                   {catalogModelCustomProps.modelName} ({catalogModelCustomProps.tag})
                 </span>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   FlexItem,
   ContentVariants,
+  Content,
   Title,
   Bullseye,
   Spinner,
@@ -20,6 +21,7 @@ import {
   getLabels,
   getProperties,
   isPipelineRunExist,
+  getCustomPropString,
   mergeUpdatedLabels,
 } from '~/pages/modelRegistry/screens/utils';
 import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
@@ -35,6 +37,8 @@ import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegiste
 import { globalPipelineRunDetailsRoute } from '~/routes';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import { pipelineRunSpecificKeys } from './const';
+import { ModelDetailsRouteParams } from '~/pages/modelCatalog/const';
+import { getModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
 
 type ModelVersionDetailsViewProps = {
   modelVersion: ModelVersion;
@@ -49,7 +53,6 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
 }) => {
   const [modelArtifacts, modelArtifactsLoaded, modelArtifactsLoadError, refreshModelArtifacts] =
     useModelArtifactsByVersionId(mv.id);
-
   const modelArtifact = modelArtifacts.items.length ? modelArtifacts.items[0] : null;
   const { apiState } = React.useContext(ModelRegistryContext);
   const storageFields = uriToStorageFields(modelArtifact?.uri || '');
@@ -96,6 +99,16 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
     }
   };
 
+  const modelDetailsRouteParams: ModelDetailsRouteParams = {
+    sourceName: getCustomPropString(mv.customProperties, "_registeredFromCatalogSourceName"),
+    repositoryName: getCustomPropString(mv.customProperties, "_registeredFromCatalogRepositoryName"),
+    modelName: getCustomPropString(mv.customProperties, "_registeredFromCatalogModelName"),
+    tag: getCustomPropString(mv.customProperties, "_registeredFromCatalogTag"),
+  }
+  const modelDetailsUrl = getModelDetailsUrl(modelDetailsRouteParams);
+  console.log({modelDetailsRouteParams, modelDetailsUrl});
+
+  
   return (
     <Flex
       direction={{ default: 'column', md: 'row' }}
@@ -192,6 +205,16 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
               </Flex>
             </DashboardDescriptionListGroup>
           )}
+          {modelDetailsUrl && <DashboardDescriptionListGroup
+            title="Registered from"
+            isEmpty={!mv.id}
+          >
+            <Link to={modelDetailsUrl}>
+              <span style={{fontWeight: 'var(--pf-t--global--font--weight--body--bold)'}}>{modelDetailsRouteParams.modelName} ({modelDetailsRouteParams.tag})</span>
+            </Link>{' '}
+            in Model catalog
+          </DashboardDescriptionListGroup>
+          }
         </DescriptionList>
 
         <Title style={{ margin: '1em 0' }} headingLevel={ContentVariants.h3}>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -19,7 +19,7 @@ import ModelPropertiesDescriptionListGroup from '~/pages/modelRegistry/screens/M
 import {
   getLabels,
   mergeUpdatedLabels,
-  getCatalogModelCustomProps,
+  getCatalogModelDetailsProps,
   getPipelineModelCustomProps,
 } from '~/pages/modelRegistry/screens/utils';
 import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
@@ -34,8 +34,8 @@ import {
 import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegisteredModelById';
 import { globalPipelineRunDetailsRoute } from '~/routes';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
-import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
-import { getModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
+import { getCatalogModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
 
 type ModelVersionDetailsViewProps = {
   modelVersion: ModelVersion;
@@ -96,10 +96,10 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
     }
   };
 
-  const catalogModelCustomProps: CatalogModelCustomProps = getCatalogModelCustomProps(
+  const catalogModelCustomProps: CatalogModelDetailsParams = getCatalogModelDetailsProps(
     mv.customProperties,
   );
-  const modelDetailsUrl = getModelDetailsUrl(catalogModelCustomProps);
+  const catalogModelDetailsUrl = getCatalogModelDetailsUrl(catalogModelCustomProps);
 
   return (
     <Flex
@@ -197,9 +197,9 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
               </Flex>
             </DashboardDescriptionListGroup>
           )}
-          {modelDetailsUrl && (
+          {catalogModelDetailsUrl && (
             <DashboardDescriptionListGroup title="Registered from" isEmpty={!mv.id}>
-              <Link to={modelDetailsUrl} data-testid="registered-from-catalog">
+              <Link to={catalogModelDetailsUrl} data-testid="registered-from-catalog">
                 <span style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}>
                   {catalogModelCustomProps.modelName} ({catalogModelCustomProps.tag})
                 </span>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/const.ts
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/const.ts
@@ -13,3 +13,9 @@ export const pipelineRunSpecificKeys: string[] = [
   '_registeredFromPipelineRunId',
   '_registeredFromPipelineRunName',
 ];
+
+export type PipelineModelCustomProps = {
+  project: string;
+  runId: string;
+  runName: string;
+};

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -19,7 +19,7 @@ import {
   sortModelVersionsByCreateTime,
   isValidHttpUrl,
   isRedHatRegistryUri,
-  getCatalogModelCustomProps,
+  getCatalogModelDetailsProps,
   getPipelineModelCustomProps,
   getCustomPropString,
 } from '~/pages/modelRegistry/screens/utils';
@@ -191,8 +191,8 @@ describe('getCustomPropString', () => {
   });
 });
 
-describe('getCatalogModelCustomProps', () => {
-  it('should return a CatalogModelCustomProps object with the string values of the catalog model custom props', () => {
+describe('getCatalogModelDetailsParams', () => {
+  it('should return a CatalogModelDetailsParams object with the string values of the catalog model custom props', () => {
     const customProperties: ModelRegistryCustomProperties = {
       property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
       _lastModified: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
@@ -225,7 +225,7 @@ describe('getCatalogModelCustomProps', () => {
         string_value: 'runName',
       },
     };
-    const result = getCatalogModelCustomProps(customProperties);
+    const result = getCatalogModelDetailsProps(customProperties);
     expect(result).toEqual({
       sourceName: 'sourceName',
       repositoryName: 'repoName',

--- a/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelRegistry/screens/__tests__/utils.spec.ts
@@ -18,12 +18,12 @@ import {
   filterRegisteredModels,
   sortModelVersionsByCreateTime,
   isValidHttpUrl,
-  filterCustomProperties,
-  isPipelineRunExist,
   isRedHatRegistryUri,
+  getCatalogModelCustomProps,
+  getPipelineModelCustomProps,
+  getCustomPropString,
 } from '~/pages/modelRegistry/screens/utils';
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
-import { pipelineRunSpecificKeys } from '~/pages/modelRegistry/screens/ModelVersionDetails/const';
 
 describe('getLabels', () => {
   it('should return an empty array when customProperties is empty', () => {
@@ -160,6 +160,121 @@ describe('getProperties', () => {
     };
     const result = getProperties(customProperties);
     expect(result).toEqual({});
+  });
+
+  it('should return with _lastModified and _registeredFrom props filtered out', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _lastModified: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _registeredFromSomething: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'non-empty',
+      },
+    };
+    const result = getProperties(customProperties);
+    expect(result).toEqual({
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+    });
+  });
+});
+
+describe('getCustomPropString', () => {
+  it('should return the string value of a custom property', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'prop1' },
+      property2: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'prop2' },
+    };
+    const prop1Result = getCustomPropString(customProperties, 'property1');
+    const prop2Result = getCustomPropString(customProperties, 'property2');
+    expect(prop1Result).toEqual('prop1');
+    expect(prop2Result).toEqual('prop2');
+  });
+});
+
+describe('getCatalogModelCustomProps', () => {
+  it('should return a CatalogModelCustomProps object with the string values of the catalog model custom props', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _lastModified: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _registeredFromCatalogSourceName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'sourceName',
+      },
+      _registeredFromCatalogRepositoryName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'repoName',
+      },
+      _registeredFromCatalogModelName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'modelName',
+      },
+      _registeredFromCatalogTag: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'tag',
+      },
+      _registeredFromCatalogProject: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'project',
+      },
+      _registeredFromPipelineRunId: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'runId',
+      },
+      _registeredFromPipelineRunName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'runName',
+      },
+    };
+    const result = getCatalogModelCustomProps(customProperties);
+    expect(result).toEqual({
+      sourceName: 'sourceName',
+      repositoryName: 'repoName',
+      modelName: 'modelName',
+      tag: 'tag',
+    });
+  });
+});
+
+describe('getPipelineModelCustomProps', () => {
+  it('should return a PipelineModelCustomProps object with the string values of the pipeline model custom props', () => {
+    const customProperties: ModelRegistryCustomProperties = {
+      property1: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _lastModified: { metadataType: ModelRegistryMetadataType.STRING, string_value: 'non-empty' },
+      _registeredFromCatalogSourceName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'sourceName',
+      },
+      _registeredFromCatalogRepositoryName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'repoName',
+      },
+      _registeredFromCatalogModelName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'modelName',
+      },
+      _registeredFromCatalogTag: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'tag',
+      },
+      _registeredFromPipelineProject: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'project',
+      },
+      _registeredFromPipelineRunId: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'runId',
+      },
+      _registeredFromPipelineRunName: {
+        metadataType: ModelRegistryMetadataType.STRING,
+        string_value: 'runName',
+      },
+    };
+    const result = getPipelineModelCustomProps(customProperties);
+    expect(result).toEqual({
+      project: 'project',
+      runId: 'runId',
+      runName: 'runName',
+    });
   });
 });
 
@@ -406,74 +521,6 @@ describe('isValidHttpUrl', () => {
 
   it('should return false for a URL with an invalid format', () => {
     expect(isValidHttpUrl('http://example..com')).toBe(false);
-  });
-});
-
-describe('filterCustomProperties', () => {
-  it('filter pipeline specific keys from custom properties', () => {
-    const customProperties: ModelRegistryCustomProperties = {
-      'Label x': {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: '',
-      },
-      _registeredFromPipelineProject: {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: 'test-project',
-      },
-      _registeredFromPipelineRunId: {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: 'pipelinerun1',
-      },
-      _registeredFromPipelineRunName: {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: 'pipeline-run-test',
-      },
-    };
-    const result = filterCustomProperties(customProperties, pipelineRunSpecificKeys);
-    expect(result).toStrictEqual({
-      'Label x': {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: '',
-      },
-    });
-  });
-});
-
-describe('isPipelineRunExist', () => {
-  it('return True when pipeline run specific key exist in custom properties', () => {
-    const customProperties: ModelRegistryCustomProperties = {
-      'Label x': {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: '',
-      },
-      _registeredFromPipelineProject: {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: 'test-project',
-      },
-      _registeredFromPipelineRunId: {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: 'pipelinerun1',
-      },
-      _registeredFromPipelineRunName: {
-        metadataType: ModelRegistryMetadataType.STRING,
-        string_value: 'pipeline-run-test',
-      },
-    };
-    const result = isPipelineRunExist(customProperties, pipelineRunSpecificKeys);
-    expect(result).toEqual(true);
-  });
-
-  it('return false, when pipeline run specific key doesnot exist in custom properties', () => {
-    const result = isPipelineRunExist(
-      {
-        'Label x': {
-          metadataType: ModelRegistryMetadataType.STRING,
-          string_value: '',
-        },
-      },
-      pipelineRunSpecificKeys,
-    );
-    expect(result).toEqual(false);
   });
 });
 

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -1,13 +1,16 @@
 import { SearchType } from '~/concepts/dashboard/DashboardSearchField';
 import {
   ModelRegistryCustomProperties,
+  ModelRegistryCustomProperty,
   ModelRegistryMetadataType,
   ModelRegistryStringCustomProperties,
   ModelVersion,
   RegisteredModel,
 } from '~/concepts/modelRegistry/types';
 import { ServiceKind } from '~/k8sTypes';
+import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
 import { KeyValuePair } from '~/types';
+import { PipelineModelCustomProps } from './ModelVersionDetails/const';
 
 // Retrieves the labels from customProperties that have non-empty string_value.
 export const getLabels = <T extends ModelRegistryCustomProperties>(customProperties: T): string[] =>
@@ -38,7 +41,7 @@ export const mergeUpdatedLabels = (
   return customPropertiesCopy;
 };
 
-// Retrives the customProperties that are not labels (they have a defined string_value).
+// Retrives the customProperties that are not special (_RegisteredFrom) or labels (they have a defined string_value).
 export const getProperties = <T extends ModelRegistryCustomProperties>(
   customProperties: T,
 ): ModelRegistryStringCustomProperties => {
@@ -46,7 +49,7 @@ export const getProperties = <T extends ModelRegistryCustomProperties>(
   return Object.keys(customProperties).reduce((acc, key) => {
     // _lastModified is a property that is required to update the timestamp on the backend and we have a workaround for it. It should be resolved by
     // backend team See https://issues.redhat.com/browse/RHOAIENG-17614 .
-    if (key === '_lastModified' || /^_registeredFromCatalog/.test(key)) {
+    if (key === '_lastModified' || /^_registeredFrom/.test(key)) {
       return acc;
     }
 
@@ -82,16 +85,36 @@ export const mergeUpdatedProperty = (
   return customPropertiesCopy;
 };
 
-export const getCustomPropString = <T extends ModelRegistryCustomProperties>(
+export const getCustomPropString = <
+  T extends Record<string, ModelRegistryCustomProperty | undefined>,
+>(
   customProperties: T,
   key: string,
 ): string => {
   const prop = customProperties[key];
-  if (prop.metadataType === 'MetadataStringValue') {
+
+  if (prop?.metadataType === 'MetadataStringValue') {
     return prop.string_value;
   }
   return '';
 };
+
+export const getCatalogModelCustomProps = (
+  customProps: ModelRegistryCustomProperties,
+): CatalogModelCustomProps => ({
+  sourceName: getCustomPropString(customProps, '_registeredFromCatalogSourceName'),
+  repositoryName: getCustomPropString(customProps, '_registeredFromCatalogRepositoryName'),
+  modelName: getCustomPropString(customProps, '_registeredFromCatalogModelName'),
+  tag: getCustomPropString(customProps, '_registeredFromCatalogTag'),
+});
+
+export const getPipelineModelCustomProps = (
+  customProps: ModelRegistryCustomProperties,
+): PipelineModelCustomProps => ({
+  project: getCustomPropString(customProps, '_registeredFromPipelineProject'),
+  runId: getCustomPropString(customProps, '_registeredFromPipelineRunId'),
+  runName: getCustomPropString(customProps, '_registeredFromPipelineRunName'),
+});
 
 export const filterModelVersions = (
   unfilteredModelVersions: ModelVersion[],
@@ -188,22 +211,5 @@ export const isValidHttpUrl = (value: string): boolean => {
   }
 };
 
-export const filterCustomProperties = (
-  customProperties: ModelRegistryCustomProperties,
-  keys: string[],
-): ModelRegistryCustomProperties => {
-  const filteredCustomProperties: ModelRegistryCustomProperties = {};
-  Object.keys(customProperties).forEach((key) => {
-    if (!keys.includes(key)) {
-      filteredCustomProperties[key] = customProperties[key];
-    }
-  });
-  return filteredCustomProperties;
-};
-
-export const isPipelineRunExist = (
-  customProperties: ModelRegistryCustomProperties,
-  keys: string[],
-): boolean => keys.every((key) => key in customProperties);
 export const isRedHatRegistryUri = (uri: string): boolean =>
   uri.startsWith('oci://registry.redhat.io/');

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -8,7 +8,7 @@ import {
   RegisteredModel,
 } from '~/concepts/modelRegistry/types';
 import { ServiceKind } from '~/k8sTypes';
-import { CatalogModelCustomProps } from '~/pages/modelCatalog/const';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
 import { KeyValuePair } from '~/types';
 import { PipelineModelCustomProps } from './ModelVersionDetails/const';
 
@@ -41,7 +41,7 @@ export const mergeUpdatedLabels = (
   return customPropertiesCopy;
 };
 
-// Retrives the customProperties that are not special (_RegisteredFrom) or labels (they have a defined string_value).
+// Retrieves the customProperties that are not special (_RegisteredFrom) or labels (they have a defined string_value).
 export const getProperties = <T extends ModelRegistryCustomProperties>(
   customProperties: T,
 ): ModelRegistryStringCustomProperties => {
@@ -99,9 +99,9 @@ export const getCustomPropString = <
   return '';
 };
 
-export const getCatalogModelCustomProps = (
+export const getCatalogModelDetailsProps = (
   customProps: ModelRegistryCustomProperties,
-): CatalogModelCustomProps => ({
+): CatalogModelDetailsParams => ({
   sourceName: getCustomPropString(customProps, '_registeredFromCatalogSourceName'),
   repositoryName: getCustomPropString(customProps, '_registeredFromCatalogRepositoryName'),
   modelName: getCustomPropString(customProps, '_registeredFromCatalogModelName'),

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -46,7 +46,7 @@ export const getProperties = <T extends ModelRegistryCustomProperties>(
   return Object.keys(customProperties).reduce((acc, key) => {
     // _lastModified is a property that is required to update the timestamp on the backend and we have a workaround for it. It should be resolved by
     // backend team See https://issues.redhat.com/browse/RHOAIENG-17614 .
-    if (key === '_lastModified') {
+    if (key === '_lastModified' || /^_registeredFromCatalog/.test(key)) {
       return acc;
     }
 
@@ -80,6 +80,17 @@ export const mergeUpdatedProperty = (
     };
   }
   return customPropertiesCopy;
+};
+
+export const getCustomPropString = <T extends ModelRegistryCustomProperties>(
+  customProperties: T,
+  key: string,
+): string => {
+  const prop = customProperties[key];
+  if (prop.metadataType === 'MetadataStringValue') {
+    return prop.string_value;
+  }
+  return '';
 };
 
 export const filterModelVersions = (


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-20077

## Description
added customprop data when a version is created from the model catalog. these are used to create a link back to the model catalog from the version
![image](https://github.com/user-attachments/assets/c64f3160-7bff-46c4-b85a-cd57df32265d)


## How Has This Been Tested?
tested locally on green.

## Test Impact
added some unit and cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change. @yih-wang 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
