### PR TITLE
Fix PF 6.2.0 Style Error with Page Component

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -75,3 +75,14 @@ body,
     overflow: hidden;
   }
 }
+
+// TODO: Remove when PF bug is fixed.
+// https://issues.redhat.com/browse/RHOAIENG-23580
+// https://github.com/patternfly/patternfly/issues/7452
+.pf-v6-c-page {
+  --pf-v6-c-page__sidebar--Width: 0;
+
+  &:has(.pf-v6-c-page__sidebar) {
+    --pf-v6-c-page__sidebar--Width: 18.125rem;
+  }
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
https://issues.redhat.com/browse/RHOAIENG-23563

Added temporary style override to `App.tsx` until https://github.com/patternfly/patternfly/issues/7452 is resolved.

Before:
<img width="1511" alt="Screenshot 2025-04-10 at 2 56 12 PM" src="https://github.com/user-attachments/assets/f92794a7-3e25-4ba9-896c-e916f140579f" />

After:
<img width="1511" alt="Screenshot 2025-04-10 at 2 57 44 PM" src="https://github.com/user-attachments/assets/fc36feba-7e68-4f5e-a336-78fc3dcfb0c7" /> 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A, style changes only.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A, style changes only.
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
