### PR TITLE
changed terminology for cluster settings

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterSettings.ts
@@ -61,7 +61,7 @@ class PVCSizeSettings extends ClusterSettings {
 
 class CullterSettings extends ClusterSettings {
   findStopIdleNotebooks() {
-    return cy.findByText('Stop idle notebooks', { exact: true });
+    return cy.findByText('Idle workbench timeout', { exact: true });
   }
 
   findHint() {

--- a/frontend/src/pages/clusterSettings/CullerSettings.tsx
+++ b/frontend/src/pages/clusterSettings/CullerSettings.tsx
@@ -66,14 +66,14 @@ const CullerSettings: React.FC<CullerSettingsProps> = ({
 
   return (
     <SettingSection
-      title="Stop idle notebooks"
-      description="Set the time limit for idle notebooks to be stopped."
+      title="Idle workbench timeout"
+      description="Define if and when idle workbenches are stopped."
       footer={
         <HelperText>
           <HelperTextItem>
-            All idle notebooks are stopped at cluster log out. To edit the cluster log out time,
-            discuss with your OpenShift administrator to see if the OpenShift Authentication Timeout
-            value can be modified.
+            All idle workbenches are stopped upon cluster logout. Cluster logout time is determined
+            by the OpenShift Authentication Timeout value, which is set by your OpenShift
+            administrator.
           </HelperTextItem>
         </HelperText>
       }
@@ -85,7 +85,7 @@ const CullerSettings: React.FC<CullerSettingsProps> = ({
               <Radio
                 id="culler-timeout-unlimited"
                 data-testid="culler-timeout-unlimited"
-                label="Do not stop idle notebooks"
+                label="Do not stop idle workbenches"
                 isChecked={cullerTimeoutChecked === CULLER_TIMEOUT_UNLIMITED}
                 name={CULLER_TIMEOUT_UNLIMITED}
                 onChange={radioCheckedChange}
@@ -96,7 +96,7 @@ const CullerSettings: React.FC<CullerSettingsProps> = ({
               <Radio
                 id="culler-timeout-limited"
                 data-testid="culler-timeout-limited"
-                label="Stop idle notebooks after"
+                label="Stop idle workbenches after defined period"
                 isChecked={cullerTimeoutChecked === CULLER_TIMEOUT_LIMITED}
                 name={CULLER_TIMEOUT_LIMITED}
                 onChange={radioCheckedChange}
@@ -175,7 +175,7 @@ const CullerSettings: React.FC<CullerSettingsProps> = ({
               data-testid="culler-timeout-helper-text"
               variant={cullerTimeout < MIN_CULLER_TIMEOUT ? 'error' : 'default'}
             >
-              Note: Notebook culler timeout must be between 10 minutes and 1000 hours.
+              Timeout period must be between 10 minutes and 1000 hours.
             </HelperTextItem>
           </HelperText>
         </StackItem>

--- a/frontend/src/pages/clusterSettings/PVCSizeSettings.tsx
+++ b/frontend/src/pages/clusterSettings/PVCSizeSettings.tsx
@@ -28,8 +28,7 @@ const PVCSizeSettings: React.FC<PVCSizeSettingsProps> = ({ initialValue, pvcSize
   return (
     <SettingSection
       title="PVC size"
-      description="Changing the PVC size changes the storage size attached to the new notebook servers for
-all users."
+      description="Changing the PVC size will affect the storage size attached to new workbenches only, for all users."
     >
       <Stack hasGutter>
         <StackItem>

--- a/frontend/src/pages/clusterSettings/TolerationSettings.tsx
+++ b/frontend/src/pages/clusterSettings/TolerationSettings.tsx
@@ -33,7 +33,7 @@ const TolerationSettings: React.FC<TolerationSettingsProps> = ({
 
   return (
     <SettingSection
-      title="Notebook pod tolerations"
+      title="Workbench pod tolerations"
       footer={
         <HelperText>
           {tolerationSettings.error && (
@@ -42,9 +42,9 @@ const TolerationSettings: React.FC<TolerationSettingsProps> = ({
             </HelperTextItem>
           )}
           <HelperTextItem>
-            The toleration key above will be applied to all notebook pods when they are created. Add
-            a matching taint key (with any value) to the Machine Pool(s) that you want to dedicate
-            to Notebooks.
+            The toleration key will be applied to new workbench pods upon creation. Add a matching
+            taint key (with any value) to the machine pools that you want to dedicate to
+            workbenches.
           </HelperTextItem>
         </HelperText>
       }
@@ -52,7 +52,7 @@ const TolerationSettings: React.FC<TolerationSettingsProps> = ({
       <Stack hasGutter>
         <StackItem>
           <Checkbox
-            label="Add a toleration to notebook pods to allow them to be scheduled to tainted nodes"
+            label="Add a toleration to workbench pods to allow them to be scheduled to tainted nodes"
             isChecked={tolerationSettings.enabled}
             onChange={(e, enabled) => {
               const newNotebookTolerationSettings: NotebookTolerationFormSettings = {
@@ -67,7 +67,7 @@ const TolerationSettings: React.FC<TolerationSettingsProps> = ({
             name="tolerationsEnabledCheckbox"
             body={
               <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                <FlexItem>Toleration key for notebook pods:</FlexItem>
+                <FlexItem>Toleration key for workbench pods:</FlexItem>
                 <FlexItem>
                   <TextInput
                     id="toleration-key-input"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-24102

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Edited the cluster settings terminology.

<img width="1715" alt="Screenshot 2025-04-21 at 6 39 24 PM" src="https://github.com/user-attachments/assets/5df536f3-b014-49ef-8d73-afb77cefcf7d" />
<img width="1715" alt="Screenshot 2025-04-21 at 6 39 43 PM" src="https://github.com/user-attachments/assets/e6dcd702-7c4f-49cf-a9ce-d2cb095f42bb" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to the cluster settings page in the sidebar

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, simple microcopy change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
