### PR TITLE
fix(RHOAIENG-21303): added default pull access type connection, test cases and recommended connection type 

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -295,6 +295,15 @@ class InferenceServiceModal extends Modal {
     return this.find().findByTestId(`field ${envVar}`);
   }
 
+  verifyPullSecretCheckbox() {
+    return this.find()
+      .get('.pf-v6-c-menu')
+      .contains('Pull secret')
+      .parent()
+      .find('input[type="checkbox"]')
+      .should('be.checked');
+  }
+
   findOCIModelURI() {
     return this.find().findByTestId('model-uri');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -623,6 +623,7 @@ describe('Deploy model version', () => {
           data: {
             '.dockerconfigjson': 'aHR0cHM6Ly9kZW1vLW1vZGVscy9zb21lLXBhdGguemlw',
             OCI_HOST: 'dGVzdC5pby90ZXN0',
+            ACCESS_TYPE: 'WyJQdWxsIl0',
           },
         }),
       ]),

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -251,7 +251,7 @@ describe('Deploy model version', () => {
     cy.findByTestId('oci-deploy-kserve-alert').should('exist');
   });
 
-  it('Selects Create Connection in case of no matching OCI connections', () => {
+  it('Selects Create Connection in case of no matching OCI connections and verifies the prepopulation of Pull Access type', () => {
     initIntercepts({});
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version 3');
@@ -268,6 +268,12 @@ describe('Deploy model version', () => {
     // Validate connection section
     kserveModal.findNewConnectionOption().should('be.checked');
     kserveModal.findModelURITextBox().should('have.value', 'test.io/test/private:test');
+    kserveModal
+      .findConnectionFieldInput('ACCESS_TYPE')
+      .click()
+      .then(() => {
+        kserveModal.verifyPullSecretCheckbox();
+      });
   });
 
   it('Selects Current URI in case of built-in registry OCI connections', () => {

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -144,6 +144,7 @@ export enum ModelServingCompatibleTypes {
 
 export const URIConnectionTypeKeys = ['URI'];
 export const OCIConnectionTypeKeys = ['.dockerconfigjson', 'OCI_HOST'];
+export const OCIAccessTypeKey = ['ACCESS_TYPE'];
 export const S3ConnectionTypeKeys = [
   'AWS_ACCESS_KEY_ID',
   'AWS_SECRET_ACCESS_KEY',

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -52,6 +52,7 @@ import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { isModelPathValid } from '~/pages/modelServing/screens/projects/utils';
 import usePersistentData from '~/pages/projects/screens/detail/connections/usePersistentData';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import { AccessTypes } from '~/pages/projects/dataConnections/const';
 import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 import ConnectionOciPathField from './ConnectionOciPathField';
 import { ConnectionOciAlert } from './ConnectionOciAlert';
@@ -332,7 +333,7 @@ const NewConnectionField: React.FC<NewConnectionFieldProps> = ({
         onValidate={(field, error, value) => {
           let newError = error;
           if (field.envVar === 'ACCESS_TYPE' && Array.isArray(value)) {
-            if (value.includes('Push') && !value.includes('Pull')) {
+            if (value.includes(AccessTypes.PUSH) && !value.includes(AccessTypes.PULL)) {
               newError = 'Access type must include pull';
             }
           }

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
@@ -584,19 +584,20 @@ describe('usePrefillModelDeployModal', () => {
         mockSetCreateData,
         mockRegisteredModelDeployInfo,
       );
-
-      expect(renderResult).hookToStrictEqual({
-        connections: [
-          {
-            connection: mockConnection({}),
+      waitFor(() => {
+        expect(renderResult).hookToStrictEqual({
+          connections: [
+            {
+              connection: mockConnection({}),
+            },
+          ],
+          connectionsLoadError: undefined,
+          connectionsLoaded: true,
+          initialNewConnectionType: undefined,
+          initialNewConnectionValues: {
+            ACCESS_TYPE: ['Pull'],
           },
-        ],
-        connectionsLoadError: undefined,
-        connectionsLoaded: true,
-        initialNewConnectionType: undefined,
-        initialNewConnectionValues: {
-          ACCESS_TYPE: ['Pull'],
-        },
+        });
       });
 
       expect(mockSetCreateData.mock.calls).toEqual([
@@ -790,34 +791,34 @@ describe('usePrefillModelDeployModal', () => {
         mockSetCreateData,
         mockRegisteredModelDeployInfo,
       );
-
-      expect(renderResult).hookToStrictEqual({
-        connections: [
-          {
-            connection: mockConnection({
-              data: {
-                OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
-                ACCESS_TYPE: 'WyJQdWxsIl0',
-              },
-            }),
-            isRecommended: true,
-          },
-          {
-            connection: mockConnection({
-              data: {
-                OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
-                ACCESS_TYPE: 'WyJQdWxsIl0',
-              },
-            }),
-            isRecommended: true,
-          },
-        ],
-        connectionsLoadError: undefined,
-        connectionsLoaded: true,
-        initialNewConnectionType: undefined,
-        initialNewConnectionValues: {},
+      waitFor(() => {
+        expect(renderResult).hookToStrictEqual({
+          connections: [
+            {
+              connection: mockConnection({
+                data: {
+                  OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
+                  ACCESS_TYPE: 'WyJQdWxsIl0',
+                },
+              }),
+              isRecommended: true,
+            },
+            {
+              connection: mockConnection({
+                data: {
+                  OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
+                  ACCESS_TYPE: 'WyJQdWxsIl0',
+                },
+              }),
+              isRecommended: true,
+            },
+          ],
+          connectionsLoadError: undefined,
+          connectionsLoaded: true,
+          initialNewConnectionType: undefined,
+          initialNewConnectionValues: {},
+        });
       });
-
       expect(mockSetCreateData.mock.calls).toEqual([
         ['name', 'test-model'],
         [

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
@@ -585,18 +585,18 @@ describe('usePrefillModelDeployModal', () => {
         mockRegisteredModelDeployInfo,
       );
 
-      waitFor(() => {
-        expect(renderResult).hookToStrictEqual({
-          connections: [
-            {
-              connection: mockConnection({}),
-            },
-          ],
-          connectionsLoadError: undefined,
-          connectionsLoaded: true,
-          initialNewConnectionType: undefined,
-          initialNewConnectionValues: {},
-        });
+      expect(renderResult).hookToStrictEqual({
+        connections: [
+          {
+            connection: mockConnection({}),
+          },
+        ],
+        connectionsLoadError: undefined,
+        connectionsLoaded: true,
+        initialNewConnectionType: undefined,
+        initialNewConnectionValues: {
+          ACCESS_TYPE: ['Pull'],
+        },
       });
 
       expect(mockSetCreateData.mock.calls).toEqual([
@@ -695,6 +695,7 @@ describe('usePrefillModelDeployModal', () => {
             data: {
               OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
               '.dockerconfigjson': 'aHR0cHM6Ly9kZW1vLW1vZGVscy9zb21lLXBhdGguemlw',
+              ACCESS_TYPE: 'WyJQdWxsIl0',
             },
           }),
         ],
@@ -725,6 +726,7 @@ describe('usePrefillModelDeployModal', () => {
                 data: {
                   OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
                   '.dockerconfigjson': 'aHR0cHM6Ly9kZW1vLW1vZGVscy9zb21lLXBhdGguemlw',
+                  ACCESS_TYPE: 'WyJQdWxsIl0',
                 },
               }),
               isRecommended: true,
@@ -766,10 +768,10 @@ describe('usePrefillModelDeployModal', () => {
       mockUseConnections.mockReturnValue([
         [
           mockConnection({
-            data: { OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=' },
+            data: { OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=', ACCESS_TYPE: 'WyJQdWxsIl0' },
           }),
           mockConnection({
-            data: { OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=' },
+            data: { OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=', ACCESS_TYPE: 'WyJQdWxsIl0' },
           }),
         ],
         true,
@@ -789,31 +791,31 @@ describe('usePrefillModelDeployModal', () => {
         mockRegisteredModelDeployInfo,
       );
 
-      waitFor(() => {
-        expect(renderResult).hookToStrictEqual({
-          connections: [
-            {
-              connection: mockConnection({
-                data: {
-                  OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
-                },
-              }),
-              isRecommended: true,
-            },
-            {
-              connection: mockConnection({
-                data: {
-                  OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
-                },
-              }),
-              isRecommended: true,
-            },
-          ],
-          connectionsLoadError: undefined,
-          connectionsLoaded: true,
-          initialNewConnectionType: undefined,
-          initialNewConnectionValues: {},
-        });
+      expect(renderResult).hookToStrictEqual({
+        connections: [
+          {
+            connection: mockConnection({
+              data: {
+                OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
+                ACCESS_TYPE: 'WyJQdWxsIl0',
+              },
+            }),
+            isRecommended: true,
+          },
+          {
+            connection: mockConnection({
+              data: {
+                OCI_HOST: 'cmVnaXN0cnkucmVkaGF0LmlvL3JoZWxhaTE=',
+                ACCESS_TYPE: 'WyJQdWxsIl0',
+              },
+            }),
+            isRecommended: true,
+          },
+        ],
+        connectionsLoadError: undefined,
+        connectionsLoaded: true,
+        initialNewConnectionType: undefined,
+        initialNewConnectionValues: {},
       });
 
       expect(mockSetCreateData.mock.calls).toEqual([

--- a/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
@@ -43,7 +43,7 @@ const useLabeledConnections = (
       if (modelLocation.ociUri && connection.data?.OCI_HOST) {
         const findURI = modelLocation.ociUri.includes(window.atob(connection.data.OCI_HOST));
         const accessTypes = connection.data.ACCESS_TYPE && window.atob(connection.data.ACCESS_TYPE);
-        if (findURI && accessTypes.includes(AccessTypes.PULL)) {
+        if (findURI && accessTypes && accessTypes.includes(AccessTypes.PULL)) {
           return { connection, isRecommended: true };
         }
       }

--- a/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
@@ -3,7 +3,7 @@ import { Connection } from '~/concepts/connectionTypes/types';
 import { convertObjectStorageSecretData } from '~/concepts/connectionTypes/utils';
 import { ModelLocation, uriToModelLocation } from '~/concepts/modelRegistry/utils';
 import { LabeledConnection } from '~/pages/modelServing/screens/types';
-import { AwsKeys } from '~/pages/projects/dataConnections/const';
+import { AwsKeys, AccessTypes } from '~/pages/projects/dataConnections/const';
 
 const useLabeledConnections = (
   modelArtifactUri: string | undefined,
@@ -43,7 +43,7 @@ const useLabeledConnections = (
       if (modelLocation.ociUri && connection.data?.OCI_HOST) {
         const findURI = modelLocation.ociUri.includes(window.atob(connection.data.OCI_HOST));
         const accessTypes = connection.data.ACCESS_TYPE && window.atob(connection.data.ACCESS_TYPE);
-        if (findURI && accessTypes.includes('Pull')) {
+        if (findURI && accessTypes.includes(AccessTypes.PULL)) {
           return { connection, isRecommended: true };
         }
       }

--- a/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
@@ -42,8 +42,8 @@ const useLabeledConnections = (
       }
       if (modelLocation.ociUri && connection.data?.OCI_HOST) {
         const findURI = modelLocation.ociUri.includes(window.atob(connection.data.OCI_HOST));
-        const accessTypes = JSON.parse(window.atob(connection.data.ACCESS_TYPE));
-        if (findURI && Array.isArray(accessTypes) && accessTypes.includes('Pull')) {
+        const accessTypes = connection.data.ACCESS_TYPE && window.atob(connection.data.ACCESS_TYPE);
+        if (findURI && accessTypes.includes('Pull')) {
           return { connection, isRecommended: true };
         }
       }

--- a/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useLabeledConnections.ts
@@ -42,7 +42,8 @@ const useLabeledConnections = (
       }
       if (modelLocation.ociUri && connection.data?.OCI_HOST) {
         const findURI = modelLocation.ociUri.includes(window.atob(connection.data.OCI_HOST));
-        if (findURI) {
+        const accessTypes = JSON.parse(window.atob(connection.data.ACCESS_TYPE));
+        if (findURI && Array.isArray(accessTypes) && accessTypes.includes('Pull')) {
           return { connection, isRecommended: true };
         }
       }

--- a/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
+++ b/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
@@ -15,6 +15,7 @@ import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { isRedHatRegistryUri } from '~/pages/modelRegistry/screens/utils';
 import {
   getMRConnectionValues,
+  OCIAccessTypeKey,
   OCIConnectionTypeKeys,
   S3ConnectionTypeKeys,
   URIConnectionTypeKeys,
@@ -185,6 +186,7 @@ const usePrefillModelDeployModal = (
             type: InferenceServiceStorageType.NEW_STORAGE,
             alert,
           });
+          setinitialNewConnectionValues({ [`${OCIAccessTypeKey}`]: ['Pull'] });
           setInitialNewConnectionType(
             withRequiredFields(
               connectionTypes.find(

--- a/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
+++ b/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
@@ -10,7 +10,11 @@ import {
   CreatingInferenceServiceObject,
   InferenceServiceStorageType,
 } from '~/pages/modelServing/screens/types';
-import { AwsKeys, EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
+import {
+  AccessTypes,
+  AwsKeys,
+  EMPTY_AWS_SECRET_DATA,
+} from '~/pages/projects/dataConnections/const';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { isRedHatRegistryUri } from '~/pages/modelRegistry/screens/utils';
 import {
@@ -186,7 +190,7 @@ const usePrefillModelDeployModal = (
             type: InferenceServiceStorageType.NEW_STORAGE,
             alert,
           });
-          setinitialNewConnectionValues({ [`${OCIAccessTypeKey}`]: ['Pull'] });
+          setinitialNewConnectionValues({ [`${OCIAccessTypeKey}`]: [AccessTypes.PULL] });
           setInitialNewConnectionType(
             withRequiredFields(
               connectionTypes.find(

--- a/frontend/src/pages/projects/dataConnections/const.ts
+++ b/frontend/src/pages/projects/dataConnections/const.ts
@@ -9,6 +9,10 @@ export enum AwsKeys {
   DEFAULT_REGION = 'AWS_DEFAULT_REGION',
   AWS_S3_BUCKET = 'AWS_S3_BUCKET',
 }
+export enum AccessTypes {
+  PULL = 'Pull',
+  PUSH = 'Push',
+}
 export const PIPELINE_AWS_KEY = [
   AwsKeys.ACCESS_KEY_ID,
   AwsKeys.SECRET_ACCESS_KEY,


### PR DESCRIPTION
closes [RHOAIENG-21303](https://issues.redhat.com/browse/RHOAIENG-21303)
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Scenarios Included:
1. When Deploying any model registered using an OCI - URI but not containingoci://registry.redhat.io, you will find "Existing connection" with the fields filled. When you click on the connection name dropdown, you should see the "Recommended" label as shown in the screenshot.(You can test this by deploying the version inside "oci-model" model on the "mdas" project - you should see "Existing connection" preselected and fields filled [ui-green](https://console-openshift-console.apps.ui-green.dev.datahub.redhat.com/) cluster)

The recommended label will now be based on whether the connection includes a Pull request selected in the connection type as seen in the screenshot below even though we have another OCI connection present prior to this where even if the OCI connection did not have a Pull type as selected it was recommended.

<img width="1512" alt="Screenshot 2025-04-11 at 4 13 09 PM" src="https://github.com/user-attachments/assets/f7851b23-9366-4afc-8b3c-14774c24f87e" />

**OCI connection without Pull request checked**

<img width="1512" alt="Screenshot 2025-04-11 at 4 13 28 PM" src="https://github.com/user-attachments/assets/ee9ff9d9-b9fc-4092-b756-0247e6e00ab5" />

Fig: **OCI connection without Pull request checked and included in the recommended tag**

<img width="1512" alt="Screenshot 2025-04-11 at 9 54 09 PM" src="https://github.com/user-attachments/assets/f15f8197-32c7-4a2b-a703-ff882f93685d" />


https://github.com/user-attachments/assets/caa5a6c6-d171-4a89-9f0f-a714e909b2f7


2. When deploying any model registered using an OCI - URI but not containing oci://registry.redhat.io and not containing any matching connection, you will find "Create connection" with the "Model URI" field filled. (You can test this by deploying the version inside "oci-model" model on the "mturley test" project - you should see "Create connection" preselected and "Model URI" field filled [ui-green](https://console-openshift-console.apps.ui-green.dev.datahub.redhat.com/) cluster)

Now the pull connection will be preselected by default.

https://github.com/user-attachments/assets/dd304aba-2b8b-4d52-8618-e22ae1896138

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Test case for handling the preselection of the pull request on OCI create connection

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Cypress tests added.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
