### PR TITLE
removed last modified field in migrations table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
@@ -110,7 +110,7 @@ class HardwareProfile {
   }
 
   getFeatureLabels(rowIndex: number) {
-    return this.getLabelsFromCell(rowIndex, 3);
+    return this.getLabelsFromCell(rowIndex, 2);
   }
 
   private wait() {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/legacyHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/legacyHardwareProfiles.cy.ts
@@ -526,8 +526,8 @@ describe('legacy profiles table', () => {
       legacyHardwareProfile.visit();
       legacyHardwareProfile.findExpandButton().click();
 
-      legacyHardwareProfile.getCell(0, 2).should('have.text', 'Accelerator profile');
-      legacyHardwareProfile.getCell(1, 2).should('have.text', 'Accelerator profile');
+      legacyHardwareProfile.getCell(0, 4).should('have.text', 'Accelerator profile');
+      legacyHardwareProfile.getCell(1, 4).should('have.text', 'Accelerator profile');
     });
   });
 
@@ -707,7 +707,7 @@ describe('legacy profiles table', () => {
       legacyHardwareProfile.visit();
       legacyHardwareProfile.findExpandButton().click();
 
-      legacyHardwareProfile.getCell(0, 2).should('have.text', 'Workbench container size');
+      legacyHardwareProfile.getCell(0, 4).should('have.text', 'Workbench container size');
     });
   });
 
