### PR TITLE
Fix Model catalog icon background to teal instead of orange

### DIFF
--- a/frontend/src/pages/home/modelCatalog/ModelCatalogSectionHeader.tsx
+++ b/frontend/src/pages/home/modelCatalog/ModelCatalogSectionHeader.tsx
@@ -6,7 +6,7 @@ import { ProjectObjectType, SectionType } from '~/concepts/design/utils';
 const ModelCatalogSectionHeader: React.FC = () => (
   <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
     <FlexItem>
-      <HeaderIcon type={ProjectObjectType.modelCatalog} sectionType={SectionType.organize} />
+      <HeaderIcon type={ProjectObjectType.modelCatalog} sectionType={SectionType.training} />
     </FlexItem>
     <FlexItem>
       <Content component={ContentVariants.h1}>Model catalog</Content>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-24897

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The Model catalog icon background color should be teal to remain consistent with the model catalog page and not orange as currently implemented. This is due to section type being set to `organize` instead of `training`.

<img width="527" alt="image" src="https://github.com/user-attachments/assets/9edcdcf0-867a-4163-ac72-02128fe780ef" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the homepage, check that the model catalog icon has a teal background color instead of orange.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Checked visually in local run. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
