### PR TITLE
added optimizations to fetch mlmd contexts in a single call

### DIFF
--- a/frontend/src/__mocks__/mlmd/mockGetContextsByType.ts
+++ b/frontend/src/__mocks__/mlmd/mockGetContextsByType.ts
@@ -1,0 +1,84 @@
+/* eslint-disable camelcase */
+import { Context } from '~/__mocks__/third_party/mlmd';
+import { GetContextsByTypeResponse } from '~/__mocks__/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service';
+import createGrpcResponse, { GrpcResponse } from './utils';
+
+const mockedContext: Context[] = [
+  {
+    id: 106, // The id of the pipeline run to mock
+    name: 'run-1',
+    typeId: 11,
+    type: 'system.PipelineRun',
+    properties: {},
+    customProperties: {
+      bucket_session_info: {
+        stringValue:
+          '{"Region":"us-east-1","Endpoint":"https://s3.amazonaws.com","DisableSSL":false,"SecretName":"secret-3t3ar6","AccessKeyKey":"AWS_ACCESS_KEY_ID","SecretKeyKey":"AWS_SECRET_ACCESS_KEY"}',
+      },
+      namespace: {
+        stringValue: 'jps-fun-world',
+      },
+      pipeline_root: {
+        stringValue: 's3://aballant-pipelines/metrics-visualization-pipeline/${name}',
+      },
+      resource_name: {
+        stringValue: 'run-resource',
+      },
+    },
+    createTimeSinceEpoch: 1712899519123,
+    lastUpdateTimeSinceEpoch: 1712899519123,
+  },
+  {
+    id: 107, // The id of the pipeline run to mock
+    name: 'run-2',
+    typeId: 11,
+    type: 'system.PipelineRun',
+    properties: {},
+    customProperties: {
+      bucket_session_info: {
+        stringValue:
+          '{"Region":"us-east-1","Endpoint":"https://s3.amazonaws.com","DisableSSL":false,"SecretName":"secret-3t3ar6","AccessKeyKey":"AWS_ACCESS_KEY_ID","SecretKeyKey":"AWS_SECRET_ACCESS_KEY"}',
+      },
+      namespace: {
+        stringValue: 'jps-fun-world',
+      },
+      pipeline_root: {
+        stringValue: 's3://aballant-pipelines/metrics-visualization-pipeline/${name}',
+      },
+      resource_name: {
+        stringValue: 'run-resource',
+      },
+    },
+    createTimeSinceEpoch: 1712899519123,
+    lastUpdateTimeSinceEpoch: 1712899519123,
+  },
+  {
+    id: 108, // The id of the pipeline run to mock
+    name: 'run-3',
+    typeId: 11,
+    type: 'system.PipelineRun',
+    properties: {},
+    customProperties: {
+      bucket_session_info: {
+        stringValue:
+          '{"Region":"us-east-1","Endpoint":"https://s3.amazonaws.com","DisableSSL":false,"SecretName":"secret-3t3ar6","AccessKeyKey":"AWS_ACCESS_KEY_ID","SecretKeyKey":"AWS_SECRET_ACCESS_KEY"}',
+      },
+      namespace: {
+        stringValue: 'jps-fun-world',
+      },
+      pipeline_root: {
+        stringValue: 's3://aballant-pipelines/metrics-visualization-pipeline/${name}',
+      },
+      resource_name: {
+        stringValue: 'run-resource',
+      },
+    },
+    createTimeSinceEpoch: 1712899519123,
+    lastUpdateTimeSinceEpoch: 1712899519123,
+  },
+];
+
+export const mockGetContextsByType = (): GrpcResponse => {
+  const binary = GetContextsByTypeResponse.encode({ contexts: mockedContext }).finish();
+  return createGrpcResponse(binary);
+};

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -632,6 +632,11 @@ declare global {
           response: OdhResponse<GrpcResponse>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: `POST /api/service/mlmd/:namespace/:serviceName/ml_metadata.MetadataStoreService/GetContextsByType`,
+          options: { path: { namespace: string; serviceName: string } },
+          response: OdhResponse<GrpcResponse>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'GET /api/rolebindings/opendatahub/openshift-ai-notebooks-image-pullers',
           response: OdhResponse<K8sResourceListResult<RoleBindingKind>>,
         ) => Cypress.Chainable<null>) &

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/mlmdUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/mlmdUtils.ts
@@ -10,6 +10,7 @@ import { mockGetExecutionsByID } from '~/__mocks__/mlmd/mockGetExecutionsByID';
 import { GetExecutionsRequest } from '~/__mocks__/third_party/mlmd';
 import { mockGetContextsByExecution } from '~/__mocks__/mlmd/mockGetContextsByExecution';
 import { mockGetContextType } from '~/__mocks__/mlmd/mockGetContextType';
