### PR TITLE
Resiliency enhancement to clusterStorageCreation test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
@@ -107,7 +107,7 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
       clusterStorage
         .getClusterStorageRow(pvStorageNameEdited)
         .findKebabAction('Delete storage')
-        .click();
+        .click({ force: true });
       deleteModal.shouldBeOpen();
       deleteModal.findInput().type(pvStorageNameEdited);
       deleteModal.findSubmitButton().should('be.enabled').click();


### PR DESCRIPTION
## Description
- Small resiliency enhancements to testClusterStorageCreation test adding a more stringent check to ensure creation/editing and also added a 'force' to the submit.

## How Has This Been Tested?
- An oc login should be performed in the cluster before running the test
- test-variables.yml should be configured properly
- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml
- Locally against a PSI cluster and ODH-Nightly
![image](https://github.com/user-attachments/assets/11f96119-9bc2-4e1f-a8b7-37c589af8343)

## Test Impact
- None - this is a test

## How to run?
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress open . This will open the Cypress UI where testClusterStorageCreation.cy.ts can be run.

Headless
Go to odh-dashboard/frontend/src/tests/cypress and run the command npx cypress run --spec "cypress/tests/e2e/dataScienceProjects/testClusterStorageCreation.cy.ts" --browser chrome

or Execute 'npx cypress run --env grepTags=@ODS-1824'

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
