### PR TITLE
Adding associated events to workbench status modal

### DIFF
--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -76,10 +76,7 @@ describe('Start Notebook modal', () => {
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
     expect(steps).toHaveLength(14);
-    /* TODO: This finds the POD_PROBLEM: 'There was a problem with the pod'
-      once text and location of error is finalized with UX set the error location index and error text
-    */
-    //expect(steps[3]).toHaveTextContent('Failed to scale-up');
+    expect(steps[1]).toHaveTextContent('There was a problem with the pod');
   });
 
   it('should show in progress notebook startup status', async () => {

--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -77,7 +77,7 @@ describe('Start Notebook modal', () => {
     const steps = screen.getAllByRole('listitem');
     expect(steps).toHaveLength(14);
     /* TODO: This finds the POD_PROBLEM: 'There was a problem with the pod'
-      once text and location of error is finalized with UX set the error location and error text
+      once text and location of error is finalized with UX set the error location index and error text
     */
     //expect(steps[3]).toHaveTextContent('Failed to scale-up');
   });

--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -34,21 +34,20 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
+    expect(steps).toHaveLength(13);
     expect(steps[0]).toHaveTextContent('Server requested');
     expect(steps[1]).toHaveTextContent('Pod created');
     expect(steps[2]).toHaveTextContent('Pod assigned');
-    expect(steps[3]).toHaveTextContent('PVC attached');
-    expect(steps[4]).toHaveTextContent('Interface added');
-    expect(steps[5]).toHaveTextContent('Pulling workbench image');
-    expect(steps[6]).toHaveTextContent('Workbench image pulled');
-    expect(steps[7]).toHaveTextContent('Workbench container created');
-    expect(steps[8]).toHaveTextContent('Workbench container started');
-    expect(steps[9]).toHaveTextContent('Pulling oauth proxy');
-    expect(steps[10]).toHaveTextContent('Oauth proxy pulled');
-    expect(steps[11]).toHaveTextContent('Oauth proxy container created');
-    expect(steps[12]).toHaveTextContent('Oauth proxy container started');
-    expect(steps[13]).toHaveTextContent('Server started');
+    expect(steps[3]).toHaveTextContent('Interface added');
+    expect(steps[4]).toHaveTextContent('Pulling workbench image');
+    expect(steps[5]).toHaveTextContent('Workbench image pulled');
+    expect(steps[6]).toHaveTextContent('Workbench container created');
+    expect(steps[7]).toHaveTextContent('Workbench container started');
+    expect(steps[8]).toHaveTextContent('Pulling oauth proxy');
+    expect(steps[9]).toHaveTextContent('Oauth proxy pulled');
+    expect(steps[10]).toHaveTextContent('Oauth proxy container created');
+    expect(steps[11]).toHaveTextContent('Oauth proxy container started');
+    expect(steps[12]).toHaveTextContent('Server started');
   });
 
   it('should show failed notebook startup status', async () => {
@@ -76,8 +75,11 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(15);
-    expect(steps[1]).toHaveTextContent('Failed to scale-up');
+    expect(steps).toHaveLength(14);
+    /* TODO: This finds the POD_PROBLEM: 'There was a problem with the pod'
+      once text and location of error is finalized with UX set the error location and error text
+    */
+    //expect(steps[3]).toHaveTextContent('Failed to scale-up');
   });
 
   it('should show in progress notebook startup status', async () => {
@@ -181,7 +183,7 @@ describe('Start Notebook modal', () => {
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
     const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(14);
+    expect(steps).toHaveLength(13);
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(13);
   });
 });

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -251,9 +251,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
               titleId={`${progressStep.timestamp}-title`}
               data-testid={`step-status-${progressStep.status}`}
             >
