### PR TITLE
fix: resolve model selection issues for models with complex version formats

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -85,7 +85,7 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
     getModelNames();
   }, [isEditing, inferenceServiceData.format.name]);
 
-  const getSupportedModelFormatsInfo = (key: string) => {
+  const extractModelAndVersion = (key: string) => {
     const matchedModelsInfo = modelList.filter((model) => key.startsWith(`${model.name}-`));
 
     if (matchedModelsInfo.length === 0) {
@@ -98,24 +98,19 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
 
     const { name } = modelInfo;
     const version = key.slice(name.length + 1);
+    return { modelInfo, version };
+  };
 
-    return { name, version };
+  const getSupportedModelFormatsInfo = (key: string) => {
+    const result = extractModelAndVersion(key);
+    return result ? { name: result.modelInfo.name, version: result.version } : null;
   };
 
   const getNIMImageName = (key: string) => {
-    const matchedModelsInfo = modelList.filter((model) => key.startsWith(`${model.name}-`));
-
-    if (matchedModelsInfo.length === 0) {
-      return '';
-    }
-
-    const modelInfo = matchedModelsInfo.reduce((longest, current) =>
-      current.name.length > longest.name.length ? current : longest,
-    );
-
-    const { name, namespace } = modelInfo;
-    const version = key.slice(name.length + 1);
-    return `nvcr.io/${namespace}/${name}:${version}`;
+    const result = extractModelAndVersion(key);
+    return result
+      ? `nvcr.io/${result.modelInfo.namespace}/${result.modelInfo.name}:${result.version}`
+      : '';
   };
 
   const onSelect = (

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/NIMModelListSection.tsx
@@ -86,25 +86,36 @@ const NIMModelListSection: React.FC<NIMModelListSectionProps> = ({
   }, [isEditing, inferenceServiceData.format.name]);
 
   const getSupportedModelFormatsInfo = (key: string) => {
-    const lastHyphenIndex = key.lastIndexOf('-');
-    if (lastHyphenIndex === -1) {
+    const matchedModelsInfo = modelList.filter((model) => key.startsWith(`${model.name}-`));
+
+    if (matchedModelsInfo.length === 0) {
       return null;
     }
-    const name = key.slice(0, lastHyphenIndex);
-    const version = key.slice(lastHyphenIndex + 1);
-    const modelInfo = modelList.find((model) => model.name === name);
-    return modelInfo ? { name: modelInfo.name, version } : null;
+
+    const modelInfo = matchedModelsInfo.reduce((longest, current) =>
+      current.name.length > longest.name.length ? current : longest,
+    );
+
+    const { name } = modelInfo;
+    const version = key.slice(name.length + 1);
+
+    return { name, version };
   };
 
   const getNIMImageName = (key: string) => {
-    const lastHyphenIndex = key.lastIndexOf('-');
-    if (lastHyphenIndex === -1) {
+    const matchedModelsInfo = modelList.filter((model) => key.startsWith(`${model.name}-`));
+
+    if (matchedModelsInfo.length === 0) {
       return '';
     }
-    const name = key.slice(0, lastHyphenIndex);
-    const version = key.slice(lastHyphenIndex + 1);
-    const imageInfo = modelList.find((model) => model.name === name);
-    return imageInfo ? `nvcr.io/${imageInfo.namespace}/${name}:${version}` : '';
+
+    const modelInfo = matchedModelsInfo.reduce((longest, current) =>
+      current.name.length > longest.name.length ? current : longest,
+    );
+
+    const { name, namespace } = modelInfo;
+    const version = key.slice(name.length + 1);
+    return `nvcr.io/${namespace}/${name}:${version}`;
   };
 
   const onSelect = (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA- https://issues.redhat.com/browse/NVPE-218
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR addresses an issue with selecting models that have versions containing hyphens (e.g., 1.1.0-rtx). The existing logic failed to correctly handle these models, causing errors such as "Model not found" or incorrect image name generation when such models were selected.

This fix ensures that models with hyphenated versions can be selected and processed correctly without errors.

Before-
![image](https://github.com/user-attachments/assets/76d814ce-0192-46d4-94bd-513fe4759d96)

After-
![Screenshot from 2025-03-24 14-00-32](https://github.com/user-attachments/assets/43023111-a32b-4275-93db-08344f75aae1)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Ensure that NIM is correctly enabled in the environment.
2. Attempt to deploy a model with a version containing -rtx (e.g NeMo Retriever PaddleOCR - 1.1.0-rtx).
3. Verify that no errors related to model name resolution or version parsing appear.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested locally.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`