### PR TITLE
Load data before rendering Deploy form, when deploying from model catalog or registry

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -122,6 +122,10 @@ class InferenceServiceModal extends Modal {
     return this.k8sNameDescription.findDisplayNameInput();
   }
 
+  findSpinner() {
+    return this.find().findByTestId('spinner');
+  }
+
   findServingRuntimeSelect() {
     return this.find().findByTestId('inference-service-model-selection');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDeploy.cy.ts
@@ -16,14 +16,16 @@ type HandlersProps = {
   catalogModels?: ModelCatalogSource[];
   modelMeshInstalled?: boolean;
   kServeInstalled?: boolean;
+  isEmpty?: boolean;
 };
 
 const initIntercepts = ({
   catalogModels = [mockModelCatalogSource({})],
   modelMeshInstalled = true,
   kServeInstalled = true,
+  isEmpty = false,
 }: HandlersProps) => {
-  initDeployPrefilledModelIntercepts({ modelMeshInstalled, kServeInstalled });
+  initDeployPrefilledModelIntercepts({ modelMeshInstalled, kServeInstalled, isEmpty });
 
   cy.interceptK8s(
     {
@@ -77,6 +79,7 @@ describe('Deploy catalog model', () => {
 
     // Validate name input field
     kserveModal.findModelNameInput().should('exist');
+    kserveModal.findModelNameInput().should('have.value', 'granite-8b-code-instruct - 1.3.0');
 
     // Validate model framework section
     kserveModal.findModelFrameworkSelect().should('be.disabled');
@@ -89,5 +92,13 @@ describe('Deploy catalog model', () => {
         'oci://registry.redhat.io/rhelai1/granite-8b-code-instruct:1.3-1732870892',
       ).should('exist');
     });
+  });
+
+  it('Deploy modal will show spinner, if the data is still loading', () => {
+    initIntercepts({ isEmpty: true });
+    modelDetailsPage.visit();
+    modelDetailsPage.findDeployModelButton().click();
+    modelCatalogDeployModal.selectProjectByName('KServe project');
+    kserveModal.findSpinner().should('exist');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -33,6 +33,7 @@ type HandlersProps = {
   kServeInstalled?: boolean;
   disableProjectScoped?: boolean;
   disableHardwareProfiles?: boolean;
+  isEmpty?: boolean;
 };
 
 const registeredModelMocked = mockRegisteredModel({ name: 'test-1' });
@@ -61,12 +62,14 @@ const initIntercepts = ({
   kServeInstalled = true,
   disableProjectScoped = true,
   disableHardwareProfiles = true,
+  isEmpty = false,
 }: HandlersProps) => {
   initDeployPrefilledModelIntercepts({
     modelMeshInstalled,
     kServeInstalled,
     disableProjectScoped,
     disableHardwareProfiles,
+    isEmpty,
   });
 
   cy.interceptK8sList(
@@ -672,5 +675,14 @@ describe('Deploy model version', () => {
       .findExistingConnectionSelectValueField()
       .findSelectOption('Test Secret Match 2 Recommended Type: URI - v1')
       .should('exist');
+  });
+
+  it('Deploy modal will show spinner, if the data is still loading', () => {
+    initIntercepts({ isEmpty: true });
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version 3');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+    kserveModal.findSpinner().should('exist');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
@@ -31,11 +31,13 @@ export const initDeployPrefilledModelIntercepts = ({
   kServeInstalled = true,
   disableProjectScoped = true,
   disableHardwareProfiles = true,
+  isEmpty = false,
 }: {
   modelMeshInstalled?: boolean;
   kServeInstalled?: boolean;
   disableProjectScoped?: boolean;
   disableHardwareProfiles?: boolean;
+  isEmpty?: boolean;
 }): void => {
   cy.interceptOdh(
     'GET /api/config',
@@ -77,31 +79,33 @@ export const initDeployPrefilledModelIntercepts = ({
 
   cy.interceptK8sList(
     TemplateModel,
-    mockK8sResourceList(
-      [
-        mockServingRuntimeTemplateK8sResource({
-          name: 'template-1',
-          displayName: 'Multi Platform',
-          platforms: [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI],
-        }),
-        mockServingRuntimeTemplateK8sResource({
-          name: 'template-2',
-          displayName: 'Caikit',
-          platforms: [ServingRuntimePlatform.SINGLE],
-        }),
-        mockServingRuntimeTemplateK8sResource({
-          name: 'template-3',
-          displayName: 'New OVMS Server',
-          platforms: [ServingRuntimePlatform.MULTI],
-        }),
-        mockServingRuntimeTemplateK8sResource({
-          name: 'template-4',
-          displayName: 'Serving Runtime with No Annotations',
-        }),
-        mockInvalidTemplateK8sResource({}),
-      ],
-      { namespace: 'opendatahub' },
-    ),
+    isEmpty
+      ? mockK8sResourceList([])
+      : mockK8sResourceList(
+          [
+            mockServingRuntimeTemplateK8sResource({
+              name: 'template-1',
+              displayName: 'Multi Platform',
+              platforms: [ServingRuntimePlatform.SINGLE, ServingRuntimePlatform.MULTI],
+            }),
+            mockServingRuntimeTemplateK8sResource({
+              name: 'template-2',
+              displayName: 'Caikit',
+              platforms: [ServingRuntimePlatform.SINGLE],
+            }),
+            mockServingRuntimeTemplateK8sResource({
+              name: 'template-3',
+              displayName: 'New OVMS Server',
+              platforms: [ServingRuntimePlatform.MULTI],
+            }),
+            mockServingRuntimeTemplateK8sResource({
+              name: 'template-4',
+              displayName: 'Serving Runtime with No Annotations',
+            }),
+            mockInvalidTemplateK8sResource({}),
+          ],
+          { namespace: 'opendatahub' },
+        ),
   );
 
   cy.interceptK8sList(

--- a/frontend/src/concepts/modelCatalog/content/ModelCatalogLabels.tsx
+++ b/frontend/src/concepts/modelCatalog/content/ModelCatalogLabels.tsx
@@ -14,19 +14,19 @@ export const ModelCatalogLabels: React.FC<{
       switch (label) {
         case ReservedILabLabel.LabBase:
           return (
-            <Label data-testid="model-catalog-label" color="yellow" variant="filled">
+            <Label key={l} data-testid="model-catalog-label" color="yellow" variant="filled">
               LAB starter
             </Label>
           );
         case ReservedILabLabel.LabTeacher:
           return (
-            <Label data-testid="model-catalog-label" color="purple" variant="filled">
+            <Label key={l} data-testid="model-catalog-label" color="purple" variant="filled">
               LAB teacher
             </Label>
           );
         case ReservedILabLabel.LabJudge:
           return (
-            <Label data-testid="model-catalog-label" color="orange" variant="filled">
+            <Label key={l} data-testid="model-catalog-label" color="orange" variant="filled">
               LAB judge
             </Label>
           );

--- a/frontend/src/concepts/modelCatalog/content/ModelCatalogLabels.tsx
+++ b/frontend/src/concepts/modelCatalog/content/ModelCatalogLabels.tsx
@@ -14,19 +14,19 @@ export const ModelCatalogLabels: React.FC<{
       switch (label) {
         case ReservedILabLabel.LabBase:
           return (
-            <Label key={l} data-testid="model-catalog-label" color="yellow" variant="filled">
+            <Label key={label} data-testid="model-catalog-label" color="yellow" variant="filled">
               LAB starter
             </Label>
           );
         case ReservedILabLabel.LabTeacher:
           return (
-            <Label key={l} data-testid="model-catalog-label" color="purple" variant="filled">
+            <Label key={label} data-testid="model-catalog-label" color="purple" variant="filled">
               LAB teacher
             </Label>
           );
         case ReservedILabLabel.LabJudge:
           return (
-            <Label key={l} data-testid="model-catalog-label" color="orange" variant="filled">
+            <Label key={label} data-testid="model-catalog-label" color="orange" variant="filled">
               LAB judge
             </Label>
           );

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -57,7 +57,6 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     useK8sNameDescriptionFieldData({ initialData: editInfo });
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
-  const [isLoading, setIsLoading] = React.useState(!!modelDeployPrefillInfo);
 
   const currentProjectName = projectContext?.currentProject.metadata.name || '';
   const currentServingRuntimeName = projectContext?.currentServingRuntime?.metadata.name || '';
@@ -69,6 +68,11 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     connectionsLoaded,
     connectionsLoadError,
   } = usePrefillModelDeployModal(projectContext, createData, setCreateData, modelDeployPrefillInfo);
+
+  const isDataReady =
+    !modelDeployPrefillInfo ||
+    (!!inferenceServiceNameDesc.name && (!projectContext || connectionsLoaded));
+  const isLoading = !isDataReady;
 
   const modelMeshConnections = React.useMemo(
     () =>
@@ -102,19 +106,10 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
   };
 
   React.useEffect(() => {
-    if (createData.name && createData.name !== inferenceServiceNameDesc.name) {
+    if (createData.name) {
       setInferenceServiceNameDesc('name', createData.name);
     }
-    setIsLoading(false);
-  }, [inferenceServiceNameDesc.name, createData.name, setInferenceServiceNameDesc]);
-
-  React.useEffect(() => {
-    if (modelDeployPrefillInfo) {
-      const isDataReady = !!inferenceServiceNameDesc.name && (!projectContext || connectionsLoaded);
-
-      setIsLoading(!isDataReady);
-    }
-  }, [inferenceServiceNameDesc.name, projectContext, connectionsLoaded, modelDeployPrefillInfo]);
+  }, [createData.name, setInferenceServiceNameDesc]);
 
   const isDisabled =
     actionInProgress ||

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, FormSection, HelperTextItem } from '@patternfly/react-core';
+import { Form, FormSection, HelperTextItem, Spinner } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import {
@@ -57,6 +57,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     useK8sNameDescriptionFieldData({ initialData: editInfo });
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
+  const [isLoading, setIsLoading] = React.useState(!!modelDeployPrefillInfo);
 
   const currentProjectName = projectContext?.currentProject.metadata.name || '';
   const currentServingRuntimeName = projectContext?.currentServingRuntime?.metadata.name || '';
@@ -99,6 +100,21 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     }
     return isConnectionValid;
   };
+
+  React.useEffect(() => {
+    if (createData.name && createData.name !== inferenceServiceNameDesc.name) {
+      setInferenceServiceNameDesc('name', createData.name);
+    }
+    setIsLoading(false);
+  }, [inferenceServiceNameDesc.name, createData.name, setInferenceServiceNameDesc]);
+
+  React.useEffect(() => {
+    if (modelDeployPrefillInfo) {
+      const isDataReady = !!inferenceServiceNameDesc.name && (!projectContext || connectionsLoaded);
+
+      setIsLoading(!isDataReady);
+    }
+  }, [inferenceServiceNameDesc.name, projectContext, connectionsLoaded, modelDeployPrefillInfo]);
 
   const isDisabled =
     actionInProgress ||
@@ -173,7 +189,8 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
             }
           />
         )}
-        {!shouldFormHidden && (
+        {!shouldFormHidden && isLoading && <Spinner />}
+        {!shouldFormHidden && !isLoading && (
           <>
             <K8sNameDescriptionField
               data={inferenceServiceNameDesc}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -162,7 +162,6 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const servingRuntimeParamsEnabled = useIsAreaAvailable(
     SupportedArea.SERVING_RUNTIME_PARAMS,
   ).status;
-  const [isLoading, setIsLoading] = React.useState(!!modelDeployPrefillInfo);
 
   React.useEffect(() => {
     if (currentProjectName) {
@@ -186,28 +185,16 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [createDataInferenceService.name, setKserveNameDesc]);
 
-  React.useEffect(() => {
-    if (modelDeployPrefillInfo) {
-      const isDataReady =
-        !!kServeNameDesc.name &&
-        Array.isArray(servingRuntimeTemplates) &&
-        servingRuntimeTemplates.length > 0 &&
-        (!projectContext || connectionsLoaded) &&
-        (podSpecOptionsState.acceleratorProfile.loaded ||
-          podSpecOptionsState.hardwareProfile.profilesLoaded);
+  const isDataReady =
+    !modelDeployPrefillInfo ||
+    (!!kServeNameDesc.name &&
+      Array.isArray(servingRuntimeTemplates) &&
+      servingRuntimeTemplates.length > 0 &&
+      (!projectContext || connectionsLoaded) &&
+      (podSpecOptionsState.acceleratorProfile.loaded ||
+        podSpecOptionsState.hardwareProfile.profilesLoaded));
 
-      setIsLoading(!isDataReady);
-    }
-  }, [
-    kServeNameDesc.name,
-    servingRuntimeTemplates,
-    projectTemplates,
-    projectContext,
-    connectionsLoaded,
-    modelDeployPrefillInfo,
-    podSpecOptionsState.acceleratorProfile.loaded,
-    podSpecOptionsState.hardwareProfile.profilesLoaded,
-  ]);
+  const isLoading = !isDataReady;
 
   // Serving Runtime Validation
   const isDisabledServingRuntime = namespace === '' || actionInProgress;


### PR DESCRIPTION
Closes: [RHOAIENG-23292](https://issues.redhat.com/browse/RHOAIENG-23292)

## Description
This PR aims to load the data fully before rendering deploy form, when deploying a model from model catalog and model registry.
1. Model catalog

https://github.com/user-attachments/assets/370cd733-5983-492f-9b8f-2403dd4a6817

2. Model Registry with kServe

https://github.com/user-attachments/assets/c6ccd7c6-7c91-4e30-b357-a5059e410e9e

3. Model registry with model mesh

https://github.com/user-attachments/assets/d746b286-fb38-4b55-9ca8-2a3b9a701135


## How Has This Been Tested?
1. deploy a model from model catalog, make sure spinner is displayed and data is loaded before the form renders.
2. Same goes for model registry.(check for both single and multi model platform)
3. Also, check for model deployment page  - this should work as expected.

## Test Impact
Added cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
