### PR TITLE
Display project-specific serving runtimes in dropdown

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -17,6 +17,9 @@ type MockResourceConfigType = {
   disableModelMeshAnnotations?: boolean;
   tolerations?: Toleration[];
   nodeSelector?: NodeSelector;
+  templateDisplayName?: string;
+  isProjectScoped?: boolean;
+  scope?: string;
 };
 
 export const mockServingRuntimeK8sResourceLegacy = ({
@@ -122,6 +125,9 @@ export const mockServingRuntimeK8sResource = ({
   disableResources = false,
   disableReplicas = false,
   disableModelMeshAnnotations = false,
+  templateDisplayName = 'OpenVINO Serving Runtime (Supports GPUs)',
+  isProjectScoped = false,
+  scope,
 }: MockResourceConfigType): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
@@ -132,7 +138,7 @@ export const mockServingRuntimeK8sResource = ({
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',
     },
     annotations: {
-      'opendatahub.io/template-display-name': 'OpenVINO Serving Runtime (Supports GPUs)',
+      'opendatahub.io/template-display-name': templateDisplayName,
       'opendatahub.io/accelerator-name': acceleratorName,
       'opendatahub.io/hardware-profile-name': hardwareProfileName,
       'opendatahub.io/template-name': 'ovms',
@@ -142,6 +148,7 @@ export const mockServingRuntimeK8sResource = ({
         'enable-auth': auth ? 'true' : 'false',
         'enable-route': route ? 'true' : 'false',
       }),
+      ...(isProjectScoped && { 'opendatahub.io/serving-runtime-scope': scope }),
     },
     name,
     namespace,

--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,4 +1,4 @@
-import { TemplateKind } from '~/k8sTypes';
+import { SupportedModelFormats, TemplateKind } from '~/k8sTypes';
 import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 
 type MockResourceConfigType = {
@@ -12,6 +12,7 @@ type MockResourceConfigType = {
   isModelmesh?: boolean;
   containerName?: string;
   containerEnvVars?: { name: string; value: string }[];
+  supportedModelFormats?: SupportedModelFormats[];
 };
 
 export const mockServingRuntimeTemplateK8sResource = ({
@@ -25,6 +26,18 @@ export const mockServingRuntimeTemplateK8sResource = ({
   preInstalled = false,
   containerName = 'ovms',
   containerEnvVars = undefined,
+  supportedModelFormats = [
+    {
+      autoSelect: true,
+      name: 'openvino_ir',
+      version: 'opset1',
+    },
+    {
+      autoSelect: true,
+      name: 'onnx',
+      version: '1',
+    },
+  ],
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -92,18 +105,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
         multiModel: true,
         protocolVersions: ['grpc-v1'],
         ...(isModelmesh && { replicas }),
-        supportedModelFormats: [
-          {
-            autoSelect: true,
-            name: 'openvino_ir',
-            version: 'opset1',
-          },
-          {
-            autoSelect: true,
-            name: 'onnx',
-            version: '1',
-          },
-        ],
+        supportedModelFormats,
       },
     },
   ],

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -4,6 +4,7 @@ import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
 import { mixin } from '~/__tests__/cypress/cypress/utils/mixin';
 import { K8sNameDescriptionField } from '~/__tests__/cypress/cypress/pages/components/subComponents/K8sNameDescriptionField';
 import { TableToolbar } from './components/TableToolbar';
+import { Contextual } from './components/Contextual';
 
 class ModelServingToolbar extends TableToolbar {}
 class ModelServingGlobal {
@@ -92,7 +93,13 @@ class ModelServingGlobal {
   getTableToolbar() {
     return new ModelServingToolbar(() => cy.findByTestId('dashboard-table-toolbar'));
   }
+
+  findServingRuntime(name: string) {
+    return this.findModelsTable().find(`[data-label=Serving Runtime]`).contains(name);
+  }
 }
+
+class ServingRuntimeGroup extends Contextual<HTMLElement> {}
 
 class InferenceServiceModal extends Modal {
   k8sNameDescription = new K8sNameDescriptionField('inference-service');
@@ -117,6 +124,26 @@ class InferenceServiceModal extends Modal {
 
   findServingRuntimeSelect() {
     return this.find().findByTestId('inference-service-model-selection');
+  }
+
+  findServingRuntimeTemplateSearchSelector() {
+    return this.find().findByTestId('serving-runtime-template-selection-toggle');
+  }
+
+  findProjectScopedLabel() {
+    return this.find().findByTestId('project-scoped-image');
+  }
+
+  findGlobalScopedLabel() {
+    return this.find().findByTestId('global-scoped-image');
+  }
+
+  getProjectScopedServingRuntime() {
+    return new ServingRuntimeGroup(() => cy.findByTestId('project-scoped-serving-runtimes'));
+  }
+
+  getGlobalScopedServingRuntime() {
+    return new ServingRuntimeGroup(() => cy.findByTestId('global-scoped-serving-runtimes'));
   }
 
   findServingRuntimeTemplate() {
@@ -474,6 +501,10 @@ class KServeRow extends ModelMeshRow {
 
   findDescriptionListItem(itemName: string) {
     return this.find().next('tr').find(`dt:contains("${itemName}")`);
+  }
+
+  findProjectScopedLabel() {
+    return this.find().findByTestId('project-scoped-label');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
@@ -24,15 +24,18 @@ import { ServingRuntimePlatform } from '~/types';
 export const initDeployPrefilledModelIntercepts = ({
   modelMeshInstalled = true,
   kServeInstalled = true,
+  disableProjectScoped = true,
 }: {
   modelMeshInstalled?: boolean;
   kServeInstalled?: boolean;
+  disableProjectScoped?: boolean;
 }): void => {
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({
       disableModelRegistry: false,
       disableModelCatalog: false,
+      disableProjectScoped,
     }),
   );
 
@@ -92,6 +95,34 @@ export const initDeployPrefilledModelIntercepts = ({
       { namespace: 'opendatahub' },
     ),
   );
+
+  cy.interceptK8sList(
+    TemplateModel,
+    mockK8sResourceList(
+      [
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-1',
+          displayName: 'Multi Platform',
+          platforms: [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI],
+        }),
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-2',
+          displayName: 'Caikit',
+          platforms: [ServingRuntimePlatform.SINGLE],
+          supportedModelFormats: [
+            {
+              autoSelect: true,
+              name: 'openvino_ir',
+              version: 'opset1',
+            },
+          ],
+        }),
+        mockInvalidTemplateK8sResource({}),
+      ],
+      { namespace: 'kserve-project' },
+    ),
+  );
+
   cy.interceptOdh('GET /api/connection-types', [
     mockConnectionTypeConfigMap({
       displayName: 'URI - v1',

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -41,6 +41,7 @@ export const assembleServingRuntime = (
     tokenAuth,
     imageName,
     supportedModelFormatsInfo,
+    scope,
   } = data;
   const createName = isCustomServingRuntimesEnabled
     ? k8sName || translateDisplayNameForK8s(displayName)
@@ -60,6 +61,10 @@ export const assembleServingRuntime = (
     annotations['enable-auth'] = 'true';
   } else {
     delete annotations['enable-auth'];
+  }
+
+  if (scope) {
+    annotations['opendatahub.io/serving-runtime-scope'] = scope;
   }
 
   // TODO: Enable GRPC

--- a/frontend/src/components/searchSelector/SearchSelector.tsx
+++ b/frontend/src/components/searchSelector/SearchSelector.tsx
@@ -39,7 +39,7 @@ type SearchSelectorProps = {
   searchHelpText?: string;
   searchPlaceholder?: string;
   searchValue: string;
-  toggleText: string;
+  toggleContent: React.ReactNode | string;
   toggleVariant?: React.ComponentProps<typeof MenuToggle>['variant'];
 };
 
@@ -56,7 +56,7 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
   searchHelpText,
   searchPlaceholder,
   searchValue,
-  toggleText,
+  toggleContent,
   toggleVariant,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -93,7 +93,7 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
           data-testid={`${dataTestId}-toggle`}
           variant={toggleVariant}
         >
-          <Truncate content={toggleText} />
+          {typeof toggleContent !== 'string' ? toggleContent : <Truncate content={toggleContent} />}
         </MenuToggle>
       }
       menu={

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -37,7 +37,7 @@ const InnerExperimentSelector: React.FC<
     searchValue={searchProps.value ?? ''}
     isLoading={!initialLoaded}
     isFullWidth
-    toggleText={
+    toggleContent={
       initialLoaded
         ? selection || (totalSize === 0 ? 'No experiments available' : 'Select an experiment')
         : 'Loading experiments'

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineSelector.tsx
@@ -36,7 +36,7 @@ const PipelineSelector: React.FC<PipelineSelectorProps> = ({ selection, onSelect
       searchValue={searchProps.value ?? ''}
       isLoading={!initialLoaded}
       isFullWidth
-      toggleText={
+      toggleContent={
         initialLoaded
           ? selection || (totalSize === 0 ? 'No pipelines available' : 'Select a pipeline')
           : 'Loading pipelines'

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineVersionSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/PipelineVersionSelector.tsx
@@ -51,7 +51,7 @@ const PipelineVersionSelector: React.FC<PipelineVersionSelectorProps> = ({
       searchValue={searchProps.value ?? ''}
       isLoading={!!pipelineId && !initialLoaded}
       isFullWidth
-      toggleText={
+      toggleContent={
         !pipelineId
           ? 'Select a pipeline version'
           : initialLoaded

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -65,7 +65,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       searchValue={searchText}
       isLoading={isLoading}
       isDisabled={isLoading}
-      toggleText={toggleLabel}
+      toggleContent={toggleLabel}
       toggleVariant={primary ? 'primary' : undefined}
     >
       <>

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -135,6 +135,7 @@ export type ServingRuntimeAnnotations = Partial<{
   'opendatahub.io/recommended-accelerators': string;
   'opendatahub.io/accelerator-name': string;
   'opendatahub.io/apiProtocol': string;
+  'opendatahub.io/serving-runtime-scope': string;
   'enable-route': string;
   'enable-auth': string;
   'modelmesh-enabled': 'true' | 'false';

--- a/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
@@ -243,7 +243,7 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
               onSearchChange={(newValue) => setSearchConfigSecretName(newValue)}
               onSearchClear={() => setSearchConfigSecretName('')}
               searchValue={searchConfigSecretName}
-              toggleText={secureDBInfo.resourceName || 'Select a ConfigMap or a Secret'}
+              toggleContent={secureDBInfo.resourceName || 'Select a ConfigMap or a Secret'}
             >
               {getFilteredExistingCAResources()}
             </SearchSelector>
@@ -261,7 +261,7 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
               isDisabled={!secureDBInfo.resourceName}
               onSearchClear={() => setSearchKey('')}
               searchValue={searchKey}
-              toggleText={
+              toggleContent={
                 secureDBInfo.key ||
                 (!secureDBInfo.resourceName
                   ? 'Select a resource to view its available keys'

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -1,5 +1,10 @@
 import { ModelServingSize } from './types';
 
+export const SERVING_RUNTIME_SCOPE = {
+  Global: 'global',
+  Project: 'project',
+};
+
 export const DEFAULT_MODEL_SERVER_SIZES: ModelServingSize[] = [
   {
     name: 'Small',

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -1,13 +1,47 @@
+import { Label } from '@patternfly/react-core';
 import * as React from 'react';
+import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import { getDisplayNameFromServingRuntimeTemplate } from '~/pages/modelServing/customServingRuntimes/utils';
+import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
 
 type Props = {
   servingRuntime?: ServingRuntimeKind;
+  isProjectScoped?: boolean;
 };
 
-const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime }) => (
-  <>{servingRuntime ? getDisplayNameFromServingRuntimeTemplate(servingRuntime) : 'Unknown'}</>
+const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isProjectScoped }) => (
+  <>
+    {servingRuntime ? (
+      <>
+        {getDisplayNameFromServingRuntimeTemplate(servingRuntime)}
+        {isProjectScoped &&
+          servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
+            SERVING_RUNTIME_SCOPE.Project && (
+            <>
+              {' '}
+              <Label
+                variant="outline"
+                color="blue"
+                data-testid="project-scoped-label"
+                isCompact
+                icon={
+                  <img
+                    style={{ height: '15px', paddingTop: '3px' }}
+                    src={typedObjectImage(ProjectObjectType.project)}
+                    alt=""
+                  />
+                }
+              >
+                Project-scoped
+              </Label>
+            </>
+          )}
+      </>
+    ) : (
+      'Unknown'
+    )}
+  </>
 );
 
 export default InferenceServiceServingRuntime;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -41,6 +41,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
   const isKServeNIMEnabled = project ? isProjectNIMSupported(project) : false;
   const servingPlatformStatuses = useServingPlatformStatuses();
   const isNIMAvailable = servingPlatformStatuses.kServeNIM.enabled;
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
   const [modelMetricsEnabled] = useModelMetricsEnabled();
   const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
@@ -79,7 +80,10 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
 
       {columnNames.includes(ColumnField.ServingRuntime) && (
         <Td dataLabel="Serving Runtime">
-          <InferenceServiceServingRuntime servingRuntime={servingRuntime} />
+          <InferenceServiceServingRuntime
+            servingRuntime={servingRuntime}
+            isProjectScoped={isProjectScoped}
+          />
         </Td>
       )}
 

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import {
   Button,
+  Divider,
+  Flex,
+  FlexItem,
   FormGroup,
   FormHelperText,
   HelperText,
   HelperTextItem,
   Label,
+  MenuGroup,
+  MenuItem,
+  Skeleton,
   Split,
   SplitItem,
   Truncate,
@@ -21,12 +27,18 @@ import {
 import { isCompatibleWithIdentifier } from '~/pages/projects/screens/spawner/spawnerUtils';
 import SimpleSelect from '~/components/SimpleSelect';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import SearchSelector from '~/components/searchSelector/SearchSelector';
+import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
+import GlobalIcon from '~/images/icons/GlobalIcon';
+import { CustomWatchK8sResult } from '~/types';
+import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
 
 type ServingRuntimeTemplateSectionProps = {
   data: CreatingServingRuntimeObject;
   onConfigureParamsClick?: () => void;
   setData: UpdateObjectAtPropAndValue<CreatingServingRuntimeObject>;
   templates: TemplateKind[];
+  projectSpecificTemplates?: CustomWatchK8sResult<TemplateKind[]>;
   isEditing?: boolean;
   compatibleIdentifiers?: string[];
   resetModelFormat?: () => void;
@@ -37,11 +49,17 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
   onConfigureParamsClick,
   setData,
   templates,
+  projectSpecificTemplates,
   isEditing,
   compatibleIdentifiers,
   resetModelFormat,
 }) => {
   const isHardwareProfilesAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+
+  const [searchServingRuntime, setSearchServingRuntime] = React.useState('');
+  const [servingRuntimeDisplayName, setServingRuntimeDisplayName] = React.useState('');
+
   const filteredTemplates = React.useMemo(
     () =>
       templates.filter((template) => {
@@ -52,6 +70,19 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
         }
       }),
     [templates],
+  );
+
+  const filterProjectScopedTemplates = React.useMemo(
+    () =>
+      projectSpecificTemplates &&
+      projectSpecificTemplates[0].filter((template) => {
+        try {
+          return isServingRuntimeKind(template.objects[0]);
+        } catch (e) {
+          return false;
+        }
+      }),
+    [projectSpecificTemplates],
   );
 
   const options = filteredTemplates.map((template) => ({
@@ -76,34 +107,254 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
     ),
   }));
 
-  return (
-    <FormGroup label="Serving runtime" fieldId="serving-runtime-template-selection" isRequired>
-      <SimpleSelect
-        isFullWidth
-        isDisabled={isEditing}
-        dataTestId="serving-runtime-template-selection"
-        aria-label="Select a template"
-        options={options}
-        placeholder={
-          isEditing || filteredTemplates.length === 0
-            ? data.servingRuntimeTemplateName
-            : 'Select one'
+  const getServingRuntime = () => (
+    <>
+      <MenuGroup
+        data-testid="project-scoped-serving-runtimes"
+        label={
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+            style={{ paddingBottom: '5px' }}
+          >
+            <FlexItem style={{ display: 'flex', paddingLeft: '12px' }}>
+              <img
+                style={{ height: '20px', paddingTop: '3px' }}
+                src={typedObjectImage(ProjectObjectType.project)}
+                alt=""
+              />
+            </FlexItem>
+            <FlexItem>Project-scoped serving runtimes</FlexItem>
+          </Flex>
         }
-        toggleProps={{ id: 'serving-runtime-template-selection' }}
-        value={data.servingRuntimeTemplateName}
-        onChange={(name) => {
-          // Avoid onChange function is called twice
-          // In KServe modal, it would set the model framework field to empty if there is only one option
-          if (name !== data.servingRuntimeTemplateName) {
-            setData('servingRuntimeTemplateName', name);
-            // Reset model framework selection when changing the template in KServe modal only
-            if (resetModelFormat) {
-              resetModelFormat();
-            }
+      >
+        {filterProjectScopedTemplates &&
+          filterProjectScopedTemplates
+            .filter((template) =>
+              getServingRuntimeDisplayNameFromTemplate(template)
+                .toLocaleLowerCase()
+                .includes(searchServingRuntime.toLocaleLowerCase()),
+            )
+            .map((template, index) => (
+              <MenuItem
+                key={`servingRuntime-${index}`}
+                data-testid={`servingRuntime ${getServingRuntimeNameFromTemplate(template)}`}
+                isSelected={
+                  data.servingRuntimeTemplateName === getServingRuntimeNameFromTemplate(template) &&
+                  data.scope === SERVING_RUNTIME_SCOPE.Project
+                }
+                onClick={() => {
+                  if (
+                    getServingRuntimeNameFromTemplate(template) !==
+                      data.servingRuntimeTemplateName ||
+                    data.scope !== SERVING_RUNTIME_SCOPE.Project
+                  ) {
+                    setData(
+                      'servingRuntimeTemplateName',
+                      getServingRuntimeNameFromTemplate(template),
+                    );
+                    setData('scope', SERVING_RUNTIME_SCOPE.Project);
+                    setServingRuntimeDisplayName(
+                      getServingRuntimeDisplayNameFromTemplate(template),
+                    );
+                    // Reset model framework selection when changing the template in KServe modal only
+                    if (resetModelFormat) {
+                      resetModelFormat();
+                    }
+                  }
+                }}
+              >
+                <Flex
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <FlexItem style={{ display: 'flex' }}>
+                    <img
+                      style={{ height: '20px' }}
+                      src={typedObjectImage(ProjectObjectType.project)}
+                      alt=""
+                    />
+                  </FlexItem>
+                  <FlexItem>
+                    <Truncate content={getServingRuntimeDisplayNameFromTemplate(template)} />
+                  </FlexItem>
+                  <FlexItem align={{ default: 'alignRight' }}>
+                    {compatibleIdentifiers?.some((identifier) =>
+                      isCompatibleWithIdentifier(identifier, template.objects[0]),
+                    ) && (
+                      <Label color="blue">
+                        Compatible with{' '}
+                        {isHardwareProfilesAvailable ? 'hardware profile' : 'accelerator'}
+                      </Label>
+                    )}
+                  </FlexItem>
+                </Flex>
+              </MenuItem>
+            ))}
+      </MenuGroup>
+      <Divider component="li" />
+      <MenuGroup
+        data-testid="global-scoped-serving-runtimes"
+        label={
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+            style={{ paddingBottom: '5px' }}
+          >
+            <FlexItem
+              style={{ display: 'flex', paddingLeft: '10px' }}
+              data-testid="ds-project-image"
+            >
+              <GlobalIcon />
+            </FlexItem>
+            <FlexItem>Global serving runtimes</FlexItem>
+          </Flex>
+        }
+      >
+        {filteredTemplates
+          .filter((template) =>
+            getServingRuntimeDisplayNameFromTemplate(template)
+              .toLocaleLowerCase()
+              .includes(searchServingRuntime.toLocaleLowerCase()),
+          )
+          .map((template, index) => (
+            <MenuItem
+              key={`servingRuntime-${index}`}
+              data-testid={`servingRuntime ${getServingRuntimeNameFromTemplate(template)}`}
+              isSelected={
+                data.servingRuntimeTemplateName === getServingRuntimeNameFromTemplate(template) &&
+                data.scope === SERVING_RUNTIME_SCOPE.Global
+              }
+              onClick={() => {
+                if (
+                  getServingRuntimeNameFromTemplate(template) !== data.servingRuntimeTemplateName ||
+                  data.scope !== SERVING_RUNTIME_SCOPE.Global
+                ) {
+                  setData(
+                    'servingRuntimeTemplateName',
+                    getServingRuntimeNameFromTemplate(template),
+                  );
+                  setData('scope', SERVING_RUNTIME_SCOPE.Global);
+
+                  setServingRuntimeDisplayName(getServingRuntimeDisplayNameFromTemplate(template));
+                  // Reset model framework selection when changing the template in KServe modal only
+                  if (resetModelFormat) {
+                    resetModelFormat();
+                  }
+                }
+              }}
+              icon={<GlobalIcon />}
+            >
+              <Split>
+                <SplitItem isFilled>
+                  <Truncate content={getServingRuntimeDisplayNameFromTemplate(template)} />
+                </SplitItem>
+                <SplitItem>
+                  {compatibleIdentifiers?.some((identifier) =>
+                    isCompatibleWithIdentifier(identifier, template.objects[0]),
+                  ) && (
+                    <Label color="blue">
+                      Compatible with{' '}
+                      {isHardwareProfilesAvailable ? 'hardware profile' : 'accelerator'}
+                    </Label>
+                  )}
+                </SplitItem>
+              </Split>
+            </MenuItem>
+          ))}
+      </MenuGroup>
+    </>
+  );
+
+  if (isProjectScoped && projectSpecificTemplates && !projectSpecificTemplates[1]) {
+    return (
+      <FormGroup label="Serving runtime" fieldId="serving-runtime-template-selection" isRequired>
+        <Skeleton />
+      </FormGroup>
+    );
+  }
+
+  return (
+    // TODO: need to add popover from this PR: https://github.com/opendatahub-io/odh-dashboard/pull/3955
+    <FormGroup label="Serving runtime" fieldId="serving-runtime-template-selection" isRequired>
+      {isProjectScoped &&
+      filterProjectScopedTemplates &&
+      filterProjectScopedTemplates.length > 0 ? (
+        <SearchSelector
+          isFullWidth
+          isDisabled={isEditing}
+          dataTestId="serving-runtime-template-selection"
+          onSearchChange={(newValue) => setSearchServingRuntime(newValue)}
+          onSearchClear={() => setSearchServingRuntime('')}
+          searchValue={searchServingRuntime}
+          toggleContent={
+            data.servingRuntimeTemplateName ? (
+              <>
+                {isEditing ? data.servingRuntimeTemplateName : servingRuntimeDisplayName}{' '}
+                {data.scope === SERVING_RUNTIME_SCOPE.Project && (
+                  <Label
+                    variant="outline"
+                    color="blue"
+                    data-testid="project-scoped-image"
+                    isCompact
+                    icon={
+                      <img
+                        style={{ height: '15px', paddingTop: '3px' }}
+                        src={typedObjectImage(ProjectObjectType.project)}
+                        alt=""
+                      />
+                    }
+                  >
+                    Project-scoped
+                  </Label>
+                )}
+                {data.scope === SERVING_RUNTIME_SCOPE.Global && (
+                  <Label
+                    variant="outline"
+                    color="blue"
+                    isCompact
+                    icon={<GlobalIcon />}
+                    data-testid="global-scoped-image"
+                  >
+                    Global-scoped
+                  </Label>
+                )}
+              </>
+            ) : (
+              'Select one'
+            )
           }
-        }}
-        popperProps={{ appendTo: 'inline' }}
-      />
+        >
+          {getServingRuntime()}
+        </SearchSelector>
+      ) : (
+        <SimpleSelect
+          isFullWidth
+          isDisabled={isEditing}
+          dataTestId="serving-runtime-template-selection"
+          aria-label="Select a template"
+          options={options}
+          placeholder={
+            isEditing || filteredTemplates.length === 0
+              ? data.servingRuntimeTemplateName
+              : 'Select one'
+          }
+          toggleProps={{ id: 'serving-runtime-template-selection' }}
+          value={data.servingRuntimeTemplateName}
+          onChange={(name) => {
+            // Avoid onChange function is called twice
+            // In KServe modal, it would set the model framework field to empty if there is only one option
+            if (name !== data.servingRuntimeTemplateName) {
+              setData('servingRuntimeTemplateName', name);
+              // Reset model framework selection when changing the template in KServe modal only
+              if (resetModelFormat) {
+                resetModelFormat();
+              }
+            }
+          }}
+          popperProps={{ appendTo: 'inline' }}
+        />
+      )}
       {data.servingRuntimeTemplateName && onConfigureParamsClick && (
         <FormHelperText>
           <HelperText>

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -137,6 +137,8 @@ export const useCreateServingRuntimeObject = (existingData?: {
   const existingTokens = useDeepCompareMemoize(getServingRuntimeTokens(existingData?.secrets));
 
   const existingImageName = existingData?.servingRuntime?.spec.containers[0].image;
+  const servingRuntimeScope =
+    existingData?.servingRuntime?.metadata.annotations?.['opendatahub.io/serving-runtime-scope'];
 
   React.useEffect(() => {
     if (existingServingRuntimeName) {
@@ -147,6 +149,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
       setCreateData('tokenAuth', existingTokenAuth);
       setCreateData('tokens', existingTokens);
       setCreateData('imageName', existingImageName);
+      setCreateData('scope', servingRuntimeScope);
     }
   }, [
     existingServingRuntimeName,
@@ -157,6 +160,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
     existingTokens,
     setCreateData,
     existingImageName,
+    servingRuntimeScope,
   ]);
 
   return [...createModelState];

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -46,6 +46,7 @@ export type CreatingServingRuntimeObject = CreatingModelServingObjectCommon & {
   numReplicas: number;
   imageName?: string;
   supportedModelFormatsInfo?: SupportedModelFormatsInfo;
+  scope?: string;
 };
 
 export type ServingRuntimeToken = {


### PR DESCRIPTION
Closes: [RHOAIENG-20300](https://issues.redhat.com/browse/RHOAIENG-20300)

## Description
This PR aims to add display project-specific serving runtimes in KServe. Display the project-scoped labels on table and serving runtime dropdown selection.

https://github.com/user-attachments/assets/8d465955-647c-4b0c-ab7c-70905b7b41ef

<img width="847" alt="Screenshot 2025-03-28 at 2 43 53 PM" src="https://github.com/user-attachments/assets/133b1cc1-3076-4583-98b4-4007cfd6ab02" />

<img width="835" alt="Screenshot 2025-03-28 at 2 44 56 PM" src="https://github.com/user-attachments/assets/c37f8222-2ccf-427a-ae8a-8ad60a3a64a1" />

<img width="868" alt="Screenshot 2025-03-28 at 7 13 18 PM" src="https://github.com/user-attachments/assets/bd4da0da-2ca7-415a-83a4-314a16a17c25" />

<img width="847" alt="Screenshot 2025-03-28 at 7 17 14 PM" src="https://github.com/user-attachments/assets/43501874-f4bc-4db1-9a14-3d71aac45906" />

Note: Needs to add popover, we have that component in this PR: https://github.com/opendatahub-io/odh-dashboard/pull/3955

## How Has This Been Tested?
Make sure that the form is working as expected with/without disableProjectScoped feature flag.

We can check this behavior on:
1. Project details page Models tab
2. Model deployment page
3. Model registry deployment 

## Test Impact
Added cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

