### PR TITLE
fix: check lastAccountCheck

### DIFF
--- a/backend/src/routes/api/integrations/nim/index.ts
+++ b/backend/src/routes/api/integrations/nim/index.ts
@@ -4,10 +4,10 @@ import { KubeFastifyInstance, VariablesValidationStatus } from '../../../../type
 import { isString } from 'lodash';
 import {
   apiKeyValidationStatus,
-  apiKeyValidationTimestamp,
   createNIMAccount,
   deleteNIMAccount,
   errorMsgList,
+  getLastAccountCheckTimestamp,
   getNIMAccount,
   isAppEnabled,
   manageNIMSecret,
@@ -23,13 +23,13 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           // Installed
           const isEnabled = isAppEnabled(response);
           const keyValidationStatus: string = apiKeyValidationStatus(response);
-          const keyValidationTimestamp: string = apiKeyValidationTimestamp(response);
+          const accountStatusTimestamp: string = getLastAccountCheckTimestamp(response);
           const errorMsg: string = errorMsgList(response)[0];
           reply.send({
             isInstalled: true,
             isEnabled: isEnabled,
             variablesValidationStatus: keyValidationStatus,
-            variablesValidationTimestamp: keyValidationTimestamp,
+            variablesValidationTimestamp: accountStatusTimestamp,
             canInstall: !isEnabled,
             error: errorMsg,
           });
@@ -96,12 +96,12 @@ module.exports = async (fastify: KubeFastifyInstance) => {
             const nimAccount = !account ? await createNIMAccount(fastify) : account;
             const isEnabled = isAppEnabled(nimAccount);
             const keyValidationStatus: string = apiKeyValidationStatus(nimAccount);
-            const keyValidationTimeStamp: string = apiKeyValidationTimestamp(nimAccount);
+            const accountStatusTimestamp: string = getLastAccountCheckTimestamp(nimAccount);
             reply.send({
               isInstalled: true,
               isEnabled: isEnabled,
               variablesValidationStatus: keyValidationStatus,
-              variablesValidationTimestamp: keyValidationTimeStamp,
+              variablesValidationTimestamp: accountStatusTimestamp,
               canInstall: !isEnabled,
               error: '',
             });

--- a/backend/src/routes/api/integrations/nim/nimUtils.ts
+++ b/backend/src/routes/api/integrations/nim/nimUtils.ts
@@ -12,10 +12,8 @@ export const errorMsgList = (app: NIMAccountKind): string[] => {
     .map((condition) => condition.message);
 };
 
-export const apiKeyValidationTimestamp = (app: NIMAccountKind): string => {
-  const conditions = app?.status?.conditions || [];
-  const apiKeyCondition = conditions.find((condition) => condition.type === 'APIKeyValidation');
-  return apiKeyCondition?.lastTransitionTime || '';
+export const getLastAccountCheckTimestamp = (app: NIMAccountKind): string => {
+  return app?.status?.lastAccountCheck || '';
 };
 
 export const apiKeyValidationStatus = (app: NIMAccountKind): string => {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1295,6 +1295,7 @@ export type NIMAccountKind = K8sResourceCommon & {
       name: string;
     };
     conditions?: K8sCondition[];
+    lastAccountCheck?: string;
   };
 };
 

--- a/frontend/src/utilities/useEnableApplication.tsx
+++ b/frontend/src/utilities/useEnableApplication.tsx
@@ -7,7 +7,7 @@ import {
 } from '~/services/integrationAppService';
 import { addNotification, forceComponentsUpdate } from '~/redux/actions/actions';
 import { useAppDispatch } from '~/redux/hooks';
-import { IntegrationAppStatus, VariablesValidationStatus } from '~/types';
+import { IntegrationAppStatus } from '~/types';
 import { isInternalRouteIntegrationsApp } from './utils';
 
 export enum EnableApplicationStatus {
@@ -84,20 +84,12 @@ export const useEnableApplication = (
                 return;
               }
               setEnableStatus({
-                status:
-                  response.variablesValidationStatus === VariablesValidationStatus.SUCCESS
-                    ? EnableApplicationStatus.SUCCESS
-                    : EnableApplicationStatus.FAILED,
-                error:
-                  response.variablesValidationStatus === VariablesValidationStatus.SUCCESS
-                    ? ''
-                    : response.error,
+                status: response.isEnabled
+                  ? EnableApplicationStatus.SUCCESS
+                  : EnableApplicationStatus.FAILED,
+                error: response.isEnabled ? '' : response.error,
               });
-              dispatchResults(
-                response.variablesValidationStatus === VariablesValidationStatus.SUCCESS
-                  ? undefined
-                  : response.error,
-              );
+              dispatchResults(response.isEnabled ? undefined : response.error);
             })
             .catch((e) => {
               if (!cancelled) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/NVPE-243

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Change to check lastAccountCheck and isEnabled status instead of relying on APIKeyValidation, so the 'Enable' button would reflect the account availability. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Verified that the 'Enable' button does not prematurely disappears as soon as APIKeyValidation status changes while the reconciliation is still in progress.

After entering the API key, once the "Enable" button disappears, the application should now correctly appear on the Enabled page.
Prior to this change, the disappearance of the "Enable" button only indicated that validation was complete, but the application remained disabled on the Enabled page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
