### PR TITLE
Cypress e2e - Model Serving Test Resiliency fix and update Quarantined tests

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/connections.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/connections.ts
@@ -34,7 +34,7 @@ class ConnectionsPage {
 }
 class ConnectionModal extends Modal {
   constructor(edit = false) {
-    super(`${edit ? 'Edit' : 'Add'} connection`);
+    super(`${edit ? 'Edit' : 'Create'} connection`);
   }
 
   findConnectionTypeDropdown() {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -19,63 +19,59 @@ const testPipelineName = 'test-pipelines-pipeline';
 const testRunName = 'test-pipelines-run';
 const awsBucket = 'BUCKET_3' as const;
 
-describe(
-  '[Product Bug: RHOAIENG-20642] An admin user can import and run a pipeline',
-  { testIsolation: false },
-  () => {
-    retryableBefore(() => {
-      // Create a Project for pipelines
-      provisionProjectForPipelines(projectName, dspaSecretName, awsBucket);
-    });
+describe('An admin user can import and run a pipeline', { testIsolation: false }, () => {
+  retryableBefore(() => {
+    // Create a Project for pipelines
+    provisionProjectForPipelines(projectName, dspaSecretName, awsBucket);
+  });
 
-    after(() => {
-      //Check if the Before Method was executed to perform the setup
-      if (!wasSetupPerformed()) return;
+  after(() => {
+    //Check if the Before Method was executed to perform the setup
+    if (!wasSetupPerformed()) return;
 
-      // Delete provisioned Project
-      deleteOpenShiftProject(projectName);
-    });
+    // Delete provisioned Project
+    deleteOpenShiftProject(projectName);
+  });
 
-    it(
-      'An admin User can Import and Run a Pipeline',
-      { tags: ['@Smoke', '@SmokeSet1', '@Dashboard', ' @Pipelines', '@Bug'] },
-      () => {
-        cy.step('Navigate to DSP ${projectName}');
-        cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
-        projectListPage.navigate();
-        projectListPage.filterProjectByName(projectName);
-        projectListPage.findProjectLink(projectName).click();
+  it(
+    'An admin User can Import and Run a Pipeline',
+    { tags: ['@Smoke', '@SmokeSet1', '@Dashboard', '@Pipelines'] },
+    () => {
+      cy.step('Navigate to DSP ${projectName}');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
 
-        cy.step('Import a pipeline by URL');
-        // Increasing the timeout to ~3mins so the DSPA can be loaded
-        projectDetails.findImportPipelineButton(180000).click();
-        // Fill the Import Pipeline modal
-        pipelineImportModal.findPipelineNameInput().type(testPipelineName);
-        pipelineImportModal.findPipelineDescriptionInput().type('Pipeline Description');
-        pipelineImportModal.findImportPipelineRadio().click();
-        pipelineImportModal
-          .findPipelineUrlInput()
-          .type(
-            'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
-          );
-        pipelineImportModal.submit();
+      cy.step('Import a pipeline by URL');
+      // Increasing the timeout to ~3mins so the DSPA can be loaded
+      projectDetails.findImportPipelineButton(180000).click();
+      // Fill the Import Pipeline modal
+      pipelineImportModal.findPipelineNameInput().type(testPipelineName);
+      pipelineImportModal.findPipelineDescriptionInput().type('Pipeline Description');
+      pipelineImportModal.findImportPipelineRadio().click();
+      pipelineImportModal
+        .findPipelineUrlInput()
+        .type(
+          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
+        );
+      pipelineImportModal.submit();
 
-        // Verify that we are at the details page of the pipeline by checking the title
-        // It can take a little longer to load
-        pipelineDetails.findPageTitle(60000).should('have.text', testPipelineName);
+      // Verify that we are at the details page of the pipeline by checking the title
+      // It can take a little longer to load
+      pipelineDetails.findPageTitle(60000).should('have.text', testPipelineName);
 
-        cy.step('Run the pipeline from the Actions button in the pipeline detail view');
-        pipelineDetails.selectActionDropdownItem('Create run');
-        createRunPage.experimentSelect.findToggleButton().click();
-        createRunPage.selectExperimentByName('Default');
-        createRunPage.fillName(testRunName);
-        createRunPage.fillDescription('Run Description');
-        createRunPage.findSubmitButton().click();
+      cy.step('Run the pipeline from the Actions button in the pipeline detail view');
+      pipelineDetails.selectActionDropdownItem('Create run');
+      createRunPage.experimentSelect.findToggleButton().click();
+      createRunPage.selectExperimentByName('Default');
+      createRunPage.fillName(testRunName);
+      createRunPage.fillDescription('Run Description');
+      createRunPage.findSubmitButton().click();
 
-        cy.step('Expect the run to Succeed');
-        //Redirected to the Graph view of the created run
-        pipelineRunDetails.expectStatusLabelToBe('Succeeded', 180000);
-      },
-    );
-  },
-);
+      cy.step('Expect the run to Succeed');
+      //Redirected to the Graph view of the created run
+      pipelineRunDetails.expectStatusLabelToBe('Succeeded', 180000);
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -18,6 +18,7 @@ import {
   retryableBefore,
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 
 let testData: DataScienceProjectData;
 let projectName: string;
@@ -136,8 +137,7 @@ describe('[Automation Bug: RHOAIENG-20591] Verify Admin Multi Model Creation and
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
       checkInferenceServiceState(testData.multiModelAdminName);
       modelServingSection.findModelServerName(testData.multiModelAdminName);
-      modelServingSection.findStatusTooltip().click({ force: true });
-      cy.contains('Loaded', { timeout: 120000 }).should('be.visible');
+      attemptToClickTooltip();
 
       //Verify the Model is accessible externally
       cy.step('Verify the model is accessible externally');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -26,7 +26,7 @@ let modelName: string;
 let modelFilePath: string;
 const awsBucket = 'BUCKET_1' as const;
 
-describe('[Automation Bug: RHOAIENG-20591] Verify Admin Multi Model Creation and Validation using the UI', () => {
+describe('[Product Bug: RHOAIENG-20213] Verify Admin Multi Model Creation and Validation using the UI', () => {
   retryableBefore(() => {
     Cypress.on('uncaught:exception', (err) => {
       if (err.message.includes('Error: secrets "ds-pipeline-config" already exists')) {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -17,6 +17,7 @@ import {
   retryableBefore,
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 
 let testData: DataScienceProjectData;
 let projectName: string;
@@ -109,8 +110,7 @@ describe('[Product Bug: RHOAIENG-20213] Verify Admin Single Model Creation and V
       modelServingSection.findModelServerName(testData.singleModelAdminName);
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();
-      modelServingSection.findStatusTooltip().click({ force: true });
-      cy.contains('Loaded', { timeout: 120000 }).should('be.visible');
+      attemptToClickTooltip();
 
       //Verify the Model is accessible externally
       cy.step('Verify the model is accessible externally');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -19,6 +19,7 @@ import {
   retryableBefore,
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 
 let testData: DataScienceProjectData;
 let projectName: string;
@@ -106,8 +107,7 @@ describe('[Product Bug: RHOAIENG-21662] Verify Model Creation and Validation usi
       modelServingSection.findModelServerName(testData.singleModelName);
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();
-      modelServingSection.findStatusTooltip().click({ force: true });
-      cy.contains('Loaded', { timeout: 120000 }).should('be.visible');
+      attemptToClickTooltip();
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -28,7 +28,7 @@ let modelName: string;
 let modelFilePath: string;
 const awsBucket = 'BUCKET_3' as const;
 
-describe('[Product Bug: RHOAIENG-21662] Verify Model Creation and Validation using the UI', () => {
+describe('Verify Model Creation and Validation using the UI', () => {
   retryableBefore(() => {
     Cypress.on('uncaught:exception', (err) => {
       if (err.message.includes('Error: secrets "ds-pipeline-config" already exists')) {
@@ -69,7 +69,7 @@ describe('[Product Bug: RHOAIENG-21662] Verify Model Creation and Validation usi
 
   it(
     'Verify that a Non Admin can Serve and Query a Model using the UI',
-    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2552', '@Dashboard', '@Modelserving', '@Bug'] },
+    { tags: ['@Smoke', '@SmokeSet3', '@ODS-2552', '@Dashboard', '@Modelserving'] },
     () => {
       cy.log('Model Name:', modelName);
       // Authentication and navigation

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
@@ -14,7 +14,7 @@ import {
   wasSetupPerformed,
 } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
-describe('[Product Bug RHOAIENG-21039] Workbenches - negative tests', () => {
+describe('[Automation Bug RHOAIENG-21039] Workbenches - negative tests', () => {
   let testData: WBNegativeTestsData;
   let projectName: string;
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
@@ -70,7 +70,8 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
 
   it(
     'Validate pod tolerations are applied to a Workbench',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1969', '@ODS-2057', '@Dashboard', '@Bug'] },
+    // TODO: This test will be reworked this Sprint as part of RHOAIENG-20099
+    { tags: ['@Featureflagged', '@HardwareProfiles'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
@@ -133,7 +133,8 @@ describe('[Automation Bug: RHOAIENG-20099] Workbenches - tolerations tests', () 
 
   it(
     'Validate pod tolerations for a stopped workbench',
-    { tags: ['@Sanity', '@SanitySet2', '@ODS-1969', '@ODS-2057', '@Dashboard', '@Bug'] },
+    // TODO: This test will be reworked this Sprint as part of RHOAIENG-20099
+    { tags: ['@Featureflagged', '@HardwareProfiles'] },
     () => {
       // Authentication and navigation
       cy.step('Log into the application');

--- a/frontend/src/__tests__/cypress/cypress/utils/models.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/models.ts
@@ -1,4 +1,25 @@
+import { modelServingSection } from '~/__tests__/cypress/cypress/pages/modelServing';
 // Re-exports all api/models to allow tests to reference models.
 
 // eslint-disable-next-line no-restricted-imports
 export * from '~/api/models';
+
+const maxAttempts = 5;
+let attempts = 0;
+
+export function attemptToClickTooltip(): void {
+  if (attempts >= maxAttempts) {
+    throw new Error('Failed to find and click the status tooltip after 5 attempts');
+  }
+
+  modelServingSection.findStatusTooltip().then(($tooltip) => {
+    if ($tooltip.length > 0 && $tooltip.is(':visible')) {
+      modelServingSection.findStatusTooltip().click({ force: true });
+      cy.contains('Loaded', { timeout: 120000 }).should('be.visible');
+    } else {
+      attempts++;
+      cy.reload();
+      attemptToClickTooltip();
+    }
+  });
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-20591

## Description
- Improve resiliency of Model Serving tests, added a custom Utility that checks multiple times for the Status Tooltip.
- Note that the  testMultiModelAdminCreation is still failing after this resiliency update, but now due to a known bug https://issues.redhat.com/browse/RHOAIENG-20213 and not due to the Status Tooltip issue previously. 
- Remove a number of tests from quarantine that are now passing
  - testSingleModelContributorCreation.cy.ts
  - pipelines.cy.ts
- Cleaned up test titles and amended titles for tests

## How Has This Been Tested?
- An oc login should be performed in the cluster before running the test
- test-variables.yml should be configured properly
- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml
- Locally against a PSI cluster and ODH-Nightly
![image](https://github.com/user-attachments/assets/54f8124e-5ce0-4053-9caf-1fe8dc6a8378)

## Test Impact
- None - this is a test 
- 
How to run?
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress open . This will open the Cypress UI where the pipelines and model serving test can be run.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
