### PR TITLE
Remove superfluous secureRoute usages

### DIFF
--- a/backend/src/routes/api/connection-types/index.ts
+++ b/backend/src/routes/api/connection-types/index.ts
@@ -1,7 +1,7 @@
 import { V1ConfigMap } from '@kubernetes/client-node';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { KubeFastifyInstance, RecursivePartial } from '../../../types';
-import { secureAdminRoute, secureRoute } from '../../../utils/route-security';
+import { secureAdminRoute } from '../../../utils/route-security';
 import {
   getConnectionType,
   listConnectionTypes,
@@ -12,27 +12,22 @@ import {
 } from './connectionTypeUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  fastify.get(
-    '/',
-    secureRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) =>
-      listConnectionTypes(fastify)
-        .then((res) => res)
-        .catch((res) => {
-          reply.send(res);
-        }),
-    ),
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) =>
+    listConnectionTypes(fastify)
+      .then((res) => res)
+      .catch((res) => {
+        reply.send(res);
+      }),
   );
 
   fastify.get(
     '/:name',
-    secureRoute(fastify)(
-      async (request: FastifyRequest<{ Params: { name: string } }>, reply: FastifyReply) =>
-        getConnectionType(fastify, request.params.name)
-          .then((res) => res)
-          .catch((res) => {
-            reply.send(res);
-          }),
-    ),
+    async (request: FastifyRequest<{ Params: { name: string } }>, reply: FastifyReply) =>
+      getConnectionType(fastify, request.params.name)
+        .then((res) => res)
+        .catch((res) => {
+          reply.send(res);
+        }),
   );
 
   fastify.post(

--- a/backend/src/routes/api/docs/index.ts
+++ b/backend/src/routes/api/docs/index.ts
@@ -1,17 +1,13 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { listDocs } from './list';
-import { secureRoute } from '../../../utils/route-security';
 import { KubeFastifyInstance } from '../../../types';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  fastify.get(
-    '/',
-    secureRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) =>
-      listDocs(fastify, request)
-        .then((res) => res)
-        .catch((res) => {
-          reply.send(res);
-        }),
-    ),
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) =>
+    listDocs(fastify, request)
+      .then((res) => res)
+      .catch((res) => {
+        reply.send(res);
+      }),
   );
 };

--- a/backend/src/routes/api/dsc/index.ts
+++ b/backend/src/routes/api/dsc/index.ts
@@ -1,10 +1,6 @@
 import { KubeFastifyInstance } from '../../../types';
-import { secureRoute } from '../../../utils/route-security';
 import { getClusterStatus } from '../../../utils/resourceUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  fastify.get(
-    '/status',
-    secureRoute(fastify)(async () => getClusterStatus(fastify)),
-  );
+  fastify.get('/status', async () => getClusterStatus(fastify));
 };

--- a/backend/src/routes/api/dsci/index.ts
+++ b/backend/src/routes/api/dsci/index.ts
@@ -1,10 +1,6 @@
 import { getClusterInitialization } from '../../../utils/dsci';
 import { KubeFastifyInstance } from '../../../types';
-import { secureRoute } from '../../../utils/route-security';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  fastify.get(
-    '/status',
-    secureRoute(fastify)(async () => getClusterInitialization(fastify)),
-  );
+  fastify.get('/status', async () => getClusterInitialization(fastify));
 };

--- a/backend/src/routes/api/quickstarts/index.ts
+++ b/backend/src/routes/api/quickstarts/index.ts
@@ -1,17 +1,13 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { listQuickStarts } from './list';
 import { KubeFastifyInstance } from '../../../types';
-import { secureRoute } from '../../../utils/route-security';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  fastify.get(
-    '/',
-    secureRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) =>
-      listQuickStarts()
-        .then((res) => res)
-        .catch((res) => {
-          reply.send(res);
-        }),
-    ),
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) =>
+    listQuickStarts()
+      .then((res) => res)
+      .catch((res) => {
+        reply.send(res);
+      }),
   );
 };

--- a/backend/src/routes/api/segment-key/index.ts
+++ b/backend/src/routes/api/segment-key/index.ts
@@ -1,19 +1,15 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { getSegmentKey } from './segmentKeyUtils';
-import { secureRoute } from '../../../utils/route-security';
 import { KubeFastifyInstance } from '../../../types';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  fastify.get(
-    '/',
-    secureRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
-      return getSegmentKey(fastify)
-        .then((res) => {
-          return res;
-        })
-        .catch((res) => {
-          reply.send(res);
-        });
-    }),
-  );
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return getSegmentKey(fastify)
+      .then((res) => {
+        return res;
+      })
+      .catch((res) => {
+        reply.send(res);
+      });
+  });
 };

--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -1,23 +1,20 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { status } from './statusUtils';
 import { getAllowedUsers } from './adminAllowedUsers';
-import { secureAdminRoute, secureRoute } from '../../../utils/route-security';
+import { secureAdminRoute } from '../../../utils/route-security';
 import { KubeFastifyInstance } from '../../../types';
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  fastify.get(
-    '/',
-    secureRoute(fastify)(async (request: FastifyRequest, reply: FastifyReply) => {
-      return status(fastify, request)
-        .then((res) => {
-          return res;
-        })
-        .catch((e) => {
-          fastify.log.error(`Failed to get status, ${e.response?.body?.message || e.message}}`);
-          reply.send(e.response?.body?.message || e.message);
-        });
-    }),
-  );
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return status(fastify, request)
+      .then((res) => {
+        return res;
+      })
+      .catch((e) => {
+        fastify.log.error(`Failed to get status, ${e.response?.body?.message || e.message}}`);
+        reply.send(e.response?.body?.message || e.message);
+      });
+  });
 
   fastify.get(
     '/:namespace/allowedUsers',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-16091

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Cleanup of superfluous secureRoute usages -- the only use-case for this utility is to help secure jupyter tile endpoints... other usages are invalid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With the nodejs backend -- locally via `:ext` or hosting an image. 

Testing the corresponding areas of the app that match for the routes modified.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
