### PR TITLE
Rhoaieng 24513 -Model catalog and registry pages don't check if model serving is enabled before rendering deploy buttons and deployments tab

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -187,6 +187,10 @@ class ModelVersionDetails {
   findStartRunModal() {
     return cy.findByRole('dialog', { hidden: true }).contains('Start a LAB-tuning run');
   }
+
+  findDeployModelButton() {
+    return cy.findByTestId('deploy-button');
+  }
 }
 
 class PropertyRow extends TableRow {}

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDeploy.cy.ts
@@ -49,10 +49,12 @@ describe('Deploy catalog model', () => {
   it('Error if kserve is not enabled', () => {
     initIntercepts({ kServeInstalled: false });
     modelDetailsPage.visit();
-    modelDetailsPage.findDeployModelButton().click();
-    cy.wait('@getProjects');
-    modelCatalogDeployModal.selectProjectByName('KServe project');
-    cy.findByText('Single-model platform is not installed').should('exist');
+    modelDetailsPage.findDeployModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelDetailsPage.findDeployModelButton().focus();
+    cy.findByRole('tooltip').should(
+      'contain.text',
+      'To deploy this model, an administrator must first enable single-model serving in the cluster settings.',
+    );
   });
 
   it('Allow using a project with no platform selected (it will use kserve)', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import {
   mockCustomSecretK8sResource,
+  mockDashboardConfig,
   mockK8sResourceList,
   mockSecretK8sResource,
 } from '~/__mocks__';
@@ -720,5 +721,33 @@ describe('Deploy model version', () => {
     modelVersionRow.findKebabAction('Deploy').click();
     modelVersionDeployModal.selectProjectByName('KServe project');
     kserveModal.findSpinner().should('exist');
+  });
+
+  it('does not show deploy in the kebab menu option when model serving is disabled', () => {
+    initIntercepts({});
+    cy.interceptOdh(
+      'GET /api/config',
+      mockDashboardConfig({
+        disableModelServing: true,
+      }),
+    );
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version 3');
+    modelVersionRow.findKebab().click();
+    cy.get('[role="menu"]').within(() => {
+      cy.contains('Deploy').should('not.exist');
+    });
+  });
+
+  it('shows a disabled deploy menu option in the kebab menu for the model with OCI URI when kserve is disabled', () => {
+    initIntercepts({ kServeInstalled: false });
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow('test model version 4');
+    modelVersionRow.findKebabAction('Deploy').click();
+    cy.findByRole('tooltip').should(
+      'contain.text',
+      'To deploy this model, an administrator must first enable single-model serving in the cluster settings.',
+    );
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -689,4 +689,35 @@ describe('Model version details', () => {
       modelVersionDetails.findStartRunModal().should('exist');
     });
   });
+
+  describe('model serving is disabled', () => {
+    beforeEach(() => {
+      initIntercepts();
+      // Mock fine-tuning as enabled
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          installedComponents: {
+            'model-registry-operator': true,
+            'data-science-pipelines-operator': true,
+          },
+        }),
+      );
+      modelVersionDetails.visit();
+    });
+
+    it('should show the deploy button as disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableModelServing: true,
+        }),
+      );
+      modelVersionDetails.findDeployModelButton().click();
+      cy.findByRole('tooltip').should(
+        'contain.text',
+        'To enable model serving, an administrator must first select a model serving platform in the cluster settings.',
+      );
+    });
+  });
 });

--- a/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelCatalog/__tests__/utils.spec.ts
@@ -9,8 +9,10 @@ import {
   getTagFromModel,
   isLabBase,
   removeILabLabels,
+  getDeployButtonState,
 } from '~/pages/modelCatalog/utils';
 import { EMPTY_CUSTOM_PROPERTY_STRING } from '~/pages/modelCatalog/const';
