### PR TITLE
Fix http prefix removal for OCI path

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField.tsx
@@ -73,7 +73,7 @@ const ConnectionOciPathField: React.FC<ConnectionOciPathFieldProps> = ({
                   setModelUri(value);
                 }}
                 onBlur={() => {
-                  setModelUri(addUriPrefix(modelUri));
+                  setModelUri(addUriPrefix(hideUriPrefix(modelUri)));
                 }}
               />
             </InputGroupItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-24886
## Description
Fixing a blocker bug that causes the url prefix to be submitted when pasting into the input since the `onChange` is not triggered when you paste and blur the field.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Manually test. See Jira for more details.
1. Go to deploy an oci model (can create the connection first or do it in model)
2. for the oci path paste in your url with a prefix (`http://`, `https://`, `oci://`, etc)
3. Click submit or click away (blur the field) and then submit

Both should submit the proper inference service (check the storageUri field on the ISVC). storageUri should always have an `oci://` prefix
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
