### PR TITLE
Updating SA permissions

### DIFF
--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -134,9 +134,11 @@ rules:
       - rbac.authorization.k8s.io
     verbs:
       - list
+      - get
     resources:
       - rolebindings
       - clusterrolebindings
+      - roles
   - apiGroups:
       - ''
       - events.k8s.io

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -133,17 +133,10 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     verbs:
-      - get
       - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
     resources:
       - rolebindings
       - clusterrolebindings
-      - roles
   - apiGroups:
       - ''
       - events.k8s.io

--- a/manifests/core-bases/base/role.yaml
+++ b/manifests/core-bases/base/role.yaml
@@ -33,17 +33,10 @@ rules:
   - apiGroups:
       - batch
     verbs:
-      - create
-      - delete
       - get
-      - list
-      - patch
       - update
-      - watch
     resources:
       - cronjobs
-      - jobs
-      - jobs/status
   - apiGroups:
       - image.openshift.io
     verbs:
@@ -58,16 +51,10 @@ rules:
   - apiGroups:
       - build.openshift.io
     verbs:
-      - get
       - list
-      - watch
-      - create
-      - patch
-      - delete
     resources:
       - builds
       - buildconfigs
-      - buildconfigs/instantiate
   - apiGroups:
       - apps
     verbs:


### PR DESCRIPTION
Closes [RHOAIENG-16858](https://issues.redhat.com/browse/RHOAIENG-16858)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
**Updating service account permissions:
Role updates:**
batch -> GET, UPDATE / cronjobs -> Enabled/Explore tiles
build.openshift.io -> LIST / builds, buildconfigs -> List build statuses of images
**Cluster-Role updates:**
rbac.authorization.k8s.io -> LIST, GET / rolebindings, clusterrolebindings, roles -> Secure admin route general infrastructure -> and standalone workbench

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using devFlags for manifest changes on my cluster side by side with another cluster with unchanged SA permissions.
### **As cluster admin:**
Homepage: same
Projects pages: same (pipeline stuff broken as expected, ignore)
DSP Page: same
Model Registry: ignore
Deploy Models: same
Pipelines: ignore
Experiments: ignore
DW: Not configured on either cluster but showing up same
Applications:
	-Enabled: same
	-Explore: same
Resources: same
Settings:
	-Notebook Images: same
	-Cluster Settings: same 
	-Accelerator Profiles: same
	-Serving Runtimes: same 
	-Connection Types: same
	-Storage Classes: same
	-Model Registry Settings: same
	-User Management: same

### **As User:**
Homepage: same
Projects pages: same (pipeline stuff broken as expected)
DSP Page: same
Model Registry: request access both
Deploy Models: no deployed models
Pipelines: enable pipelines
Experiments: enable pipelines
DW: Not configured on either cluster but showing up same
Applications:
	-Enabled: same
	-Explore: same
Resources: same
Settings: not visible on either

### **As regular admin:**
Homepage: same
Projects pages: same
DSP Page: same
Model Registry: request access both
Deploy Models: same
Pipelines: enable pipelines
Experiments: enable pipelines
DW: Not configured on either cluster but showing up same
Applications:
	-Enabled: same
	-Explore: same
Resources: same
Settings:
	-User Management: ‘Can’t find that page’ on both?

If you want to test this:
-Grab this -> "https://github.com/katieperry4/odh-dashboard/tarball/16858/SA-permissions"
-Go to your cluster
-Operators > installed operators > Open data hub operator > data science cluster > default-dsc > YAML
-Find 

>  spec:
      components:
          dashboard:

-Edit it to be like this:

>     dashboard:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/katieperry4/odh-dashboard/tarball/16858/SA-permissions'
      managementState: Managed

Open ODH via openshift console

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
