### PR TITLE
Fix Cypress Click Issue - Projects Tabs

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
@@ -1,5 +1,5 @@
 import type { DataScienceProjectData, DashboardConfig } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
@@ -62,7 +62,7 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
 
   it(
     'Create, Edit and Delete a Persistent Volume Storage',
-    { tags: ['@Sanity', '@SanitySet1', '@ODS-1824', '@Dashboard'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1824', '@Dashboard', '@Andrew'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -78,9 +78,7 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
 
       //Navigate to Cluster Storage and click to Add Storage
       cy.step('Navigate to Cluster Storage and click to create Cluster Storage');
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('cluster-storages').click();
-      cy.visit(`projects/${projectName}?section=cluster-storages`);
+      projectDetails.findSectionTab('cluster-storages').click();
       clusterStorage.findCreateButton().click();
 
       // Enter validate Cluster Storage details into the Cluster Storage Modal

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
@@ -62,7 +62,7 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
 
   it(
     'Create, Edit and Delete a Persistent Volume Storage',
-    { tags: ['@Sanity', '@SanitySet1', '@ODS-1824', '@Dashboard', '@Andrew'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1824', '@Dashboard'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/connections/testConnectionCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/connections/testConnectionCreation.cy.ts
@@ -1,5 +1,5 @@
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import type { DataScienceProjectData, AWSS3BucketDetails } from '~/__tests__/cypress/cypress/types';
 import { connectionsPage, addConnectionModal } from '~/__tests__/cypress/cypress/pages/connections';
@@ -76,9 +76,7 @@ describe('Verify Connections - Creation and Deletion', () => {
 
       //Navigate to Connections and create Connection
       cy.step('Navigate to Connections and click to create Connection');
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('connections').click();
-      cy.visit(`projects/${projectName}?section=connections`);
+      projectDetails.findSectionTab('connections').click();
       connectionsPage.findCreateConnectionButton().click();
 
       // Enter validate Connection details into the Connection Modal

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -2,7 +2,7 @@ import type { DataScienceProjectData } from '~/__tests__/cypress/cypress/types';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   modelServingGlobal,
   inferenceServiceModal,
@@ -74,6 +74,7 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Multi Model Creation and Va
         '@Dashboard',
         '@Modelserving',
         '@Bug',
+        '@Andrew',
       ],
     },
     () => {
@@ -92,9 +93,7 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Multi Model Creation and Va
 
       // Navigate to Model Serving tab and Deploy a Multi Model
       cy.step('Navigate to Model Serving and click to Deploy a Model Server');
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('model-server').click();
-      cy.visit(`projects/${projectName}?section=model-server`);
+      projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.findMultiModelButton().click();
       modelServingSection.findAddModelServerButton().click();
       createServingRuntimeModal.findModelServerName().type(testData.multiModelAdminName);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -74,7 +74,6 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Multi Model Creation and Va
         '@Dashboard',
         '@Modelserving',
         '@Bug',
-        '@Andrew',
       ],
     },
     () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -2,7 +2,7 @@ import type { DataScienceProjectData } from '~/__tests__/cypress/cypress/types';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   modelServingGlobal,
   inferenceServiceModal,
@@ -64,7 +64,9 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Single Model Creation and V
 
   it(
     'Verify that an Admin can Serve, Query a Single Model using both the UI and External links',
-    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2626', '@Dashboard', '@Modelserving', '@Bug'] },
+    {
+      tags: ['@Smoke', '@SmokeSet3', '@ODS-2626', '@Dashboard', '@Modelserving', '@Bug', '@Andrew'],
+    },
     () => {
       cy.log('Model Name:', modelName);
       // Authentication and navigation
@@ -81,9 +83,7 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Single Model Creation and V
 
       // Navigate to Model Serving tab and Deploy a Single Model
       cy.step('Navigate to Model Serving and click to Deploy a Single Model');
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('model-server').click();
-      cy.visit(`projects/${projectName}?section=model-server`);
+      projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.findSingleServingModelButton().click();
       modelServingGlobal.findDeployModelButton().click();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -65,7 +65,7 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Single Model Creation and V
   it(
     'Verify that an Admin can Serve, Query a Single Model using both the UI and External links',
     {
-      tags: ['@Smoke', '@SmokeSet3', '@ODS-2626', '@Dashboard', '@Modelserving', '@Bug', '@Andrew'],
+      tags: ['@Smoke', '@SmokeSet3', '@ODS-2626', '@Dashboard', '@Modelserving', '@Bug'],
     },
     () => {
       cy.log('Model Name:', modelName);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -5,7 +5,7 @@ import {
 } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { LDAP_CONTRIBUTOR_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   modelServingGlobal,
   inferenceServiceModal,
@@ -69,7 +69,7 @@ describe('Verify Model Creation and Validation using the UI', () => {
 
   it(
     'Verify that a Non Admin can Serve and Query a Model using the UI',
-    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2552', '@Dashboard', '@Modelserving'] },
+    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2552', '@Dashboard', '@Modelserving', '@Andrew'] },
     () => {
       cy.log('Model Name:', modelName);
       // Authentication and navigation
@@ -86,9 +86,7 @@ describe('Verify Model Creation and Validation using the UI', () => {
 
       // Navigate to Model Serving tab and Deploy a Single Model
       cy.step('Navigate to Model Serving and click to Deploy a Single Model');
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('model-server').click();
-      cy.visit(`projects/${projectName}?section=model-server`);
+      projectDetails.findSectionTab('model-server').click();
       modelServingGlobal.findSingleServingModelButton().click();
       modelServingGlobal.findDeployModelButton().click();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -69,7 +69,7 @@ describe('Verify Model Creation and Validation using the UI', () => {
 
   it(
     'Verify that a Non Admin can Serve and Query a Model using the UI',
-    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2552', '@Dashboard', '@Modelserving', '@Andrew'] },
+    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2552', '@Dashboard', '@Modelserving'] },
     () => {
       cy.log('Model Name:', modelName);
       // Authentication and navigation

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectAdminPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectAdminPermissions.cy.ts
@@ -48,15 +48,7 @@ describe('Verify that users can provide admin project permissions to non-admin u
   it(
     'Verify that user can be added as an Admin for a Project',
     {
-      tags: [
-        '@Smoke',
-        '@SmokeSet1',
-        '@ODS-2194',
-        '@ODS-2201',
-        '@ODS-2208',
-        '@Dashboard',
-        '@Andrew',
-      ],
+      tags: ['@Smoke', '@SmokeSet1', '@ODS-2194', '@ODS-2201', '@ODS-2208', '@Dashboard'],
     },
     () => {
       // Authentication and navigation
@@ -92,15 +84,7 @@ describe('Verify that users can provide admin project permissions to non-admin u
   it(
     'Verify user can assign access permissions to user group',
     {
-      tags: [
-        '@Smoke',
-        '@SmokeSet1',
-        '@ODS-2194',
-        '@ODS-2201',
-        '@ODS-2208',
-        '@Dashboard',
-        '@Andrew',
-      ],
+      tags: ['@Smoke', '@SmokeSet1', '@ODS-2194', '@ODS-2201', '@ODS-2208', '@Dashboard'],
     },
     () => {
       // Authentication and navigation
@@ -130,15 +114,7 @@ describe('Verify that users can provide admin project permissions to non-admin u
   it(
     'Verify that user can access the created project with Admin rights',
     {
-      tags: [
-        '@Smoke',
-        '@SmokeSet1',
-        '@ODS-2194',
-        '@ODS-2201',
-        '@ODS-2208',
-        '@Dashboard',
-        '@Andrew',
-      ],
+      tags: ['@Smoke', '@SmokeSet1', '@ODS-2194', '@ODS-2201', '@ODS-2208', '@Dashboard'],
     },
     () => {
       // Authentication and navigation

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectAdminPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectAdminPermissions.cy.ts
@@ -1,5 +1,5 @@
 import type { DataScienceProjectData } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { permissions } from '~/__tests__/cypress/cypress/pages/permissions';
 import {
   HTPASSWD_CLUSTER_ADMIN_USER,
@@ -48,7 +48,15 @@ describe('Verify that users can provide admin project permissions to non-admin u
   it(
     'Verify that user can be added as an Admin for a Project',
     {
-      tags: ['@Smoke', '@SmokeSet1', '@ODS-2194', '@ODS-2201', '@ODS-2208', '@Dashboard'],
+      tags: [
+        '@Smoke',
+        '@SmokeSet1',
+        '@ODS-2194',
+        '@ODS-2201',
+        '@ODS-2208',
+        '@Dashboard',
+        '@Andrew',
+      ],
     },
     () => {
       // Authentication and navigation
@@ -62,9 +70,7 @@ describe('Verify that users can provide admin project permissions to non-admin u
       projectListPage.navigate();
       projectListPage.filterProjectByName(testData.projectPermissionResourceName);
       projectListPage.findProjectLink(testData.projectPermissionResourceName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('permissions').click();
-      cy.visit(`projects/${projectName}?section=permissions`);
+      projectDetails.findSectionTab('permissions').click();
 
       cy.step('Assign admin user Project Permissions');
       permissions.findAddUserButton().click();
@@ -86,7 +92,15 @@ describe('Verify that users can provide admin project permissions to non-admin u
   it(
     'Verify user can assign access permissions to user group',
     {
-      tags: ['@Smoke', '@SmokeSet1', '@ODS-2194', '@ODS-2201', '@ODS-2208', '@Dashboard'],
+      tags: [
+        '@Smoke',
+        '@SmokeSet1',
+        '@ODS-2194',
+        '@ODS-2201',
+        '@ODS-2208',
+        '@Dashboard',
+        '@Andrew',
+      ],
     },
     () => {
       // Authentication and navigation
@@ -100,9 +114,7 @@ describe('Verify that users can provide admin project permissions to non-admin u
       projectListPage.navigate();
       projectListPage.filterProjectByName(testData.projectPermissionResourceName);
       projectListPage.findProjectLink(testData.projectPermissionResourceName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('permissions').click();
-      cy.visit(`projects/${projectName}?section=permissions`);
+      projectDetails.findSectionTab('permissions').click();
 
       cy.step('Assign admin group Project Permissions');
       permissions.findAddGroupButton().click();
@@ -118,7 +130,15 @@ describe('Verify that users can provide admin project permissions to non-admin u
   it(
     'Verify that user can access the created project with Admin rights',
     {
-      tags: ['@Smoke', '@SmokeSet1', '@ODS-2194', '@ODS-2201', '@ODS-2208', '@Dashboard'],
+      tags: [
+        '@Smoke',
+        '@SmokeSet1',
+        '@ODS-2194',
+        '@ODS-2201',
+        '@ODS-2208',
+        '@Dashboard',
+        '@Andrew',
+      ],
     },
     () => {
       // Authentication and navigation
@@ -130,9 +150,7 @@ describe('Verify that users can provide admin project permissions to non-admin u
       projectListPage.navigate();
       projectListPage.filterProjectByName(testData.projectPermissionResourceName);
       projectListPage.findProjectLink(testData.projectPermissionResourceName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('permissions').click();
-      cy.visit(`projects/${projectName}?section=permissions`);
+      projectDetails.findSectionTab('permissions').click();
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectContributorPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectContributorPermissions.cy.ts
@@ -46,7 +46,7 @@ describe('Verify that users can provide contributor project permissions to non-a
 
   it(
     'Verify that user can be added as a Contributor for a Project',
-    { tags: ['@Smoke', '@SmokeSet2', '@ODS-2194', '@ODS-2201', '@Dashboard', '@Andrew'] },
+    { tags: ['@Smoke', '@SmokeSet2', '@ODS-2194', '@ODS-2201', '@Dashboard'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectContributorPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectContributorPermissions.cy.ts
@@ -46,7 +46,7 @@ describe('Verify that users can provide contributor project permissions to non-a
 
   it(
     'Verify that user can be added as a Contributor for a Project',
-    { tags: ['@Smoke', '@SmokeSet2', '@ODS-2194', '@ODS-2201', '@Dashboard'] },
+    { tags: ['@Smoke', '@SmokeSet2', '@ODS-2194', '@ODS-2201', '@Dashboard', '@Andrew'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -59,9 +59,7 @@ describe('Verify that users can provide contributor project permissions to non-a
       projectListPage.navigate();
       projectListPage.filterProjectByName(testData.projectContributorResourceName);
       projectListPage.findProjectLink(testData.projectContributorResourceName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('permissions').click();
-      cy.visit(`projects/${projectName}?section=permissions`);
+      projectDetails.findSectionTab('permissions').click();
 
       cy.step('Assign contributor user Project Permissions');
       permissions.findAddUserButton().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
@@ -1,5 +1,5 @@
 import type { WBControlSuiteTestData } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   workbenchPage,
   createSpawnerPage,
@@ -61,6 +61,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
         '@ODS-1975',
         '@Dashboard',
         '@Workbenches',
+        '@Andrew',
       ],
     },
     () => {
@@ -75,9 +76,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(controlSuiteTestNamespace);
       projectListPage.findProjectLink(controlSuiteTestNamespace).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${controlSuiteTestNamespace}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench
       cy.step(`Create workbench ${controlSuiteTestNamespace}`);
@@ -127,6 +126,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
         '@ODS-1975',
         '@Dashboard',
         '@Workbenches',
+        '@Andrew',
       ],
     },
     () => {
@@ -140,9 +140,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(controlSuiteTestNamespace);
       projectListPage.findProjectLink(controlSuiteTestNamespace).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${controlSuiteTestNamespace}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench
       cy.step(`Create workbench ${controlSuiteTestNamespace}`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
@@ -61,7 +61,6 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
         '@ODS-1975',
         '@Dashboard',
         '@Workbenches',
-        '@Andrew',
       ],
     },
     () => {
@@ -126,7 +125,6 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
         '@ODS-1975',
         '@Dashboard',
         '@Workbenches',
-        '@Andrew',
       ],
     },
     () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchEditing.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchEditing.cy.ts
@@ -1,5 +1,5 @@
 import type { WBEditTestData } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   workbenchPage,
   createSpawnerPage,
@@ -53,7 +53,7 @@ describe('Edit and Update a Workbench in RHOAI', () => {
 
   it(
     'Editing Workbench Name and Description',
-    { tags: ['@Sanity', '@SanitySet1', '@ODS-1931', '@Dashboard', '@Workbenches'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1931', '@Dashboard', '@Workbenches', '@Andrew'] },
     () => {
       const workbenchName = editTestNamespace.replace('dsp-', '');
 
@@ -66,9 +66,7 @@ describe('Edit and Update a Workbench in RHOAI', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(editTestNamespace);
       projectListPage.findProjectLink(editTestNamespace).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${editTestNamespace}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench
       cy.step(`Create workbench ${editTestNamespace} using storage ${pvcEditDisplayName}`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchEditing.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchEditing.cy.ts
@@ -53,7 +53,7 @@ describe('Edit and Update a Workbench in RHOAI', () => {
 
   it(
     'Editing Workbench Name and Description',
-    { tags: ['@Sanity', '@SanitySet1', '@ODS-1931', '@Dashboard', '@Workbenches', '@Andrew'] },
+    { tags: ['@Sanity', '@SanitySet1', '@ODS-1931', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = editTestNamespace.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
@@ -50,7 +50,7 @@ describe('Workbenches - negative tests', () => {
 
   it(
     'Verify UI informs users about workbenches failed to start',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches', '@Andrew'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 
@@ -85,7 +85,7 @@ describe('Workbenches - negative tests', () => {
   );
   it(
     'Verify User cannot create a workbench using special characters or long names in the Resource name field',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches', '@Andrew'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
@@ -14,7 +14,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Automation Bug RHOAIENG-21039] Workbenches - negative tests', () => {
+describe('Workbenches - negative tests', () => {
   let testData: WBNegativeTestsData;
   let projectName: string;
 
@@ -50,7 +50,7 @@ describe('[Automation Bug RHOAIENG-21039] Workbenches - negative tests', () => {
 
   it(
     'Verify UI informs users about workbenches failed to start',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches', '@Andrew'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 
@@ -85,7 +85,7 @@ describe('[Automation Bug RHOAIENG-21039] Workbenches - negative tests', () => {
   );
   it(
     'Verify User cannot create a workbench using special characters or long names in the Resource name field',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1973', '@Dashboard', '@Workbenches', '@Andrew'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
@@ -49,7 +49,7 @@ describe('Workbenches - status tests', () => {
 
   it(
     'Verify user can access progress and event log - validate status and successful workbench creation',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1970', '@Dashboard', '@Workbenches', '@Andrew'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1970', '@Dashboard', '@Workbenches'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
@@ -1,5 +1,5 @@
 import type { WBStatusTestData } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   workbenchPage,
   createSpawnerPage,
@@ -49,7 +49,7 @@ describe('Workbenches - status tests', () => {
 
   it(
     'Verify user can access progress and event log - validate status and successful workbench creation',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1970', '@Dashboard', '@Workbenches'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1970', '@Dashboard', '@Workbenches', '@Andrew'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 
@@ -62,9 +62,7 @@ describe('Workbenches - status tests', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench
       cy.step(`Create workbench ${workbenchName}`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -47,15 +47,7 @@ describe('Workbenches - variable tests', () => {
   it(
     'Verify user can set environment variables in their workbenches by uploading a yaml Secret and Config Map file.',
     {
-      tags: [
-        '@Sanity',
-        '@SanitySet2',
-        '@ODS-1883',
-        '@ODS-1864',
-        '@Dashboard',
-        '@Workbenches',
-        '@Andrew',
-      ],
+      tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'],
     },
     () => {
       const workbenchName = projectName;
@@ -133,15 +125,7 @@ describe('Workbenches - variable tests', () => {
   it(
     'Verify that the user can inject environment variables manually into a workbench using Key / Value',
     {
-      tags: [
-        '@Sanity',
-        '@SanitySet2',
-        '@ODS-1883',
-        '@ODS-1864',
-        '@Dashboard',
-        '@Workbenches',
-        '@Andrew',
-      ],
+      tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'],
     },
     () => {
       const workbenchName = projectName;

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -1,5 +1,5 @@
 import type { WBVariablesTestData } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { workbenchPage, createSpawnerPage } from '~/__tests__/cypress/cypress/pages/workbench';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import { loadWBVariablesFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
@@ -46,7 +46,17 @@ describe('Workbenches - variable tests', () => {
   });
   it(
     'Verify user can set environment variables in their workbenches by uploading a yaml Secret and Config Map file.',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'] },
+    {
+      tags: [
+        '@Sanity',
+        '@SanitySet2',
+        '@ODS-1883',
+        '@ODS-1864',
+        '@Dashboard',
+        '@Workbenches',
+        '@Andrew',
+      ],
+    },
     () => {
       const workbenchName = projectName;
       const workbenchName2 = projectName.replace('dsp-', 'secondwb-');
@@ -59,9 +69,7 @@ describe('Workbenches - variable tests', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench with Secret variables by uploading a yaml file
       cy.step(`Create workbench ${workbenchName} using secret variables`);
@@ -124,7 +132,17 @@ describe('Workbenches - variable tests', () => {
   );
   it(
     'Verify that the user can inject environment variables manually into a workbench using Key / Value',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'] },
+    {
+      tags: [
+        '@Sanity',
+        '@SanitySet2',
+        '@ODS-1883',
+        '@ODS-1864',
+        '@Dashboard',
+        '@Workbenches',
+        '@Andrew',
+      ],
+    },
     () => {
       const workbenchName = projectName;
       const workbenchName2 = projectName.replace('dsp-', 'secondwb-');
@@ -137,9 +155,7 @@ describe('Workbenches - variable tests', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench with Secret variables via Key / Value
       cy.step(`Create workbench ${workbenchName} using secret variables`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
@@ -64,7 +64,7 @@ describe('Workbench and PVSs tests', () => {
 
   it(
     'Verify users can create a workbench and connect an existent PersistentVolume',
-    { tags: ['@Smoke', '@SmokeSet1', '@ODS-1814', '@Dashboard', '@Andrew'] },
+    { tags: ['@Smoke', '@SmokeSet1', '@ODS-1814', '@Dashboard'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
@@ -1,5 +1,5 @@
 import type { PVCReplacements } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   workbenchPage,
   createSpawnerPage,
@@ -64,7 +64,7 @@ describe('Workbench and PVSs tests', () => {
 
   it(
     'Verify users can create a workbench and connect an existent PersistentVolume',
-    { tags: ['@Smoke', '@SmokeSet1', '@ODS-1814', '@Dashboard'] },
+    { tags: ['@Smoke', '@SmokeSet1', '@ODS-1814', '@Dashboard', '@Andrew'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
 
@@ -76,9 +76,7 @@ describe('Workbench and PVSs tests', () => {
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       cy.step(`Create Workbench ${projectName} using storage ${PVCDisplayName}`);
       workbenchPage.findCreateButton().click();
@@ -98,9 +96,7 @@ describe('Workbench and PVSs tests', () => {
       notebookRow.shouldHaveContainerSize('Small');
 
       cy.step(`Check the cluster storage ${PVCDisplayName} is now connected to ${workbenchName}`);
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('cluster-storages').click();
-      cy.visit(`projects/${projectName}?section=cluster-storages`);
+      projectDetails.findSectionTab('cluster-storages').click();
       const csRow = clusterStorage.getClusterStorageRow(PVCDisplayName);
       csRow.findConnectedWorkbenches().should('have.text', workbenchName);
     },

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
@@ -71,7 +71,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
   it(
     'Validate pod tolerations are applied to a Workbench',
     // TODO: This test will be reworked this Sprint as part of RHOAIENG-20099
-    { tags: ['@Featureflagged', '@HardwareProfiles', '@Andrew'] },
+    { tags: ['@Featureflagged', '@HardwareProfiles'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -132,7 +132,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
   it(
     'Validate pod tolerations for a stopped workbench',
     // TODO: This test will be reworked this Sprint as part of RHOAIENG-20099
-    { tags: ['@Featureflagged', '@HardwareProfiles', '@Andrew'] },
+    { tags: ['@Featureflagged', '@HardwareProfiles'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -203,7 +203,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
 
   it(
     'Verifies that a new toleration is added to a new workbench but not to an already running workbench',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1969', '@ODS-2057', '@Dashboard', '@Bug', '@Andrew'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1969', '@ODS-2057', '@Dashboard', '@Bug'] },
     () => {
       // Set Pod Tolerations
       cy.step('Navigate to Cluster Settings, save and set pod tolerations');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
@@ -1,5 +1,5 @@
 import type { WBTolerationsTestData } from '~/__tests__/cypress/cypress/types';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import {
   workbenchPage,
   createSpawnerPage,
@@ -71,7 +71,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
   it(
     'Validate pod tolerations are applied to a Workbench',
     // TODO: This test will be reworked this Sprint as part of RHOAIENG-20099
-    { tags: ['@Featureflagged', '@HardwareProfiles'] },
+    { tags: ['@Featureflagged', '@HardwareProfiles', '@Andrew'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -97,9 +97,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create workbench and verify it starts running
       cy.step(`Create workbench ${testData.workbenchName}`);
@@ -134,7 +132,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
   it(
     'Validate pod tolerations for a stopped workbench',
     // TODO: This test will be reworked this Sprint as part of RHOAIENG-20099
-    { tags: ['@Featureflagged', '@HardwareProfiles'] },
+    { tags: ['@Featureflagged', '@HardwareProfiles', '@Andrew'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');
@@ -145,9 +143,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Stop workbench and verify it stops running
       cy.step(`Stop workbench ${testData.workbenchName}`);
@@ -186,9 +182,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Stop workbench and verify it stops running
       cy.step(`Restart workbench ${testData.workbenchName} and validate it has been started`);
@@ -209,7 +203,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
 
   it(
     'Verifies that a new toleration is added to a new workbench but not to an already running workbench',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1969', '@ODS-2057', '@Dashboard', '@Bug'] },
+    { tags: ['@Sanity', '@SanitySet2', '@ODS-1969', '@ODS-2057', '@Dashboard', '@Bug', '@Andrew'] },
     () => {
       // Set Pod Tolerations
       cy.step('Navigate to Cluster Settings, save and set pod tolerations');
@@ -225,9 +219,7 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('workbenches').click();
-      cy.visit(`projects/${projectName}?section=workbenches`);
+      projectDetails.findSectionTab('workbenches').click();
 
       // Create a second workbench with Config Map variables by uploading a yaml file
       cy.step(`Create a second workbench ${testData.workbenchName2} using config map variables`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -4,7 +4,7 @@ import {
   tearDownClusterStorageSCFeature,
 } from '~/__tests__/cypress/cypress/utils/storageClass';
 import { addClusterStorageModal } from '~/__tests__/cypress/cypress/pages/clusterStorage';
-import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { findAddClusterStorageButton } from '~/__tests__/cypress/cypress/utils/clusterStorage';
 import { disableNonDefaultStorageClasses } from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
 import {
@@ -30,7 +30,7 @@ describe('Regular Users can make use of the Storage Classes in the Cluster Stora
 
   it(
     'If all SC are disabled except one, the SC dropdown should be disabled',
-    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard'] },
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@Andrew'] },
     () => {
       // Authentication and navigation
       cy.visitWithLogin('/projects', LDAP_CONTRIBUTOR_USER);
@@ -40,9 +40,7 @@ describe('Regular Users can make use of the Storage Classes in the Cluster Stora
       projectListPage.findProjectLink(dspName).click();
       cy.step('Navigate to the Cluster Storage tab and disable all non-default storage classes');
       // Go to cluster storage tab
-      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
-      // Reapply projectDetails.findSectionTab('cluster-storages').click();
-      cy.visit(`projects/${dspName}?section=cluster-storages`);
+      projectDetails.findSectionTab('cluster-storages').click();
       // Disable all non-default storage classes
       disableNonDefaultStorageClasses().then(() => {
         // Open the Create cluster storage Modal

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -30,7 +30,7 @@ describe('Regular Users can make use of the Storage Classes in the Cluster Stora
 
   it(
     'If all SC are disabled except one, the SC dropdown should be disabled',
-    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@Andrew'] },
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard'] },
     () => {
       // Authentication and navigation
       cy.visitWithLogin('/projects', LDAP_CONTRIBUTOR_USER);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -375,7 +375,7 @@ describe('Pipeline topology', () => {
 
         pipelineRecurringRunDetails.findDetailsTab().click();
         pipelineRecurringRunDetails.findDetailItem('Project').findValue().find('a').click();
-        verifyRelativeURL(`/projects/${projectId}?section=overview`);
+        verifyRelativeURL(`/projects/${projectId}`);
       });
 
       it('Test pipeline recurring run details pipeline version navigation', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
@@ -442,6 +442,7 @@ describe('Project Details', () => {
       projectDetails.getKserveModelMetricLink('Test Inference Service').click();
       cy.findByTestId('app-page-title').should('have.text', 'Test Inference Service metrics');
     });
+
     it('Multi model serving platform is enabled', () => {
       initIntercepts({ templates: true, disableKServeConfig: true, disableModelConfig: false });
       projectDetails.visit('test-project');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -905,7 +905,7 @@ describe('Workbench page', () => {
     notFoundSpawnerPage.shouldHaveErrorMessageTitle('Unable to edit workbench');
     notFoundSpawnerPage.findReturnToPage().should('be.enabled');
     notFoundSpawnerPage.findReturnToPage().click();
-    verifyRelativeURL('/projects/test-project?section=overview');
+    verifyRelativeURL('/projects/test-project');
   });
 
   it('Expanded workbench table row', () => {

--- a/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
+++ b/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
@@ -1,27 +1,30 @@
 import * as React from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { Tabs, Tab, TabTitleIcon, TabTitleText, PageSection } from '@patternfly/react-core';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
-type GenericHorizontalBarProps = {
-  activeKey: string | null;
-  sections: {
-    title: string;
-    component: React.ReactNode;
-    icon?: React.ReactElement<React.ComponentClass<SVGIconProps>>;
-    id: string;
-  }[];
+export type SectionDefinition = {
+  title: string;
+  component: React.ReactNode;
+  icon?: React.ReactElement<React.ComponentClass<SVGIconProps>>;
+  id: string;
 };
 
-const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({ activeKey, sections }) => {
-  const [queryParams, setQueryParams] = useSearchParams();
+type GenericHorizontalBarProps = {
+  activeKey: string | null;
+  sections: [SectionDefinition, ...SectionDefinition[]];
+  onSectionChange: (sectionId: SectionDefinition['id'], replace?: boolean) => void;
+};
 
+const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({
+  activeKey,
+  sections,
+  onSectionChange,
+}) => {
   React.useEffect(() => {
-    if (!sections.find((s) => s.id === activeKey) && sections[0].id) {
-      queryParams.set('section', sections[0].id);
-      setQueryParams(queryParams, { replace: true });
+    if (activeKey && !sections.find((s) => s.id === activeKey)) {
+      onSectionChange(sections[0].id, true);
     }
-  }, [sections, activeKey, queryParams, setQueryParams]);
+  }, [sections, activeKey, onSectionChange]);
 
   const activeSection = sections.find((section) => section.id === activeKey) || sections[0];
 
@@ -35,10 +38,9 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({ activeKey, 
         aria-label="horizontal-bar-tab-section"
       >
         <Tabs
-          activeKey={activeKey || sections[0].id}
+          activeKey={activeSection.id}
           onSelect={(event, tabIndex) => {
-            queryParams.set('section', `${tabIndex}`);
-            setQueryParams(queryParams);
+            onSectionChange(`${tabIndex}`);
           }}
           aria-label="Horizontal bar"
           style={{ paddingInlineStart: 'var(--pf-t--global--spacer--lg' }}

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -40,8 +40,8 @@ const ProjectDetails: React.FC = () => {
   const projectSharingEnabled = useIsAreaAvailable(SupportedArea.DS_PROJECTS_PERMISSIONS).status;
   const pipelinesEnabled = useIsAreaAvailable(SupportedArea.DS_PIPELINES).status;
   const modelServingEnabled = useModelServingEnabled();
-  const [queryParams, setSearchParams] = useSearchParams();
-  const state = queryParams.get('section');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const state = searchParams.get('section');
   const [allowCreate, rbacLoaded] = useAccessReview({
     ...accessReviewResource,
     namespace: currentProject.metadata.name,
@@ -79,11 +79,11 @@ const ProjectDetails: React.FC = () => {
         activeKey={state}
         onSectionChange={React.useCallback(
           (sectionId, replace) => {
-            const newSearchParams = new URLSearchParams(queryParams);
+            const newSearchParams = new URLSearchParams(searchParams);
             newSearchParams.set('section', sectionId);
             setSearchParams(newSearchParams, replace ? { replace } : undefined);
           },
-          [queryParams, setSearchParams],
+          [searchParams, setSearchParams],
         )}
         sections={React.useMemo(
           () => [

--- a/frontend/src/utilities/useQueryParams.tsx
+++ b/frontend/src/utilities/useQueryParams.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
+/** @deprecated - just use useSearchParams */
 export const useQueryParams = (): URLSearchParams => {
   const { search } = useLocation();
   return React.useMemo(() => new URLSearchParams(search), [search]);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-21039

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Interesting Cypress bug that was based on a product issue that didn't show up as a product bug.

Basically the useEffect in the Horizontal Bar had dual state (one internal and one from the caller). This left the hook triggering twice. Unifying the state and using memoizing aspects it helps it now not trigger the update when the data is not properly set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the Jenkins run job... not possible to see this dev locally or running e2e locally. Tried mocking it but it was heavily inconsistent so I omitted those tests.

https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/cypress/job/dashboard-tests/926/

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Return the old state -- working to satisfy undoing the workaround.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
