### PR TITLE
Allow dropdowns to be selectable by key navigation

### DIFF
--- a/frontend/src/app/AppLauncher.tsx
+++ b/frontend/src/app/AppLauncher.tsx
@@ -166,7 +166,7 @@ const AppLauncher: React.FC = () => {
         </MenuToggle>
       )}
       isOpen={isOpen}
-      shouldFocusToggleOnSelect
+      shouldFocusFirstItemOnOpen
     >
       {applicationSections.map(renderApplicationLauncherGroup)}
     </Dropdown>

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -248,6 +248,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
                 {userName}
               </MenuToggle>
             )}
+            shouldFocusFirstItemOnOpen
             isOpen={userMenuOpen}
           >
             <DropdownList>{userMenuItems}</DropdownList>

--- a/frontend/src/components/FilterToolbar.tsx
+++ b/frontend/src/components/FilterToolbar.tsx
@@ -48,7 +48,7 @@ function FilterToolbar<T extends string>({
           <ToolbarItem>
             <Dropdown
               onOpenChange={(isOpenChange) => setOpen(isOpenChange)}
-              shouldFocusToggleOnSelect
+              shouldFocusFirstItemOnOpen
               toggle={(toggleRef) => (
                 <MenuToggle
                   data-testid={`${testId}-dropdown`}

--- a/frontend/src/components/SimpleMenuActions.tsx
+++ b/frontend/src/components/SimpleMenuActions.tsx
@@ -64,6 +64,7 @@ const SimpleMenuActions: React.FC<SimpleDropdownProps> = ({
       popperProps={
         !toggleLabel ? { position: 'right', appendTo: 'inline' } : { appendTo: 'inline' }
       }
+      shouldFocusFirstItemOnOpen
     >
       <DropdownList>
         {dropdownItems.map((itemOrSpacer, i) =>

--- a/frontend/src/components/SimpleSelect.tsx
+++ b/frontend/src/components/SimpleSelect.tsx
@@ -135,7 +135,7 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
             {toggleLabel || <Truncate content={selectedLabel} className="truncate-no-min-width" />}
           </MenuToggle>
         )}
-        shouldFocusToggleOnSelect
+        shouldFocusFirstItemOnOpen
         popperProps={{ maxWidth: 'trigger', ...popperProps }}
       >
         {groupedOptions?.map((group, index) => (

--- a/frontend/src/components/ValueUnitField.tsx
+++ b/frontend/src/components/ValueUnitField.tsx
@@ -74,7 +74,7 @@ const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
       </SplitItem>
       <SplitItem>
         <Dropdown
-          shouldFocusToggleOnSelect
+          shouldFocusFirstItemOnOpen
           popperProps={{ appendTo: menuAppendTo }}
           toggle={(toggleRef) => (
             <MenuToggle

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -192,6 +192,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
             isFullWidth
             isSkeleton={!hardwareProfilesLoaded && !hardwareProfilesError}
             isScrollable
+            popperProps={{ appendTo: 'inline' }}
           />
         </FlexItem>
         <FlexItem>

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/TriggerTypeField.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/TriggerTypeField.tsx
@@ -125,6 +125,7 @@ const TriggerTypeField: React.FC<TriggerTypeFieldProps> = ({ data, onChange }) =
               onChange({ ...data, triggerType, value });
             }}
             popperProps={{ appendTo: 'inline' }}
+            shouldFocusToggleOnSelect
           />
         </FormGroup>
       </StackItem>

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationFields.tsx
@@ -42,6 +42,7 @@ const TolerationFields: React.FC<TolerationFieldsProps> = ({ toleration, onUpdat
           value={toleration.operator || ''}
           onChange={(key) => handleFieldUpdate('operator', key)}
           dataTestId="toleration-operator-select"
+          popperProps={{ appendTo: 'inline' }}
         />
       </FormGroup>
 
@@ -52,6 +53,7 @@ const TolerationFields: React.FC<TolerationFieldsProps> = ({ toleration, onUpdat
           value={toleration.effect || ''}
           onChange={(key) => handleFieldUpdate('effect', key)}
           dataTestId="toleration-effect-select"
+          popperProps={{ appendTo: 'inline' }}
         />
       </FormGroup>
 

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
@@ -114,6 +114,7 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
                 setIdentifier('defaultCount', EMPTY_IDENTIFIER.defaultCount);
             }
           }}
+          popperProps={{ appendTo: 'inline' }}
         />
       </FormGroup>
 

--- a/frontend/src/pages/hardwareProfiles/toleration/ManageTolerationModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/toleration/ManageTolerationModal.tsx
@@ -73,6 +73,7 @@ const ManageTolerationModal: React.FC<ManageTolerationModalProps> = ({
               setToleration('operator', operator ?? undefined);
             }}
             dataTestId="toleration-operator-select"
+            popperProps={{ appendTo: 'inline' }}
           />
         </FormGroup>
         <FormGroup label="Effect" fieldId="effect-select">
@@ -85,6 +86,7 @@ const ManageTolerationModal: React.FC<ManageTolerationModalProps> = ({
               setToleration('effect', effect ?? undefined);
             }}
             dataTestId="toleration-effect-select"
+            popperProps={{ appendTo: 'inline' }}
           />
         </FormGroup>
         <FormGroup label="Key" isRequired fieldId="toleration-key">

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -120,7 +120,7 @@ const ServingRuntimeSizeSection = ({
                     podSpecOptionState.modelSize.setSelectedSize(valuesSelected);
                   }
                 }}
-                popperProps={{ appendTo: document.body }}
+                popperProps={{ appendTo: 'inline' }}
               />
             </StackItem>
             {podSpecOptionState.modelSize.selectedSize.name === 'Custom' && (

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
@@ -44,6 +44,7 @@ export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw,
           setIsRaw(key === DeploymentMode.RawDeployment);
         }}
         isFullWidth
+        popperProps={{ appendTo: 'inline' }}
       />
     </FormGroup>
   );

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -175,6 +175,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
               }
             }}
             dataTestId="accelerator-profile-select"
+            popperProps={{ appendTo: 'inline' }}
           />
         </FormGroup>
       </StackItem>

--- a/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
@@ -60,6 +60,7 @@ const ProjectActions: React.FC<Props> = ({ project }) => {
       )}
       isOpen={open}
       popperProps={{ position: 'right', appendTo: getDashboardMainContainer() }}
+      shouldFocusFirstItemOnOpen
     >
       <DropdownList>
         {canEdit ? (


### PR DESCRIPTION
Closes: [RHOAIENG-19917](https://issues.redhat.com/browse/RHOAIENG-19917)

## Description
Updates various dropdown menus to allow for keyboard navigation. Before, using arrows to navigate into the dropdown caused the entire page to scroll. Now it will move into the menu to select. 
Example menu, Create workbench -> Notebook image, Image selection -> Should be able to select a menu option using the keyboard.

## How Has This Been Tested?
I've gone through the dashboard and tested any dropdown menus I could find. 

## Test Impact
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
