### PR TITLE
fix(RHOAIENG-21951):added fix for model customization cancel button redirection

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm.ts
@@ -46,6 +46,10 @@ class ModelCustomizationFormGlobal {
     return cy.findByTestId('model-customization-submit-button');
   }
 
+  findCancelButton() {
+    return cy.findByTestId('model-customization-cancel-button');
+  }
+
   findProjectDropdown() {
     cy.findByTestId('project-selector-toggle').click();
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/modelCustomizationForm.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/modelCustomizationForm.cy.ts
@@ -15,8 +15,14 @@ import {
   buildMockPipelineVersions,
   mockDashboardConfig,
   mockDataSciencePipelineApplicationK8sResource,
+  mockDscStatus,
   mockK8sResourceList,
+  mockModelArtifactList,
+  mockModelRegistryService,
+  mockModelVersion,
+  mockModelVersionList,
   mockProjectK8sResource,
+  mockRegisteredModel,
   mockRouteK8sResource,
   mockSecretK8sResource,
   mockStorageClassList,
@@ -27,12 +33,14 @@ import {
   ProjectModel,
   RouteModel,
   SecretModel,
+  ServiceModel,
   StorageClassModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
 import { TolerationEffect, TolerationOperator } from '~/types';
 
 const projectName = 'test-project-name-2';
+const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
 const invalidMockPipeline = buildMockPipeline();
 const initialMockPipeline = buildMockPipeline({
   display_name: 'instructlab',
@@ -53,6 +61,25 @@ const invalidMockIlabPipeline = buildMockPipelineVersion({
   pipeline_id: initialMockPipeline.pipeline_id,
 });
 
+const visitModelVersionDetails = ({
+  serviceName,
+  versionNo,
+}: {
+  serviceName: string;
+  versionNo: string;
+}) => {
+  cy.visit(`/modelRegistry/${serviceName}/registeredModels/1/versions/${versionNo}/details`);
+  cy.wait('@getRegisteredModel');
+  cy.wait('@getModelVersion');
+  cy.wait('@getModelVersions');
+  cy.findByTestId('app-page-title').contains('Version 1');
+  cy.findByTestId('lab-tune-button').click();
+  cy.findByTestId('start-run-modal').should('exist'); // Verify the start run modal appears
+  cy.findByTestId('project-selector-toggle').click(); // Select a project in the modal
+  cy.findByTestId('project-selector-menu').findByText('Test Project 2').click();
+  cy.findByTestId('modal-submit-button').should('not.be.disabled').click(); // Ensure the Continue button is enabled and click it
+};
+
 describe('Model Customization Form', () => {
   it('Empty state', () => {
     initIntercepts({ isEmptyProject: true });
@@ -65,10 +92,11 @@ describe('Model Customization Form', () => {
     modelCustomizationFormGlobal.invalidVisit();
     modelCustomizationFormGlobal.findEmptyState().should('exist');
   });
-  // TODO: update this test once the tunning button is available
+
   it('Should submit', () => {
     initIntercepts({});
-    modelCustomizationFormGlobal.visit(projectName);
+    setupModelRegistryIntercepts({ modelRegistryServiceName: 'modelregistry-sample' });
+    visitModelVersionDetails({ serviceName: 'modelregistry-sample', versionNo: '1' });
     cy.wait('@getIlabPipeline');
     cy.wait('@getPipelineVersions');
     baseModelSection.editInlineText('http://test.com');
@@ -116,6 +144,21 @@ describe('Model Customization Form', () => {
     cy.wait('@getIlabPipeline');
     modelCustomizationFormGlobal.findSubmitButton().should('not.exist');
   });
+
+  it('should navigate to the model customization page on clicking cancel when state is not available', () => {
+    initIntercepts({});
+    modelCustomizationFormGlobal.visit(projectName);
+    modelCustomizationFormGlobal.findCancelButton().click();
+    cy.url().should('include', `/modelCustomization`);
+  });
+
+  it('should navigate to Model Customization from Model Registry via LabTune button and back on cancel button when state is available', () => {
+    initIntercepts({});
+    setupModelRegistryIntercepts({ modelRegistryServiceName: 'modelregistry-sample' });
+    visitModelVersionDetails({ serviceName: 'modelregistry-sample', versionNo: '1' });
+    cy.url().should('include', `/modelCustomization/fine-tune/${projectName}`);
+    modelCustomizationFormGlobal.findCancelButton().click();
+  });
 });
 
 type HandlersProps = {
@@ -123,6 +166,11 @@ type HandlersProps = {
   disableHardwareProfiles?: boolean;
   isEmptyProject?: boolean;
   isValid?: boolean;
+  disableModelRegistry?: boolean;
+};
+
+type ModelRegistryProps = {
+  modelRegistryServiceName: string;
 };
 
 export const initIntercepts = (
@@ -131,6 +179,7 @@ export const initIntercepts = (
     disableHardwareProfiles = false,
     isEmptyProject,
     isValid = true,
+    disableModelRegistry = false,
   }: HandlersProps = {
     isEmptyProject: false,
   },
@@ -140,6 +189,7 @@ export const initIntercepts = (
     mockDashboardConfig({
       disableFineTuning,
       disableHardwareProfiles,
+      disableModelRegistry,
     }),
   );
   cy.interceptK8sList(
@@ -323,4 +373,78 @@ export const initIntercepts = (
     },
     buildMockPipeline(initialMockPipeline),
   ).as('getIlabPipeline');
+};
+
+const setupModelRegistryIntercepts = ({ modelRegistryServiceName }: ModelRegistryProps) => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      installedComponents: {
+        'model-registry-operator': true,
+        'data-science-pipelines-operator': true,
+      },
+    }),
+  );
+
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([mockModelRegistryService({ name: modelRegistryServiceName })]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId',
+    {
+      path: {
+        serviceName: modelRegistryServiceName,
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
+    mockRegisteredModel({}),
+  ).as('getRegisteredModel');
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models/:registeredModelId/versions',
+    {
+      path: {
+        serviceName: modelRegistryServiceName,
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        registeredModelId: 1,
+      },
+    },
+    mockModelVersionList({
+      items: [
+        mockModelVersion({
+          name: 'Version 1',
+          author: 'Author 1',
+          registeredModelId: '1',
+          id: '1',
+        }),
+      ],
+    }),
+  ).as('getModelVersions');
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId',
+    {
+      path: {
+        serviceName: modelRegistryServiceName,
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 1,
+      },
+    },
+    mockModelVersion({ id: '1', name: 'Version 1' }),
+  ).as('getModelVersion');
+
+  cy.interceptOdh(
+    'GET /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/model_versions/:modelVersionId/artifacts',
+    {
+      path: {
+        serviceName: modelRegistryServiceName,
+        apiVersion: MODEL_REGISTRY_API_VERSION,
+        modelVersionId: 1,
+      },
+    },
+    mockModelArtifactList({}),
+  ).as('getModelArtifacts');
 };

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
@@ -7,13 +7,18 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { ModelCustomizationFormData } from '~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
 import useRunFormData from '~/concepts/pipelines/content/createRun/useRunFormData';
 import { handleSubmit } from '~/concepts/pipelines/content/createRun/submitUtils';
 import { isRunSchedule } from '~/concepts/pipelines/utils';
-import { globalPipelineRunDetailsRoute, globalPipelineRunsRoute } from '~/routes';
+import {
+  getModelCustomizationPath,
+  globalPipelineRunDetailsRoute,
+  globalPipelineRunsRoute,
+  ModelCustomizationRouterState,
+} from '~/routes';
 import useNotification from '~/utilities/useNotification';
 import {
   NotificationWatcherContext,
@@ -69,13 +74,13 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
   ilabPipelineVersion,
   ociConnectionType,
 }) => {
-  const { metadataStoreServiceClient } = usePipelinesAPI();
   const [error, setError] = React.useState<Error>();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-  const { api, namespace } = usePipelinesAPI();
+  const { api, namespace, metadataStoreServiceClient, project } = usePipelinesAPI();
   const { registerNotification } = React.useContext(NotificationWatcherContext);
   const notification = useNotification();
   const navigate = useNavigate();
+  const { state }: { state?: ModelCustomizationRouterState } = useLocation();
   const contextPath = globalPipelineRunsRoute(namespace);
   const {
     isValid: isNewConnectionFieldValid,
@@ -326,7 +331,22 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
             <Button
               variant="link"
               onClick={() => {
-                navigate(-1);
+                if (
+                  state &&
+                  state.modelVersionId &&
+                  state.registeredModelId &&
+                  state.modelRegistryName
+                ) {
+                  navigate(
+                    modelVersionUrl(
+                      state.modelVersionId,
+                      state.registeredModelId,
+                      state.modelRegistryName,
+                    ),
+                  );
+                } else {
+                  navigate(getModelCustomizationPath(project.metadata.name));
+                }
               }}
             >
               Cancel

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
@@ -14,9 +14,9 @@ import useRunFormData from '~/concepts/pipelines/content/createRun/useRunFormDat
 import { handleSubmit } from '~/concepts/pipelines/content/createRun/submitUtils';
 import { isRunSchedule } from '~/concepts/pipelines/utils';
 import {
-  getModelCustomizationPath,
   globalPipelineRunDetailsRoute,
   globalPipelineRunsRoute,
+  modelCustomizationRootPath,
   ModelCustomizationRouterState,
 } from '~/routes';
 import useNotification from '~/utilities/useNotification';
@@ -76,7 +76,7 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
 }) => {
   const [error, setError] = React.useState<Error>();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-  const { api, namespace, metadataStoreServiceClient, project } = usePipelinesAPI();
+  const { api, namespace, metadataStoreServiceClient } = usePipelinesAPI();
   const { registerNotification } = React.useContext(NotificationWatcherContext);
   const notification = useNotification();
   const navigate = useNavigate();
@@ -330,6 +330,7 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
           <ActionListItem>
             <Button
               variant="link"
+              data-testid="model-customization-cancel-button"
               onClick={() => {
                 if (
                   state &&
@@ -345,7 +346,7 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
                     ),
                   );
                 } else {
-                  navigate(getModelCustomizationPath(project.metadata.name));
+                  navigate(modelCustomizationRootPath);
                 }
               }}
             >


### PR DESCRIPTION
Closes [RHOAIENG-21733](https://issues.redhat.com/browse/RHOAIENG-21733)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Added refactoring of redirect logic to the Model Registry page in case of state being available from the router state.
2. On state not being available added a fallback usecase of getModelCustomizationPath

https://github.com/user-attachments/assets/3a8ec2af-28ce-4ef6-a90c-7e453d8a78b1


1. Model Registry > select a model version > click on the lab tune button and select the project 
![image](https://github.com/user-attachments/assets/090982f6-b12d-44f4-ae7c-d5c4022e6eca)
 
 on cancelling the model customization form it would fall back to the model registry page

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Added intercepts for handling redirection from model registry to model customization form
2. Added test case changes to handle submit form for model customization after redirection from model registry by clicking on labtune button.
3. Added test case to handle redirection to model customization landing page on clicking cancel button when no state is available
4. Added test case to handle redirection to model registry page on clicking cancel button when state is available


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
