### PR TITLE
Standardize the behavior of data-dependent buttons on the spawner page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -399,6 +399,33 @@ describe('Workbench page', () => {
     verifyRelativeURL('/projects/test-project?section=workbenches');
   });
 
+  it('Cannot create workbench without a connection', () => {
+    initIntercepts({ isEmpty: true });
+    cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableConnectionTypes: false }));
+    cy.interceptOdh('GET /api/connection-types', []);
+    cy.interceptK8sList({ model: SecretModel, ns: 'test-project' }, mockK8sResourceList([]));
+
+    workbenchPage.visit('test-project');
+    workbenchPage.findCreateButton().click();
+
+    createSpawnerPage.findAttachConnectionButton().should('have.attr', 'aria-disabled', 'true');
+    createSpawnerPage.findSubmitButton().should('be.disabled');
+  });
+
+  it('Cannot create workbench without a storage', () => {
+    initIntercepts({ isEmpty: true });
+    cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableConnectionTypes: false }));
+    cy.interceptK8sList({ model: PVCModel, ns: 'test-project' }, mockK8sResourceList([]));
+
+    workbenchPage.visit('test-project');
+    workbenchPage.findCreateButton().click();
+
+    createSpawnerPage
+      .findAttachExistingStorageButton()
+      .should('have.attr', 'aria-disabled', 'true');
+    createSpawnerPage.findSubmitButton().should('be.disabled');
+  });
+
   it('Create workbench with connection', () => {
     initIntercepts({ isEmpty: true });
     cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableConnectionTypes: false }));

