### PR TITLE
Add "top 5" to DW donut charts

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/distributedWorkloadMetrics/testWorkloadMetricsDefaultPageContents.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/distributedWorkloadMetrics/testWorkloadMetricsDefaultPageContents.cy.ts
@@ -98,7 +98,7 @@ describe('Verify Workload Metrics Default page Contents', () => {
         .should('equal', `Total shared quota: ${testData.memoryQuota} GiB`);
       cy.findByTestId('dw-top-consuming-workloads')
         .should('be.visible')
-        .and('contain', 'Top FIVE resource-consuming distributed workloads')
+        .and('contain', 'Top 5 resource-consuming distributed workloads')
         .and('contain', 'No distributed workloads')
         .and(
           'contain',

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/distributedWorkloadMetrics/testWorkloadMetricsDefaultPageContents.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/distributedWorkloadMetrics/testWorkloadMetricsDefaultPageContents.cy.ts
@@ -98,7 +98,7 @@ describe('Verify Workload Metrics Default page Contents', () => {
         .should('equal', `Total shared quota: ${testData.memoryQuota} GiB`);
       cy.findByTestId('dw-top-consuming-workloads')
         .should('be.visible')
-        .and('contain', 'Top resource-consuming distributed workloads')
+        .and('contain', 'Top FIVE resource-consuming distributed workloads')
         .and('contain', 'No distributed workloads')
         .and(
           'contain',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -218,7 +218,7 @@ describe('Distributed Workload Metrics root page', () => {
 
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/projectMetrics/test-project');
-    cy.findByText('Top resource-consuming distributed workloads').should('exist');
+    cy.findByText('Top FIVE resource-consuming distributed workloads').should('exist');
 
     cy.findByLabelText('Distributed workload status tab').click();
     cy.url().should('include', '/workloadStatus/test-project');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -218,7 +218,7 @@ describe('Distributed Workload Metrics root page', () => {
 
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/projectMetrics/test-project');
-    cy.findByText('Top 5resource-consuming distributed workloads').should('exist');
+    cy.findByText('Top 5 resource-consuming distributed workloads').should('exist');
 
     cy.findByLabelText('Distributed workload status tab').click();
     cy.url().should('include', '/workloadStatus/test-project');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -218,7 +218,7 @@ describe('Distributed Workload Metrics root page', () => {
 
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/projectMetrics/test-project');
-    cy.findByText('Top FIVE resource-consuming distributed workloads').should('exist');
+    cy.findByText('Top 5resource-consuming distributed workloads').should('exist');
 
     cy.findByLabelText('Distributed workload status tab').click();
     cy.url().should('include', '/workloadStatus/test-project');

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -22,7 +22,7 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => (
     </StackItem>
     <StackItem data-testid="dw-top-consuming-workloads">
       <DWSectionCard
-        title="Top FIVE resource-consuming distributed workloads"
+        title="Top 5 resource-consuming distributed workloads"
         content={<TopResourceConsumingWorkloads />}
       />
     </StackItem>

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/GlobalDistributedWorkloadsProjectMetricsTab.tsx
@@ -22,7 +22,7 @@ const GlobalDistributedWorkloadsProjectMetricsTab: React.FC = () => (
     </StackItem>
     <StackItem data-testid="dw-top-consuming-workloads">
       <DWSectionCard
-        title="Top resource-consuming distributed workloads"
+        title="Top FIVE resource-consuming distributed workloads"
         content={<TopResourceConsumingWorkloads />}
       />
     </StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-7714 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added "5" 
![Screenshot 2025-04-02 at 11 27 19 AM](https://github.com/user-attachments/assets/acf2eb2e-1a35-4629-9682-27f546bec46e)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On green cluster in comalley-test project
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated the microcopy in the tests as well 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
