### PR TITLE
refractor clusterStorageModal

### DIFF
--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
@@ -2,39 +2,28 @@ import * as React from 'react';
 import { Button, Stack, FormGroup, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { isEqual } from 'lodash-es';
-import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
-import { ClusterStorageNotebookSelection, StorageData } from '~/pages/projects/types';
+import { PersistentVolumeClaimKind } from '~/k8sTypes';
+import { StorageData } from '~/pages/projects/types';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import {
-  attachNotebookPVC,
-  createPvc,
-  removeNotebookPVC,
-  restartNotebook,
-  updateNotebookPVC,
-  updatePvc,
-} from '~/api';
 import {
   ConnectedNotebookContext,
   useRelatedNotebooks,
 } from '~/pages/projects/notebook/useRelatedNotebooks';
 import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksRestart';
 import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
-import { Table } from '~/components/table';
-import { getNotebookPVCMountPathMap } from '~/pages/projects/notebook/utils';
-import { MOUNT_PATH_PREFIX } from '~/pages/projects/screens/spawner/storage/const';
 import NotebookRestartAlert from '~/pages/projects/components/NotebookRestartAlert';
-import { MountPathFormat } from '~/pages/projects/screens/spawner/storage/types';
 import { useCreateStorageObject } from '~/pages/projects/screens/spawner/storage/utils';
 import BaseStorageModal from './BaseStorageModal';
 import {
-  handleConnectedNotebooks,
-  isPvcUpdateRequired,
+  handleNotebooksChanges,
   getInUseMountPaths,
   validateClusterMountPath,
   getDefaultMountPathFromStorageName,
+  hasAllValidNotebookRelationship,
 } from './utils';
-import { storageColumns } from './clusterTableColumns';
-import ClusterStorageTableRow from './ClusterStorageTableRow';
+import useClusterStorageFormState from './useClusterStorageFormState';
+import ClusterStorageTable from './ClusterStorageTable';
+import { handleSubmit } from './submitUtils';
 
 type ClusterStorageModalProps = {
   existingPvc?: PersistentVolumeClaimKind;
@@ -52,42 +41,17 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
     ConnectedNotebookContext.REMOVABLE_PVC,
     existingPvc?.metadata.name,
   );
-
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
   const [{ name }] = useCreateStorageObject(existingPvc);
   const [storageName, setStorageName] = React.useState<string>(name);
-  const hasExistingNotebookConnections = connectedNotebooks.length > 0;
-  const [notebookData, setNotebookData] = React.useState<ClusterStorageNotebookSelection[]>([]);
+  const { notebookData, setNotebookData } = useClusterStorageFormState(
+    connectedNotebooks,
+    existingPvc,
+  );
   const [newRowId, setNewRowId] = React.useState<number>(1);
-
-  React.useEffect(() => {
-    if (hasExistingNotebookConnections) {
-      const addData = connectedNotebooks.map((connectedNotebook) => ({
-        name: connectedNotebook.metadata.name,
-        notebookDisplayName: connectedNotebook.metadata.annotations?.['openshift.io/display-name'],
-        mountPath: {
-          value: existingPvc
-            ? getNotebookPVCMountPathMap(connectedNotebook)[existingPvc.metadata.name]
-            : '',
-          error: '',
-        },
-        existingPvc: true,
-        isUpdatedValue: false,
-      }));
-      setNotebookData(addData);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [existingPvc, hasExistingNotebookConnections]);
-
-  const availableNotebooks = React.useMemo(
-    () =>
-      allNotebooks.filter(
-        (currentNotebookData) =>
-          !notebookData.some(
-            (currentNotebook) => currentNotebook.name === currentNotebookData.metadata.name,
-          ),
-      ),
-    [allNotebooks, notebookData],
+  const isValid = React.useMemo(
+    () => hasAllValidNotebookRelationship(notebookData),
+    [notebookData],
   );
 
   const addEmptyRow = React.useCallback(() => {
@@ -105,94 +69,7 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
       },
     ]);
     setNewRowId((prev) => prev + 1);
-  }, [newRowId, notebookData, storageName]);
-
-  const { updatedNotebooks, removedNotebooks } = handleConnectedNotebooks(
-    notebookData,
-    connectedNotebooks,
-  );
-
-  const newNotebooks = notebookData.filter((notebook) => !notebook.existingPvc);
-
-  const restartNotebooks = useWillNotebooksRestart([
-    ...updatedNotebooks.map((updatedNotebook) => updatedNotebook.name),
-    ...removedNotebooks,
-    ...newNotebooks.map((newNotebook) => newNotebook.name),
-  ]);
-
-  const handleSubmit = async (submitData: StorageData, dryRun?: boolean) => {
-    const promises: Promise<PersistentVolumeClaimKind | NotebookKind>[] = [];
-    if (existingPvc) {
-      const pvcName = existingPvc.metadata.name;
-
-      // Check if PVC needs to be updated (name, description, size, storageClass)
-      if (isPvcUpdateRequired(existingPvc, submitData)) {
-        promises.push(updatePvc(submitData, existingPvc, namespace, { dryRun }));
-      }
-
-      // Restart notebooks if the PVC size has changed
-      if (existingPvc.spec.resources.requests.storage !== submitData.size) {
-        restartNotebooks.map((connectedNotebook) =>
-          promises.push(
-            restartNotebook(connectedNotebook.notebook.metadata.name, namespace, { dryRun }),
-          ),
-        );
-      }
-
-      if (updatedNotebooks.length > 0) {
-        promises.push(
-          ...updatedNotebooks.map((nM) =>
-            updateNotebookPVC(nM.name, namespace, nM.mountPath.value, pvcName, { dryRun }),
-          ),
-        );
-      }
-
-      if (removedNotebooks.length > 0) {
-        promises.push(
-          ...removedNotebooks.map((nM) => removeNotebookPVC(nM, namespace, pvcName, { dryRun })),
-        );
-      }
-      if (newNotebooks.length > 0) {
-        promises.push(
-          ...newNotebooks.map((nM) =>
-            attachNotebookPVC(nM.name, namespace, pvcName, nM.mountPath.value, { dryRun }),
-          ),
-        );
-      }
-      await Promise.all(promises);
-      return;
-    }
-
-    const createdPvc = await createPvc(submitData, namespace, { dryRun });
-
-    const newCreatedPVCPromises: Promise<PersistentVolumeClaimKind | NotebookKind>[] = [];
-
-    if (newNotebooks.length > 0) {
-      newCreatedPVCPromises.push(
-        ...newNotebooks.map((nM) =>
-          attachNotebookPVC(nM.name, namespace, createdPvc.metadata.name, nM.mountPath.value, {
-            dryRun,
-          }),
-        ),
-      );
-    }
-    await Promise.all(newCreatedPVCPromises);
-  };
-
-  const submit = async (dataSubmit: StorageData) =>
-    handleSubmit(dataSubmit, true).then(() => handleSubmit(dataSubmit, false));
-
-  const hasAllValidNotebookRelationship = React.useMemo(
-    () =>
-      notebookData.every((currentNotebookData) =>
-        currentNotebookData.name
-          ? !!currentNotebookData.mountPath.value && !currentNotebookData.mountPath.error
-          : false,
-      ),
-    [notebookData],
-  );
-
-  const isValid = hasAllValidNotebookRelationship;
+  }, [newRowId, notebookData, setNotebookData, storageName]);
 
   const updatePathWithNameChange = React.useCallback(
     (newStorageName: string) => {
@@ -224,40 +101,37 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
         setNotebookData(updatedData);
       }
     },
