### PR TITLE
Small fix for connections radio

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -369,6 +369,7 @@ export const ConnectionSection: React.FC<Props> = ({
               setData('storage', {
                 ...data.storage,
                 type: InferenceServiceStorageType.NEW_STORAGE,
+                dataConnection: '',
                 uri: undefined,
                 alert: undefined,
               });


### PR DESCRIPTION
Closes: [RHOAIENG-22646](https://issues.redhat.com/browse/RHOAIENG-22646)

## Description
Fixes small bug found in this PR - https://github.com/opendatahub-io/odh-dashboard/pull/4056
There was an issue where if a connection already existed and was pre-selected, and the user clicked new connection, the new connection name would be auto filled with the name of the existing connection. 

## How Has This Been Tested?
Tested locally

- Navigate to your data science projects, and to the Models tab.
- Ensure that you have one existing connection, then click deploy model.
- In the model window, the existing connection should be pre-selected. Click create connection
- The new connection name field should be blank

## Test Impact
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
