### PR TITLE
Update breadcrumb and model name when registering model from catalog

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/registerCatalogModel.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/registerCatalogModel.ts
@@ -1,15 +1,15 @@
 class RegisterCatalogModelPage {
-  visit() {
+  visit(name?: string) {
     const sourceName = 'Red%20Hat';
     const repositoryName = 'rhelai1';
-    const modelName = 'granite-8b-code-instruct';
+    const modelName = name ?? 'granite-8b-code-instruct';
     const tag = '1%2E3%2E0';
     cy.visitWithLogin(`/modelCatalog/${sourceName}/${repositoryName}/${modelName}/${tag}/register`);
-    this.wait();
+    this.wait(modelName);
   }
 
-  private wait() {
-    const modelName = 'granite-8b-code-instruct';
+  private wait(name?: string) {
+    const modelName = name ?? 'granite-8b-code-instruct';
 
     cy.findByTestId('app-page-title').should('exist');
     cy.findByTestId('app-page-title').contains(`Register ${modelName} model`);

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
@@ -33,6 +33,14 @@ class RegisterModelPage {
     cy.testA11y();
   }
 
+  findAppTitle() {
+    return cy.findByTestId('app-page-title');
+  }
+
+  findBreadcrumbModelName() {
+    return cy.findByTestId('breadcrumb-model-name');
+  }
+
   findFormField(selector: FormFieldSelector) {
     return cy.get(selector);
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
@@ -198,6 +198,19 @@ describe('Register catalog model page', () => {
     registerModelPage.findSubmitButton().should('be.enabled');
   });
 
+  it('Verify the app title and breadcrumb', () => {
+    initIntercepts({
+      modelRegistries: [mockModelRegistryService({ name: 'modelregistry-sample' })],
+    });
+    registerCatalogModelPage.visit('granite-3.1-8b-code-instruct-1.3.0');
+    registerModelPage
+      .findAppTitle()
+      .should('have.text', 'Register granite-3.1-8b-code-instruct-1.3.0 model');
+    registerModelPage
+      .findBreadcrumbModelName()
+      .should('have.text', 'granite-3.1-8b-code-instruct-1.3.0');
+  });
+
   it('Register catalog model page ', () => {
     initIntercepts({});
     registerCatalogModelPage.visit();

--- a/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
+++ b/frontend/src/pages/modelCatalog/screens/RegisterCatalogModel.tsx
@@ -192,15 +192,20 @@ const RegisterCatalogModel: React.FC = () => {
 
   return (
     <ApplicationsPage
-      title={`Register ${params.modelName || ''} model`}
+      title={`Register ${decodedParams.modelName || ''} model`}
       description="Create a new model and register the first version of your new model."
       breadcrumb={
         <Breadcrumb>
           <BreadcrumbItem render={() => <Link to="/modelCatalog">Model catalog</Link>} />
           <BreadcrumbItem
-            render={() => (
-              <Link to={getCatalogModelDetailsUrl(params)}>{params.modelName || 'Loading...'}</Link>
-            )}
+            data-testid="breadcrumb-model-name"
+            render={() =>
+              !decodedParams.modelName ? (
+                'Loading...'
+              ) : (
+                <Link to={getCatalogModelDetailsUrl(decodedParams)}>{decodedParams.modelName}</Link>
+              )
+            }
           />
           <BreadcrumbItem data-testid="breadcrumb-version-name" isActive>
             Register model

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetails.tsx
@@ -92,11 +92,15 @@ const ModelVersionsDetails: React.FC<ModelVersionsDetailProps> = ({ tab, ...page
             )}
           />
           <BreadcrumbItem
-            render={() => (
-              <Link to={registeredModelUrl(rmId, preferredModelRegistry?.metadata.name)}>
-                {rm?.name || 'Loading...'}
-              </Link>
-            )}
+            render={() =>
+              !rm?.name ? (
+                'Loading...'
+              ) : (
+                <Link to={registeredModelUrl(rmId, preferredModelRegistry?.metadata.name)}>
+                  {rm.name}
+                </Link>
+              )
+            }
           />
           <BreadcrumbItem data-testid="breadcrumb-version-name" isActive>
             {mv?.name || 'Loading...'}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ArchiveModelVersionDetailsBreadcrumb.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ArchiveModelVersionDetailsBreadcrumb.tsx
@@ -28,11 +28,15 @@ const ArchiveModelVersionDetailsBreadcrumb: React.FC<ArchiveModelVersionDetailsB
       )}
     />
     <BreadcrumbItem
-      render={() => (
-        <Link to={registeredModelArchiveDetailsUrl(registeredModel?.id, preferredModelRegistry)}>
-          {registeredModel?.name || 'Loading...'}
-        </Link>
-      )}
+      render={() =>
+        !registeredModel?.name ? (
+          'Loading...'
+        ) : (
+          <Link to={registeredModelArchiveDetailsUrl(registeredModel.id, preferredModelRegistry)}>
+            {registeredModel.name}
+          </Link>
+        )
+      }
     />
     <BreadcrumbItem isActive>{modelVersionName || 'Loading...'}</BreadcrumbItem>
   </Breadcrumb>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetailsBreadcrumb.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionArchiveDetailsBreadcrumb.tsx
@@ -23,11 +23,15 @@ const ModelVersionArchiveDetailsBreadcrumb: React.FC<ModelVersionArchiveDetailsB
       render={() => <Link to="/modelRegistry">Model registry - {preferredModelRegistry}</Link>}
     />
     <BreadcrumbItem
-      render={() => (
-        <Link to={registeredModelUrl(registeredModel?.id, preferredModelRegistry)}>
-          {registeredModel?.name || 'Loading...'}
-        </Link>
-      )}
+      render={() =>
+        !registeredModel?.name ? (
+          'Loading...'
+        ) : (
+          <Link to={registeredModelUrl(registeredModel.id, preferredModelRegistry)}>
+            {registeredModel.name}
+          </Link>
+        )
+      }
     />
     <BreadcrumbItem
       render={() => (

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchive.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionsArchive/ModelVersionsArchive.tsx
@@ -35,11 +35,15 @@ const ModelVersionsArchive: React.FC<ModelVersionsArchiveProps> = ({ ...pageProp
             )}
           />
           <BreadcrumbItem
-            render={() => (
-              <Link to={registeredModelUrl(rmId, preferredModelRegistry?.metadata.name)}>
-                {rm?.name || 'Loading...'}
-              </Link>
-            )}
+            render={() =>
+              !rm?.name ? (
+                'Loading...'
+              ) : (
+                <Link to={registeredModelUrl(rmId, preferredModelRegistry?.metadata.name)}>
+                  {rm.name}
+                </Link>
+              )
+            }
           />
           <BreadcrumbItem data-testid="archive-version-page-breadcrumb" isActive>
             Archived versions


### PR DESCRIPTION
Closes: [RHOAIENG-21958](https://issues.redhat.com/browse/RHOAIENG-21958)

## Description
This PR aims to update the breadcrumb and model name when registering model from catalog
<img width="706" alt="Screenshot 2025-04-07 at 8 35 22 PM" src="https://github.com/user-attachments/assets/26d19ffe-f4b6-4585-a4f2-ee5623ff9d0f" />



## How Has This Been Tested?
1. Navigate to Model Catalog
2. Select the model granite-3.1-8b-lab-v1
3. Click 'Register Model'
4. Observe the error in the breadcrumb & model name 

## Test Impact
Added cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
