### PR TITLE
Await auth helper before completing proxy service request

### DIFF
--- a/backend/src/utils/proxy.ts
+++ b/backend/src/utils/proxy.ts
@@ -154,7 +154,7 @@ export const proxyService =
           // Assign the `upstream` param so we can dynamically set the upstream URL for http-proxy
           setParam(request, 'upstream', upstream);
           if (tls) {
-            setAuthorizationHeader(request, fastify);
+            await setAuthorizationHeader(request, fastify);
           }
           fastify.log.info(`Proxy ${request.method} request ${request.url} to ${upstream}`);
           done();
@@ -232,7 +232,7 @@ export const registerProxy = async (
         return;
       }
       if (authorize) {
-        setAuthorizationHeader(request, fastify);
+        await setAuthorizationHeader(request, fastify);
       }
       fastify.log.info(`Proxy ${request.method} request ${request.url} to ${upstream}`);
     },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

PR https://github.com/opendatahub-io/odh-dashboard/pull/3799 refactored the backend `proxyService` so that setting the `Bearer` token header is factored into a new common util called `setAuthorizationHeader`. In the `doServiceRequest` function within `proxyService`, the old code had an `await` and the new code does not, so it calls `done()` before the header is set and the proxy request proceeds without the Bearer token. This is leading to features that rely on the service proxy like Model Registry not working.

cc @christianvogt 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

(TODO - will test with the PR image)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No tests in the backend :(

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
