### PR TITLE
Fix Resource certificate group not hidden correctly

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -596,6 +596,20 @@ describe('CreateModal', () => {
     modelRegistrySettings.resourceNameSelect.openAndSelectItem('sampleSecret', true);
     modelRegistrySettings.findExistingCAKeyInputToggle().should('be.enabled');
     modelRegistrySettings.keySelect.openAndSelectItem('bar.crt', true);
+    // Open the resource selector and verify both groups are initially visible
+    modelRegistrySettings.resourceNameSelect.findToggleButton().click();
+    cy.contains('ConfigMaps').should('be.visible');
+    cy.contains('Secrets').should('be.visible');
+
+    // Search for a value that exists in ConfigMaps but not in Secrets
+    modelRegistrySettings.resourceNameSelect
+      .findSearchInput()
+      .should('be.visible')
+      .type('sampleSecret');
+
+    // Wait for and verify the groups are visible
+    cy.contains('Secrets').should('be.visible');
+    cy.get('body').should('not.contain', 'ConfigMaps');
 
     modelRegistrySettings.findSubmitButton().should('be.enabled');
     modelRegistrySettings.findSubmitButton().click();
@@ -652,6 +666,18 @@ describe('CreateModal', () => {
     modelRegistrySettings.resourceNameSelect.openAndSelectItem('foo-bar', true);
     modelRegistrySettings.findExistingCAKeyInputToggle().should('be.enabled');
     modelRegistrySettings.keySelect.openAndSelectItem('bar.crt', true);
+
+    // Open the resource selector and verify both groups are initially visible
+    modelRegistrySettings.resourceNameSelect.findToggleButton().click();
+    cy.contains('ConfigMaps').should('be.visible');
+    cy.contains('Secrets').should('be.visible');
+
+    // Search for a value that exists in ConfigMaps but not in Secrets
+    modelRegistrySettings.resourceNameSelect.findSearchInput().should('be.visible').type('foo-bar');
+
+    // Wait for and verify the groups are visible
+    cy.contains('ConfigMaps').should('be.visible');
+    cy.get('body').should('not.contain', 'Secrets');
 
     modelRegistrySettings.findSubmitButton().should('be.enabled');
     modelRegistrySettings.findSubmitButton().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -596,18 +596,15 @@ describe('CreateModal', () => {
     modelRegistrySettings.resourceNameSelect.openAndSelectItem('sampleSecret', true);
     modelRegistrySettings.findExistingCAKeyInputToggle().should('be.enabled');
     modelRegistrySettings.keySelect.openAndSelectItem('bar.crt', true);
-    // Open the resource selector and verify both groups are initially visible
     modelRegistrySettings.resourceNameSelect.findToggleButton().click();
     cy.contains('ConfigMaps').should('be.visible');
     cy.contains('Secrets').should('be.visible');
 
-    // Search for a value that exists in ConfigMaps but not in Secrets
     modelRegistrySettings.resourceNameSelect
       .findSearchInput()
       .should('be.visible')
       .type('sampleSecret');
 
-    // Wait for and verify the groups are visible
     cy.contains('Secrets').should('be.visible');
     cy.get('body').should('not.contain', 'ConfigMaps');
 
@@ -667,15 +664,12 @@ describe('CreateModal', () => {
     modelRegistrySettings.findExistingCAKeyInputToggle().should('be.enabled');
     modelRegistrySettings.keySelect.openAndSelectItem('bar.crt', true);
 
-    // Open the resource selector and verify both groups are initially visible
     modelRegistrySettings.resourceNameSelect.findToggleButton().click();
     cy.contains('ConfigMaps').should('be.visible');
     cy.contains('Secrets').should('be.visible');
 
-    // Search for a value that exists in ConfigMaps but not in Secrets
     modelRegistrySettings.resourceNameSelect.findSearchInput().should('be.visible').type('foo-bar');
 
-    // Wait for and verify the groups are visible
     cy.contains('ConfigMaps').should('be.visible');
     cy.get('body').should('not.contain', 'Secrets');
 
@@ -707,6 +701,36 @@ describe('CreateModal', () => {
         databasePassword: 'strongPassword',
       });
     });
+  });
+
+  it('shows "No results found" when searching for non-existent value in both ConfigMaps and Secrets', () => {
+    setupMocksForMRSettingAccess({
+      disableModelRegistrySecureDB: false,
+    });
+    modelRegistrySettings.visit(true);
+    cy.findByText('Create model registry').click();
+    modelRegistrySettings.findAddSecureDbMRCheckbox().should('exist');
+    modelRegistrySettings.findAddSecureDbMRCheckbox().check();
+    modelRegistrySettings.findExistingCARadio().should('be.enabled');
+
+    modelRegistrySettings.findClusterWideCARadio().should('be.disabled');
+    modelRegistrySettings.findOpenshiftCARadio().should('be.disabled');
+    modelRegistrySettings.findExistingCARadio().should('be.checked');
+
+    modelRegistrySettings.findExistingCAKeyInputToggle().should('be.disabled');
+    modelRegistrySettings.findExistingCAResourceInputToggle().should('be.enabled');
+
+    modelRegistrySettings.resourceNameSelect.findToggleButton().click();
+
+    modelRegistrySettings.resourceNameSelect
+      .findSearchInput()
+      .should('be.visible')
+      .type('non-existent-value');
+
+    cy.contains('No results found').should('be.visible');
+
+    cy.contains('ConfigMaps').should('not.exist');
+    cy.contains('Secrets').should('not.exist');
   });
 
   it('create a model registry with Upload new certificate option', () => {

--- a/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
@@ -110,38 +110,43 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
     setSecureDBInfo({ ...newInfo, isValid: isValid(newInfo) });
   };
 
-  const getFilteredExistingCAResources = () => (
-    <>
-      <MenuGroup label="ConfigMaps">
-        {existingCertConfigMaps
-          .filter((configMap) =>
-            configMap.name.toLowerCase().includes(searchConfigSecretName.toLowerCase()),
-          )
-          .map((configMap, index) => (
-            <MenuItem
-              key={`configmap-${index}`}
-              onClick={() => handleResourceSelect(configMap.name, ResourceType.ConfigMap)}
-            >
-              {configMap.name}
-            </MenuItem>
-          ))}
-      </MenuGroup>
-      <MenuGroup label="Secrets">
-        {existingCertSecrets
-          .filter((secret) =>
-            secret.name.toLowerCase().includes(searchConfigSecretName.toLowerCase()),
-          )
-          .map((secret, index) => (
-            <MenuItem
-              key={`secret-${index}`}
-              onClick={() => handleResourceSelect(secret.name, ResourceType.Secret)}
-            >
-              {secret.name}
-            </MenuItem>
-          ))}
-      </MenuGroup>
-    </>
-  );
+  const getFilteredExistingCAResources = () => {
+    const filteredConfigMaps = existingCertConfigMaps.filter((configMap) =>
+      configMap.name.toLowerCase().includes(searchConfigSecretName.toLowerCase()),
+    );
+    const filteredSecrets = existingCertSecrets.filter((secret) =>
+      secret.name.toLowerCase().includes(searchConfigSecretName.toLowerCase()),
+    );
+
+    return (
+      <>
+        {filteredConfigMaps.length > 0 && (
+          <MenuGroup label="ConfigMaps">
+            {filteredConfigMaps.map((configMap, index) => (
+              <MenuItem
+                key={`configmap-${index}`}
+                onClick={() => handleResourceSelect(configMap.name, ResourceType.ConfigMap)}
+              >
+                {configMap.name}
+              </MenuItem>
+            ))}
+          </MenuGroup>
+        )}
+        {filteredSecrets.length > 0 && (
+          <MenuGroup label="Secrets">
+            {filteredSecrets.map((secret, index) => (
+              <MenuItem
+                key={`secret-${index}`}
+                onClick={() => handleResourceSelect(secret.name, ResourceType.Secret)}
+              >
+                {secret.name}
+              </MenuItem>
+            ))}
+          </MenuGroup>
+        )}
+      </>
+    );
+  };
 
   return (
     <>

--- a/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateMRSecureDBSection.tsx
@@ -118,6 +118,10 @@ export const CreateMRSecureDBSection: React.FC<CreateMRSecureDBSectionProps> = (
       secret.name.toLowerCase().includes(searchConfigSecretName.toLowerCase()),
     );
 
+    if (filteredConfigMaps.length === 0 && filteredSecrets.length === 0) {
+      return <MenuItem isDisabled>No results found</MenuItem>;
+    }
+
     return (
       <>
         {filteredConfigMaps.length > 0 && (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-17869 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Navigate to Settings > Model registry settings
Create a model registry and select the 'Add CA certificate to secure database connection' option
Select Choose from existing certificates
Search for a Secret or ConfigMap that is only available in one or the other
Verify that now only one of the groups is there for particular values 
Before 👎 
<img width="824" alt="Screenshot 2025-04-07 at 12 45 56 PM" src="https://github.com/user-attachments/assets/84a06967-fd43-47c6-8e77-88f8c9ddda2a" />
After 👍 
<img width="825" alt="Screenshot 2025-04-07 at 12 45 12 PM" src="https://github.com/user-attachments/assets/8f32d3d5-b0b6-4659-ac6c-9d93c1a694d2" />
<img width="887" alt="Screenshot 2025-04-07 at 12 46 13 PM" src="https://github.com/user-attachments/assets/546b69c5-a11b-46b4-97b4-1340349b6c6f" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On green cluster as described

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test effect 
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
