### PR TITLE
Render hardware profile column correctly on project details page workbench list

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
@@ -21,6 +21,8 @@ export type UseHardwareProfileConfigResult = {
   isFormDataValid: boolean;
   setFormData: UpdateObjectAtPropAndValue<HardwareProfileConfig>;
   resetFormData: () => void;
+  profilesLoaded: boolean;
+  profilesLoadError?: Error;
 };
 
 const matchToHardwareProfile = (
@@ -103,7 +105,8 @@ export const useHardwareProfileConfig = (
   nodeSelector?: NodeSelector,
   visibleIn?: HardwareProfileFeatureVisibility[],
 ): UseHardwareProfileConfigResult => {
-  const [profiles, profilesLoaded] = useHardwareProfilesByFeatureVisibility(visibleIn);
+  const [profiles, profilesLoaded, profilesLoadError] =
+    useHardwareProfilesByFeatureVisibility(visibleIn);
   const initialHardwareProfile = useRef<HardwareProfileKind | undefined>(undefined);
   const [formData, setFormData, resetFormData] = useGenericObjectState<HardwareProfileConfig>({
     selectedProfile: undefined,
@@ -168,5 +171,7 @@ export const useHardwareProfileConfig = (
     isFormDataValid,
     setFormData,
     resetFormData,
+    profilesLoaded,
+    profilesLoadError,
   };
 };

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -24,6 +24,7 @@ import NotebookStateAction from '~/pages/projects/notebook/NotebookStateAction';
 import StopNotebookConfirmModal from '~/pages/projects/notebook/StopNotebookConfirmModal';
 import { useNotebookKindPodSpecOptionsState } from '~/concepts/hardwareProfiles/useNotebookPodSpecOptionsState';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import NotebookTableRowHardwareProfile from '~/pages/projects/screens/detail/notebooks/NotebookTableRowHardwareProfile';
 import { NotebookImageAvailability } from './const';
 import { NotebookImageDisplayName } from './NotebookImageDisplayName';
 import NotebookStorageBars from './NotebookStorageBars';
@@ -70,9 +71,6 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const [inProgress, setInProgress] = React.useState(false);
   const { name: notebookName, namespace: notebookNamespace } = obj.notebook.metadata;
   const isHardwareProfileAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
-  const {
-    hardwareProfile: { initialHardwareProfile },
-  } = useNotebookKindPodSpecOptionsState(obj.notebook);
 
   const onStart = React.useCallback(() => {
     setInProgress(true);
@@ -179,9 +177,15 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             alignItems={{ default: 'alignItemsCenter' }}
           >
             <FlexItem>
-              {isHardwareProfileAvailable
-                ? initialHardwareProfile?.spec.displayName ?? <i>Custom</i>
-                : notebookSize?.name ?? <i>{lastDeployedSize.name}</i>}
+              {isHardwareProfileAvailable ? (
+                <NotebookTableRowHardwareProfile
+                  loaded={podSpecOptionsState.hardwareProfile.profilesLoaded}
+                  loadError={podSpecOptionsState.hardwareProfile.profilesLoadError}
+                  hardwareProfile={podSpecOptionsState.hardwareProfile.initialHardwareProfile}
+                />
+              ) : (
+                notebookSize?.name ?? <i>{lastDeployedSize.name}</i>
+              )}
             </FlexItem>
           </Flex>
         </Td>

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRowHardwareProfile.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRowHardwareProfile.tsx
@@ -1,0 +1,31 @@
+import { HelperText, HelperTextItem, Spinner } from '@patternfly/react-core';
+import React from 'react';
+import { HardwareProfileKind } from '~/k8sTypes';
+
+type NotebookTableRowHardwareProfileProps = {
+  loaded: boolean;
+  loadError?: Error;
+  hardwareProfile?: HardwareProfileKind;
+};
+
+const NotebookTableRowHardwareProfile: React.FC<NotebookTableRowHardwareProfileProps> = ({
+  loaded,
+  loadError,
+  hardwareProfile,
+}) => {
+  if (loadError) {
+    return (
+      <HelperText>
+        <HelperTextItem variant="error">Custom</HelperTextItem>
+      </HelperText>
+    );
+  }
+
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+
+  return <>{hardwareProfile?.spec.displayName ?? <i>Custom</i>}</>;
+};
+
+export default NotebookTableRowHardwareProfile;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-21732](https://issues.redhat.com/browse/RHOAIENG-21732)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We cannot replace `useNotebookKindPodSpecOptionsState` with `useNotebookHardwareProfileConfig` as mentioned in the JIRA ticket because the pod spec options are also used for the user interaction tracking in this component. Thus, what we need to do is only to expose the load state and the load error from the `useNotebookHardwareProfileConfig` hook. And render a spinner if it's loading.

Loading:
<img width="1512" alt="Screenshot 2025-03-25 at 9 10 39 PM" src="https://github.com/user-attachments/assets/41e917b1-d3bd-479d-8ebe-1d1e4f23dc56" />

Error (Error state `Custom`):
<img width="1512" alt="Screenshot 2025-03-25 at 9 11 20 PM" src="https://github.com/user-attachments/assets/4c6c4c27-5b36-4256-9208-dd58502a3b53" />

No initial hardware profile (Plain text `Custom`):
<img width="1512" alt="Screenshot 2025-03-25 at 9 12 10 PM" src="https://github.com/user-attachments/assets/8cd5ace5-f257-4f11-8920-c426f3dbc3a2" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
