### PR TITLE
Revert a small cypress change from testConnectionCreation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/connections/testConnectionCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/connections/testConnectionCreation.cy.ts
@@ -1,5 +1,5 @@
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
-import { projectListPage, projectDetails } from '~/__tests__/cypress/cypress/pages/projects';
+import { projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import type { DataScienceProjectData, AWSS3BucketDetails } from '~/__tests__/cypress/cypress/types';
 import { connectionsPage, addConnectionModal } from '~/__tests__/cypress/cypress/pages/connections';
@@ -76,7 +76,9 @@ describe('Verify Connections - Creation and Deletion', () => {
 
       //Navigate to Connections and create Connection
       cy.step('Navigate to Connections and click to create Connection');
-      projectDetails.findSectionTab('connections').click();
+      // TODO: Revert the cy.visit(...) method once RHOAIENG-21039 is resolved
+      // Reapply projectDetails.findSectionTab('connections').click();
+      cy.visit(`projects/${projectName}?section=connections`);
       connectionsPage.findCreateConnectionButton().click();
 
       // Enter validate Connection details into the Connection Modal


### PR DESCRIPTION


## Description
Reverts a small change made in [Data Connections clean up](https://github.com/opendatahub-io/odh-dashboard/pull/3846)

## How Has This Been Tested?

## Test Impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
