### PR TITLE
OCI storage location is not prefilled with URI

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -472,6 +472,35 @@ describe('Deploy model version', () => {
     kserveModal.findLocationPathInput().should('have.value', 'demo-models/test-path');
   });
 
+  it('Selects Create Connection in case of no matching URI connections', () => {
+    initIntercepts({});
+    cy.interceptK8sList(
+      SecretModel,
+      mockK8sResourceList([
+        mockCustomSecretK8sResource({
+          namespace: 'kserve-project',
+          name: 'test-secret',
+          annotations: {
+            'opendatahub.io/connection-type': 'uri-v1-1',
+            'openshift.io/display-name': 'Test Secret-1',
+          },
+          data: { URI: 'aHR0cDovL3Rlc3Rz' },
+        }),
+      ]),
+    );
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version 2');
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+    kserveModal
+      .findConnectionFieldInput('URI')
+      .should('have.value', 'https://demo-models/some-path.zip');
+    kserveModal.selectConnectionType(
+      'OCI compliant registry - v1 Connection type description Category: Database, Testing',
+    );
+    kserveModal.findOCIModelURI().should('have.value', '');
+  });
+
   it('Check whether all data is still persistent, if user changes connection types', () => {
     initIntercepts({});
     cy.interceptK8sList(

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
@@ -420,7 +420,7 @@ describe('usePrefillModelDeployModal', () => {
             dataConnection: '',
             path: '',
             type: 'new-storage',
-            uri: 'http://test',
+            uri: '',
           },
         ],
       ]);

--- a/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
+++ b/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
@@ -134,7 +134,7 @@ const usePrefillModelDeployModal = (
         if (recommendedConnections.length === 0) {
           setCreateData('storage', {
             awsData: EMPTY_AWS_SECRET_DATA,
-            uri: modelLocation.uri,
+            uri: '',
             dataConnection: '',
             path: '',
             type: InferenceServiceStorageType.NEW_STORAGE,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-22645

## Description
When we deploy a model (created with uri-connection type) via model registry to a project with no matching connection types, we will prefill the uri field. switching it to OCI - check if the oci field is not prefilled by same uri





https://github.com/user-attachments/assets/fa6ad1ad-b9c4-4feb-90df-c9f89da54d64







<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Navigate to Model Registry
- Register a new model using a URI connection type
- Select Deploy for the model version
- Choose a project with no matching connection types
- URI connection will be prefilled, switch to OCI and observe that the uri model location doesnt prefills the OCI storage location

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated unit test
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
