### PR TITLE
Serving Platform Change Button Bug Fix

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -433,8 +433,7 @@ describe('Serving Runtime List', () => {
       });
       projectDetails.visitSection('test-project', 'model-server');
       // shouldn't exist because kServe is disabled and theres nothing to change to
-      cy.findByTestId('change-serving-platform-button').should('not.exist');
-
+      projectDetails.findResetPlatformButton().should('not.exist');
       // simulate modelMesh being disabled
       cy.interceptOdh(
         'GET /api/dsc/status',
@@ -445,7 +444,7 @@ describe('Serving Runtime List', () => {
       );
 
       cy.reload();
-      cy.findByTestId('change-serving-platform-button').should('exist');
+      projectDetails.findResetPlatformButton().should('exist');
     });
   });
   describe('No server available', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -422,6 +422,32 @@ const initIntercepts = ({
 };
 
 describe('Serving Runtime List', () => {
+  describe('Change button visiblity', () => {
+    it('Change button visible when current platform is disabled', () => {
+      // starts with modelMesh enabled and kServe disabled
+      initIntercepts({
+        disableModelMeshConfig: false,
+        disableKServeConfig: true,
+        servingRuntimes: [],
+        projectEnableModelMesh: true,
+      });
+      projectDetails.visitSection('test-project', 'model-server');
+      // shouldn't exist because kServe is disabled and theres nothing to change to
+      cy.findByTestId('change-serving-platform-button').should('not.exist');
+
+      // simulate modelMesh being disabled
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: undefined,
+          installedComponents: { kserve: false, 'model-mesh': false },
+        }),
+      );
+
+      cy.reload();
+      cy.findByTestId('change-serving-platform-button').should('exist');
+    });
+  });
   describe('No server available', () => {
     it('No model serving platform available', () => {
       initIntercepts({

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -1,5 +1,10 @@
 import { ModelServingSize } from './types';
 
+export const platformKeyMap = {
+  single: 'kServe',
+  multi: 'modelMesh',
+} as const;
+
 export const SERVING_RUNTIME_SCOPE = {
   Global: 'global',
   Project: 'project',

--- a/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelServingPlatform.tsx
@@ -24,7 +24,10 @@ import {
   getTemplateEnabledForPlatform,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { ServingRuntimePlatform } from '~/types';
-import { getProjectModelServingPlatform } from '~/pages/modelServing/screens/projects/utils';
+import {
+  getProjectModelServingPlatform,
+  isCurrentServingPlatformEnabled,
+} from '~/pages/modelServing/screens/projects/utils';
 import KServeInferenceServiceTable from '~/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable';
 import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 import DetailsSection from '~/pages/projects/screens/detail/DetailsSection';
@@ -99,6 +102,11 @@ const ModelServingPlatform: React.FC = () => {
     servingPlatformStatuses.platformEnabledCount !== 1 && !currentProjectServingPlatform;
 
   const isProjectModelMesh = currentProjectServingPlatform === ServingRuntimePlatform.MULTI;
+
+  const isCurrentPlatformEnabled = isCurrentServingPlatformEnabled(
+    currentProjectServingPlatform,
+    servingPlatformStatuses,
+  );
 
   const onSubmit = (submit: boolean) => {
     setPlatformSelected(undefined);
@@ -324,21 +332,26 @@ const ModelServingPlatform: React.FC = () => {
                   <Label data-testid="serving-platform-label">
                     {isKServeNIMEnabled
                       ? 'NVIDIA NIM serving enabled'
-                      : isProjectModelMesh
-                      ? 'Multi-model serving enabled'
-                      : 'Single-model serving enabled'}
+                      : isCurrentPlatformEnabled
+                      ? isProjectModelMesh
+                        ? 'Multi-model serving enabled'
+                        : 'Single-model serving enabled'
+                      : 'Current platform disabled'}
                   </Label>
 
-                  {emptyModelServer && servingPlatformStatuses.platformEnabledCount > 1 && (
-                    <ModelServingPlatformSelectButton
-                      namespace={currentProject.metadata.name}
-                      servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
-                      setError={setErrorSelectingPlatform}
-                      variant="link"
-                      isInline
-                      data-testid="change-serving-platform-button"
-                    />
-                  )}
+                  {emptyModelServer &&
+                    (servingPlatformStatuses.platformEnabledCount > 1 ||
+                      !isCurrentPlatformEnabled ||
+                      platformError) && (
+                      <ModelServingPlatformSelectButton
+                        namespace={currentProject.metadata.name}
+                        servingPlatform={NamespaceApplicationCase.RESET_MODEL_SERVING_PLATFORM}
+                        setError={setErrorSelectingPlatform}
+                        variant="link"
+                        isInline
+                        data-testid="change-serving-platform-button"
+                      />
+                    )}
                 </Flex>,
               ]
             : undefined

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   getCreateInferenceServiceLabels,
   getProjectModelServingPlatform,
   getUrlFromKserveInferenceService,
+  isCurrentServingPlatformEnabled,
 } from '~/pages/modelServing/screens/projects/utils';
 import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
@@ -516,5 +517,37 @@ describe('updateServingRuntimeTemplate', () => {
     const result = updateServingRuntimeTemplate(servingRuntimeWithoutVolumeMounts, pvcName);
 
     expect(result.spec.containers[0].volumeMounts).toBeUndefined();
+  });
+});
+
+describe('isCurrentServingPlatformEnabled', () => {
+  const baseStatuses = {
+    kServe: { enabled: true, installed: true },
+    kServeNIM: { enabled: false, installed: false },
+    modelMesh: { enabled: true, installed: true },
+    platformEnabledCount: 2,
+    refreshNIMAvailability: async () => true,
+  };
+
+  it('returns true if currentPlatform is single and kServe is enabled', () => {
+    expect(isCurrentServingPlatformEnabled(ServingRuntimePlatform.SINGLE, baseStatuses)).toBe(true);
+  });
+
+  it('returns false if currentPlatform is single and kServe is disabled', () => {
+    const statuses = { ...baseStatuses, kServe: { enabled: false, installed: true } };
+    expect(isCurrentServingPlatformEnabled(ServingRuntimePlatform.SINGLE, statuses)).toBe(false);
+  });
+
+  it('returns true if currentPlatform is multi and modelMesh is enabled', () => {
+    expect(isCurrentServingPlatformEnabled(ServingRuntimePlatform.MULTI, baseStatuses)).toBe(true);
+  });
+
+  it('returns false if currentPlatform is multi and modelMesh is disabled', () => {
+    const statuses = { ...baseStatuses, modelMesh: { enabled: false, installed: true } };
+    expect(isCurrentServingPlatformEnabled(ServingRuntimePlatform.MULTI, statuses)).toBe(false);
+  });
+
+  it('returns false if currentPlatform is undefined', () => {
+    expect(isCurrentServingPlatformEnabled(undefined, baseStatuses)).toBe(false);
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -744,6 +744,5 @@ export function isCurrentServingPlatformEnabled(
     multi: 'modelMesh',
   } as const;
   const mappedKey = platformKeyMap[currentPlatform];
-  // mappedKey will be 'kServe' or 'modelMesh', both are always present in statuses
   return statuses[mappedKey].enabled;
 }

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -21,7 +21,7 @@ import {
   ServingRuntimeEditInfo,
 } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
-import { DEFAULT_MODEL_SERVER_SIZES } from '~/pages/modelServing/screens/const';
+import { DEFAULT_MODEL_SERVER_SIZES, platformKeyMap } from '~/pages/modelServing/screens/const';
 import { useDeepCompareMemoize } from '~/utilities/useDeepCompareMemoize';
 import { EMPTY_AWS_SECRET_DATA } from '~/pages/projects/dataConnections/const';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
@@ -739,10 +739,6 @@ export function isCurrentServingPlatformEnabled(
   if (!currentPlatform) {
     return false;
   }
-  const platformKeyMap = {
-    single: 'kServe',
-    multi: 'modelMesh',
-  } as const;
   const mappedKey = platformKeyMap[currentPlatform];
   return statuses[mappedKey].enabled;
 }

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -731,3 +731,19 @@ export const fetchInferenceServiceCount = async (namespace: string): Promise<num
     );
   }
 };
+
+export function isCurrentServingPlatformEnabled(
+  currentPlatform: ServingRuntimePlatform | undefined,
+  statuses: ServingPlatformStatuses,
+): boolean {
+  if (!currentPlatform) {
+    return false;
+  }
+  const platformKeyMap = {
+    single: 'kServe',
+    multi: 'modelMesh',
+  } as const;
+  const mappedKey = platformKeyMap[currentPlatform];
+  // mappedKey will be 'kServe' or 'modelMesh', both are always present in statuses
+  return statuses[mappedKey].enabled;
+}


### PR DESCRIPTION
Closes [RHOAIENG-15829](https://issues.redhat.com/browse/RHOAIENG-15829)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The serving platform change button would only appear if there was more than one platform enabled. If you had a project using modelMesh and modelMesh got disabled, you'd be stuck with an error on the models tab saying "Multi-model platform is not installed" and unable to switch to kServe.

I added a util to see if the current platform is enabled, if it's not, show the change button and change the label to say the current platform is disabled.

**Previously:**
![Screenshot 2025-05-02 at 10 42 41 AM](https://github.com/user-attachments/assets/a4b6da1a-64a2-453d-b4cd-df21ad546a55)

**Now:**
![Screenshot 2025-05-02 at 1 24 43 PM](https://github.com/user-attachments/assets/d4958b75-d061-4d26-af0b-d0138127c32e)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with `npm run test`

If you want to test it: (using kServe in this example but the same can be done for modelMesh)
- Create or open a project with no models.
- Select single-model serving -> don't serve a model.
- Open the openshift console.
- Find the ODH operator -> go to the DSC yaml.
- Under `spec: components:` find `kserve` and set `managementState` to `Removed`.
- It can take a few minutes for this to come through so wait a bit and refresh the page now and then.
- Eventually you'll get an error saying the platform is not installed. But you should see the 'change' button and when you click it, you'll be automatically switched over to modelMesh.
- When you're done go back to the DSC and set the `kserve` `managementState` to `Managed`.

You might be wondering what happens when both kServe and modelMesh are disabled. Don't worry, I tried it:
![Screenshot 2025-05-02 at 2 13 09 PM](https://github.com/user-attachments/assets/9c0825e7-20f8-475e-af2f-4a359aeefddb)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests for the `isCurrentServingPlatformEnabled` util.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
