### PR TITLE
Display project scoped workbench images

### DIFF
--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -23,6 +23,7 @@ type MockResourceConfigType = {
   additionalEnvs?: EnvironmentVariable[];
   resources?: ContainerResources;
   image?: string;
+  imageDisplayName?: string;
   lastImageSelection?: string;
   opts?: RecursivePartial<NotebookKind>;
   uid?: string;
@@ -47,6 +48,7 @@ export const mockNotebookK8sResource = ({
   description = '',
   resources = DEFAULT_NOTEBOOK_SIZES[0].resources,
   image = 'test-imagestream:1.2',
+  imageDisplayName = 'test-image',
   lastImageSelection = 's2i-minimal-notebook:py3.8-v1',
   opts = {},
   uid = genUID('notebook'),
@@ -60,6 +62,7 @@ export const mockNotebookK8sResource = ({
       kind: 'Notebook',
       metadata: {
         annotations: {
+          'opendatahub.io/image-display-name': imageDisplayName,
           'notebooks.kubeflow.org/last-activity': '2023-02-14T21:45:14Z',
           'notebooks.opendatahub.io/inject-oauth': 'true',
           'notebooks.opendatahub.io/last-image-selection': lastImageSelection,

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -187,6 +187,10 @@ class NotebookRow extends TableRow {
     return this;
   }
 
+  findProjectScopedLabel() {
+    return this.find().findByTestId('project-scoped-label');
+  }
+
   findNotebookRouteLink() {
     return this.find().findByTestId('notebook-route-link');
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -147,7 +147,7 @@ class NotebookDeleteModal extends Modal {
 
 class NotebookRow extends TableRow {
   shouldHaveNotebookImageName(name: string) {
-    this.find().find(`[data-label="Notebook image"]`).should('have.text', name);
+    this.find().find(`[data-label="Notebook image"]`).find('span').should('have.text', name);
     return this;
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -147,7 +147,7 @@ class NotebookDeleteModal extends Modal {
 
 class NotebookRow extends TableRow {
   shouldHaveNotebookImageName(name: string) {
-    this.find().find(`[data-label="Notebook image"]`).find('span').should('have.text', name);
+    this.find().find(`[data-label="Notebook image"]`).should('have.text', name);
     return this;
   }
 
@@ -298,6 +298,7 @@ class StorageTable {
   }
 }
 
+class NotebookImageGroup extends Contextual<HTMLElement> {}
 class CreateSpawnerPage {
   k8sNameDescription = new K8sNameDescriptionField('workbench');
 
@@ -374,6 +375,26 @@ class CreateSpawnerPage {
       .findByTestId('workbench-image-stream-selection')
       .findDropdownItemByTestId(name)
       .scrollIntoView();
+  }
+
+  findNotebookImageSearchSelector() {
+    return cy.findByTestId('image-stream-selector-toggle');
+  }
+
+  findProjectScopedLabel() {
+    return cy.findByTestId('project-scoped-image');
+  }
+
+  findGlobalScopedLabel() {
+    return cy.findByTestId('global-scoped-image');
+  }
+
+  getProjectScopedNotebookImages() {
+    return new NotebookImageGroup(() => cy.findByTestId('project-scoped-notebook-images'));
+  }
+
+  getGlobalScopedNotebookImages() {
+    return new NotebookImageGroup(() => cy.findByTestId('global-scoped-notebook-images'));
   }
 
   findNotebookVersion(version: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -572,7 +572,7 @@ describe('Workbench page', () => {
     verifyRelativeURL('/projects/test-project?section=workbenches');
   });
 
-  it.only('Display project-scoped label for a notebook in workbenches table', () => {
+  it('Display project-scoped label for a notebook in workbenches table', () => {
     initIntercepts({
       disableProjectScoped: false,
       notebookSizes: [

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -601,7 +601,7 @@ describe('Workbench page', () => {
     });
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-    notebookRow.shouldHaveNotebookImageName('Test ImagePython v3.8');
+    notebookRow.shouldHaveNotebookImageName('Test Image');
     notebookRow.shouldHaveContainerSize('Small');
     notebookRow.findHaveNotebookStatusText().should('have.text', 'Running');
     notebookRow.findNotebookRouteLink().should('have.attr', 'aria-disabled', 'false');
@@ -990,7 +990,7 @@ describe('Workbench page', () => {
     });
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-    notebookRow.shouldHaveNotebookImageName('Test ImagePython v3.8');
+    notebookRow.shouldHaveNotebookImageName('Test Image');
     notebookRow.shouldHaveContainerSize('Custom');
     notebookRow.findKebabAction('Edit workbench').click();
     editSpawnerPage.shouldHaveContainerSizeInput('Keep custom size');

--- a/frontend/src/components/ProjectScopedPopover.tsx
+++ b/frontend/src/components/ProjectScopedPopover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import PopoverListContent from './PopoverListContent';
 
 type PropjectScopedPopoverProps = {
   title: string;
@@ -10,20 +11,21 @@ type PropjectScopedPopoverProps = {
 
 const ProjectScopedPopover: React.FC<PropjectScopedPopoverProps> = ({ title, item }) => (
   <Popover
+    showClose
+    hasAutoWidth
+    maxWidth="370px"
     bodyContent={
-      <>
-        <strong>{title} accessibility</strong>
-        <div>
-          <ul>
-            <li key="project-scoped">
-              <strong>Project-scoped {item}</strong> are accessible only within this project
-            </li>
-            <li key="global-scoped">
-              <strong>Global {item}</strong> are accessible across all projects
-            </li>
-          </ul>
-        </div>
-      </>
+      <PopoverListContent
+        listHeading={`${title} accessibility`}
+        listItems={[
+          <span key="project-scoped">
+            <strong>Project-scoped {item}</strong> are accessible only within this project
+          </span>,
+          <span key="global-scoped">
+            <strong>Global {item}</strong> are accessible across all projects
+          </span>,
+        ]}
+      />
     }
   >
     <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />

--- a/frontend/src/components/ProjectScopedPopover.tsx
+++ b/frontend/src/components/ProjectScopedPopover.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+
+type PropjectScopedPopoverProps = {
+  title: string;
+  item: string;
+};
+
+const ProjectScopedPopover: React.FC<PropjectScopedPopoverProps> = ({ title, item }) => (
+  <Popover
+    bodyContent={
+      <>
+        <strong>{title} accessibility</strong>
+        <div>
+          <ul>
+            <li key="project-scoped">
+              <strong>Project-scoped {item}</strong> are accessible only within this project
+            </li>
+            <li key="global-scoped">
+              <strong>Global {item}</strong> are accessible across all projects
+            </li>
+          </ul>
+        </div>
+      </>
+    }
+  >
+    <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+  </Popover>
+);
+
+export default ProjectScopedPopover;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -32,6 +32,7 @@ import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import GlobalIcon from '~/images/icons/GlobalIcon';
 import { CustomWatchK8sResult } from '~/types';
 import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
+import ProjectScopedPopover from '~/components/ProjectScopedPopover';
 
 type ServingRuntimeTemplateSectionProps = {
   data: CreatingServingRuntimeObject;
@@ -275,8 +276,18 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
   }
 
   return (
-    // TODO: need to add popover from this PR: https://github.com/opendatahub-io/odh-dashboard/pull/3955
-    <FormGroup label="Serving runtime" fieldId="serving-runtime-template-selection" isRequired>
+    <FormGroup
+      label="Serving runtime"
+      fieldId="serving-runtime-template-selection"
+      isRequired
+      labelHelp={
+        isProjectScoped &&
+        filterProjectScopedTemplates &&
+        filterProjectScopedTemplates.length > 0 ? (
+          <ProjectScopedPopover title="Serving runtime" item="serving runtimes" />
+        ) : undefined
+      }
+    >
       {isProjectScoped &&
       filterProjectScopedTemplates &&
       filterProjectScopedTemplates.length > 0 ? (

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import { NotebookImageAvailability } from './const';
 import { NotebookImage } from './types';
 
@@ -95,6 +96,8 @@ export const NotebookImageDisplayName = ({
         return 'grey';
       case NotebookImageAvailability.DELETED:
         return 'red';
+      case NotebookImageAvailability.ENABLED:
+        return 'blue';
       default:
         return undefined;
     }
@@ -107,6 +110,10 @@ export const NotebookImageDisplayName = ({
         return <InfoCircleIcon />;
       case NotebookImageAvailability.DELETED:
         return <ExclamationCircleIcon />;
+      case NotebookImageAvailability.ENABLED:
+        return (
+          <img style={{ height: 25 }} src={typedObjectImage(ProjectObjectType.project)} alt="" />
+        );
       default:
         return undefined;
     }

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -130,7 +130,7 @@ export const NotebookImageDisplayName = ({
                 data-testid="project-scoped-label"
                 icon={
                   <img
-                    style={{ height: 20 }}
+                    style={{ height: '20px' }}
                     src={typedObjectImage(ProjectObjectType.project)}
                     alt=""
                   />

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -127,6 +127,7 @@ export const NotebookImageDisplayName = ({
                 isCompact
                 variant="outline"
                 color="blue"
+                data-testid="project-scoped-label"
                 icon={
                   <img
                     style={{ height: 20 }}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -19,6 +19,7 @@ import { NotebookImageAvailability } from './const';
 import { NotebookImage } from './types';
 
 type NotebookImageDisplayNameProps = {
+  isImageStreamProjectScoped: boolean;
   notebookImage: NotebookImage | null;
   loaded: boolean;
   loadError?: Error;
@@ -26,6 +27,7 @@ type NotebookImageDisplayNameProps = {
 };
 
 export const NotebookImageDisplayName = ({
+  isImageStreamProjectScoped,
   notebookImage,
   loaded,
   loadError,
@@ -39,7 +41,6 @@ export const NotebookImageDisplayName = ({
       </HelperText>
     );
   }
-
   // If the image is not loaded, display a spinner
   if (!loaded || !notebookImage) {
     return <Spinner size="md" />;
@@ -85,7 +86,6 @@ export const NotebookImageDisplayName = ({
         variant: 'danger',
       };
     }
-
     return {};
   };
 
@@ -96,8 +96,6 @@ export const NotebookImageDisplayName = ({
         return 'grey';
       case NotebookImageAvailability.DELETED:
         return 'red';
-      case NotebookImageAvailability.ENABLED:
-        return 'blue';
       default:
         return undefined;
     }
@@ -110,10 +108,6 @@ export const NotebookImageDisplayName = ({
         return <InfoCircleIcon />;
       case NotebookImageAvailability.DELETED:
         return <ExclamationCircleIcon />;
-      case NotebookImageAvailability.ENABLED:
-        return (
-          <img style={{ height: 25 }} src={typedObjectImage(ProjectObjectType.project)} alt="" />
-        );
       default:
         return undefined;
     }
@@ -123,9 +117,27 @@ export const NotebookImageDisplayName = ({
   if (notebookImage.imageAvailability === NotebookImageAvailability.ENABLED) {
     return (
       <>
-        <HelperText>
-          <HelperTextItem>{notebookImage.imageDisplayName}</HelperTextItem>
-        </HelperText>
+        <Flex>
+          <FlexItem>{notebookImage.imageDisplayName}</FlexItem>
+          <FlexItem>
+            {isImageStreamProjectScoped && (
+              <Label
+                isCompact
+                variant="outline"
+                color="blue"
+                icon={
+                  <img
+                    style={{ height: 20 }}
+                    src={typedObjectImage(ProjectObjectType.project)}
+                    alt=""
+                  />
+                }
+              >
+                Project-scoped
+              </Label>
+            )}
+          </FlexItem>
+        </Flex>
         {isExpanded && (
           <Content component={ContentVariants.small}>{notebookImage.tagSoftware}</Content>
         )}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -15,6 +15,7 @@ import {
 import React from 'react';
 import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
 import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { NotebookImageAvailability } from './const';
 import { NotebookImage } from './types';
 
@@ -33,6 +34,7 @@ export const NotebookImageDisplayName = ({
   loadError,
   isExpanded,
 }: NotebookImageDisplayNameProps): React.JSX.Element => {
+  const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   // if there was an error loading the image, display unknown WITHOUT a label
   if (loadError) {
     return (
@@ -117,10 +119,10 @@ export const NotebookImageDisplayName = ({
   if (notebookImage.imageAvailability === NotebookImageAvailability.ENABLED) {
     return (
       <>
-        <Flex>
-          <FlexItem>{notebookImage.imageDisplayName}</FlexItem>
-          <FlexItem>
-            {isImageStreamProjectScoped && (
+        <HelperText style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <HelperTextItem>{notebookImage.imageDisplayName}</HelperTextItem>
+          {isProjectScopedAvailable && isImageStreamProjectScoped && (
+            <HelperTextItem>
               <Label
                 isCompact
                 variant="outline"
@@ -135,9 +137,9 @@ export const NotebookImageDisplayName = ({
               >
                 Project-scoped
               </Label>
-            )}
-          </FlexItem>
-        </Flex>
+            </HelperTextItem>
+          )}
+        </HelperText>
         {isExpanded && (
           <Content component={ContentVariants.small}>{notebookImage.tagSoftware}</Content>
         )}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -55,6 +55,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const acceleratorResources = extractAcceleratorResources(
     obj.notebook.spec.template.spec.containers[0].resources,
   );
+  const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
   const lastDeployedSize: NotebookSize = {
     name: 'Custom',
@@ -63,7 +64,11 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
       requests: {},
     },
   };
-  const [notebookImage, loaded, loadError] = useNotebookImage(obj.notebook);
+  const [notebookImage, loaded, loadError] = useNotebookImage(
+    obj.notebook,
+    currentProject.metadata.name,
+    isProjectScopedAvailable,
+  );
   const podSpecOptionsState = useNotebookKindPodSpecOptionsState(obj.notebook);
   const [dontShowModalValue] = useStopNotebookModalAvailability();
   const { dashboardConfig } = useAppContext();

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -32,6 +32,7 @@ import NotebookSizeDetails from './NotebookSizeDetails';
 import useNotebookImage from './useNotebookImage';
 import useNotebookDeploymentSize from './useNotebookDeploymentSize';
 import { extractAcceleratorResources } from './utils';
+import useNotebookImageData from './useNotebookImageData';
 
 type NotebookTableRowProps = {
   obj: NotebookState;
@@ -68,6 +69,10 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
     obj.notebook,
     currentProject.metadata.name,
     isProjectScopedAvailable,
+  );
+  const [data, notebookImageStreamLoaded] = useNotebookImageData(
+    obj.notebook,
+    currentProject.metadata.name,
   );
   const podSpecOptionsState = useNotebookKindPodSpecOptionsState(obj.notebook);
   const [dontShowModalValue] = useStopNotebookModalAvailability();
@@ -137,6 +142,11 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           <Split>
             <SplitItem>
               <NotebookImageDisplayName
+                isImageStreamProjectScoped={
+                  notebookImageStreamLoaded &&
+                  data.imageAvailability !== NotebookImageAvailability.DELETED &&
+                  data.imageStream.metadata.namespace === currentProject.metadata.name
+                }
                 notebookImage={notebookImage}
                 loaded={loaded}
                 loadError={loadError}

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
@@ -10,10 +10,15 @@ import { NotebookImage } from './types';
 
 const useNotebookImage = (
   notebook: NotebookKind | undefined,
+  project: string,
+  isProjectScopedAvailable?: boolean,
 ):
   | [notebookImage: null, loaded: false, loadError?: Error]
   | [notebookImage: NotebookImage, loaded: true, loadError: undefined] => {
-  const [data, loaded, loadError] = useNotebookImageData(notebook);
+  const [data, loaded, loadError] = useNotebookImageData(
+    notebook,
+    isProjectScopedAvailable ? project : undefined,
+  );
 
   if (!notebook || !loaded) {
     return [null, false, loadError];

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -89,7 +89,7 @@ const useNotebookImageData = (notebook?: NotebookKind, project?: string): Notebo
     }
     let allImages = dashboardImages;
 
-    if (project) {
+    if (projectLoaded && projectImages.length > 0) {
       allImages = [...projectImages, ...dashboardImages];
     }
     const data = getNotebookImageData(notebook, allImages);
@@ -104,7 +104,6 @@ const useNotebookImageData = (notebook?: NotebookKind, project?: string): Notebo
     dashboardLoaded,
     projectLoaded,
     dashboardImages,
-    project,
     dashboardLoadError,
     projectLoadError,
     projectImages,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -264,6 +264,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
               aria-label={SpawnerPageSectionTitles[SpawnerPageSectionID.NOTEBOOK_IMAGE]}
             >
               <ImageSelectorField
+                currentProject={currentProject.metadata.name}
                 selectedImage={selectedImage}
                 setSelectedImage={setSelectedImage}
                 compatibleIdentifiers={profileIdentifiers}

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -75,6 +75,7 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
     <>
       <ImageStreamSelector
         currentProjectStreams={currentProjectImageStreams}
+        currentProject={currentProject}
         imageStreams={imageStreams.filter((imageStream) => !isInvalidBYONImageStream(imageStream))}
         buildStatuses={buildStatuses}
         onImageStreamSelect={onImageStreamSelect}

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -15,12 +15,14 @@ import ImageVersionSelector from './ImageVersionSelector';
 import ImageStreamSelector from './ImageStreamSelector';
 
 type ImageSelectorFieldProps = {
+  currentProject: string;
   selectedImage: ImageStreamAndVersion;
   setSelectedImage: React.Dispatch<React.SetStateAction<ImageStreamAndVersion>>;
   compatibleIdentifiers?: string[];
 };
 
 const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
+  currentProject,
   selectedImage,
   setSelectedImage,
   compatibleIdentifiers,
@@ -28,6 +30,11 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
   const { dashboardNamespace } = useDashboardNamespace();
   const buildStatuses = useBuildStatuses(dashboardNamespace);
   const [imageStreams, loaded, error] = useImageStreams(dashboardNamespace);
+  const [
+    currentProjectImageStreams,
+    currentProjectImageStreamsLoaded,
+    currentProjectImageStreamsError,
+  ] = useImageStreams(currentProject);
 
   const imageVersionData = React.useMemo(() => {
     const { imageStream } = selectedImage;
@@ -52,21 +59,22 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
     });
   };
 
-  if (error) {
+  if (error || currentProjectImageStreamsError) {
     return (
       <Alert title="Image loading error" variant="danger">
-        {error.message}
+        {error?.message || currentProjectImageStreamsError?.message}
       </Alert>
     );
   }
 
-  if (!loaded) {
+  if (!loaded || !currentProjectImageStreamsLoaded) {
     return <Skeleton />;
   }
 
   return (
     <>
       <ImageStreamSelector
+        currentProjectStreams={currentProjectImageStreams}
         imageStreams={imageStreams.filter((imageStream) => !isInvalidBYONImageStream(imageStream))}
         buildStatuses={buildStatuses}
         onImageStreamSelect={onImageStreamSelect}

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -59,10 +59,11 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
     });
   };
 
-  if (error || currentProjectImageStreamsError) {
+  const errorMessage = error?.message || currentProjectImageStreamsError?.message;
+  if (errorMessage) {
     return (
       <Alert title="Image loading error" variant="danger">
-        {error?.message || currentProjectImageStreamsError?.message}
+        {errorMessage}
       </Alert>
     );
   }

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -28,6 +28,7 @@ import ProjectScopedPopover from '~/components/ProjectScopedPopover';
 
 type ImageStreamSelectorProps = {
   currentProjectStreams?: ImageStreamKind[];
+  currentProject?: string;
   imageStreams: ImageStreamKind[];
   buildStatuses: BuildStatus[];
   selectedImageStream?: ImageStreamKind;
@@ -37,6 +38,7 @@ type ImageStreamSelectorProps = {
 
 const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
   currentProjectStreams,
+  currentProject,
   imageStreams,
   selectedImageStream,
   onImageStreamSelect,
@@ -78,6 +80,12 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
             .map((imageStream, index) => (
               <MenuItem
                 key={`imageStream-${index}`}
+                isSelected={
+                  selectedImageStream &&
+                  getImageStreamDisplayName(selectedImageStream) ===
+                    getImageStreamDisplayName(imageStream) &&
+                  selectedImageStream.metadata.namespace === imageStream.metadata.namespace
+                }
                 onClick={() => onImageStreamSelect(imageStream)}
                 icon={
                   <img
@@ -122,6 +130,12 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
           .map((imageStream, index) => (
             <MenuItem
               key={`imageStream-global-${index}`}
+              isSelected={
+                selectedImageStream &&
+                getImageStreamDisplayName(selectedImageStream) ===
+                  getImageStreamDisplayName(imageStream) &&
+                selectedImageStream.metadata.namespace === imageStream.metadata.namespace
+              }
               onClick={() => onImageStreamSelect(imageStream)}
               icon={<GlobalIcon />}
             >
@@ -197,7 +211,8 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
               <Flex>
                 {getImageStreamDisplayName(selectedImageStream)}
                 <FlexItem>
-                  {currentProjectStreams.includes(selectedImageStream) ? (
+                  {currentProjectStreams.includes(selectedImageStream) &&
+                  selectedImageStream.metadata.namespace === currentProject ? (
                     <Label
                       isCompact
                       variant="outline"

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -205,8 +205,8 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
           searchValue={searchImageStreamName}
           toggleContent={
             selectedImageStream && (
-              <Flex>
-                {getImageStreamDisplayName(selectedImageStream)}
+              <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                <FlexItem>{getImageStreamDisplayName(selectedImageStream)}</FlexItem>
                 <FlexItem>
                   {selectedImageStream.metadata.namespace === currentProject ? (
                     <Label

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -191,7 +191,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
       label="Image selection"
       fieldId="workbench-image-stream-selection"
       labelHelp={
-        isProjectScopedAvailable ? (
+        isProjectScopedAvailable && currentProjectStreams && currentProjectStreams.length > 0 ? (
           <ProjectScopedPopover title="Workbench image" item="images" />
         ) : (
           <></>
@@ -210,8 +210,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
               <Flex>
                 {getImageStreamDisplayName(selectedImageStream)}
                 <FlexItem>
-                  {currentProjectStreams.includes(selectedImageStream) &&
-                  selectedImageStream.metadata.namespace === currentProject ? (
+                  {selectedImageStream.metadata.namespace === currentProject ? (
                     <Label
                       isCompact
                       variant="outline"

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {
   Divider,
+  Flex,
+  FlexItem,
   FormGroup,
   Label,
   MenuGroup,
@@ -49,16 +51,23 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
     <>
       <MenuGroup
         label={
-          <Split>
-            <SplitItem>
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+            style={{ paddingBottom: '5px' }}
+          >
+            <FlexItem
+              style={{ display: 'flex', paddingLeft: '12px' }}
+              data-testid="project-scoped-image"
+            >
               <img
-                style={{ height: 20 }}
+                style={{ height: 20, paddingTop: '3px' }}
                 src={typedObjectImage(ProjectObjectType.project)}
                 alt=""
               />
-            </SplitItem>
-            <SplitItem>Project-scoped images </SplitItem>
-          </Split>
+            </FlexItem>
+            <FlexItem>Project-scoped images</FlexItem>
+          </Flex>
         }
       >
         {currentProjectStreams &&
@@ -70,15 +79,15 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
               <MenuItem
                 key={`imageStream-${index}`}
                 onClick={() => onImageStreamSelect(imageStream)}
+                icon={
+                  <img
+                    style={{ height: 25 }}
+                    src={typedObjectImage(ProjectObjectType.project)}
+                    alt=""
+                  />
+                }
               >
                 <Split>
-                  <SplitItem>
-                    <img
-                      style={{ height: 25 }}
-                      src={typedObjectImage(ProjectObjectType.project)}
-                      alt=""
-                    />
-                  </SplitItem>
                   {getImageStreamDisplayName(imageStream)}
                   <SplitItem isFilled />
                   <SplitItem>
@@ -87,7 +96,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                     ) && (
                       <Label color="blue">
                         Compatible with
-                        {isHardwareProfilesAvailable ? 'hardware profile' : 'accelerator'}
+                        {isHardwareProfilesAvailable ? ' hardware profile' : ' accelerator'}
                       </Label>
                     )}
                   </SplitItem>
@@ -98,13 +107,12 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
       <Divider />
       <MenuGroup
         label={
-          <Split>
-            <SplitItem>
+          <Flex>
+            <FlexItem style={{ paddingLeft: '12px', paddingRight: 0 }}>
               <GlobalIcon />
-            </SplitItem>
-            <SplitItem />
-            <SplitItem> Global images </SplitItem>
-          </Split>
+            </FlexItem>
+            <FlexItem> Global images </FlexItem>
+          </Flex>
         }
       >
         {imageStreams
@@ -115,11 +123,9 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
             <MenuItem
               key={`imageStream-global-${index}`}
               onClick={() => onImageStreamSelect(imageStream)}
+              icon={<GlobalIcon />}
             >
               <Split>
-                <SplitItem>
-                  <GlobalIcon />
-                </SplitItem>
                 {getImageStreamDisplayName(imageStream)}
                 <SplitItem isFilled />
                 <SplitItem>
@@ -128,7 +134,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                   ) && (
                     <Label color="blue">
                       Compatible with
-                      {isHardwareProfilesAvailable ? 'hardware profile' : 'accelerator'}
+                      {isHardwareProfilesAvailable ? ' hardware profile' : ' accelerator'}
                     </Label>
                   )}
                 </SplitItem>
@@ -157,7 +163,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
               isCompatibleWithIdentifier(identifier, imageStream),
             ) && (
               <Label color="blue">
-                Compatible with {isHardwareProfilesAvailable ? 'hardware profile' : 'accelerator'}
+                Compatible with {isHardwareProfilesAvailable ? ' hardware profile' : ' accelerator'}
               </Label>
             )}
           </SplitItem>
@@ -188,11 +194,12 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
           searchValue={searchImageStreamName}
           toggleText={
             selectedImageStream && (
-              <Split>
+              <Flex>
                 {getImageStreamDisplayName(selectedImageStream)}
-                <SplitItem>
+                <FlexItem>
                   {currentProjectStreams.includes(selectedImageStream) ? (
                     <Label
+                      isCompact
                       variant="outline"
                       color="blue"
                       icon={
@@ -206,12 +213,12 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                       Project-scoped
                     </Label>
                   ) : (
-                    <Label variant="outline" color="blue" icon={<GlobalIcon />}>
+                    <Label isCompact variant="outline" color="blue" icon={<GlobalIcon />}>
                       Global-scoped
                     </Label>
                   )}
-                </SplitItem>
-              </Split>
+                </FlexItem>
+              </Flex>
             )
           }
         >

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -52,16 +52,14 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
   const getFilteredImageStreams = () => (
     <>
       <MenuGroup
+        data-testid="project-scoped-notebook-images"
         label={
           <Flex
             spaceItems={{ default: 'spaceItemsXs' }}
             alignItems={{ default: 'alignItemsCenter' }}
             style={{ paddingBottom: '5px' }}
           >
-            <FlexItem
-              style={{ display: 'flex', paddingLeft: '12px' }}
-              data-testid="project-scoped-image"
-            >
+            <FlexItem style={{ display: 'flex', paddingLeft: '12px' }}>
               <img
                 style={{ height: 20, paddingTop: '3px' }}
                 src={typedObjectImage(ProjectObjectType.project)}
@@ -114,6 +112,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
       </MenuGroup>
       <Divider />
       <MenuGroup
+        data-testid="global-scoped-notebook-images"
         label={
           <Flex>
             <FlexItem style={{ paddingLeft: '12px', paddingRight: 0 }}>
@@ -217,6 +216,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                       isCompact
                       variant="outline"
                       color="blue"
+                      data-testid="project-scoped-image"
                       icon={
                         <img
                           style={{ height: 20 }}
@@ -228,7 +228,13 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                       Project-scoped
                     </Label>
                   ) : (
-                    <Label isCompact variant="outline" color="blue" icon={<GlobalIcon />}>
+                    <Label
+                      isCompact
+                      variant="outline"
+                      data-testid="global-scoped-image"
+                      color="blue"
+                      icon={<GlobalIcon />}
+                    >
                       Global-scoped
                     </Label>
                   )}

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -110,7 +110,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
               </MenuItem>
             ))}
       </MenuGroup>
-      <Divider />
+      <Divider component="li" />
       <MenuGroup
         data-testid="global-scoped-notebook-images"
         label={

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -193,9 +193,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
       labelHelp={
         isProjectScopedAvailable && currentProjectStreams && currentProjectStreams.length > 0 ? (
           <ProjectScopedPopover title="Workbench image" item="images" />
-        ) : (
-          <></>
-        )
+        ) : undefined
       }
     >
       {isProjectScopedAvailable && currentProjectStreams && currentProjectStreams.length > 0 ? (
@@ -205,7 +203,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
           onSearchChange={(newValue) => setSearchImageStreamName(newValue)}
           onSearchClear={() => setSearchImageStreamName('')}
           searchValue={searchImageStreamName}
-          toggleText={
+          toggleContent={
             selectedImageStream && (
               <Flex>
                 {getImageStreamDisplayName(selectedImageStream)}
@@ -218,7 +216,7 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                       data-testid="project-scoped-image"
                       icon={
                         <img
-                          style={{ height: 20 }}
+                          style={{ height: '20px' }}
                           src={typedObjectImage(ProjectObjectType.project)}
                           alt=""
                         />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-20299](https://issues.redhat.com/browse/RHOAIENG-20299)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Display project scoped workbench images in the dropdown as per [Figma designs](https://www.figma.com/proto/ZvdiudUctzI3HM8W2IHOuT/Project-Enhancements---2025?node-id=6502-12148&p=f&t=nYdiWSDFzrecu3ok-1&scaling=scale-down-width&content-scaling=fixed&page-id=6502%3A12147&starting-point-node-id=6502%3A12148)
Add shared popover component 

Popover:
<img width="340" alt="Screenshot 2025-03-28 at 11 45 18 PM" src="https://github.com/user-attachments/assets/5727f790-ff0e-4e51-bd4a-51e5075e177b" />

Dropdown content with selected global and project-scoped labels after selection:
<img width="657" alt="Screenshot 2025-03-28 at 11 44 48 PM" src="https://github.com/user-attachments/assets/cafc7649-7160-4661-869d-ab9d0c538532" />

<img width="651" alt="Screenshot 2025-03-28 at 11 44 38 PM" src="https://github.com/user-attachments/assets/f683c8fe-9c11-4944-a6a0-f7c0b617a8fa" />


With hardware profile labels on the right(selected and unselected):
<img width="666" alt="Screenshot 2025-03-28 at 11 48 20 PM" src="https://github.com/user-attachments/assets/61346134-c119-4da6-8a95-4a5d9ec092de" />


While searching a specific image:
<img width="650" alt="Screenshot 2025-03-28 at 11 45 00 PM" src="https://github.com/user-attachments/assets/68d9235a-4e3a-4f03-8db8-c145b5e29fa7" />

Project-scoped label in workbenches table:
<img width="1042" alt="Screenshot 2025-03-28 at 11 44 13 PM" src="https://github.com/user-attachments/assets/1ade460b-c523-4165-8c07-dbab80bec3bd" />

Serving runtimes popover if the feature flag is ON and there are project-scoped serving runtimes:
<img width="701" alt="Screenshot 2025-04-04 at 5 20 41 PM" src="https://github.com/user-attachments/assets/9bbf66cf-d513-40b6-8b8e-49c3112557d0" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable the `disableProjectScoped` feature flag and add an image stream with a namespace apart from `opendatahub` or `redhat-ods-applications`.
2. Go to the same project and try creating a workbench with the custom image. You should see the above dropdown
3. After you create a workbench using a project-scoped image, you should see the "project-scoped" label but the global ones don't have a label in the Notebook image column of Workbenches table.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Cypress tests in progress

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