+import { mockGetContextsByType } from '~/__mocks__/mlmd/mockGetContextsByType';
 
 export const initMlmdIntercepts = (
   projectName: string,
@@ -67,6 +68,11 @@ export const initMlmdIntercepts = (
     'POST /api/service/mlmd/:namespace/:serviceName/ml_metadata.MetadataStoreService/GetEventsByArtifactIDs',
     { path: { namespace: projectName, serviceName: 'dspa' } },
     mockGetEventsByArtifactIDs(),
+  );
+  cy.interceptOdh(
+    'POST /api/service/mlmd/:namespace/:serviceName/ml_metadata.MetadataStoreService/GetContextsByType',
+    { path: { namespace: projectName, serviceName: 'dspa' } },
+    mockGetContextsByType(),
   );
 };
 

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/__tests__/useMlmdContextByType.spec.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/__tests__/useMlmdContextByType.spec.ts
@@ -1,0 +1,88 @@
+import { testHook, standardUseFetchState } from '~/__tests__/unit/testUtils/hooks';
+import { MetadataStoreServicePromiseClient, Context } from '~/third_party/mlmd';
+import { MlmdContextTypes } from '~/concepts/pipelines/apiHooks/mlmd/types';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+import { GetContextsByTypeResponse } from '~/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
+import { useMlmdContextsByType } from '~/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType';
+
+// Mock the usePipelinesAPI hook
+jest.mock('~/concepts/pipelines/context', () => ({
+  usePipelinesAPI: jest.fn(),
+}));
+
+// Mock the getMlmdContext function
+jest.mock('~/concepts/pipelines/apiHooks/mlmd/useMlmdContext', () => ({
+  ...jest.requireActual('~/concepts/pipelines/apiHooks/mlmd/useMlmdContext'),
+  getMlmdContext: jest.fn(),
+}));
+
+// Mock the MetadataStoreServicePromiseClient
+jest.mock('~/third_party/mlmd', () => {
+  const originalModule = jest.requireActual('~/third_party/mlmd');
+  return {
+    ...originalModule,
+    MetadataStoreServicePromiseClient: jest.fn().mockImplementation(() => ({
+      getContextsByType: jest.fn(),
+    })),
+    GetContextsByTypeRequest: originalModule.GetContextsByTypeRequest,
+  };
+});
+
+describe('useMlmdContextByType', () => {
+  const mockClient = new MetadataStoreServicePromiseClient('');
+  const mockUsePipelinesAPI = jest.mocked(
+    usePipelinesAPI as () => Partial<ReturnType<typeof usePipelinesAPI>>,
+  );
+  const mockGetContextsByType = jest.mocked(mockClient.getContextsByType);
+
+  const mockContext = new Context();
+  mockContext.setName('test-context');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePipelinesAPI.mockReturnValue({
+      metadataStoreServiceClient: mockClient,
+    });
+  });
+
+  it('should return an error when no type is provided', async () => {
+    const renderResult = testHook(useMlmdContextsByType)(MlmdContextTypes.RUN);
+
+    expect(renderResult.result.current).toStrictEqual(
+      standardUseFetchState(null, false, undefined),
+    );
+  });
+
+  it('should fetch and return the context', async () => {
+    mockGetContextsByType.mockResolvedValue({
+      getContextsList: () => [mockContext],
+    } as GetContextsByTypeResponse);
+
+    const renderResult = testHook(useMlmdContextsByType)(MlmdContextTypes.RUN);
+
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState([mockContext], true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
+  it('should handle errors from getMlmdContext', async () => {
+    const error = new Error('Test error');
+    mockGetContextsByType.mockRejectedValue(error);
+
+    const renderResult = testHook(useMlmdContextsByType)(MlmdContextTypes.RUN);
+
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(null));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // wait for update
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(null, false, error));
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+});

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/__tests__/useMlmdContextsByType.spec.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/__tests__/useMlmdContextsByType.spec.ts
@@ -28,7 +28,7 @@ jest.mock('~/third_party/mlmd', () => {
   };
 });
 
