### PR TITLE
Fix types related to TrustyAI service

### DIFF
--- a/frontend/src/api/trustyai/rawTypes.ts
+++ b/frontend/src/api/trustyai/rawTypes.ts
@@ -28,9 +28,9 @@ export type BaseMetric = {
 
 // Request type only for user input
 export type BaseMetricRequestInput = {
-  favorableOutcome: string;
-  privilegedAttribute: string;
-  unprivilegedAttribute: string;
+  favorableOutcome: string | number | boolean;
+  privilegedAttribute: string | number | boolean;
+  unprivilegedAttribute: string | number | boolean;
 } & BaseMetric;
 
 // Request type for creating

--- a/frontend/src/pages/modelServing/screens/metrics/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/__tests__/utils.spec.ts
@@ -17,7 +17,7 @@ describe('convertInputType', () => {
       expect(convertInputType('-123')).toBe(-123);
       expect(convertInputType('0')).toBe(0);
     });
-    it('should handle number mixed with string input', () => {
+    it('should handle number input directly', () => {
       expect(convertInputType(123)).toBe(123);
       expect(convertInputType(-123)).toBe(-123);
       expect(convertInputType(1.23)).toBe(1.23);

--- a/frontend/src/pages/modelServing/screens/metrics/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/metrics/__tests__/utils.spec.ts
@@ -1,0 +1,42 @@
+import { convertInputType } from '~/pages/modelServing/screens/metrics/utils';
+
+describe('convertInputType', () => {
+  describe('string inputs', () => {
+    it('should return empty string for empty input', () => {
+      expect(convertInputType('')).toBe('');
+    });
+    it('should return original string for non-convertible string input', () => {
+      expect(convertInputType('hello')).toBe('hello');
+      expect(convertInputType('test123test')).toBe('test123test');
+    });
+  });
+  describe('number inputs', () => {
+    it('should convert string numbers to actual numbers', () => {
+      expect(convertInputType('123')).toBe(123);
+      expect(convertInputType('1.23')).toBe(1.23);
+      expect(convertInputType('-123')).toBe(-123);
+      expect(convertInputType('0')).toBe(0);
+    });
+    it('should handle number mixed with string input', () => {
+      expect(convertInputType(123)).toBe(123);
+      expect(convertInputType(-123)).toBe(-123);
+      expect(convertInputType(1.23)).toBe(1.23);
+    });
+  });
+  describe('boolean inputs', () => {
+    it('should convert string booleans to actual booleans', () => {
+      expect(convertInputType('true')).toBe(true);
+      expect(convertInputType('false')).toBe(false);
+      expect(convertInputType('TRUE')).toBe(true);
+      expect(convertInputType('FALSE')).toBe(false);
+    });
+    it('should handle boolean input directly', () => {
+      expect(convertInputType(true)).toBe(true);
+      expect(convertInputType(false)).toBe(false);
+    });
+    it('should handle mixed case boolean input', () => {
+      expect(convertInputType('True')).toBe(true);
+      expect(convertInputType('faLse')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -123,7 +123,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           <TextInput
             id="privileged-value"
             data-testid="privileged-value"
-            value={configuration.privilegedAttribute}
+            value={String(configuration.privilegedAttribute)}
             onChange={(e, value) => setConfiguration('privilegedAttribute', value)}
           />
         </FormGroup>
@@ -137,7 +137,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           <TextInput
             id="unprivileged-value"
             data-testid="unprivileged-value"
-            value={configuration.unprivilegedAttribute}
+            value={String(configuration.unprivilegedAttribute)}
             onChange={(e, value) => setConfiguration('unprivilegedAttribute', value)}
           />
         </FormGroup>
@@ -165,7 +165,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
           <TextInput
             id="output-value"
             data-testid="output-value"
-            value={configuration.favorableOutcome}
+            value={String(configuration.favorableOutcome)}
             onChange={(e, value) => setConfiguration('favorableOutcome', value)}
           />
         </FormGroup>

--- a/frontend/src/pages/modelServing/screens/metrics/utils.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/utils.tsx
@@ -271,9 +271,16 @@ export const createBiasSelectOption = (biasMetricConfig: BiasMetricConfig): Bias
     compareTo: byId(id),
   };
 };
-export const convertInputType = (input: string): number | boolean | string => {
-  if (input !== '' && !Number.isNaN(Number(input))) {
-    return Number(input);
+export const convertInputType = (input: string | number | boolean): string | number | boolean => {
+  if (typeof input !== 'string') {
+    return input;
+  }
+  if (input === '') {
+    return input;
+  }
+  const numberValue = Number(input);
+  if (!Number.isNaN(numberValue)) {
+    return numberValue;
   }
   if (input.toLowerCase() === 'true') {
     return true;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Issue: https://issues.redhat.com/browse/RHOAIENG-2688

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- modified BaseMetricRequestInput property types
- fixed errors from changing BaseMetricRequestInput in trustyai api rawTypes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing tests were ran and showed success.
- addtional tests were added for convertInputType function


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Unit test cases were added for convertInputType

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