@@ -885,7 +885,7 @@ describe('legacy profiles table', () => {
       legacyHardwareProfile.visit();
       legacyHardwareProfile.findExpandButton().click();
 
-      legacyHardwareProfile.getCell(0, 2).should('have.text', 'Model serving container size');
+      legacyHardwareProfile.getCell(0, 4).should('have.text', 'Model serving container size');
     });
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/legacyHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/legacyHardwareProfiles.cy.ts
@@ -229,11 +229,6 @@ describe('legacy profiles table', () => {
       legacyHardwareProfile.findTableHeaderButton('Name').should(be.sortDescending);
       legacyHardwareProfile.findTableHeaderButton('Name').click();
       legacyHardwareProfile.findTableHeaderButton('Name').should(be.sortAscending);
-
-      legacyHardwareProfile.findTableHeaderButton('Last modified').click();
-      legacyHardwareProfile.findTableHeaderButton('Last modified').should(be.sortAscending);
-      legacyHardwareProfile.findTableHeaderButton('Last modified').click();
-      legacyHardwareProfile.findTableHeaderButton('Last modified').should(be.sortDescending);
     });
 
     it('should show the expandable section for items', () => {

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
@@ -82,7 +82,12 @@ const HardwareProfilesTable: React.FC<HardwareProfilesTableProps> = ({
   );
 
   const filteredColumns = React.useMemo(
-    () => hardwareProfileColumns.filter((column) => isMigratedTable || column.field !== 'source'),
+    () =>
+      hardwareProfileColumns.filter(
+        (column) =>
+          (isMigratedTable && column.field !== 'last_modified') ||
+          (!isMigratedTable && column.field !== 'source'),
+      ),
     [isMigratedTable],
   );
 
@@ -105,6 +110,7 @@ const HardwareProfilesTable: React.FC<HardwareProfilesTableProps> = ({
               key={cr.metadata.name}
               rowIndex={index}
               hardwareProfile={cr}
+              isMigratedTable={isMigratedTable}
               handleDelete={(hardwareProfile) =>
                 setDeleteHardwareProfile({ hardwareProfile, migrationAction })
               }

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
@@ -110,7 +110,6 @@ const HardwareProfilesTable: React.FC<HardwareProfilesTableProps> = ({
               key={cr.metadata.name}
               rowIndex={index}
               hardwareProfile={cr}
-              isMigratedTable={isMigratedTable}
               handleDelete={(hardwareProfile) =>
                 setDeleteHardwareProfile({ hardwareProfile, migrationAction })
               }

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -38,7 +38,7 @@ type HardwareProfilesTableRowProps = {
   rowIndex: number;
   hardwareProfile: HardwareProfileKind;
   migrationAction?: MigrationAction;
-  isMigratedTable?: boolean;
+  isMigratedTable: boolean;
   handleDelete: (cr: HardwareProfileKind) => void;
   handleMigrate: (migrationAction: MigrationAction) => void;
 };
@@ -47,7 +47,7 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
   hardwareProfile,
   rowIndex,
   migrationAction,
-  isMigratedTable = false,
+  isMigratedTable,
   handleDelete,
   handleMigrate,
 }) => {

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -38,7 +38,6 @@ type HardwareProfilesTableRowProps = {
   rowIndex: number;
   hardwareProfile: HardwareProfileKind;
   migrationAction?: MigrationAction;
-  isMigratedTable: boolean;
   handleDelete: (cr: HardwareProfileKind) => void;
   handleMigrate: (migrationAction: MigrationAction) => void;
 };
@@ -47,7 +46,6 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
   hardwareProfile,
   rowIndex,
   migrationAction,
-  isMigratedTable,
   handleDelete,
   handleMigrate,
 }) => {
@@ -120,17 +118,6 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
             }
           />
         </Td>
-        {migrationAction && (
-          <Td dataLabel="Source">
-            <TableRowTitleDescription
-              title={
-                MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type].charAt(0).toUpperCase() +
-                MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type].slice(1)
-              }
-              resource={migrationAction.source.resource}
-            />
-          </Td>
-        )}
         <Td dataLabel="Features">
           {useCases.length === 0 ? (
             <i>All features</i>
@@ -153,7 +140,18 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
             <HardwareProfileEnableToggle hardwareProfile={hardwareProfile} />
           )}
         </Td>
-        {!isMigratedTable && (
+        {migrationAction && (
+          <Td dataLabel="Source">
+            <TableRowTitleDescription
+              title={
+                MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type].charAt(0).toUpperCase() +
+                MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type].slice(1)
+              }
+              resource={migrationAction.source.resource}
+            />
+          </Td>
+        )}
+        {!migrationAction && (
           <Td dataLabel="Last modified">
             {modifiedDate && !Number.isNaN(new Date(modifiedDate).getTime()) ? (
               <Timestamp

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -38,6 +38,7 @@ type HardwareProfilesTableRowProps = {
   rowIndex: number;
   hardwareProfile: HardwareProfileKind;
   migrationAction?: MigrationAction;
+  isMigratedTable?: boolean;
   handleDelete: (cr: HardwareProfileKind) => void;
   handleMigrate: (migrationAction: MigrationAction) => void;
 };
@@ -46,6 +47,7 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
   hardwareProfile,
   rowIndex,
   migrationAction,
+  isMigratedTable = false,
   handleDelete,
   handleMigrate,
 }) => {
@@ -151,20 +153,22 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
             <HardwareProfileEnableToggle hardwareProfile={hardwareProfile} />
           )}
         </Td>
-        <Td dataLabel="Last modified">
-          {modifiedDate && !Number.isNaN(new Date(modifiedDate).getTime()) ? (
-            <Timestamp
-              date={new Date(modifiedDate)}
-              tooltip={{
-                variant: TimestampTooltipVariant.default,
-              }}
-            >
-              {relativeTime(Date.now(), new Date(modifiedDate).getTime())}
-            </Timestamp>
-          ) : (
-            '--'
-          )}
-        </Td>
+        {!isMigratedTable && (
+          <Td dataLabel="Last modified">
+            {modifiedDate && !Number.isNaN(new Date(modifiedDate).getTime()) ? (
+              <Timestamp
+                date={new Date(modifiedDate)}
+                tooltip={{
+                  variant: TimestampTooltipVariant.default,
+                }}
+              >
+                {relativeTime(Date.now(), new Date(modifiedDate).getTime())}
+              </Timestamp>
+            ) : (
+              '--'
+            )}
+          </Td>
+        )}
         <Td isActionCell>
           <ActionsColumn
             items={[

--- a/frontend/src/pages/hardwareProfiles/const.tsx
+++ b/frontend/src/pages/hardwareProfiles/const.tsx
@@ -20,19 +20,6 @@ export const hardwareProfileColumns: SortableData<HardwareProfileKind>[] = [
     width: 40,
   },
   {
-    field: 'source',
-    label: 'Source',
-    sortable: false,
-    width: 20,
-    info: {
-      popover:
-        'This is the legacy resource type that this hardware profile was created from, such as an accelerator profile.',
-      popoverProps: {
-        showClose: false,
-      },
-    },
-  },
-  {
     field: 'visibility',
     label: 'Visibility',
     sortable: (a: HardwareProfileKind, b: HardwareProfileKind): number => {
@@ -80,6 +67,19 @@ export const hardwareProfileColumns: SortableData<HardwareProfileKind>[] = [
       },
     },
     width: 15,
+  },
+  {
+    field: 'source',
+    label: 'Source',
+    sortable: false,
+    width: 20,
+    info: {
+      popover:
+        'This is the legacy resource type that this hardware profile was created from, such as an accelerator profile.',
+      popoverProps: {
+        showClose: false,
+      },
+    },
   },
   {
     field: 'last_modified',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-21960

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Removed the last modified field from the migrations table, as it doesn't have any functionality.

<img width="1222" alt="Screenshot 2025-03-26 at 9 48 07 AM" src="https://github.com/user-attachments/assets/fff0a602-53c8-4d35-ab57-dfefc51e676d" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to the hardware profiles page and see the changes.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Removed tests that checked for this field.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
