### PR TITLE
Fix for when modelRegistryNamespace is undefined and no DSC status in response

### DIFF
--- a/frontend/src/__mocks__/mockDscStatus.ts
+++ b/frontend/src/__mocks__/mockDscStatus.ts
@@ -137,7 +137,7 @@ export const mockDscStatus = ({
   installedComponents: Object.values(StackComponent).reduce(
     (acc, component) => ({
       ...acc,
-      [component]: installedComponents[component] ?? true,
+      [component]: installedComponents[component] ?? false,
     }),
     {},
   ),

--- a/frontend/src/__mocks__/mockDscStatus.ts
+++ b/frontend/src/__mocks__/mockDscStatus.ts
@@ -33,7 +33,10 @@ export const mockDscStatus = ({
       ],
     },
   },
-  installedComponents,
+  installedComponents = Object.values(StackComponent).reduce(
+    (acc, component) => ({ ...acc, [component]: true }),
+    {},
+  ),
   conditions = [],
   phase = 'Ready',
 }: MockDscStatus): DataScienceClusterKindStatus => ({
@@ -134,7 +137,7 @@ export const mockDscStatus = ({
   installedComponents: Object.values(StackComponent).reduce(
     (acc, component) => ({
       ...acc,
-      [component]: installedComponents?.[component] ?? false,
+      [component]: installedComponents[component] ?? true,
     }),
     {},
   ),

--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -21,8 +21,8 @@ import 'cypress-mochawesome-reporter/register';
 import 'cypress-plugin-steps';
 import './commands';
 import { asProjectAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
+import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import { addCommands as webSocketsAddCommands } from './websockets';
-
 // Define a custom type for test options that includes tags.
 type TestOptions = {
   tags?: string[];
@@ -183,6 +183,7 @@ beforeEach(function beforeEachHook(this: Mocha.Context) {
     // Fallback: return 404 for all API requests.
     cy.intercept({ pathname: '/api/**' }, { statusCode: 404 });
     // Default intercepts.
+    cy.interceptOdh('GET /api/dsc/status', mockDscStatus({}));
     asProjectAdminUser();
   }
 });

--- a/frontend/src/api/useRulesReview.ts
+++ b/frontend/src/api/useRulesReview.ts
@@ -18,12 +18,18 @@ const checkAccess = (ns: string): Promise<SelfSubjectRulesReviewKind> => {
 };
 
 export const useRulesReview = (
-  namespace: string,
+  namespace: string | undefined,
 ): [SelfSubjectRulesReviewKind['status'], boolean, () => void] => {
   const [loaded, setLoaded] = React.useState(false);
   const [status, setStatus] = React.useState<SelfSubjectRulesReviewKind['status']>(undefined);
 
   const refreshRulesReview = React.useCallback(() => {
+    // If namespace is undefined, mark as loaded but don't make the API call
+    if (!namespace) {
+      setLoaded(true);
+      return;
+    }
+
     setLoaded(false);
     checkAccess(namespace)
       .then((result) => {

--- a/frontend/src/concepts/areas/AreaContext.tsx
+++ b/frontend/src/concepts/areas/AreaContext.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye, Page, Spinner } from '@patternfly/react-core';
 import useFetchDscStatus from '~/concepts/areas/useFetchDscStatus';
 import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
 import {
   DataScienceClusterInitializationKindStatus,
   DataScienceClusterKindStatus,
 } from '~/k8sTypes';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import RedirectErrorState from '~/pages/external/RedirectErrorState';
 
 type AreaContextState = {
   /**
@@ -34,11 +36,22 @@ const AreaContextProvider: React.FC<AreaContextProps> = ({ children }) => {
   const loaded = loadedDsc && loadedDsci;
 
   const contextValue = React.useMemo(() => ({ dscStatus, dsciStatus }), [dscStatus, dsciStatus]);
-  if (error) {
+
+  if (error || (dscStatus && Object.keys(dscStatus).length === 0)) {
     return (
-      <Alert isInline variant="danger" title="Problem loading component state">
-        {error.message}
-      </Alert>
+      <Page>
+        <ApplicationsPage
+          loaded
+          empty={false}
+          loadError={error}
+          loadErrorPage={
+            <RedirectErrorState
+              title="Could not load component state"
+              errorMessage={error?.message}
+            />
+          }
+        />
+      </Page>
     );
   }
 

--- a/frontend/src/concepts/areas/AreaContext.tsx
+++ b/frontend/src/concepts/areas/AreaContext.tsx
@@ -37,7 +37,7 @@ const AreaContextProvider: React.FC<AreaContextProps> = ({ children }) => {
 
   const contextValue = React.useMemo(() => ({ dscStatus, dsciStatus }), [dscStatus, dsciStatus]);
 
-  if (error || !dscStatus || Object.keys(dscStatus).length === 0) {
+  if (error || (loaded && (!dscStatus || Object.keys(dscStatus).length === 0))) {
     return (
       <Page>
         <ApplicationsPage loaded empty={false}>

--- a/frontend/src/concepts/areas/AreaContext.tsx
+++ b/frontend/src/concepts/areas/AreaContext.tsx
@@ -37,20 +37,15 @@ const AreaContextProvider: React.FC<AreaContextProps> = ({ children }) => {
 
   const contextValue = React.useMemo(() => ({ dscStatus, dsciStatus }), [dscStatus, dsciStatus]);
 
-  if (error || (dscStatus && Object.keys(dscStatus).length === 0)) {
+  if (error || !dscStatus || Object.keys(dscStatus).length === 0) {
     return (
       <Page>
-        <ApplicationsPage
-          loaded
-          empty={false}
-          loadError={error}
-          loadErrorPage={
-            <RedirectErrorState
-              title="Could not load component state"
-              errorMessage={error?.message}
-            />
-          }
-        />
+        <ApplicationsPage loaded empty={false}>
+          <RedirectErrorState
+            title="Could not load component state"
+            errorMessage={error?.message}
+          />
+        </ApplicationsPage>
       </Page>
     );
   }
@@ -65,5 +60,4 @@ const AreaContextProvider: React.FC<AreaContextProps> = ({ children }) => {
 
   return <AreaContext.Provider value={contextValue}>{children}</AreaContext.Provider>;
 };
-
 export default AreaContextProvider;

--- a/frontend/src/concepts/areas/useFetchDscStatus.ts
+++ b/frontend/src/concepts/areas/useFetchDscStatus.ts
@@ -11,11 +11,11 @@ const fetchDscStatus = (): Promise<DataScienceClusterKindStatus | null> => {
     .get(url)
     .then((response) => response.data)
     .catch((e) => {
-      if (e.response.status === 404) {
-        // DSC is not available, assume v1 Operator
+      // Handle 404 errors specifically to maintain backward compatibility with tests
+      if (e.response?.status === 404) {
         return null;
       }
-      throw new Error(e.response.data.message);
+      throw new Error(e.response?.data?.message || e.message);
     });
 };
 

--- a/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
@@ -67,9 +67,7 @@ export const useModelRegistryServices = (
     { ...accessReviewResource, namespace: namespace || '' },
     !!namespace,
   );
-  const [rulesReviewStatus, rulesReviewLoaded, refreshRulesReview] = useRulesReview(
-    namespace || '',
-  );
+  const [rulesReviewStatus, rulesReviewLoaded, refreshRulesReview] = useRulesReview(namespace);
 
   const serviceNames = React.useMemo(() => {
     if (!rulesReviewLoaded) {
@@ -83,19 +81,17 @@ export const useModelRegistryServices = (
       .flatMap((rule) => rule.resourceNames || []);
   }, [rulesReviewLoaded, rulesReviewStatus]);
 
-  const callback = React.useCallback<FetchStateCallbackPromise<ServiceKind[]>>(() => {
-    if (!namespace) {
-      return Promise.reject(new NotReadyError('No registries namespace could be found'));
-    }
-
-    return listServicesOrFetchThemByNames(
-      allowList,
-      accessReviewLoaded,
-      rulesReviewLoaded,
-      namespace,
-      serviceNames,
-    );
-  }, [allowList, accessReviewLoaded, rulesReviewLoaded, serviceNames, namespace]);
+  const callback = React.useCallback<FetchStateCallbackPromise<ServiceKind[]>>(
+    () =>
+      listServicesOrFetchThemByNames(
+        allowList,
+        accessReviewLoaded,
+        rulesReviewLoaded,
+        namespace,
+        serviceNames,
+      ),
+    [allowList, accessReviewLoaded, rulesReviewLoaded, serviceNames, namespace],
+  );
 
   const [modelRegistryServices, isLoaded, error] = useFetchState(callback, [], {
     initialPromisePurity: true,

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -55,13 +55,10 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChild
     [],
   );
 
-  // Create a stable namespace value for the hook
   const namespaceForHook = React.useMemo(
     () => modelRegistryNamespace || '',
     [modelRegistryNamespace],
   );
-
-  // Always call the hook with the stable value
   const {
     modelRegistryServices = [],
     isLoaded,
@@ -70,11 +67,9 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChild
   } = useModelRegistryServices(namespaceForHook);
 
   const contextValue = React.useMemo(() => {
-    // Move error calculation inside useMemo
     const error = !modelRegistryNamespace
       ? new Error('No registries namespace could be found')
       : servicesError;
-
     return {
       modelRegistryServicesLoaded: isLoaded,
       modelRegistryServicesLoadError: error,

--- a/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
+++ b/frontend/src/concepts/modelRegistry/context/ModelRegistrySelectorContext.tsx
@@ -55,25 +55,22 @@ const EnabledModelRegistrySelectorContextProvider: React.FC<React.PropsWithChild
     [],
   );
 
-  const namespaceForHook = React.useMemo(
-    () => modelRegistryNamespace || '',
-    [modelRegistryNamespace],
-  );
   const {
     modelRegistryServices = [],
     isLoaded,
     error: servicesError,
     refreshRulesReview,
-  } = useModelRegistryServices(namespaceForHook);
+  } = useModelRegistryServices(modelRegistryNamespace);
 
   const contextValue = React.useMemo(() => {
     const error = !modelRegistryNamespace
       ? new Error('No registries namespace could be found')
       : servicesError;
+
     return {
       modelRegistryServicesLoaded: isLoaded,
       modelRegistryServicesLoadError: error,
-      modelRegistryServices: modelRegistryNamespace ? modelRegistryServices : [],
+      modelRegistryServices,
       preferredModelRegistry: preferredModelRegistry ?? modelRegistryServices[0],
       updatePreferredModelRegistry,
       refreshRulesReview,

--- a/frontend/src/concepts/modelRegistry/context/useModelRegistryNamespaceCR.ts
+++ b/frontend/src/concepts/modelRegistry/context/useModelRegistryNamespaceCR.ts
@@ -17,13 +17,20 @@ export const isModelRegistryCRStatusAvailable = (cr: ModelRegistryKind): boolean
 export const isModelRegistryAvailable = ([state, loaded]: FetchState<State>): boolean =>
   loaded && !!state && isModelRegistryCRStatusAvailable(state);
 
-export const useModelRegistryNamespaceCR = (namespace: string, name: string): FetchState<State> => {
+export const useModelRegistryNamespaceCR = (
+  namespace: string | undefined,
+  name: string,
+): FetchState<State> => {
   const modelRegistryAreaAvailable = useModelRegistryEnabled();
 
   const callback = React.useCallback<FetchStateCallbackPromise<State>>(
     (opts) => {
       if (!modelRegistryAreaAvailable) {
         return Promise.reject(new NotReadyError('Model registry not enabled'));
+      }
+
+      if (!namespace) {
+        return Promise.reject(new NotReadyError('No registries namespace could be found'));
       }
 
       return getModelRegistryCR(namespace, name, opts).catch((e) => {

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -66,45 +66,43 @@ const ModelDetailsPage: React.FC = conditionalArea(
     [modelCatalogSources, decodedParams],
   );
 
-  const registerModelButton = () => {
+  const registerModelButton = (isSecondary = false) => {
     if (modelRegistryServicesLoadError) {
       return null;
     }
 
-    if (modelRegistryServices.length === 0) {
-      return (
-        <ActionListItem>
-          <Popover
-            headerContent="Register model"
-            bodyContent={
-              <PopoverListContent
-                title="No model registries available"
-                listItems={[
-                  'Contact your administrator to create a model registry.',
-                  ...FindAdministratorOptions,
-                ]}
-              />
-            }
-          >
-            <Button variant="secondary" isDisabled>
-              Register model
-            </Button>
-          </Popover>
-        </ActionListItem>
-      );
-    }
-
-    return (
-      <ActionListItem>
+    return modelRegistryServices.length === 0 ? (
+      <Popover
+        headerContent="Request access to a model registry"
+        triggerAction="hover"
+        data-testid="register-catalog-model-popover"
+        bodyContent={
+          <PopoverListContent
+            data-testid="Register-model-button-popover"
+            leadText="To request a new model registry, or to request permission to access an existing model registry, contact your administrator."
+            listHeading="Your administrator might be:"
+            listItems={FindAdministratorOptions}
+          />
+        }
+      >
         <Button
-          variant="secondary"
-          onClick={() => {
-            navigate(getRegisterCatalogModelUrl(decodedParams));
-          }}
+          variant={isSecondary ? 'secondary' : 'primary'}
+          isAriaDisabled
+          data-testid="register-model-button"
         >
           Register model
         </Button>
-      </ActionListItem>
+      </Popover>
+    ) : (
+      <Button
+        data-testid="register-model-button"
+        variant={isSecondary ? 'secondary' : 'primary'}
+        onClick={() => {
+          navigate(getRegisterCatalogModelUrl(decodedParams));
+        }}
+      >
+        Register model
+      </Button>
     );
   };
 
@@ -124,7 +122,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
       footerContent={
         <ActionList>
           <ActionListGroup>
-            {registerModelButton()}
+            <ActionListItem>{registerModelButton(true)}</ActionListItem>
             <ActionListItem>
               <Button variant="link" onClick={() => navigate(modelCustomizationRootPath)}>
                 Learn more about model customization

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -52,8 +52,8 @@ const ModelDetailsPage: React.FC = conditionalArea(
   const { modelRegistryServices, modelRegistryServicesLoaded, modelRegistryServicesLoadError } =
     React.useContext(ModelRegistrySelectorContext);
   const tuningAvailable = useIsAreaAvailable(SupportedArea.FINE_TUNING).status;
-  const loaded = modelRegistryServicesLoaded && modelCatalogSources.loaded;
-
+  const loaded =
+    (modelRegistryServicesLoaded || !!modelRegistryServicesLoadError) && modelCatalogSources.loaded;
   const model: CatalogModel | null = React.useMemo(
     () =>
       findModelFromModelCatalogSources(

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -66,38 +66,47 @@ const ModelDetailsPage: React.FC = conditionalArea(
     [modelCatalogSources, decodedParams],
   );
 
-  const registerModelButton = (isSecondary = false) =>
-    modelRegistryServices.length === 0 ? (
-      <Popover
-        headerContent="Request access to a model registry"
-        triggerAction="hover"
-        data-testid="register-catalog-model-popover"
-        bodyContent={
-          <PopoverListContent
-            data-testid="Register-model-button-popover"
-            leadText="To request a new model registry, or to request permission to access an existing model registry, contact your administrator."
-            listHeading="Your administrator might be:"
-            listItems={FindAdministratorOptions}
-          />
-        }
-      >
+  const registerModelButton = () => {
+    if (modelRegistryServicesLoadError) {
+      return null;
+    }
+
+    if (modelRegistryServices.length === 0) {
+      return (
+        <ActionListItem>
+          <Popover
+            headerContent="Register model"
+            bodyContent={
+              <PopoverListContent
+                title="No model registries available"
+                listItems={[
+                  'Contact your administrator to create a model registry.',
+                  ...FindAdministratorOptions,
+                ]}
+              />
+            }
+          >
+            <Button variant="secondary" isDisabled>
+              Register model
+            </Button>
+          </Popover>
+        </ActionListItem>
+      );
+    }
+
+    return (
+      <ActionListItem>
         <Button
-          data-testid="register-model-button"
-          isAriaDisabled
-          variant={isSecondary ? 'secondary' : 'primary'}
+          variant="secondary"
+          onClick={() => {
+            navigate(getRegisterCatalogModelUrl(decodedParams));
+          }}
         >
           Register model
         </Button>
-      </Popover>
-    ) : (
-      <Button
-        variant={isSecondary ? 'secondary' : 'primary'}
-        data-testid="register-model-button"
-        onClick={() => navigate(getRegisterCatalogModelUrl(params))}
-      >
-        Register model
-      </Button>
+      </ActionListItem>
     );
+  };
 
   const fineTuneActionItem = (
     <Popover
@@ -115,7 +124,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
       footerContent={
         <ActionList>
           <ActionListGroup>
-            <ActionListItem>{registerModelButton(true)}</ActionListItem>
+            {registerModelButton()}
             <ActionListItem>
               <Button variant="link" onClick={() => navigate(modelCustomizationRootPath)}>
                 Learn more about model customization
@@ -186,7 +195,7 @@ const ModelDetailsPage: React.FC = conditionalArea(
           )}
         />
       }
-      loadError={modelRegistryServicesLoadError || modelCatalogSources.error}
+      loadError={modelCatalogSources.error}
       loaded={loaded}
       errorMessage="Unable to load model catalog"
       provideChildrenPadding

--- a/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Navigate, Outlet, useParams } from 'react-router';
-import { Bullseye, Alert } from '@patternfly/react-core';
+import { Bullseye } from '@patternfly/react-core';
 import { conditionalArea, SupportedArea } from '~/concepts/areas';
 import { ModelRegistryContextProvider } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 import ApplicationsPage from '~/pages/ApplicationsPage';
@@ -9,7 +9,6 @@ import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import WhosMyAdministrator from '~/components/WhosMyAdministrator';
 import RedirectErrorState from '~/pages/external/RedirectErrorState';
-import { AreaContext } from '~/concepts/areas/AreaContext';
 import InvalidModelRegistry from './screens/InvalidModelRegistry';
 import EmptyModelRegistryState from './screens/components/EmptyModelRegistryState';
 import ModelRegistrySelectorNavigator from './screens/ModelRegistrySelectorNavigator';
@@ -32,8 +31,6 @@ const ModelRegistryCoreLoader: React.FC<ModelRegistryCoreLoaderProps> =
     true,
   )(({ getInvalidRedirectPath }) => {
     const { modelRegistry } = useParams<{ modelRegistry: string }>();
-    const { dscStatus } = React.useContext(AreaContext);
-    const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace;
     const {
       modelRegistryServicesLoaded,
       modelRegistryServicesLoadError,
@@ -58,29 +55,14 @@ const ModelRegistryCoreLoader: React.FC<ModelRegistryCoreLoaderProps> =
       preferredModelRegistry?.metadata.name,
     ]);
 
-    if (!modelRegistryNamespace) {
-      return (
-        <ApplicationsPage
-          loaded
-          empty={false}
-          loadError={new Error('No registries namespace could be found')}
-          loadErrorPage={
-            <RedirectErrorState
-              title="Could not load component state"
-              errorMessage="No registries namespace could be found"
-            />
-          }
-        />
-      );
-    }
-
     if (modelRegistryServicesLoadError) {
       return (
-        <Bullseye>
-          <Alert title="Model registry load error" variant="danger" isInline>
-            {modelRegistryServicesLoadError.message}
-          </Alert>
-        </Bullseye>
+        <ApplicationsPage loaded loadError={modelRegistryServicesLoadError} empty={false}>
+          <RedirectErrorState
+            title="Model registry load error"
+            errorMessage={modelRegistryServicesLoadError.message}
+          />
+        </ApplicationsPage>
       );
     }
     if (!modelRegistryServicesLoaded) {

--- a/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
@@ -39,7 +39,24 @@ const ModelRegistryCoreLoader: React.FC<ModelRegistryCoreLoaderProps> =
       modelRegistryServicesLoadError,
       modelRegistryServices,
       preferredModelRegistry,
+      updatePreferredModelRegistry,
     } = React.useContext(ModelRegistrySelectorContext);
+    const modelRegistryFromRoute = modelRegistryServices.find(
+      (mr) => mr.metadata.name === modelRegistry,
+    );
+
+    React.useEffect(() => {
+      if (
+        modelRegistryFromRoute &&
+        preferredModelRegistry?.metadata.name !== modelRegistryFromRoute.metadata.name
+      ) {
+        updatePreferredModelRegistry(modelRegistryFromRoute);
+      }
+    }, [
+      modelRegistryFromRoute,
+      updatePreferredModelRegistry,
+      preferredModelRegistry?.metadata.name,
+    ]);
 
     if (!modelRegistryNamespace) {
       return (

--- a/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
+++ b/frontend/src/pages/modelRegistry/ModelRegistryCoreLoader.tsx
@@ -8,6 +8,8 @@ import TitleWithIcon from '~/concepts/design/TitleWithIcon';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';
 import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import WhosMyAdministrator from '~/components/WhosMyAdministrator';
+import RedirectErrorState from '~/pages/external/RedirectErrorState';
+import { AreaContext } from '~/concepts/areas/AreaContext';
 import InvalidModelRegistry from './screens/InvalidModelRegistry';
 import EmptyModelRegistryState from './screens/components/EmptyModelRegistryState';
 import ModelRegistrySelectorNavigator from './screens/ModelRegistrySelectorNavigator';
@@ -30,30 +32,30 @@ const ModelRegistryCoreLoader: React.FC<ModelRegistryCoreLoaderProps> =
     true,
   )(({ getInvalidRedirectPath }) => {
     const { modelRegistry } = useParams<{ modelRegistry: string }>();
+    const { dscStatus } = React.useContext(AreaContext);
+    const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace;
     const {
       modelRegistryServicesLoaded,
       modelRegistryServicesLoadError,
       modelRegistryServices,
       preferredModelRegistry,
-      updatePreferredModelRegistry,
     } = React.useContext(ModelRegistrySelectorContext);
 
-    const modelRegistryFromRoute = modelRegistryServices.find(
-      (mr) => mr.metadata.name === modelRegistry,
-    );
-
-    React.useEffect(() => {
-      if (
-        modelRegistryFromRoute &&
-        preferredModelRegistry?.metadata.name !== modelRegistryFromRoute.metadata.name
-      ) {
-        updatePreferredModelRegistry(modelRegistryFromRoute);
-      }
-    }, [
-      modelRegistryFromRoute,
-      updatePreferredModelRegistry,
-      preferredModelRegistry?.metadata.name,
-    ]);
+    if (!modelRegistryNamespace) {
+      return (
+        <ApplicationsPage
+          loaded
+          empty={false}
+          loadError={new Error('No registries namespace could be found')}
+          loadErrorPage={
+            <RedirectErrorState
+              title="Could not load component state"
+              errorMessage="No registries namespace could be found"
+            />
+          }
+        />
+      );
+    }
 
     if (modelRegistryServicesLoadError) {
       return (

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -281,7 +281,10 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
   if (!modelRegistryNamespace) {
     return (
       <ApplicationsPage loaded empty={false}>
-        <RedirectErrorState title="Could not load component state" errorMessage={error?.message} />
+        <RedirectErrorState
+          title="Could not load component state"
+          errorMessage="No registries namespace could be found"
+        />
       </ApplicationsPage>
     );
   }

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -280,17 +280,9 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
 
   if (!modelRegistryNamespace) {
     return (
-      <ApplicationsPage
-        loaded
-        empty={false}
-        loadError={new Error('No registries namespace could be found')}
-        loadErrorPage={
-          <RedirectErrorState
-            title="Could not load component state"
-            errorMessage="No registries namespace could be found"
-          />
-        }
-      />
+      <ApplicationsPage loaded empty={false}>
+        <RedirectErrorState title="Could not load component state" errorMessage={error?.message} />
+      </ApplicationsPage>
     );
   }
 

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -37,6 +37,8 @@ import {
 import { RecursivePartial } from '~/typeHelpers';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
+import ApplicationsPage from '~/pages/ApplicationsPage';
+import RedirectErrorState from '~/pages/external/RedirectErrorState';
 import { CreateMRSecureDBSection, SecureDBInfo } from './CreateMRSecureDBSection';
 import ModelRegistryDatabasePassword from './ModelRegistryDatabasePassword';
 import { ResourceType, SecureDBRType } from './const';
@@ -80,7 +82,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
     key: '',
     isValid: true,
   });
-  const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace || '';
+  const modelRegistryNamespace = dscStatus?.components?.modelregistry?.registriesNamespace;
 
   React.useEffect(() => {
     if (configSecretsLoaded && !configSecretsError && !mr) {
@@ -204,7 +206,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
         kind: 'ModelRegistry',
         metadata: {
           name: nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name),
-          namespace: dscStatus?.components?.modelregistry?.registriesNamespace || '',
+          namespace: modelRegistryNamespace!,
           annotations: {
             'openshift.io/description': nameDesc.description,
             'openshift.io/display-name': nameDesc.name.trim(),
@@ -275,6 +277,22 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
     hasContent(username) &&
     hasContent(database) &&
     (!addSecureDB || (secureDBInfo.isValid && !configSecretsError));
+
+  if (!modelRegistryNamespace) {
+    return (
+      <ApplicationsPage
+        loaded
+        empty={false}
+        loadError={new Error('No registries namespace could be found')}
+        loadErrorPage={
+          <RedirectErrorState
+            title="Could not load component state"
+            errorMessage="No registries namespace could be found"
+          />
+        }
+      />
+    );
+  }
 
   return (
     <Modal

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
@@ -34,12 +34,16 @@ const ModelRegistriesManagePermissions: React.FC = () => {
   const [ownerReference, setOwnerReference] = React.useState<ModelRegistryKind>();
   const [groups] = useGroups();
   const roleBindings = useContextResourceData<RoleBindingKind>(useModelRegistryRoleBindings());
-  const { mrName } = useParams();
-  const state = useModelRegistryNamespaceCR(modelRegistryNamespace || '', mrName || '');
+  const { mrName } = useParams<{ mrName: string }>();
+  const state = useModelRegistryNamespaceCR(modelRegistryNamespace, mrName || '');
   const [modelRegistryCR, crLoaded] = state;
   const filteredRoleBindings = roleBindings.data.filter(
     (rb) => rb.metadata.labels?.['app.kubernetes.io/name'] === mrName,
   );
+
+  const error = !modelRegistryNamespace
+    ? new Error('No registries namespace could be found')
+    : null;
 
   React.useEffect(() => {
     if (modelRegistryCR) {
@@ -51,17 +55,9 @@ const ModelRegistriesManagePermissions: React.FC = () => {
 
   if (!modelRegistryNamespace) {
     return (
-      <ApplicationsPage
-        loaded
-        empty={false}
-        loadError={new Error('No registries namespace could be found')}
-        loadErrorPage={
-          <RedirectErrorState
-            title="Could not load component state"
-            errorMessage="No registries namespace could be found"
-          />
-        }
-      />
+      <ApplicationsPage loaded empty={false}>
+        <RedirectErrorState title="Could not load component state" errorMessage={error?.message} />
+      </ApplicationsPage>
     );
   }
 

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesPermissions.tsx
@@ -23,6 +23,7 @@ import {
   createModelRegistryRoleBinding,
   deleteModelRegistryRoleBinding,
 } from '~/services/modelRegistrySettingsService';
+import RedirectErrorState from '~/pages/external/RedirectErrorState';
 import useModelRegistryRoleBindings from './useModelRegistryRoleBindings';
 import ProjectsSettingsTab from './ProjectsTab/ProjectsSettingsTab';
 
@@ -47,6 +48,22 @@ const ModelRegistriesManagePermissions: React.FC = () => {
       setOwnerReference(undefined);
     }
   }, [modelRegistryCR]);
+
+  if (!modelRegistryNamespace) {
+    return (
+      <ApplicationsPage
+        loaded
+        empty={false}
+        loadError={new Error('No registries namespace could be found')}
+        loadErrorPage={
+          <RedirectErrorState
+            title="Could not load component state"
+            errorMessage="No registries namespace could be found"
+          />
+        }
+      />
+    );
+  }
 
   if (
     (roleBindings.loaded && filteredRoleBindings.length === 0) ||
@@ -114,7 +131,7 @@ const ModelRegistriesManagePermissions: React.FC = () => {
                 'app.kubernetes.io/name': mrName || '',
                 component: SupportedArea.MODEL_REGISTRY,
               }}
-              projectName={modelRegistryNamespace || ''}
+              projectName={modelRegistryNamespace}
               description={
                 <>
                   To enable access for all cluster users, add{' '}
@@ -155,7 +172,7 @@ const ModelRegistriesManagePermissions: React.FC = () => {
                 'app.kubernetes.io/name': mrName || '',
                 component: SupportedArea.MODEL_REGISTRY,
               }}
-              projectName={modelRegistryNamespace || ''}
+              projectName={modelRegistryNamespace}
               isProjectSubject={activeTabKey === 'projects'}
               roleBindingPermissionsRB={{ ...roleBindings, data: filteredRoleBindings }}
             />

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistrySettings.tsx
@@ -16,6 +16,7 @@ import { ProjectObjectType } from '~/concepts/design/utils';
 import useModelRegistriesBackend from '~/concepts/modelRegistrySettings/useModelRegistriesBackend';
 import { useContextResourceData } from '~/utilities/useContextResourceData';
 import { RoleBindingKind } from '~/k8sTypes';
+import { ModelRegistrySelectorContext } from '~/concepts/modelRegistry/context/ModelRegistrySelectorContext';
 import ModelRegistriesTable from './ModelRegistriesTable';
 import CreateModal from './CreateModal';
 import useModelRegistryRoleBindings from './useModelRegistryRoleBindings';
@@ -28,26 +29,23 @@ const ModelRegistrySettings: React.FC = () => {
   const [modelRegistries, mrloaded, loadError, refreshModelRegistries] =
     useModelRegistriesBackend();
   const roleBindings = useContextResourceData<RoleBindingKind>(useModelRegistryRoleBindings());
+  const { refreshRulesReview } = React.useContext(ModelRegistrySelectorContext);
   const loaded = mrloaded && roleBindings.loaded;
 
   const refreshAll = React.useCallback(
-    () => Promise.all([refreshModelRegistries(), roleBindings.refresh()]),
-    [refreshModelRegistries, roleBindings],
+    () => Promise.all([refreshModelRegistries(), roleBindings.refresh(), refreshRulesReview()]),
+    [refreshModelRegistries, roleBindings, refreshRulesReview],
   );
+
+  const error = !modelRegistryNamespace
+    ? new Error('No registries namespace could be found')
+    : null;
 
   if (!modelRegistryNamespace) {
     return (
-      <ApplicationsPage
-        loaded
-        empty={false}
-        loadError={new Error('No registries namespace could be found')}
-        loadErrorPage={
-          <RedirectErrorState
-            title="Could not load component state"
-            errorMessage="No registries namespace could be found"
-          />
-        }
-      />
+      <ApplicationsPage loaded empty={false}>
+        <RedirectErrorState title="Could not load component state" errorMessage={error?.message} />
+      </ApplicationsPage>
     );
   }
   return (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-19890

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->This PR improves error handling when the Model Registry namespace is not configured(Case 1) or when the DSC status returns an empty object(case 2). Previously, we were using fallback empty strings (modelRegistryNamespace || '') which masked the underlying issue and could lead to unexpected behavior.
Key changes:
Removed fallback empty strings - We no longer use modelRegistryNamespace || '' or registriesNamespace || '' in component logic, instead properly handling the undefined case.
Component-specific error handling - Each component that requires the Model Registry namespace now shows a specific error page when the namespace is undefined:
ModelRegistriesPermissions.tsx - Shows an error page when trying to manage permissions
CreateModal.tsx - Shows an error page when trying to create/edit a Model Registry
ModelRegistrySelectorContext.tsx - Sets an error state in the context when namespace is undefined
Improved empty DSC status handling - Added proper error handling in AreaContext.tsx to detect when fetchDscStatus returns an empty object ({}), showing a clear error page without the navbar instead of crashing the application.
Case 1 
![Screenshot 2025-03-25 at 2 36 13 PM](https://github.com/user-attachments/assets/5598b1b5-0d9a-4f47-a50e-fd0e996f12f0)
![Screenshot 2025-03-25 at 2 36 20 PM](https://github.com/user-attachments/assets/e1c56247-5fcc-43a0-8e04-812e68f73b3a)


Case 2 - it was agreed that when dsc status is undefined the whole app is not usable anymore, and we just show this error page. Note the error message in the screenshot is mocked and in reality will be the error message from the fetchDscStatus
![Screenshot 2025-03-25 at 12 08 46 PM](https://github.com/user-attachments/assets/40c1a45b-de5a-4bf8-aaca-314a4c0551f2)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not too many useful ways to test except for in code. 


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test impact 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
