### PR TITLE
Fixing workbench image pull event success bug

### DIFF
--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -5,12 +5,11 @@ import StartNotebookModal from '~/concepts/notebooks/StartNotebookModal';
 import {
   mockCompletedStates,
   mockFailedStates,
-  //mockInitialStates,
   mockInProgressStates,
 } from '~/concepts/__tests__/mockNotebookStates';
 
 describe('Start Notebook modal', () => {
-  //TODO: RHOAIENG-22056 uncomment this test once 'pod created' event is reintroduced AND uncomment the mockInitialStates import
+  //TODO: RHOAIENG-22056 uncomment this test once 'pod created' event is reintroduced
   // it('should show initial notebook startup status', async () => {
   //   const mockData = mockInitialStates;
   //   render(
@@ -52,7 +51,6 @@ describe('Start Notebook modal', () => {
   //   expect(steps[13]).toHaveTextContent('Server started');
   // });
 
-  //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
   it('should show failed notebook startup status', async () => {
     const mockData = mockFailedStates;
     render(
@@ -78,11 +76,10 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
+    expect(steps).toHaveLength(14); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
     expect(steps[1]).toHaveTextContent('Failed to scale-up');
   });
 
-  //TODO: RHOAIENG-22056 increment 'listItem' AND 'step-status-success' .toHaveLength after reintroducting the 'pod created' event
   it('should show in progress notebook startup status', async () => {
     const mockData = mockInProgressStates;
     render(
@@ -106,12 +103,11 @@ describe('Start Notebook modal', () => {
     // Validate the steps
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    expect(screen.getAllByRole('listitem')).toHaveLength(13);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(9);
+    expect(screen.getAllByRole('listitem')).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(9); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
     expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(4);
   });
 
-  //TODO: RHOAIENG-22056 increment both .toHaveLength after reintroducting the 'pod created' event
   it('should show completed notebook startup status', async () => {
     const mockData = mockCompletedStates;
     render(
@@ -133,11 +129,10 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13);
+    expect(steps).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
   });
 
-  //TODO: RHOAIENG-22056 increment both .toHaveLength after reintroducting the 'pod created' event
   it('should show completed notebook startup status for standalone notebooks', async () => {
     const mockData = mockCompletedStates;
     render(
@@ -159,11 +154,10 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13);
+    expect(steps).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
   });
 
-  //TODO: RHOAIENG-22056 increment both .toHaveLength after reintroducting the 'pod created' event
   it('should show stopping notebook status', async () => {
     render(
       <StartNotebookModal
@@ -187,7 +181,7 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
-    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(13);
+    expect(steps).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(13); //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
   });
 });

--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -5,52 +5,54 @@ import StartNotebookModal from '~/concepts/notebooks/StartNotebookModal';
 import {
   mockCompletedStates,
   mockFailedStates,
-  mockInitialStates,
+  //mockInitialStates,
   mockInProgressStates,
 } from '~/concepts/__tests__/mockNotebookStates';
 
 describe('Start Notebook modal', () => {
-  it('should show initial notebook startup status', async () => {
-    const mockData = mockInitialStates;
-    render(
-      <StartNotebookModal
-        notebookStatus={mockData.notebookStatus}
-        isStarting={mockData.notebookState.isStarting}
-        isStopping={mockData.notebookState.isStopping}
-        isRunning={mockData.notebookState.isRunning}
-        events={mockData.events}
-        buttons={null}
-      />,
-    );
+  //TODO: RHOAIENG-22056 uncomment this test once 'pod created' event is reintroduced AND uncomment the mockInitialStates import
+  // it('should show initial notebook startup status', async () => {
+  //   const mockData = mockInitialStates;
+  //   render(
+  //     <StartNotebookModal
+  //       notebookStatus={mockData.notebookStatus}
+  //       isStarting={mockData.notebookState.isStarting}
+  //       isStopping={mockData.notebookState.isStopping}
+  //       isRunning={mockData.notebookState.isRunning}
+  //       events={mockData.events}
+  //       buttons={null}
+  //     />,
+  //   );
 
-    // Validate the header contents
-    const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusStarting');
+  //   // Validate the header contents
+  //   const header = screen.getByTestId('notebook-status-modal-header');
+  //   expect(header).toHaveTextContent('Workbench statusStarting');
 
-    const statusLabel = screen.getByTestId('notebook-latest-status');
-    expect(statusLabel).toHaveTextContent('Waiting for server request to start');
+  //   const statusLabel = screen.getByTestId('notebook-latest-status');
+  //   expect(statusLabel).toHaveTextContent('Waiting for server request to start');
 
-    // Validate the steps
-    const stepper = screen.getByTestId('notebook-startup-steps');
-    expect(stepper).toBeTruthy();
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(steps[0]).toHaveTextContent('Server requested');
-    expect(steps[1]).toHaveTextContent('Pod created');
-    expect(steps[2]).toHaveTextContent('Pod assigned');
-    expect(steps[3]).toHaveTextContent('PVC attached');
-    expect(steps[4]).toHaveTextContent('Interface added');
-    expect(steps[5]).toHaveTextContent('Pulling workbench image');
-    expect(steps[6]).toHaveTextContent('Workbench image pulled');
-    expect(steps[7]).toHaveTextContent('Workbench container created');
-    expect(steps[8]).toHaveTextContent('Workbench container started');
-    expect(steps[9]).toHaveTextContent('Pulling oauth proxy');
-    expect(steps[10]).toHaveTextContent('Oauth proxy pulled');
-    expect(steps[11]).toHaveTextContent('Oauth proxy container created');
-    expect(steps[12]).toHaveTextContent('Oauth proxy container started');
-    expect(steps[13]).toHaveTextContent('Server started');
-  });
+  //   // Validate the steps
+  //   const stepper = screen.getByTestId('notebook-startup-steps');
+  //   expect(stepper).toBeTruthy();
+  //   const steps = screen.getAllByRole('listitem');
+  //   expect(steps).toHaveLength(14);
+  //   expect(steps[0]).toHaveTextContent('Server requested');
+  //   expect(steps[1]).toHaveTextContent('Pod created');
+  //   expect(steps[2]).toHaveTextContent('Pod assigned');
+  //   expect(steps[3]).toHaveTextContent('PVC attached');
+  //   expect(steps[4]).toHaveTextContent('Interface added');
+  //   expect(steps[5]).toHaveTextContent('Pulling workbench image');
+  //   expect(steps[6]).toHaveTextContent('Workbench image pulled');
+  //   expect(steps[7]).toHaveTextContent('Workbench container created');
+  //   expect(steps[8]).toHaveTextContent('Workbench container started');
+  //   expect(steps[9]).toHaveTextContent('Pulling oauth proxy');
+  //   expect(steps[10]).toHaveTextContent('Oauth proxy pulled');
+  //   expect(steps[11]).toHaveTextContent('Oauth proxy container created');
+  //   expect(steps[12]).toHaveTextContent('Oauth proxy container started');
+  //   expect(steps[13]).toHaveTextContent('Server started');
+  // });
 
+  //TODO: RHOAIENG-22056 increment .toHaveLength after reintroducting the 'pod created' event
   it('should show failed notebook startup status', async () => {
     const mockData = mockFailedStates;
     render(
@@ -76,10 +78,11 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(15);
+    expect(steps).toHaveLength(14);
     expect(steps[1]).toHaveTextContent('Failed to scale-up');
   });
 
+  //TODO: RHOAIENG-22056 increment 'listItem' AND 'step-status-success' .toHaveLength after reintroducting the 'pod created' event
   it('should show in progress notebook startup status', async () => {
     const mockData = mockInProgressStates;
     render(
@@ -103,11 +106,12 @@ describe('Start Notebook modal', () => {
     // Validate the steps
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    expect(screen.getAllByRole('listitem')).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(10);
+    expect(screen.getAllByRole('listitem')).toHaveLength(13);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(9);
     expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(4);
   });
 
+  //TODO: RHOAIENG-22056 increment both .toHaveLength after reintroducting the 'pod created' event
   it('should show completed notebook startup status', async () => {
     const mockData = mockCompletedStates;
     render(
@@ -129,10 +133,11 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(14);
+    expect(steps).toHaveLength(13);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13);
   });
 
+  //TODO: RHOAIENG-22056 increment both .toHaveLength after reintroducting the 'pod created' event
   it('should show completed notebook startup status for standalone notebooks', async () => {
     const mockData = mockCompletedStates;
     render(
@@ -154,10 +159,11 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(14);
+    expect(steps).toHaveLength(13);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(13);
   });
 
+  //TODO: RHOAIENG-22056 increment both .toHaveLength after reintroducting the 'pod created' event
   it('should show stopping notebook status', async () => {
     render(
       <StartNotebookModal
@@ -181,7 +187,7 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(14);
+    expect(steps).toHaveLength(13);
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(13);
   });
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -603,7 +603,6 @@ export enum NotebookState {
 
 export enum ProgressionStep {
   SERVER_REQUESTED = 'SERVER_REQUESTED',
-  POD_CREATED = 'POD_CREATED',
   POD_ASSIGNED = 'POD_ASSIGNED',
   PVC_ATTACHED = 'PVC_ATTACHED',
   INTERFACE_ADDED = 'INTERFACE_ADDED',
@@ -620,7 +619,6 @@ export enum ProgressionStep {
 
 export const ProgressionStepTitles = {
   [ProgressionStep.SERVER_REQUESTED]: 'Server requested',
-  [ProgressionStep.POD_CREATED]: 'Pod created',
   [ProgressionStep.POD_ASSIGNED]: 'Pod assigned',
   [ProgressionStep.PVC_ATTACHED]: 'PVC attached',
   [ProgressionStep.INTERFACE_ADDED]: 'Interface added',

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -356,7 +356,7 @@ export const getNotebookEventStatus = (
         };
     }
   }
-  //for events not related to oauth
+  //for notebook events
   switch (event.reason) {
     case 'Scheduled':
       return {

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -309,8 +309,8 @@ export const getNotebookEventStatus = (
   gracePeriod?: boolean,
 ): NotebookProgressStep => {
   const timestamp = new Date(getEventTimestamp(event)).getTime();
-
-  if (event.message.includes('oauth-proxy')) {
+  //for oauth-related events
+  if (event.message.includes('oauth-proxy') || event.message.includes('ose-oauth-proxy')) {
     switch (event.reason) {
       case 'Pulling':
         return {
@@ -356,7 +356,7 @@ export const getNotebookEventStatus = (
         };
     }
   }
-
+  //for events not related to oauth
   switch (event.reason) {
     case 'Scheduled':
       return {
@@ -546,7 +546,6 @@ export const useNotebookProgress = (
       }
     }
   });
-
 
   // If the container is started and the server is running, mark the server started step complete
   if (

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -247,7 +247,7 @@ export const getEventFullMessage = (event: EventKind): string =>
 const filterEvents = (
   allEvents: EventKind[],
   lastActivity: Date,
-): [filterEvents: EventKind[], thisInstanceEvents: EventKind[], gracePeroid: boolean] => {
+): [filterEvents: EventKind[], thisInstanceEvents: EventKind[], gracePeriod: boolean] => {
   const thisInstanceEvents = allEvents
     .filter((event) => new Date(getEventTimestamp(event)) >= lastActivity)
     .toSorted((a, b) => getEventTimestamp(a).localeCompare(getEventTimestamp(b)));

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -547,17 +547,6 @@ export const useNotebookProgress = (
     }
   });
 
-  // Some events are not always received, mark all steps prior to the last completed step complete.
-  const lastCompleteIndex = progressSteps.findLastIndex(
-    (step) => step.status === EventStatus.SUCCESS,
-  );
-  if (lastCompleteIndex > 0) {
-    for (let i = 0; i < lastCompleteIndex; i++) {
-      if (progressSteps[i].status === EventStatus.PENDING) {
-        progressSteps[i].status = EventStatus.SUCCESS;
-      }
-    }
-  }
 
   // If the container is started and the server is running, mark the server started step complete
   if (

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -358,12 +358,6 @@ export const getNotebookEventStatus = (
   }
 
   switch (event.reason) {
-    case 'SuccessfulCreate':
-      return {
-        step: ProgressionStep.POD_CREATED,
-        status: EventStatus.SUCCESS,
-        timestamp,
-      };
     case 'Scheduled':
       return {
         step: ProgressionStep.POD_ASSIGNED,


### PR DESCRIPTION
Closes: [RHOAIENG-21741](https://issues.redhat.com/browse/RHOAIENG-21741)

## Description
- Removed code that assumed steps were successful if later steps succeeded. 
- Also removed the 'pod created' step as it was never being sent by Kubernetes and therefore the event never succeeded. (Might be added again in the [follow up ticket.](https://issues.redhat.com/browse/RHOAIENG-22056)
- Added additional check for 'ose-oauth-proxy' for clarity in differentiating between oauth and notebook events.
- Fixed a typo.

## How Has This Been Tested?
I ran `npm run test` with 6 test failures due to the removal of the 'pod created' event, otherwise all other tests passed.

## Test Impact
No additional tests were written, but the unit tests were temporarily modified to handle the removal of the 'pod created' event and will be reverted/reinstated during the [follow up ticket](https://issues.redhat.com/browse/RHOAIENG-22056).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
