### PR TITLE
Remove disableKServeOCIModels in rest of repo

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -35,7 +35,6 @@ export type DashboardConfig = K8sResourceCommon & {
       disableKServeAuth: boolean;
       disableKServeMetrics: boolean;
       disableKServeRaw: boolean;
-      disableKServeOCIModels: boolean;
       disableModelMesh: boolean;
       disableAcceleratorProfiles: boolean;
       disableHardwareProfiles: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -61,7 +61,6 @@ export const blankDashboardCR: DashboardConfig = {
       disableKServeAuth: false,
       disableKServeMetrics: false,
       disableKServeRaw: false,
-      disableKServeOCIModels: true,
       disableModelMesh: false,
       disableAcceleratorProfiles: false,
       disableHardwareProfiles: true,

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -29,7 +29,6 @@ The following are a list of features that are supported, along with there defaul
 | disableKServeAuth            | false   | Disables the ability to use auth in KServe.                                                          |
 | disableKServeMetrics         | false   | Disables the ability to see KServe Metrics.                                                          |
 | disableKServeRaw             | false   | Disables the option to deploy in raw instead of serverless.                                          |
-| disableKServeOCIModels       | true    | Disables the option to deploy models in the OCI format.                                              |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
 | disableHardwareProfiles      | true    | Disables Hardware profiles from the Admin Panel.                                                     |

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -65,8 +65,6 @@ spec:
                       type: boolean
                     disableKServeRaw:
                       type: boolean
-                    disableKServeOCIModels:
-                      type: boolean
                     disableModelMesh:
                       type: boolean
                     disableAcceleratorProfiles:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes https://issues.redhat.com/browse/RHOAIENG-21796

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The `disableKServeOCIModels` is supposed to be removed, it was removed in the frontend code, but not outside of it. This PR deletes the flag in all the rest

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
oc apply the crd yaml and check the custom crd in openshift

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Misc cleanup so no changes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
