### PR TITLE
Model Deployment Failure Notification

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -21,6 +21,7 @@ type MockResourceConfigType = {
   maxReplicas?: number;
   imagePullSecrets?: Array<{ name: string }>;
   lastFailureInfoMessage?: string;
+  lastFailureInfoReason?: string;
   resources?: ContainerResources;
   kserveInternalUrl?: string;
   statusPredictor?: Record<string, string>;
@@ -88,6 +89,7 @@ export const mockInferenceServiceK8sResource = ({
   maxReplicas = 1,
   imagePullSecrets = undefined,
   lastFailureInfoMessage = 'Waiting for runtime Pod to become available',
+  lastFailureInfoReason,
   resources,
   statusPredictor = undefined,
   kserveInternalUrl = '',
@@ -192,7 +194,7 @@ export const mockInferenceServiceK8sResource = ({
           lastFailureInfo: {
             message: lastFailureInfoMessage,
             modelRevisionName: 'model-size__isvc-59ce37c85b',
-            reason: 'RuntimeUnhealthy',
+            reason: lastFailureInfoReason,
             location: '',
             time: '',
           },

--- a/frontend/src/concepts/notificationWatcher/__tests__/NotificationWatcherContext.spec.tsx
+++ b/frontend/src/concepts/notificationWatcher/__tests__/NotificationWatcherContext.spec.tsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import {
   FinalNotificationWatcherResponse,
+  NotificationResponseStatus,
   NotificationWatcherContext,
   NotificationWatcherContextProvider,
   NotificationWatcherResponse,
@@ -30,7 +31,7 @@ const createCallbackMock = ({
 }) => {
   const callbackMock = jest.fn();
   Array.from({ length: repollCount }).forEach(() =>
-    callbackMock.mockResolvedValueOnce({ status: 'repoll' }),
+    callbackMock.mockResolvedValueOnce({ status: NotificationResponseStatus.REPOLL }),
   );
   callbackMock.mockResolvedValueOnce(finalResponse);
   return callbackMock;
@@ -66,7 +67,7 @@ describe('NotificationWatcherContextProvider', () => {
 
   it("should trigger 'success' notification", async () => {
     const finalResponse: FinalNotificationWatcherResponse = {
-      status: 'success',
+      status: NotificationResponseStatus.SUCCESS,
       title: 'Success Title',
       message: 'Success Message',
     };
@@ -87,7 +88,7 @@ describe('NotificationWatcherContextProvider', () => {
 
   it("should trigger 'error' notification", async () => {
     const finalResponse: NotificationWatcherResponse = {
-      status: 'error',
+      status: NotificationResponseStatus.ERROR,
       title: 'Error Title',
       message: 'Error Message',
       actions: [{ title: 'Action', onClick: jest.fn() }],
@@ -108,7 +109,9 @@ describe('NotificationWatcherContextProvider', () => {
   });
 
   it("should not do anything if the reported status is 'stop'", async () => {
-    const callbackMock = createCallbackMock({ finalResponse: { status: 'stop' } });
+    const callbackMock = createCallbackMock({
+      finalResponse: { status: NotificationResponseStatus.STOP },
+    });
 
     renderTestComponent([callbackMock]);
 
@@ -127,7 +130,7 @@ describe('NotificationWatcherContextProvider', () => {
     const callbackDelay = 1000;
 
     const finalResponse: NotificationWatcherResponse = {
-      status: 'success',
+      status: NotificationResponseStatus.SUCCESS,
       title: 'Repoll with delay Success Title',
       message: 'Repoll with delay Success Message',
       actions: [{ title: 'Action', onClick: jest.fn() }],
@@ -158,7 +161,7 @@ describe('NotificationWatcherContextProvider', () => {
 
   it("should retry when response is 'repoll' (single callback)", async () => {
     const finalResponse: NotificationWatcherResponse = {
-      status: 'success',
+      status: NotificationResponseStatus.SUCCESS,
       title: 'Repoll Success Title',
       message: 'Repoll Success Message',
       actions: [{ title: 'Action', onClick: jest.fn() }],
@@ -184,7 +187,7 @@ describe('NotificationWatcherContextProvider', () => {
     const callbackMocks = repollCounts.map((repollCount) =>
       createCallbackMock({
         finalResponse: {
-          status: 'success',
+          status: NotificationResponseStatus.SUCCESS,
           title: `${repollCount}x Repoll Success Title`,
           message: `${repollCount}x Repoll Success Message`,
         },
@@ -253,10 +256,10 @@ describe('NotificationWatcherContextProvider', () => {
             callback: async () => {
               try {
                 await callbackMock();
-                return { status: 'repoll' };
+                return { status: NotificationResponseStatus.REPOLL };
               } catch (err) {
                 errorTracker(err);
-                return { status: 'stop' };
+                return { status: NotificationResponseStatus.STOP };
               }
             },
             callbackDelay: 0,

--- a/frontend/src/concepts/pipelines/content/ManageSamplePipelinesModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ManageSamplePipelinesModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from '@patternfly/react-core/deprecated';
 import { getPipelinesCR, toggleInstructLabState } from '~/api';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import {
+  NotificationResponseStatus,
   NotificationWatcherContext,
   NotificationWatcherResponse,
 } from '~/concepts/notificationWatcher/NotificationWatcherContext';
@@ -82,26 +83,26 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
                     // Refresh the pipelines list to make the ilab pipeline shown
                     refreshAllAPI();
                     return {
-                      status: 'success',
+                      status: NotificationResponseStatus.SUCCESS,
                       title,
                     };
                   }
                   if (iLabPipelineResponse.error) {
                     notificationWatcherRef.current = false;
                     return {
-                      status: 'error',
+                      status: NotificationResponseStatus.ERROR,
                       title: 'Error enabling InstructLab pipeline',
                       message: iLabPipelineResponse.error.message,
                     };
                   }
                   if (!serverReady) {
                     // re-poll only if the server is not ready
-                    return { status: 'repoll' };
+                    return { status: NotificationResponseStatus.REPOLL };
                   }
-                  return { status: 'stop' };
+                  return { status: NotificationResponseStatus.STOP };
                 })
                 // e.g. 404 error when InstructLab pipeline is not ready, we keep re-polling it
-                .catch(() => ({ status: 'repoll' })),
+                .catch(() => ({ status: NotificationResponseStatus.REPOLL })),
             callbackDelay: 10000,
           });
         }

--- a/frontend/src/pages/modelServing/screens/global/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/global/__tests__/utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   checkModelStatus,
   getInferenceServiceStatusMessage,
+  getInferenceServiceLastFailureReason,
 } from '~/pages/modelServing/screens/global/utils';
 import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
 import { mockInferenceServiceK8sResource } from '~/__mocks__';
@@ -79,5 +80,31 @@ describe('getInferenceServiceStatusMessage', () => {
       targetModelState: '',
     });
     expect(getInferenceServiceStatusMessage(inferenceService)).toEqual('');
+  });
+});
+
+describe('getInferenceServiceLastFailureReason', () => {
+  it('Should return last failure reason when present', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      lastFailureInfoReason: 'RuntimeUnhealthy',
+    });
+    expect(getInferenceServiceLastFailureReason(inferenceService)).toEqual('RuntimeUnhealthy');
+  });
+
+  it('Should return undefined when no status exists', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      missingStatus: true,
+    });
+    expect(getInferenceServiceLastFailureReason(inferenceService)).toEqual('Unknown');
+  });
+
+  it('Should return status message when reason is missing', () => {
+    const inferenceService = mockInferenceServiceK8sResource({
+      activeModelState: 'FailedToLoad',
+      lastFailureInfoMessage: 'Some message',
+      lastFailureInfoReason: undefined,
+    });
+
+    expect(getInferenceServiceLastFailureReason(inferenceService)).toEqual('Some message');
   });
 });

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -10,6 +10,11 @@ export const getInferenceServiceModelState = (
   asEnumMember(is.status?.modelStatus?.states?.activeModelState, InferenceServiceModelState) ||
   InferenceServiceModelState.UNKNOWN;
 
+export const getInferenceServiceLastFailureReason = (is: InferenceServiceKind): string =>
+  is.status?.modelStatus?.lastFailureInfo?.reason ||
+  is.status?.modelStatus?.lastFailureInfo?.message ||
+  'Unknown';
+
 export const getInferenceServiceStatusMessage = (is: InferenceServiceKind): string => {
   const activeModelState = is.status?.modelStatus?.states?.activeModelState;
   const targetModelState = is.status?.modelStatus?.states?.targetModelState;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -115,13 +115,13 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     createData.servingRuntimeName === '' ||
     !storageCanCreate();
 
+  const onSuccess = () => {
+    onClose(true);
+  };
+
   const setErrorModal = (e: Error) => {
     setError(e);
     setActionInProgress(false);
-  };
-
-  const onSuccess = () => {
-    onClose(true);
   };
 
   const submit = () => {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -59,7 +59,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
   const [actionInProgress, setActionInProgress] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
 
-  const { notifyError, watchDeployment } = useModelDeploymentNotification(
+  const { watchDeployment } = useModelDeploymentNotification(
     createData.project,
     createData.k8sName,
     false,
@@ -116,7 +116,6 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
     !storageCanCreate();
 
   const setErrorModal = (e: Error) => {
-    notifyError(e);
     setError(e);
     setActionInProgress(false);
   };

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -18,6 +18,12 @@ jest.mock('~/app/AppContext', () => ({
   useAppContext: jest.fn(),
 }));
 
+jest.mock('~/pages/modelServing/screens/projects/useModelDeploymentNotification', () => ({
+  useModelDeploymentNotification: () => ({
+    watchDeployment: jest.fn(),
+  }),
+}));
+
 const useServingRuntimesMock = jest.mocked(useServingRuntimes);
 const useAppContextMock = jest.mocked(useAppContext);
 

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -98,7 +98,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
   const currentProjectName = projectContext?.currentProject.metadata.name;
   const namespace = currentProjectName || createDataInferenceService.project;
 
-  const { notifyError, watchDeployment } = useModelDeploymentNotification(
+  const { watchDeployment } = useModelDeploymentNotification(
     namespace,
     createDataInferenceService.k8sName,
     false,
@@ -239,7 +239,6 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
   };
 
   const setErrorModal = (e: Error) => {
-    notifyError(e);
     setError(e);
     setActionInProgress(false);
   };

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -164,7 +164,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     SupportedArea.SERVING_RUNTIME_PARAMS,
   ).status;
 
-  const { notifyError, watchDeployment } = useModelDeploymentNotification(
+  const { watchDeployment } = useModelDeploymentNotification(
     namespace,
     createDataInferenceService.k8sName,
     true,
@@ -247,7 +247,6 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   };
 
   const setErrorModal = (e: Error) => {
-    notifyError(e);
     setError(e);
     setActionInProgress(false);
   };

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -57,6 +57,7 @@ import usePrefillModelDeployModal, {
 } from '~/pages/modelServing/screens/projects/usePrefillModelDeployModal';
 import { useKServeDeploymentMode } from '~/pages/modelServing/useKServeDeploymentMode';
 import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
+import { useModelDeploymentNotification } from '~/pages/modelServing/screens/projects/useModelDeploymentNotification';
 import KServeAutoscalerReplicaSection from './KServeAutoscalerReplicaSection';
 import EnvironmentVariablesSection from './EnvironmentVariablesSection';
 import ServingRuntimeArgsSection from './ServingRuntimeArgsSection';
@@ -163,6 +164,12 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
     SupportedArea.SERVING_RUNTIME_PARAMS,
   ).status;
 
+  const { notifyError, watchDeployment } = useModelDeploymentNotification(
+    namespace,
+    createDataInferenceService.k8sName,
+    true,
+  );
+
   React.useEffect(() => {
     if (currentProjectName) {
       setCreateDataInferenceService('project', currentProjectName);
@@ -240,6 +247,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   };
 
   const setErrorModal = (e: Error) => {
+    notifyError(e);
     setError(e);
     setActionInProgress(false);
   };
@@ -313,6 +321,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         props.success = true;
         fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
         onSuccess(props);
+        watchDeployment();
       })
       .catch((e) => {
         props.success = false;

--- a/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
@@ -12,7 +12,6 @@ import { useModelStatus } from '~/pages/modelServing/screens/global/useModelStat
 
 type ModelDeploymentNotification = {
   watchDeployment: () => void;
-  notifyError: (error: Error) => void;
 };
 
 export const useModelDeploymentNotification = (
@@ -98,20 +97,5 @@ export const useModelDeploymentNotification = (
     notification,
   ]);
 
-  const notifyError = React.useCallback(
-    (error: Error) => {
-      notification.error('Model deployment failed', error.message, [
-        {
-          title: 'View details',
-          onClick: () => {
-            // TODO: Navigate to deployment details
-            // This will be implemented in a follow-up PR
-          },
-        },
-      ]);
-    },
-    [notification],
-  );
-
-  return { watchDeployment, notifyError };
+  return { watchDeployment };
 };

--- a/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
@@ -32,20 +32,17 @@ export const useModelDeploymentNotification = (
       callback: async (signal) => {
         // Early failure detection from pod scheduling
         if (modelStatus?.failedToSchedule) {
-          return {
-            status: NotificationResponseStatus.ERROR,
-            title: 'Model deployment failed',
-            message:
-              'Insufficient resources to schedule the model deployment. Please check your resource quotas and try again.',
-            actions: [
+          notification.error(
+            'Model deployment failed',
+            'Insufficient resources to schedule the model deployment. Please check your resource quotas and try again.',
+            [
               {
                 title: 'View deployment',
-                onClick: () => {
-                  navigate(`/modelServing/${namespace}`);
-                },
+                onClick: () => navigate(`/modelServing/${namespace}`),
               },
             ],
-          };
+          );
+          return { status: NotificationResponseStatus.STOP };
         }
 
         try {

--- a/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import useNotification from '~/utilities/useNotification';
-import { NotificationWatcherContext } from '~/concepts/notificationWatcher/NotificationWatcherContext';
+import {
+  NotificationResponseStatus,
+  NotificationWatcherContext,
+} from '~/concepts/notificationWatcher/NotificationWatcherContext';
 import { getInferenceService } from '~/api';
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
 import {
@@ -30,7 +33,7 @@ export const useModelDeploymentNotification = (
         // Early failure detection from pod scheduling
         if (modelStatus?.failedToSchedule) {
           return {
-            status: 'error',
+            status: NotificationResponseStatus.ERROR,
             title: 'Model deployment failed',
             message:
               'Insufficient resources to schedule the model deployment. Please check your resource quotas and try again.',
@@ -62,24 +65,23 @@ export const useModelDeploymentNotification = (
                   },
                 ],
               );
-              return { status: 'stop' };
+              return { status: NotificationResponseStatus.STOP };
             case InferenceServiceModelState.LOADED:
             case InferenceServiceModelState.STANDBY:
-              return { status: 'stop' };
+              return { status: NotificationResponseStatus.STOP };
             case InferenceServiceModelState.PENDING:
             case InferenceServiceModelState.LOADING:
             case InferenceServiceModelState.UNKNOWN:
             default:
-              return { status: 'repoll' };
+              return { status: NotificationResponseStatus.REPOLL };
           }
         } catch (error: unknown) {
-          // Let the user know if there's an error but continue polling for model state updates
           notification.error(
             'Error checking model deployment',
             error instanceof Error ? error.message : 'Unknown error',
           );
           return {
-            status: 'repoll',
+            status: NotificationResponseStatus.STOP,
           };
         }
       },

--- a/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import useNotification from '~/utilities/useNotification';
+import { NotificationWatcherContext } from '~/concepts/notificationWatcher/NotificationWatcherContext';
+import { getInferenceService } from '~/api';
+import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
+import {
+  getInferenceServiceModelState,
+  getInferenceServiceStatusMessage,
+} from '~/pages/modelServing/screens/global/utils';
+import { useModelStatus } from '~/pages/modelServing/screens/global/useModelStatus';
+
+type ModelDeploymentNotification = {
+  watchDeployment: () => void;
+  notifyError: (error: Error) => void;
+};
+
+export const useModelDeploymentNotification = (
+  namespace: string,
+  modelName: string,
+  isKserve: boolean,
+): ModelDeploymentNotification => {
+  const navigate = useNavigate();
+  const notification = useNotification();
+  const { registerNotification } = React.useContext(NotificationWatcherContext);
+  const [modelStatus] = useModelStatus(namespace, modelName, isKserve);
+
+  const watchDeployment = React.useCallback(() => {
+    //console.log('📡 watching Deployment');
+
+    registerNotification({
+      callback: async (signal) => {
+        //console.log('🔁 in the polling callback');
+        //console.log('🔁 modelStatus', modelStatus);
+        // Early failure detection from pod scheduling
+        if (modelStatus?.failedToSchedule) {
+          return {
+            status: 'error',
+            title: 'Model deployment failed',
+            message:
+              'Insufficient resources to schedule the model deployment. Please check your resource quotas and try again.',
+            actions: [
+              {
+                title: 'View details',
+                onClick: () => {
+                  // TODO: Navigate to deployment details
+                },
+              },
+            ],
+          };
+        }
+
+        try {
+          const inferenceService = await getInferenceService(modelName, namespace, { signal });
+          console.log('fetched InferenceService', inferenceService.status);
+          const modelState = getInferenceServiceModelState(inferenceService);
+          console.log('modelState:', modelState);
+          const statusMessage = getInferenceServiceStatusMessage(inferenceService);
+
+          switch (modelState) {
+            case InferenceServiceModelState.FAILED_TO_LOAD:
+              console.log('Model deployment failed');
+              return {
+                status: 'error',
+                title: 'Model deployment failed',
+                message:
+                  statusMessage ||
+                  'Failed to load the model. Please check the model configuration and try again.',
+                actions: [
+                  {
+                    title: 'View details',
+                    onClick: () => {
+                      navigate(`/modelServing/${namespace}`);
+                    },
+                  },
+                ],
+              };
+            case InferenceServiceModelState.LOADED:
+            case InferenceServiceModelState.STANDBY:
+              return { status: 'stop' };
+            case InferenceServiceModelState.PENDING:
+            case InferenceServiceModelState.LOADING:
+            case InferenceServiceModelState.UNKNOWN:
+            default:
+              return { status: 'repoll' };
+          }
+        } catch (error: unknown) {
+          if (
+            typeof error === 'object' &&
+            error !== null &&
+            'statusObject' in error &&
+            error.statusObject &&
+            typeof error.statusObject === 'object' &&
+            'code' in error.statusObject &&
+            error.statusObject.code === 404
+          ) {
+            console.log('⏳ InferenceService not found yet, keep polling');
+            return { status: 'repoll' };
+          }
+          //console.error('🔥 Unexpected error fetching inference service:', error);
+          return {
+            status: 'error',
+            title: 'Error checking model deployment',
+            message: error instanceof Error ? error.message : 'Unknown error',
+          };
+        }
+      },
+    });
+  }, [registerNotification, modelStatus, modelName, namespace, navigate]);
+
+  const notifyError = React.useCallback(
+    (error: Error) => {
+      notification.error('Model deployment failed', error.message, [
+        {
+          title: 'View details',
+          onClick: () => {
+            // TODO: Navigate to deployment details
+            // This will be implemented in a follow-up PR
+          },
+        },
+      ]);
+    },
+    [notification],
+  );
+
+  return { watchDeployment, notifyError };
+};

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
@@ -22,6 +22,7 @@ import {
 } from '~/routes';
 import useNotification from '~/utilities/useNotification';
 import {
+  NotificationResponseStatus,
   NotificationWatcherContext,
   NotificationWatcherResponse,
 } from '~/concepts/notificationWatcher/NotificationWatcherContext';
@@ -175,7 +176,7 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
                 model.modelRegistryName
               ) {
                 return {
-                  status: 'success',
+                  status: NotificationResponseStatus.SUCCESS,
                   title: `${resource.display_name} successfully completed`,
                   message: `Your new model, ${resource.display_name}, is within the model registry`,
                   actions: [
@@ -196,7 +197,7 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
               }
 
               return {
-                status: 'success',
+                status: NotificationResponseStatus.SUCCESS,
                 title: `${resource.display_name} successfully completed`,
                 message: `Your run ${resource.display_name} has successfully completed`,
                 actions: [
@@ -211,7 +212,7 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
             }
             if (response.state === RuntimeStateKF.FAILED) {
               return {
-                status: 'error',
+                status: NotificationResponseStatus.ERROR,
                 title: `${resource.display_name} has failed`,
                 message: `Your run ${resource.display_name} has failed`,
                 actions: [
@@ -228,15 +229,15 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
               response.state === RuntimeStateKF.RUNNING ||
               response.state === RuntimeStateKF.PENDING
             ) {
-              return { status: 'repoll' };
+              return { status: NotificationResponseStatus.REPOLL };
             }
             // Stop on any other state
-            return { status: 'stop' };
+            return { status: NotificationResponseStatus.STOP };
           })
           .catch((e) => {
             // eslint-disable-next-line no-console
             console.error('Error calling api.getPipelineRun', e);
-            return { status: 'stop' };
+            return { status: NotificationResponseStatus.STOP };
           }),
     });
   };


### PR DESCRIPTION
Closes: [RHOAIENG-553](https://issues.redhat.com/browse/RHOAIENG-553)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
-Adds a notification when model deployment fails. The notification pops up in the corner on whatever page the user is on and goes into the notification sidebar. 
-Added an enum to useNotificationWatcherContext for NotificationResponseStatus and updated all usages.

**Popup notification:**
![popup](https://github.com/user-attachments/assets/a042c41d-b2aa-4996-b186-9b920075c787)

**Notification sidebar:**
![side](https://github.com/user-attachments/assets/2969f41a-54c1-46f3-b599-9a21a826e382)

**Deployment status:** Where 'View deployment' redirects to (unchanged but I thought I'd show it, there's already a [ticket](https://issues.redhat.com/browse/RHOAIENG-2478) for the status message (which is only applicable to single-model serving)
![deployment](https://github.com/user-attachments/assets/3a214bb4-6b78-430c-9de2-bc58c3a395ba)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with `npm run test`

**If you want to test this:**
- Navigate to or create a data science project. (The fastest way I've found is with multi-model serving).
- Create a model with a fake URI connection. Ex: `https://github.com/fake/fake/fake.zip`
- Wait for it to fail, should be quick. It can sometimes take a couple seconds for the notification to pop up. You'll have to keep an eye on it since the timeout on the popup notification it pretty quick. It's okay if you miss it you'll still be able to see it in the notification sidebar.
- While waiting, you can navigate around but don't refresh the application.
- Once the model fails, open the notification sidebar and click 'View deployment', it will take you to the model deployment page for the failed model where you can see the model status.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a unit test for `getInferenceServiceLastFailureReason` and added a mock `useModelDeploymentNotification` in ManageInferenceServiceModal.spc.tsx to pass a test failure there.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
