### PR TITLE
Move ModelServingContext from pages to concepts

### DIFF
--- a/frontend/src/concepts/modelServing/context/ModelServingContext.tsx
+++ b/frontend/src/concepts/modelServing/context/ModelServingContext.tsx
@@ -25,12 +25,12 @@ import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformS
 import { useTemplates } from '~/api';
 import { Connection } from '~/concepts/connectionTypes/types';
 import useConnections from '~/pages/projects/screens/detail/connections/useConnections';
-import useInferenceServices from './useInferenceServices';
-import useServingRuntimes from './useServingRuntimes';
-import useTemplateOrder from './customServingRuntimes/useTemplateOrder';
-import useTemplateDisablement from './customServingRuntimes/useTemplateDisablement';
-import { getTokenNames } from './utils';
-import useServingRuntimeSecrets from './screens/projects/useServingRuntimeSecrets';
+import useInferenceServices from '~/pages/modelServing/useInferenceServices';
+import useServingRuntimes from '~/pages/modelServing/useServingRuntimes';
+import useTemplateOrder from '~/pages/modelServing/customServingRuntimes/useTemplateOrder';
+import useTemplateDisablement from '~/pages/modelServing/customServingRuntimes/useTemplateDisablement';
+import { getTokenNames } from '~/pages/modelServing/utils';
+import useServingRuntimeSecrets from '~/pages/modelServing/screens/projects/useServingRuntimeSecrets';
 
 export type ModelServingContextType = {
   refreshAllData: () => void;

--- a/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
+++ b/frontend/src/pages/modelServing/screens/global/EmptyModelServing.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Truncate } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import { ModelServingContext } from '~/concepts/modelServing/context/ModelServingContext';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
 import EmptyDetailsView from '~/components/EmptyDetailsView';
 import { ProjectObjectType, typedEmptyImage } from '~/concepts/design/utils';

--- a/frontend/src/pages/modelServing/screens/global/GlobalModelServingCoreLoader.tsx
+++ b/frontend/src/pages/modelServing/screens/global/GlobalModelServingCoreLoader.tsx
@@ -3,7 +3,7 @@ import { Navigate, Outlet, useParams } from 'react-router-dom';
 import ApplicationsPage from '~/pages/ApplicationsPage';
 import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import InvalidProject from '~/concepts/projects/InvalidProject';
-import ModelServingContextProvider from '~/pages/modelServing/ModelServingContext';
+import ModelServingContextProvider from '~/concepts/modelServing/context/ModelServingContext';
 import ModelServingNoProjects from '~/pages/modelServing/screens/global/ModelServingNoProjects';
 import ModelServingProjectSelection from '~/pages/modelServing/screens/global/ModelServingProjectSelection';
 

--- a/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ModelServingGlobal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router';
 import ApplicationsPage from '~/pages/ApplicationsPage';
-import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import { ModelServingContext } from '~/concepts/modelServing/context/ModelServingContext';
 import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
 import { getProjectModelServingPlatform } from '~/pages/modelServing/screens/projects/utils';
 import { ProjectObjectType } from '~/concepts/design/utils';

--- a/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx
+++ b/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
-import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import { ModelServingContext } from '~/concepts/modelServing/context/ModelServingContext';
 import {
   getSortedTemplates,
   getTemplateEnabled,

--- a/frontend/src/pages/modelServing/screens/metrics/ModelMetricsPathWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/ModelMetricsPathWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import { ModelServingContext } from '~/concepts/modelServing/context/ModelServingContext';
 import NotFound from '~/pages/NotFound';
 import { InferenceServiceKind } from '~/k8sTypes';
 

--- a/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
@@ -11,7 +11,7 @@ import { ServingRuntimePlatform } from '~/types';
 import ManageInferenceServiceModal from '~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import ModelServingContextProvider, {
   ModelServingContext,
-} from '~/pages/modelServing/ModelServingContext';
+} from '~/concepts/modelServing/context/ModelServingContext';
 import { getKServeTemplates } from '~/pages/modelServing/customServingRuntimes/utils';
 import { isRedHatRegistryUri } from '~/pages/modelRegistry/screens/utils';
 import useServingConnections from '~/pages/projects/screens/detail/connections/useServingConnections';

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/useProjectErrorForPrefilledModel.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/useProjectErrorForPrefilledModel.spec.ts
@@ -5,7 +5,7 @@ import { testHook } from '~/__tests__/unit/testUtils/hooks';
 import { useAccessReview } from '~/api';
 import { useAppContext } from '~/app/AppContext';
 import { ServingRuntimeKind } from '~/k8sTypes';
-import { ModelServingContextType } from '~/pages/modelServing/ModelServingContext';
+import { ModelServingContextType } from '~/concepts/modelServing/context/ModelServingContext';
 import useProjectErrorForPrefilledModel from '~/pages/modelServing/screens/projects/useProjectErrorForPrefilledModel';
 import { ServingRuntimePlatform } from '~/types';
 

--- a/frontend/src/pages/modelServing/screens/projects/useProjectErrorForPrefilledModel.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useProjectErrorForPrefilledModel.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ServingRuntimePlatform } from '~/types';
-import { ModelServingContext } from '~/pages/modelServing/ModelServingContext';
+import { ModelServingContext } from '~/concepts/modelServing/context/ModelServingContext';
 
 const useProjectErrorForPrefilledModel = (
   projectName?: string,

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsSection.tsx
@@ -29,7 +29,7 @@ import OverviewCard from '~/pages/projects/screens/detail/overview/components/Ov
 import AddModelFooter from '~/pages/projects/screens/detail/overview/serverModels/AddModelFooter';
 import { InferenceServiceKind } from '~/k8sTypes';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
-import ModelServingContextProvider from '~/pages/modelServing/ModelServingContext';
+import ModelServingContextProvider from '~/concepts/modelServing/context/ModelServingContext';
 import { isProjectNIMSupported } from '~/pages/modelServing/screens/projects/nimUtils';
 import { NamespaceApplicationCase } from '~/pages/projects/types';
 import ModelServingPlatformSelectButton from '~/pages/modelServing/screens/projects/ModelServingPlatformSelectButton';


### PR DESCRIPTION
Closes [RHOAIENG-2115](https://issues.redhat.com/browse/RHOAIENG-2115)

## Description
- Added a modelServing folder in concepts and a context folder within it.
- Moved ModelServingContext from the pages folder to the new concepts modelServing/context folder. 
- Updated imports.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally serving models etc as well as `npm run test`

Try it out yourself:
- Open or create a data science project with no models (so we can see empty model serving as an example)
- Serve a model (you'll use the serveModelButton, which also had an import changed)
- View the model in model deployments (to see DeployedModelsSection is still working as well)
- These are just examples of some of the changes but feel free to check out the others, run `npm run test`, or anything else you'd like to check out

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Anywhere that used ModelServingContext has its import changed, which included a test file.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
