### PR TITLE
Added unit test for useModelCatalogSources.ts

### DIFF
--- a/frontend/src/concepts/modelCatalog/__tests__/useModelCatalogSources.spec.ts
+++ b/frontend/src/concepts/modelCatalog/__tests__/useModelCatalogSources.spec.ts
@@ -1,0 +1,174 @@
+import { renderHook, act } from '@testing-library/react';
+import { getConfigMap } from '~/api';
+import { useIsAreaAvailable } from '~/concepts/areas';
+import useNamespaces from '~/pages/notebookController/useNamespaces';
+import { useModelCatalogSources } from '~/concepts/modelCatalog/useModelCatalogSources';
+import {
+  MODEL_CATALOG_SOURCES_CONFIGMAP,
+  MODEL_CATALOG_UNMANAGED_SOURCES_CONFIGMAP,
+} from '~/concepts/modelCatalog/const';
+
+// Mock the dependencies
+jest.mock('~/api', () => ({
+  getConfigMap: jest.fn(),
+  isK8sStatus: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('~/pages/notebookController/useNamespaces', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('~/concepts/areas', () => ({
+  useIsAreaAvailable: jest.fn(),
+}));
+
+describe('useModelCatalogSources', () => {
+  const mockDashboardNamespace = 'test-namespace';
+  const mockModelCatalogSources = {
+    sources: [
+      { name: 'source1', url: 'http://source1.com' },
+      { name: 'source2', url: 'http://source2.com' },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNamespaces as jest.Mock).mockReturnValue({ dashboardNamespace: mockDashboardNamespace });
+    (useIsAreaAvailable as jest.Mock).mockReturnValue({ status: true });
+  });
+
+  describe('when model catalog is not available', () => {
+    it('should return empty array', async () => {
+      (useIsAreaAvailable as jest.Mock).mockReturnValue({ status: false });
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([]);
+      expect(result.current[1]).toBe(false);
+    });
+  });
+
+  describe('when fetching model catalog sources', () => {
+    it('should handle multiple config maps', async () => {
+      const mockUnmanagedSources = {
+        sources: [{ name: 'unmanaged1', url: 'http://unmanaged1.com' }],
+      };
+
+      (getConfigMap as jest.Mock).mockImplementation((namespace, name) => {
+        if (name === MODEL_CATALOG_SOURCES_CONFIGMAP) {
+          return Promise.resolve({
+            data: {
+              modelCatalogSources: JSON.stringify(mockModelCatalogSources),
+            },
+          });
+        }
+        if (name === MODEL_CATALOG_UNMANAGED_SOURCES_CONFIGMAP) {
+          return Promise.resolve({
+            data: {
+              modelCatalogSources: JSON.stringify(mockUnmanagedSources),
+            },
+          });
+        }
+        return Promise.reject({ statusObject: { code: 404 } });
+      });
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([
+        ...mockModelCatalogSources.sources,
+        ...mockUnmanagedSources.sources,
+      ]);
+    });
+
+    it('should return empty array when config map is not found', async () => {
+      (getConfigMap as jest.Mock).mockRejectedValue({ statusObject: { code: 404 } });
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([]);
+    });
+  });
+
+  describe('when handling invalid data', () => {
+    it('should handle invalid JSON data', async () => {
+      (getConfigMap as jest.Mock).mockImplementation((namespace, name) => {
+        if (name === MODEL_CATALOG_SOURCES_CONFIGMAP) {
+          return Promise.resolve({
+            data: {
+              modelCatalogSources: 'invalid-json',
+            },
+          });
+        }
+        return Promise.reject({ statusObject: { code: 404 } });
+      });
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([]);
+    });
+
+    it('should handle missing modelCatalogSources field', async () => {
+      (getConfigMap as jest.Mock).mockImplementation((namespace, name) => {
+        if (name === MODEL_CATALOG_SOURCES_CONFIGMAP) {
+          return Promise.resolve({
+            data: {},
+          });
+        }
+        return Promise.reject({ statusObject: { code: 404 } });
+      });
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([]);
+    });
+  });
+
+  describe('when handling errors', () => {
+    it('should handle API errors', async () => {
+      (getConfigMap as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([]);
+      expect(result.current[2]).toBeDefined();
+    });
+
+    it('should handle non-404 errors', async () => {
+      (getConfigMap as jest.Mock).mockRejectedValue({ statusObject: { code: 500 } });
+
+      const { result } = renderHook(() => useModelCatalogSources());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current[0]).toEqual([]);
+      expect(result.current[2]).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes [RHOAIENG-24224](https://issues.redhat.com/browse/RHOAIENG-24224)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added unit test to cover that test file

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run npm run test and make sure all the tests are passing

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added the unit test, no other test changes happened
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
