### PR TITLE
Updated workbench terminology in project section

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -161,7 +161,7 @@ class NotebookImageUpdateModal {
 
 class NotebookRow extends TableRow {
   shouldHaveNotebookImageName(name: string) {
-    this.find().find(`[data-label="Notebook image"]`).find('span').should('have.text', name);
+    this.find().find(`[data-label="Workbench image"]`).find('span').should('have.text', name);
     return this;
   }
 

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -154,7 +154,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             resource={obj.notebook}
           />
         </Td>
-        <Td dataLabel="Notebook image">
+        <Td dataLabel="Workbench image">
           <Split>
             <SplitItem>
               <NotebookImageDisplayName

--- a/frontend/src/pages/projects/screens/detail/notebooks/data.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/data.ts
@@ -20,7 +20,7 @@ export const columns: SortableData<NotebookState>[] = [
   },
   {
     field: 'image',
-    label: 'Notebook image',
+    label: 'Workbench image',
     width: 20,
     sortable: false,
   },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-24100

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1678" alt="Screenshot 2025-04-21 at 9 09 47 AM" src="https://github.com/user-attachments/assets/08a8e574-c15f-4733-896b-30a7b2d080d8" />
<img width="669" alt="Screenshot 2025-04-21 at 9 10 30 AM" src="https://github.com/user-attachments/assets/39821a3e-9021-491c-93b7-48b58c2581f3" />

Changed the table name to `Workbench Image`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Navigate to `Projects` and then go to the `Workbenches` tab

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Fixed existing Cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
