### PR TITLE
Fix odd spacing around model version actions

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   ButtonVariant,
   ActionList,
+  ActionListGroup,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
@@ -41,49 +42,53 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
 
   return (
     <ActionList>
-      <Button
-        id="deploy-button"
-        aria-label="Deploy version"
-        ref={tooltipRef}
-        variant={ButtonVariant.primary}
-        onClick={() => setIsDeployModalOpen(true)}
-      >
-        Deploy
-      </Button>
-      <Dropdown
-        isOpen={isOpenActionDropdown}
-        onSelect={() => setOpenActionDropdown(false)}
-        onOpenChange={(open) => setOpenActionDropdown(open)}
-        popperProps={{ position: 'right', appendTo: 'inline' }}
-        toggle={(toggleRef) => (
-          <MenuToggle
-            variant={ButtonVariant.secondary}
-            ref={toggleRef}
-            onClick={() => setOpenActionDropdown(!isOpenActionDropdown)}
-            isExpanded={isOpenActionDropdown}
-            aria-label="Model version details action toggle"
-            data-testid="model-version-details-action-button"
-          >
-            Actions
-          </MenuToggle>
-        )}
-      >
-        <DropdownList>
-          <DropdownItem
-            isAriaDisabled={hasDeployment}
-            id="archive-version-button"
-            aria-label="Archive model version"
-            key="archive-version-button"
-            onClick={() => setIsArchiveModalOpen(true)}
-            tooltipProps={
-              hasDeployment ? { content: 'Deployed model versions cannot be archived' } : undefined
-            }
-            ref={tooltipRef}
-          >
-            Archive model version
-          </DropdownItem>
-        </DropdownList>
-      </Dropdown>
+      <ActionListGroup>
+        <Button
+          id="deploy-button"
+          aria-label="Deploy version"
+          ref={tooltipRef}
+          variant={ButtonVariant.primary}
+          onClick={() => setIsDeployModalOpen(true)}
+        >
+          Deploy
+        </Button>
+        <Dropdown
+          isOpen={isOpenActionDropdown}
+          onSelect={() => setOpenActionDropdown(false)}
+          onOpenChange={(open) => setOpenActionDropdown(open)}
+          popperProps={{ position: 'right', appendTo: 'inline' }}
+          toggle={(toggleRef) => (
+            <MenuToggle
+              variant={ButtonVariant.secondary}
+              ref={toggleRef}
+              onClick={() => setOpenActionDropdown(!isOpenActionDropdown)}
+              isExpanded={isOpenActionDropdown}
+              aria-label="Model version details action toggle"
+              data-testid="model-version-details-action-button"
+            >
+              Actions
+            </MenuToggle>
+          )}
+        >
+          <DropdownList>
+            <DropdownItem
+              isAriaDisabled={hasDeployment}
+              id="archive-version-button"
+              aria-label="Archive model version"
+              key="archive-version-button"
+              onClick={() => setIsArchiveModalOpen(true)}
+              tooltipProps={
+                hasDeployment
+                  ? { content: 'Deployed model versions cannot be archived' }
+                  : undefined
+              }
+              ref={tooltipRef}
+            >
+              Archive model version
+            </DropdownItem>
+          </DropdownList>
+        </Dropdown>
+      </ActionListGroup>
       {isDeployModalOpen ? (
         <DeployRegisteredModelModal
           onSubmit={() => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-17782](https://issues.redhat.com/browse/RHOAIENG-17782)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixed odd spacing around `Deploy` button and `Actions` dropdown in MR version header.

Couldn't reproduce "The Model registry page shows the Action button menu below the registry description" - seems it's already fixed

Before(with long description):
<img width="1040" alt="Screenshot 2025-03-11 at 1 17 22 PM" src="https://github.com/user-attachments/assets/fc1d6199-9081-44b7-8fa5-078c4f214bdd" />

After(with long description):
<img width="1039" alt="Screenshot 2025-03-11 at 1 16 49 PM" src="https://github.com/user-attachments/assets/3091cb87-e307-4a91-a454-66b91b001c77" />

Before(without long description):
<img width="1038" alt="Screenshot 2025-03-11 at 1 13 55 PM" src="https://github.com/user-attachments/assets/10c20db7-1114-4efc-933a-7ad1b631e609" />

After(without long description):
<img width="1046" alt="Screenshot 2025-03-11 at 1 13 21 PM" src="https://github.com/user-attachments/assets/5393c3cc-4776-462f-94b2-a09f8bbfb9bf" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check that spacing in MR version header is as shown in the screenshots. 
1. Go to any registered model's version
2. Check the spacing between the button and dropdown in the MR version header page on the top right corner.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
PF spacing change. No test needed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
