### PR TITLE
Update hardware profile resource formatting to use proper display units

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -197,7 +197,9 @@ describe('NotebookServer', () => {
       .should('not.satisfy', (arr: string[]) => arr.some((item) => item.includes('Test GPU')));
     notebookServer
       .findHardwareProfileSelect()
-      .findSelectOption('Large CPU: Request = 7; Limit = 7; Memory: Request = 56Gi; Limit = 56Gi')
+      .findSelectOption(
+        'Large CPU: Request = 7 Cores; Limit = 7 Cores; Memory: Request = 56 GiB; Limit = 56 GiB',
+      )
       .click();
     notebookServer.findHardwareProfileSelect().should('contain', 'Large');
     notebookServer.findStartServerButton().should('be.visible');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -167,10 +167,10 @@ describe('Workbench Hardware Profiles', () => {
 
     // Verify available profiles
     hardwareProfileSection.selectProfile(
-      'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
+      'Small Profile CPU: Request = 1 Cores; Limit = 1 Cores; Memory: Request = 2 GiB; Limit = 2 GiB',
     );
     hardwareProfileSection.selectProfile(
-      'Large Profile CPU: Request = 4; Limit = 4; Memory: Request = 8Gi; Limit = 8Gi',
+      'Large Profile CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
     );
   });
 
@@ -184,7 +184,7 @@ describe('Workbench Hardware Profiles', () => {
 
     // Select profile and open customization
     hardwareProfileSection.selectProfile(
-      'Large Profile CPU: Request = 4; Limit = 4; Memory: Request = 8Gi; Limit = 8Gi',
+      'Large Profile CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
     );
     hardwareProfileSection.findCustomizeButton().click();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/modelCustomizationForm.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/modelCustomizationForm.cy.ts
@@ -111,7 +111,7 @@ describe('Model Customization Form', () => {
     taxonomySection.findTaxonomyUsername().fill('test');
     taxonomySection.findTaxonomyToken().fill('test');
     hardwareSection.selectProfile(
-      'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi; Nvidia.com/gpu: Request = 2; Limit = 2',
+      'Small Profile CPU: Request = 1 Cores; Limit = 1 Cores; Memory: Request = 2 GiB; Limit = 2 GiB; Nvidia.com/gpu: Request = 2; Limit = 2',
     );
     hardwareSection.findTrainingNodePlusButton().click();
 

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -128,6 +128,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                         identifier.displayName,
                         identifier.defaultCount.toString(),
                         identifier.defaultCount.toString(),
+                        identifier.resourceType,
                       ),
                     )
                     .join('; ')}

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -36,8 +36,16 @@ export const formatToleration = (toleration: Toleration): string => {
 export const formatNodeSelector = (selector: NodeSelector): string[] =>
   Object.entries(selector).map(([key, value]) => `Key = ${key}; Value = ${value}`);
 
-export const formatResource = (identifier: string, request: string, limit: string): string =>
-  `${identifier}: Request = ${request}; Limit = ${limit}`;
+export const formatResource = (
+  identifier: string,
+  request: string,
+  limit: string,
+  resourceType?: IdentifierResourceType,
+): string =>
+  `${identifier}: Request = ${formatResourceValue(
+    request,
+    resourceType,
+  )}; Limit = ${formatResourceValue(limit, resourceType)}`;
 
 export const useProfileIdentifiers = (
   acceleratorProfile?: AcceleratorProfileKind,


### PR DESCRIPTION
[RHOAIENG-21739](https://issues.redhat.com/browse/RHOAIENG-21739)

## Description
Updated the function `formatResource` to include resource values. 

![Screenshot 2025-03-18 at 1 15 55 PM](https://github.com/user-attachments/assets/7b476824-2fb1-4609-bc63-64c5cd0113a9)

![Screenshot 2025-03-18 at 1 16 00 PM](https://github.com/user-attachments/assets/285a4e5a-acc8-47ba-a94a-cda668707a5d)


## How Has This Been Tested?
Check Hardware profile selector on Spawner page

## Test Impact
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
