### PR TITLE
removed text input from hardware profile migration modal

### DIFF
--- a/frontend/src/pages/hardwareProfiles/migration/MigrationModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/migration/MigrationModal.tsx
@@ -1,15 +1,5 @@
 import * as React from 'react';
-import {
-  Alert,
-  Button,
-  Flex,
-  FlexItem,
-  List,
-  ListItem,
-  Stack,
-  StackItem,
-  TextInput,
-} from '@patternfly/react-core';
+import { Alert, Button, List, ListItem, Stack, StackItem } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
 import { MigrationAction, MigrationSourceType } from './types';
 import { MIGRATION_SOURCE_TYPE_LABELS } from './const';
@@ -21,7 +11,6 @@ type MigrationModalProps = {
 };
 
 const MigrationModal: React.FC<MigrationModalProps> = ({ onClose, onMigrate, migrationAction }) => {
-  const [value, setValue] = React.useState('');
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>(undefined);
   const migrationNameSanitized = React.useMemo(
@@ -53,7 +42,7 @@ const MigrationModal: React.FC<MigrationModalProps> = ({ onClose, onMigrate, mig
           key="delete-button"
           variant="danger"
           isLoading={loading}
-          isDisabled={loading || value.trim() !== migrationNameSanitized}
+          isDisabled={loading}
           onClick={handleMigrate}
         >
           Migrate
@@ -107,27 +96,6 @@ const MigrationModal: React.FC<MigrationModalProps> = ({ onClose, onMigrate, mig
               </List>
             </StackItem>
           </Stack>
-        </StackItem>
-        <StackItem>
-          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              Type <strong>{migrationNameSanitized}</strong> to confirm legacy profile migration and
-              deletion of the source resource:
-            </FlexItem>
-
-            <TextInput
-              id="migration-modal-input"
-              data-testid="migration-modal-input"
-              aria-label="Migration modal input"
-              value={value}
-              onChange={(_e, newValue) => setValue(newValue)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && value.trim() === migrationNameSanitized) {
-                  onClose();
-                }
-              }}
-            />
-          </Flex>
         </StackItem>
 
         {error && (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-21735

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The text input from the hardware profiles migration modal has been removed.

<img width="1712" alt="Screenshot 2025-03-17 at 10 45 05 AM" src="https://github.com/user-attachments/assets/d77772d5-ae96-4c81-9f51-f49aa96e4586" />
<img width="1712" alt="Screenshot 2025-03-17 at 10 44 51 AM" src="https://github.com/user-attachments/assets/1090f3ad-fa51-49d2-9b69-3c7025697e58" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. create an accelerator profile
2. go to hardware profiles, click on legacy profiles, and migrate it
3. the modal should show the removed input text box

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

n/a, small change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
