### PR TITLE
Fix dependent legacy hardware profile migration from edit page

### DIFF
--- a/frontend/src/__mocks__/mockHardwareProfile.ts
+++ b/frontend/src/__mocks__/mockHardwareProfile.ts
@@ -60,9 +60,7 @@ export const mockHardwareProfile = ({
       effect: TolerationEffect.NO_SCHEDULE,
     },
   ],
-  nodeSelector = {
-    test: 'value',
-  },
+  nodeSelector,
   annotations,
   labels,
 }: MockResourceConfigType): HardwareProfileKind => ({
@@ -83,7 +81,7 @@ export const mockHardwareProfile = ({
     displayName,
     enabled,
     tolerations,
-    nodeSelector,
+    ...(nodeSelector ? { nodeSelector } : {}),
     description,
   },
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
@@ -1,8 +1,12 @@
-import { TolerationEffect, TolerationOperator } from '~/types';
+import { IdentifierResourceType, TolerationEffect, TolerationOperator } from '~/types';
 import { mockK8sResourceList } from '~/__mocks__/mockK8sResourceList';
-import { HardwareProfileModel } from '~/__tests__/cypress/cypress/utils/models';
+import {
+  HardwareProfileModel,
+  AcceleratorProfileModel,
+} from '~/__tests__/cypress/cypress/utils/models';
 import { asProductAdminUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
+import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
 import {
   createHardwareProfile,
   createNodeResourceModal,
@@ -13,7 +17,11 @@ import {
   editNodeResourceModal,
   editNodeSelectorModal,
   editTolerationModal,
+  hardwareProfile,
+  legacyHardwareProfile,
 } from '~/__tests__/cypress/cypress/pages/hardwareProfile';
+import { migrationModal } from '~/__tests__/cypress/cypress/pages/components/MigrationModal';
+import { mock200Status, mockDashboardConfig } from '~/__mocks__';
 
 type HandlersProps = {
   isPresent?: boolean;
@@ -585,5 +593,198 @@ describe('Manage Hardware Profile', () => {
     createHardwareProfile
       .getNodeResourceTableRow('test-identifier2')
       .shouldHaveResourceIdentifier('test-identifier2');
+  });
+
+  it('migrate hardware profile', () => {
+    // mocked model server size
+    const modelServerSize = {
+      name: 'Test Model Server Size',
+      resources: { requests: { cpu: '2', memory: '2Gi' }, limits: { cpu: '3', memory: '3Gi' } },
+    };
+    // mocked notebook size
+    const notebookSize = {
+      name: 'Test Notebook Size',
+      resources: { requests: { cpu: '1', memory: '1Gi' }, limits: { cpu: '2', memory: '2Gi' } },
+    };
+    // mock dashboard config
+    const dashboardConfig = mockDashboardConfig({
+      modelServerSizes: [modelServerSize],
+      notebookSizes: [notebookSize],
+    });
+
+    cy.interceptOdh('GET /api/config', dashboardConfig);
+
+    const originalAcceleratorProfile = mockAcceleratorProfile({
+      namespace: 'opendatahub',
+      name: 'legacy-hardware-profile',
+      displayName: 'Legacy Hardware Profile',
+      description: 'Legacy profile to be migrated',
+      identifier: 'nvidia.com/gpu',
+      enabled: true,
+      tolerations: [
+        {
+          key: 'nvidia.com/gpu',
+          operator: TolerationOperator.EXISTS,
+          effect: TolerationEffect.NO_SCHEDULE,
+        },
+      ],
+    });
+
+    // Mock the accelerator profile that will be migrated
+    cy.interceptK8sList(
+      { model: AcceleratorProfileModel, ns: 'opendatahub' },
+      mockK8sResourceList([originalAcceleratorProfile]),
+    );
+
+    const migratedServingHardwareProfile = mockHardwareProfile({
+      namespace: 'opendatahub',
+      name: `${originalAcceleratorProfile.metadata.name}-serving`,
+      displayName: originalAcceleratorProfile.spec.displayName,
+      description: originalAcceleratorProfile.spec.description,
+      annotations: {
+        'opendatahub.io/dashboard-feature-visibility': '["model-serving","pipelines"]',
+      },
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: modelServerSize.resources.requests.cpu,
+          maxCount: modelServerSize.resources.limits.cpu,
+          defaultCount: modelServerSize.resources.requests.cpu,
+          resourceType: IdentifierResourceType.CPU,
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: modelServerSize.resources.requests.memory,
+          maxCount: modelServerSize.resources.limits.memory,
+          defaultCount: modelServerSize.resources.requests.memory,
+          resourceType: IdentifierResourceType.MEMORY,
+        },
+        {
+          displayName: originalAcceleratorProfile.spec.identifier,
+          identifier: originalAcceleratorProfile.spec.identifier,
+          minCount: 0,
+          defaultCount: 1,
+        },
+      ],
+      tolerations: originalAcceleratorProfile.spec.tolerations,
+    });
+
+    const migratedNotebooksHardwareProfile = mockHardwareProfile({
+      namespace: 'opendatahub',
+      name: `${originalAcceleratorProfile.metadata.name}-notebooks`,
+      annotations: {
+        'opendatahub.io/dashboard-feature-visibility': '["workbench"]',
+      },
+      displayName: originalAcceleratorProfile.spec.displayName,
+      description: originalAcceleratorProfile.spec.description,
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: notebookSize.resources.requests.cpu,
+          maxCount: notebookSize.resources.limits.cpu,
+          defaultCount: notebookSize.resources.requests.cpu,
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: notebookSize.resources.requests.memory,
+          maxCount: notebookSize.resources.limits.memory,
+          defaultCount: notebookSize.resources.requests.memory,
+        },
+        {
+          displayName: originalAcceleratorProfile.spec.identifier,
+          identifier: originalAcceleratorProfile.spec.identifier,
+          minCount: 0,
+          defaultCount: 1,
+        },
+      ],
+      tolerations: originalAcceleratorProfile.spec.tolerations,
+    });
+
+    // Mock the API calls for migration
+    cy.interceptK8s(
+      'DELETE',
+      { model: AcceleratorProfileModel, ns: 'opendatahub', name: 'legacy-hardware-profile' },
+      mock200Status({}),
+    ).as('deleteSource');
+
+    // Mock the creation of the new hardware profiles
+    cy.interceptK8s('POST', { model: HardwareProfileModel, ns: 'opendatahub' }, (req) => {
+      // Check if the request body has the specific annotation
+      const annotations =
+        req.body.metadata?.annotations?.['opendatahub.io/dashboard-feature-visibility'];
+
+      if (annotations?.includes('model-serving')) {
+        req.reply(migratedServingHardwareProfile);
+      } else if (annotations?.includes('workbench')) {
+        req.reply(migratedNotebooksHardwareProfile);
+      }
+    }).as('create');
+
+    // Visit the hardware profiles page
+    hardwareProfile.visit();
+
+    // expand the migrated hardware profiles section
+    legacyHardwareProfile.findExpandButton().click();
+
+    // Find the legacy hardware profile row
+    const legacyProfileRow = legacyHardwareProfile.getRow('Legacy Hardware Profile');
+
+    // Click the edit action
+    legacyProfileRow.findKebabAction('Edit').click();
+
+    // submit manage hardware profile form
+    editHardwareProfile.findSubmitButton().click();
+
+    // submit migration modal
+    migrationModal.findSubmitButton().should('be.enabled').click();
+
+    // assert the creation of the new hardware profiles
+    cy.wait('@deleteSource');
+    cy.wait('@create').then((interception) => {
+      // Assert individually the properties that include random values
+      const { name, annotations } = interception.request.body.metadata;
+      expect(annotations).to.have.property('opendatahub.io/modified-date');
+
+      const actual = Cypress._.omit(
+        interception.request.body,
+        'metadata.annotations["opendatahub.io/modified-date"]',
+        'metadata.name',
+      );
+
+      const visibility =
+        interception.request.body.metadata?.annotations?.[
+          'opendatahub.io/dashboard-feature-visibility'
+        ];
+
+      if (visibility?.includes('model-serving')) {
+        expect(name).to.match(new RegExp(`${originalAcceleratorProfile.metadata.name}-.*-serving`));
+        expect(actual).to.eql({
+          ...migratedServingHardwareProfile,
+          metadata: {
+            namespace: 'opendatahub',
+            annotations: {
+              'opendatahub.io/dashboard-feature-visibility': '["model-serving","pipelines"]',
+            },
+          },
+        });
+      } else if (visibility?.includes('workbench')) {
+        expect(name).to.match(
+          new RegExp(`${originalAcceleratorProfile.metadata.name}-.*-notebooks`),
+        );
+        expect(actual).to.eql({
+          ...migratedNotebooksHardwareProfile,
+          metadata: {
+            namespace: 'opendatahub',
+            annotations: {
+              'opendatahub.io/dashboard-feature-visibility': '["workbench"]',
+            },
+          },
+        });
+      }
+    });
   });
 });

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
@@ -132,7 +132,13 @@ const HardwareProfilesTable: React.FC<HardwareProfilesTableProps> = ({
           onClose={() => setMigrateModalMigrationAction(undefined)}
           onMigrate={async () => {
             const getMigrationPromises = (dryRun: boolean) => [
+              // delete source resource
               migrateModalMigrationAction.deleteSourceResource({ dryRun }),
+              // create dependent profiles
+              ...migrateModalMigrationAction.dependentProfiles.map((profile) =>
+                createHardwareProfileFromResource(profile, { dryRun }),
+              ),
+              // create target profile
               createHardwareProfileFromResource(migrateModalMigrationAction.targetProfile, {
                 dryRun,
               }),


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-22843

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- accelerator profiles now correctly create two hardware profiles on migration instead of just the one being edited

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- create an accelerator profile
- go to hardware profile manage page
- find legacy accelerator profile in expandable table section
- edit one of the two accelerator profiles
- submit form
- confirm modal and migrate
- two new hardware profile should be created

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
added a mocked cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
