### PR TITLE
fix: add skeleton placeholder while loading StorageClass field

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, getUniqueId, Stack, StackItem } from '@patternfly/react-core';
+import { Form, getUniqueId, Skeleton, Stack, StackItem } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import {
@@ -135,8 +135,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     editInfo?.servingRuntimeEditInfo?.servingRuntime,
   );
 
-  const isStorageClassesAvailable = useIsAreaAvailable(SupportedArea.STORAGE_CLASSES).status;
-  const [defaultSc] = useAdminDefaultStorageClass();
+  const [defaultSc, defaultStorageClassLoaded] = useAdminDefaultStorageClass();
   const defaultStorageClassName = defaultSc?.metadata.name || '';
   const deployedStorageClassName = pvc?.spec.storageClassName || '';
   const [storageClassName, setStorageClassName] = React.useState(
@@ -383,15 +382,18 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
             </StackItem>
           </StackItem>
           <StackItem>
-            {isStorageClassesAvailable && (
+            {defaultStorageClassLoaded ? (
               <StorageClassSelect
                 storageClassName={storageClassName}
                 setStorageClassName={setStorageClassName}
                 isRequired
                 disableStorageClassSelect={!!editInfo}
               />
+            ) : (
+              <Skeleton width="300px" height="36px" />
             )}
           </StackItem>
+
           <StackItem>
             <NIMPVCSizeSection pvcSize={pvcSize} setPvcSize={setPvcSize} />
           </StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-251

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Replaced empty space with a <Skeleton /> component to provide better visual feedback.
<img width="826" alt="image" src="https://github.com/user-attachments/assets/cb02fb10-2629-4798-af51-0c58f9a55ce7" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- Verified that the skeleton is displayed when the default storage class is not yet loaded.
- Confirmed that the actual StorageClassSelect field replaces the skeleton once loading is complete.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
