### PR TITLE
cypress flake in pipelineRuns.cy.ts

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -417,7 +417,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.display_name.includes('run 1')),
             projectName,
-            1,
           );
 
           // Verify only rows with the typed run name exist
@@ -443,7 +442,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.experiment_id === 'test-experiment-1'),
             projectName,
-            1,
           );
 
           // Select an experiment to filter by
@@ -470,7 +468,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.created_at.includes('2024-02-10')),
             projectName,
-            1,
           );
           pipelineRunsGlobal
             .findActiveRunsToolbar()
@@ -490,7 +487,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.created_at.includes('2024-02-15')),
             projectName,
-            1,
           );
           pipelineRunsGlobal
             .findActiveRunsToolbar()
@@ -515,7 +511,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.state === RuntimeStateKF.RUNNING),
             projectName,
-            1,
           );
           // Select a filter value of 'RUNNING'
           pipelineRunsGlobal
@@ -532,7 +527,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.state === RuntimeStateKF.SUCCEEDED),
             projectName,
-            1,
           );
           // Select a filter value of 'SUCCEEDED'
           pipelineRunsGlobal
@@ -549,7 +543,6 @@ describe('Pipeline runs', () => {
           activeRunsTable.mockGetActiveRuns(
             mockActiveRuns.filter((mockRun) => mockRun.state === RuntimeStateKF.PENDING),
             projectName,
-            1,
           );
           // Select a filter value of 'PENDING'
           pipelineRunsGlobal
@@ -661,7 +654,6 @@ describe('Pipeline runs', () => {
           archivedRunsTable.mockGetArchivedRuns(
             mockArchivedRuns.filter((mockRun) => mockRun.display_name.includes('run 1')),
             projectName,
-            1,
           );
 
           // Verify only rows with the typed run name exist
@@ -685,7 +677,6 @@ describe('Pipeline runs', () => {
           archivedRunsTable.mockGetArchivedRuns(
             mockArchivedRuns.filter((mockRun) => mockRun.experiment_id === 'test-experiment-1'),
             projectName,
-            1,
           );
 
           // Select an experiment to filter by
@@ -709,7 +700,6 @@ describe('Pipeline runs', () => {
           archivedRunsTable.mockGetArchivedRuns(
             mockArchivedRuns.filter((mockRun) => mockRun.created_at.includes('2024-02-05')),
             projectName,
-            1,
           );
           pipelineRunsGlobal
             .findArchivedRunsToolbar()
@@ -726,7 +716,6 @@ describe('Pipeline runs', () => {
           archivedRunsTable.mockGetArchivedRuns(
             mockArchivedRuns.filter((mockRun) => mockRun.created_at.includes('2024-02-15')),
             projectName,
-            1,
           );
           pipelineRunsGlobal
             .findArchivedRunsToolbar()
@@ -749,7 +738,6 @@ describe('Pipeline runs', () => {
           archivedRunsTable.mockGetArchivedRuns(
             mockArchivedRuns.filter((mockRun) => mockRun.state === RuntimeStateKF.SUCCEEDED),
             projectName,
-            1,
           );
           // Select a filter value of 'SUCCEEDED'
           pipelineRunsGlobal
@@ -767,7 +755,6 @@ describe('Pipeline runs', () => {
           archivedRunsTable.mockGetArchivedRuns(
             mockArchivedRuns.filter((mockRun) => mockRun.state === RuntimeStateKF.RUNNING),
             projectName,
-            1,
           );
           // Select a filter value of 'RUNNING'
           pipelineRunsGlobal


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-21797

## Description
cypress flake in pipelineRuns.cy.ts, this might be a side effect of mocking the network request only 1 time in the test case
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Since this is flaky test this doesnt occurs regularly, run pipelineRuns.cy.ts test file multiple times
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Cypress test
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
