### PR TITLE
RHOAIENG-24706: Part 1: Replace Deprecated Modal Instances with PF6 Modal

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/Modal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/Modal.ts
@@ -12,10 +12,7 @@ export class Modal {
   }
 
   find(): Cypress.Chainable<JQuery<HTMLElement>> {
-    // FIXME Remove `hidden: true` once PF version is upgraded to 6.1.0.
-    // https://issues.redhat.com/browse/RHOAIENG-11946
-    // https://github.com/patternfly/patternfly-react/issues/11041
-    return cy.findByRole('dialog', { name: this.title, hidden: true });
+    return cy.findByRole('dialog');
   }
 
   findCloseButton(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/archiveModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/archiveModal.ts
@@ -9,7 +9,7 @@ class ArchiveModal extends Modal {
   }
 
   find() {
-    return cy.findByTestId(this.testId).parents('div[role="dialog"]');
+    return cy.findByTestId(this.testId);
   }
 
   findConfirmInput() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -8,7 +8,7 @@ class PipelineImportModal extends Modal {
   }
 
   find() {
-    return cy.findByTestId('import-pipeline-modal').parents('div[role="dialog"]');
+    return cy.findByTestId('import-pipeline-modal');
   }
 
   findPipelineNameInput() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
@@ -11,7 +11,7 @@ class PipelineImportModal extends Modal {
   }
 
   find() {
-    return cy.findByTestId('import-pipeline-modal').parents('div[role="dialog"]');
+    return cy.findByTestId('import-pipeline-modal');
   }
 
   findSubmitButton() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/restoreModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/restoreModal.ts
@@ -12,7 +12,7 @@ class RestoreModal extends Modal {
   }
 
   find() {
-    return cy.findByTestId(this.testId).parents('div[role="dialog"]');
+    return cy.findByTestId(this.testId);
   }
 
   findAlertMessage() {

--- a/frontend/src/app/DevFeatureFlagsBanner.tsx
+++ b/frontend/src/app/DevFeatureFlagsBanner.tsx
@@ -7,8 +7,11 @@ import {
   Split,
   SplitItem,
   Tooltip,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
 } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
 import { CloseIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { allFeatureFlags } from '~/concepts/areas/const';
@@ -106,13 +109,15 @@ const DevFeatureFlagsBanner: React.FC<Props> = ({
         <Modal
           data-testid="dev-feature-flags-modal"
           variant="large"
-          title="Feature flags"
           isOpen
           onClose={() => {
             setModalOpen(false);
             setDevFeatureFlagQueryVisible(false);
           }}
-          actions={[
+        >
+          <ModalHeader title="Feature flags" />
+          <ModalBody>{renderDevFeatureFlags()}</ModalBody>
+          <ModalFooter>
             <Button
               data-testid="reset-feature-flags-modal-button"
               key="confirm"
@@ -120,10 +125,8 @@ const DevFeatureFlagsBanner: React.FC<Props> = ({
               onClick={() => resetDevFeatureFlags()}
             >
               Reset to defaults
-            </Button>,
-          ]}
-        >
-          {renderDevFeatureFlags()}
+            </Button>
+          </ModalFooter>
         </Modal>
       ) : null}
     </>

--- a/frontend/src/concepts/connectionTypes/ConnectionTypePreviewModal.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypePreviewModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Form } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Form, Modal, ModalBody, ModalHeader } from '@patternfly/react-core';
 import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
 import { ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 
@@ -15,12 +14,16 @@ const ConnectionTypePreviewModal: React.FC<Props> = ({ onClose, obj }) => (
     isOpen
     variant="medium"
     onClose={() => onClose()}
-    title="Preview connection"
-    description="This preview shows the user view of the connection form, and is for reference only."
   >
-    <Form>
-      <ConnectionTypeForm isPreview connectionType={obj} />
-    </Form>
+    <ModalHeader
+      title="Preview connection"
+      description="This preview shows the user view of the connection form, and is for reference only."
+    />
+    <ModalBody>
+      <Form>
+        <ConnectionTypeForm isPreview connectionType={obj} />
+      </Form>
+    </ModalBody>
   </Modal>
 );
 

--- a/frontend/src/concepts/pipelines/content/ArchiveModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ArchiveModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { Flex, FlexItem, Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
@@ -72,13 +81,33 @@ export const ArchiveModal: React.FC<ArchiveModalProps> = ({
   }, [onSubmit, onClose, refreshAllAPI, eventName]);
 
   return (
-    <Modal
-      isOpen
-      title={title}
-      titleIconVariant="warning"
-      variant="small"
-      onClose={onCancelClose}
-      footer={
+    <Modal isOpen variant="small" onClose={onCancelClose} data-testid={testId}>
+      <ModalHeader title={title} titleIconVariant="warning"></ModalHeader>
+      <ModalBody>
+        <Stack hasGutter>
+          {children}
+          <StackItem>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                Type <strong>{confirmMessage}</strong> to confirm archiving:
+              </FlexItem>
+              <TextInput
+                id="confirm-archive-input"
+                data-testid="confirm-archive-input"
+                aria-label="confirm archive input"
+                value={confirmInputValue}
+                onChange={(_e, newValue) => setConfirmInputValue(newValue)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !isDisabled) {
+                    onConfirm();
+                  }
+                }}
+              />
+            </Flex>
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onCancelClose}
           onSubmit={onConfirm}
@@ -88,31 +117,7 @@ export const ArchiveModal: React.FC<ArchiveModalProps> = ({
           error={error}
           alertTitle={alertTitle}
         />
-      }
-      data-testid={testId}
-    >
-      <Stack hasGutter>
-        {children}
-        <StackItem>
-          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              Type <strong>{confirmMessage}</strong> to confirm archiving:
-            </FlexItem>
-            <TextInput
-              id="confirm-archive-input"
-              data-testid="confirm-archive-input"
-              aria-label="confirm archive input"
-              value={confirmInputValue}
-              onChange={(_e, newValue) => setConfirmInputValue(newValue)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && !isDisabled) {
-                  onConfirm();
-                }
-              }}
-            />
-          </Flex>
-        </StackItem>
-      </Stack>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/ArchiveModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ArchiveModal.tsx
@@ -82,7 +82,7 @@ export const ArchiveModal: React.FC<ArchiveModalProps> = ({
 
   return (
     <Modal isOpen variant="small" onClose={onCancelClose} data-testid={testId}>
-      <ModalHeader title={title} titleIconVariant="warning"></ModalHeader>
+      <ModalHeader title={title} titleIconVariant="warning" />
       <ModalBody>
         <Stack hasGutter>
           {children}

--- a/frontend/src/concepts/pipelines/content/ManageSamplePipelinesModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ManageSamplePipelinesModal.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { Alert, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { getPipelinesCR, toggleInstructLabState } from '~/api';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import {
@@ -115,20 +122,49 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
 
   return (
     <Modal
-      title="Manage preconfigured pipelines"
-      description={
-        <>
-          Select a preconfigured pipeline to install it on your project and enable automatic
-          updates. After installation, you can deselect the pipeline to disable automatic updates.
-          <br />
-          <br />
-          Note: You can manually delete preconfigured pipelines after installation.
-        </>
-      }
       isOpen
       variant="small"
       onClose={() => onClose()}
-      footer={
+      data-testid="manage-sample-pipelines-modal"
+    >
+      <ModalHeader
+        title="Manage preconfigured pipelines"
+        description={
+          <>
+            Select a preconfigured pipeline to install it on your project and enable automatic
+            updates. After installation, you can deselect the pipeline to disable automatic updates.
+            <br />
+            <br />
+            Note: You can manually delete preconfigured pipelines after installation.
+          </>
+        }
+      />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <InstructLabPipelineEnablement isEnabled={checked} setEnabled={setChecked} />
+          </StackItem>
+          {!isInstructLabEnabled && checked ? (
+            <StackItem>
+              <Alert
+                isInline
+                variant="warning"
+                title="Installing the InstructLab pipeline will cause the pipeline server to restart."
+              />
+            </StackItem>
+          ) : null}
+          {isInstructLabEnabled && !checked ? (
+            <StackItem>
+              <Alert
+                isInline
+                variant="warning"
+                title="If you want to remove the InstructLab pipeline, you must manually delete it."
+              />
+            </StackItem>
+          ) : null}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={() => onClose()}
           onSubmit={onSubmit}
@@ -138,32 +174,7 @@ const ManageSamplePipelinesModal: React.FC<ManageSamplePipelinesModalProps> = ({
           error={error}
           alertTitle="Error managing sample pipelines"
         />
-      }
-      data-testid="manage-sample-pipelines-modal"
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <InstructLabPipelineEnablement isEnabled={checked} setEnabled={setChecked} />
-        </StackItem>
-        {!isInstructLabEnabled && checked ? (
-          <StackItem>
-            <Alert
-              isInline
-              variant="warning"
-              title="Installing the InstructLab pipeline will cause the pipeline server to restart."
-            />
-          </StackItem>
-        ) : null}
-        {isInstructLabEnabled && !checked ? (
-          <StackItem>
-            <Alert
-              isInline
-              variant="warning"
-              title="If you want to remove the InstructLab pipeline, you must manually delete it."
-            />
-          </StackItem>
-        ) : null}
-      </Stack>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/RestoreModal.tsx
+++ b/frontend/src/concepts/pipelines/content/RestoreModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
+import { Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';

--- a/frontend/src/concepts/pipelines/content/RestoreModal.tsx
+++ b/frontend/src/concepts/pipelines/content/RestoreModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
@@ -65,12 +64,10 @@ export const RestoreModal: React.FC<RestoreModalProps> = ({
   }, [onSubmit, fireFormTrackingEventForRestore, refreshAllAPI, onCancel]);
 
   return (
-    <Modal
-      isOpen
-      title={title}
-      variant="small"
-      onClose={onCancel}
-      footer={
+    <Modal isOpen variant="small" onClose={onCancel} data-testid={testId}>
+      <ModalHeader title={title} />
+      <ModalBody>{children}</ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onSubmit={onConfirm}
           isSubmitDisabled={isSubmitting}
@@ -80,24 +77,7 @@ export const RestoreModal: React.FC<RestoreModalProps> = ({
           alertTitle={alertTitle}
           error={error}
         />
-      }
-      actions={[
-        <Button
-          key="confirm"
-          variant="primary"
-          onClick={onConfirm}
-          isDisabled={isSubmitting}
-          isLoading={isSubmitting}
-        >
-          Restore
-        </Button>,
-        <Button key="cancel" variant="link" onClick={onCancel}>
-          Cancel
-        </Button>,
-      ]}
-      data-testid={testId}
-    >
-      {children}
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ViewPipelineServerModal.tsx
@@ -5,8 +5,10 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   Title,
+  Modal,
+  ModalBody,
+  ModalHeader,
 } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import PasswordHiddenText from '~/components/PasswordHiddenText';
 import { dataEntryToRecord } from '~/utilities/dataEntryToRecord';
@@ -33,91 +35,94 @@ const ViewPipelineServerModal: React.FC<ViewPipelineServerModalProps> = ({
   const databaseSecret = dataEntryToRecord(result?.values?.data ?? []);
 
   return (
-    <Modal title="View pipeline server" isOpen onClose={onClose} variant="small">
-      {pipelineNamespaceCR && (
-        <DescriptionList termWidth="20ch" isHorizontal>
-          {!!pipelineNamespaceCR.spec.objectStorage.externalStorage?.s3CredentialsSecret
-            .secretName && (
-            <>
-              <Title headingLevel="h2">Object storage connection</Title>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Access key</DescriptionListTerm>
-                <DescriptionListDescription data-testid="access-key-field">
-                  {pipelineSecret[
-                    pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
-                      .accessKey
-                  ] || ''}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Secret key</DescriptionListTerm>
-                <DescriptionListDescription data-testid="secret-key-field">
-                  <PasswordHiddenText
-                    password={
-                      pipelineSecret[
-                        pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
-                          .secretKey
-                      ] ?? ''
-                    }
-                  />
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Endpoint</DescriptionListTerm>
-                <DescriptionListDescription data-testid="endpoint-field">
-                  {pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme &&
-                  pipelineNamespaceCR.spec.objectStorage.externalStorage.host
-                    ? `${pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme}://${pipelineNamespaceCR.spec.objectStorage.externalStorage.host}`
-                    : ''}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Bucket</DescriptionListTerm>
-                <DescriptionListDescription data-testid="bucket-field">
-                  {pipelineNamespaceCR.spec.objectStorage.externalStorage.bucket}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            </>
-          )}
-          {!!pipelineNamespaceCR.spec.database &&
-            !!pipelineNamespaceCR.spec.database.externalDB &&
-            !!databaseSecret[ExternalDatabaseSecret.KEY] && (
+    <Modal isOpen onClose={onClose} variant="small">
+      <ModalHeader title="View pipeline server" />
+      <ModalBody>
+        {pipelineNamespaceCR && (
+          <DescriptionList termWidth="20ch" isHorizontal>
+            {!!pipelineNamespaceCR.spec.objectStorage.externalStorage?.s3CredentialsSecret
+              .secretName && (
               <>
-                <Title headingLevel="h2">Database</Title>
+                <Title headingLevel="h2">Object storage connection</Title>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Host</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {pipelineNamespaceCR.spec.database.externalDB.host}
+                  <DescriptionListTerm>Access key</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="access-key-field">
+                    {pipelineSecret[
+                      pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
+                        .accessKey
+                    ] || ''}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Port</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {pipelineNamespaceCR.spec.database.externalDB.port}
+                  <DescriptionListTerm>Secret key</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="secret-key-field">
+                    <PasswordHiddenText
+                      password={
+                        pipelineSecret[
+                          pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
+                            .secretKey
+                        ] ?? ''
+                      }
+                    />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Username</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {pipelineNamespaceCR.spec.database.externalDB.username}
+                  <DescriptionListTerm>Endpoint</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="endpoint-field">
+                    {pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme &&
+                    pipelineNamespaceCR.spec.objectStorage.externalStorage.host
+                      ? `${pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme}://${pipelineNamespaceCR.spec.objectStorage.externalStorage.host}`
+                      : ''}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Password</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <PasswordHiddenText password={databaseSecret[ExternalDatabaseSecret.KEY]} />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Database</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {pipelineNamespaceCR.spec.database.externalDB.pipelineDBName}
+                  <DescriptionListTerm>Bucket</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="bucket-field">
+                    {pipelineNamespaceCR.spec.objectStorage.externalStorage.bucket}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               </>
             )}
-        </DescriptionList>
-      )}
+            {!!pipelineNamespaceCR.spec.database &&
+              !!pipelineNamespaceCR.spec.database.externalDB &&
+              !!databaseSecret[ExternalDatabaseSecret.KEY] && (
+                <>
+                  <Title headingLevel="h2">Database</Title>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Host</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {pipelineNamespaceCR.spec.database.externalDB.host}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Port</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {pipelineNamespaceCR.spec.database.externalDB.port}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Username</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {pipelineNamespaceCR.spec.database.externalDB.username}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Password</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <PasswordHiddenText password={databaseSecret[ExternalDatabaseSecret.KEY]} />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Database</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {pipelineNamespaceCR.spec.database.externalDB.pipelineDBName}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </>
+              )}
+          </DescriptionList>
+        )}
+      </ModalBody>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
-import { Alert, Form, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Form,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { createPipelinesCR, deleteSecret } from '~/api';
 import { EMPTY_AWS_PIPELINE_DATA } from '~/pages/projects/dataConnections/const';
@@ -116,13 +124,42 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
   };
 
   return (
-    <Modal
-      title="Configure pipeline server"
-      variant="medium"
-      description="Configuring a pipeline server enables you to create and manage pipelines."
-      isOpen
-      onClose={onCancel}
-      footer={
+    <Modal variant="medium" isOpen onClose={onCancel}>
+      <ModalHeader
+        title="Configure pipeline server"
+        description="Configuring a pipeline server enables you to create and manage pipelines."
+      />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Alert
+              variant="info"
+              isInline
+              title="Pipeline server configuration cannot be edited after creation. To use a different configuration after creation, delete the pipeline server and create a new one."
+            />
+          </StackItem>
+          <StackItem>
+            <Form
+              onSubmit={(e) => {
+                e.preventDefault();
+                submit();
+              }}
+            >
+              <ObjectStorageSection
+                setConfig={setConfig}
+                config={config}
+                loaded={loaded}
+                connections={connections}
+              />
+              <PipelinesDatabaseSection setConfig={setConfig} config={config} />
+              {isFineTuningAvailable && (
+                <SamplePipelineSettingsSection setConfig={setConfig} config={config} />
+              )}
+            </Form>
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel="Configure pipeline server"
           onSubmit={submit}
@@ -132,36 +169,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
           alertTitle="Error configuring pipeline server"
           error={error}
         />
-      }
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <Alert
-            variant="info"
-            isInline
-            title="Pipeline server configuration cannot be edited after creation. To use a different configuration after creation, delete the pipeline server and create a new one."
-          />
-        </StackItem>
-        <StackItem>
-          <Form
-            onSubmit={(e) => {
-              e.preventDefault();
-              submit();
-            }}
-          >
-            <ObjectStorageSection
-              setConfig={setConfig}
-              config={config}
-              loaded={loaded}
-              connections={connections}
-            />
-            <PipelinesDatabaseSection setConfig={setConfig} config={config} />
-            {isFineTuningAvailable && (
-              <SamplePipelineSettingsSection setConfig={setConfig} config={config} />
-            )}
-          </Form>
-        </StackItem>
-      </Stack>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
@@ -7,8 +7,11 @@ import {
   Stack,
   StackItem,
   TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
 } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import useCreateExperimentData from '~/concepts/pipelines/content/experiment/useCreateExperimentData';
 import { ExperimentKF } from '~/concepts/pipelines/kfTypes';
@@ -47,11 +50,61 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
   return (
     <Modal
       isOpen
-      title="Create experiment"
       onClose={() => {
         onBeforeClose();
       }}
-      actions={[
+      variant="small"
+    >
+      <ModalHeader title="Create experiment" />
+      <ModalBody>
+        <Form>
+          <Stack hasGutter>
+            <StackItem>
+              <FormGroup label="Project" fieldId="project-name">
+                {getDisplayNameFromK8sResource(project)}
+              </FormGroup>
+            </StackItem>
+            <StackItem>
+              <FormGroup label="Experiment name" isRequired fieldId="experiment-name">
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="experiment-name"
+                  name="experiment-name"
+                  value={name}
+                  onChange={(_, value) => setData('name', value)}
+                  maxLength={NAME_CHARACTER_LIMIT}
+                />
+
+                <CharLimitHelperText limit={NAME_CHARACTER_LIMIT} />
+              </FormGroup>
+            </StackItem>
+            <StackItem>
+              <FormGroup label="Description" fieldId="experiment-description">
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="experiment-description"
+                  name="experiment-description"
+                  value={description}
+                  onChange={(_, value) => setData('description', value)}
+                  maxLength={DESCRIPTION_CHARACTER_LIMIT}
+                />
+
+                <CharLimitHelperText limit={DESCRIPTION_CHARACTER_LIMIT} />
+              </FormGroup>
+            </StackItem>
+            {error && (
+              <StackItem>
+                <Alert title="Error creating experiment" isInline variant="danger">
+                  {error.message}
+                </Alert>
+              </StackItem>
+            )}
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="create-button"
           variant="primary"
@@ -81,59 +134,11 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
           }}
         >
           Create experiment
-        </Button>,
+        </Button>
         <Button key="cancel-button" variant="secondary" onClick={() => onBeforeClose()}>
           Cancel
-        </Button>,
-      ]}
-      variant="small"
-    >
-      <Form>
-        <Stack hasGutter>
-          <StackItem>
-            <FormGroup label="Project" fieldId="project-name">
-              {getDisplayNameFromK8sResource(project)}
-            </FormGroup>
-          </StackItem>
-          <StackItem>
-            <FormGroup label="Experiment name" isRequired fieldId="experiment-name">
-              <TextInput
-                isRequired
-                type="text"
-                id="experiment-name"
-                name="experiment-name"
-                value={name}
-                onChange={(_, value) => setData('name', value)}
-                maxLength={NAME_CHARACTER_LIMIT}
-              />
-
-              <CharLimitHelperText limit={NAME_CHARACTER_LIMIT} />
-            </FormGroup>
-          </StackItem>
-          <StackItem>
-            <FormGroup label="Description" fieldId="experiment-description">
-              <TextInput
-                isRequired
-                type="text"
-                id="experiment-description"
-                name="experiment-description"
-                value={description}
-                onChange={(_, value) => setData('description', value)}
-                maxLength={DESCRIPTION_CHARACTER_LIMIT}
-              />
-
-              <CharLimitHelperText limit={DESCRIPTION_CHARACTER_LIMIT} />
-            </FormGroup>
-          </StackItem>
-          {error && (
-            <StackItem>
-              <Alert title="Error creating experiment" isInline variant="danger">
-                {error.message}
-              </Alert>
-            </StackItem>
-          )}
-        </Stack>
-      </Form>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/import/PipelineImportBase.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineImportBase.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
-import { Form, FormGroup, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormGroup,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
@@ -106,10 +114,61 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
 
   return (
     <Modal
-      title={title}
       isOpen
       onClose={() => onBeforeClose()}
-      footer={
+      variant="medium"
+      data-testid="import-pipeline-modal"
+    >
+      <ModalHeader title={title} />
+      <ModalBody>
+        <Form>
+          <Stack hasGutter>
+            <StackItem>
+              <FormGroup label="Project" fieldId="project-name">
+                {getDisplayNameFromK8sResource(project)}
+              </FormGroup>
+            </StackItem>
+            {children}
+            <StackItem>
+              <NameDescriptionField
+                nameFieldId="pipeline-name"
+                nameFieldLabel="Pipeline name"
+                descriptionFieldLabel="Pipeline description"
+                descriptionFieldId="pipeline-description"
+                data={{ name, description: description || '' }}
+                hasNameError={hasDuplicateName}
+                setData={(newData) => {
+                  setData('name', newData.name);
+                  setData('description', newData.description);
+                }}
+                maxLengthName={NAME_CHARACTER_LIMIT}
+                maxLengthDesc={DESCRIPTION_CHARACTER_LIMIT}
+                onNameChange={(value) => {
+                  setHasDuplicateName(false);
+                  debouncedCheckForDuplicateName(value);
+                }}
+                nameHelperText={
+                  hasDuplicateName ? <DuplicateNameHelperText isError name={name} /> : undefined
+                }
+              />
+            </StackItem>
+            <StackItem>
+              <PipelineUploadRadio
+                fileContents={fileContents}
+                setFileContents={(value) => {
+                  setData('fileContents', value);
+                  setError(undefined);
+                }}
+                pipelineUrl={pipelineUrl}
+                setPipelineUrl={(url) => setData('pipelineUrl', url)}
+                uploadOption={uploadOption}
+                setUploadOption={(option) => setData('uploadOption', option)}
+              />
+            </StackItem>
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={() => onBeforeClose()}
           onSubmit={onSubmit}
@@ -126,56 +185,7 @@ const PipelineImportBase: React.FC<PipelineImportBaseProps> = ({
           }
           alertLinks={isV1PipelineFile ? <PipelineMigrationNoteLinks /> : undefined}
         />
-      }
-      variant="medium"
-      data-testid="import-pipeline-modal"
-    >
-      <Form>
-        <Stack hasGutter>
-          <StackItem>
-            <FormGroup label="Project" fieldId="project-name">
-              {getDisplayNameFromK8sResource(project)}
-            </FormGroup>
-          </StackItem>
-          {children}
-          <StackItem>
-            <NameDescriptionField
-              nameFieldId="pipeline-name"
-              nameFieldLabel="Pipeline name"
-              descriptionFieldLabel="Pipeline description"
-              descriptionFieldId="pipeline-description"
-              data={{ name, description: description || '' }}
-              hasNameError={hasDuplicateName}
-              setData={(newData) => {
-                setData('name', newData.name);
-                setData('description', newData.description);
-              }}
-              maxLengthName={NAME_CHARACTER_LIMIT}
-              maxLengthDesc={DESCRIPTION_CHARACTER_LIMIT}
-              onNameChange={(value) => {
-                setHasDuplicateName(false);
-                debouncedCheckForDuplicateName(value);
-              }}
-              nameHelperText={
-                hasDuplicateName ? <DuplicateNameHelperText isError name={name} /> : undefined
-              }
-            />
-          </StackItem>
-          <StackItem>
-            <PipelineUploadRadio
-              fileContents={fileContents}
-              setFileContents={(value) => {
-                setData('fileContents', value);
-                setError(undefined);
-              }}
-              pipelineUrl={pipelineUrl}
-              setPipelineUrl={(url) => setData('pipelineUrl', url)}
-              uploadOption={uploadOption}
-              setUploadOption={(option) => setData('uploadOption', option)}
-            />
-          </StackItem>
-        </Stack>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/CustomMetricsColumnsModal.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/CustomMetricsColumnsModal.tsx
@@ -8,8 +8,11 @@ import {
   Stack,
   StackItem,
   Tooltip,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
 } from '@patternfly/react-core';
-import { Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core/deprecated';
 import { DragDropSort, DraggableObject } from '@patternfly/react-drag-drop';
 import { getMetricsColumnsLocalStorageKey } from './utils';
 import { MetricColumnSearchInput } from './MetricColumnSearchInput';
@@ -44,54 +47,47 @@ export const CustomMetricsColumnsModal: React.FC<CustomMetricsColumnsModalProps>
 
   return (
     <Modal
-      bodyAriaLabel="Metrics column names"
       tabIndex={0}
-      hasNoBodyWrapper
       aria-label="Custom metrics columns modal"
-      variant={ModalVariant.small}
-      title="Customize metrics columns"
-      description={
-        <Stack hasGutter className="pf-v6-u-pb-md">
-          <StackItem className="pf-v6-u-mt-sm">
-            Select up to 10 metrics that will display as columns in the table. Drag and drop column
-            names to reorder them.
-          </StackItem>
-
-          <StackItem>
-            <MetricColumnSearchInput
-              onSearch={(searchText) => {
-                let newColumns = defaultColumns;
-
-                if (searchText) {
-                  newColumns = defaultColumns.filter((column) =>
-                    String(column.id).toLowerCase().includes(searchText.toLowerCase()),
-                  );
-                }
-
-                setFilteredColumns(newColumns);
-              }}
-            />
-          </StackItem>
-
-          <StackItem>
-            <Label>
-              {selectedColumnNames.length} / total {defaultColumns.length} selected
-            </Label>
-          </StackItem>
-        </Stack>
-      }
+      variant="small"
       isOpen
       onClose={onClose}
-      actions={[
-        <Button key="update" variant="primary" onClick={onUpdate}>
-          Update
-        </Button>,
-        <Button key="cancel" variant="link" onClick={onClose}>
-          Cancel
-        </Button>,
-      ]}
     >
-      <ModalBoxBody
+      <ModalHeader
+        title="Customize metrics columns"
+        description={
+          <Stack hasGutter className="pf-v6-u-pb-md">
+            <StackItem className="pf-v6-u-mt-sm">
+              Select up to 10 metrics that will display as columns in the table. Drag and drop
+              column names to reorder them.
+            </StackItem>
+
+            <StackItem>
+              <MetricColumnSearchInput
+                onSearch={(searchText) => {
+                  let newColumns = defaultColumns;
+
+                  if (searchText) {
+                    newColumns = defaultColumns.filter((column) =>
+                      String(column.id).toLowerCase().includes(searchText.toLowerCase()),
+                    );
+                  }
+
+                  setFilteredColumns(newColumns);
+                }}
+              />
+            </StackItem>
+
+            <StackItem>
+              <Label>
+                {selectedColumnNames.length} / total {defaultColumns.length} selected
+              </Label>
+            </StackItem>
+          </Stack>
+        }
+      />
+      <ModalBody
+        aria-label="Metrics column names"
         className="pf-v6-u-pt-0 pf-v6-u-pl-md pf-v6-u-pr-md"
         style={{ maxHeight: '500px' }}
       >
@@ -156,7 +152,15 @@ export const CustomMetricsColumnsModal: React.FC<CustomMetricsColumnsModalProps>
             setColumns(newColumns);
           }}
         />
-      </ModalBoxBody>
+      </ModalBody>
+      <ModalFooter>
+        <Button key="update" variant="primary" onClick={onUpdate}>
+          Update
+        </Button>
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/trustyai/content/InstallTrustyModal.tsx
+++ b/frontend/src/concepts/trustyai/content/InstallTrustyModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Form, Radio } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Form, Radio, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import TrustyDBSecretFields from '~/concepts/trustyai/content/TrustyDBSecretFields';
 import useTrustyInstallModalData, {
@@ -29,12 +28,53 @@ const InstallTrustyModal: React.FC<InstallTrustyModalProps> = ({
   const formData = useTrustyInstallModalData(namespace);
 
   return (
-    <Modal
-      title="Configure TrustyAI service"
-      isOpen
-      variant="medium"
-      onClose={onClose}
-      footer={
+    <Modal isOpen variant="medium" onClose={onClose}>
+      <ModalHeader title="Configure TrustyAI service" />
+      <ModalBody>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
+          <Radio
+            id="existing"
+            data-testid={`${TRUSTYAI_INSTALL_MODAL_TEST_ID}-radio-existing`}
+            label={
+              <>
+                Specify an existing secret{' '}
+                <FieldGroupHelpLabelIcon content="Provide the name of an existing Kubernetes secret within your project." />
+              </>
+            }
+            name="secret-value"
+            isChecked={formData.type === TrustyInstallModalFormType.EXISTING}
+            onChange={() => formData.onModeChange(TrustyInstallModalFormType.EXISTING)}
+            body={
+              formData.type === TrustyInstallModalFormType.EXISTING && (
+                <TrustyDBExistingSecretField formData={formData} />
+              )
+            }
+          />
+          <Radio
+            id="new"
+            data-testid={`${TRUSTYAI_INSTALL_MODAL_TEST_ID}-radio-new`}
+            label={
+              <>
+                Create a new secret{' '}
+                <FieldGroupHelpLabelIcon content="Consult the product documentation for more information on these fields." />
+              </>
+            }
+            name="secret-value"
+            isChecked={formData.type === TrustyInstallModalFormType.NEW}
+            onChange={() => formData.onModeChange(TrustyInstallModalFormType.NEW)}
+            body={
+              formData.type === TrustyInstallModalFormType.NEW && (
+                <TrustyDBSecretFields data={formData.data} onDataChange={formData.onDataChange} />
+              )
+            }
+          />
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onClose}
           onSubmit={() => {
@@ -63,50 +103,7 @@ const InstallTrustyModal: React.FC<InstallTrustyModalProps> = ({
           error={installError}
           alertTitle="Install error"
         />
-      }
-    >
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-        }}
-      >
-        <Radio
-          id="existing"
-          data-testid={`${TRUSTYAI_INSTALL_MODAL_TEST_ID}-radio-existing`}
-          label={
-            <>
-              Specify an existing secret{' '}
-              <FieldGroupHelpLabelIcon content="Provide the name of an existing Kubernetes secret within your project." />
-            </>
-          }
-          name="secret-value"
-          isChecked={formData.type === TrustyInstallModalFormType.EXISTING}
-          onChange={() => formData.onModeChange(TrustyInstallModalFormType.EXISTING)}
-          body={
-            formData.type === TrustyInstallModalFormType.EXISTING && (
-              <TrustyDBExistingSecretField formData={formData} />
-            )
-          }
-        />
-        <Radio
-          id="new"
-          data-testid={`${TRUSTYAI_INSTALL_MODAL_TEST_ID}-radio-new`}
-          label={
-            <>
-              Create a new secret{' '}
-              <FieldGroupHelpLabelIcon content="Consult the product documentation for more information on these fields." />
-            </>
-          }
-          name="secret-value"
-          isChecked={formData.type === TrustyInstallModalFormType.NEW}
-          onChange={() => formData.onModeChange(TrustyInstallModalFormType.NEW)}
-          body={
-            formData.type === TrustyInstallModalFormType.NEW && (
-              <TrustyDBSecretFields data={formData.data} onDataChange={formData.onDataChange} />
-            )
-          }
-        />
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/pipelines/global/runs/RestoreRunWithArchivedExperimentModal.tsx
+++ b/frontend/src/pages/pipelines/global/runs/RestoreRunWithArchivedExperimentModal.tsx
@@ -7,8 +7,11 @@ import {
   Label,
   Stack,
   StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
 } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import useRestoreStatuses from '~/concepts/pipelines/content/useRestoreStatuses';
 import { ExperimentKF, PipelineRunKF } from '~/concepts/pipelines/kfTypes';
@@ -102,8 +105,6 @@ const RestoreRunWithArchivedExperimentModal: React.FC<
 
   return (
     <Modal
-      title={`Restore ${isSingleRestoring ? 'run' : `${selectedRuns.length} runs`}`}
-      titleIconVariant="warning"
       isOpen
       data-testid="restore-run-modal"
       onClose={() =>
@@ -113,7 +114,75 @@ const RestoreRunWithArchivedExperimentModal: React.FC<
           runStatuses.map((status) => status.status),
         )
       }
-      footer={
+      variant="small"
+    >
+      <ModalHeader
+        title={`Restore ${isSingleRestoring ? 'run' : `${selectedRuns.length} runs`}`}
+        titleIconVariant="warning"
+      />
+      <ModalBody>
+        {isSingleRestoring ? (
+          <Stack hasGutter>
+            <StackItem>
+              <Alert
+                data-testid="single-restoring-alert-message"
+                isInline
+                variant="info"
+                component="p"
+                title={
+                  <span style={{ fontWeight: 'normal' }} className="pf-v6-c-alert__description">
+                    The selected run belongs to the archived{' '}
+                    <strong>{archivedExperiments[0].display_name}</strong> experiment. Restoring it
+                    will also restore the experiment, but not other archived runs.
+                  </span>
+                }
+              />
+            </StackItem>
+            <StackItem>
+              The <strong>{selectedRuns[0].display_name}</strong> run and its associated{' '}
+              <strong>{archivedExperiments[0].display_name}</strong> experiment will be restored.
+            </StackItem>
+          </Stack>
+        ) : (
+          <Stack hasGutter>
+            <StackItem>
+              <Alert
+                isInline
+                variant="info"
+                title="At least one selected run belongs to an archived experiment. Restoring it will also restore the experiment, but not other archived runs."
+              />
+            </StackItem>
+            <StackItem>
+              {selectedRuns.length} runs will be restored and returned to the{' '}
+              <b>{PipelineRunTabTitle.ACTIVE} tab</b>. {archivedExperiments.length} associated
+              experiments will be restored.
+            </StackItem>
+            <StackItem>
+              <ExpandableSection
+                isExpanded={isExpanded}
+                onToggle={(_, expanded) => setIsExpanded(expanded)}
+                toggleContent={
+                  <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <FlexItem>Selected runs</FlexItem>
+                    <Label color="blue" isCompact>
+                      {selectedRuns.length}
+                    </Label>
+                  </Flex>
+                }
+              >
+                <RunsWithArchivedExperimentTable
+                  runs={selectedRuns}
+                  archivedExperiments={archivedExperiments}
+                  runStatus={runStatuses}
+                  experimentStatus={experimentStatuses}
+                  isSubmitting={isSubmitting}
+                />
+              </ExpandableSection>
+            </StackItem>
+          </Stack>
+        )}
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onSubmit={onSubmit}
           isSubmitLoading={isSubmitting}
@@ -134,69 +203,7 @@ const RestoreRunWithArchivedExperimentModal: React.FC<
           alertTitle="Restoration failed"
           error={error}
         />
-      }
-      variant="small"
-    >
-      {isSingleRestoring ? (
-        <Stack hasGutter>
-          <StackItem>
-            <Alert
-              data-testid="single-restoring-alert-message"
-              isInline
-              variant="info"
-              component="p"
-              title={
-                <span style={{ fontWeight: 'normal' }} className="pf-v6-c-alert__description">
-                  The selected run belongs to the archived{' '}
-                  <strong>{archivedExperiments[0].display_name}</strong> experiment. Restoring it
-                  will also restore the experiment, but not other archived runs.
-                </span>
-              }
-            />
-          </StackItem>
-          <StackItem>
-            The <strong>{selectedRuns[0].display_name}</strong> run and its associated{' '}
-            <strong>{archivedExperiments[0].display_name}</strong> experiment will be restored.
-          </StackItem>
-        </Stack>
-      ) : (
-        <Stack hasGutter>
-          <StackItem>
-            <Alert
-              isInline
-              variant="info"
-              title="At least one selected run belongs to an archived experiment. Restoring it will also restore the experiment, but not other archived runs."
-            />
-          </StackItem>
-          <StackItem>
-            {selectedRuns.length} runs will be restored and returned to the{' '}
-            <b>{PipelineRunTabTitle.ACTIVE} tab</b>. {archivedExperiments.length} associated
-            experiments will be restored.
-          </StackItem>
-          <StackItem>
-            <ExpandableSection
-              isExpanded={isExpanded}
-              onToggle={(_, expanded) => setIsExpanded(expanded)}
-              toggleContent={
-                <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                  <FlexItem>Selected runs</FlexItem>
-                  <Label color="blue" isCompact>
-                    {selectedRuns.length}
-                  </Label>
-                </Flex>
-              }
-            >
-              <RunsWithArchivedExperimentTable
-                runs={selectedRuns}
-                archivedExperiments={archivedExperiments}
-                runStatus={runStatuses}
-                experimentStatus={experimentStatuses}
-                isSubmitting={isSubmitting}
-              />
-            </ExpandableSection>
-          </StackItem>
-        </Stack>
-      )}
+      </ModalFooter>
     </Modal>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

**JIRA:** https://issues.redhat.com/browse/RHOAIENG-24706

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is the first PR to replace deprecated Modal component with PF6 Modal. Below are the major changes implemented in the PR,

> In PF6, we have separate ModalBody, ModalHeader, ModalFooter components. In the deprecated version, we pass header and footer/actions as props. So we just have to use these new components instead of props.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Manually tested the UI for the affected areas of the dashboard to make sure that the new Modal loads correctly with all the right content.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I have just made sure that the tests which are already present are passing. I have fixed the cypress mock tests which failed.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
