### PR TITLE
Improvements to project permissions

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/permissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/permissions.cy.ts
@@ -5,7 +5,7 @@ import { permissions } from '~/__tests__/cypress/cypress/pages/permissions';
 import { be } from '~/__tests__/cypress/cypress/utils/should';
 import { ProjectModel, RoleBindingModel } from '~/__tests__/cypress/cypress/utils/models';
 import type { RoleBindingSubject } from '~/k8sTypes';
-import { asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
+// import { asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 
 const userSubjects: RoleBindingSubject[] = [
   {
@@ -57,12 +57,12 @@ describe('Permissions tab', () => {
   const userTable = permissions.getUserTable();
   const groupTable = permissions.getGroupTable();
 
-  it('should not be accessible for non-project admins', () => {
-    asProjectEditUser();
-    initIntercepts({ isEmpty: false });
-    permissions.visit('test-project');
-    cy.url().should('include', '/projects/test-project?section=overview');
-  });
+  // it('should not be accessible for non-project admins', () => {
+  //   asProjectEditUser();
+  //   initIntercepts({ isEmpty: false });
+  //   permissions.visit('test-project');
+  //   cy.url().should('include', '/projects/test-project?section=overview');
+  // });
 
   it('Empty table for groups and users', () => {
     initIntercepts({ isEmpty: true });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/permissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/permissions.cy.ts
@@ -5,7 +5,7 @@ import { permissions } from '~/__tests__/cypress/cypress/pages/permissions';
 import { be } from '~/__tests__/cypress/cypress/utils/should';
 import { ProjectModel, RoleBindingModel } from '~/__tests__/cypress/cypress/utils/models';
 import type { RoleBindingSubject } from '~/k8sTypes';
-// import { asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
+import { asProjectEditUser } from '~/__tests__/cypress/cypress/utils/mockUsers';
 
 const userSubjects: RoleBindingSubject[] = [
   {
@@ -57,12 +57,12 @@ describe('Permissions tab', () => {
   const userTable = permissions.getUserTable();
   const groupTable = permissions.getGroupTable();
 
-  // it('should not be accessible for non-project admins', () => {
-  //   asProjectEditUser();
-  //   initIntercepts({ isEmpty: false });
-  //   permissions.visit('test-project');
-  //   cy.url().should('include', '/projects/test-project?section=overview');
-  // });
+  it('should not be accessible for non-project admins', () => {
+    asProjectEditUser();
+    initIntercepts({ isEmpty: false });
+    permissions.visit('test-project');
+    cy.url().should('include', '/projects/test-project?section=overview');
+  });
 
   it('Empty table for groups and users', () => {
     initIntercepts({ isEmpty: true });

--- a/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
@@ -153,6 +153,11 @@ const setUserConfig = (userConfig: UserConfig = {}, isAllowed = true) => {
       return true;
     }
 
+    if (resource === 'rolebindings' && !projectAdmin) {
+      Cypress.log({ message: 'Users cannot access permissions tab' });
+      return false;
+    }
+
     if (PROJECT_ADMIN_RESOURCES.includes(resource) && EDIT_VERBS.includes(verb)) {
       if (projectAdmin) {
         Cypress.log({ message: 'Project admins allowed edit on project resources' });

--- a/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/mockUsers.ts
@@ -139,48 +139,155 @@ const setUserConfig = (userConfig: UserConfig = {}, isAllowed = true) => {
     const EDIT_VERBS = ['*', 'create', 'delete', 'deletecollection', 'update', 'patch'];
 
     if (clusterAdmin) {
-      Cypress.log({ message: 'Cluster admin can do everything' });
+      Cypress.log({
+        name: 'SSAR Permission Check',
+        displayName: 'Cluster Admin:',
+        message: 'Full access granted',
+        consoleProps: () => {
+          return {
+            Verb: resourceAttributes.verb,
+            Resource: resourceAttributes.resource,
+            Namespace: resourceAttributes.namespace,
+            Group: resourceAttributes.group,
+          };
+        },
+      });
       return true;
     }
 
     if (productAdmin) {
       if (namespace === 'opendatahub') {
         Cypress.log({
-          message:
-            'Product admins are getting direct access to resources in the deployment namespace (but importantly, not other projects)',
+          name: 'SSAR Permission Check',
+          displayName: 'Product Admin:',
+          message: 'Access to resources in deployment namespace',
+          consoleProps: () => {
+            return {
+              Verb: resourceAttributes.verb,
+              Resource: resourceAttributes.resource,
+              Namespace: resourceAttributes.namespace,
+              Group: resourceAttributes.group,
+            };
+          },
         });
         return true;
       }
       if (!EDIT_VERBS.includes(verb)) {
-        Cypress.log({ message: 'Product admins will be limited to listing resources' });
+        Cypress.log({
+          name: 'SSAR Permission Check',
+          displayName: 'Product Admin:',
+          message: 'Limited to listing resources',
+          consoleProps: () => {
+            return {
+              Verb: resourceAttributes.verb,
+              Resource: resourceAttributes.resource,
+              Namespace: resourceAttributes.namespace,
+              Group: resourceAttributes.group,
+            };
+          },
+        });
         return true;
       }
     }
 
     if (resource === 'projectrequests' && selfProvisioner) {
-      Cypress.log({ message: 'Self provisioner capabilities grant access to project creation' });
+      Cypress.log({
+        name: 'SSAR Permission Check',
+        displayName: 'Self Provisioner:',
+        message: 'Grant access to project creation',
+        consoleProps: () => {
+          return {
+            Verb: resourceAttributes.verb,
+            Resource: resourceAttributes.resource,
+            Namespace: resourceAttributes.namespace,
+            Group: resourceAttributes.group,
+          };
+        },
+      });
       return true;
     }
 
     if (resource === 'rolebindings' && !projectAdmin) {
-      Cypress.log({ message: 'Users cannot access permissions tab' });
+      Cypress.log({
+        name: 'SSAR Permission Check',
+        displayName: 'Project Users:',
+        message: 'Access denied (requires Project Admin)',
+        consoleProps: () => {
+          return {
+            Verb: resourceAttributes.verb,
+            Resource: resourceAttributes.resource,
+            Namespace: resourceAttributes.namespace,
+            Group: resourceAttributes.group,
+          };
+        },
+      });
       return false;
     }
 
     if (PROJECT_ADMIN_RESOURCES.includes(resource) && EDIT_VERBS.includes(verb)) {
       if (projectAdmin) {
-        Cypress.log({ message: 'Project admins allowed edit on project resources' });
+        Cypress.log({
+          name: 'SSAR Permission Check',
+          displayName: 'Project Admin:',
+          message: 'Edit access granted',
+          consoleProps: () => {
+            return {
+              Verb: resourceAttributes.verb,
+              Resource: resourceAttributes.resource,
+              Namespace: resourceAttributes.namespace,
+              Group: resourceAttributes.group,
+            };
+          },
+        });
         return true;
       }
-      Cypress.log({ message: 'Project users not allowed to edit project resources' });
+      Cypress.log({
+        name: 'SSAR Permission Check',
+        displayName: 'Project Users:',
+        message: 'Edit access denied',
+        consoleProps: () => {
+          return {
+            Verb: resourceAttributes.verb,
+            Resource: resourceAttributes.resource,
+            Namespace: resourceAttributes.namespace,
+            Group: resourceAttributes.group,
+          };
+        },
+      });
       return false;
     }
-
     if (namespace) {
-      Cypress.log({ message: 'Everyone else can perform any action within' });
+      if (namespace === 'opendatahub' && !productAdmin) {
+        Cypress.log({
+          name: 'SSAR Permission Check',
+          displayName: 'Permission:',
+          message: 'Access denied to opendatahub namespace',
+          consoleProps: () => {
+            return {
+              Verb: resourceAttributes.verb,
+              Resource: resourceAttributes.resource,
+              Namespace: resourceAttributes.namespace,
+              Group: resourceAttributes.group,
+            };
+          },
+        });
+        return false;
+      }
+      Cypress.log({
+        name: 'SSAR Permission Check',
+        displayName: 'Permission:',
+        message: 'Access granted within namespace',
+        consoleProps: () => {
+          return {
+            Verb: resourceAttributes.verb,
+            Resource: resourceAttributes.resource,
+            Namespace: resourceAttributes.namespace,
+            Group: resourceAttributes.group,
+          };
+        },
+      });
       return true;
     }
-
     return false;
   };
 

--- a/frontend/src/concepts/projects/accessChecks.tsx
+++ b/frontend/src/concepts/projects/accessChecks.tsx
@@ -50,5 +50,6 @@ export const useProjectPermissionsTabVisible = (
     shouldRunCheck,
   );
 
+// TODO: expand this out to meet future needs
 export const useProjectSettingsTabVisible = (): boolean =>
   useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;

--- a/frontend/src/concepts/projects/accessChecks.tsx
+++ b/frontend/src/concepts/projects/accessChecks.tsx
@@ -1,5 +1,6 @@
 import { K8sVerb } from '~/k8sTypes';
 import { useAccessReview } from '~/api';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 
 /**
  * Effectively this check is equivalent to checking if a user is a project admin, specifically on the verb passed.
@@ -34,3 +35,20 @@ export const useProjectPermissionsAccessReview = (
     },
     shouldRunCheck,
   );
+
+export const useProjectPermissionsTabVisible = (
+  projectName: string,
+  shouldRunCheck?: boolean,
+): ReturnType<typeof useAccessReview> =>
+  useAccessReview(
+    {
+      group: 'rbac.authorization.k8s.io',
+      resource: 'rolebindings',
+      namespace: projectName,
+      verb: 'list',
+    },
+    shouldRunCheck,
+  );
+
+export const useProjectSettingsTabVisible = (): boolean =>
+  useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;

--- a/frontend/src/pages/projects/projectSettings/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/projects/projectSettings/ProjectSettingsPage.tsx
@@ -7,6 +7,7 @@ import { useProjectSettingsTabVisible } from '~/concepts/projects/accessChecks';
 
 const ProjectSettingsPage = (): ReactElement => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
+  const projectSettingsTabVisible = useProjectSettingsTabVisible();
 
   return (
     <PageSection
@@ -16,7 +17,7 @@ const ProjectSettingsPage = (): ReactElement => {
       id={ProjectSectionID.SETTINGS}
     >
       <Stack hasGutter>
-        {useProjectSettingsTabVisible() && (
+        {projectSettingsTabVisible && (
           <StackItem>
             <ModelBiasSettingsCard project={currentProject} />
           </StackItem>

--- a/frontend/src/pages/projects/projectSettings/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/projects/projectSettings/ProjectSettingsPage.tsx
@@ -2,12 +2,11 @@ import React, { ReactElement } from 'react';
 import { PageSection, Stack, StackItem } from '@patternfly/react-core';
 import ModelBiasSettingsCard from '~/pages/projects/projectSettings/ModelBiasSettingsCard';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
-import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
+import { useProjectSettingsTabVisible } from '~/concepts/projects/accessChecks';
 
 const ProjectSettingsPage = (): ReactElement => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
-  const biasMetricsAreaAvailable = useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;
 
   return (
     <PageSection
@@ -17,7 +16,7 @@ const ProjectSettingsPage = (): ReactElement => {
       id={ProjectSectionID.SETTINGS}
     >
       <Stack hasGutter>
-        {biasMetricsAreaAvailable && (
+        {useProjectSettingsTabVisible() && (
           <StackItem>
             <ModelBiasSettingsCard project={currentProject} />
           </StackItem>

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -10,11 +10,10 @@ import ProjectSettingsPage from '~/pages/projects/projectSettings/ProjectSetting
 import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
-import { AccessReviewResourceAttributes } from '~/k8sTypes';
-import { useAccessReview } from '~/api';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import HeaderIcon from '~/concepts/design/HeaderIcon';
+import { useProjectPermissionsTabVisible } from '~/concepts/projects/accessChecks';
 import useCheckLogoutParams from './useCheckLogoutParams';
 import ProjectOverview from './overview/ProjectOverview';
 import NotebookList from './notebooks/NotebookList';
@@ -24,12 +23,6 @@ import PipelinesSection from './pipelines/PipelinesSection';
 import ProjectActions from './ProjectActions';
 
 import './ProjectDetails.scss';
-
-const accessReviewResource: AccessReviewResourceAttributes = {
-  group: 'rbac.authorization.k8s.io',
-  resource: 'rolebindings',
-  verb: 'create',
-};
 
 const ProjectDetails: React.FC = () => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
@@ -41,10 +34,9 @@ const ProjectDetails: React.FC = () => {
   const modelServingTab = useModelServingTab();
   const [searchParams, setSearchParams] = useSearchParams();
   const state = searchParams.get('section');
-  const [allowCreate, rbacLoaded] = useAccessReview({
-    ...accessReviewResource,
-    namespace: currentProject.metadata.name,
-  });
+
+  const [allowCreate, rbacLoaded] = useProjectPermissionsTabVisible(currentProject.metadata.name);
+
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
 
   useCheckLogoutParams();


### PR DESCRIPTION
Closes: [RHOAIENG-23534](https://issues.redhat.com/browse/RHOAIENG-23534)

## Description
Makes updates to improve how some of our project permissions are handled. Moves additional checks into `accessChecks.tsx` to allow them to be reusable for future projects.

## How Has This Been Tested?
Tested locally as a user 

## Test Impact
No tested changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
