### PR TITLE
fixed scrolling issue between Model Catalog and Model Catalog details page 

### DIFF
--- a/frontend/src/pages/modelCatalog/screens/ModelCatalog.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelCatalog.tsx
@@ -8,6 +8,7 @@ import { conditionalArea, SupportedArea } from '~/concepts/areas';
 import EmptyModelCatalogState from '~/pages/modelCatalog/EmptyModelCatalogState';
 import { ModelCatalogContext } from '~/concepts/modelCatalog/context/ModelCatalogContext';
 import { ModelCatalogCards } from '~/pages/modelCatalog/components/ModelCatalogCards';
+import ScrollViewOnMount from '~/components/ScrollViewOnMount';
 
 const ModelCatalog: React.FC = conditionalArea(
   SupportedArea.MODEL_CATALOG,
@@ -16,27 +17,30 @@ const ModelCatalog: React.FC = conditionalArea(
   const { modelCatalogSources } = React.useContext(ModelCatalogContext);
 
   return (
-    <ApplicationsPage
-      title={<TitleWithIcon title="Model catalog" objectType={ProjectObjectType.modelCatalog} />}
-      description="Discover models that are available for your organization to register, deploy, and customize."
-      empty={modelCatalogSources.data.length === 0}
-      emptyStatePage={
-        <EmptyModelCatalogState
-          testid="empty-model-catalog-state"
-          title="Request access to model catalog"
-          description="To request access to model catalog, contact your administrator."
-        />
-      }
-      headerContent={null}
-      loaded={modelCatalogSources.loaded}
-      loadError={modelCatalogSources.error}
-      errorMessage="Unable to load model catalog"
-      provideChildrenPadding
-    >
-      <PageSection isFilled>
-        <ModelCatalogCards sources={modelCatalogSources.data} />
-      </PageSection>
-    </ApplicationsPage>
+    <>
+      <ScrollViewOnMount shouldScroll />
+      <ApplicationsPage
+        title={<TitleWithIcon title="Model catalog" objectType={ProjectObjectType.modelCatalog} />}
+        description="Discover models that are available for your organization to register, deploy, and customize."
+        empty={modelCatalogSources.data.length === 0}
+        emptyStatePage={
+          <EmptyModelCatalogState
+            testid="empty-model-catalog-state"
+            title="Request access to model catalog"
+            description="To request access to model catalog, contact your administrator."
+          />
+        }
+        headerContent={null}
+        loaded={modelCatalogSources.loaded}
+        loadError={modelCatalogSources.error}
+        errorMessage="Unable to load model catalog"
+        provideChildrenPadding
+      >
+        <PageSection isFilled>
+          <ModelCatalogCards sources={modelCatalogSources.data} />
+        </PageSection>
+      </ApplicationsPage>
+    </>
   );
 });
 

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -39,6 +39,7 @@ import { modelCustomizationRootPath, getRegisterCatalogModelRoute } from '~/rout
 import RhUiControlsIcon from '~/images/icons/RhUiControlsIcon';
 import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
 import { ODH_PRODUCT_NAME } from '~/utilities/const';
+import ScrollViewOnMount from '~/components/ScrollViewOnMount';
 import ModelDetailsView from './ModelDetailsView';
 import DeployCatalogModelModal from './DeployCatalogModelModal';
 
