### PR TITLE
the tooltip arrow doesnot look distorted in memory chart

### DIFF
--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/RequestedResourcesBulletChart.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/RequestedResourcesBulletChart.tsx
@@ -104,6 +104,7 @@ export const RequestedResourcesBulletChart: React.FC<RequestedResourcesBulletCha
     <div ref={containerRef} style={{ height: `${chartHeight}px` }}>
       <svg viewBox={`0 0 ${width} ${chartHeight}`} preserveAspectRatio="none" width="100%">
         <ChartBullet
+          constrainToVisibleArea
           standalone={false}
           title={metricLabel}
           subTitle={capitalize(unitLabel)}
@@ -125,11 +126,10 @@ export const RequestedResourcesBulletChart: React.FC<RequestedResourcesBulletCha
           titlePosition="top-left"
           legendPosition="bottom-left"
           legendOrientation="vertical"
-          constrainToVisibleArea
           width={width}
           padding={{
             bottom: 100, // Adjusted to accommodate legend
-            left: 50,
+            left: 100,
             right: 50,
             top: 100, // Adjusted to accommodate labels
           }}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-17069
## Description
This fixes the distortion of tooltip in memory chart under the `Project Metrics` tab in the distributed workload pages
Before:
![Screenshot 2025-04-21 at 4 33 02 PM](https://github.com/user-attachments/assets/7f38ba5c-6639-4925-8a0c-22f6869afa35)

After the changes:

![Screenshot 2025-04-21 at 4 37 18 PM](https://github.com/user-attachments/assets/11c2d244-341f-4674-8951-f38ad33beef7)


<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Go to distributed workload page under the `project metrics` tab on the requested resources card, check the tooltip if its not distorted


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
cc @kywalker-rh 
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
