### PR TITLE
fix: set baseline timestamp 1s earlier to prevent polling loop

### DIFF
--- a/frontend/src/utilities/useEnableApplication.tsx
+++ b/frontend/src/utilities/useEnableApplication.tsx
@@ -140,8 +140,9 @@ export const useEnableApplication = (
     let closed = false;
     if (doEnable) {
       if (isInternalRouteIntegrationsApp(internalRoute)) {
-        // Capture the baseline timestamp before polling starts.
-        baselineTimestampRef.current = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+        // Set baseline timestamp 1s earlier to avoid polling loop
+        const oneSecondAgo = new Date(Date.now() - 1000);
+        baselineTimestampRef.current = oneSecondAgo.toISOString().replace(/\.\d{3}Z$/, 'Z');
         enableIntegrationApp(internalRoute, enableValues)
           .then((response) => {
             if (!closed) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-242

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Setting baseline timestamp 1s earlier to prevent polling loop

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested by submitting the same invalid API key within the same second to confirm the app no longer enters an infinite loop.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
