### PR TITLE
Fix (2.16.2): consistency of NIM status between explore and enabled pages  + Enable button spinner for non-admin user

### DIFF
--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -13,6 +13,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { OdhApplication } from '~/types';
 import { EnableApplicationStatus, useEnableApplication } from '~/utilities/useEnableApplication';
 import { asEnumMember } from '~/utilities/utils';
+import { getIntegrationAppEnablementStatus } from '~/services/integrationAppService';
 import EnableVariable from './EnableVariable';
 import './EnableModal.scss';
 
@@ -20,17 +21,6 @@ type EnableModalProps = {
   selectedApp: OdhApplication;
   shown: boolean;
   onClose: () => void;
-};
-
-// Poll /api/integrations/nim to confirm backend enablement
-const fetchNimIntegrationStatus = async (): Promise<boolean> => {
-  try {
-    const res = await fetch('/api/integrations/nim');
-    const data = await res.json();
-    return data?.isEnabled === true;
-  } catch {
-    return false;
-  }
 };
 
 const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }) => {
@@ -64,10 +54,14 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
   };
 
   React.useEffect(() => {
-    if (validationInProgress && validationStatus === EnableApplicationStatus.SUCCESS) {
+    if (
+      validationInProgress &&
+      validationStatus === EnableApplicationStatus.SUCCESS &&
+      selectedApp.spec.internalRoute
+    ) {
       const interval = setInterval(async () => {
-        const isEnabled = await fetchNimIntegrationStatus();
-        if (isEnabled) {
+        const result = await getIntegrationAppEnablementStatus(selectedApp.spec.internalRoute!);
+        if (result.isEnabled === true) {
           clearInterval(interval);
           clearTimeout(timeout);
           setValidationInProgress(false);
@@ -76,7 +70,8 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
       }, 1000);
 
       const timeout = setTimeout(() => {
-        const timeoutError = 'Validation failed: The API key was not accepted by the backend.';
+        const timeoutError =
+          'Validation failed: The API key was not accepted by the backend. Contact your admin.';
         clearInterval(interval);
         setPostError(timeoutError);
         setValidationInProgress(false);
@@ -99,17 +94,14 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
     validationStatus,
     validationErrorMessage,
     onClose,
+    selectedApp.spec.internalRoute,
     selectedApp.metadata.name,
   ]);
 
   React.useEffect(() => {
     if (shown && !validationInProgress) {
-      const isTimeoutError = postError.includes(
-        'The API key was not accepted by the backend. Contact your admin.',
-      );
-      const isNim = selectedApp.metadata.name === 'nvidia-nim';
-
-      if (!(isNim && isTimeoutError)) {
+      const isTimeoutError = postError.includes('The API key was not accepted by the backend');
+      if (!isTimeoutError) {
         setPostError('');
       }
     }
@@ -151,18 +143,18 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
         </Button>,
       ]}
     >
-      {enable.description ? enable.description : null}
-      {enable.link ? (
+      {enable.description && <div>{enable.description}</div>}
+      {enable.link && (
         <div className="odh-enable-modal__enable-link">
-          {enable.linkPreface ? <div>{enable.linkPreface}</div> : null}
+          {enable.linkPreface && <div>{enable.linkPreface}</div>}
           <a href={enable.link} target="_blank" rel="noopener noreferrer">
             {enable.link} <ExternalLinkAltIcon />
           </a>
         </div>
-      ) : null}
-      {enable.variables ? (
+      )}
+      {enable.variables && (
         <Form>
-          {postError ? (
+          {postError && (
             <FormAlert>
               <Alert
                 variantLabel="error"
@@ -174,8 +166,8 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
                 {postError}
               </Alert>
             </FormAlert>
-          ) : null}
-          {validationInProgress ? (
+          )}
+          {validationInProgress && (
             <FormAlert>
               <Alert
                 className="m-no-alert-icon"
@@ -190,7 +182,7 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
                 isInline
               />
             </FormAlert>
-          ) : null}
+          )}
           {Object.keys(enable.variables).map((key, index) => (
             <EnableVariable
               key={key}
@@ -206,7 +198,7 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
             />
           ))}
         </Form>
-      ) : null}
+      )}
     </Modal>
   );
 };

--- a/frontend/src/pages/exploreApplication/useIntegratedAppStatus.ts
+++ b/frontend/src/pages/exploreApplication/useIntegratedAppStatus.ts
@@ -9,8 +9,8 @@ export const useIntegratedAppStatus = (app?: OdhApplication): FetchState<Integra
     if (!app) {
       return Promise.reject(new NotReadyError('Need an app to check'));
     }
+
     if (!isIntegrationApp(app)) {
-      // Silently ignore apps who aren't an integration app -- the logic is not needed
       return Promise.resolve({
         isInstalled: false,
         isEnabled: false,

--- a/frontend/src/utilities/useEnableApplication.tsx
+++ b/frontend/src/utilities/useEnableApplication.tsx
@@ -32,16 +32,20 @@ export const useEnableApplication = (
   const dispatchResults = React.useCallback(
     (error?: string) => {
       if (!error) {
-        dispatch(
-          addNotification({
-            status: AlertVariant.success,
-            title: `${appName} has been added to the Enabled page.`,
-            timestamp: new Date(),
-          }),
-        );
+        // Skip notification for NVIDIA NIM; inline message will handle it
+        if (appId !== 'nvidia-nim') {
+          dispatch(
+            addNotification({
+              status: AlertVariant.success,
+              title: `${appName} has been added to the Enabled page.`,
+              timestamp: new Date(),
+            }),
+          );
+        }
         dispatch(forceComponentsUpdate());
         return;
       }
+
       dispatch(
         addNotification({
           status: AlertVariant.danger,
@@ -51,7 +55,7 @@ export const useEnableApplication = (
         }),
       );
     },
-    [appName, dispatch],
+    [appId, appName, dispatch],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Related to the following:
https://issues.redhat.com/browse/NVPE-229
https://issues.redhat.com/browse/NVPE-233
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In OpenShift AI 2.16, when enabling NVIDIA NIM from the Explore page, the app appeared to be enabled immediately without actually waiting for the real backend response. Not only that, but in the Enabled page it didn't show up or was shown as disabled. After my fix, NIM now appears on the Enabled page only after it is truly enabled, and users no longer get false-positive UI states. In addition, the "Enble" button disappears after enabling. In addition, in case the user is a non-admin user, there won't be an option for the user to enable NIM. (There won't be an "Enable" button)
This created an inconsistent and confusing user experience.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Go to the Explore page and choose NIM.
2. Click the Enable button.
3. You should get success message and the button should disappear if key is valid.
4. Go to Enabled page and make sure NIM is there as enabled.

Regarding the second issue:
1. Log in with a non-admin user.
2. Go to the Explore page and choose NIM.
3. Enable button should not be seen.

https://github.com/user-attachments/assets/efff5e1d-4d97-4123-b7bb-5f0b3fba6b02


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