+import { DEPLOY_BUTTON_TOOLTIP } from '~/pages/modelServing/screens/const';
 
 describe('findModelFromModelCatalogSources', () => {
   const catalogModelMock = [mockModelCatalogSource({})];
@@ -189,5 +191,62 @@ describe('createCustomPropertiesFromModel', () => {
     );
 
     expect(result).toEqual({});
+  });
+});
+
+describe('getDeployButtonState', () => {
+  it('returns not visible if model serving is disabled', () => {
+    expect(
+      getDeployButtonState({
+        isModelServingEnabled: false,
+        platformEnabledCount: 1,
+        isKServeEnabled: true,
+        isOciModel: false,
+      }),
+    ).toEqual({ visible: false });
+  });
+
+  it('returns disabled with tooltip if no platforms are enabled', () => {
+    expect(
+      getDeployButtonState({
+        isModelServingEnabled: true,
+        platformEnabledCount: 0,
+        isKServeEnabled: false,
+        isOciModel: false,
+      }),
+    ).toEqual({
+      visible: true,
+      enabled: false,
+      tooltip: DEPLOY_BUTTON_TOOLTIP.ENABLE_MODEL_SERVING_PLATFORM,
+    });
+  });
+
+  it('returns disabled with tooltip if OCI model and kserve is not enabled', () => {
+    expect(
+      getDeployButtonState({
+        isModelServingEnabled: true,
+        platformEnabledCount: 1,
+        isKServeEnabled: false,
+        isOciModel: true,
+      }),
+    ).toEqual({
+      visible: true,
+      enabled: false,
+      tooltip: DEPLOY_BUTTON_TOOLTIP.ENABLE_SINGLE_MODEL_SERVING,
+    });
+  });
+
+  it('returns enabled if all requirements are met', () => {
+    expect(
+      getDeployButtonState({
+        isModelServingEnabled: true,
+        platformEnabledCount: 1,
+        isKServeEnabled: true,
+        isOciModel: false,
+      }),
+    ).toEqual({
+      visible: true,
+      enabled: true,
+    });
   });
 });

--- a/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/frontend/src/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -93,14 +93,18 @@ const ModelDetailsPage: React.FC = conditionalArea(
           />
         }
       >
