### PR TITLE
Fix: Prevent API key from being removed when closing input early

### DIFF
--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -50,7 +50,12 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
   };
 
   const handleClose = React.useCallback(() => {
-    setEnableValues({});
+    // Clear only the values, keeping the keys intact
+    const resetValues: { [key: string]: string } = {};
+    Object.keys(enableValues).forEach((key) => {
+      resetValues[key] = "";
+    });
+    setEnableValues(resetValues);
     setPostError('');
     onClose();
   }, [onClose]);

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -60,6 +60,13 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
     onClose();
   }, [onClose, enableValues]);
 
+  // Managing validation state after the modal closes
+  React.useEffect(() => {
+    if (!shown) {
+      setValidationInProgress(false);
+    }
+  }, [shown]);
+
   React.useEffect(() => {
     if (validationInProgress && validationStatus === EnableApplicationStatus.SUCCESS) {
       setValidationInProgress(false);

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -53,12 +53,12 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
     // Clear only the values, keeping the keys intact
     const resetValues: { [key: string]: string } = {};
     Object.keys(enableValues).forEach((key) => {
-      resetValues[key] = "";
+      resetValues[key] = '';
     });
     setEnableValues(resetValues);
     setPostError('');
     onClose();
-  }, [onClose]);
+  }, [onClose, enableValues]);
 
   React.useEffect(() => {
     if (validationInProgress && validationStatus === EnableApplicationStatus.SUCCESS) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA - [https://issues.redhat.com/browse/NVPE-151](https://issues.redhat.com/browse/NVPE-151)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR fixes an issue where the `api_key` was being removed when closing the input window before it finished. The key was missing in the resulting Secret. Now, the `api_key` is handled correctly and is not removed unintentionally.

**Before:**
- When the input window was closed before it finished, a Secret was created without any data keys, resulting in a missing `api_key` in the account.
![image](https://github.com/user-attachments/assets/06d1bc98-3dae-4dad-a4b6-36c230db3d9d)

**After:**
- The API key is now properly preserved, even when the input window is closed prematurely.
![image](https://github.com/user-attachments/assets/385c2e1a-f974-475f-ba25-0922dca5d816)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
following these steps:
1. Enabled NVIDIA.
2. Closed the input window before it finished.
3. Verified that the API key is now included in the Secret and no longer missing.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
