### PR TITLE
adjusting width for the top description too

### DIFF
--- a/frontend/src/pages/pipelines/global/modelCustomization/landingPage/ModelCustomization.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/landingPage/ModelCustomization.tsx
@@ -26,6 +26,8 @@ const title = 'Model customization';
 const description =
   'Optionally customize foundation models to adhere more to domain-specific capabilities, output formats, and styles, using the Large-scale Alignment for chatBots (LAB) method or your own fine-tuning workflow.';
 
+const maxWidth = '485px';
+
 const ModelCustomization: React.FC = () => {
   const drawerContentRef = React.useRef<ModelCustomizationDrawerContentRef>(null);
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
@@ -55,7 +57,7 @@ const ModelCustomization: React.FC = () => {
               <TitleWithIcon title={title} objectType={ProjectObjectType.modelCustomization} />
             }
             provideChildrenPadding
-            description={description}
+            description={<div style={{ maxWidth }}>{description}</div>}
             loaded
             empty={false}
           >
@@ -66,7 +68,7 @@ const ModelCustomization: React.FC = () => {
                   objectType={ProjectObjectType.labTuning}
                 />
               </CardTitle>
-              <CardBody style={{ maxWidth: '485px' }}>
+              <CardBody style={{ maxWidth }}>
                 <Stack hasGutter>
                   <StackItem>
                     LAB-tuning significantly reduces limitations associated with traditional


### PR DESCRIPTION
addition to: https://issues.redhat.com/browse/RHOAIENG-22899

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
adjusting width to be consistent.

<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
before change:
<img width="1383" alt="Screenshot 2025-04-22 at 4 02 04 PM" src="https://github.com/user-attachments/assets/d0b5b13e-f533-455f-90ef-90fb929f880b" />


after change:

<img width="1177" alt="Screenshot 2025-04-22 at 4 01 40 PM" src="https://github.com/user-attachments/assets/5f751df0-ca97-49ba-8134-59c88856a903" />


## How Has This Been Tested?
viewed the page; this is just a style/width/css change. extremely minor

## Test Impact
so minor; no tests needed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
