### PR TITLE
add proper empty state for hardware profile table

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
@@ -17,7 +17,6 @@ import {
 import { BanIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
-import { ODH_PRODUCT_NAME } from '~/utilities/const';
 import HardwareProfilesTable from '~/pages/hardwareProfiles/HardwareProfilesTable';
 import { useAccessAllowed, verbModelAccess } from '~/concepts/userSSAR';
 import { HardwareProfileModel } from '~/api';
@@ -28,7 +27,8 @@ import { ProjectObjectType } from '~/concepts/design/utils';
 import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import useMigratedHardwareProfiles from './migration/useMigratedHardwareProfiles';
 
-const description = `Manage hardware profile settings for users in your organization.`;
+const description =
+  'Hardware profiles enable administrators to create profiles for additional types of identifiers, limit workload resource allocations, and target workloads to specific nodes by including tolerations and nodeSelectors in profiles.';
 
 const HardwareProfiles: React.FC = () => {
   const { dashboardNamespace } = useDashboardNamespace();
@@ -66,12 +66,11 @@ const HardwareProfiles: React.FC = () => {
           icon={PlusCircleIcon}
         >
           <Title data-testid="no-available-hardware-profiles" headingLevel="h5" size="lg">
-            No available hardware profiles yet
+            No hardware profiles
           </Title>
           <EmptyStateBody>
-            You don&apos;t have any hardware profiles yet. To get started, please ask your cluster
-            administrator about the hardware availability in your cluster and create corresponding
-            profiles in {ODH_PRODUCT_NAME}.
+            To get started, contact your cluster administrator to learn about hardware availability
+            in your cluster, then create corresponding hardware profiles.
           </EmptyStateBody>
           <EmptyStateFooter>
             <EmptyStateActions>
@@ -88,12 +87,11 @@ const HardwareProfiles: React.FC = () => {
       ) : (
         <EmptyState variant={EmptyStateVariant.full} data-id="empty-empty-state" icon={BanIcon}>
           <Title data-testid="no-available-hardware-profiles" headingLevel="h5" size="lg">
-            No available hardware profiles
+            No hardware profiles
           </Title>
           <EmptyStateBody>
-            You don&apos;t have any hardware profiles yet. To get started, please ask your cluster
-            administrator about the hardware availability in your cluster and to set up
-            corresponding profiles in {ODH_PRODUCT_NAME}.
+            To get started, contact your cluster administrator to learn about hardware availability
+            in your cluster and to set up corresponding hardware profiles.
           </EmptyStateBody>
         </EmptyState>
       )}
@@ -139,9 +137,7 @@ const HardwareProfiles: React.FC = () => {
         {migratedHardwareProfiles.length > 0 && (
           <>
             <StackItem>
-              <Title headingLevel="h2">
-                {hardwareProfiles.length > 0 ? 'Legacy profiles' : 'Migrate your legacy profiles'}
-              </Title>
+              <Title headingLevel="h2">Migrate your legacy profiles</Title>
             </StackItem>
             <StackItem>
               Your accelerator profiles and existing custom workbench and model deployment container

--- a/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
@@ -129,14 +129,15 @@ const HardwareProfiles: React.FC = () => {
             </Alert>
           </StackItem>
         )}
-        {migratedHardwareProfiles.length > 0 ? (
+        <StackItem>
+          {hardwareProfiles.length > 0 ? (
+            <HardwareProfilesTable hardwareProfiles={hardwareProfiles} />
+          ) : (
+            noHardwareProfilePageSection
+          )}
+        </StackItem>
+        {migratedHardwareProfiles.length > 0 && (
           <>
-            <StackItem>
-              <HardwareProfilesTable
-                hardwareProfiles={hardwareProfiles}
-                getMigrationAction={getMigrationAction}
-              />
-            </StackItem>
             <StackItem>
               <Title headingLevel="h2">
                 {hardwareProfiles.length > 0 ? 'Legacy profiles' : 'Migrate your legacy profiles'}
@@ -161,10 +162,6 @@ const HardwareProfiles: React.FC = () => {
               </ExpandableSection>
             </StackItem>
           </>
-        ) : (
-          <StackItem>
-            <HardwareProfilesTable hardwareProfiles={hardwareProfiles} />
-          </StackItem>
         )}
       </Stack>
     </ApplicationsPage>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-21526

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
fixes empty states for when there are no hardware profiles but migrated profiles
![Screenshot 2025-03-12 at 10 09 32 AM](https://github.com/user-attachments/assets/b044bfb0-8717-4a86-a7c6-3d54a34156d9)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
get to the state provided in the description and ensure empty state is there

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
@vconzola 
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
