### PR TITLE
Connection type switches from create new connections to current uri, when we deploy a model from model catalog

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
@@ -39,6 +39,10 @@ const mockUseConnections = jest.mocked(useConnections);
 const mockuseWatchConnectionTypes = jest.mocked(useWatchConnectionTypes);
 
 describe('usePrefillModelDeployModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('when no storage filed exist', () => {
     const mockRegisteredModelDeployInfo: ModelDeployPrefillInfo = {
       modelName: 'test-model',
@@ -73,6 +77,42 @@ describe('usePrefillModelDeployModal', () => {
     });
 
     expect(mockSetCreateData.mock.calls).toEqual([]);
+  });
+
+  it('should only prefill once even if dependencies change', () => {
+    const mockRegisteredModelDeployInfo: ModelDeployPrefillInfo = {
+      modelName: 'test-model',
+      modelArtifactUri: 's3://test/test?endpoint=test&defaultRegion=test',
+      initialConnectionName: 'test-key',
+    };
+
+    mockUseConnections.mockReturnValue([[mockConnection({})], true, undefined, jest.fn()]);
+    mockuseWatchConnectionTypes.mockReturnValue([
+      [mockConnectionTypeConfigMapObj({})],
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+
+    const { rerender } = testHook(usePrefillModelDeployModal)(
+      mockProjectContext,
+      data,
+      mockSetCreateData,
+      mockRegisteredModelDeployInfo,
+    );
+
+    expect(mockSetCreateData).toHaveBeenCalledTimes(2);
+    mockSetCreateData.mockClear();
+
+    mockUseConnections.mockReturnValue([
+      [mockConnection({}), mockConnection({})],
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+
+    rerender(mockProjectContext, data, mockSetCreateData, mockRegisteredModelDeployInfo);
+    expect(mockSetCreateData).not.toHaveBeenCalled();
   });
 
   describe('S3 -  connection', () => {
@@ -170,7 +210,7 @@ describe('usePrefillModelDeployModal', () => {
             alert: {
               message:
                 'The selected project does not have a connection that matches the model location. You can create a matching connection by using the data in the autopopulated fields, or edit the fields to create a different connection. Alternatively, click Existing connection to select an existing non-matching connection.',
-              title: 'We’ve populated the details of a new connection for you.',
+              title: "We've populated the details of a new connection for you.",
               type: 'info',
             },
             awsData: [
@@ -406,7 +446,7 @@ describe('usePrefillModelDeployModal', () => {
             alert: {
               message:
                 'The selected project does not have a connection that matches the model location. You can create a matching connection by using the data in the autopopulated fields, or edit the fields to create a different connection. Alternatively, click Existing connection to select an existing non-matching connection.',
-              title: 'We’ve populated the details of a new connection for you.',
+              title: "We've populated the details of a new connection for you.",
               type: 'info',
             },
             awsData: [
@@ -608,7 +648,7 @@ describe('usePrefillModelDeployModal', () => {
             alert: {
               message:
                 'The selected project does not have a connection that matches the model location. You can create a matching connection by using the data in the autopopulated fields, or edit the fields to create a different connection. Alternatively, click Existing connection to select an existing non-matching connection.',
-              title: 'We’ve populated the details of a new connection for you.',
+              title: "We've populated the details of a new connection for you.",
               type: 'info',
             },
             awsData: [

--- a/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
+++ b/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
@@ -68,14 +68,21 @@ const usePrefillModelDeployModal = (
   const loaded = connectionsLoaded && connectionTypesLoaded;
   const loadError = connectionsLoadError || connectionTypeError;
 
+  // Add a hasPrefilledRef to track whether the form has been prefilled
+  // This prevents the connection type from switching back to Current URI
+  const hasPrefilledRef = React.useRef(false);
+
   React.useEffect(() => {
     const alert = {
       type: AlertVariant.info,
-      title: 'We’ve populated the details of a new connection for you.',
+      title: "We've populated the details of a new connection for you.",
       message:
         'The selected project does not have a connection that matches the model location. You can create a matching connection by using the data in the autopopulated fields, or edit the fields to create a different connection. Alternatively, click Existing connection to select an existing non-matching connection.',
     };
-    if (modelDeployPrefillInfo?.modelArtifactUri && loaded) {
+    if (modelDeployPrefillInfo?.modelArtifactUri && loaded && !hasPrefilledRef.current) {
+      // Mark as prefilled to prevent future prefills
+      hasPrefilledRef.current = true;
+
       setCreateData('name', modelDeployPrefillInfo.modelName);
       const recommendedConnections = connections.filter(
         (dataConnection) => dataConnection.isRecommended,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-24410

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
* added `hasPrefilledRef` to make sure prefill happens once.
* fixed up unit test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested manually
- also added unit tests
Screen Recording: https://github.com/user-attachments/assets/ac047d22-a5d7-4cb2-89c8-cb8a92adc3dd

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Unit test was updated and all are passing.
<img width="767" alt="Screenshot 2025-05-01 at 10 15 16" src="https://github.com/user-attachments/assets/eb50bf06-e35f-4f8b-85a7-3c6420854a57" />

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
