### PR TITLE
[Tech debt] Add eslint no-non-null-assertion rule to config

### DIFF
--- a/backend/.eslintrc
+++ b/backend/.eslintrc
@@ -33,6 +33,7 @@
   "settings": {},
   "rules": {
     "no-barrel-files/no-barrel-files": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "eqeqeq": ["error", "always", { "null": "ignore" }],
     "no-restricted-properties": [
       "error",

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -56,6 +56,7 @@
   },
   "rules": {
     "no-barrel-files/no-barrel-files": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "jsx-a11y/no-autofocus": ["error", { "ignoreNonDOM": true }],
     "jsx-a11y/anchor-is-valid": [
       "error",

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/application.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/application.cy.ts
@@ -105,7 +105,9 @@ describe('Application', () => {
   it('should show the about modal for RHOAI application', () => {
     // Validate RHOAI about settings
     const mockConfig = mockDashboardConfig({});
-    mockConfig.metadata!.namespace = 'redhat-ods-applications';
+    if (mockConfig.metadata) {
+      mockConfig.metadata.namespace = 'redhat-ods-applications';
+    }
     cy.interceptOdh('GET /api/config', mockConfig);
     cy.interceptOdh('GET /api/operator-subscription-status', {
       channel: 'fast',

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -74,7 +74,9 @@ describe('AboutDialog', () => {
 
   beforeEach(() => {
     dashboardConfig = mockDashboardConfig({});
-    dashboardConfig.metadata!.namespace = 'odh-dashboard';
+    if (dashboardConfig.metadata) {
+      dashboardConfig.metadata.namespace = 'odh-dashboard';
+    }
     appContext = {
       buildStatuses: [],
       dashboardConfig,
@@ -167,11 +169,14 @@ describe('AboutDialog', () => {
   });
 
   it('should show the appropriate RHOAI values', async () => {
-    dashboardConfig.metadata!.namespace = 'redhat-ods-applications';
+    if (dashboardConfig.metadata) {
+      dashboardConfig.metadata.namespace = 'redhat-ods-applications';
+    }
     appContext.isRHOAI = true;
     userInfo.isAdmin = true;
-    dsciStatus.release!.name = 'OpenShift AI Self-Managed version';
-
+    if (dsciStatus.release) {
+      dsciStatus.release.name = 'OpenShift AI Self-Managed version';
+    }
     useAppContextMock.mockReturnValue(appContext);
     useUserMock.mockReturnValue(userInfo);
     useClusterInfoMock.mockReturnValue(clusterInfo);

--- a/frontend/src/concepts/topology/PipelineVisualizationSurface.tsx
+++ b/frontend/src/concepts/topology/PipelineVisualizationSurface.tsx
@@ -123,16 +123,17 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
       const model = controller.toModel();
 
       // Get all the non-spacer nodes, mark them all visible again
-      const nonSpacerNodes = model
-        .nodes!.filter((n) => n.type !== DEFAULT_SPACER_NODE_TYPE)
-        .map((n) => ({
-          ...n,
-          visible: true,
-        }));
+      const nonSpacerNodes = model.nodes
+        ? model.nodes.filter((n) => n.type !== DEFAULT_SPACER_NODE_TYPE)
+        : [];
+      const visibleNodes = nonSpacerNodes.map((n) => ({
+        ...n,
+        visible: true,
+      }));
 
       // If collapsing, set the size of the collapsed group nodes
       if (collapseAll) {
-        nonSpacerNodes.forEach((node) => {
+        visibleNodes.forEach((node) => {
           const newNode = node;
           if (node.group && node.collapsed) {
             newNode.width = NODE_WIDTH;
@@ -141,7 +142,7 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
         });
       }
       // Determine the new set of nodes, including the spacer nodes
-      const pipelineNodes = addSpacerNodes(nonSpacerNodes);
+      const pipelineNodes = addSpacerNodes(visibleNodes);
 
       // Determine the new edges
       const edges = getEdgesFromNodes(

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -206,7 +206,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
         kind: 'ModelRegistry',
         metadata: {
           name: nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name),
-          namespace: modelRegistryNamespace!,
+          namespace: modelRegistryNamespace || '',
           annotations: {
             'openshift.io/description': nameDesc.description,
             'openshift.io/display-name': nameDesc.name.trim(),

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -127,6 +127,17 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
     }
   }, [mr]);
 
+  if (!modelRegistryNamespace) {
+    return (
+      <ApplicationsPage loaded empty={false}>
+        <RedirectErrorState
+          title="Could not load component state"
+          errorMessage="No registries namespace could be found"
+        />
+      </ApplicationsPage>
+    );
+  }
+
   const onCancelClose = () => {
     fireFormTrackingEvent(mr ? updateEventName : createEventName, {
       outcome: TrackingOutcome.cancel,
@@ -206,7 +217,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
         kind: 'ModelRegistry',
         metadata: {
           name: nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name),
-          namespace: modelRegistryNamespace || '',
+          namespace: modelRegistryNamespace,
           annotations: {
             'openshift.io/description': nameDesc.description,
             'openshift.io/display-name': nameDesc.name.trim(),
@@ -277,17 +288,6 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
     hasContent(username) &&
     hasContent(database) &&
     (!addSecureDB || (secureDBInfo.isValid && !configSecretsError));
-
-  if (!modelRegistryNamespace) {
-    return (
-      <ApplicationsPage loaded empty={false}>
-        <RedirectErrorState
-          title="Could not load component state"
-          errorMessage="No registries namespace could be found"
-        />
-      </ApplicationsPage>
-    );
-  }
 
   return (
     <Modal

--- a/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
@@ -82,7 +82,9 @@ const DeployPrefilledModelModalContents: React.FC<
   const loadError = prefillInfoLoadError; // Note: serving context load errors are handled/rendered in ModelServingContextProvider
 
   const handleSubmit = React.useCallback(async () => {
-    onSubmit?.(selectedProject!);
+    if (selectedProject) {
+      onSubmit?.(selectedProject);
+    }
   }, [onSubmit, selectedProject]);
 
   const onClose = React.useCallback(

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
@@ -154,7 +154,9 @@ const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = (
                   value={envVar.name}
                   onChange={(_event, value) => updateEnvVar(index, { name: value })}
                   ref={
-                    index === data.servingRuntimeEnvVars!.length - 1 ? lastNameFieldRef : undefined
+                    data.servingRuntimeEnvVars && index === data.servingRuntimeEnvVars.length - 1
+                      ? lastNameFieldRef
+                      : undefined
                   }
                   validated={error ? 'error' : 'default'}
                 />

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -121,9 +121,11 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
                 key="edit"
                 variant="link"
                 onClick={() => {
-                  navigate(
-                    `/projects/${notebook!.metadata.namespace}/spawner/${notebook!.metadata.name}`,
-                  );
+                  if (notebook.metadata.namespace && notebook.metadata.name) {
+                    navigate(
+                      `/projects/${notebook.metadata.namespace}/spawner/${notebook.metadata.name}`,
+                    );
+                  }
                 }}
               >
                 Edit workbench


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Issue: https://issues.redhat.com/browse/RHOAIENG-23621

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- added no-non-null-assertion to eslint config in both frontend and backend package.json files
- fixed resulting linting errors

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests were ran and all passed.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No additional tests were added.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
