### PR TITLE
Permission fix for project users

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
@@ -36,7 +36,7 @@ import {
 } from '~/__tests__/cypress/cypress/utils/models';
 import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
 import { mockInferenceServiceK8sResource } from '~/__mocks__/mockInferenceServiceK8sResource';
-import { asProjectAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
+import { asProjectAdminUser, asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
 import { mockNimServingRuntimeTemplate } from '~/__mocks__/mockNimResource';
 import { mockNimAccount } from '~/__mocks__/mockNimAccount';
@@ -329,12 +329,20 @@ describe('Project Details', () => {
         .should('have.text', 'Data connection unsuccessfully verified');
     });
 
-    it('Should not allow actions for non-provisioning users', () => {
-      asProjectAdminUser({ isSelfProvisioner: false });
+    it('Should not allow actions toggle for project Edit users', () => {
+      asProjectEditUser({ isSelfProvisioner: false });
       initIntercepts({ disableKServeConfig: true, disableModelConfig: true });
       projectDetails.visit('test-project');
 
       projectDetails.findProjectActions().should('not.exist');
+    });
+
+    it('Should allow actions toggle for project Admin users', () => {
+      asProjectAdminUser({ isSelfProvisioner: true });
+      initIntercepts({ disableKServeConfig: true, disableModelConfig: true });
+      projectDetails.visit('test-project');
+
+      projectDetails.findProjectActions().should('exist');
     });
 
     it('Should allow actions for provisioning users', () => {

--- a/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
@@ -108,6 +108,7 @@ const setUserConfig = (userConfig: UserConfig = {}, isAllowed = true) => {
     },
   );
 
+  const PROJECT_ADMIN_RESOURCES = ['projects', 'rolebindings'];
   const EDIT_VERBS = ['*', 'create', 'delete', 'deletecollection', 'update', 'patch'];
   cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
     const { verb, group, resource, namespace } = req.body.spec.resourceAttributes;
@@ -124,8 +125,8 @@ const setUserConfig = (userConfig: UserConfig = {}, isAllowed = true) => {
             : // self provisioner capabilities grant access to project creation
             resource === 'projectrequests'
             ? isSelfProvisioner
-            : // only project admins can create rolebindings
-            resource === 'rolebindings' && EDIT_VERBS.includes(verb)
+            : // project admins
+            PROJECT_ADMIN_RESOURCES.includes(resource) && EDIT_VERBS.includes(verb)
             ? isProjectAdmin
             : isProductAdmin
             ? // product admins are getting direct access to resources in the deployment namespace (but importantly, not other projects)

--- a/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
@@ -122,7 +122,7 @@ const setUserConfig = (userConfig: UserConfig = {}, isAllowed = true) => {
           isClusterAdmin
             ? true
             : // self provisioner capabilities grant access to project creation
-            resource === 'projectrequests' || resource === 'projects'
+            resource === 'projectrequests'
             ? isSelfProvisioner
             : // only project admins can create rolebindings
             resource === 'rolebindings' && EDIT_VERBS.includes(verb)

--- a/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
@@ -122,7 +122,7 @@ const setUserConfig = (userConfig: UserConfig = {}, isAllowed = true) => {
           isClusterAdmin
             ? true
             : // self provisioner capabilities grant access to project creation
-            resource === 'projectrequests'
+            resource === 'projectrequests' || resource === 'projects'
             ? isSelfProvisioner
             : // only project admins can create rolebindings
             resource === 'rolebindings' && EDIT_VERBS.includes(verb)

--- a/frontend/src/concepts/projects/accessChecks.tsx
+++ b/frontend/src/concepts/projects/accessChecks.tsx
@@ -1,6 +1,10 @@
 import { K8sVerb } from '~/k8sTypes';
 import { useAccessReview } from '~/api';
 
+/**
+ * Effectively this check is equivalent to checking if a user is a project admin, specifically on the verb passed.
+ */
+
 export const useProjectAccessReview = (
   verb: K8sVerb,
   projectName: string,
@@ -11,6 +15,21 @@ export const useProjectAccessReview = (
       group: 'project.openshift.io',
       resource: 'projects',
       name: projectName,
+      verb,
+    },
+    shouldRunCheck,
+  );
+
+export const useRoleBindingsAccessReview = (
+  verb: K8sVerb,
+  projectName: string,
+  shouldRunCheck?: boolean,
+): ReturnType<typeof useAccessReview> =>
+  useAccessReview(
+    {
+      group: 'rbac.authorization.k8s.io',
+      resource: 'rolebindings',
+      namespace: projectName,
       verb,
     },
     shouldRunCheck,

--- a/frontend/src/concepts/projects/accessChecks.tsx
+++ b/frontend/src/concepts/projects/accessChecks.tsx
@@ -1,0 +1,17 @@
+import { K8sVerb } from '~/k8sTypes';
+import { useAccessReview } from '~/api';
+
+export const useProjectAccessReview = (
+  verb: K8sVerb,
+  projectName: string,
+  shouldRunCheck?: boolean,
+): ReturnType<typeof useAccessReview> =>
+  useAccessReview(
+    {
+      group: 'project.openshift.io',
+      resource: 'projects',
+      name: projectName,
+      verb,
+    },
+    shouldRunCheck,
+  );

--- a/frontend/src/concepts/projects/accessChecks.tsx
+++ b/frontend/src/concepts/projects/accessChecks.tsx
@@ -20,7 +20,7 @@ export const useProjectAccessReview = (
     shouldRunCheck,
   );
 
-export const useRoleBindingsAccessReview = (
+export const useProjectPermissionsAccessReview = (
   verb: K8sVerb,
   projectName: string,
   shouldRunCheck?: boolean,

--- a/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
@@ -5,7 +5,7 @@ import { getDashboardMainContainer } from '~/utilities/utils';
 import { ProjectKind } from '~/k8sTypes';
 import DeleteProjectModal from '~/pages/projects/screens/projects/DeleteProjectModal';
 import ManageProjectModal from '~/pages/projects/screens/projects/ManageProjectModal';
-import { useRoleBindingsAccessReview } from '~/concepts/projects/accessChecks';
+import { useProjectAccessReview } from '~/concepts/projects/accessChecks';
 
 type Props = {
   project: ProjectKind;
@@ -13,11 +13,8 @@ type Props = {
 
 const ProjectActions: React.FC<Props> = ({ project }) => {
   const navigate = useNavigate();
-  const [canEdit, editRbacLoaded] = useRoleBindingsAccessReview('update', project.metadata.name);
-  const [canDelete, deleteRbacLoaded] = useRoleBindingsAccessReview(
-    'delete',
-    project.metadata.name,
-  );
+  const [canEdit, editRbacLoaded] = useProjectAccessReview('update', project.metadata.name);
+  const [canDelete, deleteRbacLoaded] = useProjectAccessReview('delete', project.metadata.name);
   const [open, setOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
   const [editOpen, setEditOpen] = React.useState(false);

--- a/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
@@ -5,7 +5,7 @@ import { getDashboardMainContainer } from '~/utilities/utils';
 import { ProjectKind } from '~/k8sTypes';
 import DeleteProjectModal from '~/pages/projects/screens/projects/DeleteProjectModal';
 import ManageProjectModal from '~/pages/projects/screens/projects/ManageProjectModal';
-import { useProjectAccessReview } from '~/concepts/projects/accessChecks';
+import { useRoleBindingsAccessReview } from '~/concepts/projects/accessChecks';
 
 type Props = {
   project: ProjectKind;
@@ -13,8 +13,11 @@ type Props = {
 
 const ProjectActions: React.FC<Props> = ({ project }) => {
   const navigate = useNavigate();
-  const [canEdit, editRbacLoaded] = useProjectAccessReview('update', project.metadata.name);
-  const [canDelete, deleteRbacLoaded] = useProjectAccessReview('delete', project.metadata.name);
+  const [canEdit, editRbacLoaded] = useRoleBindingsAccessReview('update', project.metadata.name);
+  const [canDelete, deleteRbacLoaded] = useRoleBindingsAccessReview(
+    'delete',
+    project.metadata.name,
+  );
   const [open, setOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
   const [editOpen, setEditOpen] = React.useState(false);

--- a/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectActions.tsx
@@ -2,22 +2,10 @@ import * as React from 'react';
 import { Dropdown, DropdownItem, MenuToggle, DropdownList, Divider } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { getDashboardMainContainer } from '~/utilities/utils';
-import { AccessReviewResourceAttributes, ProjectKind } from '~/k8sTypes';
-import { useAccessReview } from '~/api';
+import { ProjectKind } from '~/k8sTypes';
 import DeleteProjectModal from '~/pages/projects/screens/projects/DeleteProjectModal';
 import ManageProjectModal from '~/pages/projects/screens/projects/ManageProjectModal';
-
-const projectEditAccessReview: AccessReviewResourceAttributes = {
-  group: 'project.openshift.io',
-  resource: 'projectrequests',
-  verb: 'update',
-};
-
-const projectDeleteAccessReview: AccessReviewResourceAttributes = {
-  group: 'project.openshift.io',
-  resource: 'projectrequests',
-  verb: 'delete',
-};
+import { useProjectAccessReview } from '~/concepts/projects/accessChecks';
 
 type Props = {
   project: ProjectKind;
@@ -25,14 +13,8 @@ type Props = {
 
 const ProjectActions: React.FC<Props> = ({ project }) => {
   const navigate = useNavigate();
-  const [canEdit, editRbacLoaded] = useAccessReview({
-    ...projectEditAccessReview,
-    namespace: project.metadata.name,
-  });
-  const [canDelete, deleteRbacLoaded] = useAccessReview({
-    ...projectDeleteAccessReview,
-    namespace: project.metadata.name,
-  });
+  const [canEdit, editRbacLoaded] = useProjectAccessReview('update', project.metadata.name);
+  const [canDelete, deleteRbacLoaded] = useProjectAccessReview('delete', project.metadata.name);
   const [open, setOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
   const [editOpen, setEditOpen] = React.useState(false);

--- a/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
+++ b/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TooltipProps } from '@patternfly/react-core';
-import { useAccessReview } from '~/api';
-import { AccessReviewResourceAttributes, ProjectKind } from '~/k8sTypes';
+import { ProjectKind } from '~/k8sTypes';
+import { useProjectAccessReview } from '~/concepts/projects/accessChecks';
 
 type KebabItem = {
   title?: string;
@@ -10,11 +10,6 @@ type KebabItem = {
   isSeparator?: boolean;
   onClick?: () => void;
   tooltipProps?: TooltipProps;
-};
-const accessReviewResource: AccessReviewResourceAttributes = {
-  group: 'rbac.authorization.k8s.io',
-  resource: 'rolebindings',
-  verb: 'create',
 };
 const useProjectTableRowItems = (
   project: ProjectKind,
@@ -25,27 +20,14 @@ const useProjectTableRowItems = (
   const navigate = useNavigate();
   const [shouldRunCheck, setShouldRunCheck] = React.useState(false);
 
-  const [allowUpdate, allowUpdateLoaded] = useAccessReview(
-    {
-      ...accessReviewResource,
-      namespace: project.metadata.name,
-      verb: 'update',
-    },
+  const [allowUpdate, allowUpdateLoaded] = useProjectAccessReview(
+    'update',
+    project.metadata.name,
     shouldRunCheck,
   );
-  const [allowCreate, allowCreateLoaded] = useAccessReview(
-    {
-      ...accessReviewResource,
-      namespace: project.metadata.name,
-    },
-    shouldRunCheck,
-  );
-  const [allowDelete, allowDeleteLoaded] = useAccessReview(
-    {
-      ...accessReviewResource,
-      namespace: project.metadata.name,
-      verb: 'delete',
-    },
+  const [allowDelete, allowDeleteLoaded] = useProjectAccessReview(
+    'delete',
+    project.metadata.name,
     shouldRunCheck,
   );
 
@@ -69,11 +51,11 @@ const useProjectTableRowItems = (
     },
     {
       title: 'Edit permissions',
-      isAriaDisabled: !allowCreate || !allowCreateLoaded,
+      isAriaDisabled: !allowUpdate || !allowUpdateLoaded,
       onClick: () => {
         navigate(`/projects/${project.metadata.name}?section=permissions`);
       },
-      ...noPermissionToolTip(allowCreate, allowCreateLoaded),
+      ...noPermissionToolTip(allowUpdate, allowUpdateLoaded),
     },
     {
       isSeparator: true,

--- a/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
+++ b/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TooltipProps } from '@patternfly/react-core';
 import { ProjectKind } from '~/k8sTypes';
-import { useProjectAccessReview } from '~/concepts/projects/accessChecks';
+import {
+  useProjectAccessReview,
+  useProjectPermissionsAccessReview,
+} from '~/concepts/projects/accessChecks';
 
 type KebabItem = {
   title?: string;
@@ -22,6 +25,11 @@ const useProjectTableRowItems = (
 
   const [allowUpdate, allowUpdateLoaded] = useProjectAccessReview(
     'update',
+    project.metadata.name,
+    shouldRunCheck,
+  );
+  const [allowCreate, allowCreateLoaded] = useProjectPermissionsAccessReview(
+    'create',
     project.metadata.name,
     shouldRunCheck,
   );
@@ -55,7 +63,7 @@ const useProjectTableRowItems = (
       onClick: () => {
         navigate(`/projects/${project.metadata.name}?section=permissions`);
       },
-      ...noPermissionToolTip(allowUpdate, allowUpdateLoaded),
+      ...noPermissionToolTip(allowCreate, allowCreateLoaded),
     },
     {
       isSeparator: true,

--- a/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
+++ b/frontend/src/pages/projects/screens/projects/useProjectTableRowItems.ts
@@ -28,7 +28,7 @@ const useProjectTableRowItems = (
     project.metadata.name,
     shouldRunCheck,
   );
-  const [allowCreate, allowCreateLoaded] = useProjectPermissionsAccessReview(
+  const [allowPermissions, allowPermissionsLoaded] = useProjectPermissionsAccessReview(
     'create',
     project.metadata.name,
     shouldRunCheck,
@@ -59,11 +59,11 @@ const useProjectTableRowItems = (
     },
     {
       title: 'Edit permissions',
-      isAriaDisabled: !allowUpdate || !allowUpdateLoaded,
+      isAriaDisabled: !allowPermissions || !allowPermissionsLoaded,
       onClick: () => {
         navigate(`/projects/${project.metadata.name}?section=permissions`);
       },
-      ...noPermissionToolTip(allowCreate, allowCreateLoaded),
+      ...noPermissionToolTip(allowPermissions, allowPermissionsLoaded),
     },
     {
       isSeparator: true,


### PR DESCRIPTION
Closes: [RHOAIENG-18968](https://issues.redhat.com/browse/RHOAIENG-18968)

## Description
Corrected a permission bug that always blocked the user from seeing the actions toggle. 

When logged in as a non-admin user, you should now be able to see the Actions dropdown option for projects you’ve created. It should still be hidden for projects created by the Admin.

I’ve also created a new file for this permission check to help with future usage

## How Has This Been Tested?
Tested locally as a non-admin user

## Test Impact
No tests changed

## Screenshots
Before (Actions dropdown hidden):
![Screenshot 2025-04-03 at 1 07 39 PM](https://github.com/user-attachments/assets/b1136c89-4a7c-4781-aeb0-0e0b65fc32d8)

After (Actions available):
![Screenshot 2025-04-03 at 1 07 01 PM](https://github.com/user-attachments/assets/2534c0c4-e75e-4585-a17f-932d7db26019)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
