### PR TITLE
Replace hardcoded value with matching ErrorCode enum

### DIFF
--- a/frontend/src/concepts/pipelines/content/import/PipelineFileUpload.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineFileUpload.tsx
@@ -57,7 +57,6 @@ const PipelineFileUpload: React.FC<PipelineFileUploadProps> = ({ fileContents, o
               const error = rejections[0]?.errors?.[0] ?? {};
 
               let reason = error.message || 'Unknown reason';
-              // TODO: Find out from PF how to get access to ErrorCode.FileTooLarge
               if (error.code === ErrorCode.FileTooLarge) {
                 reason = `File size exceeds ${MAX_SIZE_AS_MB} MB`;
               }

--- a/frontend/src/concepts/pipelines/content/import/PipelineFileUpload.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineFileUpload.tsx
@@ -6,6 +6,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
+import { ErrorCode } from 'react-dropzone';
 
 type PipelineFileUploadProps = {
   fileContents: string;
@@ -57,7 +58,7 @@ const PipelineFileUpload: React.FC<PipelineFileUploadProps> = ({ fileContents, o
 
               let reason = error.message || 'Unknown reason';
               // TODO: Find out from PF how to get access to ErrorCode.FileTooLarge
-              if (error.code === 'file-too-large') {
+              if (error.code === ErrorCode.FileTooLarge) {
                 reason = `File size exceeds ${MAX_SIZE_AS_MB} MB`;
               }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-8111

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updated hardcoded value with Dropzone's ErrorCode enum. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's been tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I created a scenario where the error in question would be thrown (FileTooLarge), and verified that the same error is thrown before and after the change:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/49e12196-3f41-43d8-9879-80d21f9dadc5" />

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
