### PR TITLE
limit heading level within model card

### DIFF
--- a/frontend/src/components/MarkdownView.tsx
+++ b/frontend/src/components/MarkdownView.tsx
@@ -10,6 +10,7 @@ type MarkdownViewProps = {
   /** Strips some padding out so the content can fit as an inline-block effort */
   conciseDisplay?: boolean;
   component?: 'div' | 'span';
+  maxHeading?: number;
 };
 
 const MarkdownView: React.FC<MarkdownViewProps & React.HTMLAttributes<HTMLDivElement>> = ({
@@ -17,6 +18,7 @@ const MarkdownView: React.FC<MarkdownViewProps & React.HTMLAttributes<HTMLDivEle
   markdown = '',
   conciseDisplay,
   component = 'div',
+  maxHeading,
   ...props
 }) => {
   const Component = component;
@@ -26,7 +28,7 @@ const MarkdownView: React.FC<MarkdownViewProps & React.HTMLAttributes<HTMLDivEle
         'odh-markdown-view--with-padding': !conciseDisplay,
       })}
       {...props}
-      dangerouslySetInnerHTML={{ __html: markdownConverter.makeHtml(markdown) }}
+      dangerouslySetInnerHTML={{ __html: markdownConverter.makeHtml(markdown, maxHeading) }}
     />
   );
 };

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -33,7 +33,9 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({ model }) => (
           <h2>Model card</h2>
           {!model.readme && <p className={text.textColorDisabled}>No model card</p>}
         </Content>
-        {model.readme && <MarkdownView data-testid="model-card-markdown" markdown={model.readme} />}
+        {model.readme && (
+          <MarkdownView data-testid="model-card-markdown" markdown={model.readme} maxHeading={3} />
+        )}
       </SidebarContent>
       <SidebarPanel>
         <DescriptionList isFillColumns>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-21744

## Description
downgrading heading levels in model card markdown so that nothing has a higher level than h3. this prevents the a11y issue of having a heading as high or higher than those above it (h2)
![image](https://github.com/user-attachments/assets/6cf20832-1503-41cc-a19f-8a4f808dd54f)



## How Has This Been Tested?
locally, green cluster

## Test Impact
none, just styling

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change. @yih-wang gave a thumbs up on the visual in slack

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
