### PR TITLE
RHOAIENG-24707: Part 2: Replace Deprecated Modal Instances with PF6 Modal

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -152,7 +152,7 @@ class StorageClassEditModal extends Modal {
   }
 
   find() {
-    return cy.findByTestId('edit-sc-modal').parents('div[role="dialog"]');
+    return cy.findByTestId('edit-sc-modal');
   }
 
   findOpenshiftScName() {

--- a/frontend/src/pages/BYONImages/BYONImageModal/ManageBYONImageModal.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageModal/ManageBYONImageModal.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
-import { Form, FormGroup, Tabs, Tab, TabTitleText, Popover } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormGroup,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Popover,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { importBYONImage, updateBYONImage } from '~/services/imagesService';
 import { ResponseStatus, BYONImagePackage, BYONImage } from '~/types';
@@ -104,11 +114,104 @@ const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({ existingIma
   return (
     <Modal
       onEscapePress={(e) => e.preventDefault()}
-      variant={ModalVariant.medium}
-      title={`${existingImage ? 'Update' : 'Import'} workbench image`}
+      variant="medium"
       isOpen
       onClose={() => onClose(false)}
-      footer={
+      data-testid="workbench-image-modal"
+    >
+      <ModalHeader title={`${existingImage ? 'Update' : 'Import'} workbench image`} />
+      <ModalBody>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
+          <ImageLocationField
+            isDisabled={!!existingImage}
+            location={repository}
+            setLocation={setRepository}
+          />
+          <K8sNameDescriptionField
+            data={byonNameDesc}
+            onDataChange={setByonNameDesc}
+            dataTestId="byon-image"
+          />
+          {isHardwareProfileAvailable ? (
+            <FormGroup
+              label="Hardware profile identifier"
+              labelHelp={
+                <Popover bodyContent="Add recommended hardware profile identifiers for this image.">
+                  <DashboardPopupIconButton
+                    icon={<OutlinedQuestionCircleIcon />}
+                    aria-label="More info for identifier field"
+                  />
+                </Popover>
+              }
+            >
+              <HardwareProfileIdentifierMultiselect
+                setData={(identifiers) => setRecommendedAcceleratorIdentifiers(identifiers)}
+                data={recommendedAcceleratorIdentifiers}
+              />
+            </FormGroup>
+          ) : (
+            <FormGroup
+              label="Accelerator identifier"
+              labelHelp={
+                <Popover bodyContent="Add recommended accelerator identifiers for this image.">
+                  <DashboardPopupIconButton
+                    icon={<OutlinedQuestionCircleIcon />}
+                    aria-label="More info for identifier field"
+                  />
+                </Popover>
+              }
+            >
+              <AcceleratorIdentifierMultiselect
+                setData={(identifiers) => setRecommendedAcceleratorIdentifiers(identifiers)}
+                data={recommendedAcceleratorIdentifiers}
+              />
+            </FormGroup>
+          )}
+          <FormGroup label="Displayed contents" fieldId="byon-image-software-packages">
+            <Tabs
+              id="byon-image-software-packages"
+              data-testid="byon-image-software-packages-tabs"
+              activeKey={activeTabKey}
+              onSelect={(e, indexKey) => {
+                setActiveTabKey(indexKey);
+              }}
+            >
+              <Tab
+                eventKey={DisplayedContentTab.SOFTWARE}
+                title={<TabTitleText>Software</TabTitleText>}
+                aria-label="Displayed content software tab"
+                data-testid="displayed-content-software-tab"
+                tabContentId={`tabContent-${DisplayedContentTab.SOFTWARE}`}
+              />
+              <Tab
+                eventKey={DisplayedContentTab.PACKAGES}
+                title={<TabTitleText>Packages</TabTitleText>}
+                aria-label="Displayed content packages tab"
+                data-testid="displayed-content-packages-tab"
+                tabContentId={`tabContent-${DisplayedContentTab.PACKAGES}`}
+              />
+            </Tabs>
+            <DisplayedContentTabContent
+              activeKey={activeTabKey}
+              tabKey={DisplayedContentTab.SOFTWARE}
+              resources={software}
+              setResources={setSoftware}
+            />
+            <DisplayedContentTabContent
+              activeKey={activeTabKey}
+              tabKey={DisplayedContentTab.PACKAGES}
+              resources={packages}
+              setResources={setPackages}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           error={error}
           alertTitle={`Error ${existingImage ? 'updating' : 'importing'} workbench image`}
@@ -119,98 +222,7 @@ const ManageBYONImageModal: React.FC<ManageBYONImageModalProps> = ({ existingIma
           onSubmit={submit}
           onCancel={() => onClose(false)}
         />
-      }
-      data-testid="workbench-image-modal"
-    >
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit();
-        }}
-      >
-        <ImageLocationField
-          isDisabled={!!existingImage}
-          location={repository}
-          setLocation={setRepository}
-        />
-        <K8sNameDescriptionField
-          data={byonNameDesc}
-          onDataChange={setByonNameDesc}
-          dataTestId="byon-image"
-        />
-        {isHardwareProfileAvailable ? (
-          <FormGroup
-            label="Hardware profile identifier"
-            labelHelp={
-              <Popover bodyContent="Add recommended hardware profile identifiers for this image.">
-                <DashboardPopupIconButton
-                  icon={<OutlinedQuestionCircleIcon />}
-                  aria-label="More info for identifier field"
-                />
-              </Popover>
-            }
-          >
-            <HardwareProfileIdentifierMultiselect
-              setData={(identifiers) => setRecommendedAcceleratorIdentifiers(identifiers)}
-              data={recommendedAcceleratorIdentifiers}
-            />
-          </FormGroup>
-        ) : (
-          <FormGroup
-            label="Accelerator identifier"
-            labelHelp={
-              <Popover bodyContent="Add recommended accelerator identifiers for this image.">
-                <DashboardPopupIconButton
-                  icon={<OutlinedQuestionCircleIcon />}
-                  aria-label="More info for identifier field"
-                />
-              </Popover>
-            }
-          >
-            <AcceleratorIdentifierMultiselect
-              setData={(identifiers) => setRecommendedAcceleratorIdentifiers(identifiers)}
-              data={recommendedAcceleratorIdentifiers}
-            />
-          </FormGroup>
-        )}
-        <FormGroup label="Displayed contents" fieldId="byon-image-software-packages">
-          <Tabs
-            id="byon-image-software-packages"
-            data-testid="byon-image-software-packages-tabs"
-            activeKey={activeTabKey}
-            onSelect={(e, indexKey) => {
-              setActiveTabKey(indexKey);
-            }}
-          >
-            <Tab
-              eventKey={DisplayedContentTab.SOFTWARE}
-              title={<TabTitleText>Software</TabTitleText>}
-              aria-label="Displayed content software tab"
-              data-testid="displayed-content-software-tab"
-              tabContentId={`tabContent-${DisplayedContentTab.SOFTWARE}`}
-            />
-            <Tab
-              eventKey={DisplayedContentTab.PACKAGES}
-              title={<TabTitleText>Packages</TabTitleText>}
-              aria-label="Displayed content packages tab"
-              data-testid="displayed-content-packages-tab"
-              tabContentId={`tabContent-${DisplayedContentTab.PACKAGES}`}
-            />
-          </Tabs>
-          <DisplayedContentTabContent
-            activeKey={activeTabKey}
-            tabKey={DisplayedContentTab.SOFTWARE}
-            resources={software}
-            setResources={setSoftware}
-          />
-          <DisplayedContentTabContent
-            activeKey={activeTabKey}
-            tabKey={DisplayedContentTab.PACKAGES}
-            resources={packages}
-            setResources={setPackages}
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/acceleratorProfiles/screens/list/DisableAcceleratorProfileModal.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/DisableAcceleratorProfileModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 
 type DisableAcceleratorProfileModalType = {
   onClose: (confirmStatus: boolean) => void;
@@ -9,12 +8,14 @@ type DisableAcceleratorProfileModalType = {
 const DisableAcceleratorProfileModal: React.FC<DisableAcceleratorProfileModalType> = ({
   onClose,
 }) => (
-  <Modal
-    variant="small"
-    title="Disable accelerator profile"
-    isOpen
-    onClose={() => onClose(false)}
-    actions={[
+  <Modal variant="small" isOpen onClose={() => onClose(false)}>
+    <ModalHeader title="Disable accelerator profile" />
+    <ModalBody>
+      This will disable the accelerator profile and it will no longer be available for use with new
+      workbenches and runtimes. Existing resources using this profile will retain it unless a new
+      profile is selected.
+    </ModalBody>
+    <ModalFooter>
       <Button
         data-testid="disable-button"
         key="confirm-disable"
@@ -22,7 +23,7 @@ const DisableAcceleratorProfileModal: React.FC<DisableAcceleratorProfileModalTyp
         onClick={() => onClose(true)}
       >
         Disable
-      </Button>,
+      </Button>
       <Button
         data-testid="cancel-button"
         key="cancel"
@@ -30,12 +31,8 @@ const DisableAcceleratorProfileModal: React.FC<DisableAcceleratorProfileModalTyp
         onClick={() => onClose(false)}
       >
         Cancel
-      </Button>,
-    ]}
-  >
-    This will disable the accelerator profile and it will no longer be available for use with new
-    workbenches and runtimes. Existing resources using this profile will retain it unless a new
-    profile is selected.
+      </Button>
+    </ModalFooter>
   </Modal>
 );
 

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/ManageTolerationModal.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/ManageTolerationModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Form } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Form, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import { Toleration } from '~/types';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import TolerationFields from './TolerationFields';
@@ -38,13 +37,19 @@ const ManageTolerationModal: React.FC<ManageTolerationModalProps> = ({
 
   return (
     <Modal
-      title={initialToleration ? 'Edit toleration' : 'Add toleration'}
       variant="medium"
       isOpen
       onClose={() => {
         onBeforeClose();
       }}
-      footer={
+    >
+      <ModalHeader title={initialToleration ? 'Edit toleration' : 'Add toleration'} />
+      <ModalBody>
+        <Form>
+          <TolerationFields toleration={toleration} onUpdate={handleUpdate} />
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={initialToleration ? 'Update' : 'Add'}
           onSubmit={() => {
@@ -55,11 +60,7 @@ const ManageTolerationModal: React.FC<ManageTolerationModalProps> = ({
           isSubmitDisabled={isButtonDisabled}
           alertTitle="Error saving toleration"
         />
-      }
-    >
-      <Form>
-        <TolerationFields toleration={toleration} onUpdate={handleUpdate} />
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldModal.tsx
@@ -9,8 +9,11 @@ import {
   Popover,
   TextArea,
   TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
 } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import {
@@ -101,9 +104,143 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
     <Modal
       isOpen
       variant="medium"
-      title={isEdit ? 'Edit field' : 'Add field'}
       onClose={onClose}
-      footer={
+      data-testid="archive-model-version-modal"
+      elementToFocus="#name"
+    >
+      <ModalHeader title={isEdit ? 'Edit field' : 'Add field'} />
+      <ModalBody>
+        <Form>
+          <FormGroup fieldId="name" label="Name" isRequired>
+            <TextInput
+              id="name"
+              value={name}
+              onChange={(_ev, value) => {
+                setData('name', value);
+                if (autoGenerateEnvVar) {
+                  setData('envVar', fieldNameToEnvVar(value));
+                }
+              }}
+              data-testid="field-name-input"
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId="description"
+            label="Description"
+            labelHelp={
+              <Popover
+                aria-label="description help"
+                headerContent="Description"
+                bodyContent="Use the description to provide users in your organization with additional information about a field, or instructions for completing the field. Your input will appear in a popover, like this one."
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info for section heading"
+                />
+              </Popover>
+            }
+          >
+            <TextArea
+              id="description"
+              data-testid="field-description-input"
+              value={description}
+              onChange={(_ev, value) => setData('description', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId="envVar"
+            label="Environment variable"
+            labelHelp={
+              <Popover
+                aria-label="environment variable help"
+                headerContent="Environment variable"
+                bodyContent="Environment variables are how the system references the field value in a workbench or model server. Your input will appear in a popover, like this one. "
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info for section heading"
+                />
+              </Popover>
+            }
+            isRequired
+          >
+            <TextInput
+              id="envVar"
+              value={envVar}
+              onChange={(_ev, value) => {
+                if (autoGenerateEnvVar) {
+                  setAutoGenerateEnvVar(false);
+                }
+                setData('envVar', value);
+              }}
+              data-testid="field-env-var-input"
+              validated={!isEnvVarValid || isEnvVarConflict ? 'warning' : 'default'}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem
+                  variant={isEnvVarValid ? 'default' : 'warning'}
+                  icon={isEnvVarValid ? undefined : <WarningTriangleIcon />}
+                >
+                  For highest compatibility, field must consist of alphanumeric characters, ( - ), (
+                  _ ), or ( . )
+                </HelperTextItem>
+              </HelperText>
+              {isEnvVarConflict ? (
+                <HelperText data-testid="envvar-conflict-warning">
+                  <HelperTextItem icon={<WarningTriangleIcon />} variant="warning">
+                    {envVar} already exists within this connection type. Try a different name.
+                  </HelperTextItem>
+                </HelperText>
+              ) : undefined}
+            </FormHelperText>
+          </FormGroup>
+          <FormGroup fieldId="fieldType" label="Type" isRequired data-testid="field-type-select">
+            <SimpleSelect
+              id="fieldType"
+              onChange={(selection) => {
+                if (isConnectionTypeFieldType(selection)) {
+                  setPropertiesValid(true);
+                  setData('properties', {});
+                  // setProperties({});
+                  setData('fieldType', selection);
+                  // setFieldType(selection);
+                }
+              }}
+              options={connectionTypeDataFields
+                .map((value) => ({ label: fieldTypeToString(value), value }))
+                .toSorted((a, b) => a.label.localeCompare(b.label))
+                .map(({ value, label }) => ({
+                  key: value,
+                  label: value,
+                  dropdownLabel: label,
+                  dataTestId: `field-${value}-select`,
+                }))}
+              shouldFocusToggleOnSelect
+              isFullWidth
+              value={fieldType}
+              toggleLabel={fieldTypeToString(fieldType)}
+            />
+          </FormGroup>
+          <DataFieldPropertiesForm
+            field={newField}
+            onChange={(value) => setData('properties', value)}
+            onValidate={setPropertiesValid}
+          />
+          <FormGroup fieldId="isRequired">
+            <Checkbox
+              id="isRequired"
+              data-testid="field-required-checkbox"
+              label="Field is required"
+              isChecked={required || false}
+              onChange={(_ev, checked) => {
+                setData('required', checked);
+              }}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onClose}
           onSubmit={handleSubmit}
@@ -111,139 +248,7 @@ export const ConnectionTypeDataFieldModal: React.FC<Props> = ({
           isSubmitDisabled={!canSubmit || !isValid}
           alertTitle="Error"
         />
-      }
-      data-testid="archive-model-version-modal"
-      elementToFocus="#name"
-    >
-      <Form>
-        <FormGroup fieldId="name" label="Name" isRequired>
-          <TextInput
-            id="name"
-            value={name}
-            onChange={(_ev, value) => {
-              setData('name', value);
-              if (autoGenerateEnvVar) {
-                setData('envVar', fieldNameToEnvVar(value));
-              }
-            }}
-            data-testid="field-name-input"
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId="description"
-          label="Description"
-          labelHelp={
-            <Popover
-              aria-label="description help"
-              headerContent="Description"
-              bodyContent="Use the description to provide users in your organization with additional information about a field, or instructions for completing the field. Your input will appear in a popover, like this one."
-            >
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info for section heading"
-              />
-            </Popover>
-          }
-        >
-          <TextArea
-            id="description"
-            data-testid="field-description-input"
-            value={description}
-            onChange={(_ev, value) => setData('description', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId="envVar"
-          label="Environment variable"
-          labelHelp={
-            <Popover
-              aria-label="environment variable help"
-              headerContent="Environment variable"
-              bodyContent="Environment variables are how the system references the field value in a workbench or model server. Your input will appear in a popover, like this one. "
-            >
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info for section heading"
-              />
-            </Popover>
-          }
-          isRequired
-        >
-          <TextInput
-            id="envVar"
-            value={envVar}
-            onChange={(_ev, value) => {
-              if (autoGenerateEnvVar) {
-                setAutoGenerateEnvVar(false);
-              }
-              setData('envVar', value);
-            }}
-            data-testid="field-env-var-input"
-            validated={!isEnvVarValid || isEnvVarConflict ? 'warning' : 'default'}
-          />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem
-                variant={isEnvVarValid ? 'default' : 'warning'}
-                icon={isEnvVarValid ? undefined : <WarningTriangleIcon />}
-              >
-                For highest compatibility, field must consist of alphanumeric characters, ( - ), ( _
-                ), or ( . )
-              </HelperTextItem>
-            </HelperText>
-            {isEnvVarConflict ? (
-              <HelperText data-testid="envvar-conflict-warning">
-                <HelperTextItem icon={<WarningTriangleIcon />} variant="warning">
-                  {envVar} already exists within this connection type. Try a different name.
-                </HelperTextItem>
-              </HelperText>
-            ) : undefined}
-          </FormHelperText>
-        </FormGroup>
-        <FormGroup fieldId="fieldType" label="Type" isRequired data-testid="field-type-select">
-          <SimpleSelect
-            id="fieldType"
-            onChange={(selection) => {
-              if (isConnectionTypeFieldType(selection)) {
-                setPropertiesValid(true);
-                setData('properties', {});
-                // setProperties({});
-                setData('fieldType', selection);
-                // setFieldType(selection);
-              }
-            }}
-            options={connectionTypeDataFields
-              .map((value) => ({ label: fieldTypeToString(value), value }))
-              .toSorted((a, b) => a.label.localeCompare(b.label))
-              .map(({ value, label }) => ({
-                key: value,
-                label: value,
-                dropdownLabel: label,
-                dataTestId: `field-${value}-select`,
-              }))}
-            shouldFocusToggleOnSelect
-            isFullWidth
-            value={fieldType}
-            toggleLabel={fieldTypeToString(fieldType)}
-          />
-        </FormGroup>
-        <DataFieldPropertiesForm
-          field={newField}
-          onChange={(value) => setData('properties', value)}
-          onValidate={setPropertiesValid}
-        />
-        <FormGroup fieldId="isRequired">
-          <Checkbox
-            id="isRequired"
-            data-testid="field-required-checkbox"
-            label="Field is required"
-            isChecked={required || false}
-            onChange={(_ev, checked) => {
-              setData('required', checked);
-            }}
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldRemoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeDataFieldRemoveModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { ConnectionTypeDataField } from '~/concepts/connectionTypes/types';
 
@@ -9,20 +9,18 @@ type Props = {
 };
 
 const ConnectionTypeDataFieldRemoveModal: React.FC<Props> = ({ field, onClose }) => (
-  <Modal
-    isOpen
-    title="Remove field?"
-    onClose={() => onClose(false)}
-    variant="small"
-    footer={
+  <Modal isOpen onClose={() => onClose(false)} variant="small">
+    <ModalHeader title="Remove field?" />
+    <ModalBody>
+      The <b>{field.name}</b> field will be removed.
+    </ModalBody>
+    <ModalFooter>
       <DashboardModalFooter
         submitLabel="Remove"
         onCancel={() => onClose(false)}
         onSubmit={() => onClose(true)}
       />
-    }
-  >
-    The <b>{field.name}</b> field will be removed.
+    </ModalFooter>
   </Modal>
 );
 

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeFieldMoveModal.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { Form, FormGroup } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormGroup,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { ConnectionTypeField, ConnectionTypeFieldType } from '~/concepts/connectionTypes/types';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import SimpleSelect, { SimpleSelectOption } from '~/components/SimpleSelect';
@@ -38,12 +44,26 @@ export const ConnectionTypeMoveFieldToSectionModal: React.FC<Props> = ({
   );
 
   return (
-    <Modal
-      isOpen
-      title="Move to section"
-      onClose={onClose}
-      variant="medium"
-      footer={
+    <Modal isOpen onClose={onClose} variant="medium">
+      <ModalHeader title="Move to section" />
+      <ModalBody>
+        <Form>
+          <div>
+            Select the section heading that <b>{row.field.name}</b> will be moved to.
+          </div>
+          <FormGroup fieldId="sectionHeading" label="Section heading" isRequired>
+            <SimpleSelect
+              id="sectionHeading"
+              dataTestId="section-heading-select"
+              options={options}
+              value={selectedSection?.key}
+              onChange={(key) => setSelectedSection(options.find((s) => s.key === key))}
+              isFullWidth
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel="Move"
           onCancel={onClose}
@@ -55,23 +75,7 @@ export const ConnectionTypeMoveFieldToSectionModal: React.FC<Props> = ({
           }}
           isSubmitDisabled={!selectedSection}
         />
-      }
-    >
-      <Form>
-        <div>
-          Select the section heading that <b>{row.field.name}</b> will be moved to.
-        </div>
-        <FormGroup fieldId="sectionHeading" label="Section heading" isRequired>
-          <SimpleSelect
-            id="sectionHeading"
-            dataTestId="section-heading-select"
-            options={options}
-            value={selectedSection?.key}
-            onChange={(key) => setSelectedSection(options.find((s) => s.key === key))}
-            isFullWidth
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { Form, FormGroup, TextInput, TextArea, Popover } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Popover,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { SectionField } from '~/concepts/connectionTypes/types';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
@@ -24,12 +33,59 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit,
   const isValid = name.length > 0;
 
   return (
-    <Modal
-      isOpen
-      title={isEdit ? 'Edit section heading' : 'Add section heading'}
-      onClose={onClose}
-      variant="medium"
-      footer={
+    <Modal isOpen onClose={onClose} variant="medium" elementToFocus="#section-name">
+      <ModalHeader title={isEdit ? 'Edit section heading' : 'Add section heading'} />
+      <ModalBody>
+        <Form>
+          <FormGroup
+            label="Section heading"
+            isRequired
+            fieldId="section-name"
+            labelHelp={
+              <Popover
+                headerContent="Section heading"
+                bodyContent="Use section headings to indicate groups of related fields. Use descriptive headings, for example, Details, Configuration, Preferences."
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info for section heading"
+                />
+              </Popover>
+            }
+          >
+            <TextInput
+              isRequired
+              id="section-name"
+              data-testid="section-name"
+              value={name}
+              onChange={(_e, value) => setData('name', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Section description"
+            fieldId="section-description"
+            labelHelp={
+              <Popover
+                headerContent="Section description"
+                bodyContent="Use section descriptions to summarize the required input."
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info for section description"
+                />
+              </Popover>
+            }
+          >
+            <TextArea
+              id="section-description"
+              data-testid="section-description"
+              value={description}
+              onChange={(_e, value) => setData('description', value)}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={isEdit ? 'Save' : 'Add'}
           onCancel={onClose}
@@ -41,57 +97,7 @@ const ConnectionTypeSectionModal: React.FC<Props> = ({ field, onClose, onSubmit,
           }}
           isSubmitDisabled={!canSubmit || !isValid}
         />
-      }
-      elementToFocus="#section-name"
-    >
-      <Form>
-        <FormGroup
-          label="Section heading"
-          isRequired
-          fieldId="section-name"
-          labelHelp={
-            <Popover
-              headerContent="Section heading"
-              bodyContent="Use section headings to indicate groups of related fields. Use descriptive headings, for example, Details, Configuration, Preferences."
-            >
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info for section heading"
-              />
-            </Popover>
-          }
-        >
-          <TextInput
-            isRequired
-            id="section-name"
-            data-testid="section-name"
-            value={name}
-            onChange={(_e, value) => setData('name', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Section description"
-          fieldId="section-description"
-          labelHelp={
-            <Popover
-              headerContent="Section description"
-              bodyContent="Use section descriptions to summarize the required input."
-            >
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info for section description"
-              />
-            </Popover>
-          }
-        >
-          <TextArea
-            id="section-description"
-            data-testid="section-description"
-            value={description}
-            onChange={(_e, value) => setData('description', value)}
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionRemoveModal.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ConnectionTypeSectionRemoveModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { Badge, Checkbox, ExpandableSection, List, ListItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Badge,
+  Checkbox,
+  ExpandableSection,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { ConnectionTypeField, SectionField } from '~/concepts/connectionTypes/types';
 
@@ -13,48 +22,46 @@ type Props = {
 const ConnectionTypeSectionRemoveModal: React.FC<Props> = ({ field, fields, onClose }) => {
   const [removedFields, setRemovedFields] = React.useState(false);
   return (
-    <Modal
-      isOpen
-      title="Remove section?"
-      onClose={() => onClose(false, false)}
-      variant="small"
-      footer={
+    <Modal isOpen onClose={() => onClose(false, false)} variant="small">
+      <ModalHeader title="Remove section?" />
+      <ModalBody>
+        <div>
+          The <b>{field.name}</b> section heading will be removed.
+        </div>
+        {fields.length > 0 ? (
+          <div className="pf-v6-u-mt-md">
+            <Checkbox
+              id="remove-fields-checkbox"
+              data-testid="remove-fields-checkbox"
+              label="Remove associated fields"
+              isChecked={removedFields}
+              onChange={(_, checked) => setRemovedFields(checked)}
+            />
+            <ExpandableSection
+              className="pf-v6-u-mt-md"
+              isIndented
+              toggleContent={
+                <>
+                  Associated fields <Badge isRead>{fields.length}</Badge>
+                </>
+              }
+            >
+              <List>
+                {fields.map((f, i) => (
+                  <ListItem key={i}>{f.name}</ListItem>
+                ))}
+              </List>
+            </ExpandableSection>
+          </div>
+        ) : null}
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel="Remove"
           onCancel={() => onClose(false, false)}
           onSubmit={() => onClose(true, removedFields)}
         />
-      }
-    >
-      <div>
-        The <b>{field.name}</b> section heading will be removed.
-      </div>
-      {fields.length > 0 ? (
-        <div className="pf-v6-u-mt-md">
-          <Checkbox
-            id="remove-fields-checkbox"
-            data-testid="remove-fields-checkbox"
-            label="Remove associated fields"
-            isChecked={removedFields}
-            onChange={(_, checked) => setRemovedFields(checked)}
-          />
-          <ExpandableSection
-            className="pf-v6-u-mt-md"
-            isIndented
-            toggleContent={
-              <>
-                Associated fields <Badge isRead>{fields.length}</Badge>
-              </>
-            }
-          >
-            <List>
-              {fields.map((f, i) => (
-                <ListItem key={i}>{f.name}</ListItem>
-              ))}
-            </List>
-          </ExpandableSection>
-        </div>
-      ) : null}
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -13,8 +13,11 @@ import {
   Flex,
   FlexItem,
   AlertProps,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 import { StorageClassKind } from '~/k8sTypes';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
@@ -72,12 +75,66 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
   };
 
   return (
-    <Modal
-      isOpen
-      variant={ModalVariant.small}
-      title="Edit storage class details"
-      onClose={onClose}
-      footer={
+    <Modal isOpen variant="small" onClose={onClose} data-testid="edit-sc-modal">
+      <ModalHeader title="Edit storage class details" />
+      <ModalBody>
+        <Alert
+          isInline
+          variant="info"
+          title="Editing these details will not affect the storage class in OpenShift."
+          {...alert}
+          className="pf-v6-u-mb-lg"
+          data-testid="edit-sc-modal-info-alert"
+        />
+
+        <Form id="edit-sc-form">
+          {(!alert || alert.children) && (
+            <DescriptionList>
+              <DescriptionListGroup>
+                <DescriptionListTerm>OpenShift storage class</DescriptionListTerm>
+                <DescriptionListDescription data-testid="edit-sc-openshift-class-name">
+                  <Flex
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                  >
+                    <FlexItem>{storageClassName}</FlexItem>
+                    {isOpenshiftDefaultStorageClass(storageClass) && <OpenshiftDefaultLabel />}
+                  </Flex>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>Provisioner</DescriptionListTerm>
+                <DescriptionListDescription data-testid="edit-sc-provisioner">
+                  {storageClass.provisioner}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          )}
+
+          <FormGroup label="Display name" isRequired fieldId="edit-sc-display-name">
+            <TextInput
+              isRequired
+              value={displayName}
+              onChange={(_, value) => setDisplayName(value)}
+              id="edit-sc-display-name"
+              data-testid="edit-sc-display-name"
+            />
+          </FormGroup>
+
+          <FormGroup label="Description" fieldId="edit-sc-description">
+            <TextArea
+              value={description}
+              onChange={(_, value) => setDescription(value)}
+              resizeOrientation="vertical"
+              autoResize
+              id="edit-sc-description"
+              data-testid="edit-sc-description"
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onClose}
           onSubmit={onSave}
@@ -87,64 +144,7 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
           error={updateError}
           alertTitle="Error updating storage class"
         />
-      }
-      data-testid="edit-sc-modal"
-    >
-      <Alert
-        isInline
-        variant="info"
-        title="Editing these details will not affect the storage class in OpenShift."
-        {...alert}
-        className="pf-v6-u-mb-lg"
-        data-testid="edit-sc-modal-info-alert"
-      />
-
-      <Form id="edit-sc-form">
-        {(!alert || alert.children) && (
-          <DescriptionList>
-            <DescriptionListGroup>
-              <DescriptionListTerm>OpenShift storage class</DescriptionListTerm>
-              <DescriptionListDescription data-testid="edit-sc-openshift-class-name">
-                <Flex
-                  spaceItems={{ default: 'spaceItemsSm' }}
-                  alignItems={{ default: 'alignItemsCenter' }}
-                >
-                  <FlexItem>{storageClassName}</FlexItem>
-                  {isOpenshiftDefaultStorageClass(storageClass) && <OpenshiftDefaultLabel />}
-                </Flex>
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-
-            <DescriptionListGroup>
-              <DescriptionListTerm>Provisioner</DescriptionListTerm>
-              <DescriptionListDescription data-testid="edit-sc-provisioner">
-                {storageClass.provisioner}
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-          </DescriptionList>
-        )}
-
-        <FormGroup label="Display name" isRequired fieldId="edit-sc-display-name">
-          <TextInput
-            isRequired
-            value={displayName}
-            onChange={(_, value) => setDisplayName(value)}
-            id="edit-sc-display-name"
-            data-testid="edit-sc-display-name"
-          />
-        </FormGroup>
-
-        <FormGroup label="Description" fieldId="edit-sc-description">
-          <TextArea
-            value={description}
-            onChange={(_, value) => setDescription(value)}
-            resizeOrientation="vertical"
-            autoResize
-            id="edit-sc-description"
-            data-testid="edit-sc-description"
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-24707

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is the second PR to replace deprecated Modal component with PF6 Modal. Below are the major changes implemented in the PR,

> In PF6, we have separate ModalBody, ModalHeader, ModalFooter components. In the deprecated version, we pass header and footer/actions as props. So we just have to use these new components instead of props.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Manually tested the UI for the affected areas of the dashboard to make sure that the new Modal loads correctly with all the right content.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
