### PR TITLE
Fix(RHOAIENG-23406): Datalabel removal for kebab menus

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
@@ -57,7 +57,7 @@ const ExperimentTableRow: React.FC<ExperimentTableRowProps> = ({
       <Td dataLabel="Last 5 runs">
         <LastExperimentRuns experiment={experiment} />
       </Td>
-      <Td isActionCell dataLabel="Kebab">
+      <Td isActionCell>
         <ActionsColumn items={actionColumnItems} />
       </Td>
     </Tr>

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
@@ -102,7 +102,7 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
       <Td dataLabel="Created">
         <RecurringRunCreated recurringRun={recurringRun} />
       </Td>
-      <Td isActionCell dataLabel="Kebab">
+      <Td isActionCell>
         <ActionsColumn
           items={[
             ...(!version

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -183,7 +183,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
       </Td>
       {customCells}
       {hasRowActions && (
-        <Td isActionCell dataLabel="Kebab">
+        <Td isActionCell>
           <ActionsColumn
             data-testid="pipeline-run-table-row-actions"
             items={actions}

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -109,7 +109,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
       </Td>
 
       {columnNames.includes(ColumnField.Kebab) && (
-        <Td dataLabel="Kebab" isActionCell>
+        <Td isActionCell>
           <ResourceActionsColumn
             resource={inferenceService}
             items={[


### PR DESCRIPTION
Closes [RHOAIENG-23406](https://issues.redhat.com/browse/RHOAIENG-23406)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Removed the datalabel property for kebab menus in table as on mobile screens it shows up as a label.
![Group 182](https://github.com/user-attachments/assets/cd6ae8fe-4c36-4854-aebd-b766395bc434)

![Group 181](https://github.com/user-attachments/assets/7da680c9-82a3-4ce0-8fe4-23b6679a2cf2)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Visually

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
