### PR TITLE
Fixing light/dark toggle icon colors

### DIFF
--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -14,7 +14,6 @@ import {
   DropdownList,
   ToggleGroup,
   ToggleGroupItem,
-  Icon,
 } from '@patternfly/react-core';
 import { QuestionCircleIcon, MoonIcon, SunIcon } from '@patternfly/react-icons';
 import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK, DEV_MODE, EXT_CLUSTER } from '~/utilities/const';
@@ -190,11 +189,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
             <ToggleGroup aria-label="Theme toggle group">
               <ToggleGroupItem
                 aria-label="light theme"
-                icon={
-                  <Icon size="md">
-                    <SunIcon />
-                  </Icon>
-                }
+                icon={<SunIcon />}
                 isSelected={theme === 'light'}
                 onChange={() => {
                   setTheme('light');
@@ -202,11 +197,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
               />
               <ToggleGroupItem
                 aria-label="dark theme"
-                icon={
-                  <Icon size="md">
-                    <MoonIcon />
-                  </Icon>
-                }
+                icon={<MoonIcon />}
                 isSelected={theme === 'dark'}
                 onChange={() => {
                   setTheme('dark');


### PR DESCRIPTION
Closes: [RHOAIENG-21393](https://issues.redhat.com/browse/RHOAIENG-21393)

## Description
The sun and moon icon colors in the light/dark theme toggle were inconsistent with Patternfly.

**Previously:**
In light mode, both icons were black and in dark mode both icons were white.
<img width="104" alt="Screenshot 2025-03-31 at 11 51 09 AM" src="https://github.com/user-attachments/assets/d088d188-4d67-47e0-bf96-eb70f365bce3" />
<img width="100" alt="Screenshot 2025-03-31 at 11 51 04 AM" src="https://github.com/user-attachments/assets/bded8ce9-251f-42a5-8a14-f3fa81722332" />

**Now:**
The sun is always white and the moon is always black; consistent with Patternfly.
<img width="106" alt="Screenshot 2025-03-31 at 11 49 55 AM" src="https://github.com/user-attachments/assets/eb823104-4b10-45c7-a2fe-9bdbe382b396" />
<img width="108" alt="Screenshot 2025-03-31 at 11 50 04 AM" src="https://github.com/user-attachments/assets/b80fdd6e-8f32-40bb-80e8-06cecf470408" />


## How Has This Been Tested?
Tested locally:
-Locate the theme toggle switcher
-Toggle the light/dark mode buttons and watch the icon colors

## Test Impact
No tests changed

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
