### PR TITLE
Horizontally align usage bar in distributed workload resource metrics

### DIFF
--- a/frontend/src/components/ProgressBarWithLabels.tsx
+++ b/frontend/src/components/ProgressBarWithLabels.tsx
@@ -12,24 +12,30 @@ import './ProgressBarWithLabels.scss';
 type ProgressBarWithLabelsProps = Omit<ProgressProps, 'ref' | 'measureLocation'> & {
   inUseLabel: React.ReactNode;
   maxValueLabel: number | string;
+  textMinWidth?: string;
   contentComponentVariant?: ContentVariants;
 };
 
 const ProgressBarWithLabels: React.FC<ProgressBarWithLabelsProps> = ({
   inUseLabel,
   maxValueLabel,
+  textMinWidth,
   contentComponentVariant,
   ...props
 }) => (
   <Flex alignItems={{ default: 'alignItemsCenter' }}>
     <FlexItem>
-      <Content component={contentComponentVariant}>{inUseLabel}</Content>
+      <Content style={{ minWidth: textMinWidth }} component={contentComponentVariant}>
+        {inUseLabel}
+      </Content>
     </FlexItem>
     <FlexItem grow={{ default: 'grow' }}>
       <Progress measureLocation="none" className="progress-bar" {...props} />
     </FlexItem>
     <FlexItem>
-      <Content component={contentComponentVariant}>{maxValueLabel}</Content>
+      <Content style={{ minWidth: textMinWidth }} component={contentComponentVariant}>
+        {maxValueLabel}
+      </Content>
     </FlexItem>
   </Flex>
 );

--- a/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.tsx
+++ b/frontend/src/pages/distributedWorkloads/components/WorkloadResourceUsageBar.tsx
@@ -38,6 +38,7 @@ export const WorkloadResourceUsageBar: React.FC<WorkloadResourceUsageBarProps> =
       }
     >
       <ProgressBarWithLabels
+        textMinWidth="30px"
         inUseLabel={roundNumber(used)}
         maxValueLabel={roundNumber(requested)}
         value={used}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-6500

## Description

The usage bar is now horizontally aligned in distributed workload resource metrics

![Screenshot 2025-04-21 at 3 56 14 PM](https://github.com/user-attachments/assets/2bed2b13-d819-4fee-8304-a762e0f944bb)

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Run the distributed workload having a jobd which has some requested cpu and memory
- Go to the project tab and check if all the usage bar are aligned horizontally 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A Just a width change 
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