@@ -147,91 +148,97 @@ const ModelDetailsPage: React.FC = conditionalArea(
   );
 
   return (
-    <ApplicationsPage
-      breadcrumb={
-        <Breadcrumb>
-          <BreadcrumbItem>
-            <Link to="/modelCatalog">Model catalog</Link>
-          </BreadcrumbItem>
-          <BreadcrumbItem isActive>{decodedParams.modelName}</BreadcrumbItem>
-        </Breadcrumb>
-      }
-      title={
-        <Flex spaceItems={{ default: 'spaceItemsMd' }} alignItems={{ default: 'alignItemsCenter' }}>
-          {model?.logo ? (
-            <img src={model.logo} alt="model logo" style={{ height: '40px', width: '40px' }} />
-          ) : (
-            <Skeleton
-              shape="square"
-              width="40px"
-              height="40px"
-              screenreaderText="Brand image loading"
-            />
-          )}
-          <Stack>
-            <StackItem>
-              <Flex
-                spaceItems={{ default: 'spaceItemsSm' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-              >
-                <FlexItem>{decodedParams.modelName}</FlexItem>
-                {model && (
-                  <Label variant="outline" icon={<RhUiTagIcon />}>
-                    {getTagFromModel(model)}
-                  </Label>
-                )}
-              </Flex>
-            </StackItem>
-            {model && (
-              <StackItem>
-                <Content component={ContentVariants.small}>Provided by {model.provider}</Content>
-              </StackItem>
+    <>
+      <ScrollViewOnMount shouldScroll />
+      <ApplicationsPage
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbItem>
+              <Link to="/modelCatalog">Model catalog</Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem isActive>{decodedParams.modelName}</BreadcrumbItem>
+          </Breadcrumb>
+        }
+        title={
+          <Flex
+            spaceItems={{ default: 'spaceItemsMd' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            {model?.logo ? (
+              <img src={model.logo} alt="model logo" style={{ height: '40px', width: '40px' }} />
+            ) : (
+              <Skeleton
+                shape="square"
+                width="40px"
+                height="40px"
+                screenreaderText="Brand image loading"
+              />
             )}
-          </Stack>
-        </Flex>
-      }
-      empty={model === null}
-      emptyStatePage={
-        <EmptyModelCatalogState
-          testid="empty-model-catalog-state"
-          title="Details not found"
-          description="To request access to model catalog, contact your administrator."
-          headerIcon={() => (
-            <img src={typedEmptyImage(ProjectObjectType.registeredModels)} alt="" />
-          )}
-        />
-      }
-      loadError={modelCatalogSources.error}
-      loaded={loaded}
-      errorMessage="Unable to load model catalog"
-      provideChildrenPadding
-      headerAction={
-        loaded && (
-          <ActionList>
-            <ActionListGroup>
-              {tuningAvailable && isLabBase(model?.labels) && fineTuneActionItem}
-              {registerModelButton()}
-              {deployModelButton}
-            </ActionListGroup>
-          </ActionList>
-        )
-      }
-    >
-      {model && (
-        <>
-          <ModelDetailsView model={model} />
-          {isDeployModalOpen && (
-            <DeployCatalogModelModal
-              model={model}
-              onSubmit={(selectedProject) => {
-                navigate(`/modelServing/${selectedProject.metadata.name}`);
-              }}
-              onCancel={() => setIsDeployModalOpen(false)}
-            />
-          )}
-        </>
-      )}
-    </ApplicationsPage>
+            <Stack>
+              <StackItem>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsSm' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <FlexItem>{decodedParams.modelName}</FlexItem>
+                  {model && (
+                    <Label variant="outline" icon={<RhUiTagIcon />}>
+                      {getTagFromModel(model)}
+                    </Label>
+                  )}
+                </Flex>
+              </StackItem>
+              {model && (
+                <StackItem>
+                  <Content component={ContentVariants.small}>Provided by {model.provider}</Content>
+                </StackItem>
+              )}
+            </Stack>
+          </Flex>
+        }
+        empty={model === null}
+        emptyStatePage={
+          <EmptyModelCatalogState
+            testid="empty-model-catalog-state"
+            title="Details not found"
+            description="To request access to model catalog, contact your administrator."
+            headerIcon={() => (
+              <img src={typedEmptyImage(ProjectObjectType.registeredModels)} alt="" />
+            )}
+          />
+        }
+        loadError={modelCatalogSources.error}
+        loaded={loaded}
+        errorMessage="Unable to load model catalog"
+        provideChildrenPadding
+        headerAction={
+          loaded && (
+            <ActionList>
+              <ActionListGroup>
+                {tuningAvailable && isLabBase(model?.labels) && fineTuneActionItem}
+                {registerModelButton()}
+                {deployModelButton}
+              </ActionListGroup>
+            </ActionList>
+          )
+        }
+      >
+        {model && (
+          <>
+            <ModelDetailsView model={model} />
+            {isDeployModalOpen && (
+              <DeployCatalogModelModal
+                model={model}
+                onSubmit={(selectedProject) => {
+                  navigate(`/modelServing/${selectedProject.metadata.name}`);
+                }}
+                onCancel={() => setIsDeployModalOpen(false)}
+              />
+            )}
+          </>
+        )}
+      </ApplicationsPage>
+    </>
   );
 });
 


### PR DESCRIPTION
Closes [RHOAIENG-24514](https://issues.redhat.com/browse/RHOAIENG-24514)
## Description
When navigating from the model catalog overview page to a model's details page, the scroll position was being maintained from the previous page. This meant that if a user had scrolled down on the overview page and then clicked on a model, they would land in the middle of the model's readme content instead of seeing the top of the page with the model's title and action buttons. This behavior was confusing users during testing of third-party models.

## Changes
- Added `ScrollViewOnMount` component to both `ModelCatalog` and `ModelDetailsPage` components
- The component automatically scrolls to the top of the page when mounted, ensuring users always see the top of the page when navigating between model catalog pages
- This solution follows the existing pattern used elsewhere in the application for handling scroll position

## Testing
1. Navigate to the model catalog overview page
2. Scroll down to view models lower on the page
3. Click on any model to navigate to its details page
4. Verify that the page automatically scrolls to the top, showing the model's title and action buttons
5. Navigate back to the overview page and verify the scroll position is reset

## Screenshots
The fix : 
https://github.com/user-attachments/assets/e70e41c6-a86d-4f14-8dec-e55df27ae122
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
