### PR TITLE
Update SA Permissions Part Two

### DIFF
--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -135,6 +135,7 @@ rules:
     verbs:
       - list
       - get
+      - create
     resources:
       - rolebindings
       - clusterrolebindings

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -132,6 +132,8 @@ rules:
       - namespaces
   - apiGroups:
       - rbac.authorization.k8s.io
+      # The rbac.authorization.k8s.io permissions (list, get, create, patch, and delete on rolebindings, clusterrolebindings, and roles) are needed so the dashboard can handle user access and permissions automatically. 
+      # This includes tasks like assigning roles, updating existing bindings, and creating or removing access rules.
     verbs:
       - list
       - get

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -134,6 +134,7 @@ rules:
       - rbac.authorization.k8s.io
       # The rbac.authorization.k8s.io permissions (list, get, create, patch, and delete on rolebindings, clusterrolebindings, and roles) are needed so the dashboard can handle user access and permissions automatically. 
       # This includes tasks like assigning roles, updating existing bindings, and creating or removing access rules.
+      # Ex. the standalone Jupyter workbench requires the ability to create an image puller role if one doesn't exist.
     verbs:
       - list
       - get

--- a/manifests/core-bases/base/cluster-role.yaml
+++ b/manifests/core-bases/base/cluster-role.yaml
@@ -136,6 +136,8 @@ rules:
       - list
       - get
       - create
+      - patch
+      - delete
     resources:
       - rolebindings
       - clusterrolebindings

--- a/manifests/core-bases/base/role.yaml
+++ b/manifests/core-bases/base/role.yaml
@@ -35,6 +35,7 @@ rules:
     verbs:
       - get
       - update
+      - delete
     resources:
       - cronjobs
   - apiGroups:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Quick fix adding 'create' back into rbac.authorization.k8s.io for the cluster role.
After it's removal, attempting to create a standalone jupyter workbench if `opendatahub-image-pullers` didn't exist or was deleted, would result in an error. The SA account needs `create` to create a rolebinding if one doesn't exist.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my cluster
If you want to try it:
-Point your dsc dashboard devflags at this branch: `https://github.com/katieperry4/odh-dashboard/tarball/SA-Fix`
-Find the opendatahub-image-pullers rolebinding in the opendatahub namespace
-Delete it
-Open ODH
-Try to launch a standalone workbench

If you want to see the broken version (if this hasn't merged yet) point the devFlags at main
-Delete the opendatahub-image-pullers rolebinding in the opendatahub namespace
-Try to launch a standalone workbench, you'll see an error 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No changes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
