### PR TITLE
RHOAIENG-22380 Track Register Model in Catalog

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -89,6 +89,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
             fireFormTrackingEvent(serverConfiguredEvent, {
               outcome: TrackingOutcome.submit,
               success: true,
+              isILabEnabled: config.enableInstructLab,
             });
           })
           .catch((e) => {

--- a/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Modal } from '@patternfly/react-core/deprecated';
 import {
+  Alert,
+  Content,
+  ContentVariants,
   Form,
   FormGroup,
   FormHelperText,
@@ -11,9 +14,6 @@ import {
   ModalVariant,
   Stack,
   StackItem,
-  Alert,
-  Content,
-  ContentVariants,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import ProjectSelector from '~/concepts/projects/ProjectSelector';
@@ -21,6 +21,8 @@ import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { PipelineContextProvider } from '~/concepts/pipelines/context';
 import MissingConditionAlert from '~/pages/pipelines/global/modelCustomization/startRunModal/MissingConditionAlert';
 import { modelCustomizationRootPath } from '~/routes';
+import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 
 export type StartRunModalProps = {
   onSubmit: (selectedProject: string) => void;
@@ -29,6 +31,7 @@ export type StartRunModalProps = {
   loadError?: Error | null;
 };
 
+const eventName = 'Lab Tune requested';
 const StartRunModal: React.FC<StartRunModalProps> = ({
   onSubmit,
   onCancel,
@@ -47,10 +50,17 @@ const StartRunModal: React.FC<StartRunModalProps> = ({
         <DashboardModalFooter
           onSubmit={() => {
             if (selectedProject) {
+              fireFormTrackingEvent(eventName, { outcome: TrackingOutcome.submit });
               onSubmit(selectedProject);
             }
           }}
-          onCancel={onCancel}
+          onCancel={() => {
+            fireFormTrackingEvent(eventName, {
+              outcome: TrackingOutcome.cancel,
+              couldContinue: canContinue,
+            });
+            onCancel();
+          }}
           submitLabel="Continue to run details"
           isSubmitDisabled={!canContinue || !loaded || !!loadError}
         />


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-22380

## Description
Add analytics tracking for 'Register Catalog Model' and 'Start LAB tune' actions

## How Has This Been Tested?
Manual clicking through with watching the console log

## Test Impact
We decided that analytics need no automated testing.

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
