### PR TITLE
fix: show correct server size instead of defaulting to Custom in Edit

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -167,11 +167,11 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
   const hasSetDefault = React.useRef(false);
 
   React.useEffect(() => {
-    if (!hasSetDefault.current) {
+    if (!editInfo && !hasSetDefault.current) {
       podSpecOptionsState.modelSize.setSelectedSize(NIM_CUSTOM_DEFAULTS);
       hasSetDefault.current = true;
     }
-  }, [NIM_CUSTOM_DEFAULTS, podSpecOptionsState.modelSize]);
+  }, [NIM_CUSTOM_DEFAULTS, podSpecOptionsState.modelSize, editInfo]);
 
   // Serving Runtime Validation
   const isDisabledServingRuntime =


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-179

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix to show correct server size instead of defaulting to Custom in Edit mode.
<img width="831" alt="image" src="https://github.com/user-attachments/assets/92da3a00-2b46-4c34-b8fa-21d34838f980" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally. 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- Deployed a model using any option other than "Custom" and verified that, when reopening the form in edit mode, the correct option is displayed instead of defaulting to "Custom".

- Deployed a model using the "Custom" size and confirmed that, upon redeployment, the correct custom values are shown in the form.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