-    [allNotebooks, existingPvc?.metadata.name, notebookData],
+    [allNotebooks, existingPvc?.metadata.name, notebookData, setNotebookData],
   );
 
-  const handleMountPathUpdate = React.useCallback(
-    (rowIndex: number, value: string, format: MountPathFormat) => {
-      const notebook = notebookData[rowIndex];
-      const prefix = format === MountPathFormat.STANDARD ? MOUNT_PATH_PREFIX : '/';
-      const newValue = `${prefix}${value}`;
+  const notebookChangesResult = handleNotebooksChanges(notebookData, connectedNotebooks);
 
-      const inUseMountPaths = getInUseMountPaths(
-        notebook.name,
-        allNotebooks,
-        existingPvc?.metadata.name,
-      );
+  const restartNotebooks = useWillNotebooksRestart([
+    ...notebookChangesResult.updatedNotebooks.map((updatedNotebook) => updatedNotebook.name),
+    ...notebookChangesResult.removedNotebooks,
+    ...notebookChangesResult.newNotebooks.map((newNotebook) => newNotebook.name),
+  ]);
 
-      const existingPath = notebook.name
-        ? getNotebookPVCMountPathMap(allNotebooks.find((n) => n.metadata.name === notebook.name))[
-            existingPvc?.metadata.name ?? ''
-          ]
-        : '';
-
-      const error = validateClusterMountPath(newValue, inUseMountPaths);
-      const isSamePvcPath = notebook.existingPvc && newValue === existingPath;
-
-      const updatedData = [...notebookData];
-      updatedData[rowIndex] = {
-        ...notebook,
-        mountPath: { value: newValue, error },
-        isUpdatedValue: !isSamePvcPath,
-      };
-
-      setNotebookData(updatedData);
-    },
-    [notebookData, allNotebooks, existingPvc],
+  const submit = React.useCallback(
+    async (dataSubmit: StorageData) =>
+      handleSubmit(
+        dataSubmit,
+        restartNotebooks,
+        notebookChangesResult,
+        namespace,
+        existingPvc,
+        true,
+      ).then(() =>
+        handleSubmit(
+          dataSubmit,
+          restartNotebooks,
+          notebookChangesResult,
+          namespace,
+          existingPvc,
+          false,
+        ),
+      ),
+    [existingPvc, namespace, notebookChangesResult, restartNotebooks],
   );
 
   return (
@@ -273,7 +147,6 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
         setStorageName(currentName);
         updatePathWithNameChange(currentName);
       }}
