### PR TITLE
Fix resetting issue when editing a legacy hardware profile

### DIFF
--- a/frontend/src/app/useApplicationSettings.tsx
+++ b/frontend/src/app/useApplicationSettings.tsx
@@ -17,27 +17,30 @@ export const useApplicationSettings = (): {
   const [dashboardConfig, setDashboardConfig] = React.useState<DashboardConfigKind | null>(null);
   const setRefreshMarker = useTimeBasedRefresh();
 
-  const refresh = () =>
-    fetchDashboardConfig(true)
-      .then((config) => {
-        setDashboardConfig(config);
-        setLoaded(true);
-        setLoadError(undefined);
-      })
-      .catch((e) => {
-        if (e?.response?.data?.message?.includes('Error getting Oauth Info for user')) {
-          // NOTE: this endpoint only requests oauth because of the security layer, this is not an ironclad use-case
-          // Something went wrong on the server with the Oauth, let us just log them out and refresh for them
-          /* eslint-disable-next-line no-console */
-          console.error(
-            'Something went wrong with the oauth token, please log out...',
-            e.message,
-            e,
-          );
-          return;
-        }
-        setLoadError(e);
-      });
+  const refresh = React.useCallback(
+    () =>
+      fetchDashboardConfig(true)
+        .then((config) => {
+          setDashboardConfig(config);
+          setLoaded(true);
+          setLoadError(undefined);
+        })
+        .catch((e) => {
+          if (e?.response?.data?.message?.includes('Error getting Oauth Info for user')) {
+            // NOTE: this endpoint only requests oauth because of the security layer, this is not an ironclad use-case
+            // Something went wrong on the server with the Oauth, let us just log them out and refresh for them
+            /* eslint-disable-next-line no-console */
+            console.error(
+              'Something went wrong with the oauth token, please log out...',
+              e.message,
+              e,
+            );
+            return;
+          }
+          setLoadError(e);
+        }),
+    [],
+  );
 
   React.useEffect(() => {
     let watchHandle: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-22859](https://issues.redhat.com/browse/RHOAIENG-22859)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The problem in the ticket is because the editing page for the legacy hardware profiles keeps resetting to the old value every few seconds. The value could just be reset when the user migrates the hardware profile.
Tracing it back, I found the `existingHardwareProfile` that's passed to the editing page is not reference-stable. Thus it keeps triggering the initial form value setting hook.
Then tracing it back more, I found the `refresh` function in `useApplicationSettings` is not using `React.useCallback`, thus it's not reference stable. However, it's used as the dependency when we create the `migratedHardwareProfiles`.
Make it reference-stable fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the hardware profile settings page
2. Edit a legacy hardware profile
3. Change the identifier sizes in the "Resource requests and limits" section
4. Submit and confirm migration
5. Check the hardware profile identifier section after migration, make sure the values are updated

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
