### PR TITLE
Add tests for project-scoped hardware profile

### DIFF
--- a/frontend/src/__mocks__/mockHardwareProfile.ts
+++ b/frontend/src/__mocks__/mockHardwareProfile.ts
@@ -87,3 +87,111 @@ export const mockHardwareProfile = ({
     description,
   },
 });
+
+export const mockGlobalScopedHardwareProfiles = [
+  mockHardwareProfile({
+    name: 'small-profile',
+    displayName: 'Small Profile',
+    identifiers: [
+      {
+        displayName: 'CPU',
+        identifier: 'cpu',
+        minCount: '1',
+        maxCount: '2',
+        defaultCount: '1',
+        resourceType: IdentifierResourceType.CPU,
+      },
+      {
+        displayName: 'Memory',
+        identifier: 'memory',
+        minCount: '2Gi',
+        maxCount: '4Gi',
+        defaultCount: '2Gi',
+        resourceType: IdentifierResourceType.MEMORY,
+      },
+    ],
+    tolerations: [
+      {
+        effect: TolerationEffect.NO_SCHEDULE,
+        key: 'NotebooksOnlyChange',
+        operator: TolerationOperator.EXISTS,
+      },
+    ],
+    nodeSelector: {},
+  }),
+  mockHardwareProfile({
+    name: 'large-profile',
+    displayName: 'Large Profile',
+    identifiers: [
+      {
+        displayName: 'CPU',
+        identifier: 'cpu',
+        minCount: '4',
+        maxCount: '8',
+        defaultCount: '4',
+        resourceType: IdentifierResourceType.CPU,
+      },
+      {
+        displayName: 'Memory',
+        identifier: 'memory',
+        minCount: '8Gi',
+        maxCount: '16Gi',
+        defaultCount: '8Gi',
+        resourceType: IdentifierResourceType.MEMORY,
+      },
+    ],
+  }),
+];
+
+export const mockProjectScopedHardwareProfiles = [
+  mockHardwareProfile({
+    name: 'small-profile',
+    displayName: 'Small Profile',
+    namespace: 'test-project',
+    identifiers: [
+      {
+        displayName: 'CPU',
+        identifier: 'cpu',
+        minCount: '1',
+        maxCount: '2',
+        defaultCount: '1',
+      },
+      {
+        displayName: 'Memory',
+        identifier: 'memory',
+        minCount: '2Gi',
+        maxCount: '4Gi',
+        defaultCount: '2Gi',
+      },
+    ],
+    tolerations: [
+      {
+        effect: TolerationEffect.NO_SCHEDULE,
+        key: 'NotebooksOnlyChange',
+        operator: TolerationOperator.EXISTS,
+      },
+    ],
+    nodeSelector: {},
+  }),
+  mockHardwareProfile({
+    name: 'large-profile-1',
+    displayName: 'Large Profile-1',
+    namespace: 'test-project',
+    identifiers: [
+      {
+        displayName: 'CPU',
+        identifier: 'cpu',
+        minCount: '4',
+        maxCount: '8',
+        defaultCount: '4',
+      },
+      {
+        displayName: 'Memory',
+        identifier: 'memory',
+        minCount: '8Gi',
+        maxCount: '16Gi',
+        defaultCount: '8Gi',
+      },
+    ],
+  }),
+];

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -1,4 +1,8 @@
-import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
+import {
+  mockGlobalScopedHardwareProfiles,
+  mockHardwareProfile,
+  mockProjectScopedHardwareProfiles,
+} from '~/__mocks__/mockHardwareProfile';
 import { mockDashboardConfig } from '~/__mocks__/mockDashboardConfig';
 import {
   HardwareProfileModel,
@@ -28,7 +32,6 @@ import { workbenchPage, editSpawnerPage } from '~/__tests__/cypress/cypress/page
 import { hardwareProfileSection } from '~/__tests__/cypress/cypress/pages/components/HardwareProfileSection';
 import { mockDscStatus } from '~/__mocks__/mockDscStatus';
 import type { PodKind } from '~/k8sTypes';
-import { IdentifierResourceType, TolerationEffect, TolerationOperator } from '~/types';
 
 type HandlersProps = {
   isEmpty?: boolean;
@@ -48,116 +51,12 @@ const initIntercepts = ({
   // Mock hardware profiles
   cy.interceptK8sList(
     { model: HardwareProfileModel, ns: 'opendatahub' },
-    mockK8sResourceList([
-      mockHardwareProfile({
-        name: 'small-profile',
-        displayName: 'Small Profile',
-        identifiers: [
-          {
-            displayName: 'CPU',
-            identifier: 'cpu',
-            minCount: '1',
-            maxCount: '2',
-            defaultCount: '1',
-            resourceType: IdentifierResourceType.CPU,
-          },
-          {
-            displayName: 'Memory',
-            identifier: 'memory',
-            minCount: '2Gi',
-            maxCount: '4Gi',
-            defaultCount: '2Gi',
-            resourceType: IdentifierResourceType.MEMORY,
-          },
-        ],
-        tolerations: [
-          {
-            effect: TolerationEffect.NO_SCHEDULE,
-            key: 'NotebooksOnlyChange',
-            operator: TolerationOperator.EXISTS,
-          },
-        ],
-        nodeSelector: {},
-      }),
-      mockHardwareProfile({
-        name: 'large-profile',
-        displayName: 'Large Profile',
-        identifiers: [
-          {
-            displayName: 'CPU',
-            identifier: 'cpu',
-            minCount: '4',
-            maxCount: '8',
-            defaultCount: '4',
-            resourceType: IdentifierResourceType.CPU,
-          },
-          {
-            displayName: 'Memory',
-            identifier: 'memory',
-            minCount: '8Gi',
-            maxCount: '16Gi',
-            defaultCount: '8Gi',
-            resourceType: IdentifierResourceType.MEMORY,
-          },
-        ],
-      }),
-    ]),
+    mockK8sResourceList(mockGlobalScopedHardwareProfiles),
   ).as('hardwareProfiles');
 
   cy.interceptK8sList(
     { model: HardwareProfileModel, ns: 'test-project' },
-    mockK8sResourceList([
-      mockHardwareProfile({
-        name: 'small-profile',
-        displayName: 'Small Profile',
-        namespace: 'test-project',
-        identifiers: [
-          {
-            displayName: 'CPU',
-            identifier: 'cpu',
-            minCount: '1',
-            maxCount: '2',
-            defaultCount: '1',
-          },
-          {
-            displayName: 'Memory',
-            identifier: 'memory',
-            minCount: '2Gi',
-            maxCount: '4Gi',
-            defaultCount: '2Gi',
-          },
-        ],
-        tolerations: [
-          {
-            effect: TolerationEffect.NO_SCHEDULE,
-            key: 'NotebooksOnlyChange',
-            operator: TolerationOperator.EXISTS,
-          },
-        ],
-        nodeSelector: {},
-      }),
-      mockHardwareProfile({
-        name: 'large-profile-1',
-        displayName: 'Large Profile-1',
-        namespace: 'test-project',
-        identifiers: [
-          {
-            displayName: 'CPU',
-            identifier: 'cpu',
-            minCount: '4',
-            maxCount: '8',
-            defaultCount: '4',
-          },
-          {
-            displayName: 'Memory',
-            identifier: 'memory',
-            minCount: '8Gi',
-            maxCount: '16Gi',
-            defaultCount: '8Gi',
-          },
-        ],
-      }),
-    ]),
+    mockK8sResourceList(mockProjectScopedHardwareProfiles),
   ).as('hardwareProfiles');
 
   // Mock standard resources similar to workbench.cy.ts

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -22,6 +22,7 @@ import { mockModelArtifactList } from '~/__mocks__/mockModelArtifactList';
 import { kserveModal } from '~/__tests__/cypress/cypress/pages/modelServing';
 import { mockModelArtifact } from '~/__mocks__/mockModelArtifact';
 import { initDeployPrefilledModelIntercepts } from '~/__tests__/cypress/cypress/utils/modelServingUtils';
+import { hardwareProfileSection } from '~/__tests__/cypress/cypress/pages/components/HardwareProfileSection';
 
 const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
 
@@ -31,6 +32,7 @@ type HandlersProps = {
   modelMeshInstalled?: boolean;
   kServeInstalled?: boolean;
   disableProjectScoped?: boolean;
+  disableHardwareProfiles?: boolean;
 };
 
 const registeredModelMocked = mockRegisteredModel({ name: 'test-1' });
@@ -58,8 +60,14 @@ const initIntercepts = ({
   modelMeshInstalled = true,
   kServeInstalled = true,
   disableProjectScoped = true,
+  disableHardwareProfiles = true,
 }: HandlersProps) => {
-  initDeployPrefilledModelIntercepts({ modelMeshInstalled, kServeInstalled, disableProjectScoped });
+  initDeployPrefilledModelIntercepts({
+    modelMeshInstalled,
+    kServeInstalled,
+    disableProjectScoped,
+    disableHardwareProfiles,
+  });
 
   cy.interceptK8sList(
     ServiceModel,
@@ -360,6 +368,42 @@ describe('Deploy model version', () => {
     projectScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'openvino_ir - opset1');
+  });
+
+  it('Display project specific hardware profile while deploying', () => {
+    initIntercepts({ disableProjectScoped: false, disableHardwareProfiles: false });
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version 4');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+    kserveModal.findModelNameInput().should('exist');
+
+    // Verify hardware profile section exists
+    hardwareProfileSection.findHardwareProfileSearchSelector().should('exist');
+    hardwareProfileSection.findHardwareProfileSearchSelector().click();
+
+    // verify available project-scoped hardware profile
+    const projectScopedHardwareProfile = hardwareProfileSection.getProjectScopedHardwareProfile();
+    projectScopedHardwareProfile
+      .find()
+      .findByRole('menuitem', {
+        name: 'Small CPU: Request = 1; Limit = 1; Memory: Request = 4Gi; Limit = 4Gi',
+        hidden: true,
+      })
+      .click();
+    hardwareProfileSection.findProjectScopedLabel().should('exist');
+
+    // verify available global-scoped hardware profile
+    hardwareProfileSection.findHardwareProfileSearchSelector().click();
+    const globalScopedHardwareProfile = hardwareProfileSection.getGlobalScopedHardwareProfile();
+    globalScopedHardwareProfile
+      .find()
+      .findByRole('menuitem', {
+        name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
+        hidden: true,
+      })
+      .click();
+    hardwareProfileSection.findGlobalScopedLabel().should('exist');
   });
 
   it('Selects Create Connection in case of no matching connections', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -19,6 +19,7 @@ import {
   modelServingGlobal,
 } from '~/__tests__/cypress/cypress/pages/modelServing';
 import {
+  HardwareProfileModel,
   InferenceServiceModel,
   ProjectModel,
   SecretModel,
@@ -35,6 +36,11 @@ import {
   mockModelServingFields,
   mockOciConnectionTypeConfigMap,
 } from '~/__mocks__/mockConnectionType';
+import { hardwareProfileSection } from '~/__tests__/cypress/cypress/pages/components/HardwareProfileSection';
+import {
+  mockGlobalScopedHardwareProfiles,
+  mockProjectScopedHardwareProfiles,
+} from '~/__mocks__/mockHardwareProfile';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -47,6 +53,7 @@ type HandlersProps = {
   disableKServeMetrics?: boolean;
   disableServingRuntimeParamsConfig?: boolean;
   disableProjectScoped?: boolean;
+  disableHardwareProfiles?: boolean;
 };
 
 const initIntercepts = ({
@@ -60,6 +67,7 @@ const initIntercepts = ({
   disableKServeMetrics,
   disableServingRuntimeParamsConfig,
   disableProjectScoped = true,
+  disableHardwareProfiles = true,
 }: HandlersProps) => {
   cy.interceptOdh(
     'GET /api/dsc/status',
@@ -78,8 +86,20 @@ const initIntercepts = ({
       disableKServeMetrics,
       disableServingRuntimeParams: disableServingRuntimeParamsConfig,
       disableProjectScoped,
+      disableHardwareProfiles,
     }),
   );
+
+  // Mock hardware profiles
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'opendatahub' },
+    mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+  ).as('hardwareProfiles');
+
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'test-project' },
+    mockK8sResourceList(mockProjectScopedHardwareProfiles),
+  ).as('hardwareProfiles');
 
   cy.interceptK8sList(
     TemplateModel,
@@ -611,7 +631,7 @@ describe('Model Serving Global', () => {
     kserveModal.findModelFrameworkSelect().should('have.text', 'openvino_ir - opset1');
   });
 
-  it('Display project scoped label on serving runtime selection', () => {
+  it('Display project scoped label on serving runtime selection on Edit', () => {
     initIntercepts({
       projectEnableModelMesh: false,
       disableServingRuntimeParamsConfig: false,
@@ -632,6 +652,65 @@ describe('Model Serving Global', () => {
       .should('have.text', 'test-project-scoped-sr Project-scoped');
     kserveModalEdit.findProjectScopedLabel().should('exist');
     kserveModalEdit.findModelFrameworkSelect().should('have.text', 'onnx - 1');
+  });
+
+  it('should display hardware profile selection when both hardware profile and project-scoped feature flag is enabled', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableServingRuntimeParamsConfig: false,
+      disableProjectScoped: false,
+      disableHardwareProfiles: false,
+    });
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.findDeployModelButton().click();
+    kserveModal.findModelNameInput().should('exist');
+
+    // Verify hardware profile section exists
+    hardwareProfileSection.findHardwareProfileSearchSelector().should('exist');
+    hardwareProfileSection.findHardwareProfileSearchSelector().click();
+
+    // verify available project-scoped hardware profile
+    const projectScopedHardwareProfile = hardwareProfileSection.getProjectScopedHardwareProfile();
+    projectScopedHardwareProfile
+      .find()
+      .findByRole('menuitem', {
+        name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
+        hidden: true,
+      })
+      .click();
+    hardwareProfileSection.findProjectScopedLabel().should('exist');
+
+    // verify available global-scoped hardware profile
+    hardwareProfileSection.findHardwareProfileSearchSelector().click();
+    const globalScopedHardwareProfile = hardwareProfileSection.getGlobalScopedHardwareProfile();
+    globalScopedHardwareProfile
+      .find()
+      .findByRole('menuitem', {
+        name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
+        hidden: true,
+      })
+      .click();
+    hardwareProfileSection.findGlobalScopedLabel().should('exist');
+  });
+
+  it('Display project scoped label on serving runtime selection on Edit', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableServingRuntimeParamsConfig: false,
+      disableProjectScoped: false,
+      disableHardwareProfiles: false,
+      servingRuntimes: [
+        mockServingRuntimeK8sResource({
+          hardwareProfileName: 'large-profile-1',
+        }),
+      ],
+    });
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
+    hardwareProfileSection
+      .findHardwareProfileSearchSelector()
+      .should('contain.text', 'Large Profile-1');
+    hardwareProfileSection.findProjectScopedLabel().should('exist');
   });
 
   it('Display global scoped label on serving runtime selection', () => {

--- a/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
@@ -8,12 +8,17 @@ import {
   mockConnectionTypeConfigMap,
   mockModelServingFields,
 } from '~/__mocks__/mockConnectionType';
+import {
+  mockGlobalScopedHardwareProfiles,
+  mockProjectScopedHardwareProfiles,
+} from '~/__mocks__/mockHardwareProfile';
 import { mockNimAccount } from '~/__mocks__/mockNimAccount';
 import {
   mockServingRuntimeTemplateK8sResource,
   mockInvalidTemplateK8sResource,
 } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
 import {
+  HardwareProfileModel,
   NIMAccountModel,
   ProjectModel,
   TemplateModel,
@@ -25,10 +30,12 @@ export const initDeployPrefilledModelIntercepts = ({
   modelMeshInstalled = true,
   kServeInstalled = true,
   disableProjectScoped = true,
+  disableHardwareProfiles = true,
 }: {
   modelMeshInstalled?: boolean;
   kServeInstalled?: boolean;
   disableProjectScoped?: boolean;
+  disableHardwareProfiles?: boolean;
 }): void => {
   cy.interceptOdh(
     'GET /api/config',
@@ -36,6 +43,7 @@ export const initDeployPrefilledModelIntercepts = ({
       disableModelRegistry: false,
       disableModelCatalog: false,
       disableProjectScoped,
+      disableHardwareProfiles,
     }),
   );
 
@@ -122,6 +130,17 @@ export const initDeployPrefilledModelIntercepts = ({
       { namespace: 'kserve-project' },
     ),
   );
+
+  // Mock hardware profiles
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'opendatahub' },
+    mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+  ).as('hardwareProfiles');
+
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'test-project' },
+    mockK8sResourceList(mockProjectScopedHardwareProfiles),
+  ).as('hardwareProfiles');
 
   cy.interceptOdh('GET /api/connection-types', [
     mockConnectionTypeConfigMap({

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
@@ -16,7 +16,6 @@ import { getContainerResourcesFromHardwareProfile } from './utils';
 type HardwareProfileFormSectionProps<T extends PodSpecOptions> = {
   isEditing: boolean;
   project?: string;
-  isNotebookServer?: boolean;
   visibleIn?: HardwareProfileFeatureVisibility[];
   podSpecOptionsState: PodSpecOptionsState<T>;
   isHardwareProfileSupported?: (profile: HardwareProfileKind) => boolean;
@@ -25,7 +24,6 @@ type HardwareProfileFormSectionProps<T extends PodSpecOptions> = {
 const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSpecOptions>> = ({
   podSpecOptionsState,
   project,
-  isNotebookServer,
   isEditing,
   visibleIn = [],
   isHardwareProfileSupported = () => false,
@@ -72,9 +70,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
             label="Hardware profile"
             isRequired
             labelHelp={
-              isProjectScoped &&
-              !isNotebookServer &&
-              projectScopedHardwareProfiles[0].length > 0 ? (
+              isProjectScoped && project && projectScopedHardwareProfiles[0].length > 0 ? (
                 <ProjectScopedPopover title="Hardware profile" item="hardware profiles" />
               ) : undefined
             }
@@ -86,7 +82,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
               hardwareProfilesLoaded={loaded}
               hardwareProfilesError={error}
               projectScopedHardwareProfiles={
-                isNotebookServer
+                !project
                   ? [[], true, undefined, () => Promise.resolve()]
                   : projectScopedHardwareProfiles
               }

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -1,5 +1,7 @@
-import { sortIdentifiers } from '~/concepts/hardwareProfiles/utils';
-import { Identifier } from '~/types';
+import { mockHardwareProfile } from '~/__mocks__/mockHardwareProfile';
+import { getProfileScore, sortIdentifiers } from '~/concepts/hardwareProfiles/utils';
+import { HardwareProfileKind } from '~/k8sTypes';
+import { Identifier, IdentifierResourceType } from '~/types';
 
 describe('sortIdentifiers', () => {
   it('should sort CPU and memory first, followed by other identifiers', () => {
@@ -72,5 +74,118 @@ describe('sortIdentifiers', () => {
     const identifiers: Identifier[] = [];
     const result = sortIdentifiers(identifiers);
     expect(result).toEqual([]);
+  });
+});
+
+describe('getProfileScore', () => {
+  it('should return 0, if no identifier exist', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({});
+    delete profile.spec.identifiers;
+    const result = getProfileScore(profile);
+    expect(result).toEqual(0);
+  });
+
+  it('should return Number.MAX_SAFE_INTEGER, when profile with no maxValue', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          defaultCount: '2Gi',
+          resourceType: IdentifierResourceType.MEMORY,
+        },
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '2',
+          defaultCount: '1',
+          resourceType: IdentifierResourceType.CPU,
+        },
+      ],
+    });
+
+    const result = getProfileScore(profile);
+    expect(result).toEqual(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('should return NaN, if maxCount is not number', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({
+      identifiers: [
+        {
+          identifier: 'memory',
+          displayName: 'Memory',
+          minCount: 1,
+          maxCount: 'test',
+          defaultCount: 1,
+        },
+      ],
+    });
+    const result = getProfileScore(profile);
+    expect(result).toEqual(NaN);
+  });
+
+  it('convert CPU to smallest unit for comparison, when resourceType has just CPU', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '2',
+          defaultCount: '1',
+          resourceType: IdentifierResourceType.CPU,
+        },
+      ],
+    });
+    const result = getProfileScore(profile);
+    expect(result).toEqual(2000);
+  });
+
+  it('convert memory to smallest unit for comparison, when resourceType has just memory', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '2',
+          defaultCount: '1',
+          resourceType: IdentifierResourceType.CPU,
+        },
+      ],
+    });
+    const result = getProfileScore(profile);
+    expect(result).toEqual(2000);
+  });
+
+  it('convert memory & CPU to smallest unit for comparison, when identifier has both memory and CPU', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({});
+    const result = getProfileScore(profile);
+    expect(result).toEqual(5368711120);
+  });
+
+  it('calculate score, when identifier has other resourceType than memory and CPU', () => {
+    const profile: HardwareProfileKind = mockHardwareProfile({
+      identifiers: [
+        {
+          identifier: 'storage',
+          displayName: 'Storage',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+        {
+          identifier: 'gpu',
+          displayName: 'GPU',
+          minCount: 0,
+          maxCount: 4,
+          defaultCount: 0,
+        },
+      ],
+    });
+    const result = getProfileScore(profile);
+    expect(result).toEqual(8);
   });
 });

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -344,7 +344,6 @@ const SpawnerPage: React.FC = () => {
           <FormSection title="Deployment size">
             {isHardwareProfilesAvailable ? (
               <HardwareProfileFormSection
-                isNotebookServer
                 podSpecOptionsState={podSpecOptionsState}
                 isEditing={!!currentUserNotebook}
                 visibleIn={[HardwareProfileFeatureVisibility.WORKBENCH]}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -56,7 +56,6 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const acceleratorResources = extractAcceleratorResources(
     obj.notebook.spec.template.spec.containers[0].resources,
   );
-  const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
   const lastDeployedSize: NotebookSize = {
     name: 'Custom',
@@ -68,11 +67,10 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const [notebookImage, loaded, loadError] = useNotebookImage(
     obj.notebook,
     currentProject.metadata.name,
-    isProjectScopedAvailable,
   );
   const [data, notebookImageStreamLoaded] = useNotebookImageData(
-    obj.notebook,
     currentProject.metadata.name,
+    obj.notebook,
   );
   const podSpecOptionsState = useNotebookKindPodSpecOptionsState(obj.notebook);
   const [dontShowModalValue] = useStopNotebookModalAvailability();

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
@@ -11,14 +11,10 @@ import { NotebookImage } from './types';
 const useNotebookImage = (
   notebook: NotebookKind | undefined,
   project: string,
-  isProjectScopedAvailable?: boolean,
 ):
   | [notebookImage: null, loaded: false, loadError?: Error]
   | [notebookImage: NotebookImage, loaded: true, loadError: undefined] => {
-  const [data, loaded, loadError] = useNotebookImageData(
-    notebook,
-    isProjectScopedAvailable ? project : undefined,
-  );
+  const [data, loaded, loadError] = useNotebookImageData(project, notebook);
 
   if (!notebook || !loaded) {
     return [null, false, loadError];

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -73,7 +73,7 @@ export const getNotebookImageData = (
   };
 };
 
-const useNotebookImageData = (notebook?: NotebookKind, project?: string): NotebookImageData => {
+const useNotebookImageData = (project: string, notebook?: NotebookKind): NotebookImageData => {
   const { dashboardNamespace } = useNamespaces();
 
   const [dashboardImages, dashboardLoaded, dashboardLoadError] = useImageStreams(
@@ -81,7 +81,7 @@ const useNotebookImageData = (notebook?: NotebookKind, project?: string): Notebo
     true,
   );
 
-  const [projectImages, projectLoaded, projectLoadError] = useImageStreams(project ?? '', true);
+  const [projectImages, projectLoaded, projectLoadError] = useImageStreams(project, true);
 
   return React.useMemo(() => {
     if (!notebook || (!dashboardLoaded && !projectLoaded)) {

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -26,7 +26,10 @@ import CanEnableElyraPipelinesCheck from '~/concepts/pipelines/elyra/CanEnableEl
 import AcceleratorProfileSelectField from '~/pages/notebookController/screens/server/AcceleratorProfileSelectField';
 import { NotebookImageAvailability } from '~/pages/projects/screens/detail/notebooks/const';
 import useProjectPvcs from '~/pages/projects/screens/detail/storage/useProjectPvcs';
-import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
+import {
+  getDisplayNameFromK8sResource,
+  getResourceNameFromK8sResource,
+} from '~/concepts/k8s/utils';
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
@@ -171,7 +174,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     ...notebooksUsingPVCsWithSizeChanges,
   ]);
 
-  const [data, loaded, loadError] = useNotebookImageData(existingNotebook);
+  const [data, loaded, loadError] = useNotebookImageData(
+    getResourceNameFromK8sResource(currentProject),
+    existingNotebook,
+  );
+
   React.useEffect(() => {
     if (loaded) {
       if (data.imageAvailability === NotebookImageAvailability.ENABLED) {

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -10,6 +10,7 @@ import { ImageStreamAndVersion } from '~/types';
 import useImageStreams from '~/pages/projects/screens/spawner/useImageStreams';
 import { useDashboardNamespace } from '~/redux/selectors';
 import useBuildStatuses from '~/pages/projects/screens/spawner/useBuildStatuses';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import ImageStreamPopover from './ImageStreamPopover';
 import ImageVersionSelector from './ImageVersionSelector';
 import ImageStreamSelector from './ImageStreamSelector';
@@ -30,12 +31,15 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
   const { dashboardNamespace } = useDashboardNamespace();
   const buildStatuses = useBuildStatuses(dashboardNamespace);
   const [imageStreams, loaded, error] = useImageStreams(dashboardNamespace);
+  const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const [
     currentProjectImageStreams,
     currentProjectImageStreamsLoaded,
     currentProjectImageStreamsError,
   ] = useImageStreams(currentProject);
-
+  const imageStreamsLoaded = isProjectScopedAvailable
+    ? loaded && currentProjectImageStreamsLoaded
+    : loaded;
   const imageVersionData = React.useMemo(() => {
     const { imageStream } = selectedImage;
     if (!imageStream) {
@@ -68,7 +72,7 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
     );
   }
 
-  if (!loaded || !currentProjectImageStreamsLoaded) {
+  if (!imageStreamsLoaded) {
     return <Skeleton />;
   }
 


### PR DESCRIPTION
Closes: [RHOAIENG-23168](https://issues.redhat.com/browse/RHOAIENG-23168)

## Description
This PR aims to add cypress tests for hardware profile and updated loading state of notebook images.

## How Has This Been Tested?
make sure project-scoped notebook images are working as mentioned in this PR(https://github.com/opendatahub-io/odh-dashboard/pull/3955)
npm run test -  to test cypress test

## Test Impact
Added cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