-              {progressStep.step
-                ? ProgressionStepTitles[progressStep.step]
-                : progressStep.description}
+              {ProgressionStepTitles[progressStep.step]}
             </ProgressStep>
           ))}
         </ProgressStepper>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -637,23 +637,18 @@ export const ProgressionStepTitles = {
 
 export const AssociatedSteps = {
   [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: [
-    ProgressionStep.SERVER_REQUESTED,
-    ProgressionStep.POD_CREATED,
-    ProgressionStep.POD_ASSIGNED,
     ProgressionStep.PVC_ATTACHED,
     ProgressionStep.INTERFACE_ADDED,
     ProgressionStep.PULLING_NOTEBOOK_IMAGE,
     ProgressionStep.NOTEBOOK_IMAGE_PULLED,
-    ProgressionStep.NOTEBOOK_CONTAINER_CREATED,
   ],
   [ProgressionStep.OAUTH_CONTAINER_STARTED]: [
     ProgressionStep.PULLING_OAUTH,
     ProgressionStep.OAUTH_PULLED,
     ProgressionStep.OAUTH_CONTAINER_CREATED,
-    ProgressionStep.OAUTH_CONTAINER_STARTED,
   ],
   [ProgressionStep.POD_ASSIGNED]: [ProgressionStep.POD_CREATED],
-  [ProgressionStep.SERVER_STARTED]: [ProgressionStep],
+  [ProgressionStep.SERVER_STARTED]: Object.values(ProgressionStep),
 };
 
 export type NotebookProgressStep = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -605,39 +605,44 @@ export enum ProgressionStep {
   SERVER_REQUESTED = 'SERVER_REQUESTED',
   POD_CREATED = 'POD_CREATED',
   POD_ASSIGNED = 'POD_ASSIGNED',
+  POD_PROBLEM = 'POD_PROBLEM',
   PVC_ATTACHED = 'PVC_ATTACHED',
   INTERFACE_ADDED = 'INTERFACE_ADDED',
   PULLING_NOTEBOOK_IMAGE = 'PULLING_NOTEBOOK_IMAGE',
   NOTEBOOK_IMAGE_PULLED = 'NOTEBOOK_IMAGE_PULLED',
   NOTEBOOK_CONTAINER_CREATED = 'NOTEBOOK_CONTAINER_CREATED',
+  NOTEBOOK_PROBLEM = 'NOTEBOOK_PROBLEM',
   NOTEBOOK_CONTAINER_STARTED = 'NOTEBOOK_CONTAINER_STARTED',
   PULLING_OAUTH = 'PULLING_OAUTH',
   OAUTH_PULLED = 'OAUTH_PULLED',
   OAUTH_CONTAINER_CREATED = 'OAUTH_CONTAINER_CREATED',
+  OAUTH_PROBLEM = 'OAUTH_PROBLEM',
   OAUTH_CONTAINER_STARTED = 'OAUTH_CONTAINER_STARTED',
   SERVER_STARTED = 'SERVER_STARTED',
 }
 
-export const ProgressionStepTitles = {
+export const ProgressionStepTitles: Record<ProgressionStep, string> = {
   [ProgressionStep.SERVER_REQUESTED]: 'Server requested',
   [ProgressionStep.POD_CREATED]: 'Pod created',
   [ProgressionStep.POD_ASSIGNED]: 'Pod assigned',
+  [ProgressionStep.POD_PROBLEM]: 'There was a problem with the pod',
   [ProgressionStep.PVC_ATTACHED]: 'PVC attached',
   [ProgressionStep.INTERFACE_ADDED]: 'Interface added',
   [ProgressionStep.PULLING_NOTEBOOK_IMAGE]: 'Pulling workbench image',
   [ProgressionStep.NOTEBOOK_IMAGE_PULLED]: 'Workbench image pulled',
   [ProgressionStep.NOTEBOOK_CONTAINER_CREATED]: 'Workbench container created',
+  [ProgressionStep.NOTEBOOK_PROBLEM]: 'There was a problem with the notebook',
   [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: 'Workbench container started',
   [ProgressionStep.PULLING_OAUTH]: 'Pulling oauth proxy',
   [ProgressionStep.OAUTH_PULLED]: 'Oauth proxy pulled',
   [ProgressionStep.OAUTH_CONTAINER_CREATED]: 'Oauth proxy container created',
+  [ProgressionStep.OAUTH_PROBLEM]: 'There was a problem with Oauth',
   [ProgressionStep.OAUTH_CONTAINER_STARTED]: 'Oauth proxy container started',
   [ProgressionStep.SERVER_STARTED]: 'Server started',
 };
 
-export const AssociatedSteps = {
+export const AssociatedSteps: Record<string, ProgressionStep[]> = {
   [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: [
-    ProgressionStep.PVC_ATTACHED,
     ProgressionStep.INTERFACE_ADDED,
     ProgressionStep.PULLING_NOTEBOOK_IMAGE,
     ProgressionStep.NOTEBOOK_IMAGE_PULLED,
@@ -651,8 +656,17 @@ export const AssociatedSteps = {
   [ProgressionStep.SERVER_STARTED]: Object.values(ProgressionStep),
 };
 
+export const OptionalSteps: Record<string, ProgressionStep[]> = {
+  Steps: [
+    ProgressionStep.POD_PROBLEM,
+    ProgressionStep.NOTEBOOK_PROBLEM,
+    ProgressionStep.OAUTH_PROBLEM,
+    ProgressionStep.PVC_ATTACHED,
+  ],
+};
+
 export type NotebookProgressStep = {
-  step?: ProgressionStep;
+  step: ProgressionStep;
   description?: string;
   status: EventStatus;
   timestamp: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -635,6 +635,27 @@ export const ProgressionStepTitles = {
   [ProgressionStep.SERVER_STARTED]: 'Server started',
 };
 
+export const AssociatedSteps = {
+  [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: [
+    ProgressionStep.SERVER_REQUESTED,
+    ProgressionStep.POD_CREATED,
+    ProgressionStep.POD_ASSIGNED,
+    ProgressionStep.PVC_ATTACHED,
+    ProgressionStep.INTERFACE_ADDED,
+    ProgressionStep.PULLING_NOTEBOOK_IMAGE,
+    ProgressionStep.NOTEBOOK_IMAGE_PULLED,
+    ProgressionStep.NOTEBOOK_CONTAINER_CREATED,
+  ],
+  [ProgressionStep.OAUTH_CONTAINER_STARTED]: [
+    ProgressionStep.PULLING_OAUTH,
+    ProgressionStep.OAUTH_PULLED,
+    ProgressionStep.OAUTH_CONTAINER_CREATED,
+    ProgressionStep.OAUTH_CONTAINER_STARTED,
+  ],
+  [ProgressionStep.POD_ASSIGNED]: [ProgressionStep.POD_CREATED],
+  [ProgressionStep.SERVER_STARTED]: [ProgressionStep],
+};
+
 export type NotebookProgressStep = {
   step?: ProgressionStep;
   description?: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -604,8 +604,8 @@ export enum NotebookState {
 export enum ProgressionStep {
   SERVER_REQUESTED = 'SERVER_REQUESTED',
   POD_CREATED = 'POD_CREATED',
-  POD_ASSIGNED = 'POD_ASSIGNED',
   POD_PROBLEM = 'POD_PROBLEM',
+  POD_ASSIGNED = 'POD_ASSIGNED',
   PVC_ATTACHED = 'PVC_ATTACHED',
   INTERFACE_ADDED = 'INTERFACE_ADDED',
   PULLING_NOTEBOOK_IMAGE = 'PULLING_NOTEBOOK_IMAGE',
@@ -624,8 +624,8 @@ export enum ProgressionStep {
 export const ProgressionStepTitles: Record<ProgressionStep, string> = {
   [ProgressionStep.SERVER_REQUESTED]: 'Server requested',
   [ProgressionStep.POD_CREATED]: 'Pod created',
-  [ProgressionStep.POD_ASSIGNED]: 'Pod assigned',
   [ProgressionStep.POD_PROBLEM]: 'There was a problem with the pod',
+  [ProgressionStep.POD_ASSIGNED]: 'Pod assigned',
   [ProgressionStep.PVC_ATTACHED]: 'PVC attached',
   [ProgressionStep.INTERFACE_ADDED]: 'Interface added',
   [ProgressionStep.PULLING_NOTEBOOK_IMAGE]: 'Pulling workbench image',
@@ -656,14 +656,12 @@ export const AssociatedSteps: Record<string, ProgressionStep[]> = {
   [ProgressionStep.SERVER_STARTED]: Object.values(ProgressionStep),
 };
 
-export const OptionalSteps: Record<string, ProgressionStep[]> = {
-  Steps: [
-    ProgressionStep.POD_PROBLEM,
-    ProgressionStep.NOTEBOOK_PROBLEM,
-    ProgressionStep.OAUTH_PROBLEM,
-    ProgressionStep.PVC_ATTACHED,
-  ],
-};
+export const OptionalSteps: ProgressionStep[] = [
+  ProgressionStep.POD_PROBLEM,
+  ProgressionStep.NOTEBOOK_PROBLEM,
+  ProgressionStep.OAUTH_PROBLEM,
+  ProgressionStep.PVC_ATTACHED,
+];
 
 export type NotebookProgressStep = {
   step: ProgressionStep;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -603,45 +603,45 @@ export enum NotebookState {
 
 export enum ProgressionStep {
   SERVER_REQUESTED = 'SERVER_REQUESTED',
-  POD_CREATED = 'POD_CREATED',
   POD_PROBLEM = 'POD_PROBLEM',
+  POD_CREATED = 'POD_CREATED',
   POD_ASSIGNED = 'POD_ASSIGNED',
   PVC_ATTACHED = 'PVC_ATTACHED',
   INTERFACE_ADDED = 'INTERFACE_ADDED',
   PULLING_NOTEBOOK_IMAGE = 'PULLING_NOTEBOOK_IMAGE',
   NOTEBOOK_IMAGE_PULLED = 'NOTEBOOK_IMAGE_PULLED',
   NOTEBOOK_CONTAINER_CREATED = 'NOTEBOOK_CONTAINER_CREATED',
-  NOTEBOOK_PROBLEM = 'NOTEBOOK_PROBLEM',
+  NOTEBOOK_CONTAINER_PROBLEM = 'NOTEBOOK_CONTAINER_PROBLEM',
   NOTEBOOK_CONTAINER_STARTED = 'NOTEBOOK_CONTAINER_STARTED',
   PULLING_OAUTH = 'PULLING_OAUTH',
   OAUTH_PULLED = 'OAUTH_PULLED',
   OAUTH_CONTAINER_CREATED = 'OAUTH_CONTAINER_CREATED',
-  OAUTH_PROBLEM = 'OAUTH_PROBLEM',
+  OAUTH_CONTAINER_PROBLEM = 'OAUTH_CONTAINER_PROBLEM',
   OAUTH_CONTAINER_STARTED = 'OAUTH_CONTAINER_STARTED',
   SERVER_STARTED = 'SERVER_STARTED',
 }
 
 export const ProgressionStepTitles: Record<ProgressionStep, string> = {
   [ProgressionStep.SERVER_REQUESTED]: 'Server requested',
-  [ProgressionStep.POD_CREATED]: 'Pod created',
   [ProgressionStep.POD_PROBLEM]: 'There was a problem with the pod',
+  [ProgressionStep.POD_CREATED]: 'Pod created',
   [ProgressionStep.POD_ASSIGNED]: 'Pod assigned',
   [ProgressionStep.PVC_ATTACHED]: 'PVC attached',
   [ProgressionStep.INTERFACE_ADDED]: 'Interface added',
   [ProgressionStep.PULLING_NOTEBOOK_IMAGE]: 'Pulling workbench image',
   [ProgressionStep.NOTEBOOK_IMAGE_PULLED]: 'Workbench image pulled',
   [ProgressionStep.NOTEBOOK_CONTAINER_CREATED]: 'Workbench container created',
-  [ProgressionStep.NOTEBOOK_PROBLEM]: 'There was a problem with the notebook',
+  [ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM]: 'There was a problem with the notebook',
   [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: 'Workbench container started',
   [ProgressionStep.PULLING_OAUTH]: 'Pulling oauth proxy',
   [ProgressionStep.OAUTH_PULLED]: 'Oauth proxy pulled',
   [ProgressionStep.OAUTH_CONTAINER_CREATED]: 'Oauth proxy container created',
-  [ProgressionStep.OAUTH_PROBLEM]: 'There was a problem with Oauth',
+  [ProgressionStep.OAUTH_CONTAINER_PROBLEM]: 'There was a problem with Oauth',
   [ProgressionStep.OAUTH_CONTAINER_STARTED]: 'Oauth proxy container started',
   [ProgressionStep.SERVER_STARTED]: 'Server started',
 };
 
-export const AssociatedSteps: Record<string, ProgressionStep[]> = {
+export const AssociatedSteps: { [key in ProgressionStep]?: ProgressionStep[] } = {
   [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: [
     ProgressionStep.INTERFACE_ADDED,
     ProgressionStep.PULLING_NOTEBOOK_IMAGE,
@@ -658,8 +658,8 @@ export const AssociatedSteps: Record<string, ProgressionStep[]> = {
 
 export const OptionalSteps: ProgressionStep[] = [
   ProgressionStep.POD_PROBLEM,
-  ProgressionStep.NOTEBOOK_PROBLEM,
-  ProgressionStep.OAUTH_PROBLEM,
+  ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
+  ProgressionStep.OAUTH_CONTAINER_PROBLEM,
   ProgressionStep.PVC_ATTACHED,
 ];
 

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -361,6 +361,12 @@ export const getNotebookEventStatus = (
 
   // For notebook-related events
   switch (event.reason) {
+    case 'SuccessfulCreate':
+      return {
+        step: ProgressionStep.POD_CREATED,
+        status: EventStatus.SUCCESS,
+        timestamp,
+      };
     case 'Scheduled':
       return {
         step: ProgressionStep.POD_ASSIGNED,
@@ -567,7 +573,7 @@ export const useNotebookProgress = (
     if (progressSteps.find((p) => p.step === key)?.status === EventStatus.SUCCESS) {
       values.forEach((value) => {
         const currentStep = progressSteps.find((p) => p.step === value);
-        if (currentStep && currentStep.status !== EventStatus.SUCCESS) {
+        if (currentStep) {
           currentStep.status = EventStatus.SUCCESS;
         }
       });

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { createRoleBinding, getRoleBinding } from '~/services/roleBindingService';
 import {
+  AssociatedSteps,
   EnvVarReducedTypeKeyValues,
   EventStatus,
   Notebook,
@@ -566,6 +567,18 @@ export const useNotebookProgress = (
       startedStep.status = EventStatus.SUCCESS;
     }
   }
+
+  // If milestone steps are completed, mark off associated steps
+  Object.entries(AssociatedSteps).forEach(([key, values]) => {
+    if (progressSteps.find((p) => p.step === key)?.status === EventStatus.SUCCESS) {
+      values.forEach((value) => {
+        const currentStep = progressSteps.find((p) => p.step === value);
+        if (currentStep && currentStep.status !== EventStatus.SUCCESS) {
+          currentStep.status = EventStatus.SUCCESS;
+        }
+      });
+    }
+  });
 
   // Insert the last error or warning after the last pending step
   if (currentProgress.length) {

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -354,7 +354,7 @@ export const getNotebookEventStatus = (
           };
         }
         return {
-          step: ProgressionStep.OAUTH_PROBLEM,
+          step: ProgressionStep.OAUTH_CONTAINER_PROBLEM,
           status: EventStatus.WARNING,
           timestamp,
         };
@@ -443,7 +443,7 @@ export const getNotebookEventStatus = (
       }
       if (!gracePeriod && event.reason === 'BackOff') {
         return {
-          step: ProgressionStep.NOTEBOOK_PROBLEM,
+          step: ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
           description: 'ImagePullBackOff',
           status: EventStatus.ERROR,
           timestamp,
@@ -451,14 +451,14 @@ export const getNotebookEventStatus = (
       }
       if (event.type === 'Warning') {
         return {
-          step: ProgressionStep.NOTEBOOK_PROBLEM,
+          step: ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
           description: 'Issue creating workbench container',
           status: EventStatus.WARNING,
           timestamp,
         };
       }
       return {
-        step: ProgressionStep.NOTEBOOK_PROBLEM,
+        step: ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
         description: '',
         status: EventStatus.WARNING,
         timestamp,
@@ -497,11 +497,11 @@ export const useNotebookStatus = (
 
   // Parse the last event
   const lastItem = filteredEvents[filteredEvents.length - 1];
-  const { step, status } = getNotebookEventStatus(lastItem, gracePeriod);
+  const { step, description, status } = getNotebookEventStatus(lastItem, gracePeriod);
 
   return [
     {
-      currentEvent: ProgressionStepTitles[step],
+      currentEvent: description || ProgressionStepTitles[step],
       currentEventReason: lastItem.reason,
       currentEventDescription: lastItem.message,
       currentStatus: status,

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -247,7 +247,7 @@ export const getEventFullMessage = (event: EventKind): string =>
 const filterEvents = (
   allEvents: EventKind[],
   lastActivity: Date,
-): [filterEvents: EventKind[], thisInstanceEvents: EventKind[], gracePeroid: boolean] => {
+): [filterEvents: EventKind[], thisInstanceEvents: EventKind[], gracePeriod: boolean] => {
   const thisInstanceEvents = allEvents
     .filter((event) => new Date(getEventTimestamp(event)) >= lastActivity)
     .toSorted((a, b) => getEventTimestamp(a).localeCompare(getEventTimestamp(b)));

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -310,7 +310,8 @@ export const getNotebookEventStatus = (
 ): NotebookProgressStep => {
   const timestamp = new Date(getEventTimestamp(event)).getTime();
 
-  if (event.message.includes('oauth-proxy')) {
+  // For Oauth-related events
+  if (event.message.includes('oauth-proxy') || event.message.includes('ose-oauth-proxy')) {
     switch (event.reason) {
       case 'Pulling':
         return {
@@ -357,6 +358,7 @@ export const getNotebookEventStatus = (
     }
   }
 
+  // For notebook-related events
   switch (event.reason) {
     case 'SuccessfulCreate':
       return {

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -553,18 +553,6 @@ export const useNotebookProgress = (
     }
   });
 
-  // Some events are not always received, mark all steps prior to the last completed step complete.
-  const lastCompleteIndex = progressSteps.findLastIndex(
-    (step) => step.status === EventStatus.SUCCESS,
-  );
-  if (lastCompleteIndex > 0) {
-    for (let i = 0; i < lastCompleteIndex; i++) {
-      if (progressSteps[i].status === EventStatus.PENDING) {
-        progressSteps[i].status = EventStatus.SUCCESS;
-      }
-    }
-  }
-
   // If the container is started and the server is running, mark the server started step complete
   if (
     isRunning &&

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -361,12 +361,6 @@ export const getNotebookEventStatus = (
 
   // For notebook-related events
   switch (event.reason) {
-    case 'SuccessfulCreate':
-      return {
-        step: ProgressionStep.POD_CREATED,
-        status: EventStatus.SUCCESS,
-        timestamp,
-      };
     case 'Scheduled':
       return {
         step: ProgressionStep.POD_ASSIGNED,

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -578,7 +578,7 @@ export const useNotebookProgress = (
   // If milestone steps are completed, mark off associated steps
   Object.entries(AssociatedSteps).forEach(([key, values]) => {
     if (progressSteps.find((p) => p.step === key)?.status === EventStatus.SUCCESS) {
-      const filteredValues = values.filter((step) => !OptionalSteps.Steps.includes(step));
+      const filteredValues = values.filter((step) => !OptionalSteps.includes(step));
       filteredValues.forEach((value) => {
         const currentStep = progressSteps.find((p) => p.step === value);
         if (currentStep) {
@@ -592,7 +592,7 @@ export const useNotebookProgress = (
   return progressSteps.filter(
     (notebookProgressStep) =>
       !(
-        OptionalSteps.Steps.includes(notebookProgressStep.step) &&
+        OptionalSteps.includes(notebookProgressStep.step) &&
         progressSteps.find((p) => p.step === notebookProgressStep.step)?.status ===
           EventStatus.PENDING
       ),


### PR DESCRIPTION
Closes: [RHOAIENG-21741](https://issues.redhat.com/browse/RHOAIENG-21741) and [RHOAIENG-22056](https://issues.redhat.com/browse/RHOAIENG-22056)

## Description
-Removed code that assumed notebook modal events had succeeded based on the most recently successful event.
-Added an additional check for ‘ose-oauth-proxy’ for clarity in differentiating between notebook and oauth events.
-Created a new type that associated events with event milestones -> If the container started, then the image events must have succeeded and so on.
-Added a snippet that loops through the associated events and marks off events based on milestone successes.
-Added optional events and event filtering
-Fixed a typo.

## How Has This Been Tested?
-Tested with npm run test
-Tested locally with successful and broken workbenches.

-If you want to test, open a data science project
	-Navigate to the workbenches page and start a workbench.
	-Click the button in the status column to view the modal

Successful:
<img width="550" alt="Screenshot 2025-03-27 at 9 09 40 AM" src="https://github.com/user-attachments/assets/7077b7e1-1145-4a0a-850f-aa84579d4f72" />


Failed:
<img width="565" alt="Screenshot 2025-03-28 at 1 23 40 PM" src="https://github.com/user-attachments/assets/7797637e-0618-4ba6-8f90-df639bc33c38" />


## Test Impact
Modified unit tests to handle the changes made in the number of events and error text

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`