-        <Button variant="secondary" isAriaDisabled data-testid="register-model-button">
+        <Button
+          variant={!deployButtonState.visible ? 'primary' : 'secondary'}
+          isAriaDisabled
+          data-testid="register-model-button"
+        >
           Register model
         </Button>
       </Popover>
     ) : (
       <Button
         data-testid="register-model-button"
-        variant="secondary"
+        variant={!deployButtonState.visible ? 'primary' : 'secondary'}
         onClick={() => {
           navigate(getRegisterCatalogModelRoute(decodedParams));
         }}
@@ -229,8 +233,8 @@ const ModelDetailsPage: React.FC = conditionalArea(
             <ActionList>
               <ActionListGroup>
                 {tuningAvailable && isLabBase(model?.labels) && fineTuneActionItem}
-                {registerModelButton()}
                 {deployButtonState.visible && renderDeployModelButton()}
+                {registerModelButton()}
               </ActionListGroup>
             </ActionList>
           )

--- a/frontend/src/pages/modelCatalog/utils.ts
+++ b/frontend/src/pages/modelCatalog/utils.ts
@@ -6,6 +6,7 @@ import {
 } from '~/pages/modelCatalog/const';
 import { ModelRegistryCustomProperties } from '~/concepts/modelRegistry/types';
 import { CatalogModelDetailsParams } from '~/pages/modelCatalog/types';
+import { DEPLOY_BUTTON_TOOLTIP } from '~/pages/modelServing/screens/const';
 
 export const findModelFromModelCatalogSources = (
   modelCatalogSources: ModelCatalogSource[],
@@ -75,3 +76,34 @@ export const createCustomPropertiesFromModel = (
 
   return { ...labels, ...tasks };
 };
+
+export function getDeployButtonState({
+  isModelServingEnabled,
+  platformEnabledCount,
+  isKServeEnabled,
+  isOciModel,
+}: {
+  isModelServingEnabled: boolean;
+  platformEnabledCount: number;
+  isKServeEnabled: boolean;
+  isOciModel: boolean;
+}): { visible: boolean; enabled?: boolean; tooltip?: string } {
+  if (!isModelServingEnabled) {
+    return { visible: false };
+  }
+  if (platformEnabledCount === 0) {
+    return {
+      visible: true,
+      enabled: false,
+      tooltip: DEPLOY_BUTTON_TOOLTIP.ENABLE_MODEL_SERVING_PLATFORM,
+    };
+  }
+  if (isOciModel && !isKServeEnabled) {
+    return {
+      visible: true,
+      enabled: false,
+      tooltip: DEPLOY_BUTTON_TOOLTIP.ENABLE_SINGLE_MODEL_SERVING,
+    };
+  }
+  return { visible: true, enabled: true };
+}

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -21,6 +21,9 @@ import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
 import StartRunModal from '~/pages/pipelines/global/modelCustomization/startRunModal/StartRunModal';
 import { useModelVersionTuningData } from '~/concepts/modelRegistry/hooks/useModelVersionTuningData';
 import { getModelCustomizationPath } from '~/routes/pipelines/modelCustomization';
+import useDeployButtonState from '~/pages/modelServing/screens/projects/useDeployButtonState';
+import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
+import { isOciModelUri } from '~/pages/modelServing/utils';
 
 interface ModelVersionsDetailsHeaderActionsProps {
   mv: ModelVersion;
@@ -51,6 +54,9 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
     mv,
     registeredModel,
   );
+  const [modelArtifacts] = useModelArtifactsByVersionId(mv.id);
+  const isOciModel = isOciModelUri(modelArtifacts.items.map((artifact) => artifact.uri)[0]);
+  const deployButtonState = useDeployButtonState(isOciModel);
 
   if (!preferredModelRegistry) {
     return null;
@@ -59,17 +65,19 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   return (
     <ActionList className="pf-v5-u-display-flex">
       <ActionListGroup className="pf-v5-u-flex-1">
-        <ActionListItem>
-          <Button
-            id="deploy-button"
-            aria-label="Deploy version"
-            ref={tooltipRef}
-            variant={ButtonVariant.primary}
-            onClick={() => setIsDeployModalOpen(true)}
-          >
-            Deploy
-          </Button>
-        </ActionListItem>
+        {deployButtonState.visible && (
+          <ActionListItem>
+            <Button
+              id="deploy-button"
+              aria-label="Deploy version"
+              ref={tooltipRef}
+              variant={ButtonVariant.primary}
+              onClick={() => setIsDeployModalOpen(true)}
+            >
+              Deploy
+            </Button>
+          </ActionListItem>
+        )}
         {isFineTuningEnabled && (
           <ActionListItem
             className="pf-v5-u-w-100"

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -9,6 +9,7 @@ import {
   ActionList,
   ActionListItem,
   ActionListGroup,
+  Tooltip,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router';
 import { ArchiveModelVersionModal } from '~/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
@@ -62,20 +63,32 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
     return null;
   }
 
+  const deployButton = (
+    <Button
+      id="deploy-button"
+      aria-label="Deploy version"
+      ref={tooltipRef}
+      variant={ButtonVariant.primary}
+      onClick={() => setIsDeployModalOpen(true)}
+      isAriaDisabled={!deployButtonState.enabled}
+      data-testid="deploy-button"
+    >
+      Deploy
+    </Button>
+  );
+
   return (
     <ActionList className="pf-v5-u-display-flex">
       <ActionListGroup className="pf-v5-u-flex-1">
         {deployButtonState.visible && (
           <ActionListItem>
-            <Button
-              id="deploy-button"
-              aria-label="Deploy version"
-              ref={tooltipRef}
-              variant={ButtonVariant.primary}
-              onClick={() => setIsDeployModalOpen(true)}
-            >
-              Deploy
-            </Button>
+            {deployButtonState.enabled ? (
+              deployButton
+            ) : (
+              <Tooltip content={deployButtonState.tooltip}>
+                <span>{deployButton}</span>
+              </Tooltip>
+            )}
           </ActionListItem>
         )}
         {isFineTuningEnabled && (

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs.tsx
@@ -5,6 +5,7 @@ import '~/pages/pipelines/global/runs/GlobalPipelineRunsTabs.scss';
 import { ModelVersion } from '~/concepts/modelRegistry/types';
 import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import { FetchStateObject } from '~/types';
+import { SupportedArea, useIsAreaAvailable } from '~/concepts/areas';
 import { ModelVersionDetailsTabTitle, ModelVersionDetailsTab } from './const';
 import ModelVersionDetailsView from './ModelVersionDetailsView';
 import ModelVersionRegisteredDeploymentsView from './ModelVersionRegisteredDeploymentsView';
@@ -27,6 +28,8 @@ const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
   refresh,
 }) => {
   const navigate = useNavigate();
+  const { status: isModelServingEnabled } = useIsAreaAvailable(SupportedArea.MODEL_SERVING);
+
   return (
     <Tabs
       activeKey={tab}
@@ -53,7 +56,7 @@ const ModelVersionDetailsTabs: React.FC<ModelVersionDetailTabsProps> = ({
           />
         </PageSection>
       </Tab>
-      {!isArchiveVersion && (
+      {!isArchiveVersion && isModelServingEnabled && (
         <Tab
           eventKey={ModelVersionDetailsTab.DEPLOYMENTS}
           title={<TabTitleText>{ModelVersionDetailsTabTitle.DEPLOYMENTS}</TabTitleText>}

--- a/frontend/src/pages/modelServing/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import {
   getServingRuntimeOrReturnEmpty,
   resourcesArePositive,
   setUpTokenAuth,
+  isOciModelUri,
 } from '~/pages/modelServing/utils';
 import { mockServingRuntimeK8sResource } from '~/__mocks__/mockServingRuntimeK8sResource';
 import { ContainerResources } from '~/types';
@@ -292,5 +293,16 @@ describe('getServingRuntimeSizeOrReturnEmpty', () => {
     };
     const servingRuntime = mockServingRuntimeK8sResource({ resources });
     expect(getServingRuntimeOrReturnEmpty(servingRuntime)).toBe(resources);
+  });
+});
+
+describe('isOciModelUri', () => {
+  it('returns true for oci:// URIs', () => {
+    expect(isOciModelUri('oci://my-model')).toBe(true);
+  });
+  it('returns false for non-oci URIs', () => {
+    expect(isOciModelUri('s3://my-model')).toBe(false);
+    expect(isOciModelUri(undefined)).toBe(false);
+    expect(isOciModelUri('')).toBe(false);
   });
 });

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -55,3 +55,10 @@ export enum StorageKeys {
   DEFAULT_REGION = 'region',
   PATH = 'path',
 }
+
+export const DEPLOY_BUTTON_TOOLTIP = {
+  ENABLE_SINGLE_MODEL_SERVING:
+    'To deploy this model, an administrator must first enable single-model serving in the cluster settings.',
+  ENABLE_MODEL_SERVING_PLATFORM:
+    'To enable model serving, an administrator must first select a model serving platform in the cluster settings.',
+};

--- a/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
@@ -15,6 +15,7 @@ import ModelServingContextProvider, {
 import { getKServeTemplates } from '~/pages/modelServing/customServingRuntimes/utils';
 import { isRedHatRegistryUri } from '~/pages/modelRegistry/screens/utils';
 import useServingConnections from '~/pages/projects/screens/detail/connections/useServingConnections';
+import { isOciModelUri } from '~/pages/modelServing/utils';
 import { ModelDeployPrefillInfo } from './usePrefillModelDeployModal';
 
 interface DeployPrefilledModelModalProps {
@@ -70,8 +71,7 @@ const DeployPrefilledModelModalContents: React.FC<
     servingPlatformStatuses,
   );
   const [connections] = useServingConnections(selectedProject?.metadata.name);
-
-  const isOciModel = modelDeployPrefillInfo.modelArtifactUri?.includes('oci://');
+  const isOciModel = isOciModelUri(modelDeployPrefillInfo.modelArtifactUri);
   const platformToUse = platform || (isOciModel ? ServingRuntimePlatform.SINGLE : undefined);
   const { loaded: projectDeployStatusLoaded, error: projectError } =
     useProjectErrorForPrefilledModel(selectedProject?.metadata.name, platformToUse);

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/useDeployButtonState.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/useDeployButtonState.spec.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import useDeployButtonState from '~/pages/modelServing/screens/projects/useDeployButtonState';
+import { DEPLOY_BUTTON_TOOLTIP } from '~/pages/modelServing/screens/const';
+
+jest.mock('~/concepts/areas', () => ({
+  useIsAreaAvailable: jest.fn(),
+  SupportedArea: { MODEL_SERVING: 'MODEL_SERVING' },
+}));
+jest.mock('~/pages/modelServing/useServingPlatformStatuses', () => jest.fn());
+
+const mockUseIsAreaAvailable = require('~/concepts/areas').useIsAreaAvailable;
+const mockUseServingPlatformStatuses = require('~/pages/modelServing/useServingPlatformStatuses');
+
+describe('useDeployButtonState', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns visible: false if model serving is disabled', () => {
+    mockUseIsAreaAvailable.mockReturnValue({ status: false });
+    mockUseServingPlatformStatuses.mockReturnValue({
+      platformEnabledCount: 1,
+      kServe: { enabled: true },
+    });
+
+    const { result } = renderHook(() => useDeployButtonState(false));
+    expect(result.current).toEqual({ visible: false });
+  });
+
+  it('returns disabled with tooltip if no serving platforms are enabled', () => {
+    mockUseIsAreaAvailable.mockReturnValue({ status: true });
+    mockUseServingPlatformStatuses.mockReturnValue({
+      platformEnabledCount: 0,
+      kServe: { enabled: false },
+    });
+
+    const { result } = renderHook(() => useDeployButtonState(false));
+    expect(result.current).toEqual({
+      visible: true,
+      enabled: false,
+      tooltip: DEPLOY_BUTTON_TOOLTIP.ENABLE_MODEL_SERVING_PLATFORM,
+    });
+  });
+
+  it('returns disabled with tooltip if OCI model and kserve is not enabled', () => {
+    mockUseIsAreaAvailable.mockReturnValue({ status: true });
+    mockUseServingPlatformStatuses.mockReturnValue({
+      platformEnabledCount: 1,
+      kServe: { enabled: false },
+    });
+
+    const { result } = renderHook(() => useDeployButtonState(true));
+    expect(result.current).toEqual({
+      visible: true,
+      enabled: false,
+      tooltip: DEPLOY_BUTTON_TOOLTIP.ENABLE_SINGLE_MODEL_SERVING,
+    });
+  });
+
+  it('returns enabled if model serving and platform are enabled, not OCI', () => {
+    mockUseIsAreaAvailable.mockReturnValue({ status: true });
+    mockUseServingPlatformStatuses.mockReturnValue({
+      platformEnabledCount: 1,
+      kServe: { enabled: true },
+    });
+
+    const { result } = renderHook(() => useDeployButtonState(false));
+    expect(result.current).toEqual({
+      visible: true,
+      enabled: true,
+    });
+  });
+
+  it('returns enabled if model serving and platform are enabled, OCI, and kserve is enabled', () => {
+    mockUseIsAreaAvailable.mockReturnValue({ status: true });
+    mockUseServingPlatformStatuses.mockReturnValue({
+      platformEnabledCount: 1,
+      kServe: { enabled: true },
+    });
+
+    const { result } = renderHook(() => useDeployButtonState(true));
+    expect(result.current).toEqual({
+      visible: true,
+      enabled: true,
+    });
+  });
+});

--- a/frontend/src/pages/modelServing/screens/projects/useDeployButtonState.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useDeployButtonState.ts
@@ -1,0 +1,23 @@
+import { useIsAreaAvailable, SupportedArea } from '~/concepts/areas';
+import useServingPlatformStatuses from '~/pages/modelServing/useServingPlatformStatuses';
+import { getDeployButtonState } from '~/pages/modelCatalog/utils';
+
+/**
+ * Returns the deploy button state (visible, enabled, tooltip) for model deploy actions.
+ * @param isOciModel - Whether the model is an OCI model (use isOciModelUri or similar).
+ */
+const useDeployButtonState = (
+  isOciModel: boolean,
+): { visible: boolean; enabled?: boolean; tooltip?: string } => {
+  const isModelServingEnabled = useIsAreaAvailable(SupportedArea.MODEL_SERVING).status;
+  const { platformEnabledCount, kServe } = useServingPlatformStatuses();
+
+  return getDeployButtonState({
+    isModelServingEnabled,
+    platformEnabledCount,
+    isKServeEnabled: kServe.enabled,
+    isOciModel,
+  });
+};
+
+export default useDeployButtonState;

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -382,3 +382,5 @@ export const isModelServerEditInfoChanged = (
 export const isModelMesh = (inferenceService: InferenceServiceKind): boolean =>
   inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode'] ===
   DeploymentMode.ModelMesh;
+
+export const isOciModelUri = (modelUri?: string): boolean => !!modelUri?.includes('oci://');


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes [RHOAIENG-24513](https://issues.redhat.com/browse/RHOAIENG-24513)
Closes [RHOAIENG-25132](https://issues.redhat.com/browse/RHOAIENG-25132)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. If model serving is entirely disabled (useIsAreaAvailable(SupportedArea.MODEL_SERVING).status), hide the button/action/tab entirely.


https://github.com/user-attachments/assets/ca2221a5-bbb8-42d7-a030-194a876c1af2


2. If model serving is enabled and the model to be deployed is an OCI model (uri?.includes('oci://'), and the kserve platform is not available (!useServingPlatformStatuses().kServe.enabled), disable the button/action with a tooltip.This applies to all models in model catalog, and models in model registry with OCI URIs. For this case, the tooltip should read "To deploy this model, an administrator must first enable single-model serving in the cluster settings."

https://github.com/user-attachments/assets/23e72a8f-7076-4c4c-a282-035d0d050c32

3. Kserve is disabled and in model catalog, and models in model registry with OCI URIs. For this case, the tooltip should read "To deploy this model, an administrator must first enable single-model serving in the cluster settings."

https://github.com/user-attachments/assets/5a727c75-a6bb-42e4-8071-7949b5444d96


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

1. Added jest Test cases for the utility functions and cypress test cases for the disabled flow

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
