### PR TITLE
Fix page loading error in Jupyter Notebook Admin

### DIFF
--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -70,7 +70,10 @@ export const getClusterAdminUserList = async (fastify: KubeFastifyInstance): Pro
 export const getAllowedUserList = async (fastify: KubeFastifyInstance): Promise<string[]> => {
   const auth = getAuth();
   if (auth) {
-    return getGroupUserList(fastify, auth.spec.allowedGroups);
+    return getGroupUserList(
+      fastify,
+      auth.spec.allowedGroups.filter((groupName) => groupName && !groupName.startsWith('system:')), // Handle edge-cases and ignore k8s defaults
+    );
   }
 
   // FIXME: see RHOAIENG-16988


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-19355
## Description
After updating `getAllowedUserList` to use the Auth CustomResource, the `getUserGroupList` was being passed the `system:authenticated` which is not an actual group on the cluster. In this case we want to filter for any other allowed groups that aren't `system:authenticated`.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Make sure the Admin page loads at Applications > Enabled > Launch Application > Administration
You should see any users that have logged into your cluster in the list
Go to Settings > User management and add a user group to the allowed list
Users in that group should now show up in the Administration tab
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
