### PR TITLE
Update model/folder path helper text

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx
@@ -66,7 +66,7 @@ const ConnectionS3FolderPathField: React.FC<ConnectionFolderPathFieldProps> = ({
               ? containsOnlySlashes(folderPath)
                 ? 'The path must not point to a root folder.'
                 : 'Invalid path format.'
-              : 'Enter a path to a model or folder. This path cannot point to a root folder.'}
+              : 'Enter a path to your model or the folder containing your model. The path cannot point to a root folder.'}
           </HelperTextItem>
         </HelperText>
       </FormHelperText>


### PR DESCRIPTION
Closes: [RHOAIENG-2181](https://issues.redhat.com/browse/RHOAIENG-2181)

## Description
As per the ticket, the text under the 'path' input was changed from:
'Enter a path to a model or folder. This path cannot point to a root folder.'
to
'Enter a path to your model or the folder containing your model. The path cannot point to a root folder.'
<img width="817" alt="Screenshot 2025-04-01 at 11 05 12 AM" src="https://github.com/user-attachments/assets/16fb262c-c9c6-418f-b893-0763ea9e4f01" />
<img width="821" alt="Screenshot 2025-04-01 at 11 05 55 AM" src="https://github.com/user-attachments/assets/61ee86d4-aa54-4b28-b61c-d61dfe4b7246" />


## How Has This Been Tested?
Tested locally

Try it out:
- Open a project and go to the models tab
- If you don't have a model server, configure a model server
- Hit the 'deploy model' button 
- Ensure 'existing connection' is selected (you'll need to have an existing connection)
- Pick an existing connection -> the path input should show up
- Look at the text below the input. It should say "Enter a path to your model or the folder containing your model. The path cannot point to a root folder." 

## Test Impact
No tests changed.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