-      submitLabel={existingPvc ? 'Update' : 'Add storage'}
       isValid={isValid}
       onClose={(submitted) => onClose(submitted)}
       existingPvc={existingPvc}
@@ -283,61 +156,13 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
           <FormGroup label="Workbench connections" fieldId="workbench-connections">
             <Stack hasGutter>
               <StackItem>
-                <Table
-                  data-testid="workbench-connection-table"
-                  variant="compact"
-                  columns={storageColumns}
-                  data={notebookData}
-                  rowRenderer={(row, rowIndex) => (
-                    <ClusterStorageTableRow
-                      key={row.newRowId || row.name}
-                      obj={row}
-                      inUseMountPaths={getInUseMountPaths(
-                        row.name,
-                        allNotebooks,
-                        existingPvc?.metadata.name,
-                      )}
-                      availableNotebooks={{
-                        notebooks: [
-                          ...availableNotebooks,
-                          ...allNotebooks.filter(
-                            (currentData) => currentData.metadata.name === row.name,
-                          ),
-                        ],
-                        loaded,
-                      }}
-                      onMountPathUpdate={(value, format) =>
-                        handleMountPathUpdate(rowIndex, value, format)
-                      }
-                      onNotebookSelect={(notebookName) => {
-                        const updatedData = [...notebookData];
-                        updatedData[rowIndex] = {
-                          ...row,
-                          name: notebookName,
-                          mountPath: {
-                            ...row.mountPath,
-                            error: validateClusterMountPath(
-                              row.mountPath.value,
-                              getInUseMountPaths(
-                                notebookName,
-                                allNotebooks,
-                                existingPvc?.metadata.name,
-                              ),
-                            ),
-                          },
-                          existingPvc: connectedNotebooks.some(
-                            (n) => n.metadata.name === notebookName,
-                          ),
-                        };
-                        setNotebookData(updatedData);
-                      }}
-                      onDelete={() => {
-                        const updatedData = [...notebookData];
-                        updatedData.splice(rowIndex, 1);
-                        setNotebookData(updatedData);
-                      }}
-                    />
-                  )}
+                <ClusterStorageTable
+                  notebookData={notebookData}
+                  allNotebooks={allNotebooks}
+                  setNotebookData={setNotebookData}
+                  notebookLoaded={loaded}
+                  connectedNotebooks={connectedNotebooks}
+                  existingPvc={existingPvc}
                 />
               </StackItem>
               <StackItem>

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTable.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTable.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Table } from '~/components/table';
+import { ClusterStorageNotebookSelection } from '~/pages/projects/types';
+import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
+import { MountPathFormat } from '~/pages/projects/screens/spawner/storage/types';
+import { getNotebookPVCMountPathMap } from '~/pages/projects/notebook/utils';
+import { MOUNT_PATH_PREFIX } from '~/pages/projects/screens/spawner/storage/const';
+import { storageColumns } from './clusterTableColumns';
+import ClusterStorageTableRow from './ClusterStorageTableRow';
+import { getInUseMountPaths, validateClusterMountPath } from './utils';
+
+type ClusterStorageTableProps = {
+  notebookData: ClusterStorageNotebookSelection[];
+  allNotebooks: NotebookKind[];
+  setNotebookData: React.Dispatch<React.SetStateAction<ClusterStorageNotebookSelection[]>>;
+  notebookLoaded: boolean;
+  connectedNotebooks: NotebookKind[];
+  existingPvc: PersistentVolumeClaimKind | undefined;
+};
+
+const ClusterStorageTable: React.FC<ClusterStorageTableProps> = ({
+  notebookData,
+  setNotebookData,
+  allNotebooks,
+  notebookLoaded,
+  connectedNotebooks,
+  existingPvc,
+}) => {
+  const availableNotebooks = React.useMemo(
+    () =>
+      allNotebooks.filter(
+        (currentNotebookData) =>
+          !notebookData.some(
+            (currentNotebook) => currentNotebook.name === currentNotebookData.metadata.name,
+          ),
+      ),
+    [allNotebooks, notebookData],
+  );
+
+  const handleMountPathUpdate = React.useCallback(
+    (rowIndex: number, value: string, format: MountPathFormat) => {
+      const notebook = notebookData[rowIndex];
+      const prefix = format === MountPathFormat.STANDARD ? MOUNT_PATH_PREFIX : '/';
+      const newValue = `${prefix}${value}`;
+
+      const inUseMountPaths = getInUseMountPaths(
+        notebook.name,
+        allNotebooks,
+        existingPvc?.metadata.name,
+      );
+
+      const existingPath = notebook.name
+        ? getNotebookPVCMountPathMap(allNotebooks.find((n) => n.metadata.name === notebook.name))[
+            existingPvc?.metadata.name ?? ''
+          ]
+        : '';
+
+      const error = validateClusterMountPath(newValue, inUseMountPaths);
+      const isSamePvcPath = notebook.existingPvc && newValue === existingPath;
+
+      const updatedData = [...notebookData];
+      updatedData[rowIndex] = {
+        ...notebook,
+        mountPath: { value: newValue, error },
+        isUpdatedValue: !isSamePvcPath,
+      };
+
+      setNotebookData(updatedData);
+    },
+    [notebookData, allNotebooks, existingPvc?.metadata.name, setNotebookData],
+  );
+
+  return (
+    <Table
+      data-testid="workbench-connection-table"
+      variant="compact"
+      columns={storageColumns}
+      data={notebookData}
+      rowRenderer={(row, rowIndex) => (
+        <ClusterStorageTableRow
+          key={row.newRowId || row.name}
+          obj={row}
+          inUseMountPaths={getInUseMountPaths(row.name, allNotebooks, existingPvc?.metadata.name)}
+          availableNotebooks={{
+            notebooks: [
+              ...availableNotebooks,
+              ...allNotebooks.filter((currentData) => currentData.metadata.name === row.name),
+            ],
+            loaded: notebookLoaded,
+          }}
+          onMountPathUpdate={(value, format) => handleMountPathUpdate(rowIndex, value, format)}
+          onNotebookSelect={(notebookName) => {
+            const updatedData = [...notebookData];
+            updatedData[rowIndex] = {
+              ...row,
+              name: notebookName,
+              mountPath: {
+                ...row.mountPath,
+                error: validateClusterMountPath(
+                  row.mountPath.value,
+                  getInUseMountPaths(notebookName, allNotebooks, existingPvc?.metadata.name),
+                ),
+              },
+              existingPvc: connectedNotebooks.some((n) => n.metadata.name === notebookName),
+            };
+            setNotebookData(updatedData);
+          }}
+          onDelete={() => {
+            const updatedData = [...notebookData];
+            updatedData.splice(rowIndex, 1);
+            setNotebookData(updatedData);
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default ClusterStorageTable;

--- a/frontend/src/pages/projects/screens/detail/storage/__tests__/useClusterStorageFormState.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/__tests__/useClusterStorageFormState.spec.ts
@@ -1,0 +1,58 @@
+import { act } from 'react';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import useClusterStorageFormState from '~/pages/projects/screens/detail/storage/useClusterStorageFormState';
+import { mockNotebookK8sResource } from '~/__mocks__';
+import { mockPVCK8sResource } from '~/__mocks__/mockPVCK8sResource';
+
+describe('useClusterStorageFormState', () => {
+  it('should set notebookData correctly when connectedNotebooks and existingPvc are provided', () => {
+    const renderResult = testHook(useClusterStorageFormState)(
+      [mockNotebookK8sResource({})],
+      mockPVCK8sResource({}),
+    );
+
+    expect(renderResult.result.current.notebookData).toEqual([
+      {
+        existingPvc: true,
+        isUpdatedValue: false,
+        mountPath: { error: '', value: undefined },
+        name: 'test-notebook',
+        notebookDisplayName: 'Test Notebook',
+      },
+    ]);
+
+    act(() => {
+      renderResult.result.current.setNotebookData([
+        {
+          name: 'notebook3',
+          notebookDisplayName: 'Notebook 3',
+          mountPath: {
+            value: '/mnt/data/pvc3',
+            error: '',
+          },
+          existingPvc: true,
+          isUpdatedValue: false,
+        },
+      ]);
+    });
+
+    expect(renderResult.result.current.notebookData).toEqual([
+      {
+        name: 'notebook3',
+        notebookDisplayName: 'Notebook 3',
+        mountPath: {
+          value: '/mnt/data/pvc3',
+          error: '',
+        },
+        existingPvc: true,
+        isUpdatedValue: false,
+      },
+    ]);
+  });
+
+  it('should set notebookData to an empty array when no connectedNotebooks are provided', () => {
+    const renderResult = testHook(useClusterStorageFormState)([]);
+
+    expect(renderResult.result.current.notebookData).toEqual([]);
+  });
+});

--- a/frontend/src/pages/projects/screens/detail/storage/submitUtils.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/submitUtils.ts
@@ -1,0 +1,79 @@
+import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
+import { NotebookState } from '~/pages/projects/notebook/types';
+import { StorageData } from '~/pages/projects/types';
+import {
+  attachNotebookPVC,
+  createPvc,
+  removeNotebookPVC,
+  restartNotebook,
+  updateNotebookPVC,
+  updatePvc,
+} from '~/api';
+import { isPvcUpdateRequired, NotebooksChangesResult } from './utils';
+
+export const handleSubmit = async (
+  submitData: StorageData,
+  restartNotebooks: NotebookState[],
+  notebookChangesResult: NotebooksChangesResult,
+  namespace: string,
+  existingPvc?: PersistentVolumeClaimKind,
+  dryRun?: boolean,
+): Promise<void> => {
+  const promises: Promise<PersistentVolumeClaimKind | NotebookKind>[] = [];
+  if (existingPvc) {
+    const pvcName = existingPvc.metadata.name;
+
+    // Check if PVC needs to be updated (name, description, size, storageClass)
+    if (isPvcUpdateRequired(existingPvc, submitData)) {
+      promises.push(updatePvc(submitData, existingPvc, namespace, { dryRun }));
+    }
+
+    // Restart notebooks if the PVC size has changed
+    if (existingPvc.spec.resources.requests.storage !== submitData.size) {
+      restartNotebooks.map((connectedNotebook) =>
+        promises.push(
+          restartNotebook(connectedNotebook.notebook.metadata.name, namespace, { dryRun }),
+        ),
+      );
+    }
+
+    if (notebookChangesResult.updatedNotebooks.length > 0) {
+      promises.push(
+        ...notebookChangesResult.updatedNotebooks.map((nM) =>
+          updateNotebookPVC(nM.name, namespace, nM.mountPath.value, pvcName, { dryRun }),
+        ),
+      );
+    }
+
+    if (notebookChangesResult.removedNotebooks.length > 0) {
+      promises.push(
+        ...notebookChangesResult.removedNotebooks.map((nM) =>
+          removeNotebookPVC(nM, namespace, pvcName, { dryRun }),
+        ),
+      );
+    }
+    if (notebookChangesResult.newNotebooks.length > 0) {
+      promises.push(
+        ...notebookChangesResult.newNotebooks.map((nM) =>
+          attachNotebookPVC(nM.name, namespace, pvcName, nM.mountPath.value, { dryRun }),
+        ),
+      );
+    }
+    await Promise.all(promises);
+    return;
+  }
+  const createdPvc = await createPvc(submitData, namespace, { dryRun });
+
+  const newCreatedPVCPromises: Promise<PersistentVolumeClaimKind | NotebookKind>[] = [];
+
+  if (notebookChangesResult.newNotebooks.length > 0) {
+    newCreatedPVCPromises.push(
+      ...notebookChangesResult.newNotebooks.map((nM) =>
+        attachNotebookPVC(nM.name, namespace, createdPvc.metadata.name, nM.mountPath.value, {
+          dryRun,
+        }),
+      ),
+    );
+  }
+  await Promise.all(newCreatedPVCPromises);
+};

--- a/frontend/src/pages/projects/screens/detail/storage/useClusterStorageFormState.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/useClusterStorageFormState.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import { NotebookKind, PersistentVolumeClaimKind } from '~/k8sTypes';
+import { getNotebookPVCMountPathMap } from '~/pages/projects/notebook/utils';
+import { ClusterStorageNotebookSelection } from '~/pages/projects/types';
+
+const useClusterStorageFormState = (
+  connectedNotebooks: NotebookKind[],
+  existingPvc?: PersistentVolumeClaimKind,
+): {
+  notebookData: ClusterStorageNotebookSelection[];
+  setNotebookData: React.Dispatch<React.SetStateAction<ClusterStorageNotebookSelection[]>>;
+} => {
+  const [notebookData, setNotebookData] = React.useState<ClusterStorageNotebookSelection[]>([]);
+
+  React.useEffect(() => {
+    if (connectedNotebooks.length > 0) {
+      const addData = connectedNotebooks.map((connectedNotebook) => ({
+        name: connectedNotebook.metadata.name,
+        notebookDisplayName: connectedNotebook.metadata.annotations?.['openshift.io/display-name'],
+        mountPath: {
+          value: existingPvc
+            ? getNotebookPVCMountPathMap(connectedNotebook)[existingPvc.metadata.name]
+            : '',
+          error: '',
+        },
+        existingPvc: true,
+        isUpdatedValue: false,
+      }));
+      setNotebookData(addData);
+    }
+  }, [connectedNotebooks, existingPvc]);
+
+  return { notebookData, setNotebookData };
+};
+
+export default useClusterStorageFormState;

--- a/frontend/src/pages/projects/screens/detail/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/utils.ts
@@ -28,15 +28,19 @@ export const isPvcUpdateRequired = (
   existingPvc.spec.resources.requests.storage !== storageData.size ||
   existingPvc.spec.storageClassName !== storageData.storageClassName;
 
-export const handleConnectedNotebooks = (
-  tempData: ClusterStorageNotebookSelection[],
-  notebooks: NotebookKind[],
-): {
+export type NotebooksChangesResult = {
   updatedNotebooks: ClusterStorageNotebookSelection[];
   removedNotebooks: string[];
-} => {
+  newNotebooks: ClusterStorageNotebookSelection[];
+};
+
+export const handleNotebooksChanges = (
+  tempData: ClusterStorageNotebookSelection[],
+  notebooks: NotebookKind[],
+): NotebooksChangesResult => {
   const updatedNotebooks: ClusterStorageNotebookSelection[] = [];
   const removedNotebooks: string[] = [];
+  const newNotebooks = tempData.filter((notebook) => !notebook.existingPvc);
   notebooks.forEach((notebook) => {
     const tempEntry = tempData.find(
       (item) => item.existingPvc && item.name === notebook.metadata.name,
@@ -48,8 +52,17 @@ export const handleConnectedNotebooks = (
     }
   });
 
-  return { updatedNotebooks, removedNotebooks };
+  return { updatedNotebooks, removedNotebooks, newNotebooks };
 };
+
+export const hasAllValidNotebookRelationship = (
+  notebookData: ClusterStorageNotebookSelection[],
+): boolean =>
+  notebookData.every((currentNotebookData) =>
+    currentNotebookData.name
+      ? !!currentNotebookData.mountPath.value && !currentNotebookData.mountPath.error
+      : false,
+  );
 
 export const mountPathSuffix = (mountPath: string): string =>
   mountPath.startsWith(MOUNT_PATH_PREFIX)


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-21248

## Description
Refractor clusterStorageModal
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Check if the functionality remains unchanged

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
added unit test for custom hooks
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
