### PR TITLE
Clean up remaining uses of NumberInput

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -143,6 +143,11 @@
             "group": ["@patternfly/react-core"],
             "importNames": ["Select"],
             "message": "Import 'SimpleSelect', 'MultiSelection' or 'TypeaheadSelect' from '~/components' instead."
+          },
+          {
+            "group": ["@patternfly/react-core"],
+            "importNames": ["NumberInput"],
+            "message": "Import 'NumberInputWrapper' from '~/components' instead."
           }
         ]
       }

--- a/frontend/src/components/NumberInputWrapper.tsx
+++ b/frontend/src/components/NumberInputWrapper.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { NumberInput } from '@patternfly/react-core';
 
 import './NumberInputWrapper.scss';

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/TriggerTypeField.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/TriggerTypeField.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   ClipboardCopy,
   FormGroup,
-  NumberInput,
   Split,
   SplitItem,
   Stack,
@@ -18,6 +17,7 @@ import {
   DEFAULT_CRON_STRING,
   DEFAULT_PERIODIC_OPTION,
 } from '~/concepts/pipelines/content/createRun/const';
+import NumberInputWrapper from '~/components/NumberInputWrapper';
 import { extractNumberAndTimeUnit } from './utils';
 
 type TriggerTypeFieldProps = {
@@ -52,18 +52,19 @@ const TriggerTypeField: React.FC<TriggerTypeFieldProps> = ({ data, onChange }) =
         <FormGroup label="Run every" data-testid="run-every-group">
           <Split hasGutter>
             <SplitItem>
-              <NumberInput
+              <NumberInputWrapper
                 min={1}
                 value={numberPart}
                 onChange={(newNumberPart) => {
-                  const updatedValue = `${Number(newNumberPart.currentTarget.value).toLocaleString(
-                    'fullwide',
-                    { useGrouping: false },
-                  )}${unitPart}`;
-                  onChange({
-                    ...data,
-                    value: updatedValue,
-                  });
+                  if (typeof newNumberPart === 'number') {
+                    const updatedValue = `${newNumberPart.toLocaleString('fullwide', {
+                      useGrouping: false,
+                    })}${unitPart}`;
+                    onChange({
+                      ...data,
+                      value: updatedValue,
+                    });
+                  }
                 }}
               />
             </SplitItem>

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -6,7 +6,6 @@ import {
   Icon,
   InputGroup,
   Label,
-  NumberInput,
   Popover,
   Split,
   SplitItem,
@@ -14,12 +13,12 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { isHTMLInputElement } from '~/utilities/utils';
 import { AcceleratorProfileKind } from '~/k8sTypes';
 import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { AcceleratorProfileFormData } from '~/utilities/useAcceleratorProfileFormState';
 import { AcceleratorProfileState } from '~/utilities/useReadAcceleratorState';
+import NumberInputWrapper from '~/components/NumberInputWrapper';
 import useAcceleratorCountWarning from './useAcceleratorCountWarning';
 
 type AcceleratorProfileSelectFieldProps = {
@@ -119,10 +118,6 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     options.push(formatOption(formData.profile));
   }
 
-  const onStep = (step: number) => {
-    setFormData('count', Math.max(formData.count + step, 1));
-  };
-
   // if there is more than a none option, show the dropdown
   if (options.length === 1) {
     return null;
@@ -192,7 +187,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
         <StackItem>
           <FormGroup label="Number of accelerators" fieldId="number-of-accelerators">
             <InputGroup>
-              <NumberInput
+              <NumberInputWrapper
                 inputAriaLabel="Number of accelerators"
                 id="number-of-accelerators"
                 name="number-of-accelerators"
@@ -200,13 +195,9 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 validated={acceleratorCountWarning ? 'warning' : 'default'}
                 min={1}
                 max={999}
-                onPlus={() => onStep(1)}
-                onMinus={() => onStep(-1)}
-                onChange={(event) => {
-                  if (isHTMLInputElement(event.target)) {
-                    const newSize = Number(event.target.value);
-                    setFormData('count', Math.max(Math.min(newSize, 999), 1));
-                  }
+                onChange={(value) => {
+                  const newSize = Number(value);
+                  setFormData('count', Math.max(Math.min(newSize, 999), 1));
                 }}
               />
             </InputGroup>


### PR DESCRIPTION
Closes: [RHOAIENG-22660](https://issues.redhat.com/browse/RHOAIENG-22660)

## Description
Replaces the remaining uses of `NumberInput` with `NumberInputWrapper`. Also adds a eslint rule to flag future imports of `NumberInput`

## How Has This Been Tested?
Tested locally, all functionality remains the same. Also tested with `npm run test` for the eslint rule

## Test Impact
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
