### PR TITLE
Spinner makes content of a modal jump when added towards the end of a modal

### DIFF
--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Button,
   Checkbox,
-  EmptyState,
   Form,
   FormGroup,
   HelperText,

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -421,7 +421,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
               </FormGroup>
               {addSecureDB &&
                 (!configSecretsLoaded && !configSecretsError ? (
-                  <EmptyState icon={Spinner} />
+                  <Spinner className="pf-v6-u-m-md" />
                 ) : configSecretsLoaded ? (
                   <CreateMRSecureDBSection
                     secureDBInfo={secureDBInfo}

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Alert,
+  Bullseye,
   Button,
   Checkbox,
   Form,
@@ -420,7 +421,9 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
               </FormGroup>
               {addSecureDB &&
                 (!configSecretsLoaded && !configSecretsError ? (
-                  <Spinner className="pf-v6-u-m-md" />
+                  <Bullseye>
+                    <Spinner className="pf-v6-u-m-md" />
+                  </Bullseye>
                 ) : configSecretsLoaded ? (
                   <CreateMRSecureDBSection
                     secureDBInfo={secureDBInfo}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-17074

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Replaced EmptyState spinner element with PF spinner component
Recording: https://github.com/user-attachments/assets/505ca918-8e32-4be9-809b-e0599557b3cf

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually as shown in the video attached above
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Cypress and Unit tests for CreateModal under modelRegistrySettings work as usual.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
