### PR TITLE
Cypress --env option to set tests timeout: CY_TEST_TIMEOUT_SECONDS  

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -363,3 +363,17 @@ after(() => {
   });
 });
 
+// Override Mocha's global after() to skip spec-level after hooks when using grepTags
+const origAfter = (window as Window & typeof globalThis).after;
+(window as Window & typeof globalThis).after = function afterOverride(
+  nameOrFn: string | Mocha.Func,
+  fn?: Mocha.Func,
+): void {
+  if (Cypress.env('grepTags')) {
+    return; // do not register after hooks when filtering specs
+  }
+  if (fn) {
+    return (origAfter as Mocha.HookFunction).call(this, nameOrFn as string, fn as Mocha.AsyncFunc);
+  }
+  return (origAfter as Mocha.HookFunction).call(this, nameOrFn as string);
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-24885

## Description
This PR adds a new environment variable, `CY_TEST_TIMEOUT_SECONDS`, to set a global timeout for `it` tests in Cypress. The value is specified in seconds and is converted to milliseconds for compatibility with Cypress's `testTimeout` setting.

Usage example: 
`npm run --prefix frontend cypress:run -- --env CY_TEST_TIMEOUT_SECONDS=30`

Only those tests that exceeded 30 seconds will stop due to the timeout limit:

![image](https://github.com/user-attachments/assets/f0b968b5-849f-464f-9917-c7cf1792a4c9)


In addition, this PR fixes a problem when `grepTags` includes tags that do not exist in the actual test files, but e2e.ts was still executing those tests `Before` and `After` steps, instead of skipping those steps.

## How Has This Been Tested?
Tested by running Cypress with various values for `CY_TEST_TIMEOUT_SECONDS` to ensure the timeout is applied correctly to all `it` tests.

## Test Impact
The implementation has been verified to work without affecting existing tests. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
