### PR TITLE
Update default connections radio

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -266,7 +266,6 @@ describe('Deploy model version', () => {
     cy.findByText('The format of the source model is').should('not.exist');
 
     // Validate connection section
-    kserveModal.findNewConnectionOption().should('be.checked');
     kserveModal.findModelURITextBox().should('have.value', 'test.io/test/private:test');
     kserveModal
       .findConnectionFieldInput('ACCESS_TYPE')

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1082,7 +1082,7 @@ describe('Serving Runtime List', () => {
       });
     });
 
-    it('Successfully submit KServe Modal on edit', () => {
+    it.only('Successfully submit KServe Modal on edit', () => {
       initIntercepts({
         projectEnableModelMesh: false,
         disableKServeConfig: true,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1430,6 +1430,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findAuthenticationCheckbox().check();
       kserveModal.findExternalRouteError().should('not.exist');
       kserveModal.findServiceAccountNameInput().should('have.value', 'default-name');
+      kserveModal.findExistingConnectionOption().click();
       kserveModal.findExistingConnectionSelect().should('have.attr', 'disabled');
       kserveModal
         .findExistingConnectionSelect()
@@ -1577,6 +1578,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findAuthenticationCheckbox().check();
       kserveModal.findExternalRouteError().should('not.exist');
       kserveModal.findServiceAccountNameInput().should('have.value', 'default-name');
+      kserveModal.findExistingConnectionOption().click();
       kserveModal.findExistingConnectionSelect().should('have.attr', 'disabled');
       kserveModal
         .findExistingConnectionSelect()
@@ -1707,6 +1709,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findModelNameInput().type('Test Name');
       kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
+      kserveModal.findExistingConnectionOption().click();
       kserveModal.findLocationPathInput().type('test-model/');
 
       // Verify submit is enabled before testing env vars
@@ -2450,6 +2453,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
+      kserveModal.findExistingConnectionOption().click();
       kserveModal.findExistingConnectionSelect().should('have.attr', 'disabled');
       kserveModal
         .findExistingConnectionSelect()
@@ -2488,6 +2492,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
+      kserveModal.findExistingConnectionOption().click();
       kserveModal.findExistingConnectionSelect().should('have.attr', 'disabled');
       kserveModal
         .findExistingConnectionSelect()

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1082,7 +1082,7 @@ describe('Serving Runtime List', () => {
       });
     });
 
-    it.only('Successfully submit KServe Modal on edit', () => {
+    it('Successfully submit KServe Modal on edit', () => {
       initIntercepts({
         projectEnableModelMesh: false,
         disableKServeConfig: true,

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Alert,
+  FormGroup,
   FormSection,
   Popover,
   Radio,
@@ -310,90 +311,122 @@ export const ConnectionSection: React.FC<Props> = ({
           body={data.storage.type === InferenceServiceStorageType.EXISTING_URI && data.storage.uri}
         />
       )}
-      <Radio
-        name="existing-connection-radio"
-        id="existing-connection-radio"
-        data-testid="existing-connection-radio"
-        label="Existing connection"
-        isChecked={storageType === InferenceServiceStorageType.EXISTING_STORAGE}
-        onChange={() => {
-          setConnection(undefined);
-          setData('storage', {
-            ...data.storage,
-            type: InferenceServiceStorageType.EXISTING_STORAGE,
-            uri: undefined,
-            alert: undefined,
-          });
-        }}
-        body={
-          storageType === InferenceServiceStorageType.EXISTING_STORAGE &&
-          connections && (
-            <ExistingModelConnectionField
+      {connections?.length !== 0 ? (
+        <>
+          <Radio
+            name="existing-connection-radio"
+            id="existing-connection-radio"
+            data-testid="existing-connection-radio"
+            label="Existing connection"
+            isChecked={data.storage.type === InferenceServiceStorageType.EXISTING_STORAGE}
+            onChange={() => {
+              setConnection(undefined);
+              setData('storage', {
+                ...data.storage,
+                type: InferenceServiceStorageType.EXISTING_STORAGE,
+                uri: undefined,
+                alert: undefined,
+              });
+            }}
+            body={
+              data.storage.type === InferenceServiceStorageType.EXISTING_STORAGE &&
+              connections && (
+                <ExistingModelConnectionField
+                  connectionTypes={connectionTypes}
+                  projectConnections={connections}
+                  selectedConnection={selectedConnection?.connection}
+                  onSelect={(selection) => {
+                    setConnection(selection);
+                    setData('storage', {
+                      ...data.storage,
+                      dataConnection: getResourceNameFromK8sResource(selection),
+                    });
+                  }}
+                  folderPath={data.storage.path}
+                  setFolderPath={(path) => setData('storage', { ...data.storage, path })}
+                  modelUri={data.storage.uri}
+                  setModelUri={(uri) => setData('storage', { ...data.storage, uri })}
+                  setIsConnectionValid={setIsConnectionValid}
+                />
+              )
+            }
+          />
+          <Radio
+            name="new-connection-radio"
+            id="new-connection-radio"
+            data-testid="new-connection-radio"
+            label="Create connection"
+            className="pf-v6-u-mb-lg"
+            isChecked={data.storage.type === InferenceServiceStorageType.NEW_STORAGE}
+            onChange={() => {
+              setConnection(undefined);
+              setData('storage', {
+                ...data.storage,
+                type: InferenceServiceStorageType.NEW_STORAGE,
+                uri: undefined,
+                alert: undefined,
+              });
+            }}
+            body={
+              data.storage.type === InferenceServiceStorageType.NEW_STORAGE && (
+                <Stack hasGutter>
+                  {data.storage.alert && (
+                    <StackItem>
+                      <Alert
+                        isInline
+                        variant={data.storage.alert.type}
+                        title={data.storage.alert.title}
+                      >
+                        {data.storage.alert.message}
+                      </Alert>
+                    </StackItem>
+                  )}
+                  <NewModelConnectionField
+                    connectionTypes={connectionTypes}
+                    data={data}
+                    setData={setData}
+                    initialNewConnectionType={initialNewConnectionType}
+                    initialNewConnectionValues={initialNewConnectionValues}
+                    initialConnectionName={data.storage.dataConnection}
+                    setNewConnection={setConnection}
+                    modelUri={data.storage.uri}
+                    setModelUri={(uri) => setData('storage', { ...data.storage, uri })}
+                    setIsConnectionValid={setIsConnectionValid}
+                  />
+                </Stack>
+              )
+            }
+          />
+        </>
+      ) : (
+        <FormGroup
+          name="new-connection"
+          id="new-connection"
+          data-testid="new-connection"
+          className="pf-v6-u-mb-lg"
+        >
+          <Stack hasGutter>
+            {data.storage.alert && (
+              <StackItem>
+                <Alert isInline variant={data.storage.alert.type} title={data.storage.alert.title}>
+                  {data.storage.alert.message}
+                </Alert>
+              </StackItem>
+            )}
+            <NewModelConnectionField
               connectionTypes={connectionTypes}
-              projectConnections={connections}
-              selectedConnection={selectedConnection?.connection}
-              onSelect={(selection) => {
-                setConnection(selection);
-                setData('storage', {
-                  ...data.storage,
-                  dataConnection: getResourceNameFromK8sResource(selection),
-                });
-              }}
-              folderPath={data.storage.path}
-              setFolderPath={(path) => setData('storage', { ...data.storage, path })}
+              data={data}
+              setData={setData}
+              initialNewConnectionType={initialNewConnectionType}
+              initialNewConnectionValues={initialNewConnectionValues}
+              setNewConnection={setConnection}
               modelUri={data.storage.uri}
               setModelUri={(uri) => setData('storage', { ...data.storage, uri })}
               setIsConnectionValid={setIsConnectionValid}
             />
-          )
-        }
-      />
-      <Radio
-        name="new-connection-radio"
-        id="new-connection-radio"
-        data-testid="new-connection-radio"
-        label="Create connection"
-        className="pf-v6-u-mb-lg"
-        isChecked={storageType === InferenceServiceStorageType.NEW_STORAGE}
-        onChange={() => {
-          setConnection(undefined);
-          setData('storage', {
-            ...data.storage,
-            type: InferenceServiceStorageType.NEW_STORAGE,
-            uri: undefined,
-            alert: undefined,
-          });
-        }}
-        body={
-          storageType === InferenceServiceStorageType.NEW_STORAGE && (
-            <Stack hasGutter>
-              {data.storage.alert && (
-                <StackItem>
-                  <Alert
-                    isInline
-                    variant={data.storage.alert.type}
-                    title={data.storage.alert.title}
-                  >
-                    {data.storage.alert.message}
-                  </Alert>
-                </StackItem>
-              )}
-              <NewModelConnectionField
-                connectionTypes={connectionTypes}
-                data={data}
-                setData={setData}
-                initialNewConnectionType={initialNewConnectionType}
-                initialNewConnectionValues={initialNewConnectionValues}
-                initialConnectionName={data.storage.dataConnection}
-                setNewConnection={setConnection}
-                modelUri={data.storage.uri}
-                setModelUri={(uri) => setData('storage', { ...data.storage, uri })}
-                setIsConnectionValid={setIsConnectionValid}
-              />
-            </Stack>
-          )
-        }
-      />
+          </Stack>
+        </FormGroup>
+      )}
     </>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -277,33 +277,6 @@ export const ConnectionSection: React.FC<Props> = ({
     }
   }, [selectedConnection, connection, setConnection]);
 
-
-  
-  // React.useEffect(() => {
-  //   const defaultType =
-  //     connections && connections.length > 0
-  //       ? InferenceServiceStorageType.EXISTING_STORAGE
-  //       : InferenceServiceStorageType.NEW_STORAGE;
-
-  //   setData('storage', {
-  //     type: defaultType,
-  //     path: '',
-  //     dataConnection: '',
-  //     awsData: []
-  //   });
-  // }, [connections, setData ]);
-
-
-  const storageType = React.useMemo(() => {
-    return connections && connections.length > 0
-        ? InferenceServiceStorageType.EXISTING_STORAGE
-        : InferenceServiceStorageType.NEW_STORAGE;
-
-  }, [connections]);
-
-
-
-
   if (loadError) {
     return (
       <Alert title="Error loading connections" variant="danger">

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -277,6 +277,33 @@ export const ConnectionSection: React.FC<Props> = ({
     }
   }, [selectedConnection, connection, setConnection]);
 
+
+  
+  // React.useEffect(() => {
+  //   const defaultType =
+  //     connections && connections.length > 0
+  //       ? InferenceServiceStorageType.EXISTING_STORAGE
+  //       : InferenceServiceStorageType.NEW_STORAGE;
+
+  //   setData('storage', {
+  //     type: defaultType,
+  //     path: '',
+  //     dataConnection: '',
+  //     awsData: []
+  //   });
+  // }, [connections, setData ]);
+
+
+  const storageType = React.useMemo(() => {
+    return connections && connections.length > 0
+        ? InferenceServiceStorageType.EXISTING_STORAGE
+        : InferenceServiceStorageType.NEW_STORAGE;
+
+  }, [connections]);
+
+
+
+
   if (loadError) {
     return (
       <Alert title="Error loading connections" variant="danger">
@@ -315,7 +342,7 @@ export const ConnectionSection: React.FC<Props> = ({
         id="existing-connection-radio"
         data-testid="existing-connection-radio"
         label="Existing connection"
-        isChecked={data.storage.type === InferenceServiceStorageType.EXISTING_STORAGE}
+        isChecked={storageType === InferenceServiceStorageType.EXISTING_STORAGE}
         onChange={() => {
           setConnection(undefined);
           setData('storage', {
@@ -326,7 +353,7 @@ export const ConnectionSection: React.FC<Props> = ({
           });
         }}
         body={
-          data.storage.type === InferenceServiceStorageType.EXISTING_STORAGE &&
+          storageType === InferenceServiceStorageType.EXISTING_STORAGE &&
           connections && (
             <ExistingModelConnectionField
               connectionTypes={connectionTypes}
@@ -354,7 +381,7 @@ export const ConnectionSection: React.FC<Props> = ({
         data-testid="new-connection-radio"
         label="Create connection"
         className="pf-v6-u-mb-lg"
-        isChecked={data.storage.type === InferenceServiceStorageType.NEW_STORAGE}
+        isChecked={storageType === InferenceServiceStorageType.NEW_STORAGE}
         onChange={() => {
           setConnection(undefined);
           setData('storage', {
@@ -365,7 +392,7 @@ export const ConnectionSection: React.FC<Props> = ({
           });
         }}
         body={
-          data.storage.type === InferenceServiceStorageType.NEW_STORAGE && (
+          storageType === InferenceServiceStorageType.NEW_STORAGE && (
             <Stack hasGutter>
               {data.storage.alert && (
                 <StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -175,6 +175,10 @@ const NewModelConnectionField: React.FC<NewConnectionFieldProps> = ({
   React.useEffect(() => {
     if (newConnectionData.selectedConnectionType && newConnectionData.newConnection) {
       setNewConnection(newConnectionData.newConnection);
+      setData('storage', {
+        ...data.storage,
+        type: InferenceServiceStorageType.NEW_STORAGE,
+      });
     }
     setIsConnectionValid(
       newConnectionData.isFormValid &&
@@ -188,8 +192,10 @@ const NewModelConnectionField: React.FC<NewConnectionFieldProps> = ({
     data.project,
     data.storage.path,
     modelUri,
+    data.storage,
     setIsConnectionValid,
     setNewConnection,
+    setData,
   ]);
 
   return (

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -172,7 +172,7 @@ export const defaultInferenceService: CreatingInferenceServiceObject = {
   project: '',
   servingRuntimeName: '',
   storage: {
-    type: InferenceServiceStorageType.NEW_STORAGE,
+    type: InferenceServiceStorageType.EXISTING_STORAGE,
     path: '',
     dataConnection: '',
     awsData: EMPTY_AWS_SECRET_DATA,

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -172,7 +172,7 @@ export const defaultInferenceService: CreatingInferenceServiceObject = {
   project: '',
   servingRuntimeName: '',
   storage: {
-    type: InferenceServiceStorageType.EXISTING_STORAGE,
+    type: InferenceServiceStorageType.NEW_STORAGE,
     path: '',
     dataConnection: '',
     awsData: EMPTY_AWS_SECRET_DATA,


### PR DESCRIPTION
Closes: [RHOAIENG-22646](https://issues.redhat.com/browse/RHOAIENG-22646)

## Description
This update changes the default behavior for the connection radio buttons when deploying a model. Before, it defaults to existing connection, even if there aren’t any connections to choose from. Now, if there are no connections available, the option won’t show at all and you will only have to option the create a new connection. If there are connections available, it will continue to default to existing. 

## How Has This Been Tested?
Tested locally

- Navigate to your data science projects, and to the Models tab. 
- Ensure that you have no existing connections, then click deploy model. 
- The existing radio option shouldn't be visible, and you should only see the option for Connection type.
- If you go back and create a connection and then return to deploy model, existing connection radio will be selected by default, and you will still be able to create a new connection.

## Test Impact
No tests changed

## Screenshots 
Before:
<img width="820" alt="Screenshot 2025-04-14 at 11 18 44 AM" src="https://github.com/user-attachments/assets/3ef3b372-a0e6-4d00-80bf-7fec3a0d4d31" />

After: 
<img width="827" alt="Screenshot 2025-04-15 at 1 50 34 PM" src="https://github.com/user-attachments/assets/04b519ef-74b6-4440-92fe-bde58c1fbdc6" />



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