-describe('useMlmdContextByType', () => {
+describe('useMlmdContextsByType', () => {
   const mockClient = new MetadataStoreServicePromiseClient('');
   const mockUsePipelinesAPI = jest.mocked(
     usePipelinesAPI as () => Partial<ReturnType<typeof usePipelinesAPI>>,
@@ -48,9 +48,7 @@ describe('useMlmdContextByType', () => {
   it('should return an error when no type is provided', async () => {
     const renderResult = testHook(useMlmdContextsByType)(MlmdContextTypes.RUN);
 
-    expect(renderResult.result.current).toStrictEqual(
-      standardUseFetchState(null, false, undefined),
-    );
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState([], false, undefined));
   });
 
   it('should fetch and return the context', async () => {
@@ -60,7 +58,7 @@ describe('useMlmdContextByType', () => {
 
     const renderResult = testHook(useMlmdContextsByType)(MlmdContextTypes.RUN);
 
-    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(null));
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState([]));
     expect(renderResult).hookToHaveUpdateCount(1);
 
     // wait for update
@@ -76,13 +74,13 @@ describe('useMlmdContextByType', () => {
 
     const renderResult = testHook(useMlmdContextsByType)(MlmdContextTypes.RUN);
 
-    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(null));
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState([]));
     expect(renderResult).hookToHaveUpdateCount(1);
 
     // wait for update
     await renderResult.waitForNextUpdate();
 
-    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(null, false, error));
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState([], false, error));
     expect(renderResult).hookToHaveUpdateCount(2);
   });
 });

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetArtifactsByRuns.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetArtifactsByRuns.ts
@@ -1,42 +1,37 @@
 import React from 'react';
 
-import { Artifact } from '~/third_party/mlmd';
+import { Artifact, Context } from '~/third_party/mlmd';
 import { GetArtifactsByContextRequest } from '~/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
 import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
-import { MlmdContextTypes } from './types';
-import { getMlmdContext } from './useMlmdContext';
 
 export const useGetArtifactsByRuns = (
   runs: PipelineRunKF[],
+  contexts: Context[] | null,
 ): FetchState<Record<string, Artifact[]>[]> => {
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
   const call = React.useCallback<FetchStateCallbackPromise<Record<string, Artifact[]>[]>>(
     () =>
       Promise.all(
-        runs.map((run) =>
-          getMlmdContext(metadataStoreServiceClient, run.run_id, MlmdContextTypes.RUN).then(
-            async (context) => {
-              if (!context) {
-                throw new Error(`No context for run: ${run.run_id}`);
-              }
+        runs.map(async (run) => {
+          const context = contexts?.find((x) => x.getName() === run.run_id);
+          if (!context) {
+            throw new Error(`No context for run: ${run.run_id}`);
+          }
+          const request = new GetArtifactsByContextRequest();
+          request.setContextId(context.getId());
 
-              const request = new GetArtifactsByContextRequest();
-              request.setContextId(context.getId());
+          const response = await metadataStoreServiceClient.getArtifactsByContext(request);
+          const artifacts = response.getArtifactsList();
 
-              const response = await metadataStoreServiceClient.getArtifactsByContext(request);
-              const artifacts = response.getArtifactsList();
-
-              return {
-                [run.run_id]: artifacts,
-              };
-            },
-          ),
-        ),
+          return {
+            [run.run_id]: artifacts,
+          };
+        }),
       ),
-    [metadataStoreServiceClient, runs],
+    [contexts, metadataStoreServiceClient, runs],
   );
 
   return useFetchState(call, []);

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetArtifactsByRuns.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useGetArtifactsByRuns.ts
@@ -8,7 +8,7 @@ import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 
 export const useGetArtifactsByRuns = (
   runs: PipelineRunKF[],
-  contexts: Context[] | null,
+  contexts: Context[],
 ): FetchState<Record<string, Artifact[]>[]> => {
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
@@ -16,7 +16,7 @@ export const useGetArtifactsByRuns = (
     () =>
       Promise.all(
         runs.map(async (run) => {
-          const context = contexts?.find((x) => x.getName() === run.run_id);
+          const context = contexts.find((x) => x.getName() === run.run_id);
           if (!context) {
             throw new Error(`No context for run: ${run.run_id}`);
           }

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType.ts
@@ -29,10 +29,10 @@ const getMlmdContextsByType = async (
 export const useMlmdContextsByType = (
   type?: MlmdContextTypes,
   refreshRate?: number,
-): FetchState<Context[] | null> => {
+): FetchState<Context[]> => {
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
-  const call = React.useCallback<FetchStateCallbackPromise<Context[] | null>>(async () => {
+  const call = React.useCallback<FetchStateCallbackPromise<Context[]>>(async () => {
     if (!type) {
       return Promise.reject(new NotReadyError('No context type'));
     }
@@ -41,7 +41,7 @@ export const useMlmdContextsByType = (
     return context;
   }, [metadataStoreServiceClient, type]);
 
-  return useFetchState(call, null, {
+  return useFetchState(call, [], {
     refreshRate,
   });
 };

--- a/frontend/src/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType.ts
@@ -1,0 +1,47 @@
+import React from 'react';
+import { MlmdContextTypes } from '~/concepts/pipelines/apiHooks/mlmd/types';
+import {
+  MetadataStoreServicePromiseClient,
+  GetContextsByTypeRequest,
+  Context,
+} from '~/third_party/mlmd';
+import useFetchState, {
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '~/utilities/useFetchState';
+import { usePipelinesAPI } from '~/concepts/pipelines/context';
+
+const getMlmdContextsByType = async (
+  client: MetadataStoreServicePromiseClient,
+  type: MlmdContextTypes,
+): Promise<Context[]> => {
+  const request = new GetContextsByTypeRequest();
+  request.setTypeName(type);
+  const res = await client.getContextsByType(request);
+  return res.getContextsList();
+};
+
+/**
+ * A hook used to use the MLMD service and fetch the MLMD context by type
+ * If being used without type, this hook will throw an error
+ */
+export const useMlmdContextsByType = (
+  type?: MlmdContextTypes,
+  refreshRate?: number,
+): FetchState<Context[] | null> => {
+  const { metadataStoreServiceClient } = usePipelinesAPI();
+
+  const call = React.useCallback<FetchStateCallbackPromise<Context[] | null>>(async () => {
+    if (!type) {
+      return Promise.reject(new NotReadyError('No context type'));
+    }
+
+    const context = await getMlmdContextsByType(metadataStoreServiceClient, type);
+    return context;
+  }, [metadataStoreServiceClient, type]);
+
+  return useFetchState(call, null, {
+    refreshRate,
+  });
+};

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/useMlmdPackagesForPipelineRuns.ts
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/useMlmdPackagesForPipelineRuns.ts
@@ -12,7 +12,7 @@ import { PipelineRunRelatedMlmd } from './types';
 
 const useMlmdPackagesForPipelineRuns = (
   runs: PipelineRunKF[],
-  contexts: Context[] | null,
+  contexts: Context[],
 ): FetchState<PipelineRunRelatedMlmd[]> => {
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
@@ -20,7 +20,7 @@ const useMlmdPackagesForPipelineRuns = (
     () =>
       Promise.all(
         runs.map(async (run) => {
-          const context = contexts?.find((x) => x.getName() === run.run_id);
+          const context = contexts.find((x) => x.getName() === run.run_id);
           if (!context) {
             throw new Error(`No context for run: ${run.run_id}`);
           }

--- a/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/useMlmdPackagesForPipelineRuns.ts
+++ b/frontend/src/concepts/pipelines/content/compareRuns/metricsSection/useMlmdPackagesForPipelineRuns.ts
@@ -1,6 +1,4 @@
 import React from 'react';
-import { MlmdContextTypes } from '~/concepts/pipelines/apiHooks/mlmd/types';
-import { getMlmdContext } from '~/concepts/pipelines/apiHooks/mlmd/useMlmdContext';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import useFetchState, { FetchState, FetchStateCallbackPromise } from '~/utilities/useFetchState';
@@ -9,63 +7,60 @@ import {
   GetEventsByExecutionIDsRequest,
   GetExecutionsByContextRequest,
 } from '~/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
+import { Context } from '~/third_party/mlmd';
 import { PipelineRunRelatedMlmd } from './types';
 
 const useMlmdPackagesForPipelineRuns = (
   runs: PipelineRunKF[],
+  contexts: Context[] | null,
 ): FetchState<PipelineRunRelatedMlmd[]> => {
   const { metadataStoreServiceClient } = usePipelinesAPI();
 
   const call = React.useCallback<FetchStateCallbackPromise<PipelineRunRelatedMlmd[]>>(
     () =>
       Promise.all(
-        runs.map((run) =>
-          getMlmdContext(metadataStoreServiceClient, run.run_id, MlmdContextTypes.RUN).then(
-            async (context) => {
-              if (!context) {
-                throw new Error(`No context for run: ${run.run_id}`);
-              }
-              // get artifacts
-              const artifactRequest = new GetArtifactsByContextRequest();
-              artifactRequest.setContextId(context.getId());
-              const artifactRes = await metadataStoreServiceClient.getArtifactsByContext(
-                artifactRequest,
-              );
-              const artifacts = artifactRes.getArtifactsList();
+        runs.map(async (run) => {
+          const context = contexts?.find((x) => x.getName() === run.run_id);
+          if (!context) {
+            throw new Error(`No context for run: ${run.run_id}`);
+          }
+          // get artifacts
+          const artifactRequest = new GetArtifactsByContextRequest();
+          artifactRequest.setContextId(context.getId());
+          const artifactRes = await metadataStoreServiceClient.getArtifactsByContext(
+            artifactRequest,
+          );
+          const artifacts = artifactRes.getArtifactsList();
 
-              // get executions
-              const executionRequest = new GetExecutionsByContextRequest();
-              executionRequest.setContextId(context.getId());
-              const executionRes = await metadataStoreServiceClient.getExecutionsByContext(
-                executionRequest,
-              );
-              const executions = executionRes.getExecutionsList();
+          // get executions
+          const executionRequest = new GetExecutionsByContextRequest();
+          executionRequest.setContextId(context.getId());
+          const executionRes = await metadataStoreServiceClient.getExecutionsByContext(
+            executionRequest,
+          );
+          const executions = executionRes.getExecutionsList();
 
-              // get events
-              const eventRequest = new GetEventsByExecutionIDsRequest();
-              executions.forEach((exec) => {
-                const execId = exec.getId();
-                if (!execId) {
-                  throw new Error('Execution must have an ID');
-                }
-                eventRequest.addExecutionIds(execId);
-              });
-              const eventRes = await metadataStoreServiceClient.getEventsByExecutionIDs(
-                eventRequest,
-              );
-              const events = eventRes.getEventsList();
+          // get events
+          const eventRequest = new GetEventsByExecutionIDsRequest();
+          executions.forEach((exec) => {
+            const execId = exec.getId();
+            if (!execId) {
+              throw new Error('Execution must have an ID');
+            }
+            eventRequest.addExecutionIds(execId);
+          });
+          const eventRes = await metadataStoreServiceClient.getEventsByExecutionIDs(eventRequest);
+          const events = eventRes.getEventsList();
 
-              return {
-                run,
-                artifacts,
-                events,
-                executions,
-              };
-            },
-          ),
-        ),
+          return {
+            run,
+            artifacts,
+            events,
+            executions,
+          };
+        }),
       ),
-    [metadataStoreServiceClient, runs],
+    [contexts, metadataStoreServiceClient, runs],
   );
 
   return useFetchState(call, []);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -65,8 +65,14 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
   const { experiments: allExperiments } = React.useContext(PipelineRunExperimentsContext);
   const { namespace, refreshAllAPI } = usePipelinesAPI();
   const { onClearFilters, ...filterToolbarProps } = usePipelineFilterSearchParams(setFilter);
-  const { metricsColumnNames, runs, runArtifactsError, runArtifactsLoaded, metricsNames } =
-    useMetricColumns(runWithoutMetrics, experiment?.experiment_id);
+  const {
+    metricsColumnNames,
+    runs,
+    contextError,
+    runArtifactsError,
+    runArtifactsLoaded,
+    metricsNames,
+  } = useMetricColumns(runWithoutMetrics, experiment?.experiment_id);
   const {
     selections: selectedIds,
     tableProps: checkboxTableProps,
@@ -270,7 +276,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
             run={run}
             customCells={metricsColumnNames.map((metricName: string) => (
               <Td key={metricName} dataLabel={metricName}>
-                {!runArtifactsLoaded && !runArtifactsError ? (
+                {!runArtifactsLoaded && !runArtifactsError && !contextError ? (
                   <Skeleton />
                 ) : (
                   run.metrics.find((metric) => metric.name === metricName)?.value ?? (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -68,7 +68,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
   const {
     metricsColumnNames,
     runs,
-    contextError,
+    contextsError,
     runArtifactsError,
     runArtifactsLoaded,
     metricsNames,
@@ -276,7 +276,7 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
             run={run}
             customCells={metricsColumnNames.map((metricName: string) => (
               <Td key={metricName} dataLabel={metricName}>
-                {!runArtifactsLoaded && !runArtifactsError && !contextError ? (
+                {!runArtifactsLoaded && !runArtifactsError && !contextsError ? (
                   <Skeleton />
                 ) : (
                   run.metrics.find((metric) => metric.name === metricName)?.value ?? (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/useMetricColumns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/useMetricColumns.ts
@@ -4,6 +4,8 @@ import { ArtifactType, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
 import { getArtifactProperties } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
 import { ArtifactProperty } from '~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/types';
 import { RunWithMetrics } from '~/concepts/pipelines/content/tables/pipelineRun/types';
+import { useMlmdContextsByType } from '~/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType';
+import { MlmdContextTypes } from '~/concepts/pipelines/apiHooks/mlmd/types';
 import { getMetricsColumnsLocalStorageKey } from './utils';
 
 export const useMetricColumnNames = (
@@ -52,10 +54,15 @@ export const useMetricColumns = (
   runs: RunWithMetrics[];
   metricsColumnNames: string[];
   runArtifactsLoaded: boolean;
+  contextError: Error | undefined;
   runArtifactsError: Error | undefined;
   metricsNames: Set<string>;
 } => {
-  const [runArtifacts, runArtifactsLoaded, runArtifactsError] = useGetArtifactsByRuns(runs);
+  const [context, , contextError] = useMlmdContextsByType(MlmdContextTypes.RUN);
+  const [runArtifacts, runArtifactsLoaded, runArtifactsError] = useGetArtifactsByRuns(
+    runs,
+    context,
+  );
   const metricsNames = new Set<string>();
 
   const runsWithMetrics: RunWithMetrics[] = runs.map((run) => ({
@@ -85,6 +92,7 @@ export const useMetricColumns = (
     metricsColumnNames,
     runArtifactsLoaded,
     runArtifactsError,
+    contextError,
     metricsNames,
   };
 };

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/useMetricColumns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/useMetricColumns.ts
@@ -54,14 +54,14 @@ export const useMetricColumns = (
   runs: RunWithMetrics[];
   metricsColumnNames: string[];
   runArtifactsLoaded: boolean;
-  contextError: Error | undefined;
+  contextsError: Error | undefined;
   runArtifactsError: Error | undefined;
   metricsNames: Set<string>;
 } => {
-  const [context, , contextError] = useMlmdContextsByType(MlmdContextTypes.RUN);
+  const [contexts, , contextsError] = useMlmdContextsByType(MlmdContextTypes.RUN);
   const [runArtifacts, runArtifactsLoaded, runArtifactsError] = useGetArtifactsByRuns(
     runs,
-    context,
+    contexts,
   );
   const metricsNames = new Set<string>();
 
@@ -92,7 +92,7 @@ export const useMetricColumns = (
     metricsColumnNames,
     runArtifactsLoaded,
     runArtifactsError,
-    contextError,
+    contextsError,
     metricsNames,
   };
 };

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
@@ -22,8 +22,8 @@ import { useMlmdContextsByType } from '~/concepts/pipelines/apiHooks/mlmd/useMlm
 
 export const CompareRunMetricsSection: React.FunctionComponent = () => {
   const { runs, selectedRuns } = useCompareRuns();
-  const [context, contextLoaded] = useMlmdContextsByType(MlmdContextTypes.RUN);
-  const [mlmdPackages, mlmdPackagesLoaded] = useMlmdPackagesForPipelineRuns(runs, context);
+  const [contexts, contextLoaded] = useMlmdContextsByType(MlmdContextTypes.RUN);
+  const [mlmdPackages, mlmdPackagesLoaded] = useMlmdPackagesForPipelineRuns(runs, contexts);
   const [artifactTypes, artifactTypesLoaded] = useGetArtifactTypes();
   const [isSectionOpen, setIsSectionOpen] = React.useState(true);
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { ExpandableSection, Tab, TabContentBody, TabTitleText, Tabs } from '@patternfly/react-core';
 import { useCompareRuns } from '~/concepts/pipelines/content/compareRuns/CompareRunsContext';
 import { useGetArtifactTypes } from '~/concepts/pipelines/apiHooks/mlmd/useGetArtifactTypes';
-import { RunArtifact } from '~/concepts/pipelines/apiHooks/mlmd/types';
+import { MlmdContextTypes, RunArtifact } from '~/concepts/pipelines/apiHooks/mlmd/types';
 import {
   MetricSectionTabLabels,
   MetricsType,
@@ -18,10 +18,12 @@ import RocCurveCompare from '~/concepts/pipelines/content/compareRuns/metricsSec
 import ConfusionMatrixCompare from '~/concepts/pipelines/content/compareRuns/metricsSection/confusionMatrix/ConfusionMatrixCompare';
 import MarkdownCompare from '~/concepts/pipelines/content/compareRuns/metricsSection/markdown/MarkdownCompare';
 import useFetchMarkdownMaps from '~/concepts/pipelines/content/compareRuns/metricsSection/markdown/useFetchMarkdownMaps';
+import { useMlmdContextsByType } from '~/concepts/pipelines/apiHooks/mlmd/useMlmdContextsByType';
 
 export const CompareRunMetricsSection: React.FunctionComponent = () => {
   const { runs, selectedRuns } = useCompareRuns();
-  const [mlmdPackages, mlmdPackagesLoaded] = useMlmdPackagesForPipelineRuns(runs);
+  const [context, contextLoaded] = useMlmdContextsByType(MlmdContextTypes.RUN);
+  const [mlmdPackages, mlmdPackagesLoaded] = useMlmdPackagesForPipelineRuns(runs, context);
   const [artifactTypes, artifactTypesLoaded] = useGetArtifactTypes();
   const [isSectionOpen, setIsSectionOpen] = React.useState(true);
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(
@@ -33,7 +35,7 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
     [mlmdPackages],
   );
 
-  const isLoaded = mlmdPackagesLoaded && artifactTypesLoaded;
+  const isLoaded = mlmdPackagesLoaded && contextLoaded && artifactTypesLoaded;
 
   const [markdownArtifacts, ...allArtifacts] = React.useMemo(() => {
     if (!isLoaded) {

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/CompareRunsMetricsSection.tsx
@@ -22,7 +22,7 @@ import { useMlmdContextsByType } from '~/concepts/pipelines/apiHooks/mlmd/useMlm
 
 export const CompareRunMetricsSection: React.FunctionComponent = () => {
   const { runs, selectedRuns } = useCompareRuns();
-  const [contexts, contextLoaded] = useMlmdContextsByType(MlmdContextTypes.RUN);
+  const [contexts, contextsLoaded] = useMlmdContextsByType(MlmdContextTypes.RUN);
   const [mlmdPackages, mlmdPackagesLoaded] = useMlmdPackagesForPipelineRuns(runs, contexts);
   const [artifactTypes, artifactTypesLoaded] = useGetArtifactTypes();
   const [isSectionOpen, setIsSectionOpen] = React.useState(true);
@@ -35,7 +35,7 @@ export const CompareRunMetricsSection: React.FunctionComponent = () => {
     [mlmdPackages],
   );
 
-  const isLoaded = mlmdPackagesLoaded && contextLoaded && artifactTypesLoaded;
+  const isLoaded = mlmdPackagesLoaded && contextsLoaded && artifactTypesLoaded;
 
   const [markdownArtifacts, ...allArtifacts] = React.useMemo(() => {
     if (!isLoaded) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-21973

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Added the `useMlmdContextsByType` hook, which allows for fewer MLMD calls.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go through the code and see the optimization, where one single call is made instead of many individual ones. Alternatively, you can go to the `Runs` section and inspect network calls. `GetContextsByType` is called only once, but before, `GetContextByTypeAndName` was called many more times, resulting in substantially more MLMD calls.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
