### PR TITLE
Display project-specific hardware profiles in dropdown

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/HardwareProfileSection.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/HardwareProfileSection.ts
@@ -1,12 +1,27 @@
 import type { ContainerResources } from '~/types';
+import { Contextual } from './Contextual';
+
+class HardwareProfileGroup extends Contextual<HTMLElement> {}
 
 export class HardwareProfileSection {
   findSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('hardware-profile-select');
   }
 
+  findHardwareProfileSearchSelector(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('hardware-profile-selection-toggle');
+  }
+
   findDetails(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('hardware-profile-details');
+  }
+
+  findProjectScopedLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('project-scoped-label');
+  }
+
+  findGlobalScopedLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('global-scoped-label');
   }
 
   findDetailsPopover(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -44,6 +59,14 @@ export class HardwareProfileSection {
         cy.findByRole('option', { name: profileDisplayName }).click();
       }
     });
+  }
+
+  getProjectScopedHardwareProfile(): Contextual<HTMLElement> {
+    return new HardwareProfileGroup(() => cy.findByTestId('project-scoped-hardware-profiles'));
+  }
+
+  getGlobalScopedHardwareProfile(): Contextual<HTMLElement> {
+    return new HardwareProfileGroup(() => cy.findByTestId('global-scoped-hardware-profiles'));
   }
 
   verifyProfileDetails(resources: ContainerResources): void {

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -9,15 +9,23 @@ import {
   Truncate,
   Stack,
   StackItem,
+  Skeleton,
+  Divider,
+  MenuGroup,
+  MenuItem,
+  FormHelperText,
 } from '@patternfly/react-core';
 import * as React from 'react';
 import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
 import { HardwareProfileKind } from '~/k8sTypes';
-import { IdentifierResourceType } from '~/types';
-import { splitValueUnit, CPU_UNITS, MEMORY_UNITS_FOR_PARSING } from '~/utilities/valueUnits';
+import SearchSelector from '~/components/searchSelector/SearchSelector';
+import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import GlobalIcon from '~/images/icons/GlobalIcon';
+import TruncatedText from '~/components/TruncatedText';
 import HardwareProfileDetailsPopover from './HardwareProfileDetailsPopover';
 import { HardwareProfileConfig } from './useHardwareProfileConfig';
-import { formatResource, formatResourceValue } from './utils';
+import { formatResource, formatResourceValue, getProfileScore } from './utils';
 
 type HardwareProfileSelectProps = {
   initialHardwareProfile?: HardwareProfileKind;
@@ -25,10 +33,17 @@ type HardwareProfileSelectProps = {
   hardwareProfiles: HardwareProfileKind[];
   hardwareProfilesLoaded: boolean;
   hardwareProfilesError: Error | undefined;
+  projectScopedHardwareProfiles: [
+    data: HardwareProfileKind[],
+    loaded: boolean,
+    loadError: Error | undefined,
+    refresh: () => Promise<void>,
+  ];
   allowExistingSettings: boolean;
   hardwareProfileConfig: HardwareProfileConfig;
   isHardwareProfileSupported: (profile: HardwareProfileKind) => boolean;
   onChange: (profile: HardwareProfileKind | undefined) => void;
+  project?: string;
 };
 
 const EXISTING_SETTINGS_KEY = '.existing';
@@ -39,52 +54,25 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   hardwareProfiles,
   hardwareProfilesLoaded,
   hardwareProfilesError,
+  projectScopedHardwareProfiles,
   allowExistingSettings = false,
   hardwareProfileConfig,
   isHardwareProfileSupported,
   onChange,
+  project,
 }) => {
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+  const [searchHardwareProfile, setSearchHardwareProfile] = React.useState('');
+  const [
+    currentProjectHardwareProfiles,
+    currentProjectHardwareProfilesLoaded,
+    currentProjectHardwareProfilesError,
+  ] = projectScopedHardwareProfiles;
+
   const options = React.useMemo(() => {
     const enabledProfiles = hardwareProfiles
       .filter((hp) => hp.spec.enabled)
       .toSorted((a, b) => {
-        const getProfileScore = (profile: HardwareProfileKind) => {
-          const { identifiers } = profile.spec;
-          if (!identifiers?.length) {
-            return 0;
-          }
-
-          // Check if profile has any unlimited resources (no maxValue)
-          const hasUnlimitedResources = identifiers.some((identifier) => !identifier.maxCount);
-          // Profiles with unlimited resources should sort towards bottom
-          if (hasUnlimitedResources) {
-            return Number.MAX_SAFE_INTEGER;
-          }
-
-          let score = 0;
-
-          // Add up normalized scores for each identifier
-          identifiers.forEach((identifier) => {
-            const maxValue = identifier.maxCount;
-            if (!maxValue) {
-              return;
-            }
-
-            if (identifier.resourceType === IdentifierResourceType.CPU) {
-              // Convert CPU to smallest unit for comparison
-              const [value, unit] = splitValueUnit(maxValue.toString(), CPU_UNITS);
-              score += (value ?? 0) * unit.weight;
-            } else if (identifier.resourceType === IdentifierResourceType.MEMORY) {
-              // Convert memory to smallest unit for comparison
-              const [value, unit] = splitValueUnit(maxValue.toString(), MEMORY_UNITS_FOR_PARSING);
-              score += (value ?? 0) * unit.weight;
-            } else {
-              score += Number(maxValue);
-            }
-          });
-
-          return score;
-        };
         // First compare by whether they have extra resources
         const aHasExtra = (a.spec.identifiers ?? []).length > 2;
         const bHasExtra = (b.spec.identifiers ?? []).length > 2;
@@ -160,39 +148,374 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     return formattedOptions;
   }, [hardwareProfiles, initialHardwareProfile, allowExistingSettings, isHardwareProfileSupported]);
 
+  const getHardwareProfiles = () => {
+    const currentProjectEnabledProfiles = currentProjectHardwareProfiles
+      .filter((hp) => hp.spec.enabled)
+      .toSorted((a, b) => {
+        // First compare by whether they have extra resources
+        const aHasExtra = (a.spec.identifiers ?? []).length > 2;
+        const bHasExtra = (b.spec.identifiers ?? []).length > 2;
+
+        // If one has extra resources and the other doesn't, sort the extra resources one later
+        if (aHasExtra !== bHasExtra) {
+          return aHasExtra ? 1 : -1;
+        }
+
+        // If they're the same (both have or both don't have extra resources),
+        // then sort by their score
+        return getProfileScore(a) - getProfileScore(b);
+      });
+
+    // allow continued use of already selected profile if it is disabled
+    if (initialHardwareProfile && !initialHardwareProfile.spec.enabled) {
+      currentProjectEnabledProfiles.push(initialHardwareProfile);
+    }
+
+    const formattedOptions = currentProjectEnabledProfiles
+      .filter((profile) =>
+        profile.spec.displayName
+          .toLocaleLowerCase()
+          .includes(searchHardwareProfile.toLocaleLowerCase()),
+      )
+      .map((profile, index) => {
+        const displayName = `${profile.spec.displayName}${
+          !profile.spec.enabled ? ' (disabled)' : ''
+        }`;
+
+        return (
+          <MenuItem
+            key={index}
+            isSelected={
+              profile.metadata.name === hardwareProfileConfig.selectedProfile?.metadata.name &&
+              profile.metadata.namespace ===
+                hardwareProfileConfig.selectedProfile.metadata.namespace
+            }
+            description={
+              <Stack style={{ marginLeft: '23px' }}>
+                {profile.spec.description && (
+                  <StackItem>
+                    <Truncate content={profile.spec.description} />
+                  </StackItem>
+                )}
+                {profile.spec.identifiers && (
+                  <StackItem>
+                    <Truncate
+                      content={profile.spec.identifiers
+                        .map((identifier) =>
+                          formatResource(
+                            identifier.displayName,
+                            identifier.defaultCount.toString(),
+                            identifier.defaultCount.toString(),
+                          ),
+                        )
+                        .join('; ')}
+                    />
+                  </StackItem>
+                )}
+              </Stack>
+            }
+            onClick={() => {
+              onChange(profile);
+            }}
+          >
+            <Flex
+              spaceItems={{ default: 'spaceItemsXs' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              <FlexItem style={{ display: 'flex' }}>
+                <img
+                  style={{ height: '20px' }}
+                  src={typedObjectImage(ProjectObjectType.project)}
+                  alt=""
+                />
+              </FlexItem>
+              <FlexItem>
+                <Truncate content={displayName} />
+              </FlexItem>
+              <FlexItem align={{ default: 'alignRight' }}>
+                {isHardwareProfileSupported(profile) && <Label color="blue">Compatible</Label>}
+              </FlexItem>
+            </Flex>
+          </MenuItem>
+        );
+      });
+
+    return formattedOptions;
+  };
+
+  const getDashboardHardwareProfiles = () => {
+    const DahboardEnabledProfiles = hardwareProfiles
+      .filter((hp) => hp.spec.enabled)
+      .toSorted((a, b) => {
+        // First compare by whether they have extra resources
+        const aHasExtra = (a.spec.identifiers ?? []).length > 2;
+        const bHasExtra = (b.spec.identifiers ?? []).length > 2;
+
+        // If one has extra resources and the other doesn't, sort the extra resources one later
+        if (aHasExtra !== bHasExtra) {
+          return aHasExtra ? 1 : -1;
+        }
+
+        // If they're the same (both have or both don't have extra resources),
+        // then sort by their score
+        return getProfileScore(a) - getProfileScore(b);
+      });
+
+    // allow continued use of already selected profile if it is disabled
+    if (initialHardwareProfile && !initialHardwareProfile.spec.enabled) {
+      DahboardEnabledProfiles.push(initialHardwareProfile);
+    }
+
+    const formattedOptions = DahboardEnabledProfiles.filter((profile) =>
+      profile.spec.displayName
+        .toLocaleLowerCase()
+        .includes(searchHardwareProfile.toLocaleLowerCase()),
+    ).map((profile, index) => {
+      const displayName = `${profile.spec.displayName}${
+        !profile.spec.enabled ? ' (disabled)' : ''
+      }`;
+
+      return (
+        <MenuItem
+          key={index}
+          isSelected={
+            profile.metadata.name === hardwareProfileConfig.selectedProfile?.metadata.name &&
+            profile.metadata.namespace === hardwareProfileConfig.selectedProfile.metadata.namespace
+          }
+          description={
+            <Stack style={{ marginLeft: '23px' }}>
+              {profile.spec.description && (
+                <StackItem>
+                  <Truncate content={profile.spec.description} />
+                </StackItem>
+              )}
+              {profile.spec.identifiers && (
+                <StackItem>
+                  <Truncate
+                    content={profile.spec.identifiers
+                      .map((identifier) =>
+                        formatResource(
+                          identifier.displayName,
+                          identifier.defaultCount.toString(),
+                          identifier.defaultCount.toString(),
+                        ),
+                      )
+                      .join('; ')}
+                  />
+                </StackItem>
+              )}
+            </Stack>
+          }
+          icon={<GlobalIcon />}
+          onClick={() => {
+            onChange(profile);
+          }}
+        >
+          <Split>
+            <SplitItem>{displayName}</SplitItem>
+            <SplitItem isFilled />
+            <SplitItem>
+              {isHardwareProfileSupported(profile) && <Label color="blue">Compatible</Label>}
+            </SplitItem>
+          </Split>
+        </MenuItem>
+      );
+    });
+
+    if (allowExistingSettings) {
+      formattedOptions.push(
+        <MenuItem
+          style={{ marginLeft: '23px' }}
+          isSelected={
+            hardwareProfileConfig.useExistingSettings && !hardwareProfileConfig.selectedProfile
+          }
+          description="Use existing resource requests/limits, tolerations, and node selectors."
+          onClick={() => onChange(undefined)}
+        >
+          Use existing settings
+        </MenuItem>,
+      );
+    }
+
+    return formattedOptions;
+  };
+
+  if (isProjectScoped && !currentProjectHardwareProfilesLoaded && !hardwareProfilesLoaded) {
+    return <Skeleton />;
+  }
+
   return (
     <>
       <Flex direction={{ default: 'row' }} spaceItems={{ default: 'spaceItemsSm' }}>
         <FlexItem grow={{ default: 'grow' }}>
-          <SimpleSelect
-            dataTestId="hardware-profile-select"
-            previewDescription={previewDescription}
-            options={options}
-            value={
-              hardwareProfileConfig.selectedProfile?.metadata.name ??
-              (hardwareProfileConfig.useExistingSettings ? EXISTING_SETTINGS_KEY : undefined)
-            }
-            onChange={(key) => {
-              if (key === EXISTING_SETTINGS_KEY) {
-                onChange(undefined);
-              } else {
-                const profile = hardwareProfiles.find((hp) => hp.metadata.name === key);
-                if (profile) {
-                  onChange(profile);
+          {isProjectScoped && currentProjectHardwareProfiles.length > 0 ? (
+            <>
+              <SearchSelector
+                isFullWidth
+                dataTestId="hardware-profile-selection"
+                onSearchChange={(newValue) => setSearchHardwareProfile(newValue)}
+                onSearchClear={() => setSearchHardwareProfile('')}
+                searchValue={searchHardwareProfile}
+                toggleContent={
+                  hardwareProfileConfig.selectedProfile?.spec.displayName ? (
+                    <>
+                      {hardwareProfileConfig.selectedProfile.spec.displayName}
+                      {'  '}
+                      {hardwareProfileConfig.selectedProfile.metadata.namespace === project ? (
+                        <Label
+                          variant="outline"
+                          color="blue"
+                          data-testid="project-scoped-label"
+                          isCompact
+                          icon={
+                            <img
+                              style={{ height: '15px', paddingTop: '3px' }}
+                              src={typedObjectImage(ProjectObjectType.project)}
+                              alt=""
+                            />
+                          }
+                        >
+                          Project-scoped
+                        </Label>
+                      ) : (
+                        <Label
+                          variant="outline"
+                          color="blue"
+                          data-testid="global-scoped-label"
+                          isCompact
+                          icon={<GlobalIcon />}
+                        >
+                          Global-scoped
+                        </Label>
+                      )}
+                    </>
+                  ) : allowExistingSettings ? (
+                    'Use existing settings'
+                  ) : (
+                    'Select hardware profile...'
+                  )
                 }
-              }
-            }}
-            placeholder={
-              options.length > 0
-                ? 'Select hardware profile...'
-                : hardwareProfilesError
-                ? 'Error loading hardware profiles'
-                : 'No enabled or valid hardware profiles are available. Contact your administrator.'
-            }
-            isFullWidth
-            isSkeleton={!hardwareProfilesLoaded && !hardwareProfilesError}
-            isScrollable
-          />
+              >
+                <>
+                  <MenuGroup
+                    key="project-scoped"
+                    data-testid="project-scoped-hardware-profiles"
+                    label={
+                      <Flex
+                        spaceItems={{ default: 'spaceItemsXs' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        style={{ paddingBottom: '5px' }}
+                      >
+                        <FlexItem style={{ display: 'flex', paddingLeft: '12px' }}>
+                          <img
+                            style={{ height: '20px', paddingTop: '3px' }}
+                            src={typedObjectImage(ProjectObjectType.project)}
+                            alt=""
+                          />
+                        </FlexItem>
+                        <FlexItem>Project-scoped Hardware profiles</FlexItem>
+                      </Flex>
+                    }
+                  >
+                    {getHardwareProfiles()}
+                  </MenuGroup>
+
+                  <Divider component="li" />
+                  <MenuGroup
+                    key="global-scoped"
+                    data-testid="global-scoped-hardware-profiles"
+                    label={
+                      <Flex
+                        spaceItems={{ default: 'spaceItemsXs' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        style={{ paddingBottom: '5px' }}
+                      >
+                        <FlexItem
+                          style={{ display: 'flex', paddingLeft: '10px' }}
+                          data-testid="ds-project-image"
+                        >
+                          <GlobalIcon />
+                        </FlexItem>
+                        <FlexItem>Global hardware profiles</FlexItem>
+                      </Flex>
+                    }
+                  >
+                    {getDashboardHardwareProfiles()}
+                  </MenuGroup>
+                </>
+              </SearchSelector>
+              {previewDescription &&
+              (hardwareProfileConfig.selectedProfile?.spec.description ||
+                hardwareProfileConfig.selectedProfile?.spec.identifiers) ? (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>
+                      <TruncatedText
+                        maxLines={2}
+                        content={
+                          hardwareProfileConfig.selectedProfile.spec.description ||
+                          (hardwareProfileConfig.selectedProfile.spec.identifiers &&
+                            hardwareProfileConfig.selectedProfile.spec.identifiers
+                              .map((identifier) =>
+                                formatResource(
+                                  identifier.displayName,
+                                  identifier.defaultCount.toString(),
+                                  identifier.defaultCount.toString(),
+                                ),
+                              )
+                              .join('; '))
+                        }
+                      />
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              ) : hardwareProfileConfig.useExistingSettings ? (
+                'Use existing resource requests/limits, tolerations, and node selectors.'
+              ) : null}
+              {(hardwareProfilesError || currentProjectHardwareProfilesError) && (
+                <HelperText isLiveRegion>
+                  <HelperTextItem variant="error">Error loading hardware profiles</HelperTextItem>
+                </HelperText>
+              )}
+            </>
+          ) : (
+            <>
+              <SimpleSelect
+                dataTestId="hardware-profile-select"
+                previewDescription={previewDescription}
+                options={options}
+                value={
+                  hardwareProfileConfig.selectedProfile?.metadata.name ??
+                  (hardwareProfileConfig.useExistingSettings ? EXISTING_SETTINGS_KEY : undefined)
+                }
+                onChange={(key) => {
+                  if (key === EXISTING_SETTINGS_KEY) {
+                    onChange(undefined);
+                  } else {
+                    const profile = hardwareProfiles.find((hp) => hp.metadata.name === key);
+                    if (profile) {
+                      onChange(profile);
+                    }
+                  }
+                }}
+                placeholder={
+                  options.length > 0
+                    ? 'Select hardware profile...'
+                    : hardwareProfilesError
+                    ? 'Error loading hardware profiles'
+                    : 'No enabled or valid hardware profiles are available. Contact your administrator.'
+                }
+                isFullWidth
+                isSkeleton={!hardwareProfilesLoaded && !hardwareProfilesError}
+                isScrollable
+              />
+              {hardwareProfilesError && (
+                <HelperText isLiveRegion>
+                  <HelperTextItem variant="error">Error loading hardware profiles</HelperTextItem>
+                </HelperText>
+              )}
+            </>
+          )}
         </FlexItem>
         <FlexItem>
           {options.length > 0 && (
@@ -205,11 +528,6 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
           )}
         </FlexItem>
       </Flex>
-      {hardwareProfilesError && (
-        <HelperText isLiveRegion>
-          <HelperTextItem variant="error">Error loading hardware profiles</HelperTextItem>
-        </HelperText>
-      )}
     </>
   );
 };

--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
@@ -104,14 +104,26 @@ export const useHardwareProfileConfig = (
   tolerations?: Toleration[],
   nodeSelector?: NodeSelector,
   visibleIn?: HardwareProfileFeatureVisibility[],
+  namespace?: string,
 ): UseHardwareProfileConfigResult => {
-  const [profiles, profilesLoaded, profilesLoadError] =
+  const [dashboardProfiles, dashboardProfilesLoaded, dashboardProfilesLoadError] =
     useHardwareProfilesByFeatureVisibility(visibleIn);
+  const [projectScopedProfiles, projectScopedProfilesLoaded, projectScopedProfilesLoadError] =
+    useHardwareProfilesByFeatureVisibility(visibleIn, namespace);
   const initialHardwareProfile = useRef<HardwareProfileKind | undefined>(undefined);
   const [formData, setFormData, resetFormData] = useGenericObjectState<HardwareProfileConfig>({
     selectedProfile: undefined,
     useExistingSettings: false,
   });
+
+  let profiles = dashboardProfiles;
+  let profilesLoaded = dashboardProfilesLoaded;
+  let profilesLoadError = dashboardProfilesLoadError;
+  if (namespace) {
+    profiles = [...dashboardProfiles, ...projectScopedProfiles];
+    profilesLoaded = dashboardProfilesLoaded && projectScopedProfilesLoaded;
+    profilesLoadError = dashboardProfilesLoadError || projectScopedProfilesLoadError;
+  }
 
   const hardwareProfilesAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
   const isFormDataValid = React.useMemo(

--- a/frontend/src/concepts/hardwareProfiles/useNotebookHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useNotebookHardwareProfileConfig.ts
@@ -1,5 +1,6 @@
 import { HardwareProfileFeatureVisibility, NotebookKind } from '~/k8sTypes';
 import { Notebook } from '~/types';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import {
   useHardwareProfileConfig,
   UseHardwareProfileConfigResult,
@@ -14,10 +15,17 @@ const useNotebookHardwareProfileConfig = (
   )?.resources;
   const tolerations = notebook?.spec.template.spec.tolerations;
   const nodeSelector = notebook?.spec.template.spec.nodeSelector;
+  const namespace = notebook?.metadata.namespace;
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
-  return useHardwareProfileConfig(name, resources, tolerations, nodeSelector, [
-    HardwareProfileFeatureVisibility.WORKBENCH,
-  ]);
+  return useHardwareProfileConfig(
+    name,
+    resources,
+    tolerations,
+    nodeSelector,
+    [HardwareProfileFeatureVisibility.WORKBENCH],
+    isProjectScoped ? namespace : undefined,
+  );
 };
 
 export default useNotebookHardwareProfileConfig;

--- a/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
@@ -3,6 +3,7 @@ import {
   InferenceServiceKind,
   ServingRuntimeKind,
 } from '~/k8sTypes';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import {
   useHardwareProfileConfig,
   UseHardwareProfileConfigResult,
@@ -20,10 +21,17 @@ const useServingHardwareProfileConfig = (
     inferenceService?.spec.predictor.tolerations || servingRuntime?.spec.tolerations;
   const nodeSelector =
     inferenceService?.spec.predictor.nodeSelector || servingRuntime?.spec.nodeSelector;
+  const namespace = servingRuntime?.metadata.namespace;
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
-  return useHardwareProfileConfig(name, resources, tolerations, nodeSelector, [
-    HardwareProfileFeatureVisibility.MODEL_SERVING,
-  ]);
+  return useHardwareProfileConfig(
+    name,
+    resources,
+    tolerations,
+    nodeSelector,
+    [HardwareProfileFeatureVisibility.MODEL_SERVING],
+    isProjectScoped ? namespace : undefined,
+  );
 };
 
 export default useServingHardwareProfileConfig;

--- a/frontend/src/pages/hardwareProfiles/migration/useHardwareProfilesByFeatureVisibility.ts
+++ b/frontend/src/pages/hardwareProfiles/migration/useHardwareProfilesByFeatureVisibility.ts
@@ -7,6 +7,7 @@ import useMigratedHardwareProfiles from './useMigratedHardwareProfiles';
 
 export const useHardwareProfilesByFeatureVisibility = (
   visibility?: HardwareProfileFeatureVisibility[],
+  namespace?: string,
 ): [
   data: HardwareProfileKind[],
   loaded: boolean,
@@ -20,10 +21,10 @@ export const useHardwareProfilesByFeatureVisibility = (
     loaded: loadedMigratedHardwareProfiles,
     loadError: loadErrorMigratedHardwareProfiles,
     refresh,
-  } = useMigratedHardwareProfiles(dashboardNamespace);
+  } = useMigratedHardwareProfiles(namespace ?? dashboardNamespace);
 
   const [hardwareProfiles, loadedHardwareProfiles, loadErrorHardwareProfiles] =
-    useWatchHardwareProfiles(dashboardNamespace);
+    useWatchHardwareProfiles(namespace ?? dashboardNamespace);
 
   const loaded = loadedMigratedHardwareProfiles && loadedHardwareProfiles;
   const loadError = loadErrorMigratedHardwareProfiles || loadErrorHardwareProfiles;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -19,6 +19,7 @@ import ServingRuntimeSizeExpandedField from './ServingRuntimeSizeExpandedField';
 
 type ServingRuntimeSizeSectionProps = {
   podSpecOptionState: ModelServingPodSpecOptionsState;
+  projectName?: string;
   servingRuntimeSelected?: ServingRuntimeKind;
   infoContent?: string;
   isEditing?: boolean;
@@ -27,6 +28,7 @@ type ServingRuntimeSizeSectionProps = {
 
 const ServingRuntimeSizeSection = ({
   podSpecOptionState,
+  projectName,
   servingRuntimeSelected,
   infoContent,
   isEditing = false,
@@ -83,6 +85,7 @@ const ServingRuntimeSizeSection = ({
     <>
       {isHardwareProfileEnabled ? (
         <HardwareProfileFormSection
+          project={projectName}
           podSpecOptionsState={podSpecOptionState}
           isEditing={isEditing}
           isHardwareProfileSupported={isHardwareProfileSupported}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -415,6 +415,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
               />
               <ServingRuntimeSizeSection
                 podSpecOptionState={podSpecOptionsState}
+                projectName={namespace}
                 servingRuntimeSelected={servingRuntimeSelected}
                 infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
                 isEditing={!!editInfo}

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -344,6 +344,7 @@ const SpawnerPage: React.FC = () => {
           <FormSection title="Deployment size">
             {isHardwareProfilesAvailable ? (
               <HardwareProfileFormSection
+                project={projectName}
                 podSpecOptionsState={podSpecOptionsState}
                 isEditing={!!currentUserNotebook}
                 visibleIn={[HardwareProfileFeatureVisibility.WORKBENCH]}

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePage.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePage.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { Form, FormGroup } from '@patternfly/react-core';
 import { useLocation } from 'react-router-dom';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
-import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import {
+  getDisplayNameFromK8sResource,
+  getResourceNameFromK8sResource,
+} from '~/concepts/k8s/utils';
 import {
   FineTuneTaxonomyFormData,
   ModelCustomizationFormData,
@@ -136,6 +139,7 @@ const FineTunePage: React.FC<FineTunePageProps> = ({
                 setData('storageClass', storageClassName)
               }
               setHardwareFormData={(hardwareFormData) => setData('hardware', hardwareFormData)}
+              projectName={getResourceNameFromK8sResource(project)}
             />
             <HyperparameterPageSection
               data={data}

--- a/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingHardwareProfileFormSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingHardwareProfileFormSection.tsx
@@ -24,11 +24,13 @@ import { ZodErrorHelperText } from '~/components/ZodErrorFormHelperText';
 type TrainingHardwareProfileFormSectionProps = {
   data: HardwareProfileConfig;
   setData: UpdateObjectAtPropAndValue<HardwareProfileConfig>;
+  projectName: string;
 };
 
 const TrainingHardwareProfileFormSection: React.FC<TrainingHardwareProfileFormSectionProps> = ({
   data,
   setData,
+  projectName,
 }) => {
   const { getAllValidationIssues } = React.useContext(ValidationContext);
   const validationIssues = getAllValidationIssues(['hardware', 'hardwareProfileConfig']);
@@ -38,6 +40,10 @@ const TrainingHardwareProfileFormSection: React.FC<TrainingHardwareProfileFormSe
   const [hardwareProfiles, loaded, error] = useHardwareProfilesByFeatureVisibility([
     HardwareProfileFeatureVisibility.PIPELINES,
   ]);
+  const projectScopedHardwareProfiles = useHardwareProfilesByFeatureVisibility(
+    [HardwareProfileFeatureVisibility.PIPELINES],
+    projectName,
+  );
 
   const onProfileSelect = (profile?: HardwareProfileKind) => {
     if (profile) {
@@ -102,6 +108,8 @@ const TrainingHardwareProfileFormSection: React.FC<TrainingHardwareProfileFormSe
             hardwareProfilesError={error}
             hardwareProfileConfig={data}
             onChange={onProfileSelect}
+            projectScopedHardwareProfiles={projectScopedHardwareProfiles}
+            project={projectName}
           />
           <ZodErrorHelperText zodIssue={validationIssues} />
         </FormGroup>

--- a/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingHardwareSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingHardwareSection.tsx
@@ -24,6 +24,7 @@ type TrainingHardwareSectionProps = {
   storageClass: string;
   setStorageClass: (data: string) => void;
   setHardwareFormData: (data: ModelCustomizationFormData['hardware']) => void;
+  projectName: string;
 };
 
 const TrainingHardwareSection: React.FC<TrainingHardwareSectionProps> = ({
@@ -34,6 +35,7 @@ const TrainingHardwareSection: React.FC<TrainingHardwareSectionProps> = ({
   storageClass,
   setStorageClass,
   setHardwareFormData,
+  projectName,
 }) => {
   const isHardwareProfilesAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
   const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
@@ -59,6 +61,7 @@ const TrainingHardwareSection: React.FC<TrainingHardwareSectionProps> = ({
         <TrainingHardwareProfileFormSection
           data={podSpecOptionsState.hardwareProfile.formData}
           setData={podSpecOptionsState.hardwareProfile.setFormData}
+          projectName={projectName}
         />
       ) : (
         <TrainingAcceleratorFormSection podSpecOptionsState={podSpecOptionsState} />

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -194,6 +194,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             <FlexItem>
               {isHardwareProfileAvailable ? (
                 <NotebookTableRowHardwareProfile
+                  namespace={obj.notebook.metadata.namespace}
                   loaded={podSpecOptionsState.hardwareProfile.profilesLoaded}
                   loadError={podSpecOptionsState.hardwareProfile.profilesLoadError}
                   hardwareProfile={podSpecOptionsState.hardwareProfile.initialHardwareProfile}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRowHardwareProfile.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRowHardwareProfile.tsx
@@ -1,18 +1,23 @@
-import { HelperText, HelperTextItem, Spinner } from '@patternfly/react-core';
+import { HelperText, HelperTextItem, Label, Spinner } from '@patternfly/react-core';
 import React from 'react';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
+import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
 import { HardwareProfileKind } from '~/k8sTypes';
 
 type NotebookTableRowHardwareProfileProps = {
+  namespace: string;
   loaded: boolean;
   loadError?: Error;
   hardwareProfile?: HardwareProfileKind;
 };
 
 const NotebookTableRowHardwareProfile: React.FC<NotebookTableRowHardwareProfileProps> = ({
+  namespace,
   loaded,
   loadError,
   hardwareProfile,
 }) => {
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   if (loadError) {
     return (
       <HelperText>
@@ -25,7 +30,28 @@ const NotebookTableRowHardwareProfile: React.FC<NotebookTableRowHardwareProfileP
     return <Spinner size="md" />;
   }
 
-  return <>{hardwareProfile?.spec.displayName ?? <i>Custom</i>}</>;
+  return (
+    <>
+      {hardwareProfile?.spec.displayName ?? <i>Custom</i>}{' '}
+      {isProjectScoped && hardwareProfile?.metadata.namespace === namespace && (
+        <Label
+          variant="outline"
+          color="blue"
+          data-testid="project-scoped-label"
+          isCompact
+          icon={
+            <img
+              style={{ height: '15px', paddingTop: '3px' }}
+              src={typedObjectImage(ProjectObjectType.project)}
+              alt=""
+            />
+          }
+        >
+          Project-scoped
+        </Label>
+      )}
+    </>
+  );
 };
 
 export default NotebookTableRowHardwareProfile;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -296,6 +296,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
               ) : (
                 <HardwareProfileFormSection
                   isEditing={!!existingNotebook}
+                  project={currentProject.metadata.name}
                   podSpecOptionsState={podSpecOptionsState}
                   isHardwareProfileSupported={isHardwareProfileSupported}
                   visibleIn={[HardwareProfileFeatureVisibility.WORKBENCH]}


### PR DESCRIPTION
Closes: [RHOAIENG-20301](https://issues.redhat.com/browse/RHOAIENG-20301)

## Description
This PR aims to display project-specific Hardware profiles in create workbench form, model serving and ilab form. Display the project-scoped labels on table and hardware profile dropdown selection.

Hardware profile search selector:

https://github.com/user-attachments/assets/211b3411-9551-4e93-b712-e68b6e687d7d

Search hardware profiles:

https://github.com/user-attachments/assets/68043997-860d-46b1-b2eb-4935bda06ee6

Edit form with project-scoped HP:
<img width="1089" alt="Screenshot 2025-04-03 at 5 16 19 PM" src="https://github.com/user-attachments/assets/27b85845-3608-4907-8632-1d02be5f6c78" />


Displaying project-scoped label for Project-scoped HP and will display custom when the HP is deleted

<img width="1180" alt="Screenshot 2025-04-03 at 5 15 21 PM" src="https://github.com/user-attachments/assets/f65516a8-6f05-4924-92a2-a1b70e1931c8" />

Edit form, when the HP is deleted:
<img width="1113" alt="Screenshot 2025-04-03 at 5 13 21 PM" src="https://github.com/user-attachments/assets/512614e6-4ff5-4d1f-8b54-c3c230057958" />

Deploy model modal:

https://github.com/user-attachments/assets/a3212a20-4d46-455f-bb1c-f6b4c50d3894

<img width="834" alt="Screenshot 2025-04-03 at 8 19 12 PM" src="https://github.com/user-attachments/assets/3a21968d-f26b-4a65-a477-62abd6ab0b50" />

<img width="850" alt="Screenshot 2025-04-03 at 8 18 36 PM" src="https://github.com/user-attachments/assets/b7f27f85-a826-4e71-96bb-6b690173e40a" />

ilab form:

<img width="908" alt="Screenshot 2025-04-03 at 11 42 11 PM" src="https://github.com/user-attachments/assets/4c3fc01e-1dfc-4d34-a31e-7327fe224374" />


<img width="875" alt="Screenshot 2025-04-03 at 11 42 37 PM" src="https://github.com/user-attachments/assets/638947fd-7e86-49be-a04d-cc5ed47974a4" />


## How Has This Been Tested?
Make sure that the form is working as expected with/without disableProjectScoped feature flag.

We can check this behavior on Create/Edit workbench form.

## Test Impact
Added cypress tests and still need to add test for model serving and ilab form - will create a follow-up PR for that.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`