--- a/frontend/src/components/ExtendedButton.tsx
+++ b/frontend/src/components/ExtendedButton.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import {
+  Button,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Icon,
+  Popover,
+  Skeleton,
+  Tooltip,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+type TooltipProps = { isEnabled: true; content: React.ReactNode } | { isEnabled: false };
+
+type ExtendedButtonProps = {
+  loadProps?: { loaded: boolean; error?: Error };
+  tooltipProps?: TooltipProps;
+} & React.ComponentProps<typeof Button>;
+
+const ExtendedButton: React.FC<ExtendedButtonProps> = ({
+  loadProps = { loaded: true },
+  tooltipProps = { isEnabled: false },
+  ...props
+}) => {
+  const tooltipRef = React.useRef<HTMLButtonElement | null>(null);
+
+  if (!loadProps.loaded) {
+    return <Skeleton data-testid="skeleton-loader" style={{ width: 200 }} />;
+  }
+
+  if (loadProps.error) {
+    return (
+      <Flex
+        data-testid="error-content"
+        alignItems={{ default: 'alignItemsCenter' }}
+        spaceItems={{ default: 'spaceItemsSm' }}
+      >
+        <FlexItem>
+          <Popover aria-label="Error popover" bodyContent={loadProps.error.message}>
+            <Icon status="danger" size="sm" data-testid="error-icon">
+              <ExclamationCircleIcon />
+            </Icon>
+          </Popover>
+        </FlexItem>
+        <FlexItem>
+          <Content component={ContentVariants.small}>Could not load required data</Content>
+        </FlexItem>
+      </Flex>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        {...props}
+        ref={tooltipRef}
+        isAriaDisabled={tooltipProps.isEnabled}
+        aria-describedby={tooltipProps.isEnabled ? 'button-tooltip' : undefined}
+      >
+        {props.children}
+      </Button>
+      {tooltipProps.isEnabled && (
+        <Tooltip id="button-tooltip" content={tooltipProps.content} triggerRef={tooltipRef} />
+      )}
+    </>
+  );
+};
+
+export default ExtendedButton;

--- a/frontend/src/components/__tests__/ExtendedButton.test.tsx
+++ b/frontend/src/components/__tests__/ExtendedButton.test.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ExtendedButton from '~/components/ExtendedButton';
+
+describe('ExtendedButton', () => {
+  it('should render the Skeleton when not loaded', () => {
+    render(<ExtendedButton loadProps={{ loaded: false }} />);
+    expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+  });
+
+  it('should render the Popover when there is an error', async () => {
+    render(<ExtendedButton loadProps={{ loaded: true, error: new Error('Error message') }} />);
+    expect(screen.getByTestId('error-content')).toBeInTheDocument();
+
+    const popoverTrigger = screen.getByTestId('error-icon');
+    await userEvent.click(popoverTrigger);
+    expect(await screen.findByText('Error message')).toBeInTheDocument();
+  });
+
+  it('should render the button when loaded with no errors', () => {
+    render(<ExtendedButton loadProps={{ loaded: true }}>Click Me</ExtendedButton>);
+    expect(screen.getByRole('button', { name: 'Click Me' })).toBeInTheDocument();
+  });
+
+  it('should disable the button when tooltip is enabled', async () => {
+    const onClick = jest.fn();
+    render(
+      <ExtendedButton
+        onClick={onClick}
+        loadProps={{ loaded: true }}
+        tooltipProps={{ isEnabled: true, content: 'Tooltip message' }}
+      >
+        Click Me
+      </ExtendedButton>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Click Me' });
+    await userEvent.click(button);
+    await userEvent.hover(button);
+
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(await screen.findByText('Tooltip message')).toBeInTheDocument();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('should enable the button when tooltip is disabled', async () => {
+    const onClick = jest.fn();
+    render(
+      <ExtendedButton loadProps={{ loaded: true }} onClick={onClick}>
+        Click Me
+      </ExtendedButton>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Click Me' });
+    await userEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should behave like a regular button when no extended properties are provided', async () => {
+    const onClick = jest.fn();
+    render(<ExtendedButton onClick={onClick}>Click Me</ExtendedButton>);
+
+    const button = screen.getByRole('button', { name: 'Click Me' });
+    await userEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-core';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { ImageStreamAndVersion } from '~/types';
+import ExtendedButton from '~/components/ExtendedButton';
 import GenericSidebar from '~/components/GenericSidebar';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { HardwareProfileKind, HardwareProfileFeatureVisibility, NotebookKind } from '~/k8sTypes';
@@ -24,6 +25,7 @@ import useWillNotebooksRestart from '~/pages/projects/notebook/useWillNotebooksR
 import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableElyraPipelinesCheck';
 import AcceleratorProfileSelectField from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
+import useProjectPvcs from '~/pages/projects/screens/detail/storage/useProjectPvcs';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import K8sNameDescriptionField, {
@@ -72,7 +74,12 @@ type SpawnerPageProps = {
 const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   const {
     currentProject,
-    connections: { data: projectConnections, refresh: refreshProjectConnections },
+    connections: {
+      data: projectConnections,
+      refresh: refreshProjectConnections,
+      loaded: projectConnectionsLoaded,
+      error: projectConnectionsLoadError,
+    },
     notebooks: { data: notebooks },
   } = React.useContext(ProjectDetailsContext);
   const displayName = getDisplayNameFromK8sResource(currentProject);
@@ -93,6 +100,10 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   const preferredStorageClass = usePreferredStorageClass();
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
   const isHardwareProfilesAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
+
+  const [storages, storagesLoaded, storagesLoadError] = useProjectPvcs(
+    currentProject.metadata.name,
+  );
 
   const defaultStorageClassName = isStorageClassesAvailable
     ? defaultStorageClass?.metadata.name
@@ -313,13 +324,21 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                     {SpawnerPageSectionTitles[SpawnerPageSectionID.CLUSTER_STORAGE]}
                   </FlexItem>
 
-                  <Button
+                  <ExtendedButton
                     variant="secondary"
                     data-testid="existing-storage-button"
                     onClick={() => setIsAttachStorageModalOpen(true)}
+                    loadProps={{
+                      loaded: storagesLoaded,
+                      error: storagesLoadError,
+                    }}
+                    tooltipProps={{
+                      isEnabled: storages.length === 0,
+                      content: 'No storage available',
+                    }}
                   >
                     Attach existing storage
-                  </Button>
+                  </ExtendedButton>
 
                   <Button
                     variant="secondary"
@@ -349,6 +368,8 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
               project={currentProject}
               projectConnections={projectConnections}
               refreshProjectConnections={refreshProjectConnections}
+              projectConnectionsLoaded={projectConnectionsLoaded}
+              projectConnectionsLoadError={projectConnectionsLoadError}
               notebook={existingNotebook}
               notebookDisplayName={k8sNameDescriptionData.data.name}
               selectedConnections={notebookConnections}

--- a/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import {
   Bullseye,
-  Button,
   EmptyState,
   EmptyStateBody,
   Flex,
   FlexItem,
   FormSection,
-  Tooltip,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import ExtendedButton from '~/components/ExtendedButton';
 import { SortableData, Table } from '~/components/table';
 import { createSecret, replaceSecret } from '~/api';
 import { NotebookKind, ProjectKind } from '~/k8sTypes';
@@ -55,6 +54,8 @@ const getColumns = (connectionTypes: ConnectionTypeConfigMapObj[]): SortableData
 type Props = {
   project: ProjectKind;
   projectConnections: Connection[];
+  projectConnectionsLoaded: boolean;
+  projectConnectionsLoadError?: Error;
   refreshProjectConnections: () => void;
   notebook?: NotebookKind;
   notebookDisplayName: string;
@@ -66,12 +67,15 @@ export const ConnectionsFormSection: React.FC<Props> = ({
   project,
   projectConnections,
   refreshProjectConnections,
+  projectConnectionsLoaded,
+  projectConnectionsLoadError,
   notebook,
   notebookDisplayName,
   selectedConnections,
   setSelectedConnections,
 }) => {
-  const [connectionTypes] = useWatchConnectionTypes();
+  const [connectionTypes, connectionTypesLoaded, connectiontypesLoadError] =
+    useWatchConnectionTypes();
 
   const enabledConnectionTypes = React.useMemo(
     () => filterEnabledConnectionTypes(connectionTypes),
@@ -113,56 +117,44 @@ export const ConnectionsFormSection: React.FC<Props> = ({
     [selectedConnections],
   );
 
-  const connectionsTooltipRef = React.useRef<HTMLButtonElement>();
-  const connectionTypesTooltipRef = React.useRef<HTMLButtonElement>();
-
   return (
     <FormSection
       title={
         <Flex gap={{ default: 'gapSm' }}>
           <FlexItem>{SpawnerPageSectionTitles[SpawnerPageSectionID.CONNECTIONS]}</FlexItem>
           <FlexItem>
-            <Button
+            <ExtendedButton
               data-testid="attach-existing-connection-button"
-              aria-describedby={
-                unselectedConnections.length === 0 ? 'no-connections-tooltip' : undefined
-              }
               variant="secondary"
-              isAriaDisabled={unselectedConnections.length === 0}
               onClick={() => setShowAttachConnectionsModal(true)}
-              ref={connectionsTooltipRef}
+              loadProps={{
+                loaded: projectConnectionsLoaded,
+                error: projectConnectionsLoadError,
+              }}
+              tooltipProps={{
+                isEnabled: unselectedConnections.length === 0,
+                content: 'No connections available',
+              }}
             >
               Attach existing connections
-            </Button>
-            {unselectedConnections.length === 0 && (
-              <Tooltip
-                id="no-connections-tooltip"
-                content="No connections available"
-                triggerRef={connectionsTooltipRef}
-              />
-            )}
+            </ExtendedButton>
           </FlexItem>
           <FlexItem>
-            <Button
+            <ExtendedButton
               data-testid="create-connection-button"
-              aria-describedby={
-                enabledConnectionTypes.length === 0 ? 'no-connection-types-tooltip' : undefined
-              }
               variant="secondary"
-              content="No connection types available"
-              isAriaDisabled={enabledConnectionTypes.length === 0}
               onClick={() => setManageConnectionModal({ connection: undefined, isEdit: false })}
-              ref={connectionTypesTooltipRef}
+              loadProps={{
+                loaded: connectionTypesLoaded,
+                error: connectiontypesLoadError,
+              }}
+              tooltipProps={{
+                isEnabled: enabledConnectionTypes.length === 0,
+                content: 'No connection types available',
+              }}
             >
               Create connection
-            </Button>
-            {enabledConnectionTypes.length === 0 && (
-              <Tooltip
-                id="no-connection-types-tooltip"
-                content="No connection types available"
-                triggerRef={connectionTypesTooltipRef}
-              />
-            )}
+            </ExtendedButton>
           </FlexItem>
         </Flex>
       }

--- a/frontend/src/pages/projects/screens/spawner/connections/__tests__/ConnectionsFormSection.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/__tests__/ConnectionsFormSection.spec.tsx
@@ -9,7 +9,7 @@ jest.mock('~/pages/projects/notebook/useNotebooksStates', () => ({
   useNotebooksStates: jest.fn().mockReturnValue([[]]),
 }));
 jest.mock('~/utilities/useWatchConnectionTypes', () => ({
-  useWatchConnectionTypes: jest.fn().mockReturnValue([[]]),
+  useWatchConnectionTypes: jest.fn().mockReturnValue([[], true, undefined, jest.fn()]),
 }));
 
 describe('ConnectionsFormSection', () => {
@@ -19,6 +19,8 @@ describe('ConnectionsFormSection', () => {
         project={mockProjectK8sResource({})}
         projectConnections={[]}
         refreshProjectConnections={() => undefined}
+        projectConnectionsLoaded
+        projectConnectionsLoadError={undefined}
         notebookDisplayName=""
         selectedConnections={[]}
         setSelectedConnections={() => undefined}
@@ -40,6 +42,8 @@ describe('ConnectionsFormSection', () => {
           mockConnection({ name: 's3-connection-3', displayName: 's3 connection 3' }),
         ]}
         refreshProjectConnections={() => undefined}
+        projectConnectionsLoaded
+        projectConnectionsLoadError={undefined}
         notebookDisplayName=""
         selectedConnections={[
           mockConnection({ name: 's3-connection-1', displayName: 's3 connection 1' }),
@@ -62,6 +66,8 @@ describe('ConnectionsFormSection', () => {
         project={mockProjectK8sResource({})}
         projectConnections={[]}
         refreshProjectConnections={() => undefined}
+        projectConnectionsLoaded
+        projectConnectionsLoadError={undefined}
         notebookDisplayName=""
         selectedConnections={[
           mockConnection({
@@ -100,6 +106,8 @@ describe('ConnectionsFormSection', () => {
           mockConnection({ name: 's3-connection-3', displayName: 's3 connection 3' }),
         ]}
         refreshProjectConnections={() => undefined}
+        projectConnectionsLoaded
+        projectConnectionsLoadError={undefined}
         notebookDisplayName=""
         selectedConnections={[
           mockConnection({ name: 's3-connection-1', displayName: 's3 connection 1' }),


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

See https://issues.redhat.com/browse/RHOAIENG-21536

The proposal is to add an extended button component that, optionally:
- shows a loading skeleton while dependent data is being loaded
- shows an error message in case of errors
- disables the button if a tooltip is provided

With that, standardize the behavior of data-dependent buttons on the spawner page to fix the reported issue.

**No connection/storage available**

https://github.com/user-attachments/assets/169b8ddc-afe7-4db5-bea7-ed6a1d32de8f

**Connection/storage available**

https://github.com/user-attachments/assets/e920eec1-0090-447c-bf17-3e664e4b2dfe

The skeleton is shown while data is being loaded.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to Create Workbench page and check the buttons in the Connections and Storage areas

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit and mocked Cypress tests to cover the new code.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
