### PR TITLE
Show ilab student/teacher/judge model indicators on models in model catalog

### DIFF
--- a/frontend/src/__mocks__/mockModelCatalogConfigMap.ts
+++ b/frontend/src/__mocks__/mockModelCatalogConfigMap.ts
@@ -3,9 +3,11 @@ import { ModelCatalogSourcesObject } from '~/concepts/modelCatalog/types';
 import { mockConfigMap } from './mockConfigMap';
 import { mockModelCatalogSource } from './mockModelCatalogSource';
 
-export const mockModelCatalogConfigMap = (): ConfigMapKind => {
+export const mockModelCatalogConfigMap = (
+  sources = [mockModelCatalogSource({})],
+): ConfigMapKind => {
   const sourcesObj: ModelCatalogSourcesObject = {
-    sources: [mockModelCatalogSource({})],
+    sources,
   };
   return mockConfigMap({
     name: 'model-catalog-sources',

--- a/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/modelCatalog.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/modelCatalog.ts
@@ -53,6 +53,33 @@ class ModelCatalog {
     return cy.findByTestId('model-catalog-cards');
   }
 
+  findModelCatalogCard(modelName: string) {
+    return cy
+      .findAllByTestId('model-catalog-card')
+      .contains('[data-testid~=model-catalog-card]', modelName);
+  }
+
+  expandCardLabelGroup(modelName: string) {
+    this.findModelCatalogCard(modelName)
+      .findAllByTestId('model-catalog-label-group')
+      .find('button')
+      .click();
+  }
+
+  findCardLabelByIndex(modelName: string, index: number) {
+    return this.findModelCatalogCard(modelName).findAllByTestId('model-catalog-label').eq(index);
+  }
+
+  findCardLabelByText(modelName: string, text: string) {
+    return this.findModelCatalogCard(modelName)
+      .findAllByTestId('model-catalog-label')
+      .contains(text);
+  }
+
+  findModelCatalogCardsLabelGroup() {
+    return cy.findByTestId('model-catalog-label-group');
+  }
+
   findModelCatalogDetailsEmptyState() {
     return cy.findByTestId('empty-model-catalog-details-state');
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
@@ -56,6 +56,14 @@ class ModelDetailsPage {
   findRegisterCatalogModelPopover() {
     return cy.findByTestId('register-catalog-model-popover');
   }
+
+  expandLabelGroup() {
+    cy.findByTestId('model-catalog-label-group').find('button').click();
+  }
+
+  findLabelByIndex(index: number) {
+    return cy.findAllByTestId('model-catalog-label').eq(index);
+  }
 }
 
 export const modelDetailsPage = new ModelDetailsPage();

--- a/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
@@ -1,11 +1,15 @@
 import { mockCatalogModel } from '~/__mocks__/mockCatalogModel';
 import { mockModelCatalogSource } from '~/__mocks__/mockModelCatalogSource';
 import {
+  createCustomPropertiesFromModel,
   decodeParams,
   encodeParams,
   findModelFromModelCatalogSources,
+  getILabLabels,
   getTagFromModel,
+  removeILabLabels,
 } from '~/pages/modelCatalog/utils';
+import { EMPTY_CUSTOM_PROPERTY_STRING } from '~/pages/modelCatalog/const';
 
 describe('findModelFromModelCatalogSources', () => {
   const catalogModelMock = [mockModelCatalogSource({})];
@@ -90,5 +94,88 @@ describe('getTagFromModel', () => {
       artifacts: [{ tags: [] }],
     });
     expect(result).toBe(undefined);
+  });
+});
+
+describe('getILabLabels', () => {
+  it('should return any matching ILab labels', () => {
+    const expected = ['lab-base', 'lab-judge'];
+
+    const result = getILabLabels(['lab-base', 'lab-judge', 'value-1', 'value-2', 'lab-zzzzxxxxx']);
+    expect(result).toEqual(expected);
+  });
+
+  it('should return an empty list when no ILab labels are present', () => {
+    const result = getILabLabels(['foo', 'bar', 'baz']);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty list if given an empty list', () => {
+    const result = getILabLabels([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty list if given undefined', () => {
+    const result = getILabLabels(undefined);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('removeILabLabels', () => {
+  it('should return all non ILab labels', () => {
+    const expected = ['foo', 'bar', 'baz'];
+    const result = removeILabLabels(['foo', 'bar', 'baz', 'lab-base', 'lab-teacher', 'lab-judge']);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return labels when no ILab labels are present', () => {
+    const expected = ['foo', 'bar', 'baz'];
+    const result = removeILabLabels(['foo', 'bar', 'baz']);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return an empty list when only ilab labels are given', () => {
+    const result = removeILabLabels(['lab-base', 'lab-teacher', 'lab-judge']);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty list if given undefined', () => {
+    const result = removeILabLabels(undefined);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('createCustomPropertiesFromModel', () => {
+  it('should return ModelRegistryCustomProperties with ilab labels removed', () => {
+    const expected = {
+      foo: EMPTY_CUSTOM_PROPERTY_STRING,
+      bar: EMPTY_CUSTOM_PROPERTY_STRING,
+      value1: EMPTY_CUSTOM_PROPERTY_STRING,
+      value2: EMPTY_CUSTOM_PROPERTY_STRING,
+    };
+
+    const result = createCustomPropertiesFromModel(
+      mockCatalogModel({
+        tasks: ['foo', 'bar'],
+        labels: ['lab-base', 'lab-teacher', 'lab-judge', 'value1', 'value2'],
+      }),
+    );
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return an empty object when properties are missing', () => {
+    const result = createCustomPropertiesFromModel(
+      mockCatalogModel({
+        tasks: undefined,
+        labels: undefined,
+      }),
+    );
+
+    expect(result).toEqual({});
   });
 });

--- a/frontend/src/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/frontend/src/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -20,12 +20,13 @@ import { CatalogModel } from '~/concepts/modelCatalog/types';
 import { getCatalogModelDetailsUrlFromModel } from '~/pages/modelCatalog/routeUtils';
 import { getTagFromModel } from '~/pages/modelCatalog/utils';
 import { RhUiTagIcon } from '~/images/icons';
+import { ModelCatalogLabels } from '~/pages/modelCatalog/components/ModelCatalogLabels';
 
 export const ModelCatalogCard: React.FC<{ model: CatalogModel; source: string }> = ({
   model,
   source,
 }) => (
-  <Card isFullHeight>
+  <Card isFullHeight data-testid="model-catalog-card">
     <CardHeader>
       <CardTitle>
         <Flex alignItems={{ default: 'alignItemsCenter' }}>
@@ -66,11 +67,7 @@ export const ModelCatalogCard: React.FC<{ model: CatalogModel; source: string }>
       </Stack>
     </CardBody>
     <CardFooter>
-      {(model.tasks ?? []).map((task, index) => (
-        <Label variant="outline" key={index}>
-          {task}
-        </Label>
-      ))}
+      <ModelCatalogLabels labels={model.labels} tasks={model.tasks} />
     </CardFooter>
   </Card>
 );

--- a/frontend/src/pages/modelCatalog/components/ModelCatalogLabels.tsx
+++ b/frontend/src/pages/modelCatalog/components/ModelCatalogLabels.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Label, LabelGroup } from '@patternfly/react-core';
+import { getILabLabels, removeILabLabels } from '~/pages/modelCatalog/utils';
+
+export const ModelCatalogLabels: React.FC<{
+  labels?: string[];
+  tasks?: string[];
+  showNonILabLabels?: boolean;
+}> = ({ labels = [], tasks = [], showNonILabLabels = false }) => (
+  <LabelGroup data-testid="model-catalog-label-group">
+    {getILabLabels(labels).map((l) => {
+      switch (l) {
+        case 'lab-base':
+          return (
+            <Label data-testid="model-catalog-label" color="yellow" variant="filled">
+              LAB starter
+            </Label>
+          );
+        case 'lab-teacher':
+          return (
+            <Label data-testid="model-catalog-label" color="purple" variant="filled">
+              LAB teacher
+            </Label>
+          );
+        case 'lab-judge':
+          return (
+            <Label data-testid="model-catalog-label" color="orange" variant="filled">
+              LAB judge
+            </Label>
+          );
+        default:
+          return (
+            <Label data-testid="model-catalog-label" key={l} variant="outline">
+              {l}
+            </Label>
+          );
+      }
+    })}
+    {tasks.map((task) => (
+      <Label data-testid="model-catalog-label" key={task} variant="outline">
+        {task}
+      </Label>
+    ))}
+    {showNonILabLabels &&
+      removeILabLabels(labels).map((label) => (
+        <Label data-testid="model-catalog-label" key={label} variant="outline">
+          {label}
+        </Label>
+      ))}
+  </LabelGroup>
+);

--- a/frontend/src/pages/modelCatalog/const.ts
+++ b/frontend/src/pages/modelCatalog/const.ts
@@ -1,6 +1,12 @@
-export type CatalogModelDetailsParams = {
-  sourceName?: string;
-  repositoryName?: string;
-  modelName?: string;
-  tag?: string;
+import {
+  ModelRegistryCustomProperty,
+  ModelRegistryMetadataType,
+} from '~/concepts/modelRegistry/types';
+
+export const RESERVED_ILAB_LABELS = ['lab-base', 'lab-teacher', 'lab-judge'];
+
+export const EMPTY_CUSTOM_PROPERTY_STRING: ModelRegistryCustomProperty = {
+  // eslint-disable-next-line camelcase
+  string_value: '',
+  metadataType: ModelRegistryMetadataType.STRING,
 };

--- a/frontend/src/pages/modelCatalog/routeUtils.ts
+++ b/frontend/src/pages/modelCatalog/routeUtils.ts
@@ -1,5 +1,6 @@
 import { CatalogModel } from '~/concepts/modelCatalog/types';
-import { CatalogModelDetailsParams } from './const';
+
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 import { encodeParams, getTagFromModel } from './utils';
 
 export const modelCatalogUrl = `/modelCatalog`;

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -29,7 +29,6 @@ import {
   findModelFromModelCatalogSources,
   getTagFromModel,
 } from '~/pages/modelCatalog/utils';
-import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
 import BrandImage from '~/components/BrandImage';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { getRegisterCatalogModelUrl } from '~/pages/modelCatalog/routeUtils';
@@ -38,6 +37,7 @@ import { FindAdministratorOptions } from '~/pages/projects/screens/projects/cons
 import { RhUiTagIcon } from '~/images/icons';
 import { modelCustomizationRootPath } from '~/routes';
 import RhUiControlsIcon from '~/images/icons/RhUiControlsIcon';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 import { ODH_PRODUCT_NAME } from '~/utilities/const';
 import ModelDetailsView from './ModelDetailsView';
 

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -3,7 +3,6 @@ import {
   Content,
   DescriptionList,
   Icon,
-  Label,
   PageSection,
   Sidebar,
   SidebarContent,
@@ -17,6 +16,7 @@ import { getTagFromModel } from '~/pages/modelCatalog/utils';
 import ExternalLink from '~/components/ExternalLink';
 import MarkdownView from '~/components/MarkdownView';
 import { RhUiTagIcon } from '~/images/icons';
+import { ModelCatalogLabels } from '~/pages/modelCatalog/components/ModelCatalogLabels';
 
 type ModelDetailsViewProps = {
   model: CatalogModel;
@@ -45,19 +45,15 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ model }) => (
             {getTagFromModel(model)}
           </DashboardDescriptionListGroup>
           <DashboardDescriptionListGroup title="Labels">
-            {!model.labels?.length
-              ? 'no labels'
-              : model.labels.map((label, index) => (
-                  <Label
-                    variant="outline"
-                    data-testid="label"
-                    key={index}
-                    marginWidth={3}
-                    style={{ marginRight: '3px' }}
-                  >
-                    {label}
-                  </Label>
-                ))}
+            {!model.labels?.length && !model.tasks?.length ? (
+              'no labels'
+            ) : (
+              <ModelCatalogLabels
+                labels={model.labels ?? []}
+                tasks={model.tasks ?? []}
+                showNonILabLabels
+              />
+            )}
           </DashboardDescriptionListGroup>
           <DashboardDescriptionListGroup title="License" groupTestId="model-license">
             <ExternalLink

--- a/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
+++ b/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
@@ -24,8 +24,6 @@ import {
   registerModel,
 } from '~/pages/modelRegistry/screens/RegisterModel/utils';
 import { SubmitLabel } from '~/pages/modelRegistry/screens/RegisterModel/const';
-import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
-import { getCatalogModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
 import RegisterModelDetailsFormSection from '~/pages/modelRegistry/screens/RegisterModel/RegisterModelDetailsFormSection';
 import RegistrationFormFooter from '~/pages/modelRegistry/screens/RegisterModel/RegistrationFormFooter';
 import { registeredModelUrl } from '~/pages/modelRegistry/screens/routeUtils';
@@ -35,6 +33,7 @@ import { CatalogModel } from '~/concepts/modelCatalog/types';
 import ModelRegistrySelector from '~/pages/modelRegistry/screens/ModelRegistrySelector';
 import useModelRegistryAPIState from '~/concepts/modelRegistry/context/useModelRegistryAPIState';
 import {
+  createCustomPropertiesFromModel,
   decodeParams,
   findModelFromModelCatalogSources,
   getTagFromModel,
@@ -43,6 +42,8 @@ import {
   ModelRegistryCustomProperties,
   ModelRegistryMetadataType,
 } from '~/concepts/modelRegistry/types';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
+import { getCatalogModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
 
 const RegisterCatalogModel: React.FC = () => {
   const navigate = useNavigate();
@@ -88,19 +89,13 @@ const RegisterCatalogModel: React.FC = () => {
 
   React.useEffect(() => {
     if (model) {
-      const labels: ModelRegistryCustomProperties = {};
+      const labels = createCustomPropertiesFromModel(model);
       setData('modelName', `${model.name}-${getTagFromModel(model) || ''}`);
       setData('modelDescription', model.longDescription?.replace(/\s*\n\s*/g, ' ') ?? '');
       setData('versionName', 'Version 1');
       setData('modelLocationType', ModelLocationType.URI);
       setData('modelLocationURI', model.artifacts?.map((artifact) => artifact.uri)[0] || '');
-      model.labels?.forEach((label) => {
-        labels[label] = {
-          // eslint-disable-next-line camelcase
-          string_value: '',
-          metadataType: ModelRegistryMetadataType.STRING,
-        };
-      });
+
       const registeredFromReferenceCustomProperties: ModelRegistryCustomProperties = Object.entries(
         decodedParams,
       )
@@ -115,7 +110,6 @@ const RegisterCatalogModel: React.FC = () => {
           }
           return acc;
         }, {});
-
       setData('modelCustomProperties', labels);
       setData('versionCustomProperties', {
         ...labels,

--- a/frontend/src/pages/modelCatalog/types.ts
+++ b/frontend/src/pages/modelCatalog/types.ts
@@ -1,0 +1,6 @@
+export type CatalogModelDetailsParams = {
+  sourceName?: string;
+  repositoryName?: string;
+  modelName?: string;
+  tag?: string;
+};

--- a/frontend/src/pages/modelCatalog/utils.ts
+++ b/frontend/src/pages/modelCatalog/utils.ts
@@ -1,5 +1,7 @@
 import { CatalogArtifacts, CatalogModel, ModelCatalogSource } from '~/concepts/modelCatalog/types';
-import { CatalogModelDetailsParams } from './const';
+import { EMPTY_CUSTOM_PROPERTY_STRING, RESERVED_ILAB_LABELS } from '~/pages/modelCatalog/const';
+import { ModelRegistryCustomProperties } from '~/concepts/modelRegistry/types';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 
 export const findModelFromModelCatalogSources = (
   modelCatalogSources: ModelCatalogSource[],
@@ -41,3 +43,28 @@ export const decodeParams = (
 
 export const getTagFromModel = (model: CatalogModel): string | undefined =>
   model.artifacts?.[0]?.tags?.[0];
+
+export const getILabLabels = (labels?: string[]): string[] =>
+  labels?.filter((l) => RESERVED_ILAB_LABELS.includes(l)) ?? [];
+
+export const removeILabLabels = (labels?: string[]): string[] =>
+  labels?.filter((l) => !RESERVED_ILAB_LABELS.includes(l)) ?? [];
+
+export const createCustomPropertiesFromModel = (
+  model: CatalogModel,
+): ModelRegistryCustomProperties => {
+  const labels = removeILabLabels(model.labels).reduce<ModelRegistryCustomProperties>(
+    (acc, cur) => {
+      acc[cur] = EMPTY_CUSTOM_PROPERTY_STRING;
+      return acc;
+    },
+    {},
+  );
+
+  const tasks = model.tasks?.reduce<ModelRegistryCustomProperties>((acc, cur) => {
+    acc[cur] = EMPTY_CUSTOM_PROPERTY_STRING;
+    return acc;
+  }, {});
+
+  return { ...labels, ...tasks };
+};

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -34,8 +34,8 @@ import {
 import useRegisteredModelById from '~/concepts/modelRegistry/apiHooks/useRegisteredModelById';
 import { globalPipelineRunDetailsRoute } from '~/routes';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
-import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
 import { getCatalogModelDetailsUrl } from '~/pages/modelCatalog/routeUtils';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 
 type ModelVersionDetailsViewProps = {
   modelVersion: ModelVersion;

--- a/frontend/src/pages/modelRegistry/screens/utils.ts
+++ b/frontend/src/pages/modelRegistry/screens/utils.ts
@@ -8,8 +8,8 @@ import {
   RegisteredModel,
 } from '~/concepts/modelRegistry/types';
 import { ServiceKind } from '~/k8sTypes';
-import { CatalogModelDetailsParams } from '~/pages/modelCatalog/const';
 import { KeyValuePair } from '~/types';
+import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 import { PipelineModelCustomProps } from './ModelVersionDetails/const';
 
 // Retrieves the labels from customProperties that have non-empty string_value.


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: https://issues.redhat.com/browse/RHOAIENG-19919

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The models in the ModelCatalogSource objects can have special labels on them for InstructLab: `lab-base`, `lab-teacher` and `lab-judge`. We need to detect those labels and give them special treatment wherever they appear in the model catalog (on cards in the overview page and in their section of the details page). These labels:
Should be positioned before other labels
Should be given special colors (see mockups for PF color variables)
Should have their raw value replaced by microcopy
lab-base becomes "LAB starter" with a yellow color
lab-teacher becomes "LAB teacher" with a purple color
lab-judge becomes "LAB judge" with an orangered color.

Also note:
Currently the `tasks` of a model are shown on the card and the `labels` are shown on the details page and used for registering to MR. We should conditionally combine them in this specific way:
The cards on the overview page should show the `lab-*` labels with their special color/microcopy first, then the `model.tasks` values and no other labels.
The labels section of the details page should show the `lab-*` labels with their special color/microcopy first, then the `model.tasks` values, then the other non-lab `model.labels` values.
When registering a model from the catalog ([see code here](https://github.com/opendatahub-io/odh-dashboard/blob/main/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx#L92-L98)), instead of just copying over all the `model.labels` as MR labels, we should exclude the `lab-` *labels and include the other `model.labels` AND the `model.tasks` values.
We may include additional metadata from the catalog as labels in the future but this is the behavior we've settled on for MVP.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Visit the model catalog page, ensure any labels on cards conform to the rules above for colour and order.
- On the catalog page ensure any labels that are not ILAB reserved labels are NOT displayed on the cards.
- Visit the details page of a model with special labels
- Validate the labels conform to the rules above, ensuring that ALL labels are displayed (unlike on the catalog page).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
