### PR TITLE
fix(21844): only show lab-tune button if lab-base tag

### DIFF
--- a/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   findModelFromModelCatalogSources,
   getILabLabels,
   getTagFromModel,
+  isLabBase,
   removeILabLabels,
 } from '~/pages/modelCatalog/utils';
 import { EMPTY_CUSTOM_PROPERTY_STRING } from '~/pages/modelCatalog/const';
@@ -146,6 +147,17 @@ describe('removeILabLabels', () => {
   it('should return an empty list if given undefined', () => {
     const result = removeILabLabels(undefined);
     expect(result).toEqual([]);
+  });
+});
+
+describe('isLabBase', () => {
+  it('should return true if lab-base is present', () => {
+    const result = isLabBase(['foo', 'lab-base', 'bar', 'baz']);
+    expect(result).toEqual(true);
+  });
+  it('should return false if lab-base is not present', () => {
+    const result = isLabBase(['foo', 'bar', 'baz']);
+    expect(result).toEqual(false);
   });
 });
 

--- a/frontend/src/pages/modelCatalog/components/ModelCatalogLabels.tsx
+++ b/frontend/src/pages/modelCatalog/components/ModelCatalogLabels.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Label, LabelGroup } from '@patternfly/react-core';
 import { getILabLabels, removeILabLabels } from '~/pages/modelCatalog/utils';
+import { ReservedILabLabel } from '~/pages/modelCatalog/const';
 
 export const ModelCatalogLabels: React.FC<{
   labels?: string[];
@@ -10,19 +11,19 @@ export const ModelCatalogLabels: React.FC<{
   <LabelGroup data-testid="model-catalog-label-group">
     {getILabLabels(labels).map((l) => {
       switch (l) {
-        case 'lab-base':
+        case ReservedILabLabel.LabBase:
           return (
             <Label data-testid="model-catalog-label" color="yellow" variant="filled">
               LAB starter
             </Label>
           );
-        case 'lab-teacher':
+        case ReservedILabLabel.LabTeacher:
           return (
             <Label data-testid="model-catalog-label" color="purple" variant="filled">
               LAB teacher
             </Label>
           );
-        case 'lab-judge':
+        case ReservedILabLabel.LabJudge:
           return (
             <Label data-testid="model-catalog-label" color="orange" variant="filled">
               LAB judge

--- a/frontend/src/pages/modelCatalog/const.ts
+++ b/frontend/src/pages/modelCatalog/const.ts
@@ -3,7 +3,12 @@ import {
   ModelRegistryMetadataType,
 } from '~/concepts/modelRegistry/types';
 
-export const RESERVED_ILAB_LABELS = ['lab-base', 'lab-teacher', 'lab-judge'];
+export enum ReservedILabLabel {
+  LabBase = 'lab-base',
+  LabTeacher = 'lab-teacher',
+  LabJudge = 'lab-judge',
+}
+export const RESERVED_ILAB_LABELS: ReservedILabLabel[] = Object.values(ReservedILabLabel);
 
 export const EMPTY_CUSTOM_PROPERTY_STRING: ModelRegistryCustomProperty = {
   // eslint-disable-next-line camelcase

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -29,6 +29,7 @@ import {
   decodeParams,
   findModelFromModelCatalogSources,
   getTagFromModel,
+  isLabBase,
 } from '~/pages/modelCatalog/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import { getRegisterCatalogModelUrl } from '~/pages/modelCatalog/routeUtils';
@@ -194,7 +195,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
         loaded && (
           <ActionList>
             <ActionListGroup>
-              {tuningAvailable && fineTuneActionItem}
+              {tuningAvailable && isLabBase(model?.labels) && fineTuneActionItem}
               {registerModelButton()}
             </ActionListGroup>
           </ActionList>

--- a/frontend/src/pages/modelCatalog/utils.ts
+++ b/frontend/src/pages/modelCatalog/utils.ts
@@ -1,5 +1,9 @@
 import { CatalogArtifacts, CatalogModel, ModelCatalogSource } from '~/concepts/modelCatalog/types';
-import { EMPTY_CUSTOM_PROPERTY_STRING, RESERVED_ILAB_LABELS } from '~/pages/modelCatalog/const';
+import {
+  EMPTY_CUSTOM_PROPERTY_STRING,
+  RESERVED_ILAB_LABELS,
+  ReservedILabLabel,
+} from '~/pages/modelCatalog/const';
 import { ModelRegistryCustomProperties } from '~/concepts/modelRegistry/types';
 import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 
@@ -45,10 +49,13 @@ export const getTagFromModel = (model: CatalogModel): string | undefined =>
   model.artifacts?.[0]?.tags?.[0];
 
 export const getILabLabels = (labels?: string[]): string[] =>
-  labels?.filter((l) => RESERVED_ILAB_LABELS.includes(l)) ?? [];
+  labels?.filter((l) => RESERVED_ILAB_LABELS.some((ril) => ril === l)) ?? [];
 
 export const removeILabLabels = (labels?: string[]): string[] =>
-  labels?.filter((l) => !RESERVED_ILAB_LABELS.includes(l)) ?? [];
+  labels?.filter((l) => !RESERVED_ILAB_LABELS.some((ril) => ril === l)) ?? [];
+
+export const isLabBase = (labels?: string[]): boolean =>
+  !!labels?.includes(ReservedILabLabel.LabBase);
 
 export const createCustomPropertiesFromModel = (
   model: CatalogModel,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-21844

## Description
lab tune button will only show up on model catalog details page if fineTune is enabled and the model has lab-base label

## How Has This Been Tested?
locally on green cluster

## Test Impact
added some tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
