### PR TITLE
Support for adding additional unmanaged model catalog sources (second configmap)

### DIFF
--- a/frontend/src/__mocks__/mockModelCatalogConfigMap.ts
+++ b/frontend/src/__mocks__/mockModelCatalogConfigMap.ts
@@ -5,15 +5,65 @@ import { mockModelCatalogSource } from './mockModelCatalogSource';
 
 export const mockModelCatalogConfigMap = (
   sources = [mockModelCatalogSource({})],
+  configMapName = 'model-catalog-sources',
 ): ConfigMapKind => {
   const sourcesObj: ModelCatalogSourcesObject = {
     sources,
   };
+
   return mockConfigMap({
-    name: 'model-catalog-sources',
+    name: configMapName,
     namespace: 'opendatahub',
     data: {
       modelCatalogSources: JSON.stringify(sourcesObj),
     },
   });
 };
+
+export const mockManagedModelCatalogConfigMap = (
+  sources = [mockModelCatalogSource({})],
+): ConfigMapKind =>
+  mockConfigMap({
+    name: 'model-catalog-sources',
+    namespace: 'opendatahub',
+    data: {
+      modelCatalogSources: JSON.stringify({ sources }),
+    },
+  });
+
+export const mockUnmanagedModelCatalogConfigMap = (
+  sources = [mockModelCatalogSource({})],
+): ConfigMapKind =>
+  mockConfigMap({
+    name: 'model-catalog-unmanaged-sources',
+    namespace: 'opendatahub',
+    data: {
+      modelCatalogSources: JSON.stringify({ sources }),
+    },
+  });
+
+export const mockConfigMap404Response = (
+  name: string,
+): {
+  statusCode: number;
+  body: {
+    kind: string;
+    apiVersion: string;
+    metadata: Record<string, never>;
+    status: 'Failure';
+    message: string;
+    reason: string;
+    code: number;
+  };
+} => ({
+  statusCode: 404,
+  body: {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Failure' as const,
+    message: `configmaps "${name}" not found`,
+    reason: 'NotFound',
+    code: 404,
+  },
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -23,7 +23,6 @@ import type { ModelCatalogSource } from '~/concepts/modelCatalog/types';
 type HandlersProps = {
   modelRegistries?: K8sResourceCommon[];
   catalogSources?: ModelCatalogSource[];
-  disableFineTuning?: boolean;
   disableModelCatalogFeature?: boolean;
   hasUnmanagedSourcesConfigMap?: boolean;
   unmanagedSources?: ModelCatalogSource[];
@@ -34,7 +33,6 @@ const initIntercepts = ({
   modelRegistries = [mockModelRegistryService({ name: 'modelregistry-sample' })],
   managedSources = [mockModelCatalogSource({})],
   unmanagedSources = [],
-  disableFineTuning = false,
   disableModelCatalogFeature = false,
   hasUnmanagedSourcesConfigMap = true,
 }: HandlersProps) => {
@@ -44,7 +42,6 @@ const initIntercepts = ({
     mockDscStatus({
       installedComponents: {
         'model-registry-operator': true,
-        'data-science-pipelines-operator': true,
       },
     }),
   );
@@ -53,7 +50,6 @@ const initIntercepts = ({
     'GET /api/config',
     mockDashboardConfig({
       disableModelCatalog: disableModelCatalogFeature,
-      disableFineTuning,
     }),
   );
 
@@ -193,7 +189,7 @@ describe('Model Catalog loading states', () => {
     cy.contains('Unable to load model catalog').should('exist');
   });
 
-  it('should show empty state when configmap has empty data', () => {
+  it('should show empty state when configmap has empty sources', () => {
     cy.interceptK8s(
       {
         model: ConfigMapModel,
@@ -208,12 +204,12 @@ describe('Model Catalog loading states', () => {
           namespace: 'opendatahub',
         },
         data: {
-          modelCatalogSources: '',
+          modelCatalogSources: JSON.stringify({ sources: [] }),
         },
       },
     );
     modelCatalog.visit();
-    cy.contains('Unable to load model catalog').should('exist');
+    cy.contains('Request access to model catalog').should('exist');
   });
 
   it('should show empty state when configmap has malformed data', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -93,7 +93,6 @@ describe('Model Catalog core', () => {
       hasUnmanagedSourcesConfigMap: false,
     });
     modelCatalog.landingPage();
-    cy.visit('/');
     cy.findByRole('button', { name: 'Models' }).click();
     cy.findByRole('link', { name: 'Model catalog' }).should('not.exist');
 
@@ -210,7 +209,7 @@ describe('Model Catalog loading states', () => {
       },
     );
     modelCatalog.visit();
-    modelCatalog.findModelCatalogEmptyState();
+    modelCatalog.findModelCatalogEmptyState().should('exist');
   });
 
   it('should show empty state when configmap has malformed data', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -92,8 +92,9 @@ describe('Model Catalog core', () => {
       disableModelCatalogFeature: true,
       hasUnmanagedSourcesConfigMap: false,
     });
-
+    modelCatalog.landingPage();
     cy.visit('/');
+    cy.findByRole('button', { name: 'Models' }).click();
     cy.findByRole('link', { name: 'Model catalog' }).should('not.exist');
 
     cy.visitWithLogin(`/modelCatalog`);
@@ -209,7 +210,7 @@ describe('Model Catalog loading states', () => {
       },
     );
     modelCatalog.visit();
-    cy.contains('Request access to model catalog').should('exist');
+    modelCatalog.findModelCatalogEmptyState();
   });
 
   it('should show empty state when configmap has malformed data', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDeploy.cy.ts
@@ -6,7 +6,10 @@ import { kserveModal } from '~/__tests__/cypress/cypress/pages/modelServing';
 import { initDeployPrefilledModelIntercepts } from '~/__tests__/cypress/cypress/utils/modelServingUtils';
 import type { ModelCatalogSource } from '~/concepts/modelCatalog/types';
 import { mockModelCatalogSource } from '~/__mocks__/mockModelCatalogSource';
-import { mockModelCatalogConfigMap } from '~/__mocks__/mockModelCatalogConfigMap';
+import {
+  mockModelCatalogConfigMap,
+  mockUnmanagedModelCatalogConfigMap,
+} from '~/__mocks__/mockModelCatalogConfigMap';
 import { modelCatalogDeployModal } from '~/__tests__/cypress/cypress/pages/modelCatalog/modelCatalogDeployModal';
 
 type HandlersProps = {
@@ -29,6 +32,14 @@ const initIntercepts = ({
       name: 'model-catalog-sources',
     },
     mockModelCatalogConfigMap(catalogModels),
+  );
+  cy.interceptK8s(
+    {
+      model: ConfigMapModel,
+      ns: 'opendatahub',
+      name: 'model-catalog-unmanaged-sources',
+    },
+    mockUnmanagedModelCatalogConfigMap(catalogModels),
   );
 };
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
@@ -58,6 +58,27 @@ const initIntercepts = ({
     mockModelCatalogConfigMap(catalogModels),
   );
 
+  cy.interceptK8s(
+    {
+      model: ConfigMapModel,
+      ns: 'opendatahub',
+      name: 'model-catalog-unmanaged-sources',
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'model-catalog-unmanaged-sources',
+        namespace: 'opendatahub',
+      },
+      data: {
+        modelCatalogSources: JSON.stringify({
+          sources: [],
+        }),
+      },
+    },
+  );
+
   cy.interceptK8sList(ServiceModel, mockK8sResourceList(modelRegistries));
 };
 
@@ -225,7 +246,8 @@ describe('Model Details loading states', () => {
     modelDetailsPage.findModelCatalogEmptyState().should('exist');
   });
 
-  it('should show empty state when configmap has empty data', () => {
+  it('should show error state when configmap has empty data', () => {
+    // Mock managed ConfigMap with empty data
     cy.interceptK8s(
       {
         model: ConfigMapModel,
@@ -244,7 +266,7 @@ describe('Model Details loading states', () => {
     );
 
     modelDetailsPage.visit();
-    modelDetailsPage.findModelCatalogEmptyState().should('exist');
+    cy.contains('Unable to load model catalog').should('exist');
   });
 
   it('should show error state when configmap fetch fails (non-404)', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
@@ -4,7 +4,10 @@ import {
   mockK8sResourceList,
   mockModelRegistryService,
 } from '~/__mocks__';
-import { mockModelCatalogConfigMap } from '~/__mocks__/mockModelCatalogConfigMap';
+import {
+  mockModelCatalogConfigMap,
+  mockUnmanagedModelCatalogConfigMap,
+} from '~/__mocks__/mockModelCatalogConfigMap';
 import { modelDetailsPage } from '~/__tests__/cypress/cypress/pages/modelCatalog/modelDetailsPage';
 import { ConfigMapModel, ServiceModel } from '~/__tests__/cypress/cypress/utils/models';
 import type { ServiceKind } from '~/k8sTypes';
@@ -63,19 +66,7 @@ const initIntercepts = ({
       ns: 'opendatahub',
       name: 'model-catalog-unmanaged-sources',
     },
-    {
-      apiVersion: 'v1',
-      kind: 'ConfigMap',
-      metadata: {
-        name: 'model-catalog-unmanaged-sources',
-        namespace: 'opendatahub',
-      },
-      data: {
-        modelCatalogSources: JSON.stringify({
-          sources: [],
-        }),
-      },
-    },
+    mockUnmanagedModelCatalogConfigMap([]),
   );
 
   cy.interceptK8sList(ServiceModel, mockK8sResourceList(modelRegistries));
@@ -245,7 +236,7 @@ describe('Model Details loading states', () => {
     modelDetailsPage.findModelCatalogEmptyState().should('exist');
   });
 
-  it('should show error state when configmap has empty sources', () => {
+  it('should show empty state when configmap has empty sources', () => {
     // Mock managed ConfigMap with empty data
     cy.interceptK8s(
       {
@@ -260,7 +251,7 @@ describe('Model Details loading states', () => {
           name: 'model-catalog-sources',
           namespace: 'opendatahub',
         },
-        modelCatalogSources: JSON.stringify({ sources: [] }),
+        data: { modelCatalogSources: JSON.stringify({ sources: [] }) },
       },
     );
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
@@ -36,7 +36,6 @@ const initIntercepts = ({
     mockDscStatus({
       installedComponents: {
         'model-registry-operator': true,
-        'data-science-pipelines-operator': true,
       },
     }),
   );
@@ -246,7 +245,7 @@ describe('Model Details loading states', () => {
     modelDetailsPage.findModelCatalogEmptyState().should('exist');
   });
 
-  it('should show error state when configmap has empty data', () => {
+  it('should show error state when configmap has empty sources', () => {
     // Mock managed ConfigMap with empty data
     cy.interceptK8s(
       {
@@ -261,12 +260,12 @@ describe('Model Details loading states', () => {
           name: 'model-catalog-sources',
           namespace: 'opendatahub',
         },
-        data: { modelCatalogSources: '' },
+        modelCatalogSources: JSON.stringify({ sources: [] }),
       },
     );
 
     modelDetailsPage.visit();
-    cy.contains('Unable to load model catalog').should('exist');
+    cy.contains('Details not found').should('exist');
   });
 
   it('should show error state when configmap fetch fails (non-404)', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
@@ -7,7 +7,10 @@ import {
   mockModelVersion,
   mockRegisteredModel,
 } from '~/__mocks__';
-import { mockModelCatalogConfigMap } from '~/__mocks__/mockModelCatalogConfigMap';
+import {
+  mockModelCatalogConfigMap,
+  mockUnmanagedModelCatalogConfigMap,
+} from '~/__mocks__/mockModelCatalogConfigMap';
 import { ConfigMapModel, ServiceModel } from '~/__tests__/cypress/cypress/utils/models';
 import type { ServiceKind } from '~/k8sTypes';
 import { mockModelArtifact } from '~/__mocks__/mockModelArtifact';
@@ -72,19 +75,7 @@ const initIntercepts = ({
       ns: 'opendatahub',
       name: 'model-catalog-unmanaged-sources',
     },
-    {
-      apiVersion: 'v1',
-      kind: 'ConfigMap',
-      metadata: {
-        name: 'model-catalog-unmanaged-sources',
-        namespace: 'opendatahub',
-      },
-      data: {
-        modelCatalogSources: JSON.stringify({
-          sources: [],
-        }),
-      },
-    },
+    mockUnmanagedModelCatalogConfigMap([]),
   );
 
   cy.interceptK8sList(ServiceModel, mockK8sResourceList(modelRegistries));

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
@@ -66,6 +66,27 @@ const initIntercepts = ({
     mockModelCatalogConfigMap(),
   );
 
+  cy.interceptK8s(
+    {
+      model: ConfigMapModel,
+      ns: 'opendatahub',
+      name: 'model-catalog-unmanaged-sources',
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'model-catalog-unmanaged-sources',
+        namespace: 'opendatahub',
+      },
+      data: {
+        modelCatalogSources: JSON.stringify({
+          sources: [],
+        }),
+      },
+    },
+  );
+
   cy.interceptK8sList(ServiceModel, mockK8sResourceList(modelRegistries));
   cy.interceptOdh(
     'POST /api/service/modelregistry/:serviceName/api/model_registry/:apiVersion/registered_models',

--- a/frontend/src/concepts/modelCatalog/const.ts
+++ b/frontend/src/concepts/modelCatalog/const.ts
@@ -1,1 +1,2 @@
 export const MODEL_CATALOG_SOURCES_CONFIGMAP = 'model-catalog-sources';
+export const MODEL_CATALOG_UNMANAGED_SOURCES_CONFIGMAP = 'model-catalog-unmanaged-sources';

--- a/frontend/src/concepts/modelCatalog/useModelCatalogSources.ts
+++ b/frontend/src/concepts/modelCatalog/useModelCatalogSources.ts
@@ -6,7 +6,10 @@ import { SupportedArea } from '~/concepts/areas/types';
 import { allSettledPromises } from '~/utilities/allSettledPromises';
 import useFetchState, { NotReadyError, FetchState } from '~/utilities/useFetchState';
 import { ModelCatalogSource, ModelCatalogSourcesObject } from './types';
-import { MODEL_CATALOG_SOURCES_CONFIGMAP } from './const';
+import {
+  MODEL_CATALOG_SOURCES_CONFIGMAP,
+  MODEL_CATALOG_UNMANAGED_SOURCES_CONFIGMAP,
+} from './const';
 
 type State = ModelCatalogSource[];
 // Temporary implementation for MVP - will be replaced with API for remote model catalog sources
@@ -30,7 +33,7 @@ export const useModelCatalogSources = (): FetchState<State> => {
 
     const [successes, fails] = await allSettledPromises([
       getConfigMap(dashboardNamespace, MODEL_CATALOG_SOURCES_CONFIGMAP),
-      getConfigMap(dashboardNamespace, 'model-catalog-unmanaged-sources'),
+      getConfigMap(dashboardNamespace, MODEL_CATALOG_UNMANAGED_SOURCES_CONFIGMAP),
     ]);
 
     for (const fail of fails) {

--- a/manifests/rhoai/shared/apps/model-catalog/kustomization.yaml
+++ b/manifests/rhoai/shared/apps/model-catalog/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - model-catalog-configmap.yaml
 - model-catalog-rbac.yaml
+- model-catalog-unmanaged-sources.yaml

--- a/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml
+++ b/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml
@@ -13,7 +13,7 @@ rules:
       - configmaps
     resourceNames:
       - model-catalog-sources
----
+      - model-catalog-unmanaged-sources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml
+++ b/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml
@@ -14,6 +14,7 @@ rules:
     resourceNames:
       - model-catalog-sources
       - model-catalog-unmanaged-sources
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml
+++ b/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: model-catalog-unmanaged-sources
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/managed: 'false'
+data:
+  modelCatalogSources: |
+    {
+      "sources": [
+          ]
+        }
+      ]
+    }

--- a/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml
+++ b/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml
@@ -4,12 +4,7 @@ metadata:
   name: model-catalog-unmanaged-sources
   labels:
     opendatahub.io/dashboard: 'true'
+  annotations:
     opendatahub.io/managed: 'false'
 data:
-  modelCatalogSources: |
-    {
-      "sources": [
-          ]
-        }
-      ]
-    }
+  modelCatalogSources: '{ "sources" : [] }'


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes [RHOAIENG-22483](https://issues.redhat.com/browse/RHOAIENG-22483)
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a support for additional configmap when the Red Hat source and another one for unmanaged that will have a Third party as a source. We need to make sure we will see both models in 2 different sections on the model Catalog. Make sure 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When testing explore the below scenarios : If it doesn't exist, there's no error rendered, we just see the existing red hat source as expected
If it exists but is malformed, there's an error rendered
If it exists and is empty (sources: [] like in the manifest) we just see the existing red hat source as expected
If it exists and has a source in it, we see two source sections in the UI

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added test cases and fixed failing ones to mitigate working woth 2 configmaps
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
![Screenshot 2025-03-26 at 2 59 06 PM](https://github.com/user-attachments/assets/b3b0337b-6304-47a7-bd6c-38c4adb3513e)
![Screenshot 2025-03-26 at 3 07 10 PM](https://github.com/user-attachments/assets/972cccef-c843-4b91-8900-22f463e0a33a)
![Screenshot 2025-03-26 at 3 07 42 PM](https://github.com/user-attachments/assets/bfbf7106-d146-4c00-95bb-c9310f971b33)

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
