### PR TITLE
feat(workload-message):added finished instead of displaying no messag…

### DIFF
--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -124,6 +124,32 @@ const mockWorkloadStatusConditions: Record<WorkloadStatusType, WorkloadCondition
   ],
 };
 
+const mockWorkloadEmptySucceedCondition: Record<WorkloadStatusType.Succeeded, WorkloadCondition[]> =
+  {
+    [WorkloadStatusType.Succeeded]: [
+      {
+        lastTransitionTime: '2024-03-18T19:15:28Z',
+        message: 'Quota reserved in ClusterQueue cluster-queue',
+        reason: 'QuotaReserved',
+        status: 'True',
+        type: 'QuotaReserved',
+      },
+      {
+        lastTransitionTime: '2024-03-18T19:15:28Z',
+        message: 'The workload is admitted',
+        reason: 'Admitted',
+        status: 'True',
+        type: 'Admitted',
+      },
+      {
+        lastTransitionTime: '2024-03-18T19:17:15Z',
+        message: '',
+        reason: 'Succeeded',
+        status: 'True',
+        type: 'Finished',
+      },
+    ],
+  };
 type MockResourceConfigType = {
   k8sName?: string;
   namespace?: string;
@@ -131,6 +157,7 @@ type MockResourceConfigType = {
   ownerName?: string;
   mockStatus?: WorkloadStatusType | null;
   podSets?: WorkloadPodSet[];
+  mockStatusEmptyWorkload?: boolean;
 };
 export const mockWorkloadK8sResource = ({
   k8sName = 'test-workload',
@@ -139,6 +166,7 @@ export const mockWorkloadK8sResource = ({
   ownerName,
   mockStatus = WorkloadStatusType.Succeeded,
   podSets = [],
+  mockStatusEmptyWorkload = false,
 }: MockResourceConfigType): WorkloadKind => ({
   apiVersion: 'kueue.x-k8s.io/v1beta1',
   kind: 'Workload',
@@ -174,6 +202,10 @@ export const mockWorkloadK8sResource = ({
     queueName: 'user-queue',
   },
   status: {
-    conditions: mockStatus ? mockWorkloadStatusConditions[mockStatus] : [],
+    conditions: mockStatus
+      ? mockStatusEmptyWorkload
+        ? mockWorkloadEmptySucceedCondition[WorkloadStatusType.Succeeded]
+        : mockWorkloadStatusConditions[mockStatus]
+      : [],
   },
 });

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -11,6 +11,7 @@ import {
   WorkloadRequestedResources,
   getQueueRequestedResources,
   getTotalSharedQuota,
+  getWorkloadStatusMessage,
 } from '~/concepts/distributedWorkloads/utils';
 import { WorkloadOwnerType, WorkloadPodSet } from '~/k8sTypes';
 import { PodContainer } from '~/types';
@@ -43,6 +44,15 @@ describe('getStatusInfo', () => {
     expect(info.color).toBe('green');
     expect(info.message).toBe('Job finished successfully');
     expect(info.status).toBe('Succeeded');
+  });
+  it('should return "Finished" when status is Succeeded and message is "No message"', () => {
+    const wl = mockWorkloadK8sResource({
+      k8sName: 'test-workload',
+      mockStatusEmptyWorkload: true,
+      mockStatus: WorkloadStatusType.Succeeded,
+    });
+    const info = getStatusInfo(wl);
+    expect(getWorkloadStatusMessage(info)).toEqual('Finished');
   });
 });
 

--- a/frontend/src/concepts/distributedWorkloads/utils.tsx
+++ b/frontend/src/concepts/distributedWorkloads/utils.tsx
@@ -267,3 +267,11 @@ export const getTotalSharedQuota = (
     ),
   };
 };
+export const getWorkloadStatusMessage = (statusInfo: WorkloadStatusInfo): string => {
+  const DEFAULT_MESSAGE = 'No message';
+  const SUCCESS_MESSAGE = 'Finished';
+  const isSuccessWithNoMessage =
+    statusInfo.status === WorkloadStatusType.Succeeded && statusInfo.message === DEFAULT_MESSAGE;
+
+  return isSuccessWithNoMessage ? SUCCESS_MESSAGE : statusInfo.message;
+};

--- a/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWWorkloadsTableRow.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/workloadStatus/DWWorkloadsTableRow.tsx
@@ -2,13 +2,18 @@ import * as React from 'react';
 import { Td, Tr } from '@patternfly/react-table';
 import { Timestamp } from '@patternfly/react-core';
 import { WorkloadKind } from '~/k8sTypes';
-import { WorkloadStatusInfo, getWorkloadName } from '~/concepts/distributedWorkloads/utils';
+import {
+  WorkloadStatusInfo,
+  getWorkloadStatusMessage,
+  getWorkloadName,
+} from '~/concepts/distributedWorkloads/utils';
 import { WorkloadStatusLabel } from '~/pages/distributedWorkloads/components/WorkloadStatusLabel';
 
 type DWWorkloadsTableRowProps = {
   workload: WorkloadKind;
   statusInfo: WorkloadStatusInfo;
 };
+
 const DWWorkloadsTableRow: React.FC<DWWorkloadsTableRowProps> = ({ workload, statusInfo }) => (
   <Tr key={workload.metadata?.uid}>
     <Td dataLabel="Name">{getWorkloadName(workload)}</Td>
@@ -23,7 +28,7 @@ const DWWorkloadsTableRow: React.FC<DWWorkloadsTableRowProps> = ({ workload, sta
         'Unknown'
       )}
     </Td>
-    <Td dataLabel="Latest Message">{statusInfo.message}</Td>
+    <Td dataLabel="Latest Message">{getWorkloadStatusMessage(statusInfo)}</Td>
   </Tr>
 );
 


### PR DESCRIPTION
Closes [RHOAIENG-9092](https://issues.redhat.com/browse/RHOAIENG-9092)
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
1. When the workload jobs have been successful for the latest message field will be showing Finished instead of showing no message.

![image](https://github.com/user-attachments/assets/29ff824e-99ee-4236-a009-8b61e7190b2d)

 Fig : **Prior to the change**

https://github.com/user-attachments/assets/0a6737af-7139-47aa-a1ef-a18d584a5657

Fig: **When jobs have been successful and completed instead of no message now Finished will be displayed.**

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Visually
2. Go to the Distributed Workloads page and select the Data science project purva on the green cluster there are already workload jobs which have been run 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
NA

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
