### PR TITLE
Show errors when failing to load artifacts for ilab modal

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersions.cy.ts
@@ -297,9 +297,42 @@ describe('Model Versions', () => {
       }),
     );
 
-    // Mock tuning data endpoint
+    modelRegistry.visit();
+    const registeredModelRow = modelRegistry.getRow('Fraud detection model');
+    registeredModelRow.findName().contains('Fraud detection model').click();
+
+    const modelVersionRow = modelRegistry.getModelVersionRow('model version');
+    modelVersionRow.findKebabAction('LAB tune').click();
+  });
+
+  it('should show error in lab tune modal if loading artifacts failed', () => {
+    initIntercepts({
+      disableModelRegistryFeature: false,
+    });
+
+    // Enable fine-tuning feature
     cy.interceptOdh(
-      'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/tuning',
+      'GET /api/config',
+      mockDashboardConfig({
+        disableModelRegistry: false,
+        disableFineTuning: false,
+      }),
+    );
+
+    // Mock DSC status with required components
+    cy.interceptOdh(
+      'GET /api/dsc/status',
+      mockDscStatus({
+        installedComponents: {
+          'model-registry-operator': true,
+          'data-science-pipelines-operator': true,
+        },
+      }),
+    );
+
+    // Mock failing artifacts data
+    cy.interceptOdh(
+      'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
       {
         method: 'GET',
         path: {
@@ -308,8 +341,8 @@ describe('Model Versions', () => {
           modelVersionId: '1',
         },
       },
-      mockModelVersion({ id: '1', name: 'model version' }),
-    ).as('getTuningData');
+      { statusCode: 500 },
+    );
 
     modelRegistry.visit();
     const registeredModelRow = modelRegistry.getRow('Fraud detection model');
@@ -317,5 +350,7 @@ describe('Model Versions', () => {
 
     const modelVersionRow = modelRegistry.getModelVersionRow('model version');
     modelVersionRow.findKebabAction('LAB tune').click();
+
+    cy.findByText('Error loading model data').should('exist');
   });
 });

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -192,7 +192,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
               modelVersionName={mv.name}
             />
           ) : null}
-          {tuningModelVersionId && tuningData && (
+          {tuningModelVersionId && (
             <StartRunModal
               onCancel={() => setTuningModelVersionId(null)}
               onSubmit={(selectedProject) => {

--- a/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
@@ -37,7 +37,7 @@ const StartRunModal: React.FC<StartRunModalProps> = ({
           }}
           onCancel={onCancel}
           submitLabel="Continue to run details"
-          isSubmitDisabled={!canContinue || !loaded}
+          isSubmitDisabled={!canContinue || !loaded || !!loadError}
         />
       }
       variant="medium"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Followup to [RHOAIENG-19017](https://issues.redhat.com/browse/RHOAIENG-19017)
cc @YuliaKrimerman 

Prompted by docs comment thread here: https://docs.google.com/document/d/1eHXWp2InljnCW7N3wdWSqc71Gzq_y2vcolxwoCIj6QM/edit?disco=AAABfj1CtpI
cc @ConorOM1 

By preventing the StartRunModal from rendering when `tuningData` isn't defined, we were blocking errors from the artifacts fetch from being rendered anywhere. It is safe to let that modal render even without tuningData because the submit button will be blocked if there is an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Force the artifacts fetch to fail (when opening the ilab modal, look in network dev tools for a fetch with a URL ending in `artifacts`, right click it and "block request URL", reload, open the modal again) and see that the modal opens and we get an error rendered

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

New Cypress test - also removed an unnecessary intercept from a similar test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
