### PR TITLE
feat(RHOAIENG-22649):added empty state test cases for the hardware profile

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
@@ -169,6 +169,18 @@ class HardwareProfile {
   findHardwareProfilesEmptyState() {
     return cy.findByTestId('dashboard-empty-table-state');
   }
+
+  findHardwareProfilesCreateButton() {
+    return cy.findByTestId('display-hardware-modal-button');
+  }
+
+  findHardwareProfilePageEmptyState() {
+    return cy.findByTestId('empty-state-hardware-profiles');
+  }
+
+  findNoProfilesAvailableText() {
+    return cy.findByTestId('no-available-hardware-profiles');
+  }
 }
 
 class NodeResourceRow extends TableRow {

--- a/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
@@ -63,6 +63,7 @@ const HardwareProfiles: React.FC = () => {
         <EmptyState
           variant={EmptyStateVariant.full}
           data-id="empty-empty-state"
+          data-testid="empty-state-hardware-profiles"
           icon={PlusCircleIcon}
         >
           <Title data-testid="no-available-hardware-profiles" headingLevel="h5" size="lg">
@@ -85,7 +86,12 @@ const HardwareProfiles: React.FC = () => {
           </EmptyStateFooter>
         </EmptyState>
       ) : (
-        <EmptyState variant={EmptyStateVariant.full} data-id="empty-empty-state" icon={BanIcon}>
+        <EmptyState
+          variant={EmptyStateVariant.full}
+          data-id="empty-empty-state"
+          icon={BanIcon}
+          data-testid="empty-state-hardware-profiles"
+        >
           <Title data-testid="no-available-hardware-profiles" headingLevel="h5" size="lg">
             No hardware profiles
           </Title>


### PR DESCRIPTION
closes [RHOAIENG-22649](https://issues.redhat.com/browse/RHOAIENG-22649)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Contains mocked cypress test cases for the no hardware profiles case

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR only adds tests for empty state hardware profile.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
This PR only adds tests for empty state hardware profile.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
