### PR TITLE
Followup to #4072: Change 'dsp' to 'kfp' in the ModelSourceKind logic

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -119,7 +119,7 @@ const mockModelVersions = mockModelVersion({
 });
 
 const mockModelArtifactWithSource = mockModelArtifact({
-  modelSourceKind: ModelSourceKind.DSP,
+  modelSourceKind: ModelSourceKind.KFP,
   modelSourceGroup: 'test-project',
   modelSourceId: 'pipelinerun1',
   modelSourceName: 'pipeline-run-test',

--- a/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
@@ -307,7 +307,7 @@ describe('modelSourcePropertiesToCatalogParams', () => {
 
   it('should return null for non-catalog source', () => {
     const properties = {
-      modelSourceKind: ModelSourceKind.DSP,
+      modelSourceKind: ModelSourceKind.KFP,
       modelSourceClass: 'class1',
       modelSourceGroup: 'group1',
       modelSourceName: 'name1',
@@ -347,9 +347,9 @@ describe('catalogParamsToModelSourceProperties', () => {
 });
 
 describe('modelSourcePropertiesToPipelineRunRef', () => {
-  it('should convert valid DSP source properties', () => {
+  it('should convert valid KFP source properties', () => {
     const properties = {
-      modelSourceKind: ModelSourceKind.DSP,
+      modelSourceKind: ModelSourceKind.KFP,
       modelSourceGroup: 'project1',
       modelSourceId: 'run1',
       modelSourceName: 'name1',
@@ -361,7 +361,7 @@ describe('modelSourcePropertiesToPipelineRunRef', () => {
     });
   });
 
-  it('should return null for non-DSP source', () => {
+  it('should return null for non-KFP source', () => {
     const properties = {
       modelSourceKind: ModelSourceKind.CATALOG,
       modelSourceGroup: 'project1',
@@ -373,7 +373,7 @@ describe('modelSourcePropertiesToPipelineRunRef', () => {
 
   it('should return null if required properties are missing', () => {
     const properties = {
-      modelSourceKind: ModelSourceKind.DSP,
+      modelSourceKind: ModelSourceKind.KFP,
       modelSourceGroup: 'project1',
       // missing modelSourceId
       modelSourceName: 'name1',

--- a/frontend/src/concepts/modelRegistry/types.ts
+++ b/frontend/src/concepts/modelRegistry/types.ts
@@ -13,7 +13,7 @@ export enum InferenceServiceState {
 
 export enum ModelSourceKind {
   CATALOG = 'catalog',
-  DSP = 'dsp',
+  KFP = 'kfp',
 }
 
 export enum ExecutionState {

--- a/frontend/src/concepts/modelRegistry/utils.ts
+++ b/frontend/src/concepts/modelRegistry/utils.ts
@@ -166,13 +166,13 @@ export const catalogParamsToModelSourceProperties = (
 /**
  * Converts model source properties to pipeline run reference
  * @param properties - The model source properties
- * @returns PipelineRunReference object or null if not a DSP source or if required properties are missing
+ * @returns PipelineRunReference object or null if not a KFP source or if required properties are missing
  */
 export const modelSourcePropertiesToPipelineRunRef = (
   properties: ModelSourceProperties,
 ): PipelineRunReference | null => {
   if (
-    properties.modelSourceKind !== ModelSourceKind.DSP ||
+    properties.modelSourceKind !== ModelSourceKind.KFP ||
     !properties.modelSourceGroup ||
     !properties.modelSourceId ||
     !properties.modelSourceName


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Quick followup to #4072 to just use a different value for the `modelSourceKind` when a model is registered from a pipelinerun. [From this slack thread](https://redhat-internal.slack.com/archives/C07J39USZND/p1745865045331399?thread_ts=1744228165.050079&cid=C07J39USZND), instead of `"dsp"` (Data Science Pipelines) we'll use `"kfp"` (KubeFlow Pipelines).

cc @YuliaKrimerman 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ensured existing tests still pass.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
