### PR TITLE
[RHOAIENG-23666] Fix dark mode styling for "Registered from" link in Model Registry

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -164,11 +164,7 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
           )}
           {catalogModelDetailsUrl && (
             <DashboardDescriptionListGroup title="Registered from" isEmpty={!mv.id}>
-              <Link
-                to={catalogModelDetailsUrl}
-                data-testid="registered-from-catalog"
-                style={{ color: 'var(--pf-t--global--link--Color)', textDecoration: 'none' }}
-              >
+              <Link to={catalogModelDetailsUrl} data-testid="registered-from-catalog">
                 <span style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}>
                   {catalogModelCustomProps.modelName} ({catalogModelCustomProps.tag})
                 </span>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsView.tsx
@@ -164,7 +164,11 @@ const ModelVersionDetailsView: React.FC<ModelVersionDetailsViewProps> = ({
           )}
           {catalogModelDetailsUrl && (
             <DashboardDescriptionListGroup title="Registered from" isEmpty={!mv.id}>
-              <Link to={catalogModelDetailsUrl} data-testid="registered-from-catalog">
+              <Link
+                to={catalogModelDetailsUrl}
+                data-testid="registered-from-catalog"
+                style={{ color: 'var(--pf-t--global--link--Color)', textDecoration: 'none' }}
+              >
                 <span style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}>
                   {catalogModelCustomProps.modelName} ({catalogModelCustomProps.tag})
                 </span>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionPipelineDescription.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionPipelineDescription.tsx
@@ -52,7 +52,6 @@ const ModelVersionPipelineDescription: React.FC<ModelVersionPipelineDescriptionP
         <TypedObjectIcon
           resourceType={ProjectObjectType.project}
           style={{ height: 24, width: 24 }}
-          useTypedColor
         />
       </FlexItem>
       <FlexItem>

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionPipelineDescription.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionPipelineDescription.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { Button, Content, Flex, FlexItem, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { globalPipelineRunDetailsRoute } from '~/routes';
-import { ProjectObjectType, typedObjectImage } from '~/concepts/design/utils';
+import TypedObjectIcon from '~/concepts/design/TypedObjectIcon';
+import { ProjectObjectType } from '~/concepts/design/utils';
 import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import { FindAdministratorOptions } from '~/pages/projects/screens/projects/const';
 import PopoverListContent from '~/components/PopoverListContent';
+import { globalPipelineRunDetailsRoute } from '~/routes';
 import { PipelineModelCustomProps } from './const';
 
 type ModelVersionPipelineDescriptionProps = {
@@ -48,7 +49,11 @@ const ModelVersionPipelineDescription: React.FC<ModelVersionPipelineDescriptionP
     >
       <FlexItem data-testid="pipeline-run-link">Run {renderRunLink} in</FlexItem>
       <FlexItem style={{ display: 'flex' }}>
-        <img style={{ height: 24 }} src={typedObjectImage(ProjectObjectType.project)} alt="" />
+        <TypedObjectIcon
+          resourceType={ProjectObjectType.project}
+          style={{ height: 24, width: 24 }}
+          useTypedColor
+        />
       </FlexItem>
       <FlexItem>
         <b>{renderProject}</b>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-23666

## Description
This PR fixes the dark mode styling issue for the "Registered from" link in the Model Registry's Model Version Details view. The current implementation doesn't properly handle dark mode theming, making the link difficult to read. The fix implements proper PatternFly theme variables to ensure consistent visibility and styling in both light and dark modes.

Changes made:
- Added PatternFly theme variable `--pf-t--global--link--Color` for link color
- Removed default text decoration for cleaner appearance
- Maintained bold font weight using PatternFly theme variable

## How Has This Been Tested?
Testing was performed in the following environments:
- Local development environment
- Browser: Chrome and Firefox
- Both light and dark mode settings

Testing steps:
1. Open Model Registry
2. Navigate to a model version that was registered from the Model Catalog
3. Switch between light and dark modes
4. Verify that the "Registered from" link is clearly visible in both modes
5. Verify that the link styling (color, weight, decoration) is consistent with PatternFly design system

## Test Impact
The changes are primarily visual and affect the styling of links in the Model Registry. The functionality remains unchanged. Testing focuses on visual verification of the styling changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has explained why testing cannot be added (changes are purely CSS-based using PatternFly variables)

UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change
- [ ] Included tags to the UX team if it was a UI/UX change

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`